### PR TITLE
Fix goroutines leak in tests due to consul in-memory KV store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,9 +60,11 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.0-alpha.0.0.20210225194612-fa82d11a958a
 	go.etcd.io/etcd/server/v3 v3.5.0-alpha.0.0.20210225194612-fa82d11a958a
 	go.uber.org/atomic v1.8.0
+	go.uber.org/goleak v1.1.10
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
+	golang.org/x/tools v0.1.5 // indirect
 	google.golang.org/api v0.48.0
 	google.golang.org/grpc v1.38.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -2279,8 +2279,9 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/alertmanager/distributor_test.go
+++ b/pkg/alertmanager/distributor_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/mimir/pkg/alertmanager/alertmanagerpb"
 	"github.com/grafana/mimir/pkg/ring"
 	"github.com/grafana/mimir/pkg/ring/kv"
@@ -335,7 +337,9 @@ func prepare(t *testing.T, numAM, numHappyAM, replicationFactor int, responseBod
 		amByAddr[a.myAddr] = ams[i]
 	}
 
-	kvStore := consul.NewInMemoryClient(ring.GetCodec())
+	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	err := kvStore.CAS(context.Background(), RingKey,
 		func(_ interface{}) (interface{}, bool, error) {
 			return &ring.Desc{

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -604,7 +604,9 @@ func TestMultitenantAlertmanager_deleteUnusedLocalUserState(t *testing.T) {
 func TestMultitenantAlertmanager_zoneAwareSharding(t *testing.T) {
 	ctx := context.Background()
 	alertStore := prepareInMemoryAlertStore()
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	const (
 		user1 = "user1"
 		user2 = "user2"
@@ -682,7 +684,8 @@ func TestMultitenantAlertmanager_deleteUnusedRemoteUserState(t *testing.T) {
 	)
 
 	alertStore := prepareInMemoryAlertStore()
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	createInstance := func(i int) *MultitenantAlertmanager {
 		reg := prometheus.NewPedanticRegistry()
@@ -998,7 +1001,8 @@ func TestMultitenantAlertmanager_InitialSyncWithSharding(t *testing.T) {
 			ctx := context.Background()
 			amConfig := mockAlertmanagerConfig(t)
 			amConfig.ShardingEnabled = true
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 			// Use an alert store with a mocked backend.
 			bkt := &bucket.ClientMock{}
@@ -1102,7 +1106,9 @@ func TestMultitenantAlertmanager_PerTenantSharding(t *testing.T) {
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			alertStore := prepareInMemoryAlertStore()
 
 			var instances []*MultitenantAlertmanager
@@ -1289,7 +1295,9 @@ func TestMultitenantAlertmanager_SyncOnRingTopologyChanges(t *testing.T) {
 			amConfig.ShardingRing.RingCheckPeriod = 100 * time.Millisecond
 			amConfig.PollInterval = time.Hour // Don't trigger the periodic check.
 
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			alertStore := prepareInMemoryAlertStore()
 
 			reg := prometheus.NewPedanticRegistry()
@@ -1340,7 +1348,9 @@ func TestMultitenantAlertmanager_RingLifecyclerShouldAutoForgetUnhealthyInstance
 	amConfig.ShardingRing.HeartbeatPeriod = 100 * time.Millisecond
 	amConfig.ShardingRing.HeartbeatTimeout = heartbeatTimeout
 
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	alertStore := prepareInMemoryAlertStore()
 
 	am, err := createMultitenantAlertmanager(amConfig, nil, nil, alertStore, ringStore, nil, log.NewNopLogger(), nil)
@@ -1372,7 +1382,8 @@ func TestMultitenantAlertmanager_InitialSyncFailureWithSharding(t *testing.T) {
 	ctx := context.Background()
 	amConfig := mockAlertmanagerConfig(t)
 	amConfig.ShardingEnabled = true
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	// Mock the store to fail listing configs.
 	bkt := &bucket.ClientMock{}
@@ -1394,7 +1405,9 @@ func TestMultitenantAlertmanager_InitialSyncFailureWithSharding(t *testing.T) {
 
 func TestAlertmanager_ReplicasPosition(t *testing.T) {
 	ctx := context.Background()
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	mockStore := prepareInMemoryAlertStore()
 	require.NoError(t, mockStore.SetAlertConfig(ctx, alertspb.AlertConfigDesc{
 		User:      "user-1",
@@ -1493,7 +1506,9 @@ func TestAlertmanager_StateReplicationWithSharding(t *testing.T) {
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			mockStore := prepareInMemoryAlertStore()
 			clientPool := newPassthroughAlertmanagerClientPool()
 			externalURL := flagext.URLValue{}
@@ -1686,7 +1701,9 @@ func TestAlertmanager_StateReplicationWithSharding_InitialSyncFromPeers(t *testi
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			mockStore := prepareInMemoryAlertStore()
 			clientPool := newPassthroughAlertmanagerClientPool()
 			externalURL := flagext.URLValue{}

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -45,7 +45,7 @@ var Fixtures = []testutils.Fixture{
 				metrics:                 newMetrics(nil),
 			}
 			object := objectclient.NewClient(&S3ObjectClient{S3: newMockS3()}, nil)
-			return index, object, table, schemaConfig, testutils.CloserFunc(func() error {
+			return index, object, table, schemaConfig, util.CloserFunc(func() error {
 				table.Stop()
 				index.Stop()
 				object.Stop()
@@ -86,7 +86,7 @@ func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) testutils.Fix
 				schemaCfg:               schemaCfg,
 				metrics:                 newMetrics(nil),
 			}
-			return storage, storage, table, schemaCfg, testutils.CloserFunc(func() error {
+			return storage, storage, table, schemaCfg, util.CloserFunc(func() error {
 				table.Stop()
 				storage.Stop()
 				return nil

--- a/pkg/chunk/cassandra/fixtures.go
+++ b/pkg/chunk/cassandra/fixtures.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/chunk"
 	"github.com/grafana/mimir/pkg/chunk/testutils"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/flagext"
 )
 
@@ -50,7 +51,7 @@ func (f *fixture) Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient,
 		return nil, nil, nil, schemaConfig, nil, err
 	}
 
-	closer := testutils.CloserFunc(func() error {
+	closer := util.CloserFunc(func() error {
 		storageClient.Stop()
 		objectClient.Stop()
 		tableClient.Stop()

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/mimir/pkg/chunk"
 	"github.com/grafana/mimir/pkg/chunk/objectclient"
 	"github.com/grafana/mimir/pkg/chunk/testutils"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -83,7 +84,7 @@ func (f *fixture) Clients() (
 		cClient = newBigtableObjectClient(Config{}, schemaConfig, client)
 	}
 
-	closer = testutils.CloserFunc(func() error {
+	closer = util.CloserFunc(func() error {
 		conn.Close()
 		return nil
 	})

--- a/pkg/chunk/local/fixtures.go
+++ b/pkg/chunk/local/fixtures.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/mimir/pkg/chunk"
 	"github.com/grafana/mimir/pkg/chunk/objectclient"
 	"github.com/grafana/mimir/pkg/chunk/testutils"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 type fixture struct {
@@ -65,7 +66,7 @@ func (f *fixture) Clients() (
 		}},
 	}
 
-	closer = testutils.CloserFunc(func() error {
+	closer = util.CloserFunc(func() error {
 		return os.RemoveAll(f.dirname)
 	})
 

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -27,14 +27,6 @@ type Fixture interface {
 	Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, chunk.SchemaConfig, io.Closer, error)
 }
 
-// CloserFunc is to io.Closer as http.HandlerFunc is to http.Handler.
-type CloserFunc func() error
-
-// Close implements io.Closer.
-func (f CloserFunc) Close() error {
-	return f()
-}
-
 // DefaultSchemaConfig returns default schema for use in test fixtures
 func DefaultSchemaConfig(kind string) chunk.SchemaConfig {
 	schemaConfig := chunk.DefaultSchemaConfig(kind, "v1", model.Now().Add(-time.Hour*2))

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -685,7 +685,11 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 				})
 				defer stopAll(ds, r)
 				codec := GetReplicaDescCodec()
-				mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
+
+				ringStore, closer := consul.NewInMemoryClient(codec)
+				t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+				mock := kv.PrefixClient(ringStore, "prefix")
 				d := ds[0]
 
 				if tc.enableTracker {
@@ -1582,7 +1586,9 @@ func BenchmarkDistributor_Push(b *testing.B) {
 		b.Run(testName, func(b *testing.B) {
 
 			// Create an in-memory KV store for the ring with 1 ingester registered.
-			kvStore := consul.NewInMemoryClient(ring.GetCodec())
+			kvStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			b.Cleanup(func() { assert.NoError(b, closer.Close()) })
+
 			err := kvStore.CAS(context.Background(), ring.IngesterRingKey,
 				func(_ interface{}) (interface{}, bool, error) {
 					d := &ring.Desc{}
@@ -2030,7 +2036,9 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 		ingestersByAddr[addr] = &ingesters[i]
 	}
 
-	kvStore := consul.NewInMemoryClient(ring.GetCodec())
+	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	err := kvStore.CAS(context.Background(), ring.IngesterRingKey,
 		func(_ interface{}) (interface{}, bool, error) {
 			return &ring.Desc{

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -119,7 +119,10 @@ func TestWatchPrefixAssignment(t *testing.T) {
 	replica := "r1"
 
 	codec := GetReplicaDescCodec()
-	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
+	kvStore, closer := consul.NewInMemoryClient(codec)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	mock := kv.PrefixClient(kvStore, "prefix")
 	c, err := newHATracker(HATrackerConfig{
 		EnableHATracker:        true,
 		KVStore:                kv.Config{Mock: mock},
@@ -303,7 +306,10 @@ func TestCheckReplicaUpdateTimeout(t *testing.T) {
 	user := "user"
 
 	codec := GetReplicaDescCodec()
-	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
+	kvStore, closer := consul.NewInMemoryClient(codec)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	mock := kv.PrefixClient(kvStore, "prefix")
 	c, err := newHATracker(HATrackerConfig{
 		EnableHATracker:        true,
 		KVStore:                kv.Config{Mock: mock},
@@ -349,7 +355,10 @@ func TestCheckReplicaMultiUser(t *testing.T) {
 	cluster := "c1"
 
 	codec := GetReplicaDescCodec()
-	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
+	kvStore, closer := consul.NewInMemoryClient(codec)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	mock := kv.PrefixClient(kvStore, "prefix")
 	c, err := newHATracker(HATrackerConfig{
 		EnableHATracker:        true,
 		KVStore:                kv.Config{Mock: mock},
@@ -426,7 +435,10 @@ func TestCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			// Init HA tracker
 			codec := GetReplicaDescCodec()
-			mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
+			kvStore, closer := consul.NewInMemoryClient(codec)
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+			mock := kv.PrefixClient(kvStore, "prefix")
 			c, err := newHATracker(HATrackerConfig{
 				EnableHATracker:        true,
 				KVStore:                kv.Config{Mock: mock},
@@ -522,7 +534,10 @@ func TestHAClustersLimit(t *testing.T) {
 	const userID = "user"
 
 	codec := GetReplicaDescCodec()
-	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
+	kvStore, closer := consul.NewInMemoryClient(codec)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	mock := kv.PrefixClient(kvStore, "prefix")
 	limits := trackerLimits{maxClusters: 2}
 
 	t1, err := newHATracker(HATrackerConfig{
@@ -688,7 +703,10 @@ func TestCheckReplicaCleanup(t *testing.T) {
 
 	reg := prometheus.NewPedanticRegistry()
 
-	mock := kv.PrefixClient(consul.NewInMemoryClient(GetReplicaDescCodec()), "prefix")
+	kvStore, closer := consul.NewInMemoryClient(GetReplicaDescCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	mock := kv.PrefixClient(kvStore, "prefix")
 	c, err := newHATracker(HATrackerConfig{
 		EnableHATracker:        true,
 		KVStore:                kv.Config{Mock: mock},

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -44,7 +44,7 @@ type testStore struct {
 	chunks map[string][]chunk.Chunk
 }
 
-func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, limits validation.Limits, reg prometheus.Registerer) (*testStore, *Ingester) {
+func newTestStore(t testing.TB, cfg Config, clientConfig client.Config, limits validation.Limits, reg prometheus.Registerer) (*testStore, *Ingester) {
 	store := &testStore{
 		chunks: map[string][]chunk.Chunk{},
 	}
@@ -58,9 +58,9 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	return store, ing
 }
 
-func newDefaultTestStore(t require.TestingT) (*testStore, *Ingester) {
+func newDefaultTestStore(t testing.TB) (*testStore, *Ingester) {
 	return newTestStore(t,
-		defaultIngesterTestConfig(),
+		defaultIngesterTestConfig(t),
 		defaultClientTestConfig(),
 		defaultLimitsTestConfig(), nil)
 }
@@ -259,7 +259,7 @@ func TestIngesterMetadataAppend(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			limits := defaultLimitsTestConfig()
 			limits.MaxLocalMetadataPerMetric = 50
-			_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits, nil)
+			_, ing := newTestStore(t, defaultIngesterTestConfig(t), defaultClientTestConfig(), limits, nil)
 			userIDs, _ := pushTestMetadata(t, ing, tc.numMetadata, tc.metadataPerMetric)
 
 			for _, userID := range userIDs {
@@ -289,7 +289,7 @@ func TestIngesterMetadataAppend(t *testing.T) {
 }
 
 func TestIngesterPurgeMetadata(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.MetadataRetainPeriod = 20 * time.Millisecond
 	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), nil)
 	userIDs, _ := pushTestMetadata(t, ing, 10, 3)
@@ -307,7 +307,7 @@ func TestIngesterPurgeMetadata(t *testing.T) {
 
 func TestIngesterMetadataMetrics(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.MetadataRetainPeriod = 20 * time.Millisecond
 	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), reg)
 	_, _ = pushTestMetadata(t, ing, 10, 3)
@@ -379,7 +379,7 @@ func TestIngesterSendsOnlySeriesWithData(t *testing.T) {
 
 func TestIngesterIdleFlush(t *testing.T) {
 	// Create test ingester with short flush cycle
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.FlushCheckPeriod = 20 * time.Millisecond
 	cfg.MaxChunkIdle = 100 * time.Millisecond
 	cfg.RetainPeriod = 500 * time.Millisecond
@@ -414,7 +414,7 @@ func TestIngesterIdleFlush(t *testing.T) {
 
 func TestIngesterSpreadFlush(t *testing.T) {
 	// Create test ingester with short flush cycle
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.SpreadFlushes = true
 	cfg.FlushCheckPeriod = 20 * time.Millisecond
 	store, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), nil)
@@ -523,7 +523,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 	require.NoError(t, os.Mkdir(blocksDir, os.ModePerm))
 
 	chunksIngesterGenerator := func() *Ingester {
-		cfg := defaultIngesterTestConfig()
+		cfg := defaultIngesterTestConfig(t)
 		cfg.WALConfig.WALEnabled = true
 		cfg.WALConfig.Recover = true
 		cfg.WALConfig.Dir = chunksDir
@@ -534,7 +534,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 	}
 
 	blocksIngesterGenerator := func() *Ingester {
-		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, defaultIngesterTestConfig(), limits, blocksDir, nil)
+		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, defaultIngesterTestConfig(t), limits, blocksDir, nil)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
 		// Wait until it's ACTIVE
@@ -646,7 +646,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 	require.NoError(t, os.Mkdir(blocksDir, os.ModePerm))
 
 	chunksIngesterGenerator := func() *Ingester {
-		cfg := defaultIngesterTestConfig()
+		cfg := defaultIngesterTestConfig(t)
 		cfg.WALConfig.WALEnabled = true
 		cfg.WALConfig.Recover = true
 		cfg.WALConfig.Dir = chunksDir
@@ -657,7 +657,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 	}
 
 	blocksIngesterGenerator := func() *Ingester {
-		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, defaultIngesterTestConfig(), limits, blocksDir, nil)
+		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, defaultIngesterTestConfig(t), limits, blocksDir, nil)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
 		// Wait until it's ACTIVE
@@ -929,7 +929,7 @@ func benchmarkData(nSeries int) (allLabels []labels.Labels, allSamples []cortexp
 }
 
 func benchmarkIngesterPush(b *testing.B, limits validation.Limits, errorsExpected bool) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(b)
 	clientCfg := defaultClientTestConfig()
 
 	const (
@@ -972,7 +972,7 @@ func benchmarkIngesterPush(b *testing.B, limits validation.Limits, errorsExpecte
 }
 
 func BenchmarkIngester_QueryStream(b *testing.B) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(b)
 	clientCfg := defaultClientTestConfig()
 	limits := defaultLimitsTestConfig()
 	_, ing := newTestStore(b, cfg, clientCfg, limits, nil)
@@ -1071,7 +1071,7 @@ func TestIngesterActiveSeries(t *testing.T) {
 			registry := prometheus.NewRegistry()
 
 			// Create a mocked ingester
-			cfg := defaultIngesterTestConfig()
+			cfg := defaultIngesterTestConfig(t)
 			cfg.LifecyclerConfig.JoinAfter = 0
 			cfg.ActiveSeriesMetricsEnabled = !testData.disableActiveSeries
 

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -508,7 +508,7 @@ func TestIngester_v2Push(t *testing.T) {
 			validation.DiscardedSamples.Reset()
 
 			// Create a mocked ingester
-			cfg := defaultIngesterTestConfig()
+			cfg := defaultIngesterTestConfig(t)
 			cfg.LifecyclerConfig.JoinAfter = 0
 			cfg.ActiveSeriesMetricsEnabled = !testData.disableActiveSeries
 			cfg.BlocksStorageConfig.TSDB.MaxExemplars = testData.maxExemplars
@@ -602,7 +602,7 @@ func TestIngester_v2Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *tes
 	registry := prometheus.NewRegistry()
 
 	// Create a mocked ingester
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, registry)
@@ -683,7 +683,7 @@ func TestIngester_v2Push_DecreaseInactiveSeries(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
 	// Create a mocked ingester
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.ActiveSeriesMetricsIdleTimeout = 100 * time.Millisecond
 	cfg.LifecyclerConfig.JoinAfter = 0
 
@@ -754,7 +754,7 @@ func benchmarkIngesterV2Push(b *testing.B, limits validation.Limits, errorsExpec
 	ctx := user.InjectOrgID(context.Background(), userID)
 
 	// Create a mocked ingester
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(b)
 	cfg.LifecyclerConfig.JoinAfter = 0
 
 	ingester, err := prepareIngesterWithBlocksStorage(b, cfg, registry)
@@ -1039,7 +1039,7 @@ func Benchmark_Ingester_v2PushOnError(b *testing.B) {
 					}
 
 					// Create a mocked ingester
-					cfg := defaultIngesterTestConfig()
+					cfg := defaultIngesterTestConfig(b)
 					cfg.LifecyclerConfig.JoinAfter = 0
 
 					limits := defaultLimitsTestConfig()
@@ -1110,7 +1110,7 @@ func Test_Ingester_v2LabelNames(t *testing.T) {
 	}
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1175,7 +1175,7 @@ func Test_Ingester_v2LabelValues(t *testing.T) {
 	}
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1294,7 +1294,7 @@ func Test_Ingester_v2Query(t *testing.T) {
 	}
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1329,7 +1329,7 @@ func Test_Ingester_v2Query(t *testing.T) {
 	}
 }
 func TestIngester_v2Query_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1349,7 +1349,7 @@ func TestIngester_v2Query_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 }
 
 func TestIngester_v2LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1369,7 +1369,7 @@ func TestIngester_v2LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T)
 }
 
 func TestIngester_v2LabelNames_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1391,7 +1391,7 @@ func TestIngester_v2LabelNames_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) 
 func TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState(t *testing.T) {
 	// Configure the lifecycler to not immediately join the ring, to make sure
 	// the ingester will NOT be in the ACTIVE state when we'll push samples.
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 10 * time.Second
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
@@ -1439,7 +1439,7 @@ func TestIngester_getOrCreateTSDB_ShouldNotAllowToCreateTSDBIfIngesterStateIsNot
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			cfg := defaultIngesterTestConfig()
+			cfg := defaultIngesterTestConfig(t)
 			cfg.LifecyclerConfig.JoinAfter = 60 * time.Second
 
 			i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
@@ -1588,7 +1588,7 @@ func Test_Ingester_v2MetricsForLabelMatchers(t *testing.T) {
 	}
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1693,7 +1693,7 @@ func createIngesterWithSeries(t testing.TB, userID string, numSeries, numSamples
 	const maxBatchSize = 1000
 
 	// Create ingester.
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	t.Cleanup(func() {
@@ -1739,7 +1739,7 @@ func createIngesterWithSeries(t testing.TB, userID string, numSeries, numSamples
 
 func TestIngester_v2QueryStream(t *testing.T) {
 	// Create ingester.
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 
 	// change stream type in runtime.
 	var streamType QueryStreamType
@@ -1843,7 +1843,7 @@ func TestIngester_v2QueryStream(t *testing.T) {
 
 func TestIngester_v2QueryStreamManySamples(t *testing.T) {
 	// Create ingester.
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -1937,7 +1937,7 @@ func TestIngester_v2QueryStreamManySamples(t *testing.T) {
 
 func TestIngester_v2QueryStreamManySamplesChunks(t *testing.T) {
 	// Create ingester.
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.StreamChunksWhenUsingBlocks = true
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
@@ -2073,7 +2073,7 @@ func BenchmarkIngester_v2QueryStream_Chunks(b *testing.B) {
 }
 
 func benchmarkV2QueryStream(b *testing.B, streamChunks bool) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(b)
 	cfg.StreamChunksWhenUsingBlocks = streamChunks
 
 	// Create ingester.
@@ -2354,7 +2354,7 @@ func TestIngester_v2OpenExistingTSDBOnStartup(t *testing.T) {
 			require.NoError(t, err)
 			defer os.RemoveAll(tempDir)
 
-			ingesterCfg := defaultIngesterTestConfig()
+			ingesterCfg := defaultIngesterTestConfig(t)
 			ingesterCfg.BlocksStorageEnabled = true
 			ingesterCfg.BlocksStorageConfig.TSDB.Dir = tempDir
 			ingesterCfg.BlocksStorageConfig.TSDB.MaxTSDBOpeningConcurrencyOnStartup = testData.concurrency
@@ -2382,7 +2382,7 @@ func TestIngester_v2OpenExistingTSDBOnStartup(t *testing.T) {
 }
 
 func TestIngester_shipBlocks(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
@@ -2420,7 +2420,7 @@ func TestIngester_shipBlocks(t *testing.T) {
 }
 
 func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
@@ -2469,7 +2469,7 @@ func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) 
 }
 
 func TestIngester_seriesCountIsCorrectAfterClosingTSDBForDeletedTenant(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
@@ -2513,7 +2513,7 @@ func TestIngester_seriesCountIsCorrectAfterClosingTSDBForDeletedTenant(t *testin
 
 func TestIngester_closeAndDeleteUserTSDBIfIdle_shouldNotCloseTSDBIfShippingIsInProgress(t *testing.T) {
 	ctx := context.Background()
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
@@ -2556,7 +2556,7 @@ func TestIngester_closeAndDeleteUserTSDBIfIdle_shouldNotCloseTSDBIfShippingIsInP
 
 func TestIngester_closingAndOpeningTsdbConcurrently(t *testing.T) {
 	ctx := context.Background()
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout = 0 // Will not run the loop, but will allow us to close any TSDB fast.
 
 	// Create ingester
@@ -2607,7 +2607,7 @@ func TestIngester_closingAndOpeningTsdbConcurrently(t *testing.T) {
 
 func TestIngester_idleCloseEmptyTSDB(t *testing.T) {
 	ctx := context.Background()
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Minute
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = 1 * time.Minute
 	cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout = 0 // Will not run the loop, but will allow us to close any TSDB fast.
@@ -2656,7 +2656,7 @@ func (m *shipperMock) Sync(ctx context.Context) (uploaded int, err error) {
 }
 
 func TestIngester_invalidSamplesDontChangeLastUpdateTime(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 
 	// Create ingester
@@ -2884,7 +2884,7 @@ func TestIngester_flushing(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cfg := defaultIngesterTestConfig()
+			cfg := defaultIngesterTestConfig(t)
 			cfg.LifecyclerConfig.JoinAfter = 0
 			cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 			cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Minute // Long enough to not be reached during the test.
@@ -2915,7 +2915,7 @@ func TestIngester_flushing(t *testing.T) {
 }
 
 func TestIngester_ForFlush(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 	cfg.BlocksStorageConfig.TSDB.ShipInterval = 10 * time.Minute // Long enough to not be reached during the test.
@@ -2993,7 +2993,7 @@ func Test_Ingester_v2UserStats(t *testing.T) {
 	}
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -3041,7 +3041,7 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 	}
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -3091,7 +3091,7 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 }
 
 func TestIngesterCompactIdleBlock(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = 1 * time.Hour      // Long enough to not be reached during the test.
@@ -3170,7 +3170,7 @@ func TestIngesterCompactIdleBlock(t *testing.T) {
 }
 
 func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Second // Required to enable shipping.
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
@@ -3366,7 +3366,7 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 	overrides, err := validation.NewOverrides(limits, nil)
 	require.NoError(t, err)
 
-	ingesterCfg := defaultIngesterTestConfig()
+	ingesterCfg := defaultIngesterTestConfig(t)
 	ingesterCfg.BlocksStorageEnabled = true
 	ingesterCfg.BlocksStorageConfig.TSDB.Dir = tempDir
 	ingesterCfg.BlocksStorageConfig.Bucket.Backend = "s3"
@@ -3390,7 +3390,7 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 }
 
 func TestIngester_CloseTSDBsOnShutdown(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.LifecyclerConfig.JoinAfter = 0
 
 	// Create ingester
@@ -3424,7 +3424,7 @@ func TestIngester_CloseTSDBsOnShutdown(t *testing.T) {
 func TestIngesterNotDeleteUnshippedBlocks(t *testing.T) {
 	chunkRange := 2 * time.Hour
 	chunkRangeMilliSec := chunkRange.Milliseconds()
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{chunkRange}
 	cfg.BlocksStorageConfig.TSDB.Retention = time.Millisecond // Which means delete all but first block.
 	cfg.LifecyclerConfig.JoinAfter = 0
@@ -3532,7 +3532,7 @@ func TestIngesterNotDeleteUnshippedBlocks(t *testing.T) {
 }
 
 func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), nil)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
 	require.NoError(t, err)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
@@ -3566,7 +3566,7 @@ func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 
 func TestIngesterNoFlushWithInFlightRequest(t *testing.T) {
 	registry := prometheus.NewRegistry()
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(), registry)
+	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), registry)
 	require.NoError(t, err)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
@@ -3716,7 +3716,7 @@ func TestIngester_v2PushInstanceLimits(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			// Create a mocked ingester
-			cfg := defaultIngesterTestConfig()
+			cfg := defaultIngesterTestConfig(t)
 			cfg.LifecyclerConfig.JoinAfter = 0
 			cfg.InstanceLimitsFn = func() *InstanceLimits {
 				return &testData.limits
@@ -3782,7 +3782,7 @@ func TestIngester_instanceLimitsMetrics(t *testing.T) {
 		MaxInMemorySeries:  30,
 	}
 
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.InstanceLimitsFn = func() *InstanceLimits {
 		return &l
 	}
@@ -3817,7 +3817,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 	limits := InstanceLimits{MaxInflightPushRequests: 1}
 
 	// Create a mocked ingester
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.InstanceLimitsFn = func() *InstanceLimits { return &limits }
 	cfg.LifecyclerConfig.JoinAfter = 0
 

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -84,7 +84,7 @@ func TestForSeriesMatchingBatching(t *testing.T) {
 func TestTeardown(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	_, ing := newTestStore(t,
-		defaultIngesterTestConfig(),
+		defaultIngesterTestConfig(t),
 		defaultClientTestConfig(),
 		defaultLimitsTestConfig(),
 		reg)

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -28,7 +28,7 @@ func TestWAL(t *testing.T) {
 		require.NoError(t, os.RemoveAll(dirname))
 	}()
 
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.WALConfig.WALEnabled = true
 	cfg.WALConfig.CheckpointEnabled = true
 	cfg.WALConfig.Recover = true
@@ -108,7 +108,7 @@ func TestWAL(t *testing.T) {
 }
 
 func TestCheckpointRepair(t *testing.T) {
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(t)
 	cfg.WALConfig.WALEnabled = true
 	cfg.WALConfig.CheckpointEnabled = true
 	cfg.WALConfig.Recover = true
@@ -290,7 +290,7 @@ func BenchmarkWALReplay(b *testing.B) {
 		require.NoError(b, os.RemoveAll(dirname))
 	}()
 
-	cfg := defaultIngesterTestConfig()
+	cfg := defaultIngesterTestConfig(b)
 	cfg.WALConfig.WALEnabled = true
 	cfg.WALConfig.CheckpointEnabled = true
 	cfg.WALConfig.Recover = true

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -328,7 +328,9 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			ctx := context.Background()
 
 			// Setup the ring state.
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			require.NoError(t, ringStore.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
 				d := ring.NewDesc()
 				testData.setup(d)
@@ -386,7 +388,9 @@ func TestBlocksStoreReplicationSet_GetClientsFor_ShouldSupportRandomLoadBalancin
 	block1 := ulid.MustNew(1, nil)
 
 	// Create a ring.
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	require.NoError(t, ringStore.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
 		d := ring.NewDesc()
 		for n := 1; n <= numInstances; n++ {

--- a/pkg/ring/basic_lifecycler_delegates_test.go
+++ b/pkg/ring/basic_lifecycler_delegates_test.go
@@ -31,7 +31,7 @@ func TestLeaveOnStoppingDelegate(t *testing.T) {
 	}
 
 	leaveDelegate := NewLeaveOnStoppingDelegate(testDelegate, log.NewNopLogger())
-	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, leaveDelegate)
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(t, cfg, leaveDelegate)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
 
@@ -58,7 +58,7 @@ func TestTokensPersistencyDelegate_ShouldSkipTokensLoadingIfFileDoesNotExist(t *
 
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
-	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, persistencyDelegate)
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(t, cfg, persistencyDelegate)
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -102,7 +102,7 @@ func TestTokensPersistencyDelegate_ShouldLoadTokensFromFileIfFileExist(t *testin
 
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
-	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, persistencyDelegate)
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(t, cfg, persistencyDelegate)
 	require.NoError(t, err)
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
@@ -166,7 +166,7 @@ func TestTokensPersistencyDelegate_ShouldHandleTheCaseTheInstanceIsAlreadyInTheR
 
 			ctx := context.Background()
 			cfg := prepareBasicLifecyclerConfig()
-			lifecycler, store, err := prepareBasicLifecyclerWithDelegate(cfg, persistencyDelegate)
+			lifecycler, store, err := prepareBasicLifecyclerWithDelegate(t, cfg, persistencyDelegate)
 			require.NoError(t, err)
 			defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -214,7 +214,7 @@ func TestDelegatesChain(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
-	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, chain)
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(t, cfg, chain)
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -273,7 +273,7 @@ func TestAutoForgetDelegate(t *testing.T) {
 			testDelegate := &mockDelegate{}
 
 			autoForgetDelegate := NewAutoForgetDelegate(forgetPeriod, testDelegate, log.NewNopLogger())
-			lifecycler, store, err := prepareBasicLifecyclerWithDelegate(cfg, autoForgetDelegate)
+			lifecycler, store, err := prepareBasicLifecyclerWithDelegate(t, cfg, autoForgetDelegate)
 			require.NoError(t, err)
 
 			// Setup the initial state of the ring.

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -83,7 +83,7 @@ func TestBasicLifecycler_RegisterOnStart(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := context.Background()
 			cfg := prepareBasicLifecyclerConfig()
-			lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+			lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 			require.NoError(t, err)
 			defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -159,7 +159,7 @@ func TestBasicLifecycler_RegisterOnStart(t *testing.T) {
 func TestBasicLifecycler_UnregisterOnStop(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
-	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 
 	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ InstanceDesc) (InstanceState, Tokens) {
@@ -195,7 +195,7 @@ func TestBasicLifecycler_HeartbeatWhileRunning(t *testing.T) {
 	cfg := prepareBasicLifecyclerConfig()
 	cfg.HeartbeatPeriod = 10 * time.Millisecond
 
-	lifecycler, _, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, _, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
@@ -219,7 +219,7 @@ func TestBasicLifecycler_HeartbeatWhileStopping(t *testing.T) {
 	cfg := prepareBasicLifecyclerConfig()
 	cfg.HeartbeatPeriod = 10 * time.Millisecond
 
-	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
 
@@ -257,7 +257,7 @@ func TestBasicLifecycler_HeartbeatAfterBackendRest(t *testing.T) {
 	cfg := prepareBasicLifecyclerConfig()
 	cfg.HeartbeatPeriod = 10 * time.Millisecond
 
-	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -291,7 +291,7 @@ func TestBasicLifecycler_HeartbeatAfterBackendRest(t *testing.T) {
 func TestBasicLifecycler_ChangeState(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
-	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -319,7 +319,7 @@ func TestBasicLifecycler_TokensObservePeriod(t *testing.T) {
 	cfg.NumTokens = 5
 	cfg.TokensObservePeriod = time.Second
 
-	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 
 	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ InstanceDesc) (InstanceState, Tokens) {
@@ -358,7 +358,7 @@ func TestBasicLifecycler_updateInstance_ShouldAddInstanceToTheRingIfDoesNotExist
 	cfg := prepareBasicLifecyclerConfig()
 	cfg.HeartbeatPeriod = time.Hour // No heartbeat during the test.
 
-	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
 	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
@@ -403,14 +403,16 @@ func prepareBasicLifecyclerConfig() BasicLifecyclerConfig {
 	}
 }
 
-func prepareBasicLifecycler(cfg BasicLifecyclerConfig) (*BasicLifecycler, *mockDelegate, kv.Client, error) {
+func prepareBasicLifecycler(t testing.TB, cfg BasicLifecyclerConfig) (*BasicLifecycler, *mockDelegate, kv.Client, error) {
 	delegate := &mockDelegate{}
-	lifecycler, store, err := prepareBasicLifecyclerWithDelegate(cfg, delegate)
+	lifecycler, store, err := prepareBasicLifecyclerWithDelegate(t, cfg, delegate)
 	return lifecycler, delegate, store, err
 }
 
-func prepareBasicLifecyclerWithDelegate(cfg BasicLifecyclerConfig, delegate BasicLifecyclerDelegate) (*BasicLifecycler, kv.Client, error) {
-	store := consul.NewInMemoryClient(GetCodec())
+func prepareBasicLifecyclerWithDelegate(t testing.TB, cfg BasicLifecyclerConfig, delegate BasicLifecyclerDelegate) (*BasicLifecycler, kv.Client, error) {
+	store, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	lifecycler, err := NewBasicLifecycler(cfg, testRingName, testRingKey, store, delegate, log.NewNopLogger(), nil)
 	return lifecycler, store, err
 }

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -137,7 +137,7 @@ func createClient(backend string, prefix string, cfg StoreConfig, codec codec.Co
 		// If we use the in-memory store, make sure everyone gets the same instance
 		// within the same process.
 		inmemoryStoreInit.Do(func() {
-			inmemoryStore = consul.NewInMemoryClient(codec)
+			inmemoryStore, _ = consul.NewInMemoryClient(codec)
 		})
 		client = inmemoryStore
 

--- a/pkg/ring/kv/consul/client_test.go
+++ b/pkg/ring/kv/consul/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	consul "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/ring/kv/codec"
@@ -29,10 +30,11 @@ func writeValuesToKV(client *Client, key string, start, end int, sleep time.Dura
 }
 
 func TestWatchKeyWithRateLimit(t *testing.T) {
-	c := NewInMemoryClientWithConfig(codec.String{}, Config{
+	c, closer := NewInMemoryClientWithConfig(codec.String{}, Config{
 		WatchKeyRateLimit: 5.0,
 		WatchKeyBurstSize: 1,
 	})
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	const key = "test"
 	const max = 100
@@ -61,9 +63,10 @@ func TestWatchKeyWithRateLimit(t *testing.T) {
 }
 
 func TestWatchKeyNoRateLimit(t *testing.T) {
-	c := NewInMemoryClientWithConfig(codec.String{}, Config{
+	c, closer := NewInMemoryClientWithConfig(codec.String{}, Config{
 		WatchKeyRateLimit: 0,
 	})
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	const key = "test"
 	const max = 100
@@ -82,7 +85,8 @@ func TestWatchKeyNoRateLimit(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	c := NewInMemoryClient(codec.String{})
+	c, closer := NewInMemoryClient(codec.String{})
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	const key = "test"
 	const max = 5
@@ -136,7 +140,8 @@ func observeValueForSomeTime(client *Client, key string, timeout time.Duration) 
 }
 
 func TestWatchKeyWithNoStartValue(t *testing.T) {
-	c := NewInMemoryClient(codec.String{})
+	c, closer := NewInMemoryClient(codec.String{})
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	const key = "test"
 

--- a/pkg/ring/kv/consul/mock.go
+++ b/pkg/ring/kv/consul/mock.go
@@ -2,12 +2,15 @@ package consul
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log/level"
 	consul "github.com/hashicorp/consul/api"
+
+	"github.com/grafana/mimir/pkg/util"
 
 	"github.com/grafana/mimir/pkg/ring/kv/codec"
 	util_log "github.com/grafana/mimir/pkg/util/log"
@@ -18,28 +21,46 @@ type mockKV struct {
 	cond    *sync.Cond
 	kvps    map[string]*consul.KVPair
 	current uint64 // the current 'index in the log'
+
+	// Channel closed once the in-memory consul mock should be closed.
+	close   chan struct{}
+	closeWg sync.WaitGroup
 }
 
 // NewInMemoryClient makes a new mock consul client.
-func NewInMemoryClient(codec codec.Codec) *Client {
+func NewInMemoryClient(codec codec.Codec) (*Client, io.Closer) {
 	return NewInMemoryClientWithConfig(codec, Config{})
 }
 
 // NewInMemoryClientWithConfig makes a new mock consul client with supplied Config.
-func NewInMemoryClientWithConfig(codec codec.Codec, cfg Config) *Client {
+func NewInMemoryClientWithConfig(codec codec.Codec, cfg Config) (*Client, io.Closer) {
 	m := mockKV{
 		kvps: map[string]*consul.KVPair{},
 		// Always start from 1, we NEVER want to report back index 0 in the responses.
 		// This is in line with Consul, and our new checks for index return value in client.go.
 		current: 1,
+		close:   make(chan struct{}),
 	}
 	m.cond = sync.NewCond(&m.mtx)
+
+	// Create a closer function used to close the main loop and wait until it's done.
+	// We need to wait until done, otherwise the goroutine leak finder used in tests
+	// may still report it as leaked.
+	closer := util.CloserFunc(func() error {
+		close(m.close)
+		m.closeWg.Wait()
+		return nil
+	})
+
+	// Start the main loop in a dedicated goroutine.
+	m.closeWg.Add(1)
 	go m.loop()
+
 	return &Client{
 		kv:    &m,
 		codec: codec,
 		cfg:   cfg,
-	}
+	}, closer
 }
 
 func copyKVPair(in *consul.KVPair) *consul.KVPair {
@@ -51,10 +72,17 @@ func copyKVPair(in *consul.KVPair) *consul.KVPair {
 
 // periodic loop to wake people up, so they can honour timeouts
 func (m *mockKV) loop() {
-	for range time.Tick(1 * time.Second) {
-		m.mtx.Lock()
-		m.cond.Broadcast()
-		m.mtx.Unlock()
+	defer m.closeWg.Done()
+
+	for {
+		select {
+		case <-m.close:
+			return
+		case <-time.After(time.Second):
+			m.mtx.Lock()
+			m.cond.Broadcast()
+			m.mtx.Unlock()
+		}
 	}
 }
 

--- a/pkg/ring/kv/etcd/mock.go
+++ b/pkg/ring/kv/etcd/mock.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/flagext"
 
 	"go.etcd.io/etcd/server/v3/embed"
@@ -46,7 +47,7 @@ func Mock(codec codec.Codec) (*Client, io.Closer, error) {
 		return nil, nil, fmt.Errorf("server took too long to start")
 	}
 
-	closer := CloserFunc(func() error {
+	closer := util.CloserFunc(func() error {
 		etcd.Server.Stop()
 		return nil
 	})
@@ -62,19 +63,6 @@ func Mock(codec codec.Codec) (*Client, io.Closer, error) {
 
 	return client, closer, nil
 }
-
-// CloserFunc is like http.HandlerFunc but for io.Closers.
-type CloserFunc func() error
-
-// Close implements io.Closer.
-func (f CloserFunc) Close() error {
-	return f()
-}
-
-// NopCloser does nothing.
-var NopCloser = CloserFunc(func() error {
-	return nil
-})
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/ring/kv/kv_test.go
+++ b/pkg/ring/kv/kv_test.go
@@ -23,7 +23,8 @@ func withFixtures(t *testing.T, f func(*testing.T, Client)) {
 		factory func() (Client, io.Closer, error)
 	}{
 		{"consul", func() (Client, io.Closer, error) {
-			return consul.NewInMemoryClient(codec.String{}), etcd.NopCloser, nil
+			client, closer := consul.NewInMemoryClient(codec.String{})
+			return client, closer, nil
 		}},
 		{"etcd", func() (Client, io.Closer, error) {
 			return etcd.Mock(codec.String{})

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -43,9 +43,12 @@ func checkNormalised(d interface{}, id string) bool {
 }
 
 func TestLifecycler_HealthyInstancesCount(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+	ringConfig.KVStore.Mock = ringStore
 
 	ctx := context.Background()
 
@@ -90,9 +93,12 @@ func TestLifecycler_HealthyInstancesCount(t *testing.T) {
 }
 
 func TestLifecycler_ZonesCount(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+	ringConfig.KVStore.Mock = ringStore
 
 	events := []struct {
 		zone          string
@@ -130,9 +136,12 @@ func TestLifecycler_ZonesCount(t *testing.T) {
 }
 
 func TestLifecycler_NilFlushTransferer(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+	ringConfig.KVStore.Mock = ringStore
 	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
 
 	// Create a lifecycler with nil FlushTransferer to make sure it operates correctly
@@ -152,9 +161,12 @@ func TestLifecycler_NilFlushTransferer(t *testing.T) {
 
 func TestLifecycler_TwoRingsWithDifferentKeysOnTheSameKVStore(t *testing.T) {
 	// Create a shared ring
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+	ringConfig.KVStore.Mock = ringStore
 
 	// Create two lifecyclers, each on a separate ring
 	lifecyclerConfig1 := testLifecyclerConfig(ringConfig, "instance-1")
@@ -189,10 +201,12 @@ func (f *nopFlushTransferer) TransferOut(_ context.Context) error {
 }
 
 func TestLifecycler_ShouldHandleInstanceAbruptlyRestarted(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	c := GetCodec()
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(c)
+	ringConfig.KVStore.Mock = ringStore
 
 	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
 	require.NoError(t, err)
@@ -322,9 +336,12 @@ func (f *noopFlushTransferer) Flush()                                {}
 func (f *noopFlushTransferer) TransferOut(ctx context.Context) error { return nil }
 
 func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+	ringConfig.KVStore.Mock = ringStore
 
 	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
 	require.NoError(t, err)
@@ -422,9 +439,12 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 }
 
 func TestTokensOnDisk(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+	ringConfig.KVStore.Mock = ringStore
 
 	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
 	require.NoError(t, err)
@@ -496,10 +516,12 @@ func TestTokensOnDisk(t *testing.T) {
 
 // JoinInLeavingState ensures that if the lifecycler starts up and the ring already has it in a LEAVING state that it still is able to auto join
 func TestJoinInLeavingState(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	c := GetCodec()
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(c)
+	ringConfig.KVStore.Mock = ringStore
 
 	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
 	require.NoError(t, err)
@@ -548,10 +570,12 @@ func TestJoinInLeavingState(t *testing.T) {
 
 // JoinInJoiningState ensures that if the lifecycler starts up and the ring already has it in a JOINING state that it still is able to auto join
 func TestJoinInJoiningState(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	c := GetCodec()
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(c)
+	ringConfig.KVStore.Mock = ringStore
 
 	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
 	require.NoError(t, err)
@@ -610,10 +634,12 @@ func TestRestoreOfZoneWhenOverwritten(t *testing.T) {
 	// so it gets removed. The current version of the lifecylcer should
 	// write it back on update during its next heartbeat.
 
+	ringStore, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
-	codec := GetCodec()
-	ringConfig.KVStore.Mock = consul.NewInMemoryClient(codec)
+	ringConfig.KVStore.Mock = ringStore
 
 	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
 	require.NoError(t, err)

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1926,7 +1926,8 @@ func compareReplicationSets(first, second ReplicationSet) (added, removed []stri
 
 // This test verifies that ring is getting updates, even after extending check in the loop method.
 func TestRingUpdates(t *testing.T) {
-	inmem := consul.NewInMemoryClient(GetCodec())
+	inmem, closer := consul.NewInMemoryClient(GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	cfg := Config{
 		KVStore:           kv.Config{Mock: inmem},
@@ -2019,10 +2020,11 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
-	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
+	inmem, closer := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
 		CasRetryDelay: 500 * time.Millisecond,
 	})
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	cfg := Config{
 		KVStore:              kv.Config{Mock: inmem},

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestRuler_rules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -78,7 +78,7 @@ func TestRuler_rules(t *testing.T) {
 }
 
 func TestRuler_rules_special_characters(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockSpecialCharRules))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockSpecialCharRules))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -135,7 +135,7 @@ func TestRuler_rules_special_characters(t *testing.T) {
 }
 
 func TestRuler_alerts(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -171,7 +171,7 @@ func TestRuler_alerts(t *testing.T) {
 }
 
 func TestRuler_Create(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -262,7 +262,7 @@ rules:
 }
 
 func TestRuler_DeleteNamespace(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRulesNamespaces))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRulesNamespaces))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -301,7 +301,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 }
 
 func TestRuler_LimitsPerGroup(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -356,7 +356,7 @@ rules:
 }
 
 func TestRuler_RulerGroupLimits(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -45,12 +45,15 @@ import (
 	"github.com/grafana/mimir/pkg/util/services"
 )
 
-func defaultRulerConfig(store rulestore.RuleStore) (Config, func()) {
+func defaultRulerConfig(t testing.TB, store rulestore.RuleStore) (Config, func()) {
 	// Create a new temporary directory for the rules, so that
 	// each test will run in isolation.
 	rulesDir, _ := ioutil.TempDir("/tmp", "ruler-tests")
+
 	codec := ring.GetCodec()
-	consul := consul.NewInMemoryClient(codec)
+	consul, closer := consul.NewInMemoryClient(codec)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	cfg.RulePath = rulesDir
@@ -179,7 +182,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	defer ts.Close()
 
 	// We create an empty rule store so that the ruler will not load any rule from it.
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(nil))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(nil))
 	defer cleanup()
 
 	cfg.AlertmanagerURL = ts.URL
@@ -211,7 +214,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 }
 
 func TestRuler_Rules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)
@@ -639,7 +642,8 @@ func TestSharding(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			kvStore := consul.NewInMemoryClient(ring.GetCodec())
+			kvStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 			setupRuler := func(id string, host string, port int, forceRing *ring.Ring) *Ruler {
 				cfg := Config{
@@ -847,7 +851,7 @@ type ruleGroupKey struct {
 }
 
 func TestRuler_ListAllRules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -95,6 +95,8 @@ func TestConfig_Validate(t *testing.T) {
 }
 
 func TestStoreGateway_InitialSyncWithDefaultShardingEnabled(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	tests := map[string]struct {
 		initialExists bool
 		initialState  ring.InstanceState
@@ -131,7 +133,9 @@ func TestStoreGateway_InitialSyncWithDefaultShardingEnabled(t *testing.T) {
 			gatewayCfg := mockGatewayConfig()
 			gatewayCfg.ShardingEnabled = true
 			storageCfg := mockStorageConfig(t)
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			bucketClient := &bucket.ClientMock{}
 
 			// Setup the initial instance state in the ring.
@@ -145,7 +149,7 @@ func TestStoreGateway_InitialSyncWithDefaultShardingEnabled(t *testing.T) {
 
 			g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), nil)
 			require.NoError(t, err)
-			defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+			t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 			assert.False(t, g.ringLifecycler.IsRegistered())
 
 			bucketClient.MockIterWithCallback("", []string{"user-1", "user-2"}, nil, func() {
@@ -175,6 +179,8 @@ func TestStoreGateway_InitialSyncWithDefaultShardingEnabled(t *testing.T) {
 }
 
 func TestStoreGateway_InitialSyncWithShardingDisabled(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	ctx := context.Background()
 	gatewayCfg := mockGatewayConfig()
 	gatewayCfg.ShardingEnabled = false
@@ -183,7 +189,7 @@ func TestStoreGateway_InitialSyncWithShardingDisabled(t *testing.T) {
 
 	g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, nil, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
-	defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+	t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 
 	bucketClient.MockIter("", []string{"user-1", "user-2"}, nil)
 	bucketClient.MockIter("user-1/", []string{}, nil)
@@ -196,11 +202,15 @@ func TestStoreGateway_InitialSyncWithShardingDisabled(t *testing.T) {
 }
 
 func TestStoreGateway_InitialSyncFailure(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	ctx := context.Background()
 	gatewayCfg := mockGatewayConfig()
 	gatewayCfg.ShardingEnabled = true
 	storageCfg := mockStorageConfig(t)
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	bucketClient := &bucket.ClientMock{}
 
 	g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), nil)
@@ -222,6 +232,8 @@ func TestStoreGateway_InitialSyncFailure(t *testing.T) {
 // their own blocks, regardless which store-gateway joined the ring first or last (even if starting
 // at the same time, they will join the ring at a slightly different time).
 func TestStoreGateway_InitialSyncWithWaitRingStability(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	bucketClient, storageDir := cortex_testutil.PrepareFilesystemBucket(t)
 
 	// This tests uses real TSDB blocks. 24h time range, 2h block range period,
@@ -300,10 +312,11 @@ func TestStoreGateway_InitialSyncWithWaitRingStability(t *testing.T) {
 				t.Log("random generator seed:", seed)
 
 				ctx := context.Background()
-				ringStore := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consul.Config{
+				ringStore, closer := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consul.Config{
 					MaxCasRetries: 20,
 					CasRetryDelay: 500 * time.Millisecond,
 				})
+				t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 				// Create the configured number of gateways.
 				var gateways []*StoreGateway
@@ -334,7 +347,7 @@ func TestStoreGateway_InitialSyncWithWaitRingStability(t *testing.T) {
 					reg := prometheus.NewPedanticRegistry()
 					g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, overrides, mockLoggingLevel(), log.NewNopLogger(), reg)
 					require.NoError(t, err)
-					defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+					t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 
 					gateways = append(gateways, g)
 					registries.AddUserRegistry(instanceID, reg)
@@ -373,6 +386,8 @@ func TestStoreGateway_InitialSyncWithWaitRingStability(t *testing.T) {
 }
 
 func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScaleUp(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	const (
 		numUsers             = 2
 		numBlocks            = numUsers * 12
@@ -402,7 +417,8 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 	t.Log("random generator seed:", seed)
 
 	ctx := context.Background()
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	// Create the configured number of gateways.
 	var initialGateways []*StoreGateway
@@ -446,8 +462,13 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 
 	// Start all gateways concurrently.
 	for _, g := range initialGateways {
+		// Local variable scope (ensures the cleanup function is called on the right gateway).
+		g := g
+
 		require.NoError(t, g.StartAsync(ctx))
-		defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+		t.Cleanup(func() {
+			assert.NoError(t, services.StopAndAwaitTerminated(ctx, g))
+		})
 	}
 
 	// Wait until all gateways are running.
@@ -478,8 +499,13 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 
 	// Start all new gateways concurrently.
 	for _, g := range scaleUpGateways {
+		// Local variable scope (ensures the cleanup function is called on the right gateway).
+		g := g
+
 		require.NoError(t, g.StartAsync(ctx))
-		defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+		t.Cleanup(func() {
+			assert.NoError(t, services.StopAndAwaitTerminated(ctx, g))
+		})
 	}
 
 	// Since we configured the new store-gateways with an high "wait stability min duration", we expect
@@ -531,6 +557,8 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 }
 
 func TestStoreGateway_ShouldSupportLoadRingTokensFromFile(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	tests := map[string]struct {
 		storedTokens      ring.Tokens
 		expectedNumTokens int
@@ -553,7 +581,7 @@ func TestStoreGateway_ShouldSupportLoadRingTokensFromFile(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
 			require.NoError(t, err)
-			defer os.Remove(tokensFile.Name()) //nolint:errcheck
+			t.Cleanup(func() { assert.NoError(t, os.Remove(tokensFile.Name())) })
 
 			// Store some tokens to the file.
 			require.NoError(t, testData.storedTokens.StoreToFile(tokensFile.Name()))
@@ -564,13 +592,15 @@ func TestStoreGateway_ShouldSupportLoadRingTokensFromFile(t *testing.T) {
 			gatewayCfg.ShardingRing.TokensFilePath = tokensFile.Name()
 
 			storageCfg := mockStorageConfig(t)
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			bucketClient := &bucket.ClientMock{}
 			bucketClient.MockIter("", []string{}, nil)
 
 			g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), nil)
 			require.NoError(t, err)
-			defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+			t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 			assert.False(t, g.ringLifecycler.IsRegistered())
 
 			require.NoError(t, services.StartAndAwaitRunning(ctx, g))
@@ -583,6 +613,8 @@ func TestStoreGateway_ShouldSupportLoadRingTokensFromFile(t *testing.T) {
 }
 
 func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	registeredAt := time.Now()
 
 	tests := map[string]struct {
@@ -689,7 +721,9 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 			storageCfg.BucketStore.SyncInterval = time.Hour // Do not trigger the periodic sync in this test.
 
 			reg := prometheus.NewPedanticRegistry()
-			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 			bucketClient := &bucket.ClientMock{}
 			bucketClient.MockIter("", []string{}, nil)
 
@@ -704,7 +738,7 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 			}))
 
 			require.NoError(t, services.StartAndAwaitRunning(ctx, g))
-			defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+			t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 
 			// Assert on the initial state.
 			regs := util.NewUserRegistries()
@@ -737,6 +771,8 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 }
 
 func TestStoreGateway_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	const unhealthyInstanceID = "unhealthy-id"
 	const heartbeatTimeout = time.Minute
 
@@ -748,14 +784,16 @@ func TestStoreGateway_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testin
 
 	storageCfg := mockStorageConfig(t)
 
-	ringStore := consul.NewInMemoryClient(ring.GetCodec())
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec())
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{}, nil)
 
 	g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, g))
-	defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+	t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 
 	// Add an unhealthy instance to the ring.
 	require.NoError(t, ringStore.CAS(ctx, RingKey, func(in interface{}) (interface{}, bool, error) {
@@ -781,13 +819,15 @@ func TestStoreGateway_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testin
 }
 
 func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 	userID := "user-1"
 
 	storageDir, err := ioutil.TempDir(os.TempDir(), "")
 	require.NoError(t, err)
-	defer os.RemoveAll(storageDir) //nolint:errcheck
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(storageDir)) })
 
 	// Generate 2 TSDB blocks with the same exact series (and data points).
 	numSeries := 2
@@ -839,7 +879,7 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 			g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, nil, defaultLimitsOverrides(t), mockLoggingLevel(), logger, nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, g))
-			defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+			t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 
 			// Query back all series.
 			req := &storepb.SeriesRequest{
@@ -875,6 +915,8 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 }
 
 func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	const chunksQueried = 10
 
 	tests := map[string]struct {
@@ -901,7 +943,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 
 	storageDir, err := ioutil.TempDir(os.TempDir(), "")
 	require.NoError(t, err)
-	defer os.RemoveAll(storageDir) //nolint:errcheck
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(storageDir)) })
 
 	// Generate 1 TSDB block with chunksQueried series. Since each mocked series contains only 1 sample,
 	// it will also only have 1 chunk.
@@ -938,7 +980,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 			g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, nil, overrides, mockLoggingLevel(), logger, nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, g))
-			defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+			t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(ctx, g)) })
 
 			// Query back all the series (1 chunk per series in this test).
 			srv := newBucketStoreSeriesServer(setUserIDToGRPCContext(ctx, userID))
@@ -999,7 +1041,7 @@ func mockTSDB(t *testing.T, dir string, numSeries, numBlocks int, minT, maxT int
 	// will be then snapshotted to the input dir.
 	tempDir, err := ioutil.TempDir(os.TempDir(), "tsdb")
 	require.NoError(t, err)
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(tempDir)) })
 
 	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
 		MinBlockDuration:  2 * time.Hour.Milliseconds(),

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -242,7 +242,8 @@ func TestDefaultShardingStrategy(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			store := consul.NewInMemoryClient(ring.GetCodec())
+			store, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 			// Initialize the ring state.
 			require.NoError(t, store.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
@@ -599,7 +600,8 @@ func TestShuffleShardingStrategy(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			store := consul.NewInMemoryClient(ring.GetCodec())
+			store, closer := consul.NewInMemoryClient(ring.GetCodec())
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 			// Initialize the ring state.
 			require.NoError(t, store.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {

--- a/pkg/util/closer.go
+++ b/pkg/util/closer.go
@@ -1,0 +1,9 @@
+package util
+
+// CloserFunc is like http.HandlerFunc but for io.Closer.
+type CloserFunc func() error
+
+// Close implements io.Closer.
+func (f CloserFunc) Close() error {
+	return f()
+}

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func VerifyNoLeak(t testing.TB) {
+	opts := []goleak.Option{
+		// Ignore opencensus default worker because it's started in a init() function.
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+
+		// The store-gateway BucketStore starts a goroutine in the index-header readers pool and
+		// it gets closed when we close the BucketStore. However, we currently don't close BucketStore
+		// on store-gateway termination so it never gets terminated.
+		goleak.IgnoreTopFunction("github.com/thanos-io/thanos/pkg/block/indexheader.NewReaderPool.func1"),
+	}
+
+	// Run it as a cleanup function so that "last added, first called" ordering execution is guaranteed.
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, opts...)
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -795,6 +795,7 @@ go.opentelemetry.io/otel/trace
 ## explicit
 go.uber.org/atomic
 # go.uber.org/goleak v1.1.10
+## explicit
 go.uber.org/goleak
 go.uber.org/goleak/internal/stack
 # go.uber.org/multierr v1.5.0
@@ -866,7 +867,8 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 ## explicit
 golang.org/x/time/rate
-# golang.org/x/tools v0.1.3
+# golang.org/x/tools v0.1.5
+## explicit
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata


### PR DESCRIPTION
**What this PR does**:
While working on https://github.com/grafana/mimir/pull/62 I realised (thanks to a suggestion from @pstibrany) that we have a lot of goroutines leaked in our unit tests. This is not necessarily an issue, considering unit tests are short lived but, after some profiling, I've noticed that the consul in-memory KV store (used by tests) was leaking > 1GB memory just while running `pkg/storegateway` tests.

In this PR I'm addressing only the leak introduced by the consul in-memory KV store. I've followed the same pattern used for etcd mock, explicitly returning `io.Closer` from `NewInMemoryClient()` and `NewInMemoryClientWithConfig()` (this way tests are forced to handle it).

I've also introduced `goleak` usage exclusively in `Gateway` and `BucketStores` tests. As I already mentioned, we have may other leaks in unit tests, so in this PR I just focused on the 2 core components of `pkg/storegateway` only.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
