### PR TITLE
Clean up packaging scripts

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -7,21 +7,22 @@ set -e
 
 case "$1" in
   configure)
-     [ -z "$CORTEX_USER" ] && CORTEX_USER="cortex"
-     [ -z "$CORTEX_GROUP" ] && CORTEX_GROUP="cortex"
-     if ! getent group "$CORTEX_GROUP" > /dev/null 2>&1 ; then
-	 groupadd -r "$CORTEX_GROUP"
-     fi
-     if ! getent passwd "$CORTEX_USER" > /dev/null 2>&1 ; then
-	 useradd -m -r -g cortex -d /var/lib/cortex -s /sbin/nologin -c "cortex user" cortex
-     fi
+    [ -z "$CORTEX_USER" ] && CORTEX_USER="cortex"
+    [ -z "$CORTEX_GROUP" ] && CORTEX_GROUP="cortex"
+    if ! getent group "$CORTEX_GROUP" >/dev/null 2>&1; then
+      groupadd -r "$CORTEX_GROUP"
+    fi
+    if ! getent passwd "$CORTEX_USER" >/dev/null 2>&1; then
+      useradd -m -r -g cortex -d /var/lib/cortex -s /sbin/nologin -c "cortex user" cortex
+    fi
 
-     chmod 640 /etc/cortex/single-process-config.yaml
-     chown root:$CORTEX_GROUP /etc/cortex/single-process-config.yaml
+    chmod 640 /etc/cortex/single-process-config.yaml
+    chown root:$CORTEX_GROUP /etc/cortex/single-process-config.yaml
 
-     if [ -z ${2+x} ] &&  [ "$RESTART_ON_UPGRADE" = "true" ]; then
-	 if command -v systemctl 2>/dev/null; then
-	     systemctl daemon-reload
-	 fi
-     fi
+    if [ -z ${2+x} ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
+      if command -v systemctl 2>/dev/null; then
+        systemctl daemon-reload
+      fi
+    fi
+    ;;
 esac

--- a/packaging/deb/control/prerm
+++ b/packaging/deb/control/prerm
@@ -5,8 +5,8 @@ set -e
 # shellcheck disable=1091
 [ -f /etc/default/cortex ] && . /etc/default/cortex
 
-if [ "$1" -eq 0 ] ; then
-    if command -v systemctl 2>/dev/null; then
-	systemctl stop cortex.service > /dev/null 2>&1 || :
-    fi
+if [ "$1" -eq 0 ]; then
+  if command -v systemctl 2>/dev/null; then
+    systemctl stop cortex.service >/dev/null 2>&1 || :
+  fi
 fi

--- a/packaging/rpm/control/post
+++ b/packaging/rpm/control/post
@@ -5,25 +5,25 @@ set -e
 # shellcheck disable=1091
 [ -f /etc/sysconfig/cortex ] && . /etc/sysconfig/cortex
 
- # Initial installation: $1 == 1
- # Upgrade: $1 == 2, and configured to restart on upgrade
- if [ "$1" -eq 1 ] ; then
-     [ -z "$CORTEX_USER" ] && CORTEX_USER="cortex"
-     [ -z "$CORTEX_GROUP" ] && CORTEX_GROUP="cortex"
-     if ! getent group "$CORTEX_GROUP" > /dev/null 2>&1 ; then
-	 groupadd -r "$CORTEX_GROUP"
-     fi
-     if ! getent passwd "$CORTEX_USER" > /dev/null 2>&1 ; then
-	 useradd -m -r -g cortex -d /var/lib/cortex -s /sbin/nologin -c "cortex user" cortex
-     fi
+# Initial installation: $1 == 1
+# Upgrade: $1 == 2, and configured to restart on upgrade
+if [ "$1" -eq 1 ]; then
+  [ -z "$CORTEX_USER" ] && CORTEX_USER="cortex"
+  [ -z "$CORTEX_GROUP" ] && CORTEX_GROUP="cortex"
+  if ! getent group "$CORTEX_GROUP" >/dev/null 2>&1; then
+    groupadd -r "$CORTEX_GROUP"
+  fi
+  if ! getent passwd "$CORTEX_USER" >/dev/null 2>&1; then
+    useradd -m -r -g cortex -d /var/lib/cortex -s /sbin/nologin -c "cortex user" cortex
+  fi
 
-     chmod 640 /etc/cortex/single-process-config.yaml
-     chown root:$CORTEX_GROUP /etc/cortex/single-process-config.yaml
+  chmod 640 /etc/cortex/single-process-config.yaml
+  chown root:$CORTEX_GROUP /etc/cortex/single-process-config.yaml
 
- elif [ "$1" -ge 2 ] ; then
-     if [ "$RESTART_ON_UPGRADE" = "true" ]; then
-	 if command -v systemctl 2>/dev/null; then
-	     systemctl daemon-reload
-	 fi
-     fi
- fi
+elif [ "$1" -ge 2 ]; then
+  if [ "$RESTART_ON_UPGRADE" = "true" ]; then
+    if command -v systemctl 2>/dev/null; then
+      systemctl daemon-reload
+    fi
+  fi
+fi

--- a/packaging/rpm/control/preun
+++ b/packaging/rpm/control/preun
@@ -7,8 +7,8 @@ set -e
 
 # Final uninstallation $1=0
 # If other copies of this RPM are installed, then $1>0
-if [ "$1" -eq 0 ] ; then
-    if command -v systemctl 2>/dev/null; then
-	systemctl stop cortex.service > /dev/null 2>&1 || :
-    fi
+if [ "$1" -eq 0 ]; then
+  if command -v systemctl 2>/dev/null; then
+    systemctl stop cortex.service >/dev/null 2>&1 || :
+  fi
 fi


### PR DESCRIPTION
**What this PR does**:
Please see individual commit messages for details. This clean up fixes some undefined behavior, removes some confusing comments, lints each script with ShellCheck, and makes indentation consistent. 

Besides the correction of the undefined equality operator behavior in posix shells, there is no functionality changed.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
