### PR TITLE
Attempt fix to TestSingleBinaryWithMemberlistScaling.

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -198,11 +198,11 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 		instances = instances[:i]
 		stop.Go(func() error { return s.Stop(c) })
 
-		// TODO(#4360): Remove this when issue is resolved.
-		//   Wait until memberlist for all nodes has recognised the instance left.
+		// TODO(#44): Remove this when issue is resolved.
+		//   Wait until the ring for all nodes has recognised the instance left.
 		//   This means that we will not gossip tombstones to leaving nodes.
 		for _, c := range instances {
-			require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(len(instances))), "memberlist_client_cluster_members_count"))
+			require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(len(instances))), "cortex_ring_members"))
 		}
 	}
 	require.NoError(t, stop.Wait())


### PR DESCRIPTION
The original fix was to check `memberlist_client_cluster_members_count`
to only scale down the next instance once the previous has been removed
everywhere. However, this does not inhibit the test enough to ensure
that tombstones are not lost, because the memberlist membership
propagates much quicker than ring membership. Therefore, instead wait
until every instance has seen the tombstone before removing another
instance.

This unfortunately takes the teeth out the test so the alternative is
to skip it or remove the test entirely, until issue #44 is fixed.
