### PR TITLE
Do no execute a non shardable query in the query-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,18 @@
 * [CHANGE] Ingester: default `-ingester.min-ready-duration` reduced from 1m to 15s. #126
 * [CHANGE] Ingester: `-ingester.min-ready-duration` now start counting the delay after the ring's health checks have passed instead of when the ring client was started. #126
 * [CHANGE] Blocks storage: memcached client DNS resolution switched from golang built-in to [`miekg/dns`](https://github.com/miekg/dns). #142
+* [CHANGE] Query-frontend: the `cortex_frontend_mapped_asts_total` metric has been renamed to `cortex_frontend_query_sharding_rewrites_attempted_total`. #150
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
-* [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage. You can now enabled querysharding for blocks storage (`-store.engine=blocks`) by setting `-querier.parallelise-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148
+* [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage. You can now enabled querysharding for blocks storage (`-store.engine=blocks`) by setting `-querier.parallelise-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150
   * New config options:
     * `-querier.total-shards`: The amount of shards to use when doing parallelisation via query sharding.
     * `-blocks-storage.bucket-store.series-hash-cache-max-size-bytes`: Max size - in bytes - of the in-memory series hash cache in the store-gateway.
   * New exported metrics:
     * `cortex_bucket_store_series_hash_cache_requests_total`
     * `cortex_bucket_store_series_hash_cache_hits_total`
+    * `cortex_frontend_query_sharding_rewrites_succeeded_total`
+  * Renamed metrics:
+    * `cortex_frontend_mapped_asts_total` to `cortex_frontend_query_sharding_rewrites_attempted_total`
 * [FEATURE] PromQL: added `present_over_time` support. #139
 * [ENHANCEMENT] Include additional limits in the per-tenant override exporter. The following limits have been added to the `cortex_overrides` metric: #21
   * `max_fetched_series_per_query`
@@ -38,6 +42,7 @@
 * [ENHANCEMENT] Added option `-distributor.excluded-zones` to exclude ingesters running in specific zones both on write and read path. #51
 * [ENHANCEMENT] Store-gateway: added `cortex_bucket_store_sent_chunk_size_bytes` metric, tracking the size of chunks sent from store-gateway to querier. #123
 * [ENHANCEMENT] Store-gateway: reduced CPU and memory utilization due to exported metrics aggregation for instances with a large number of tenants. #123 #142
+* [ENHANCEMENT] Query-frontend: if query sharding is enabled and a query is not shardable, then the query is executed by querier instead of query-frontend. #150
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16
 * [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #28
 

--- a/pkg/querier/astmapper/astmapper.go
+++ b/pkg/querier/astmapper/astmapper.go
@@ -12,14 +12,16 @@ import (
 
 // ASTMapper is the exported interface for mapping between multiple AST representations
 type ASTMapper interface {
-	Map(node parser.Node) (parser.Node, error)
+	// Map the input node and returns the mapped node as well as whether the
+	// returned mapped node has been rewritten in a shardable way.
+	Map(node parser.Node) (mapped parser.Node, sharded bool, err error)
 }
 
 // MapperFunc is a function adapter for ASTMapper
-type MapperFunc func(node parser.Node) (parser.Node, error)
+type MapperFunc func(node parser.Node) (parser.Node, bool, error)
 
 // Map applies a mapperfunc as an ASTMapper
-func (fn MapperFunc) Map(node parser.Node) (parser.Node, error) {
+func (fn MapperFunc) Map(node parser.Node) (parser.Node, bool, error) {
 	return fn(node)
 }
 
@@ -29,22 +31,27 @@ type MultiMapper struct {
 }
 
 // Map implements ASTMapper
-func (m *MultiMapper) Map(node parser.Node) (parser.Node, error) {
+func (m *MultiMapper) Map(node parser.Node) (parser.Node, bool, error) {
 	var result parser.Node = node
 	var err error
 
 	if len(m.mappers) == 0 {
-		return nil, errors.New("MultiMapper: No mappers registered")
+		return nil, false, errors.New("MultiMapper: No mappers registered")
 	}
 
+	sharded := false
 	for _, x := range m.mappers {
-		result, err = x.Map(result)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return result, nil
+		var s bool
 
+		result, s, err = x.Map(result)
+		if err != nil {
+			return nil, false, err
+		}
+
+		sharded = sharded || s
+	}
+
+	return result, sharded, nil
 }
 
 // Register adds ASTMappers into a multimapper.
@@ -54,7 +61,7 @@ func (m *MultiMapper) Register(xs ...ASTMapper) {
 	m.mappers = append(m.mappers, xs...)
 }
 
-// NewMultiMapper instaniates an ASTMapper from multiple ASTMappers
+// NewMultiMapper instantiates an ASTMapper from multiple ASTMappers.
 func NewMultiMapper(xs ...ASTMapper) *MultiMapper {
 	m := &MultiMapper{}
 	m.Register(xs...)
@@ -66,19 +73,19 @@ func CloneNode(node parser.Node) (parser.Node, error) {
 	return parser.ParseExpr(node.String())
 }
 
-// NodeMapper either maps a single AST node or returns the unaltered node.
-// It also returns a bool to signal that no further recursion is necessary.
-// This is helpful because it allows mappers to only implement logic for node types they want to change.
-// It makes some mappers trivially easy to implement
 type NodeMapper interface {
-	MapNode(node parser.Node) (mapped parser.Node, finished bool, err error)
+	// MapNode either maps a single AST node or returns the unaltered node.
+	// It returns a finished bool to signal that no further recursion is necessary,
+	// and a sharded bool to signal whether the returned mapped node has been
+	// rewritten in a shardable way.
+	MapNode(node parser.Node) (mapped parser.Node, finished, sharded bool, err error)
 }
 
 // NodeMapperFunc is an adapter for NodeMapper
-type NodeMapperFunc func(node parser.Node) (parser.Node, bool, error)
+type NodeMapperFunc func(node parser.Node) (parser.Node, bool, bool, error)
 
 // MapNode applies a NodeMapperFunc as a NodeMapper
-func (f NodeMapperFunc) MapNode(node parser.Node) (parser.Node, bool, error) {
+func (f NodeMapperFunc) MapNode(node parser.Node) (parser.Node, bool, bool, error) {
 	return f(node)
 }
 
@@ -93,100 +100,109 @@ type ASTNodeMapper struct {
 }
 
 // Map implements ASTMapper from a NodeMapper
-func (nm ASTNodeMapper) Map(node parser.Node) (parser.Node, error) {
-	node, fin, err := nm.MapNode(node)
-
+func (nm ASTNodeMapper) Map(node parser.Node) (parser.Node, bool, error) {
+	node, finished, sharded, err := nm.MapNode(node)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	if fin {
-		return node, nil
+	if finished {
+		return node, sharded, nil
 	}
 
 	switch n := node.(type) {
 	case nil:
 		// nil handles cases where we check optional fields that are not set
-		return nil, nil
+		return nil, false, nil
 
 	case parser.Expressions:
 		for i, e := range n {
-			mapped, err := nm.Map(e)
+			mapped, s, err := nm.Map(e)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			n[i] = mapped.(parser.Expr)
+			sharded = sharded || s
 		}
-		return n, nil
+		return n, sharded, nil
 
 	case *parser.AggregateExpr:
-		expr, err := nm.Map(n.Expr)
+		expr, s, err := nm.Map(n.Expr)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.Expr = expr.(parser.Expr)
-		return n, nil
+		sharded = sharded || s
+		return n, sharded, nil
 
 	case *parser.BinaryExpr:
-		lhs, err := nm.Map(n.LHS)
+		lhs, s, err := nm.Map(n.LHS)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.LHS = lhs.(parser.Expr)
+		sharded = sharded || s
 
-		rhs, err := nm.Map(n.RHS)
+		rhs, s, err := nm.Map(n.RHS)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.RHS = rhs.(parser.Expr)
-		return n, nil
+		sharded = sharded || s
+
+		return n, sharded, nil
 
 	case *parser.Call:
 		for i, e := range n.Args {
-			mapped, err := nm.Map(e)
+			mapped, s, err := nm.Map(e)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			n.Args[i] = mapped.(parser.Expr)
+			sharded = sharded || s
 		}
-		return n, nil
+		return n, sharded, nil
 
 	case *parser.SubqueryExpr:
-		mapped, err := nm.Map(n.Expr)
+		mapped, s, err := nm.Map(n.Expr)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.Expr = mapped.(parser.Expr)
-		return n, nil
+		sharded = sharded || s
+		return n, sharded, nil
 
 	case *parser.ParenExpr:
-		mapped, err := nm.Map(n.Expr)
+		mapped, s, err := nm.Map(n.Expr)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.Expr = mapped.(parser.Expr)
-		return n, nil
+		sharded = sharded || s
+		return n, sharded, nil
 
 	case *parser.UnaryExpr:
-		mapped, err := nm.Map(n.Expr)
+		mapped, s, err := nm.Map(n.Expr)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.Expr = mapped.(parser.Expr)
-		return n, nil
+		sharded = sharded || s
+		return n, sharded, nil
 
 	case *parser.EvalStmt:
-		mapped, err := nm.Map(n.Expr)
+		mapped, s, err := nm.Map(n.Expr)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		n.Expr = mapped.(parser.Expr)
-		return n, nil
+		sharded = sharded || s
+		return n, sharded, nil
 
 	case *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector, *parser.MatrixSelector:
-		return n, nil
+		return n, false, nil
 
 	default:
-		return nil, errors.Errorf("nodeMapper: unhandled node type %T", node)
+		return nil, false, errors.Errorf("nodeMapper: unhandled node type %T", node)
 	}
 }

--- a/pkg/querier/astmapper/sharding.go
+++ b/pkg/querier/astmapper/sharding.go
@@ -62,63 +62,63 @@ func (summer *shardSummer) CopyWithCurShard(curshard int) *shardSummer {
 }
 
 // shardSummer expands a query AST by sharding and re-summing when possible
-func (summer *shardSummer) MapNode(node parser.Node) (parser.Node, bool, error) {
+func (summer *shardSummer) MapNode(node parser.Node) (mapped parser.Node, finished, sharded bool, err error) {
 	switch n := node.(type) {
 	case *parser.AggregateExpr:
 		if CanParallelize(n) {
 			return summer.shardAggregate(n)
 		}
-		return n, false, nil
+		return n, false, false, nil
 
 	case *parser.VectorSelector:
 		if summer.currentShard != nil {
 			mapped, err := shardVectorSelector(*summer.currentShard, summer.shards, n)
-			return mapped, true, err
+			return mapped, true, true, err
 		}
-		return n, true, nil
+		return n, true, false, nil
 
 	case *parser.MatrixSelector:
 		if summer.currentShard != nil {
 			mapped, err := shardMatrixSelector(*summer.currentShard, summer.shards, n)
-			return mapped, true, err
+			return mapped, true, true, err
 		}
-		return n, true, nil
+		return n, true, false, nil
 
 	default:
-		return n, false, nil
+		return n, false, false, nil
 	}
 }
 
 // shardSum contains the logic for how we split/stitch legs of a parallelized sum query
-func (summer *shardSummer) shardAggregate(expr *parser.AggregateExpr) (parser.Node, bool, error) {
+func (summer *shardSummer) shardAggregate(expr *parser.AggregateExpr) (mapped parser.Node, finished, sharded bool, err error) {
 	switch expr.Op {
 	case parser.SUM:
-		mapped, err := summer.splitSum(expr)
+		mapped, err = summer.splitSum(expr)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
-		return mapped, true, nil
+		return mapped, true, true, nil
 	case parser.COUNT:
-		mapped, err := summer.splitCount(expr)
+		mapped, err = summer.splitCount(expr)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
-		return mapped, true, nil
+		return mapped, true, true, nil
 	case parser.MAX, parser.MIN:
-		mapped, err := summer.splitMinMax(expr)
+		mapped, err = summer.splitMinMax(expr)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
-		return mapped, true, nil
+		return mapped, true, true, nil
 	case parser.AVG:
-		mapped, err := summer.splitAvg(expr)
+		mapped, err = summer.splitAvg(expr)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
-		return mapped, true, nil
+		return mapped, true, true, nil
 	}
 
-	return nil, false, nil
+	return nil, false, false, nil
 }
 
 // splitSum forms the parent and child legs of a parallel query
@@ -187,7 +187,7 @@ func (summer *shardSummer) splitSum(
 		}
 
 		subSummer := NewASTNodeMapper(summer.CopyWithCurShard(i))
-		sharded, err := subSummer.Map(cloned)
+		sharded, _, err := subSummer.Map(cloned)
 		if err != nil {
 			return nil, err
 		}
@@ -239,7 +239,7 @@ func (summer *shardSummer) splitCount(
 		}
 
 		subSummer := NewASTNodeMapper(summer.CopyWithCurShard(i))
-		sharded, err := subSummer.Map(cloned)
+		sharded, _, err := subSummer.Map(cloned)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ func (summer *shardSummer) splitMinMax(
 		}
 
 		subSummer := NewASTNodeMapper(summer.CopyWithCurShard(i))
-		sharded, err := subSummer.Map(cloned)
+		sharded, _, err := subSummer.Map(cloned)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +337,7 @@ func (summer *shardSummer) splitAvg(
 		}
 
 		subSummer := NewASTNodeMapper(summer.CopyWithCurShard(i))
-		sharded, err := subSummer.Map(cloned)
+		sharded, _, err := subSummer.Map(cloned)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +377,7 @@ func (summer *shardSummer) splitAvg(
 		}
 
 		subSummer := NewASTNodeMapper(summer.CopyWithCurShard(i))
-		sharded, err := subSummer.Map(cloned)
+		sharded, _, err := subSummer.Map(cloned)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/querier/astmapper/sharding_test.go
+++ b/pkg/querier/astmapper/sharding_test.go
@@ -253,7 +253,7 @@ func Test_Mapping(t *testing.T) {
 			require.NoError(t, err)
 			out, err := parser.ParseExpr(tt.out)
 			require.NoError(t, err)
-			mapped, err := mapper.Map(expr)
+			mapped, _, err := mapper.Map(expr)
 			require.NoError(t, err)
 			require.Equal(t,
 				out.String(),
@@ -297,7 +297,7 @@ func TestShardSummerWithEncoding(t *testing.T) {
 			require.Nil(t, err)
 			expr, err := parser.ParseExpr(c.input)
 			require.Nil(t, err)
-			res, err := summer.Map(expr)
+			res, _, err := summer.Map(expr)
 			require.Nil(t, err)
 
 			expected, err := parser.ParseExpr(c.expected)

--- a/pkg/querier/astmapper/subtree_folder_test.go
+++ b/pkg/querier/astmapper/subtree_folder_test.go
@@ -105,7 +105,7 @@ func TestSubtreeMapper(t *testing.T) {
 
 			expr, err := parser.ParseExpr(tc.input)
 			require.Nil(t, err)
-			res, err := mapper.Map(expr)
+			res, _, err := mapper.Map(expr)
 			require.Nil(t, err)
 
 			expected, err := parser.ParseExpr(tc.expected)

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -11,15 +11,19 @@ import (
 	"math"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -212,97 +216,126 @@ func TestQueryShardingCorrectness(t *testing.T) {
 	)
 
 	tests := map[string]struct {
-		query string
+		query             string
+		expectedShardable bool
 	}{
 		"sum() no grouping": {
-			query: `sum(metric_counter)`,
+			query:             `sum(metric_counter)`,
+			expectedShardable: true,
 		},
 		"sum() grouping 'by'": {
-			query: `sum by(group_1) (metric_counter)`,
+			query:             `sum by(group_1) (metric_counter)`,
+			expectedShardable: true,
 		},
 		"sum() grouping 'without'": {
-			query: `sum without(unique) (metric_counter)`,
+			query:             `sum without(unique) (metric_counter)`,
+			expectedShardable: true,
 		},
 		"sum(rate()) no grouping": {
-			query: `sum(rate(metric_counter[1m]))`,
+			query:             `sum(rate(metric_counter[1m]))`,
+			expectedShardable: true,
 		},
 		"sum(rate()) grouping 'by'": {
-			query: `sum by(group_1) (rate(metric_counter[1m]))`,
+			query:             `sum by(group_1) (rate(metric_counter[1m]))`,
+			expectedShardable: true,
 		},
 		"sum(rate()) grouping 'without'": {
-			query: `sum without(unique) (rate(metric_counter[1m]))`,
+			query:             `sum without(unique) (rate(metric_counter[1m]))`,
+			expectedShardable: true,
 		},
 		"histogram_quantile() no grouping": {
-			query: `histogram_quantile(0.5, sum by(le) (rate(metric_histogram_bucket[1m])))`,
+			query:             `histogram_quantile(0.5, sum by(le) (rate(metric_histogram_bucket[1m])))`,
+			expectedShardable: true,
 		},
 		"histogram_quantile() grouping 'by'": {
-			query: `histogram_quantile(0.5, sum by(group_1, le) (rate(metric_histogram_bucket[1m])))`,
+			query:             `histogram_quantile(0.5, sum by(group_1, le) (rate(metric_histogram_bucket[1m])))`,
+			expectedShardable: true,
 		},
 		"histogram_quantile() grouping 'without'": {
-			query: `histogram_quantile(0.5, sum without(group_1, group_2, unique) (rate(metric_histogram_bucket[1m])))`,
+			query:             `histogram_quantile(0.5, sum without(group_1, group_2, unique) (rate(metric_histogram_bucket[1m])))`,
+			expectedShardable: true,
 		},
 		"min() no grouping": {
-			query: `min(metric_counter{group_1="0"})`,
+			query:             `min(metric_counter{group_1="0"})`,
+			expectedShardable: true,
 		},
 		"min() grouping 'by'": {
-			query: `min by(group_2) (metric_counter{group_1="0"})`,
+			query:             `min by(group_2) (metric_counter{group_1="0"})`,
+			expectedShardable: true,
 		},
 		"min() grouping 'without'": {
-			query: `min without(unique) (metric_counter{group_1="0"})`,
+			query:             `min without(unique) (metric_counter{group_1="0"})`,
+			expectedShardable: true,
 		},
 		"max() no grouping": {
-			query: `max(metric_counter{group_1="0"})`,
+			query:             `max(metric_counter{group_1="0"})`,
+			expectedShardable: true,
 		},
 		"max() grouping 'by'": {
-			query: `max by(group_2) (metric_counter{group_1="0"})`,
+			query:             `max by(group_2) (metric_counter{group_1="0"})`,
+			expectedShardable: true,
 		},
 		"max() grouping 'without'": {
-			query: `max without(unique) (metric_counter{group_1="0"})`,
+			query:             `max without(unique) (metric_counter{group_1="0"})`,
+			expectedShardable: true,
 		},
 		"count() no grouping": {
-			query: `count(metric_counter)`,
+			query:             `count(metric_counter)`,
+			expectedShardable: true,
 		},
 		"count() grouping 'by'": {
-			query: `count by(group_2) (metric_counter)`,
+			query:             `count by(group_2) (metric_counter)`,
+			expectedShardable: true,
 		},
 		"count() grouping 'without'": {
-			query: `count without(unique) (metric_counter)`,
+			query:             `count without(unique) (metric_counter)`,
+			expectedShardable: true,
 		},
 		"sum(count())": {
-			query: `sum(count by(group_1) (metric_counter))`,
+			query:             `sum(count by(group_1) (metric_counter))`,
+			expectedShardable: true,
 		},
 		"avg() no grouping": {
-			query: `avg(metric_counter)`,
+			query:             `avg(metric_counter)`,
+			expectedShardable: true,
 		},
 		"avg() grouping 'by'": {
-			query: `avg by(group_2) (metric_counter)`,
+			query:             `avg by(group_2) (metric_counter)`,
+			expectedShardable: true,
 		},
 		"avg() grouping 'without'": {
-			query: `avg without(unique) (metric_counter)`,
+			query:             `avg without(unique) (metric_counter)`,
+			expectedShardable: true,
 		},
 		"sum(min_over_time())": {
-			query: `sum by (group_1, group_2) (min_over_time(metric_counter{const="fixed"}[2m]))`,
+			query:             `sum by (group_1, group_2) (min_over_time(metric_counter{const="fixed"}[2m]))`,
+			expectedShardable: true,
 		},
 		"sum(max_over_time())": {
-			query: `sum by (group_1, group_2) (max_over_time(metric_counter{const="fixed"}[2m]))`,
+			query:             `sum by (group_1, group_2) (max_over_time(metric_counter{const="fixed"}[2m]))`,
+			expectedShardable: true,
 		},
 		"sum(avg_over_time())": {
-			query: `sum by (group_1, group_2) (avg_over_time(metric_counter{const="fixed"}[2m]))`,
+			query:             `sum by (group_1, group_2) (avg_over_time(metric_counter{const="fixed"}[2m]))`,
+			expectedShardable: true,
 		},
 		"or": {
-			query: `sum(rate(metric_counter{group_1="0"}[1m])) or sum(rate(metric_counter{group_1="1"}[1m]))`,
+			query:             `sum(rate(metric_counter{group_1="0"}[1m])) or sum(rate(metric_counter{group_1="1"}[1m]))`,
+			expectedShardable: true,
 		},
 		"and": {
 			query: `
 				sum without(unique) (rate(metric_counter{group_1="0"}[1m]))
 				and
 				max without(unique) (metric_counter) > 0`,
+			expectedShardable: true,
 		},
 		"sum(rate()) > avg(rate())": {
 			query: `
 				sum(rate(metric_counter[1m]))
 				>
 				avg(rate(metric_counter[1m]))`,
+			expectedShardable: true,
 		},
 		"nested count()": {
 			query: `sum(
@@ -310,16 +343,19 @@ func TestQueryShardingCorrectness(t *testing.T) {
 				    count(metric_counter) by (group_1, group_2)
 				  ) by (group_1)
 				)`,
+			expectedShardable: true,
 		},
 
 		//
 		// The following queries are not expected to be shardable.
 		//
 		"stddev()": {
-			query: `stddev(metric_counter{const="fixed"})`,
+			query:             `stddev(metric_counter{const="fixed"})`,
+			expectedShardable: false,
 		},
 		"stdvar()": {
-			query: `stdvar(metric_counter{const="fixed"})`,
+			query:             `stdvar(metric_counter{const="fixed"})`,
+			expectedShardable: false,
 		},
 	}
 
@@ -371,11 +407,12 @@ func TestQueryShardingCorrectness(t *testing.T) {
 					Step:  step.Milliseconds(),
 				}
 
+				reg := prometheus.NewPedanticRegistry()
 				shardingware := NewQueryShardingMiddleware(
 					log.NewNopLogger(),
 					engine,
 					numShards,
-					nil,
+					reg,
 				)
 				downstream := &downstreamHandler{
 					engine:    engine,
@@ -397,6 +434,24 @@ func TestQueryShardingCorrectness(t *testing.T) {
 				// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
 				// if you rerun the same query twice).
 				approximatelyEquals(t, expectedRes.(*PrometheusResponse), shardedRes.(*PrometheusResponse))
+
+				// Ensure the query has been sharded/not sharded as expected.
+				expectedSharded := 0
+				if testData.expectedShardable {
+					expectedSharded = 1
+				}
+
+				assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_frontend_query_sharding_rewrites_attempted_total Total number of queries the query-frontend attempted to shard.
+					# TYPE cortex_frontend_query_sharding_rewrites_attempted_total counter
+					cortex_frontend_query_sharding_rewrites_attempted_total 1
+
+					# HELP cortex_frontend_query_sharding_rewrites_succeeded_total Total number of queries the query-frontend successfully rewritten in a shardable way.
+					# TYPE cortex_frontend_query_sharding_rewrites_succeeded_total counter
+					cortex_frontend_query_sharding_rewrites_succeeded_total %d
+				`, expectedSharded)),
+					"cortex_frontend_query_sharding_rewrites_attempted_total",
+					"cortex_frontend_query_sharding_rewrites_succeeded_total"))
 			})
 		}
 	}


### PR DESCRIPTION
**What this PR does**:
When query sharding is enabled the query-frontend retries to rewrite the query in a shardable way. If the query can't be sharded, then the PromQL engine is still executed in the query-frontend while we should bypass it completely and fallback to the normal query execution path. This PR should address it.

Since we don't have a safe way to know if a query has been sharded or not, I've added a `bool` flag returned by the mapping functions, telling if the query was successfully rewritten in a shardable way or not.

Originally, I think the AST mapper was implemented in a generic way while adding a `sharded bool` makes it specific, but at the end of the day it's just used by query sharding and the generalisation doesn't bring any actual benefit today, so I don't think it's a big deal (also I see some generalisation may go away in future refactorings, getting down to the point the whole logic is specifically suited for the query sharding).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
