### PR TITLE
Added option to exclude zones in the ring client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   * `ruler_max_rule_groups_per_tenant`
 * [ENHANCEMENT] Querier now can use the `LabelNames` call with matchers, if matchers are provided in the `/labels` API call, instead of using the more expensive `MetricsForLabelMatchers` call as before. This can be enabled by enabling the `-querier.query-label-names-with-matchers-enabled` flag once the ingesters are updated to this version. In the future this is expected to become the default behavior. #3
 * [ENHANCEMENT] Ingester: added option `-ingester.readiness-check-ring-health` to disable the ring health check in the readiness endpoint. #48
+* [ENHANCEMENT] Added option `-distributor.excluded-zones` to exclude ingesters running in specific zones both on write and read path. #51
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16
 * [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #28
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -671,6 +671,11 @@ lifecycler:
     # CLI flag: -distributor.zone-awareness-enabled
     [zone_awareness_enabled: <boolean> | default = false]
 
+    # Comma-separated list of zones to exclude from the ring. Instances in
+    # excluded zones will be filtered out from the ring.
+    # CLI flag: -distributor.excluded-zones
+    [excluded_zones: <string> | default = ""]
+
   # Number of tokens for each ingester.
   # CLI flag: -ingester.num-tokens
   [num_tokens: <int> | default = 128]

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -99,4 +99,4 @@ Currently experimental features are:
     - `-store-gateway.sharding-ring.heartbeat-period=0`
 - `LabelNames` calls using matchers
   - `-querier.query-label-names-with-matchers-enabled`
-
+- Exclude ingesters running in specific zones (`-distributor.excluded-zones`)

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1931,65 +1931,84 @@ func compareReplicationSets(first, second ReplicationSet) (added, removed []stri
 
 // This test verifies that ring is getting updates, even after extending check in the loop method.
 func TestRingUpdates(t *testing.T) {
-	inmem, closer := consul.NewInMemoryClient(GetCodec())
-	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+	const (
+		numInstances = 3
+		numZones     = 3
+	)
 
-	cfg := Config{
-		KVStore:           kv.Config{Mock: inmem},
-		HeartbeatTimeout:  1 * time.Minute,
-		ReplicationFactor: 3,
+	tests := map[string]struct {
+		excludedZones     []string
+		expectedInstances int
+	}{
+		"without excluded zones": {
+			expectedInstances: 3,
+		},
+		"with excluded zones": {
+			excludedZones:     []string{"zone-0"},
+			expectedInstances: 2,
+		},
 	}
 
-	ring, err := New(cfg, "test", "test", nil)
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ring))
-	t.Cleanup(func() {
-		_ = services.StopAndAwaitTerminated(context.Background(), ring)
-	})
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			inmem, closer := consul.NewInMemoryClient(GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	require.Equal(t, 0, ring.InstancesCount())
+			cfg := Config{
+				KVStore:           kv.Config{Mock: inmem},
+				HeartbeatTimeout:  1 * time.Minute,
+				ReplicationFactor: 3,
+				ExcludedZones:     flagext.StringSliceCSV(testData.excludedZones),
+			}
 
-	lc1 := startLifecycler(t, cfg, 100*time.Millisecond, 1, 3)
-	test.Poll(t, 1*time.Second, 1, func() interface{} {
-		return ring.InstancesCount()
-	})
+			ring, err := New(cfg, "test", "test", nil)
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), ring))
+			t.Cleanup(func() {
+				_ = services.StopAndAwaitTerminated(context.Background(), ring)
+			})
 
-	lc2 := startLifecycler(t, cfg, 100*time.Millisecond, 2, 3)
-	test.Poll(t, 1*time.Second, 2, func() interface{} {
-		return ring.InstancesCount()
-	})
+			require.Equal(t, 0, ring.InstancesCount())
 
-	lc3 := startLifecycler(t, cfg, 100*time.Millisecond, 3, 3)
-	test.Poll(t, 1*time.Second, 3, func() interface{} {
-		return ring.InstancesCount()
-	})
+			// Start 1 lifecycler for each instance we want to register in the ring.
+			var lifecyclers []*Lifecycler
+			for instanceID := 1; instanceID <= numInstances; instanceID++ {
+				lifecyclers = append(lifecyclers, startLifecycler(t, cfg, 100*time.Millisecond, instanceID, numZones))
+			}
 
-	// Sleep for a few seconds (ring timestamp resolution is 1 second, so to verify that ring is updated in the background,
-	// sleep for 2 seconds)
-	time.Sleep(2 * time.Second)
+			// Ensure the ring client got updated.
+			test.Poll(t, 1*time.Second, testData.expectedInstances, func() interface{} {
+				return ring.InstancesCount()
+			})
 
-	rs, err := ring.GetAllHealthy(Read)
-	require.NoError(t, err)
+			// Sleep for a few seconds (ring timestamp resolution is 1 second, so to verify that ring is updated in the background,
+			// sleep for 2 seconds)
+			time.Sleep(2 * time.Second)
 
-	now := time.Now()
-	for _, ing := range rs.Instances {
-		require.InDelta(t, now.UnixNano(), time.Unix(ing.Timestamp, 0).UnixNano(), float64(1500*time.Millisecond.Nanoseconds()))
+			rs, err := ring.GetAllHealthy(Read)
+			require.NoError(t, err)
+
+			now := time.Now()
+			for _, ing := range rs.Instances {
+				require.InDelta(t, now.UnixNano(), time.Unix(ing.Timestamp, 0).UnixNano(), float64(1500*time.Millisecond.Nanoseconds()))
+
+				// Ensure there's no instance in an excluded zone.
+				if len(testData.excludedZones) > 0 {
+					assert.False(t, util.StringsContain(testData.excludedZones, ing.Zone))
+				}
+			}
+
+			// Stop all lifecyclers.
+			for _, lc := range lifecyclers {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), lc))
+			}
+
+			// Ensure the ring client got updated.
+			test.Poll(t, 1*time.Second, 0, func() interface{} {
+				return ring.InstancesCount()
+			})
+		})
 	}
-
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), lc2))
-	test.Poll(t, 1*time.Second, 2, func() interface{} {
-		return ring.InstancesCount()
-	})
-
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), lc1))
-	test.Poll(t, 1*time.Second, 1, func() interface{} {
-		return ring.InstancesCount()
-	})
-
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), lc3))
-	test.Poll(t, 1*time.Second, 0, func() interface{} {
-		return ring.InstancesCount()
-	})
 }
 
 func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecyclerID int, zones int) *Lifecycler {


### PR DESCRIPTION
**What this PR does**:
We're in the process of migrating ingesters from single-zone to multi-zone. As part of the migration process, we need to exclude a specific zone from the write path, so I did this change to allow to exclude ingesters running in a specific zone from the ring client.

Draft because:
1. I would love a review on this
2. Should we upstream or not?

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
