### PR TITLE
Add more traces to blockSeries()

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1095,7 +1095,7 @@ func benchmarkExpandedPostings(
 				partitioner:       newGapBasedPartitioner(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 			}
 
-			indexr := newBucketIndexReader(context.Background(), b)
+			indexr := newBucketIndexReader(b)
 
 			t.ResetTimer()
 			for i := 0; i < t.N(); i++ {
@@ -2232,7 +2232,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 				// must be called only from the goroutine running the Benchmark function.
 				require.NoError(b, err)
 
-				indexReader := blk.indexReader(ctx)
+				indexReader := blk.indexReader()
 				chunkReader := blk.chunkReader(ctx)
 
 				seriesSet, _, err := blockSeries(context.Background(), nil, indexReader, chunkReader, matchers, shardSelector, seriesHashCache, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates)


### PR DESCRIPTION
**What this PR does**:
If you look at store-gateway traces, basically all time is spent in `blockSeries()` but we have no visibility over its internals. In this PR I'm proposing to add few more spans to have a better understanding how time is spent there.

Given we typically query few blocks from storage (we expect to query at least 2h compacted blocks), I don't expect this change to flood our traces with spans.

An example:
![Screenshot 2021-09-17 at 16 53 46](https://user-images.githubusercontent.com/1701904/133803837-df30ade4-93d7-4417-8184-5899cbe26952.png)


**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
