### PR TITLE
Makefile: Don't mute Docker build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ exes $(EXES) protos $(PROTO_GOS) lint test cover shell mod-check check-protos we
 	@mkdir -p $(shell pwd)/.cache
 	@echo
 	@echo ">>>> Entering build container: $@"
-	@$(SUDO) time docker run --rm $(TTY) -i $(GOVOLUMES) $(BUILD_IMAGE) $@;
+	$(SUDO) time docker run --rm $(TTY) -i $(GOVOLUMES) $(BUILD_IMAGE) $@;
 
 else
 
@@ -325,7 +325,7 @@ packages: dist packaging/fpm/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	@mkdir -p $(shell pwd)/.cache
 	@echo ">>>> Entering build container: $@"
-	@$(SUDO) time docker run --rm $(TTY) \
+	$(SUDO) time docker run --rm $(TTY) \
 		-v  $(shell pwd):/src/github.com/grafana/mimir:delegated,z \
 		-i $(PACKAGE_IMAGE) $@;
 


### PR DESCRIPTION
**What this PR does**:
I suggest we unmute Docker image build commands in Makefile, since it's so difficult to debug them when they're muted (i.e. not echoed). I was just debugging a Makefile mistake, and couldn't see where it broke until I realized I had to unmute the Docker command in question. When the command did get echoed, the bug was obvious.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
