### PR TITLE
Add option to disable ring health check in the readiness endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * `ruler_max_rules_per_rule_group`
   * `ruler_max_rule_groups_per_tenant`
 * [ENHANCEMENT] Querier now can use the `LabelNames` call with matchers, if matchers are provided in the `/labels` API call, instead of using the more expensive `MetricsForLabelMatchers` call as before. This can be enabled by enabling the `-querier.query-label-names-with-matchers-enabled` flag once the ingesters are updated to this version. In the future this is expected to become the default behavior. #3
+* [ENHANCEMENT] Ingester: added option `-ingester.readiness-check-ring-health` to disable the ring health check in the readiness endpoint. #48
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16
 * [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #28
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -718,6 +718,13 @@ lifecycler:
   # CLI flag: -ingester.unregister-on-shutdown
   [unregister_on_shutdown: <boolean> | default = true]
 
+  # When enabled the readiness probe succeeds only after all instances are
+  # ACTIVE and healthy in the ring. This option should be disabled if in your
+  # cluster multiple instances can be rolled out simultaneously, otherwise
+  # rolling updates may be slowed down.
+  # CLI flag: -ingester.readiness-check-ring-health
+  [readiness_check_ring_health: <boolean> | default = true]
+
 # Number of times to try and transfer chunks before falling back to flushing.
 # Negative value or zero disables hand-over. This feature is supported only by
 # the chunks storage.

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -56,7 +56,6 @@ Currently experimental features are:
 - Metric relabeling in the distributor.
 - Scalable query-frontend (when using query-scheduler)
 - Querying store for series, labels APIs (`-querier.query-store-for-labels-enabled`)
-- Ingester: do not unregister from ring on shutdown (`-ingester.unregister-on-shutdown=false`)
 - Distributor: do not extend writes on unhealthy ingesters (`-distributor.extend-writes=false`)
 - Tenant Deletion in Purger, for blocks storage.
 - Query-frontend: query stats tracking (`-frontend.query-stats-enabled`)
@@ -81,20 +80,23 @@ Currently experimental features are:
   - user config size (`-alertmanager.max-config-size-bytes`)
   - templates count in user config (`-alertmanager.max-templates-count`)
   - max template size (`-alertmanager.max-template-size-bytes`)
-- Disabling ring heartbeat timeouts
-  - `-distributor.ring.heartbeat-timeout=0`
-  - `-ring.heartbeat-timeout=0`
-  - `-ruler.ring.heartbeat-timeout=0`
-  - `-alertmanager.sharding-ring.heartbeat-timeout=0`
-  - `-compactor.ring.heartbeat-timeout=0`
-  - `-store-gateway.sharding-ring.heartbeat-timeout=0`
-- Disabling ring heartbeats
-  - `-distributor.ring.heartbeat-period=0`
-  - `-ingester.heartbeat-period=0`
-  - `-ruler.ring.heartbeat-period=0`
-  - `-alertmanager.sharding-ring.heartbeat-period=0`
-  - `-compactor.ring.heartbeat-period=0`
-  - `-store-gateway.sharding-ring.heartbeat-period=0`
+- Hash ring
+  - Do not unregister ingesters from ring on shutdown (`-ingester.unregister-on-shutdown=false`)
+  - Disable the ring health check in the readiness endpoint (`-ingester.readiness-check-ring-health=false`)
+  - Disabling ring heartbeat timeouts
+    - `-distributor.ring.heartbeat-timeout=0`
+    - `-ring.heartbeat-timeout=0`
+    - `-ruler.ring.heartbeat-timeout=0`
+    - `-alertmanager.sharding-ring.heartbeat-timeout=0`
+    - `-compactor.ring.heartbeat-timeout=0`
+    - `-store-gateway.sharding-ring.heartbeat-timeout=0`
+  - Disabling ring heartbeats
+    - `-distributor.ring.heartbeat-period=0`
+    - `-ingester.heartbeat-period=0`
+    - `-ruler.ring.heartbeat-period=0`
+    - `-alertmanager.sharding-ring.heartbeat-period=0`
+    - `-compactor.ring.heartbeat-period=0`
+    - `-store-gateway.sharding-ring.heartbeat-period=0`
 - `LabelNames` calls using matchers
   - `-querier.query-label-names-with-matchers-enabled`
 


### PR DESCRIPTION
**What this PR does**:
We're rolling out ingesters in multiple zones. When we do it, multiple ingesters in the same zone can be rolled out simultaneously but their readiness endpoint will not succeed until all ingesters in the ring are ACTIVE and healthy.

In this PR I'm proposing to add an option to disable this check.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
