### PR TITLE
fix off-by-one error in unit test helper function

### DIFF
--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -127,14 +127,14 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 			{
 				Labels: mkZLabels("__name__", "first", "a", "a"),
 				Chunks: []storepb.AggrChunk{
-					createAggrChunkWithSineSamples(now, now.Add(100*time.Second), 3*time.Millisecond), // floor(100 / 0.003) samples (= 33333)
+					createAggrChunkWithSineSamples(now, now.Add(100*time.Second-time.Millisecond), 3*time.Millisecond), // ceil(100 / 0.003) samples (= 33334)
 				},
 			},
 			// continuation of previous series. Must have exact same labels.
 			{
 				Labels: mkZLabels("__name__", "first", "a", "a"),
 				Chunks: []storepb.AggrChunk{
-					createAggrChunkWithSineSamples(now.Add(100*time.Second), now.Add(200*time.Second), 3*time.Millisecond), // floor(100 / 0.003) samples more, 66666 in total
+					createAggrChunkWithSineSamples(now.Add(100*time.Second), now.Add(200*time.Second-time.Millisecond), 3*time.Millisecond), // ceil(100 / 0.003) samples (= 33334) samples more, 66668 in total
 				},
 			},
 			// second, with multiple chunks


### PR DESCRIPTION
The unit tests in `pkg/querier` rely on the helper function `createAggrChunkWithSineSamples` to generate mock chunks, but that function assumes that the `MinTime`/`MaxTime` properties of `storepb.AggrChunk` are inclusive/exclusive. The real `storepb.AggrChunk` are using times which are inclusive/inclusive so the mock chunks should be inclusive/inclusive as well. This fixes the helper function and adjusts the test using it accordingly.