### PR TITLE
Rename cortex_tsdb import to mimir_tsdb

### DIFF
--- a/pkg/chunk/purger/tenant_deletion_api.go
+++ b/pkg/chunk/purger/tenant_deletion_api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/tenant"
 	"github.com/grafana/mimir/pkg/util"
 )
@@ -25,7 +25,7 @@ type TenantDeletionAPI struct {
 	cfgProvider  bucket.TenantConfigProvider
 }
 
-func NewTenantDeletionAPI(storageCfg cortex_tsdb.BlocksStorageConfig, cfgProvider bucket.TenantConfigProvider, logger log.Logger, reg prometheus.Registerer) (*TenantDeletionAPI, error) {
+func NewTenantDeletionAPI(storageCfg mimir_tsdb.BlocksStorageConfig, cfgProvider bucket.TenantConfigProvider, logger log.Logger, reg prometheus.Registerer) (*TenantDeletionAPI, error) {
 	bucketClient, err := createBucketClient(storageCfg, logger, reg)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (api *TenantDeletionAPI) DeleteTenant(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = cortex_tsdb.WriteTenantDeletionMark(r.Context(), api.bucketClient, userID, api.cfgProvider, cortex_tsdb.NewTenantDeletionMark(time.Now()))
+	err = mimir_tsdb.WriteTenantDeletionMark(r.Context(), api.bucketClient, userID, api.cfgProvider, mimir_tsdb.NewTenantDeletionMark(time.Now()))
 	if err != nil {
 		level.Error(api.logger).Log("msg", "failed to write tenant deletion mark", "user", userID, "err", err)
 
@@ -118,7 +118,7 @@ func (api *TenantDeletionAPI) isBlocksForUserDeleted(ctx context.Context, userID
 	return true, nil
 }
 
-func createBucketClient(cfg cortex_tsdb.BlocksStorageConfig, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
+func createBucketClient(cfg mimir_tsdb.BlocksStorageConfig, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
 	bucketClient, err := bucket.NewClient(context.Background(), cfg.Bucket, "purger", logger, reg)
 	if err != nil {
 		return nil, errors.Wrap(err, "create bucket client")

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/flagext"
@@ -88,18 +88,18 @@ type BlocksCompactorFactory func(
 
 // Config holds the Compactor config.
 type Config struct {
-	BlockRanges           cortex_tsdb.DurationList `yaml:"block_ranges"`
-	BlockSyncConcurrency  int                      `yaml:"block_sync_concurrency"`
-	MetaSyncConcurrency   int                      `yaml:"meta_sync_concurrency"`
-	ConsistencyDelay      time.Duration            `yaml:"consistency_delay"`
-	DataDir               string                   `yaml:"data_dir"`
-	CompactionInterval    time.Duration            `yaml:"compaction_interval"`
-	CompactionRetries     int                      `yaml:"compaction_retries"`
-	CompactionConcurrency int                      `yaml:"compaction_concurrency"`
-	CleanupInterval       time.Duration            `yaml:"cleanup_interval"`
-	CleanupConcurrency    int                      `yaml:"cleanup_concurrency"`
-	DeletionDelay         time.Duration            `yaml:"deletion_delay"`
-	TenantCleanupDelay    time.Duration            `yaml:"tenant_cleanup_delay"`
+	BlockRanges           mimir_tsdb.DurationList `yaml:"block_ranges"`
+	BlockSyncConcurrency  int                     `yaml:"block_sync_concurrency"`
+	MetaSyncConcurrency   int                     `yaml:"meta_sync_concurrency"`
+	ConsistencyDelay      time.Duration           `yaml:"consistency_delay"`
+	DataDir               string                  `yaml:"data_dir"`
+	CompactionInterval    time.Duration           `yaml:"compaction_interval"`
+	CompactionRetries     int                     `yaml:"compaction_retries"`
+	CompactionConcurrency int                     `yaml:"compaction_concurrency"`
+	CleanupInterval       time.Duration           `yaml:"cleanup_interval"`
+	CleanupConcurrency    int                     `yaml:"cleanup_concurrency"`
+	DeletionDelay         time.Duration           `yaml:"deletion_delay"`
+	TenantCleanupDelay    time.Duration           `yaml:"tenant_cleanup_delay"`
 
 	// Whether the migration of block deletion marks to the global markers location is enabled.
 	BlockDeletionMarksMigrationEnabled bool `yaml:"block_deletion_marks_migration_enabled"`
@@ -126,7 +126,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ShardingRing.RegisterFlags(f)
 
-	cfg.BlockRanges = cortex_tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}
+	cfg.BlockRanges = mimir_tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}
 	cfg.retryMinBackoff = 10 * time.Second
 	cfg.retryMaxBackoff = time.Minute
 
@@ -173,7 +173,7 @@ type Compactor struct {
 	services.Service
 
 	compactorCfg   Config
-	storageCfg     cortex_tsdb.BlocksStorageConfig
+	storageCfg     mimir_tsdb.BlocksStorageConfig
 	cfgProvider    ConfigProvider
 	logger         log.Logger
 	parentLogger   log.Logger
@@ -187,7 +187,7 @@ type Compactor struct {
 	blocksCompactorFactory BlocksCompactorFactory
 
 	// Users scanner, used to discover users from the bucket.
-	usersScanner *cortex_tsdb.UsersScanner
+	usersScanner *mimir_tsdb.UsersScanner
 
 	// Blocks cleaner is responsible to hard delete blocks marked for deletion.
 	blocksCleaner *BlocksCleaner
@@ -223,7 +223,7 @@ type Compactor struct {
 }
 
 // NewCompactor makes a new Compactor.
-func NewCompactor(compactorCfg Config, storageCfg cortex_tsdb.BlocksStorageConfig, cfgProvider ConfigProvider, logger log.Logger, registerer prometheus.Registerer) (*Compactor, error) {
+func NewCompactor(compactorCfg Config, storageCfg mimir_tsdb.BlocksStorageConfig, cfgProvider ConfigProvider, logger log.Logger, registerer prometheus.Registerer) (*Compactor, error) {
 	bucketClientFactory := func(ctx context.Context) (objstore.Bucket, error) {
 		return bucket.NewClient(ctx, storageCfg.Bucket, "compactor", logger, registerer)
 	}
@@ -248,7 +248,7 @@ func NewCompactor(compactorCfg Config, storageCfg cortex_tsdb.BlocksStorageConfi
 
 func newCompactor(
 	compactorCfg Config,
-	storageCfg cortex_tsdb.BlocksStorageConfig,
+	storageCfg mimir_tsdb.BlocksStorageConfig,
 	cfgProvider ConfigProvider,
 	logger log.Logger,
 	registerer prometheus.Registerer,
@@ -351,7 +351,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 	c.bucketClient = bucketindex.BucketWithGlobalMarkers(c.bucketClient)
 
 	// Create the users scanner.
-	c.usersScanner = cortex_tsdb.NewUsersScanner(c.bucketClient, c.ownUser, c.parentLogger)
+	c.usersScanner = mimir_tsdb.NewUsersScanner(c.bucketClient, c.ownUser, c.parentLogger)
 
 	// Create the blocks cleaner (service).
 	c.blocksCleaner = NewBlocksCleaner(BlocksCleanerConfig{
@@ -517,7 +517,7 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 
 		ownedUsers[userID] = struct{}{}
 
-		if markedForDeletion, err := cortex_tsdb.TenantDeletionMarkExists(ctx, c.bucketClient, userID); err != nil {
+		if markedForDeletion, err := mimir_tsdb.TenantDeletionMarkExists(ctx, c.bucketClient, userID); err != nil {
 			c.compactionRunSkippedTenants.Inc()
 			level.Warn(c.logger).Log("msg", "unable to check if user is marked for deletion", "user", userID, "err", err)
 			continue
@@ -620,7 +620,7 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 		[]block.MetadataFilter{
 			// Remove the ingester ID because we don't shard blocks anymore, while still
 			// honoring the shard ID if sharding was done in the past.
-			NewLabelRemoverFilter([]string{cortex_tsdb.IngesterIDExternalLabel}),
+			NewLabelRemoverFilter([]string{mimir_tsdb.IngesterIDExternalLabel}),
 			block.NewConsistencyDelayMetaFilter(ulogger, c.compactorCfg.ConsistencyDelay, reg),
 			ignoreDeletionMarkFilter,
 			deduplicateBlocksFilter,

--- a/pkg/compactor/label_remover_filter_test.go
+++ b/pkg/compactor/label_remover_filter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 )
 
 func TestLabelRemoverFilter(t *testing.T) {
@@ -23,16 +23,16 @@ func TestLabelRemoverFilter(t *testing.T) {
 		expected map[ulid.ULID]map[string]string
 	}{
 		"should remove cpnfigured labels": {
-			labels: []string{cortex_tsdb.IngesterIDExternalLabel},
+			labels: []string{mimir_tsdb.IngesterIDExternalLabel},
 			input: map[ulid.ULID]map[string]string{
-				block1: {cortex_tsdb.IngesterIDExternalLabel: "ingester-0", cortex_tsdb.TenantIDExternalLabel: "user-1"},
-				block2: {cortex_tsdb.IngesterIDExternalLabel: "ingester-0", cortex_tsdb.TenantIDExternalLabel: "user-1"},
-				block3: {cortex_tsdb.IngesterIDExternalLabel: "ingester-0", cortex_tsdb.TenantIDExternalLabel: "user-1"},
+				block1: {mimir_tsdb.IngesterIDExternalLabel: "ingester-0", mimir_tsdb.TenantIDExternalLabel: "user-1"},
+				block2: {mimir_tsdb.IngesterIDExternalLabel: "ingester-0", mimir_tsdb.TenantIDExternalLabel: "user-1"},
+				block3: {mimir_tsdb.IngesterIDExternalLabel: "ingester-0", mimir_tsdb.TenantIDExternalLabel: "user-1"},
 			},
 			expected: map[ulid.ULID]map[string]string{
-				block1: {cortex_tsdb.TenantIDExternalLabel: "user-1"},
-				block2: {cortex_tsdb.TenantIDExternalLabel: "user-1"},
-				block3: {cortex_tsdb.TenantIDExternalLabel: "user-1"},
+				block1: {mimir_tsdb.TenantIDExternalLabel: "user-1"},
+				block2: {mimir_tsdb.TenantIDExternalLabel: "user-1"},
+				block3: {mimir_tsdb.TenantIDExternalLabel: "user-1"},
 			},
 		},
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -35,7 +35,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/tenant"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/concurrency"
@@ -604,7 +604,7 @@ func (i *Ingester) startingV2(ctx context.Context) error {
 	if i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout > 0 {
 		interval := i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBInterval
 		if interval == 0 {
-			interval = cortex_tsdb.DefaultCloseIdleTSDBInterval
+			interval = mimir_tsdb.DefaultCloseIdleTSDBInterval
 		}
 		closeIdleService := services.NewTimerService(interval, nil, i.closeAndDeleteIdleUserTSDBs, nil)
 		servs = append(servs, closeIdleService)
@@ -1623,10 +1623,10 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	// the series from the storage.
 	l := labels.Labels{
 		{
-			Name:  cortex_tsdb.TenantIDExternalLabel,
+			Name:  mimir_tsdb.TenantIDExternalLabel,
 			Value: userID,
 		}, {
-			Name:  cortex_tsdb.IngesterIDExternalLabel,
+			Name:  mimir_tsdb.IngesterIDExternalLabel,
 			Value: i.TSDBState.shipperIngesterID,
 		},
 	}
@@ -1872,11 +1872,11 @@ func (i *Ingester) shipBlocks(ctx context.Context, allowed *util.AllowedTenants)
 			return nil
 		}
 
-		if time.Since(time.Unix(userDB.lastDeletionMarkCheck.Load(), 0)) > cortex_tsdb.DeletionMarkCheckInterval {
+		if time.Since(time.Unix(userDB.lastDeletionMarkCheck.Load(), 0)) > mimir_tsdb.DeletionMarkCheckInterval {
 			// Even if check fails with error, we don't want to repeat it too often.
 			userDB.lastDeletionMarkCheck.Store(time.Now().Unix())
 
-			deletionMarkExists, err := cortex_tsdb.TenantDeletionMarkExists(ctx, i.TSDBState.bucket, userID)
+			deletionMarkExists, err := mimir_tsdb.TenantDeletionMarkExists(ctx, i.TSDBState.bucket, userID)
 			if err != nil {
 				// If we cannot check for deletion mark, we continue anyway, even though in production shipper will likely fail too.
 				// This however simplifies unit tests, where tenant deletion check is enabled by default, but tests don't setup bucket.

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/grafana/mimir/pkg/cortexpb"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/ring"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/services"
@@ -2449,7 +2449,7 @@ func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) 
 	numObjects := len(bucket.Objects())
 	require.NotZero(t, numObjects)
 
-	require.NoError(t, cortex_tsdb.WriteTenantDeletionMark(context.Background(), bucket, userID, nil, cortex_tsdb.NewTenantDeletionMark(time.Now())))
+	require.NoError(t, mimir_tsdb.WriteTenantDeletionMark(context.Background(), bucket, userID, nil, mimir_tsdb.NewTenantDeletionMark(time.Now())))
 	numObjects++ // For deletion marker
 
 	db := i.getTSDB(userID)
@@ -2481,7 +2481,7 @@ func TestIngester_seriesCountIsCorrectAfterClosingTSDBForDeletedTenant(t *testin
 	bucket := objstore.NewInMemBucket()
 
 	// Write tenant deletion mark.
-	require.NoError(t, cortex_tsdb.WriteTenantDeletionMark(context.Background(), bucket, userID, nil, cortex_tsdb.NewTenantDeletionMark(time.Now())))
+	require.NoError(t, mimir_tsdb.WriteTenantDeletionMark(context.Background(), bucket, userID, nil, mimir_tsdb.NewTenantDeletionMark(time.Now())))
 
 	i.TSDBState.bucket = bucket
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))

--- a/pkg/querier/blocks_finder_bucket_scan.go
+++ b/pkg/querier/blocks_finder_bucket_scan.go
@@ -21,7 +21,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 	"github.com/grafana/mimir/pkg/storegateway"
 	"github.com/grafana/mimir/pkg/util"
@@ -52,7 +52,7 @@ type BucketScanBlocksFinder struct {
 	logger          log.Logger
 	bucketClient    objstore.Bucket
 	fetchersMetrics *storegateway.MetadataFetcherMetrics
-	usersScanner    *cortex_tsdb.UsersScanner
+	usersScanner    *mimir_tsdb.UsersScanner
 
 	// We reuse the metadata fetcher instance for a given tenant both because of performance
 	// reasons (the fetcher keeps a in-memory cache) and being able to collect and group metrics.
@@ -76,7 +76,7 @@ func NewBucketScanBlocksFinder(cfg BucketScanBlocksFinderConfig, bucketClient ob
 		logger:            logger,
 		bucketClient:      bucketClient,
 		fetchers:          make(map[string]userFetcher),
-		usersScanner:      cortex_tsdb.NewUsersScanner(bucketClient, cortex_tsdb.AllUsers, logger),
+		usersScanner:      mimir_tsdb.NewUsersScanner(bucketClient, mimir_tsdb.AllUsers, logger),
 		userMetas:         make(map[string]bucketindex.Blocks),
 		userMetasLookup:   make(map[string]map[ulid.ULID]*bucketindex.Block),
 		userDeletionMarks: map[string]map[ulid.ULID]*bucketindex.BlockDeletionMark{},

--- a/pkg/querier/blocks_finder_bucket_scan_test.go
+++ b/pkg/querier/blocks_finder_bucket_scan_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 	cortex_testutil "github.com/grafana/mimir/pkg/storage/tsdb/testutil"
 	"github.com/grafana/mimir/pkg/util/services"
@@ -99,7 +99,7 @@ func TestBucketScanBlocksFinder_InitialScanFailure(t *testing.T) {
 	// Mock the storage to simulate a failure when reading objects.
 	bucket.MockIter("", []string{"user-1"}, nil)
 	bucket.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D"}, nil)
-	bucket.MockExists(path.Join("user-1", cortex_tsdb.TenantDeletionMarkPath), false, nil)
+	bucket.MockExists(path.Join("user-1", mimir_tsdb.TenantDeletionMarkPath), false, nil)
 	bucket.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "invalid", errors.New("mocked error"))
 
 	require.NoError(t, s.StartAsync(ctx))
@@ -144,7 +144,7 @@ func TestBucketScanBlocksFinder_StopWhileRunningTheInitialScanOnManyTenants(t *t
 		bucket.MockIterWithCallback(tenantID+"/", []string{}, nil, func() {
 			time.Sleep(time.Second)
 		})
-		bucket.MockExists(path.Join(tenantID, cortex_tsdb.TenantDeletionMarkPath), false, nil)
+		bucket.MockExists(path.Join(tenantID, mimir_tsdb.TenantDeletionMarkPath), false, nil)
 	}
 
 	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -33,7 +33,7 @@ import (
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/ring/kv"
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 	"github.com/grafana/mimir/pkg/storegateway"
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
@@ -167,7 +167,7 @@ func NewBlocksStoreQueryable(
 	return q, nil
 }
 
-func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegateway.Config, storageCfg cortex_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
+func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegateway.Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
 	var stores BlocksStoreSet
 
 	bucketClient, err := bucket.NewClient(context.Background(), storageCfg.Bucket, "querier", logger, reg)
@@ -176,7 +176,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	}
 
 	// Blocks finder doesn't use chunks, but we pass config for consistency.
-	cachingBucket, err := cortex_tsdb.CreateCachingBucket(storageCfg.BucketStore.ChunksCache, storageCfg.BucketStore.MetadataCache, bucketClient, logger, extprom.WrapRegistererWith(prometheus.Labels{"component": "querier"}, reg))
+	cachingBucket, err := mimir_tsdb.CreateCachingBucket(storageCfg.BucketStore.ChunksCache, storageCfg.BucketStore.MetadataCache, bucketClient, logger, extprom.WrapRegistererWith(prometheus.Labels{"component": "querier"}, reg))
 	if err != nil {
 		return nil, errors.Wrap(err, "create caching bucket")
 	}
@@ -566,7 +566,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 	leftChunksLimit int,
 ) ([]storage.SeriesSet, []ulid.ULID, storage.Warnings, int, error) {
 	var (
-		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, cortex_tsdb.TenantIDExternalLabel, q.userID)
+		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, mimir_tsdb.TenantIDExternalLabel, q.userID)
 		g, gCtx       = errgroup.WithContext(reqCtx)
 		mtx           = sync.Mutex{}
 		seriesSets    = []storage.SeriesSet(nil)
@@ -708,7 +708,7 @@ func (q *blocksStoreQuerier) fetchLabelNamesFromStore(
 	matchers []storepb.LabelMatcher,
 ) ([][]string, storage.Warnings, []ulid.ULID, error) {
 	var (
-		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, cortex_tsdb.TenantIDExternalLabel, q.userID)
+		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, mimir_tsdb.TenantIDExternalLabel, q.userID)
 		g, gCtx       = errgroup.WithContext(reqCtx)
 		mtx           = sync.Mutex{}
 		nameSets      = [][]string{}
@@ -785,7 +785,7 @@ func (q *blocksStoreQuerier) fetchLabelValuesFromStore(
 	matchers ...*labels.Matcher,
 ) ([][]string, storage.Warnings, []ulid.ULID, error) {
 	var (
-		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, cortex_tsdb.TenantIDExternalLabel, q.userID)
+		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, mimir_tsdb.TenantIDExternalLabel, q.userID)
 		g, gCtx       = errgroup.WithContext(reqCtx)
 		mtx           = sync.Mutex{}
 		valueSets     = [][]string{}

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/ring/client"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/services"
@@ -112,7 +112,7 @@ func (s *blocksStoreReplicationSet) GetClientsFor(userID string, blockIDs []ulid
 		// returned replication set.
 		bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
 
-		set, err := userRing.Get(cortex_tsdb.HashBlockID(blockID), storegateway.BlocksRead, bufDescs, bufHosts, bufZones)
+		set, err := userRing.Get(mimir_tsdb.HashBlockID(blockID), storegateway.BlocksRead, bufDescs, bufHosts, bufZones)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get store-gateway replication set owning the block %s", blockID.String())
 		}

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/ring/kv/consul"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/flagext"
 	"github.com/grafana/mimir/pkg/util/services"
@@ -31,10 +31,10 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 	block3 := ulid.MustNew(5, nil) // hash: 2931974232
 	block4 := ulid.MustNew(6, nil) // hash: 3092880371
 
-	block1Hash := cortex_tsdb.HashBlockID(block1)
-	block2Hash := cortex_tsdb.HashBlockID(block2)
-	block3Hash := cortex_tsdb.HashBlockID(block3)
-	block4Hash := cortex_tsdb.HashBlockID(block4)
+	block1Hash := mimir_tsdb.HashBlockID(block1)
+	block2Hash := mimir_tsdb.HashBlockID(block2)
+	block3Hash := mimir_tsdb.HashBlockID(block3)
+	block4Hash := mimir_tsdb.HashBlockID(block4)
 
 	userID := "user-A"
 	registeredAt := time.Now()

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -11,7 +11,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util"
 )
 
@@ -110,7 +110,7 @@ func (m *Block) ThanosMeta(userID string) *metadata.Meta {
 		Thanos: metadata.Thanos{
 			Version: metadata.ThanosVersion1,
 			Labels: map[string]string{
-				cortex_tsdb.TenantIDExternalLabel: userID,
+				mimir_tsdb.TenantIDExternalLabel: userID,
 			},
 			SegmentFiles: m.thanosMetaSegmentFiles(),
 		},

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -54,7 +54,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 )
 
 const (
@@ -2375,7 +2375,7 @@ func (r *bucketChunkReader) load(res []seriesEntry, aggrs []storepb.Aggr) error 
 			return pIdxs[i].offset < pIdxs[j].offset
 		})
 		parts := r.block.partitioner.Partition(len(pIdxs), func(i int) (start, end uint64) {
-			return uint64(pIdxs[i].offset), uint64(pIdxs[i].offset) + cortex_tsdb.EstimatedMaxChunkSize
+			return uint64(pIdxs[i].offset), uint64(pIdxs[i].offset) + mimir_tsdb.EstimatedMaxChunkSize
 		})
 
 		for _, p := range parts {
@@ -2401,7 +2401,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 		return errors.Wrap(err, "get range reader")
 	}
 	defer runutil.CloseWithLogOnErr(r.block.logger, reader, "readChunkRange close range reader")
-	bufReader := bufio.NewReaderSize(reader, cortex_tsdb.EstimatedMaxChunkSize)
+	bufReader := bufio.NewReaderSize(reader, mimir_tsdb.EstimatedMaxChunkSize)
 
 	locked := true
 	r.mtx.Lock()
@@ -2418,7 +2418,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 	r.stats.chunksFetchedSizeSum += int(part.End - part.Start)
 
 	var (
-		buf        = make([]byte, cortex_tsdb.EstimatedMaxChunkSize)
+		buf        = make([]byte, mimir_tsdb.EstimatedMaxChunkSize)
 		readOffset = int(pIdxs[0].offset)
 
 		// Save a few allocations.
@@ -2440,7 +2440,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 		// Presume chunk length to be reasonably large for common use cases.
 		// However, declaration for EstimatedMaxChunkSize warns us some chunks could be larger in some rare cases.
 		// This is handled further down below.
-		chunkLen = cortex_tsdb.EstimatedMaxChunkSize
+		chunkLen = mimir_tsdb.EstimatedMaxChunkSize
 		if i+1 < len(pIdxs) {
 			if diff = pIdxs[i+1].offset - pIdx.offset; int(diff) < chunkLen {
 				chunkLen = int(diff)

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"google.golang.org/grpc/codes"
 
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -186,10 +186,10 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		dir,
 		chunksLimiterFactory,
 		seriesLimiterFactory,
-		newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+		newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		20,
 		true,
-		cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+		mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 		true,
 		true,
 		time.Minute,

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/flagext"
 )
@@ -377,11 +377,11 @@ func testBucketStoresSeriesShouldCorrectlyQuerySeriesSpanningMultipleChunks(t *t
 	}
 }
 
-func prepareStorageConfig(t *testing.T) (cortex_tsdb.BlocksStorageConfig, func()) {
+func prepareStorageConfig(t *testing.T) (mimir_tsdb.BlocksStorageConfig, func()) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "blocks-sync-*")
 	require.NoError(t, err)
 
-	cfg := cortex_tsdb.BlocksStorageConfig{}
+	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
 	cfg.BucketStore.SyncDir = tmpDir
 
@@ -458,7 +458,7 @@ func mockLoggingLevel() logging.Level {
 func setUserIDToGRPCContext(ctx context.Context, userID string) context.Context {
 	// We have to store it in the incoming metadata because we have to emulate the
 	// case it's coming from a gRPC request, while here we're running everything in-memory.
-	return metadata.NewIncomingContext(ctx, metadata.Pairs(cortex_tsdb.TenantIDExternalLabel, userID))
+	return metadata.NewIncomingContext(ctx, metadata.Pairs(mimir_tsdb.TenantIDExternalLabel, userID))
 }
 
 func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -59,8 +59,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"go.uber.org/atomic"
 
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
-
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -519,10 +518,10 @@ func TestBucketStore_Info(t *testing.T) {
 		dir,
 		NewChunksLimiterFactory(0),
 		NewSeriesLimiterFactory(0),
-		newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+		newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		20,
 		true,
-		cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+		mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 		false,
 		false,
 		0,
@@ -767,10 +766,10 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 				dir,
 				NewChunksLimiterFactory(0),
 				NewSeriesLimiterFactory(0),
-				newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+				newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 				20,
 				true,
-				cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+				mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 				false,
 				false,
 				0,
@@ -940,7 +939,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 	id := uploadTestBlock(tb, tmpDir, bkt, 500)
 
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, cortex_tsdb.DefaultPostingOffsetInMemorySampling)
+	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, mimir_tsdb.DefaultPostingOffsetInMemorySampling)
 	assert.NoError(tb, err)
 
 	benchmarkExpandedPostings(tb, bkt, id, r, 500)
@@ -958,7 +957,7 @@ func BenchmarkBucketIndexReader_ExpandedPostings(b *testing.B) {
 	defer func() { assert.NoError(tb, bkt.Close()) }()
 
 	id := uploadTestBlock(tb, tmpDir, bkt, 50e5)
-	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, cortex_tsdb.DefaultPostingOffsetInMemorySampling)
+	r, err := indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, id, mimir_tsdb.DefaultPostingOffsetInMemorySampling)
 	assert.NoError(tb, err)
 
 	benchmarkExpandedPostings(tb, bkt, id, r, 50e5)
@@ -1084,7 +1083,7 @@ func benchmarkExpandedPostings(
 				indexCache:        noopCache{},
 				bkt:               bkt,
 				meta:              &metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: id}},
-				partitioner:       newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+				partitioner:       newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 			}
 
 			indexr := newBucketIndexReader(context.Background(), b)
@@ -1201,10 +1200,10 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 		tmpDir,
 		NewChunksLimiterFactory(0),
 		NewSeriesLimiterFactory(0),
-		newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+		newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		1,
 		false,
-		cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+		mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 		false,
 		false,
 		0,
@@ -1362,11 +1361,11 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			metrics:     newBucketStoreMetrics(nil),
 			bkt:         bkt,
 			meta:        meta,
-			partitioner: newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+			partitioner: newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 			chunkObjs:   []string{filepath.Join(id.String(), "chunks", "000001")},
 			chunkPool:   chunkPool,
 		}
-		b1.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b1.meta.ULID, cortex_tsdb.DefaultPostingOffsetInMemorySampling)
+		b1.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b1.meta.ULID, mimir_tsdb.DefaultPostingOffsetInMemorySampling)
 		assert.NoError(t, err)
 	}
 
@@ -1401,11 +1400,11 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			metrics:     newBucketStoreMetrics(nil),
 			bkt:         bkt,
 			meta:        meta,
-			partitioner: newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+			partitioner: newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 			chunkObjs:   []string{filepath.Join(id.String(), "chunks", "000001")},
 			chunkPool:   chunkPool,
 		}
-		b2.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b2.meta.ULID, cortex_tsdb.DefaultPostingOffsetInMemorySampling)
+		b2.indexHeaderReader, err = indexheader.NewBinaryReader(context.Background(), log.NewNopLogger(), bkt, tmpDir, b2.meta.ULID, mimir_tsdb.DefaultPostingOffsetInMemorySampling)
 		assert.NoError(t, err)
 	}
 
@@ -1566,10 +1565,10 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		tmpDir,
 		NewChunksLimiterFactory(10000/MaxSamplesPerChunk),
 		NewSeriesLimiterFactory(0),
-		newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+		newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		10,
 		false,
-		cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+		mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 		true,
 		false,
 		0,
@@ -1656,10 +1655,10 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		tmpDir,
 		NewChunksLimiterFactory(100000/MaxSamplesPerChunk),
 		NewSeriesLimiterFactory(0),
-		newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+		newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		10,
 		false,
-		cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+		mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 		true,
 		false,
 		0,
@@ -1839,10 +1838,10 @@ func setupStoreForHintsTest(t *testing.T) (test.TB, *BucketStore, []*storepb.Ser
 		tmpDir,
 		NewChunksLimiterFactory(10000/MaxSamplesPerChunk),
 		NewSeriesLimiterFactory(0),
-		newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil),
+		newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		10,
 		false,
-		cortex_tsdb.DefaultPostingOffsetInMemorySampling,
+		mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 		true,
 		false,
 		0,
@@ -2143,10 +2142,10 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 	chunkPool, err := NewDefaultChunkBytesPool(64 * 1024 * 1024 * 1024)
 	assert.NoError(b, err)
 
-	partitioner := newGapBasedPartitioner(cortex_tsdb.DefaultPartitionerMaxGapSize, nil)
+	partitioner := newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil)
 
 	// Create an index header reader.
-	indexHeaderReader, err := indexheader.NewBinaryReader(ctx, logger, bkt, tmpDir, blockMeta.ULID, cortex_tsdb.DefaultPostingOffsetInMemorySampling)
+	indexHeaderReader, err := indexheader.NewBinaryReader(ctx, logger, bkt, tmpDir, blockMeta.ULID, mimir_tsdb.DefaultPostingOffsetInMemorySampling)
 	assert.NoError(b, err)
 	indexCache, err := storecache.NewInMemoryIndexCacheWithConfig(logger, nil, storecache.DefaultInMemoryIndexCacheConfig)
 	assert.NoError(b, err)

--- a/pkg/storegateway/chunk_bytes_pool_test.go
+++ b/pkg/storegateway/chunk_bytes_pool_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 )
 
 func TestChunkBytesPool_Get(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	p, err := newChunkBytesPool(cortex_tsdb.ChunkPoolDefaultMinBucketSize, cortex_tsdb.ChunkPoolDefaultMaxBucketSize, 0, reg)
+	p, err := newChunkBytesPool(mimir_tsdb.ChunkPoolDefaultMinBucketSize, mimir_tsdb.ChunkPoolDefaultMaxBucketSize, 0, reg)
 	require.NoError(t, err)
 
-	_, err = p.Get(cortex_tsdb.EstimatedMaxChunkSize - 1)
+	_, err = p.Get(mimir_tsdb.EstimatedMaxChunkSize - 1)
 	require.NoError(t, err)
 
-	_, err = p.Get(cortex_tsdb.EstimatedMaxChunkSize + 1)
+	_, err = p.Get(mimir_tsdb.EstimatedMaxChunkSize + 1)
 	require.NoError(t, err)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(fmt.Sprintf(`
@@ -32,5 +32,5 @@ func TestChunkBytesPool_Get(t *testing.T) {
 		# HELP cortex_bucket_store_chunk_pool_returned_bytes_total Total bytes returned by the chunk bytes pool.
 		# TYPE cortex_bucket_store_chunk_pool_returned_bytes_total counter
 		cortex_bucket_store_chunk_pool_returned_bytes_total %d
-	`, cortex_tsdb.EstimatedMaxChunkSize*2, cortex_tsdb.EstimatedMaxChunkSize*3))))
+	`, mimir_tsdb.EstimatedMaxChunkSize*2, mimir_tsdb.EstimatedMaxChunkSize*3))))
 }

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/ring/kv"
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/services"
@@ -86,7 +86,7 @@ type StoreGateway struct {
 	services.Service
 
 	gatewayCfg Config
-	storageCfg cortex_tsdb.BlocksStorageConfig
+	storageCfg mimir_tsdb.BlocksStorageConfig
 	logger     log.Logger
 	stores     *BucketStores
 
@@ -101,7 +101,7 @@ type StoreGateway struct {
 	bucketSync *prometheus.CounterVec
 }
 
-func NewStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.BlocksStorageConfig, limits *validation.Overrides, logLevel logging.Level, logger log.Logger, reg prometheus.Registerer) (*StoreGateway, error) {
+func NewStoreGateway(gatewayCfg Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits *validation.Overrides, logLevel logging.Level, logger log.Logger, reg prometheus.Registerer) (*StoreGateway, error) {
 	var ringStore kv.Client
 
 	bucketClient, err := createBucketClient(storageCfg, logger, reg)
@@ -123,7 +123,7 @@ func NewStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.BlocksStorageConf
 	return newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, limits, logLevel, logger, reg)
 }
 
-func newStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.BlocksStorageConfig, bucketClient objstore.Bucket, ringStore kv.Client, limits *validation.Overrides, logLevel logging.Level, logger log.Logger, reg prometheus.Registerer) (*StoreGateway, error) {
+func newStoreGateway(gatewayCfg Config, storageCfg mimir_tsdb.BlocksStorageConfig, bucketClient objstore.Bucket, ringStore kv.Client, limits *validation.Overrides, logLevel logging.Level, logger log.Logger, reg prometheus.Registerer) (*StoreGateway, error) {
 	var err error
 
 	g := &StoreGateway{
@@ -369,7 +369,7 @@ func (g *StoreGateway) OnRingInstanceStopping(_ *ring.BasicLifecycler)          
 func (g *StoreGateway) OnRingInstanceHeartbeat(_ *ring.BasicLifecycler, _ *ring.Desc, _ *ring.InstanceDesc) {
 }
 
-func createBucketClient(cfg cortex_tsdb.BlocksStorageConfig, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
+func createBucketClient(cfg mimir_tsdb.BlocksStorageConfig, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
 	bucketClient, err := bucket.NewClient(context.Background(), cfg.Bucket, "store-gateway", logger, reg)
 	if err != nil {
 		return nil, errors.Wrap(err, "create bucket client")

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/grafana/mimir/pkg/ring/kv/consul"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 	cortex_testutil "github.com/grafana/mimir/pkg/storage/tsdb/testutil"
 	"github.com/grafana/mimir/pkg/util"
@@ -817,9 +817,9 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 	for idx, blockID := range blockIDs {
 		meta := metadata.Thanos{
 			Labels: map[string]string{
-				cortex_tsdb.TenantIDExternalLabel:   userID,
-				cortex_tsdb.IngesterIDExternalLabel: fmt.Sprintf("ingester-%d", idx),
-				cortex_tsdb.ShardIDExternalLabel:    fmt.Sprintf("shard-%d", idx),
+				mimir_tsdb.TenantIDExternalLabel:   userID,
+				mimir_tsdb.IngesterIDExternalLabel: fmt.Sprintf("ingester-%d", idx),
+				mimir_tsdb.ShardIDExternalLabel:    fmt.Sprintf("shard-%d", idx),
 			},
 			Source: metadata.TestSource,
 		}
@@ -974,14 +974,14 @@ func mockGatewayConfig() Config {
 	return cfg
 }
 
-func mockStorageConfig(t *testing.T) cortex_tsdb.BlocksStorageConfig {
+func mockStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "store-gateway-test-*")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	})
 
-	cfg := cortex_tsdb.BlocksStorageConfig{}
+	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
 
 	cfg.BucketStore.ConsistencyDelay = 0

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/ring"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 )
 
 const (
@@ -127,7 +127,7 @@ func filterBlocksByRingSharding(r ring.ReadRing, instanceAddr string, metas map[
 	bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
 
 	for blockID := range metas {
-		key := cortex_tsdb.HashBlockID(blockID)
+		key := mimir_tsdb.HashBlockID(blockID)
 
 		// Check if the block is owned by the store-gateway
 		set, err := r.Get(key, BlocksOwnerSync, bufDescs, bufHosts, bufZones)

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/ring/kv/consul"
-	cortex_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util/services"
 )
 
@@ -29,10 +29,10 @@ func TestDefaultShardingStrategy(t *testing.T) {
 	block4 := ulid.MustNew(6, nil) // hash: 3092880371
 	numAllBlocks := 4
 
-	block1Hash := cortex_tsdb.HashBlockID(block1)
-	block2Hash := cortex_tsdb.HashBlockID(block2)
-	block3Hash := cortex_tsdb.HashBlockID(block3)
-	block4Hash := cortex_tsdb.HashBlockID(block4)
+	block1Hash := mimir_tsdb.HashBlockID(block1)
+	block2Hash := mimir_tsdb.HashBlockID(block2)
+	block3Hash := mimir_tsdb.HashBlockID(block3)
+	block4Hash := mimir_tsdb.HashBlockID(block4)
 
 	registeredAt := time.Now()
 
@@ -304,10 +304,10 @@ func TestShuffleShardingStrategy(t *testing.T) {
 	block4 := ulid.MustNew(6, nil) // hash: 3092880371
 	numAllBlocks := 4
 
-	block1Hash := cortex_tsdb.HashBlockID(block1)
-	block2Hash := cortex_tsdb.HashBlockID(block2)
-	block3Hash := cortex_tsdb.HashBlockID(block3)
-	block4Hash := cortex_tsdb.HashBlockID(block4)
+	block1Hash := mimir_tsdb.HashBlockID(block1)
+	block2Hash := mimir_tsdb.HashBlockID(block2)
+	block3Hash := mimir_tsdb.HashBlockID(block3)
+	block4Hash := mimir_tsdb.HashBlockID(block4)
 
 	userID := "user-A"
 	registeredAt := time.Now()


### PR DESCRIPTION
**What this PR does**:
While working on #62 I've noticed we have an import named `cortex_tsdb`. In this PR I'm renaming it to `mimir_tsdb`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
