### PR TITLE
Remove deploy steps from CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,7 +1,7 @@
 name: ci
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+** # Tag filters not as strict due to different regex system on Github Actions
   pull_request:
@@ -69,15 +69,6 @@ jobs:
         run: |
           touch build-image/.uptodate
           make BUILD_IN_CONTAINER=false
-      - name: Build Website
-        run: |
-          touch build-image/.uptodate
-          make BUILD_IN_CONTAINER=false web-build
-      - name: Upload Website Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: website public
-          path: website/public/
       - name: Save Images
         run: |
           mkdir /tmp/images
@@ -175,82 +166,3 @@ jobs:
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
           make BUILD_IMAGE=quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f TTY='' configs-integration-test
-
-  deploy_website:
-    needs: [build, test]
-    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
-    runs-on: ubuntu-20.04
-    container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-        with:
-          # web-deploy script expects repo to be cloned with ssh for some commands to work
-          ssh-key: ${{ secrets.WEBSITE_DEPLOY_SSH_PRIVATE_KEY }}
-      - name: Sym Link Expected Path to Workspace
-        run: |
-          mkdir -p /go/src/github.com/cortexproject/cortex
-          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
-      - name: Download Website Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: website public
-          path: website/public
-      - name: Setup SSH Keys and known_hosts for Github Authentication to Deploy Website
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.WEBSITE_DEPLOY_SSH_PRIVATE_KEY }}"
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        shell: bash
-      - name: Deploy Website
-        # SSH is used to authentricate with Github because web-deploy script uses git to checkout and push to gh-pages
-        run: make BUILD_IN_CONTAINER=false web-deploy
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
-
-  deploy:
-    needs: [build, test, lint, integration, integration-configs-db]
-    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
-    runs-on: ubuntu-20.04
-    container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Install Docker Client
-        run: ./.github/workflows/scripts/install-docker.sh
-      - name: Sym link Expected Path to Workspace
-        run: |
-          mkdir -p /go/src/github.com/cortexproject/cortex
-          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
-      - name: Download Docker Images Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: Docker Images
-      - name: Extract Docker Images Archive
-        run: tar -xvf images.tar -C /
-      - name: Load Images
-        run: |
-          ln -s /tmp/images ./docker-images
-          make BUILD_IN_CONTAINER=false load-images
-      - name: Deploy
-        run: |
-          if [ -n "$DOCKER_REGISTRY_PASSWORD" ]; then
-            docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
-          fi
-          if [ -n "$QUAY_REGISTRY_PASSWORD" ]; then
-            docker login -u "$QUAY_REGISTRY_USER" -p "$QUAY_REGISTRY_PASSWORD" quay.io;
-          fi
-          export IMAGE_TAG=$(make image-tag)
-          ./push-images $NOQUAY
-        env:
-          DOCKER_REGISTRY_USER: ${{secrets.DOCKER_REGISTRY_USER}}
-          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
-          QUAY_REGISTRY_USER: ${{secrets.QUAY_REGISTRY_USER}}
-          QUAY_REGISTRY_PASSWORD: ${{secrets.QUAY_REGISTRY_PASSWORD}}
-          NOQUAY: ${{secrets.NOQUAY}}


### PR DESCRIPTION
**What this PR does**:
As first step after the forking, we should remove the deploy and deploy_website from CI. For now, CI should be just used to run tests.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
