### PR TITLE
Makefile: Fix $LATEST_BUILD_IMAGE_TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
-LATEST_BUILD_IMAGE_TAG ?= 20210713_update-go-1.16.6-178ab0c4f
+LATEST_BUILD_IMAGE_TAG ?= 20210802-6ece8f873
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden


### PR DESCRIPTION
**What this PR does**:
Fix `$LATEST_BUILD_IMAGE_TAG` variable in Makefile, to point to latest build image tag.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
