### PR TITLE
Fixes bad PromQL status code in the frontend.

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -7,11 +7,13 @@ package queryrange
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/weaveworks/common/httpgrpc"
 )
 
 type IntervalFn func(r Request) time.Duration
@@ -94,7 +96,7 @@ func splitQuery(r Request, interval time.Duration) ([]Request, error) {
 func evaluateAtModifierFunction(query string, start, end int64) (string, error) {
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return "", err
+		return "", httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
 		if selector, ok := n.(*parser.VectorSelector); ok {
@@ -108,7 +110,7 @@ func evaluateAtModifierFunction(query string, start, end int64) (string, error) 
 		}
 		return nil
 	})
-	return expr.String(), err
+	return expr.String(), nil
 }
 
 // Round up to the step before the next interval boundary.


### PR DESCRIPTION
This was introduced by #206, this is because the frontend will by default convert any error into 500.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

**Checklist**

- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]` I don't think we need one ?
