### PR TITLE
test: Allow group use of the e2e test temporary directory

### DIFF
--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -166,6 +166,11 @@ func GetTempDirectory() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Allow group use of the temporary directory to allow testing with non-root
+	// users.
+	if err := os.Chmod(tmpDir, 0770); err != nil {
+		return "", err
+	}
 	absDir, err := filepath.Abs(tmpDir)
 	if err != nil {
 		_ = os.RemoveAll(tmpDir)


### PR DESCRIPTION
**What this PR does**:
Facilitates testing with non-root users where files can be read
via group permissions.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>