### PR TITLE
feat: make ruler API serde pluggable

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/mimir/pkg/ring/kv/codec"
 	"github.com/grafana/mimir/pkg/ring/kv/memberlist"
 	"github.com/grafana/mimir/pkg/ruler"
+	"github.com/grafana/mimir/pkg/ruler/rulespb"
 	"github.com/grafana/mimir/pkg/scheduler"
 	"github.com/grafana/mimir/pkg/storegateway"
 	util_log "github.com/grafana/mimir/pkg/util/log"
@@ -682,7 +683,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 
 	// If the API is enabled, register the Ruler API
 	if t.Cfg.Ruler.EnableAPI {
-		t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, util_log.Logger))
+		t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, &rulespb.DefaultSerde{}, util_log.Logger))
 	}
 
 	return t.Ruler, nil

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -28,7 +28,7 @@ func TestRuler_rules(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	req := requestFor(t, "GET", "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
@@ -85,7 +85,7 @@ func TestRuler_rules_special_characters(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
@@ -142,7 +142,7 @@ func TestRuler_alerts(t *testing.T) {
 	defer rcleanup()
 	defer r.StopAsync()
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/alerts", nil, "user1")
 	w := httptest.NewRecorder()
@@ -178,7 +178,7 @@ func TestRuler_Create(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	tc := []struct {
 		name   string
@@ -269,7 +269,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	router := mux.NewRouter()
 	router.Path("/api/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(a.DeleteNamespace)
@@ -310,7 +310,7 @@ func TestRuler_LimitsPerGroup(t *testing.T) {
 
 	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	tc := []struct {
 		name   string
@@ -365,7 +365,7 @@ func TestRuler_RulerGroupLimits(t *testing.T) {
 
 	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
 
-	a := NewAPI(r, r.store, log.NewNopLogger())
+	a := NewAPI(r, r.store, &rulespb.DefaultSerde{}, log.NewNopLogger())
 
 	tc := []struct {
 		name   string

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -2,19 +2,16 @@ package ruler
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	ot "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
-	"github.com/prometheus/prometheus/pkg/rulefmt"
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/weaveworks/common/user"
 	"golang.org/x/net/context/ctxhttp"
@@ -253,37 +250,4 @@ func (r *DefaultMultiTenantManager) Stop() {
 
 	// cleanup user rules directories
 	r.mapper.cleanup()
-}
-
-func (*DefaultMultiTenantManager) ValidateRuleGroup(g rulefmt.RuleGroup) []error {
-	var errs []error
-
-	if g.Name == "" {
-		errs = append(errs, errors.New("invalid rules config: rule group name must not be empty"))
-		return errs
-	}
-
-	if len(g.Rules) == 0 {
-		errs = append(errs, fmt.Errorf("invalid rules config: rule group '%s' has no rules", g.Name))
-		return errs
-	}
-
-	for i, r := range g.Rules {
-		for _, err := range r.Validate() {
-			var ruleName string
-			if r.Alert.Value != "" {
-				ruleName = r.Alert.Value
-			} else {
-				ruleName = r.Record.Value
-			}
-			errs = append(errs, &rulefmt.Error{
-				Group:    g.Name,
-				Rule:     i,
-				RuleName: ruleName,
-				Err:      err,
-			})
-		}
-	}
-
-	return errs
 }

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -189,8 +189,6 @@ type MultiTenantManager interface {
 	GetRules(userID string) []*promRules.Group
 	// Stop stops all Manager components.
 	Stop()
-	// ValidateRuleGroup validates a rulegroup
-	ValidateRuleGroup(rulefmt.RuleGroup) []error
 }
 
 // Ruler evaluates rules.


### PR DESCRIPTION
**What this PR does**:

This PR is intended to make the Mimir ruler API pluggable in terms of how it marshals/unmarshals yaml. In GEM, rule groups support an additional field for remote-write rules. To enable that, the entire ruler API has been forked, which requires any change to this API to be manually implemented a second time in GEM. This PR should allow the remote write ruler api in GEM to reuse the `ruler.API` struct here.
