### PR TITLE
Another attempt to fix TestMultitenantAlertmanager_SyncOnRingTopologyChanges

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1323,7 +1323,7 @@ func TestMultitenantAlertmanager_SyncOnRingTopologyChanges(t *testing.T) {
 			if tt.expected {
 				expectedSyncs++
 			}
-			test.Poll(t, 5*time.Second, float64(expectedSyncs), func() interface{} {
+			test.Poll(t, 10*time.Second, float64(expectedSyncs), func() interface{} {
 				metrics := regs.BuildMetricFamiliesPerUser()
 				return metrics.GetSumOfCounters("cortex_alertmanager_sync_configs_total")
 			})


### PR DESCRIPTION

**What this PR does**:

My previous investigation into this test concluded that the sync does always happen as expected. I'm increasing the timeout to try and fix it. If it still fails after this fix, then we can investigate further.

