### PR TITLE
doc-generator: Remove check for stale type cortex.moduleName

### DIFF
--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -254,8 +254,6 @@ func getFieldType(t reflect.Type) (string, error) {
 		return "url", nil
 	case "time.Duration":
 		return "duration", nil
-	case "cortex.moduleName":
-		return "string", nil
 	case "flagext.StringSliceCSV":
 		return "string", nil
 	case "flagext.CIDRSliceCSV":


### PR DESCRIPTION
**What this PR does**:
In doc-generator, remove check for type `cortex.moduleName`, which according to @pracucci has been removed.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
