### PR TITLE
Add query sharding integration test case to TestQuerierWithBlocksStorageRunningInMicroservicesMode

### DIFF
--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -228,7 +228,7 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
-			expectedFetchedSeries += 1 // Storage only.
+			expectedFetchedSeries++ // Storage only.
 
 			result, err = c.Query("series_2", series2Timestamp)
 			require.NoError(t, err)
@@ -240,7 +240,7 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector3, result.(model.Vector))
-			expectedFetchedSeries += 1 // Ingester only.
+			expectedFetchedSeries++ // Ingester only.
 
 			// Check the in-memory index cache metrics (in the store-gateway).
 			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(7), "thanos_store_index_cache_requests_total"))
@@ -258,7 +258,7 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
-			expectedFetchedSeries += 1 // Storage only.
+			expectedFetchedSeries++ // Storage only.
 
 			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(7+2), "thanos_store_index_cache_requests_total"))
 			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2), "thanos_store_index_cache_hits_total")) // this time has used the index cache


### PR DESCRIPTION
**What this PR does**:
`TestQuerierWithBlocksStorageRunningInMicroservicesMode` is the read-path integration test both fetching data from ingesters and long-term storage. Due to its complexity, instead of adding a new test for the query sharding "smoke test", I've added a new test case to `TestQuerierWithBlocksStorageRunningInMicroservicesMode`. I've also took the opportunity to add an assertion on "query stats" to make sure it keeps working when query sharding is enabled.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
