### PR TITLE
Fix dev config for exemplars.

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -40,7 +40,6 @@ blocks_storage:
     ship_interval: 1m
     block_ranges_period: [ 2h ]
     retention_period: 3h
-    max_exemplars: 5000
 
   bucket_store:
     sync_dir: /tmp/mimir-tsdb-querier
@@ -156,6 +155,7 @@ query_range:
 limits:
   # Limit max query time range to 31d
   max_query_length: 744h
+  max_global_exemplars_per_user: 5000
 
 runtime_config:
   file: ./config/runtime.yaml


### PR DESCRIPTION
**What this PR does**: This PR fixes exemplars config in `tsdb-blocks-storage-s3`. Found while testing https://github.com/grafana/mimir/pull/193
