### PR TITLE
Add JSON support for CIDRSliceCSV types

### DIFF
--- a/pkg/util/flagext/cidr.go
+++ b/pkg/util/flagext/cidr.go
@@ -6,6 +6,7 @@
 package flagext
 
 import (
+	"encoding/json"
 	"net"
 	"strings"
 
@@ -84,4 +85,25 @@ func (c *CIDRSliceCSV) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // MarshalYAML implements yaml.Marshaler.
 func (c CIDRSliceCSV) MarshalYAML() (interface{}, error) {
 	return c.String(), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (c *CIDRSliceCSV) UnmarshalJSON(bytes []byte) error {
+	var s string
+	if err := json.Unmarshal(bytes, &s); err != nil {
+		return err
+	}
+
+	// An empty string means no CIDRs has been configured.
+	if s == "" {
+		*c = nil
+		return nil
+	}
+
+	return c.Set(s)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (c CIDRSliceCSV) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
 }

--- a/pkg/util/flagext/cidr_test.go
+++ b/pkg/util/flagext/cidr_test.go
@@ -6,17 +6,18 @@
 package flagext
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
 
-func Test_CIDRSliceCSV_YamlMarshalling(t *testing.T) {
-	type TestStruct struct {
-		CIDRs CIDRSliceCSV `yaml:"cidrs"`
-	}
+type TestStruct struct {
+	CIDRs CIDRSliceCSV `yaml:"cidrs" json:"cidrs"`
+}
 
+func Test_CIDRSliceCSV_YamlMarshalling(t *testing.T) {
 	tests := map[string]struct {
 		input    string
 		expected []string
@@ -49,6 +50,45 @@ func Test_CIDRSliceCSV_YamlMarshalling(t *testing.T) {
 
 			// Marshal.
 			out, err := yaml.Marshal(actual)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.input, string(out))
+		})
+	}
+}
+
+func Test_CIDRSliceCSV_JSONMarshalling(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected []string
+	}{
+		"should marshal empty config": {
+			input:    `{"cidrs":""}`,
+			expected: nil,
+		},
+		"should marshal single value": {
+			input:    `{"cidrs":"127.0.0.1/32"}`,
+			expected: []string{"127.0.0.1/32"},
+		},
+		"should marshal multiple comma-separated values": {
+			input:    `{"cidrs":"127.0.0.1/32,10.0.10.0/28,fdf8:f53b:82e4::/100,192.168.0.0/20"}`,
+			expected: []string{"127.0.0.1/32", "10.0.10.0/28", "fdf8:f53b:82e4::/100", "192.168.0.0/20"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Unmarshal.
+			actual := TestStruct{}
+			err := json.Unmarshal([]byte(tc.input), &actual)
+			assert.NoError(t, err)
+
+			assert.Len(t, actual.CIDRs, len(tc.expected))
+			for idx, cidr := range actual.CIDRs {
+				assert.Equal(t, tc.expected[idx], cidr.String())
+			}
+
+			// Marshal.
+			out, err := json.Marshal(actual)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.input, string(out))
 		})


### PR DESCRIPTION
Add corresponding JSON marshalling logic for CIDRSliceCSV types
that mirrors the YAML marshalling logic. This ensures that `nil`
CSVs are marshalled to an empty JSON string (the same way YAML
marshalling does).

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
