### PR TITLE
Fix flaky TestBucketStore_e2e

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1617,7 +1617,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	// so that they will span across multiple chunks.
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = filepath.Join(tmpDir, "block")
-	headOpts.ChunkRange = 10000000000
+	headOpts.ChunkRange = math.MaxInt64
 
 	h, err := tsdb.NewHead(nil, nil, nil, headOpts, nil)
 	assert.NoError(t, err)

--- a/pkg/storegateway/helpers_test.go
+++ b/pkg/storegateway/helpers_test.go
@@ -6,6 +6,7 @@ package storegateway
 
 import (
 	"context"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -50,7 +51,7 @@ func createBlock(
 ) (id ulid.ULID, err error) {
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = filepath.Join(dir, "chunks")
-	headOpts.ChunkRange = 10000000000
+	headOpts.ChunkRange = math.MaxInt64
 	h, err := tsdb.NewHead(nil, nil, nil, headOpts, nil)
 	if err != nil {
 		return id, errors.Wrap(err, "create head block")


### PR DESCRIPTION
**What this PR does**:
This PR fixes `TestBucketStore_e2e` flakyness.

I noticed the test failed in a [CI run](https://github.com/grafana/mimir/pull/179/checks?check_run_id=3434034129) with the following output (snippet):
```
--- FAIL: TestBucketStore_ManyParts_e2e (0.25s)
    --- FAIL: TestBucketStore_ManyParts_e2e/inmem (0.25s)
        --- FAIL: TestBucketStore_ManyParts_e2e/inmem/0 (0.01s)
            bucket_e2e_test.go:450: 
                	Error Trace:	bucket_e2e_test.go:450
                	Error:      	Not equal: 
                	            	expected: 3
                	            	actual  : 4
                	Test:       	TestBucketStore_ManyParts_e2e/inmem/0
```

Basically we got 1 more chunk than expected query querying the block.

I've been able to reproduce it locally and after a while I was debugging it, the issue stopped. What? How is it possible? I guessed it had something to do with `time.Now()` and I've seen it was used in `prepareStoreWithTestBlocks()`:
https://github.com/grafana/mimir/blob/c0a7b234d9ccbca237cd3f1fd2d3c41a96c22b55/pkg/storegateway/bucket_e2e_test.go#L170

So, I've tried to set the timestamp to the time while I was debugging and it was failing and... test failed again!
```
now, err := time.Parse(time.RFC3339, "2021-08-26T15:30:00Z")
require.NoError(t, err)
minTime, maxTime := prepareTestBlocks(t, now, 3, dir, bkt, series, extLset)
```

This allowed me to further investigate it and fix it. The reason is that `createBlock()` utility sets `headOpts.ChunkRange = 10000000000`, which also controls the time ranges at which a new chunk is cut. This means that every one in a 10000000000ms period the `createBlock()` function create series with 1 more chunk than expected because the chunk is cut even if it's not full because of crossing the `ChunkRange` time range.

Setting `headOpts.ChunkRange = math.MaxInt64` avoids this issue.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
