### PR TITLE
Update PR template to avoid referencing cortex issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@
 **What this PR does**:
 
 **Which issue(s) this PR fixes**:
+
+<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->
 Fixes #<issue number>
 
 **Checklist**


### PR DESCRIPTION
References to public repos can become public.

See https://raintank-corp.slack.com/archives/C9KL8THCY/p1627042453356700
