### PR TITLE
Fix goroutines leak detection in store-gateway unit tests

### DIFF
--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -258,6 +258,12 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 		case jobs <- job{userID: userID, store: bs}:
 			// Nothing to do. Will loop to push more jobs.
 		case <-ctx.Done():
+			// Wait until all workers have done, so the goroutines leak detector doesn't
+			// report any issue. This is expected to be quick, considering the done ctx
+			// is used by the worker callback function too.
+			close(jobs)
+			wg.Wait()
+
 			return ctx.Err()
 		}
 	}


### PR DESCRIPTION
**What this PR does**:
Earlier today I've merged #69 and now CI is failing because of some goroutines leaked by `syncUsersBlocks` (see https://github.com/grafana/mimir/pull/67/checks?check_run_id=3279159556).

I think it happens when when stop the store-gateway while `syncUsersBlocks()` is running. If my guess is correct, this PR should fix it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
