### PR TITLE
Moved GOPRIVATE from mod-check target to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,6 @@ shell:
 	bash
 
 mod-check:
-	go env -w GOPRIVATE=github.com/grafana/prometheus-private
 	GO111MODULE=on go mod download
 	GO111MODULE=on go mod verify
 	GO111MODULE=on go mod tidy


### PR DESCRIPTION
**What this PR does**:
The PR #68 has introduced a temporary private fork of Prometheus and the setting of `GOPRIVATE` env variable to get the CI working. However, I don't I think we actually need it because we're already covered by `.config/go/env` which should be mounted in CI too.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
