### PR TITLE
Simplify store gateway metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 * [ENHANCEMENT] Querier now can use the `LabelNames` call with matchers, if matchers are provided in the `/labels` API call, instead of using the more expensive `MetricsForLabelMatchers` call as before. This can be enabled by enabling the `-querier.query-label-names-with-matchers-enabled` flag once the ingesters are updated to this version. In the future this is expected to become the default behavior. #3
 * [ENHANCEMENT] Ingester: added option `-ingester.readiness-check-ring-health` to disable the ring health check in the readiness endpoint. #48
 * [ENHANCEMENT] Added option `-distributor.excluded-zones` to exclude ingesters running in specific zones both on write and read path. #51
+* [ENHANCEMENT] Store-gateway: added `cortex_bucket_store_sent_chunk_size_bytes` metric, tracking the size of chunks sent from store-gateway to querier. #123
+* [ENHANCEMENT] Store-gateway: reduced CPU and memory utilization due to exported metrics aggregation for instances with a large number of tenants. #123
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16
 * [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #28
 

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -195,6 +195,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		true,
 		time.Minute,
 		NewSeriesHashCache(1024*1024),
+		NewBucketStoreMetrics(nil),
 		WithLogger(s.logger),
 		WithIndexCache(s.cache),
 		WithFilterConfig(filterConf),

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -2,151 +2,194 @@
 // Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/storegateway/bucket_store_metrics.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
 
 package storegateway
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/mimir/pkg/util"
 )
 
-// BucketStoreMetrics aggregates metrics exported by Thanos Bucket Store
-// and re-exports those aggregates as Mimir metrics.
+// BucketStoreMetrics holds all the metrics tracked by BucketStore. These metrics
+// MUST be monotonic (counter, summary, histogram) because a single metrics instance
+// can be passed to multiple BucketStore and metrics MUST be correct even after a
+// BucketStore is offloaded.
 type BucketStoreMetrics struct {
+	blockLoads            prometheus.Counter
+	blockLoadFailures     prometheus.Counter
+	blockDrops            prometheus.Counter
+	blockDropFailures     prometheus.Counter
+	seriesDataTouched     *prometheus.SummaryVec
+	seriesDataFetched     *prometheus.SummaryVec
+	seriesDataSizeTouched *prometheus.SummaryVec
+	seriesDataSizeFetched *prometheus.SummaryVec
+	seriesBlocksQueried   prometheus.Summary
+	seriesGetAllDuration  prometheus.Histogram
+	seriesMergeDuration   prometheus.Histogram
+	resultSeriesCount     prometheus.Summary
+	chunkSizeBytes        prometheus.Histogram
+	queriesDropped        *prometheus.CounterVec
+	seriesRefetches       prometheus.Counter
+
+	cachedPostingsCompressions           *prometheus.CounterVec
+	cachedPostingsCompressionErrors      *prometheus.CounterVec
+	cachedPostingsCompressionTimeSeconds *prometheus.CounterVec
+	cachedPostingsOriginalSizeBytes      prometheus.Counter
+	cachedPostingsCompressedSizeBytes    prometheus.Counter
+
+	seriesHashCacheRequests prometheus.Counter
+	seriesHashCacheHits     prometheus.Counter
+
+	seriesFetchDuration   prometheus.Histogram
+	postingsFetchDuration prometheus.Histogram
+}
+
+func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
+	var m BucketStoreMetrics
+
+	m.blockLoads = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_block_loads_total",
+		Help: "Total number of remote block loading attempts.",
+	})
+	m.blockLoadFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_block_load_failures_total",
+		Help: "Total number of failed remote block loading attempts.",
+	})
+	m.blockDrops = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_block_drops_total",
+		Help: "Total number of local blocks that were dropped.",
+	})
+	m.blockDropFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_block_drop_failures_total",
+		Help: "Total number of local blocks that failed to be dropped.",
+	})
+
+	m.seriesDataTouched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name: "cortex_bucket_store_series_data_touched",
+		Help: "How many items of a data type in a block were touched for a single series request.",
+	}, []string{"data_type"})
+	m.seriesDataFetched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name: "cortex_bucket_store_series_data_fetched",
+		Help: "How many items of a data type in a block were fetched for a single series request.",
+	}, []string{"data_type"})
+
+	m.seriesDataSizeTouched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name: "cortex_bucket_store_series_data_size_touched_bytes",
+		Help: "Size of all items of a data type in a block were touched for a single series request.",
+	}, []string{"data_type"})
+	m.seriesDataSizeFetched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name: "cortex_bucket_store_series_data_size_fetched_bytes",
+		Help: "Size of all items of a data type in a block were fetched for a single series request.",
+	}, []string{"data_type"})
+
+	m.seriesBlocksQueried = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
+		Name: "cortex_bucket_store_series_blocks_queried",
+		Help: "Number of blocks in a bucket store that were touched to satisfy a query.",
+	})
+	m.seriesGetAllDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_series_get_all_duration_seconds",
+		Help:    "Time it takes until all per-block prepares and loads for a query are finished.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+	})
+	m.seriesMergeDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_series_merge_duration_seconds",
+		Help:    "Time it takes to merge sub-results from all queried blocks into a single result.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+	})
+	m.seriesRefetches = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_series_refetches_total",
+		Help: "Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.",
+	})
+	m.resultSeriesCount = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
+		Name: "cortex_bucket_store_series_result_series",
+		Help: "Number of series observed in the final result of a query.",
+	})
+	m.queriesDropped = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_queries_dropped_total",
+		Help: "Number of queries that were dropped due to the max chunks per query limit.",
+	}, []string{"reason"})
+
+	m.cachedPostingsCompressions = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_cached_postings_compressions_total",
+		Help: "Number of postings compressions and decompressions when storing to index cache.", // TODO also decompressions?
+	}, []string{"op"})
+	m.cachedPostingsCompressions.WithLabelValues(labelEncode)
+	m.cachedPostingsCompressions.WithLabelValues(labelDecode)
+
+	m.cachedPostingsCompressionErrors = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_cached_postings_compression_errors_total",
+		Help: "Number of postings compression and decompression errors.",
+	}, []string{"op"})
+	m.cachedPostingsCompressionErrors.WithLabelValues(labelEncode)
+	m.cachedPostingsCompressionErrors.WithLabelValues(labelDecode)
+
+	m.cachedPostingsCompressionTimeSeconds = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_cached_postings_compression_time_seconds",
+		Help: "Time spent compressing and decompressing postings when storing to / reading from postings cache.",
+	}, []string{"op"})
+	m.cachedPostingsCompressionTimeSeconds.WithLabelValues(labelEncode)
+	m.cachedPostingsCompressionTimeSeconds.WithLabelValues(labelDecode)
+
+	m.cachedPostingsOriginalSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_cached_postings_original_size_bytes_total",
+		Help: "Original size of postings stored into cache.",
+	})
+	m.cachedPostingsCompressedSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_cached_postings_compressed_size_bytes_total",
+		Help: "Compressed size of postings stored into cache.",
+	})
+
+	m.seriesFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_cached_series_fetch_duration_seconds",
+		Help:    "Time it takes to fetch series to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+	})
+	m.postingsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_cached_postings_fetch_duration_seconds",
+		Help:    "Time it takes to fetch postings to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+	})
+
+	m.seriesHashCacheRequests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_series_hash_cache_requests_total",
+		Help: "Total number of fetch attempts to the in-memory series hash cache.",
+	})
+	m.seriesHashCacheHits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_series_hash_cache_hits_total",
+		Help: "Total number of fetch hits to the in-memory series hash cache.",
+	})
+
+	m.chunkSizeBytes = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name: "cortex_bucket_store_sent_chunk_size_bytes",
+		Help: "Size in bytes of the chunks for the single series, which is adequate to the gRPC message size sent to querier.",
+		Buckets: []float64{
+			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
+		},
+	})
+
+	return &m
+}
+
+// IndexHeaderMetrics aggregates metrics exported by Thanos index-header lazy loader
+// and re-exports those aggregates as Mimir metrics.
+type IndexHeaderMetrics struct {
 	regs *util.UserRegistries
-
-	// exported metrics, gathered from Thanos BucketStore
-	blockLoads            *prometheus.Desc
-	blockLoadFailures     *prometheus.Desc
-	blockDrops            *prometheus.Desc
-	blockDropFailures     *prometheus.Desc
-	blocksLoaded          *prometheus.Desc
-	seriesDataTouched     *prometheus.Desc
-	seriesDataFetched     *prometheus.Desc
-	seriesDataSizeTouched *prometheus.Desc
-	seriesDataSizeFetched *prometheus.Desc
-	seriesBlocksQueried   *prometheus.Desc
-	seriesGetAllDuration  *prometheus.Desc
-	seriesMergeDuration   *prometheus.Desc
-	seriesRefetches       *prometheus.Desc
-	resultSeriesCount     *prometheus.Desc
-	queriesDropped        *prometheus.Desc
-
-	cachedPostingsCompressions           *prometheus.Desc
-	cachedPostingsCompressionErrors      *prometheus.Desc
-	cachedPostingsCompressionTimeSeconds *prometheus.Desc
-	cachedPostingsOriginalSizeBytes      *prometheus.Desc
-	cachedPostingsCompressedSizeBytes    *prometheus.Desc
-
-	seriesFetchDuration   *prometheus.Desc
-	postingsFetchDuration *prometheus.Desc
 
 	indexHeaderLazyLoadCount         *prometheus.Desc
 	indexHeaderLazyLoadFailedCount   *prometheus.Desc
 	indexHeaderLazyUnloadCount       *prometheus.Desc
 	indexHeaderLazyUnloadFailedCount *prometheus.Desc
 	indexHeaderLazyLoadDuration      *prometheus.Desc
-
-	seriesHashCacheRequests *prometheus.Desc
-	seriesHashCacheHits     *prometheus.Desc
 }
 
-func NewBucketStoreMetrics() *BucketStoreMetrics {
-	return &BucketStoreMetrics{
+func NewIndexHeaderMetrics() *IndexHeaderMetrics {
+	return &IndexHeaderMetrics{
 		regs: util.NewUserRegistries(),
-
-		blockLoads: prometheus.NewDesc(
-			"cortex_bucket_store_block_loads_total",
-			"Total number of remote block loading attempts.",
-			nil, nil),
-		blockLoadFailures: prometheus.NewDesc(
-			"cortex_bucket_store_block_load_failures_total",
-			"Total number of failed remote block loading attempts.",
-			nil, nil),
-		blockDrops: prometheus.NewDesc(
-			"cortex_bucket_store_block_drops_total",
-			"Total number of local blocks that were dropped.",
-			nil, nil),
-		blockDropFailures: prometheus.NewDesc(
-			"cortex_bucket_store_block_drop_failures_total",
-			"Total number of local blocks that failed to be dropped.",
-			nil, nil),
-		blocksLoaded: prometheus.NewDesc(
-			"cortex_bucket_store_blocks_loaded",
-			"Number of currently loaded blocks.",
-			nil, nil),
-		seriesDataTouched: prometheus.NewDesc(
-			"cortex_bucket_store_series_data_touched",
-			"How many items of a data type in a block were touched for a single series request.",
-			[]string{"data_type"}, nil),
-		seriesDataFetched: prometheus.NewDesc(
-			"cortex_bucket_store_series_data_fetched",
-			"How many items of a data type in a block were fetched for a single series request.",
-			[]string{"data_type"}, nil),
-		seriesDataSizeTouched: prometheus.NewDesc(
-			"cortex_bucket_store_series_data_size_touched_bytes",
-			"Size of all items of a data type in a block were touched for a single series request.",
-			[]string{"data_type"}, nil),
-		seriesDataSizeFetched: prometheus.NewDesc(
-			"cortex_bucket_store_series_data_size_fetched_bytes",
-			"Size of all items of a data type in a block were fetched for a single series request.",
-			[]string{"data_type"}, nil),
-		seriesBlocksQueried: prometheus.NewDesc(
-			"cortex_bucket_store_series_blocks_queried",
-			"Number of blocks in a bucket store that were touched to satisfy a query.",
-			nil, nil),
-
-		seriesGetAllDuration: prometheus.NewDesc(
-			"cortex_bucket_store_series_get_all_duration_seconds",
-			"Time it takes until all per-block prepares and preloads for a query are finished.",
-			nil, nil),
-		seriesMergeDuration: prometheus.NewDesc(
-			"cortex_bucket_store_series_merge_duration_seconds",
-			"Time it takes to merge sub-results from all queried blocks into a single result.",
-			nil, nil),
-		seriesRefetches: prometheus.NewDesc(
-			"cortex_bucket_store_series_refetches_total",
-			"Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.",
-			nil, nil),
-		resultSeriesCount: prometheus.NewDesc(
-			"cortex_bucket_store_series_result_series",
-			"Number of series observed in the final result of a query.",
-			nil, nil),
-		queriesDropped: prometheus.NewDesc(
-			"cortex_bucket_store_queries_dropped_total",
-			"Number of queries that were dropped due to the max chunks per query limit.",
-			nil, nil),
-
-		cachedPostingsCompressions: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_compressions_total",
-			"Number of postings compressions and decompressions when storing to index cache.",
-			[]string{"op"}, nil),
-		cachedPostingsCompressionErrors: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_compression_errors_total",
-			"Number of postings compression and decompression errors.",
-			[]string{"op"}, nil),
-		cachedPostingsCompressionTimeSeconds: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_compression_time_seconds",
-			"Time spent compressing and decompressing postings when storing to / reading from postings cache.",
-			[]string{"op"}, nil),
-		cachedPostingsOriginalSizeBytes: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_original_size_bytes_total",
-			"Original size of postings stored into cache.",
-			nil, nil),
-		cachedPostingsCompressedSizeBytes: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_compressed_size_bytes_total",
-			"Compressed size of postings stored into cache.",
-			nil, nil),
-
-		seriesFetchDuration: prometheus.NewDesc(
-			"cortex_bucket_store_cached_series_fetch_duration_seconds",
-			"Time it takes to fetch series to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.",
-			nil, nil),
-		postingsFetchDuration: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_fetch_duration_seconds",
-			"Time it takes to fetch postings to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.",
-			nil, nil),
 
 		indexHeaderLazyLoadCount: prometheus.NewDesc(
 			"cortex_bucket_store_indexheader_lazy_load_total",
@@ -168,99 +211,31 @@ func NewBucketStoreMetrics() *BucketStoreMetrics {
 			"cortex_bucket_store_indexheader_lazy_load_duration_seconds",
 			"Duration of the index-header lazy loading in seconds.",
 			nil, nil),
-
-		seriesHashCacheRequests: prometheus.NewDesc(
-			"cortex_bucket_store_series_hash_cache_requests_total",
-			"Total number of fetch attempts to the in-memory series hash cache.",
-			nil, nil),
-		seriesHashCacheHits: prometheus.NewDesc(
-			"cortex_bucket_store_series_hash_cache_hits_total",
-			"Total number of fetch hits to the in-memory series hash cache.",
-			nil, nil),
 	}
 }
 
-func (m *BucketStoreMetrics) AddUserRegistry(user string, reg *prometheus.Registry) {
+func (m *IndexHeaderMetrics) AddUserRegistry(user string, reg *prometheus.Registry) {
 	m.regs.AddUserRegistry(user, reg)
 }
 
-func (m *BucketStoreMetrics) RemoveUserRegistry(user string) {
+func (m *IndexHeaderMetrics) RemoveUserRegistry(user string) {
 	m.regs.RemoveUserRegistry(user, false)
 }
 
-func (m *BucketStoreMetrics) Describe(out chan<- *prometheus.Desc) {
-	out <- m.blockLoads
-	out <- m.blockLoadFailures
-	out <- m.blockDrops
-	out <- m.blockDropFailures
-	out <- m.blocksLoaded
-	out <- m.seriesDataTouched
-	out <- m.seriesDataFetched
-	out <- m.seriesDataSizeTouched
-	out <- m.seriesDataSizeFetched
-	out <- m.seriesBlocksQueried
-	out <- m.seriesGetAllDuration
-	out <- m.seriesMergeDuration
-	out <- m.seriesRefetches
-	out <- m.resultSeriesCount
-	out <- m.queriesDropped
-
-	out <- m.cachedPostingsCompressions
-	out <- m.cachedPostingsCompressionErrors
-	out <- m.cachedPostingsCompressionTimeSeconds
-	out <- m.cachedPostingsOriginalSizeBytes
-	out <- m.cachedPostingsCompressedSizeBytes
-
-	out <- m.seriesFetchDuration
-	out <- m.postingsFetchDuration
-
+func (m *IndexHeaderMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.indexHeaderLazyLoadCount
 	out <- m.indexHeaderLazyLoadFailedCount
 	out <- m.indexHeaderLazyUnloadCount
 	out <- m.indexHeaderLazyUnloadFailedCount
 	out <- m.indexHeaderLazyLoadDuration
-
-	out <- m.seriesHashCacheRequests
-	out <- m.seriesHashCacheHits
 }
 
-func (m *BucketStoreMetrics) Collect(out chan<- prometheus.Metric) {
+func (m *IndexHeaderMetrics) Collect(out chan<- prometheus.Metric) {
 	data := m.regs.BuildMetricFamiliesPerUser()
-
-	data.SendSumOfCounters(out, m.blockLoads, "thanos_bucket_store_block_loads_total")
-	data.SendSumOfCounters(out, m.blockLoadFailures, "thanos_bucket_store_block_load_failures_total")
-	data.SendSumOfCounters(out, m.blockDrops, "thanos_bucket_store_block_drops_total")
-	data.SendSumOfCounters(out, m.blockDropFailures, "thanos_bucket_store_block_drop_failures_total")
-
-	data.SendSumOfGauges(out, m.blocksLoaded, "thanos_bucket_store_blocks_loaded")
-
-	data.SendSumOfSummariesWithLabels(out, m.seriesDataTouched, "thanos_bucket_store_series_data_touched", "data_type")
-	data.SendSumOfSummariesWithLabels(out, m.seriesDataFetched, "thanos_bucket_store_series_data_fetched", "data_type")
-	data.SendSumOfSummariesWithLabels(out, m.seriesDataSizeTouched, "thanos_bucket_store_series_data_size_touched_bytes", "data_type")
-	data.SendSumOfSummariesWithLabels(out, m.seriesDataSizeFetched, "thanos_bucket_store_series_data_size_fetched_bytes", "data_type")
-	data.SendSumOfSummariesWithLabels(out, m.seriesBlocksQueried, "thanos_bucket_store_series_blocks_queried")
-
-	data.SendSumOfHistograms(out, m.seriesGetAllDuration, "thanos_bucket_store_series_get_all_duration_seconds")
-	data.SendSumOfHistograms(out, m.seriesMergeDuration, "thanos_bucket_store_series_merge_duration_seconds")
-	data.SendSumOfCounters(out, m.seriesRefetches, "thanos_bucket_store_series_refetches_total")
-	data.SendSumOfSummaries(out, m.resultSeriesCount, "thanos_bucket_store_series_result_series")
-	data.SendSumOfCounters(out, m.queriesDropped, "thanos_bucket_store_queries_dropped_total")
-
-	data.SendSumOfCountersWithLabels(out, m.cachedPostingsCompressions, "thanos_bucket_store_cached_postings_compressions_total", "op")
-	data.SendSumOfCountersWithLabels(out, m.cachedPostingsCompressionErrors, "thanos_bucket_store_cached_postings_compression_errors_total", "op")
-	data.SendSumOfCountersWithLabels(out, m.cachedPostingsCompressionTimeSeconds, "thanos_bucket_store_cached_postings_compression_time_seconds_total", "op")
-	data.SendSumOfCountersWithLabels(out, m.cachedPostingsOriginalSizeBytes, "thanos_bucket_store_cached_postings_original_size_bytes_total")
-	data.SendSumOfCountersWithLabels(out, m.cachedPostingsCompressedSizeBytes, "thanos_bucket_store_cached_postings_compressed_size_bytes_total")
-
-	data.SendSumOfHistograms(out, m.seriesFetchDuration, "thanos_bucket_store_cached_series_fetch_duration_seconds")
-	data.SendSumOfHistograms(out, m.postingsFetchDuration, "thanos_bucket_store_cached_postings_fetch_duration_seconds")
 
 	data.SendSumOfCounters(out, m.indexHeaderLazyLoadCount, "thanos_bucket_store_indexheader_lazy_load_total")
 	data.SendSumOfCounters(out, m.indexHeaderLazyLoadFailedCount, "thanos_bucket_store_indexheader_lazy_load_failed_total")
 	data.SendSumOfCounters(out, m.indexHeaderLazyUnloadCount, "thanos_bucket_store_indexheader_lazy_unload_total")
 	data.SendSumOfCounters(out, m.indexHeaderLazyUnloadFailedCount, "thanos_bucket_store_indexheader_lazy_unload_failed_total")
 	data.SendSumOfHistograms(out, m.indexHeaderLazyLoadDuration, "thanos_bucket_store_indexheader_lazy_load_duration_seconds")
-
-	data.SendSumOfCounters(out, m.seriesHashCacheRequests, "thanos_bucket_store_series_hash_cache_requests_total")
-	data.SendSumOfCounters(out, m.seriesHashCacheHits, "thanos_bucket_store_series_hash_cache_hits_total")
 }

--- a/pkg/storegateway/bucket_store_metrics_test.go
+++ b/pkg/storegateway/bucket_store_metrics_test.go
@@ -16,195 +16,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBucketStoreMetrics(t *testing.T) {
+func TestIndexHeaderMetrics(t *testing.T) {
 	mainReg := prometheus.NewPedanticRegistry()
 
-	tsdbMetrics := NewBucketStoreMetrics()
+	tsdbMetrics := NewIndexHeaderMetrics()
 	mainReg.MustRegister(tsdbMetrics)
 
-	tsdbMetrics.AddUserRegistry("user1", populateMockedBucketStoreMetrics(5328))
-	tsdbMetrics.AddUserRegistry("user2", populateMockedBucketStoreMetrics(6908))
-	tsdbMetrics.AddUserRegistry("user3", populateMockedBucketStoreMetrics(10283))
+	tsdbMetrics.AddUserRegistry("user1", populateMockedIndexHeaderMetrics(5328))
+	tsdbMetrics.AddUserRegistry("user2", populateMockedIndexHeaderMetrics(6908))
+	tsdbMetrics.AddUserRegistry("user3", populateMockedIndexHeaderMetrics(10283))
 
 	//noinspection ALL
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
-			# HELP cortex_bucket_store_blocks_loaded Number of currently loaded blocks.
-			# TYPE cortex_bucket_store_blocks_loaded gauge
-			cortex_bucket_store_blocks_loaded 22519
-
-			# HELP cortex_bucket_store_block_loads_total Total number of remote block loading attempts.
-			# TYPE cortex_bucket_store_block_loads_total counter
-			cortex_bucket_store_block_loads_total 45038
-
-			# HELP cortex_bucket_store_block_load_failures_total Total number of failed remote block loading attempts.
-			# TYPE cortex_bucket_store_block_load_failures_total counter
-			cortex_bucket_store_block_load_failures_total 67557
-
-			# HELP cortex_bucket_store_block_drops_total Total number of local blocks that were dropped.
-			# TYPE cortex_bucket_store_block_drops_total counter
-			cortex_bucket_store_block_drops_total 90076
-
-			# HELP cortex_bucket_store_block_drop_failures_total Total number of local blocks that failed to be dropped.
-			# TYPE cortex_bucket_store_block_drop_failures_total counter
-			cortex_bucket_store_block_drop_failures_total 112595
-
-			# HELP cortex_bucket_store_series_blocks_queried Number of blocks in a bucket store that were touched to satisfy a query.
-			# TYPE cortex_bucket_store_series_blocks_queried summary
-			cortex_bucket_store_series_blocks_queried_sum 1.283583e+06
-			cortex_bucket_store_series_blocks_queried_count 9
-
-			# HELP cortex_bucket_store_series_data_fetched How many items of a data type in a block were fetched for a single series request.
-			# TYPE cortex_bucket_store_series_data_fetched summary
-			cortex_bucket_store_series_data_fetched_sum{data_type="fetched-a"} 202671
-			cortex_bucket_store_series_data_fetched_count{data_type="fetched-a"} 3
-			cortex_bucket_store_series_data_fetched_sum{data_type="fetched-b"} 225190
-			cortex_bucket_store_series_data_fetched_count{data_type="fetched-b"} 3
-			cortex_bucket_store_series_data_fetched_sum{data_type="fetched-c"} 247709
-			cortex_bucket_store_series_data_fetched_count{data_type="fetched-c"} 3
-
-			# HELP cortex_bucket_store_series_data_size_fetched_bytes Size of all items of a data type in a block were fetched for a single series request.
-			# TYPE cortex_bucket_store_series_data_size_fetched_bytes summary
-			cortex_bucket_store_series_data_size_fetched_bytes_sum{data_type="size-fetched-a"} 337785
-			cortex_bucket_store_series_data_size_fetched_bytes_count{data_type="size-fetched-a"} 3
-			cortex_bucket_store_series_data_size_fetched_bytes_sum{data_type="size-fetched-b"} 360304
-			cortex_bucket_store_series_data_size_fetched_bytes_count{data_type="size-fetched-b"} 3
-			cortex_bucket_store_series_data_size_fetched_bytes_sum{data_type="size-fetched-c"} 382823
-			cortex_bucket_store_series_data_size_fetched_bytes_count{data_type="size-fetched-c"} 3
-
-			# HELP cortex_bucket_store_series_data_size_touched_bytes Size of all items of a data type in a block were touched for a single series request.
-			# TYPE cortex_bucket_store_series_data_size_touched_bytes summary
-			cortex_bucket_store_series_data_size_touched_bytes_sum{data_type="size-touched-a"} 270228
-			cortex_bucket_store_series_data_size_touched_bytes_count{data_type="size-touched-a"} 3
-			cortex_bucket_store_series_data_size_touched_bytes_sum{data_type="size-touched-b"} 292747
-			cortex_bucket_store_series_data_size_touched_bytes_count{data_type="size-touched-b"} 3
-			cortex_bucket_store_series_data_size_touched_bytes_sum{data_type="size-touched-c"} 315266
-			cortex_bucket_store_series_data_size_touched_bytes_count{data_type="size-touched-c"} 3
-
-			# HELP cortex_bucket_store_series_data_touched How many items of a data type in a block were touched for a single series request.
-			# TYPE cortex_bucket_store_series_data_touched summary
-			cortex_bucket_store_series_data_touched_sum{data_type="touched-a"} 135114
-			cortex_bucket_store_series_data_touched_count{data_type="touched-a"} 3
-			cortex_bucket_store_series_data_touched_sum{data_type="touched-b"} 157633
-			cortex_bucket_store_series_data_touched_count{data_type="touched-b"} 3
-			cortex_bucket_store_series_data_touched_sum{data_type="touched-c"} 180152
-			cortex_bucket_store_series_data_touched_count{data_type="touched-c"} 3
-
-			# HELP cortex_bucket_store_series_get_all_duration_seconds Time it takes until all per-block prepares and preloads for a query are finished.
-			# TYPE cortex_bucket_store_series_get_all_duration_seconds histogram
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="0.001"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="0.01"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="0.1"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="0.3"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="0.6"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="1"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="3"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="6"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="9"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="20"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="30"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="60"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="90"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="120"} 0
-			cortex_bucket_store_series_get_all_duration_seconds_bucket{le="+Inf"} 9
-			cortex_bucket_store_series_get_all_duration_seconds_sum 1.486254e+06
-			cortex_bucket_store_series_get_all_duration_seconds_count 9
-
-			# HELP cortex_bucket_store_series_merge_duration_seconds Time it takes to merge sub-results from all queried blocks into a single result.
-			# TYPE cortex_bucket_store_series_merge_duration_seconds histogram
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="0.001"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="0.01"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="0.1"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="0.3"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="0.6"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="1"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="3"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="6"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="9"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="20"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="30"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="60"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="90"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="120"} 0
-			cortex_bucket_store_series_merge_duration_seconds_bucket{le="+Inf"} 9
-			cortex_bucket_store_series_merge_duration_seconds_sum 1.688925e+06
-			cortex_bucket_store_series_merge_duration_seconds_count 9
-
-			# HELP cortex_bucket_store_series_refetches_total Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.
-			# TYPE cortex_bucket_store_series_refetches_total counter
-			cortex_bucket_store_series_refetches_total 743127
-
-			# HELP cortex_bucket_store_series_result_series Number of series observed in the final result of a query.
-			# TYPE cortex_bucket_store_series_result_series summary
-			cortex_bucket_store_series_result_series_sum 1.238545e+06
-			cortex_bucket_store_series_result_series_count 6
-
-			# HELP cortex_bucket_store_queries_dropped_total Number of queries that were dropped due to the max chunks per query limit.
-			# TYPE cortex_bucket_store_queries_dropped_total counter
-			cortex_bucket_store_queries_dropped_total 698089
-
-			# HELP cortex_bucket_store_cached_postings_compressions_total Number of postings compressions and decompressions when storing to index cache.
-			# TYPE cortex_bucket_store_cached_postings_compressions_total counter
-			cortex_bucket_store_cached_postings_compressions_total{op="encode"} 1125950
-			cortex_bucket_store_cached_postings_compressions_total{op="decode"} 1148469
-
-			# HELP cortex_bucket_store_cached_postings_compression_errors_total Number of postings compression and decompression errors.
-			# TYPE cortex_bucket_store_cached_postings_compression_errors_total counter
-			cortex_bucket_store_cached_postings_compression_errors_total{op="encode"} 1170988
-			cortex_bucket_store_cached_postings_compression_errors_total{op="decode"} 1193507
-
-			# HELP cortex_bucket_store_cached_postings_compression_time_seconds Time spent compressing and decompressing postings when storing to / reading from postings cache.
-			# TYPE cortex_bucket_store_cached_postings_compression_time_seconds counter
-			cortex_bucket_store_cached_postings_compression_time_seconds{op="encode"} 1216026
-			cortex_bucket_store_cached_postings_compression_time_seconds{op="decode"} 1238545
-
-			# HELP cortex_bucket_store_cached_postings_original_size_bytes_total Original size of postings stored into cache.
-			# TYPE cortex_bucket_store_cached_postings_original_size_bytes_total counter
-			cortex_bucket_store_cached_postings_original_size_bytes_total 1261064
-
-			# HELP cortex_bucket_store_cached_postings_compressed_size_bytes_total Compressed size of postings stored into cache.
-			# TYPE cortex_bucket_store_cached_postings_compressed_size_bytes_total counter
-			cortex_bucket_store_cached_postings_compressed_size_bytes_total 1283583
-
-			# HELP cortex_bucket_store_cached_series_fetch_duration_seconds Time it takes to fetch series to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.
-			# TYPE cortex_bucket_store_cached_series_fetch_duration_seconds histogram
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="0.001"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="0.01"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="0.1"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="0.3"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="0.6"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="1"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="3"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="6"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="9"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="20"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="30"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="60"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="90"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="120"} 0
-			cortex_bucket_store_cached_series_fetch_duration_seconds_bucket{le="+Inf"} 3
-			cortex_bucket_store_cached_series_fetch_duration_seconds_sum 1.306102e+06
-			cortex_bucket_store_cached_series_fetch_duration_seconds_count 3
-
-			# HELP cortex_bucket_store_cached_postings_fetch_duration_seconds Time it takes to fetch postings to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.
-			# TYPE cortex_bucket_store_cached_postings_fetch_duration_seconds histogram
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="0.001"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="0.01"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="0.1"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="0.3"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="0.6"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="1"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="3"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="6"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="9"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="20"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="30"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="60"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="90"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="120"} 0
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_bucket{le="+Inf"} 3
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_sum 1.328621e+06
-			cortex_bucket_store_cached_postings_fetch_duration_seconds_count 3
-
 			# HELP cortex_bucket_store_indexheader_lazy_load_duration_seconds Duration of the index-header lazy loading in seconds.
 			# TYPE cortex_bucket_store_indexheader_lazy_load_duration_seconds histogram
 			cortex_bucket_store_indexheader_lazy_load_duration_seconds_bucket{le="0.01"} 0
@@ -235,14 +58,6 @@ func TestBucketStoreMetrics(t *testing.T) {
 			# HELP cortex_bucket_store_indexheader_lazy_unload_total Total number of index-header lazy unload operations.
 			# TYPE cortex_bucket_store_indexheader_lazy_unload_total counter
 			cortex_bucket_store_indexheader_lazy_unload_total 1.396178e+06
-
-			# HELP cortex_bucket_store_series_hash_cache_requests_total Total number of fetch attempts to the in-memory series hash cache.
-			# TYPE cortex_bucket_store_series_hash_cache_requests_total counter
-			cortex_bucket_store_series_hash_cache_requests_total 1.486254e+06
-
-			# HELP cortex_bucket_store_series_hash_cache_hits_total Total number of fetch hits to the in-memory series hash cache.
-			# TYPE cortex_bucket_store_series_hash_cache_hits_total counter
-			cortex_bucket_store_series_hash_cache_hits_total 1.508773e+06
 `))
 	require.NoError(t, err)
 }
@@ -266,12 +81,12 @@ func BenchmarkMetricsCollections10000(b *testing.B) {
 func benchmarkMetricsCollection(b *testing.B, users int) {
 	mainReg := prometheus.NewRegistry()
 
-	tsdbMetrics := NewBucketStoreMetrics()
+	tsdbMetrics := NewIndexHeaderMetrics()
 	mainReg.MustRegister(tsdbMetrics)
 
 	base := 123456.0
 	for i := 0; i < users; i++ {
-		tsdbMetrics.AddUserRegistry(fmt.Sprintf("user-%d", i), populateMockedBucketStoreMetrics(base*float64(i)))
+		tsdbMetrics.AddUserRegistry(fmt.Sprintf("user-%d", i), populateMockedIndexHeaderMetrics(base*float64(i)))
 	}
 
 	b.ResetTimer()
@@ -280,68 +95,9 @@ func benchmarkMetricsCollection(b *testing.B, users int) {
 	}
 }
 
-func populateMockedBucketStoreMetrics(base float64) *prometheus.Registry {
+func populateMockedIndexHeaderMetrics(base float64) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
-	m := newMockedBucketStoreMetrics(reg)
-
-	m.blocksLoaded.Add(1 * base)
-	m.blockLoads.Add(2 * base)
-	m.blockLoadFailures.Add(3 * base)
-	m.blockDrops.Add(4 * base)
-	m.blockDropFailures.Add(5 * base)
-	m.seriesDataTouched.WithLabelValues("touched-a").Observe(6 * base)
-	m.seriesDataTouched.WithLabelValues("touched-b").Observe(7 * base)
-	m.seriesDataTouched.WithLabelValues("touched-c").Observe(8 * base)
-
-	m.seriesDataFetched.WithLabelValues("fetched-a").Observe(9 * base)
-	m.seriesDataFetched.WithLabelValues("fetched-b").Observe(10 * base)
-	m.seriesDataFetched.WithLabelValues("fetched-c").Observe(11 * base)
-
-	m.seriesDataSizeTouched.WithLabelValues("size-touched-a").Observe(12 * base)
-	m.seriesDataSizeTouched.WithLabelValues("size-touched-b").Observe(13 * base)
-	m.seriesDataSizeTouched.WithLabelValues("size-touched-c").Observe(14 * base)
-
-	m.seriesDataSizeFetched.WithLabelValues("size-fetched-a").Observe(15 * base)
-	m.seriesDataSizeFetched.WithLabelValues("size-fetched-b").Observe(16 * base)
-	m.seriesDataSizeFetched.WithLabelValues("size-fetched-c").Observe(17 * base)
-
-	m.seriesBlocksQueried.Observe(18 * base)
-	m.seriesBlocksQueried.Observe(19 * base)
-	m.seriesBlocksQueried.Observe(20 * base)
-
-	m.seriesGetAllDuration.Observe(21 * base)
-	m.seriesGetAllDuration.Observe(22 * base)
-	m.seriesGetAllDuration.Observe(23 * base)
-
-	m.seriesMergeDuration.Observe(24 * base)
-	m.seriesMergeDuration.Observe(25 * base)
-	m.seriesMergeDuration.Observe(26 * base)
-
-	m.resultSeriesCount.Observe(27 * base)
-	m.resultSeriesCount.Observe(28 * base)
-
-	m.chunkSizeBytes.Observe(29 * base)
-	m.chunkSizeBytes.Observe(30 * base)
-
-	m.queriesDropped.WithLabelValues("chunks").Add(31 * base)
-	m.queriesDropped.WithLabelValues("series").Add(0)
-
-	m.seriesRefetches.Add(33 * base)
-
-	m.cachedPostingsCompressions.WithLabelValues("encode").Add(50 * base)
-	m.cachedPostingsCompressions.WithLabelValues("decode").Add(51 * base)
-
-	m.cachedPostingsCompressionErrors.WithLabelValues("encode").Add(52 * base)
-	m.cachedPostingsCompressionErrors.WithLabelValues("decode").Add(53 * base)
-
-	m.cachedPostingsCompressionTimeSeconds.WithLabelValues("encode").Add(54 * base)
-	m.cachedPostingsCompressionTimeSeconds.WithLabelValues("decode").Add(55 * base)
-
-	m.cachedPostingsOriginalSizeBytes.Add(56 * base)
-	m.cachedPostingsCompressedSizeBytes.Add(57 * base)
-
-	m.seriesFetchDuration.Observe(58 * base)
-	m.postingsFetchDuration.Observe(59 * base)
+	m := newMockedIndexHeaderMetrics(reg)
 
 	m.indexHeaderLazyLoadCount.Add(60 * base)
 	m.indexHeaderLazyLoadFailedCount.Add(61 * base)
@@ -349,159 +105,19 @@ func populateMockedBucketStoreMetrics(base float64) *prometheus.Registry {
 	m.indexHeaderLazyUnloadFailedCount.Add(63 * base)
 	m.indexHeaderLazyLoadDuration.Observe(0.65)
 
-	m.seriesHashCacheRequests.Add(66 * base)
-	m.seriesHashCacheHits.Add(67 * base)
-
 	return reg
 }
 
-// copied from Thanos, pkg/store/bucket.go
-type mockedBucketStoreMetrics struct {
-	blocksLoaded          prometheus.Gauge
-	blockLoads            prometheus.Counter
-	blockLoadFailures     prometheus.Counter
-	blockDrops            prometheus.Counter
-	blockDropFailures     prometheus.Counter
-	seriesDataTouched     *prometheus.SummaryVec
-	seriesDataFetched     *prometheus.SummaryVec
-	seriesDataSizeTouched *prometheus.SummaryVec
-	seriesDataSizeFetched *prometheus.SummaryVec
-	seriesBlocksQueried   prometheus.Summary
-	seriesGetAllDuration  prometheus.Histogram
-	seriesMergeDuration   prometheus.Histogram
-	seriesRefetches       prometheus.Counter
-	resultSeriesCount     prometheus.Summary
-	chunkSizeBytes        prometheus.Histogram
-	queriesDropped        *prometheus.CounterVec
-
-	cachedPostingsCompressions           *prometheus.CounterVec
-	cachedPostingsCompressionErrors      *prometheus.CounterVec
-	cachedPostingsCompressionTimeSeconds *prometheus.CounterVec
-	cachedPostingsOriginalSizeBytes      prometheus.Counter
-	cachedPostingsCompressedSizeBytes    prometheus.Counter
-
-	seriesFetchDuration   prometheus.Histogram
-	postingsFetchDuration prometheus.Histogram
-
+type mockedIndexHeaderMetrics struct {
 	indexHeaderLazyLoadCount         prometheus.Counter
 	indexHeaderLazyLoadFailedCount   prometheus.Counter
 	indexHeaderLazyUnloadCount       prometheus.Counter
 	indexHeaderLazyUnloadFailedCount prometheus.Counter
 	indexHeaderLazyLoadDuration      prometheus.Histogram
-
-	seriesHashCacheRequests prometheus.Counter
-	seriesHashCacheHits     prometheus.Counter
 }
 
-func newMockedBucketStoreMetrics(reg prometheus.Registerer) *mockedBucketStoreMetrics {
-	var m mockedBucketStoreMetrics
-
-	m.blockLoads = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_block_loads_total",
-		Help: "Total number of remote block loading attempts.",
-	})
-	m.blockLoadFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_block_load_failures_total",
-		Help: "Total number of failed remote block loading attempts.",
-	})
-	m.blockDrops = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_block_drops_total",
-		Help: "Total number of local blocks that were dropped.",
-	})
-	m.blockDropFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_block_drop_failures_total",
-		Help: "Total number of local blocks that failed to be dropped.",
-	})
-	m.blocksLoaded = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "thanos_bucket_store_blocks_loaded",
-		Help: "Number of currently loaded blocks.",
-	})
-
-	m.seriesDataTouched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_data_touched",
-		Help: "How many items of a data type in a block were touched for a single series request.",
-	}, []string{"data_type"})
-	m.seriesDataFetched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_data_fetched",
-		Help: "How many items of a data type in a block were fetched for a single series request.",
-	}, []string{"data_type"})
-
-	m.seriesDataSizeTouched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_data_size_touched_bytes",
-		Help: "Size of all items of a data type in a block were touched for a single series request.",
-	}, []string{"data_type"})
-	m.seriesDataSizeFetched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_data_size_fetched_bytes",
-		Help: "Size of all items of a data type in a block were fetched for a single series request.",
-	}, []string{"data_type"})
-
-	m.seriesBlocksQueried = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_blocks_queried",
-		Help: "Number of blocks in a bucket store that were touched to satisfy a query.",
-	})
-	m.seriesGetAllDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_series_get_all_duration_seconds",
-		Help:    "Time it takes until all per-block prepares and preloads for a query are finished.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
-	m.seriesMergeDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_series_merge_duration_seconds",
-		Help:    "Time it takes to merge sub-results from all queried blocks into a single result.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
-	m.resultSeriesCount = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_result_series",
-		Help: "Number of series observed in the final result of a query.",
-	})
-
-	m.chunkSizeBytes = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name: "thanos_bucket_store_sent_chunk_size_bytes",
-		Help: "Size in bytes of the chunks for the single series, which is adequate to the gRPC message size sent to querier.",
-		Buckets: []float64{
-			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
-		},
-	})
-
-	m.queriesDropped = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_queries_dropped_total",
-		Help: "Number of queries that were dropped due to the limit.",
-	}, []string{"reason"})
-	m.seriesRefetches = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_series_refetches_total",
-		Help: fmt.Sprintf("Total number of cases where %v bytes was not enough was to fetch series from index, resulting in refetch.", 64*1024),
-	})
-
-	m.cachedPostingsCompressions = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_cached_postings_compressions_total",
-		Help: "Number of postings compressions before storing to index cache.",
-	}, []string{"op"})
-	m.cachedPostingsCompressionErrors = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_cached_postings_compression_errors_total",
-		Help: "Number of postings compression errors.",
-	}, []string{"op"})
-	m.cachedPostingsCompressionTimeSeconds = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_cached_postings_compression_time_seconds_total",
-		Help: "Time spent compressing postings before storing them into postings cache.",
-	}, []string{"op"})
-	m.cachedPostingsOriginalSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_cached_postings_original_size_bytes_total",
-		Help: "Original size of postings stored into cache.",
-	})
-	m.cachedPostingsCompressedSizeBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_cached_postings_compressed_size_bytes_total",
-		Help: "Compressed size of postings stored into cache.",
-	})
-
-	m.seriesFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_cached_series_fetch_duration_seconds",
-		Help:    "Time it takes to fetch series from a bucket to respond a query. It also includes the time it takes to cache fetch and store operations.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
-	m.postingsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "thanos_bucket_store_cached_postings_fetch_duration_seconds",
-		Help:    "Time it takes to fetch postings from a bucket to respond a query. It also includes the time it takes to cache fetch and store operations.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	})
+func newMockedIndexHeaderMetrics(reg prometheus.Registerer) *mockedIndexHeaderMetrics {
+	var m mockedIndexHeaderMetrics
 
 	m.indexHeaderLazyLoadCount = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_bucket_store_indexheader_lazy_load_total",
@@ -523,15 +139,6 @@ func newMockedBucketStoreMetrics(reg prometheus.Registerer) *mockedBucketStoreMe
 		Name:    "thanos_bucket_store_indexheader_lazy_load_duration_seconds",
 		Help:    "Duration of the index-header lazy loading in seconds.",
 		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5},
-	})
-
-	m.seriesHashCacheRequests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_series_hash_cache_requests_total",
-		Help: "Total number of fetch attempts to the in-memory series hash cache.",
-	})
-	m.seriesHashCacheHits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_bucket_store_series_hash_cache_hits_total",
-		Help: "Total number of fetch hits to the in-memory series hash cache.",
 	})
 
 	return &m

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -223,7 +223,7 @@ func TestBucketBlock_matchLabels(t *testing.T) {
 		},
 	}
 
-	b, err := newBucketBlock(context.Background(), log.NewNopLogger(), newBucketStoreMetrics(nil), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil)
+	b, err := newBucketBlock(context.Background(), log.NewNopLogger(), NewBucketStoreMetrics(nil), meta, bkt, path.Join(dir, blockID.String()), nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	cases := []struct {
@@ -529,6 +529,7 @@ func TestBucketStore_Info(t *testing.T) {
 		false,
 		0,
 		NewSeriesHashCache(1024*1024),
+		NewBucketStoreMetrics(nil),
 		WithChunkPool(chunkPool),
 		WithFilterConfig(allowAllFilterConf),
 	)
@@ -778,6 +779,7 @@ func testSharding(t *testing.T, reuseDisk string, bkt objstore.Bucket, all ...ul
 				false,
 				0,
 				NewSeriesHashCache(1024*1024),
+				NewBucketStoreMetrics(nil),
 				WithLogger(logger),
 				WithFilterConfig(allowAllFilterConf),
 			)
@@ -863,7 +865,7 @@ func expectedTouchedBlockOps(all, expected, cached []ulid.ULID) []string {
 func TestReadIndexCache_LoadSeries(t *testing.T) {
 	bkt := objstore.NewInMemBucket()
 
-	s := newBucketStoreMetrics(nil)
+	s := NewBucketStoreMetrics(nil)
 	b := &bucketBlock{
 		meta: &metadata.Meta{
 			BlockMeta: tsdb.BlockMeta{
@@ -1083,7 +1085,7 @@ func benchmarkExpandedPostings(
 		t.Run(c.name, func(t test.TB) {
 			b := &bucketBlock{
 				logger:            log.NewNopLogger(),
-				metrics:           newBucketStoreMetrics(nil),
+				metrics:           NewBucketStoreMetrics(nil),
 				indexHeaderReader: r,
 				indexCache:        noopCache{},
 				bkt:               bkt,
@@ -1213,6 +1215,7 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 		false,
 		0,
 		NewSeriesHashCache(1024*1024),
+		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithChunkPool(chunkPool),
 	)
@@ -1364,7 +1367,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		b1 = &bucketBlock{
 			indexCache:  indexCache,
 			logger:      logger,
-			metrics:     newBucketStoreMetrics(nil),
+			metrics:     NewBucketStoreMetrics(nil),
 			bkt:         bkt,
 			meta:        meta,
 			partitioner: newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
@@ -1403,7 +1406,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		b2 = &bucketBlock{
 			indexCache:  indexCache,
 			logger:      logger,
-			metrics:     newBucketStoreMetrics(nil),
+			metrics:     NewBucketStoreMetrics(nil),
 			bkt:         bkt,
 			meta:        meta,
 			partitioner: newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
@@ -1419,7 +1422,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		logger:          logger,
 		indexCache:      indexCache,
 		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, nil),
-		metrics:         newBucketStoreMetrics(nil),
+		metrics:         NewBucketStoreMetrics(nil),
 		blockSets: map[uint64]*bucketBlockSet{
 			labels.Labels{{Name: "ext1", Value: "1"}}.Hash(): {blocks: [][]*bucketBlock{{b1, b2}}},
 		},
@@ -1579,6 +1582,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		false,
 		0,
 		NewSeriesHashCache(1024*1024),
+		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -1670,6 +1674,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		false,
 		0,
 		NewSeriesHashCache(1024*1024),
+		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -1854,6 +1859,7 @@ func setupStoreForHintsTest(t *testing.T) (test.TB, *BucketStore, []*storepb.Ser
 		false,
 		0,
 		NewSeriesHashCache(1024*1024),
+		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
 	)
@@ -2067,7 +2073,7 @@ func BenchmarkBucketBlock_readChunkRange(b *testing.B) {
 	assert.NoError(b, err)
 
 	// Create a bucket block with only the dependencies we need for the benchmark.
-	blk, err := newBucketBlock(context.Background(), logger, newBucketStoreMetrics(nil), blockMeta, bkt, tmpDir, nil, chunkPool, nil, nil)
+	blk, err := newBucketBlock(context.Background(), logger, NewBucketStoreMetrics(nil), blockMeta, bkt, tmpDir, nil, chunkPool, nil, nil)
 	assert.NoError(b, err)
 
 	b.ResetTimer()
@@ -2162,7 +2168,7 @@ func prepareBucket(b *testing.B, resolutionLevel compact.ResolutionLevel) (*buck
 	assert.NoError(b, err)
 
 	// Create a bucket block with only the dependencies we need for the benchmark.
-	blk, err := newBucketBlock(context.Background(), logger, newBucketStoreMetrics(nil), blockMeta, bkt, tmpDir, indexCache, chunkPool, indexHeaderReader, partitioner)
+	blk, err := newBucketBlock(context.Background(), logger, NewBucketStoreMetrics(nil), blockMeta, bkt, tmpDir, indexCache, chunkPool, indexHeaderReader, partitioner)
 	assert.NoError(b, err)
 	return blk, blockMeta
 }


### PR DESCRIPTION
**What this PR does**:
Now that we imported Thanos `BucketStore` into Mimir, we can simplify the `BucketStore` metrics and avoid having to aggregate its metrics via Registerer wrapper (we still need it for index-header lazy loader metrics, which I will try to address separately in Thanos).

I've done a manual test and I think the refactoring is a noop from the user perspective, except that will use less CPU and memory to export metrics from store-gateway if you have a large number of tenants.

**Which issue(s) this PR fixes**:
Fixes partially #102

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
