### PR TITLE
Replace uses of service.StopAsync in scheduler tests

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -271,7 +271,7 @@ func TestSchedulerShutdown_FrontendLoop(t *testing.T) {
 	frontendLoop := initFrontendLoop(t, frontendClient, "frontend-12345")
 
 	// Stop the scheduler. This will disable receiving new requests from frontends.
-	scheduler.StopAsync()
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), scheduler))
 
 	// We can still send request to scheduler, but we get shutdown error back.
 	require.NoError(t, frontendLoop.Send(&schedulerpb.FrontendToScheduler{
@@ -307,7 +307,7 @@ func TestSchedulerShutdown_QuerierLoop(t *testing.T) {
 	_, err = querierLoop.Recv()
 	require.NoError(t, err)
 
-	scheduler.StopAsync()
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), scheduler))
 
 	// Unblock scheduler loop, to find next request.
 	err = querierLoop.Send(&schedulerpb.QuerierToScheduler{})


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**What this PR does**:

Replace uses of the method service.StopAsync in scheduler tests that
expect the scheduler to return a SHUTTING_DOWN response. The new method
stops the service (scheduler) and waits until it has entered the
terminated state. This ensures that the tests don't fail if they run too
fast and the service has not completed terminating yet (and thus wouldn't
return a SHUTTING_DOWN response).

**Which issue(s) this PR fixes**:

Fixes #186

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
