### PR TITLE
Test against last 3 Cortex releases

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -130,16 +130,9 @@ jobs:
           docker pull amazon/dynamodb-local:1.11.477
           docker pull consul:1.8.4
           docker pull gcr.io/etcd-development/etcd:v3.4.7
-          docker pull quay.io/cortexproject/cortex:v1.0.0
-          docker pull quay.io/cortexproject/cortex:v1.1.0
-          docker pull quay.io/cortexproject/cortex:v1.2.0
-          docker pull quay.io/cortexproject/cortex:v1.3.0
-          docker pull quay.io/cortexproject/cortex:v1.4.0
-          docker pull quay.io/cortexproject/cortex:v1.5.0
-          docker pull quay.io/cortexproject/cortex:v1.6.0
-          docker pull quay.io/cortexproject/cortex:v1.7.0
           docker pull quay.io/cortexproject/cortex:v1.8.0
           docker pull quay.io/cortexproject/cortex:v1.9.0
+          docker pull quay.io/cortexproject/cortex:v1.10.0
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull rinscy/cassandra:3.11.0
           docker pull memcached:1.6.1

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -20,43 +20,11 @@ var (
 	// If you change the image tag, remember to update it in the preloading done
 	// by GitHub Actions too (see .github/workflows/test-build-deploy.yml).
 	previousVersionImages = map[string]func(map[string]string) map[string]string{
-		"quay.io/cortexproject/cortex:v1.0.0": preCortex14Flags,
-		"quay.io/cortexproject/cortex:v1.1.0": preCortex14Flags,
-		"quay.io/cortexproject/cortex:v1.2.0": preCortex14Flags,
-		"quay.io/cortexproject/cortex:v1.3.0": preCortex14Flags,
-		"quay.io/cortexproject/cortex:v1.4.0": preCortex16Flags,
-		"quay.io/cortexproject/cortex:v1.5.0": preCortex16Flags,
-		"quay.io/cortexproject/cortex:v1.6.0": preCortex110Flags,
-		"quay.io/cortexproject/cortex:v1.7.0": preCortex110Flags,
-		"quay.io/cortexproject/cortex:v1.8.0": preCortex110Flags,
-		"quay.io/cortexproject/cortex:v1.9.0": preCortex110Flags,
+		"quay.io/cortexproject/cortex:v1.8.0":  preCortex110Flags,
+		"quay.io/cortexproject/cortex:v1.9.0":  preCortex110Flags,
+		"quay.io/cortexproject/cortex:v1.10.0": nil,
 	}
 )
-
-func preCortex14Flags(flags map[string]string) map[string]string {
-	return e2e.MergeFlagsWithoutRemovingEmpty(flags, map[string]string{
-		// Blocks storage CLI flags removed the "experimental" prefix in 1.4.
-		"-store-gateway.sharding-enabled":                 "",
-		"-store-gateway.sharding-ring.store":              "",
-		"-store-gateway.sharding-ring.consul.hostname":    "",
-		"-store-gateway.sharding-ring.replication-factor": "",
-		// Query-scheduler has been introduced in 1.6.0
-		"-frontend.scheduler-dns-lookup-period": "",
-		// Store-gateway "wait ring stability" has been introduced in 1.10.0
-		"-store-gateway.sharding-ring.wait-stability-min-duration": "",
-		"-store-gateway.sharding-ring.wait-stability-max-duration": "",
-	})
-}
-
-func preCortex16Flags(flags map[string]string) map[string]string {
-	return e2e.MergeFlagsWithoutRemovingEmpty(flags, map[string]string{
-		// Query-scheduler has been introduced in 1.6.0
-		"-frontend.scheduler-dns-lookup-period": "",
-		// Store-gateway "wait ring stability" has been introduced in 1.10.0
-		"-store-gateway.sharding-ring.wait-stability-min-duration": "",
-		"-store-gateway.sharding-ring.wait-stability-max-duration": "",
-	})
-}
 
 func preCortex110Flags(flags map[string]string) map[string]string {
 	return e2e.MergeFlagsWithoutRemovingEmpty(flags, map[string]string{


### PR DESCRIPTION
**What this PR does**:
We accumulated a pretty long list of Cortex versions against which we test for backward compatibility. What do you think if we just test against the latest 3?

_I've also added 1.10 which was recently released._

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
