### PR TITLE
Upgrade prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ replace github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915
 replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20210820163747-fbe211d3a873
+replace github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20210824070104-175efada22fe
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,8 @@ github.com/grafana/dskit v0.0.0-20210818123532-6645f87e9e12 h1:tTI5ZeCBbGhSwyGBK
 github.com/grafana/dskit v0.0.0-20210818123532-6645f87e9e12/go.mod h1:QaNAQaCSFOtG/NHf6Jd/zh67H25kkrVCq36U61Y2Mhw=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
-github.com/grafana/prometheus-private v0.0.0-20210820163747-fbe211d3a873 h1:OydS5BbNmAMXrdr741mVh4/M7uQnBOrm/3z1Jns/evQ=
-github.com/grafana/prometheus-private v0.0.0-20210820163747-fbe211d3a873/go.mod h1:ZHczEifRAgXT0ypud2xADA4wVWymlQeZiPAzEvTNDas=
+github.com/grafana/prometheus-private v0.0.0-20210824070104-175efada22fe h1:gSl+jzW12DkGyUfiYAolWrJUJD5IYB40ib+glkHTtRw=
+github.com/grafana/prometheus-private v0.0.0-20210824070104-175efada22fe/go.mod h1:ZHczEifRAgXT0ypud2xADA4wVWymlQeZiPAzEvTNDas=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -497,7 +497,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20210720123808-b1ed4a0a663d => github.com/grafana/prometheus-private v0.0.0-20210820163747-fbe211d3a873
+# github.com/prometheus/prometheus v1.8.2-0.20210720123808-b1ed4a0a663d => github.com/grafana/prometheus-private v0.0.0-20210824070104-175efada22fe
 ## explicit
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1067,7 +1067,7 @@ sigs.k8s.io/yaml
 # k8s.io/api => k8s.io/api v0.20.4
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-# github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20210820163747-fbe211d3a873
+# github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20210824070104-175efada22fe
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # google.golang.org/grpc => google.golang.org/grpc v1.38.0


### PR DESCRIPTION
**What this PR does**:
Upgrading Prometheus to cherry-pick the WAL replay deadlock fix (https://github.com/prometheus/prometheus/pull/9170).

Not updated CHANGELOG since it's not a bugfix compared to the previous stable release.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
