### PR TITLE
Log: Remove a metric, rename another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Mimir - master / unreleased
 
+* [CHANGE] Renamed metric `experimental_features_in_use_total` as `experimental_features_used_total`. #32
+* [CHANGE] Removed `log_messages_total` metric. #32
 * [CHANGE] Removed `configdb` support from Ruler and Alertmanager backend storages. #15
 * [CHANGE] Changed `-ruler.storage.type` default value from `configdb` to `local`. #15
 * [CHANGE] Changed `-alertmanager.storage.type` default value from `configdb` to `local`. #15

--- a/pkg/util/log/experimental.go
+++ b/pkg/util/log/experimental.go
@@ -9,7 +9,7 @@ import (
 var experimentalFeaturesInUse = promauto.NewCounter(
 	prometheus.CounterOpts{
 		Namespace: "cortex",
-		Name:      "experimental_features_in_use_total",
+		Name:      "experimental_features_used_total",
 		Help:      "The number of experimental features in use.",
 	},
 )


### PR DESCRIPTION
**What this PR does**:
In order to avoid conflicts between Mimir and Cortex globally registering the same metrics, remove `log_messages_total` metric and rename `experimental_features_in_use_total` metric to `experimental_features_used_total`.

Changing these metrics is necessary to quickly fix backend-enterprise, since it vendors both Cortex and Mimir and these globally registered metrics were conflicting.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
