### PR TITLE
Increase allowed delta between sharded queriers in integration tests

### DIFF
--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -186,7 +186,11 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	if cfg.shuffleShardingEnabled {
 		require.Equal(t, float64(numQueries), diff)
 	} else {
-		require.InDelta(t, 0, diff, numQueries*0.20) // Both queriers should have roughly equal number of requests, with possible delta.
+		// Both queriers should have roughly equal number of requests, with possible delta. 50% delta is
+		// picked to be small enough so that load between queriers would not be wildly different (allow a
+		// max difference of 25 queries vs 75 queries) but tolerant of the variability of doing something
+		// probabilistic like this with such a small sample size (only 100 queries).
+		require.InDelta(t, 0, diff, numQueries*0.50)
 	}
 
 	// Ensure no service-specific metrics prefix is used by the wrong service.


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**What this PR does**:

Increase the allowed difference in number of queries handled by each sharded
querier during integration tests to %50 of the total number of queries. This
number is picked to verify that each querier handles _some_ non-trivial portion
of the requests but we allow for the variability we often see in these tests.

**Checklist**

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
