### PR TITLE
Use concatenation for ShardSelector label value

### DIFF
--- a/pkg/querier/astmapper/sharding.go
+++ b/pkg/querier/astmapper/sharding.go
@@ -338,7 +338,7 @@ func (summer *shardSummer) shardAndSquashAggregateExpr(expr *parser.AggregateExp
 }
 
 func shardVectorSelector(curshard, shards int, selector *parser.VectorSelector) (parser.Node, error) {
-	shardMatcher, err := labels.NewMatcher(labels.MatchEqual, querysharding.ShardLabel, fmt.Sprintf(querysharding.ShardLabelFmt, curshard, shards))
+	shardMatcher, err := querysharding.ShardSelector{ShardIndex: uint64(curshard), ShardCount: uint64(shards)}.LabelMatcher()
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +356,7 @@ func shardVectorSelector(curshard, shards int, selector *parser.VectorSelector) 
 }
 
 func shardMatrixSelector(curshard, shards int, selector *parser.MatrixSelector) (parser.Node, error) {
-	shardMatcher, err := labels.NewMatcher(labels.MatchEqual, querysharding.ShardLabel, fmt.Sprintf(querysharding.ShardLabelFmt, curshard, shards))
+	shardMatcher, err := querysharding.ShardSelector{ShardIndex: uint64(curshard), ShardCount: uint64(shards)}.LabelMatcher()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/querysharding/label_test.go
+++ b/pkg/querier/querysharding/label_test.go
@@ -170,3 +170,10 @@ func TestShardFromMatchers(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkShardSelector_LabelValue(b *testing.B) {
+	for i := 0; i <= b.N; i++ {
+		selector := ShardSelector{ShardIndex: uint64(i % 3), ShardCount: uint64(i % 7)}
+		_ = selector.LabelValue()
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

While getting familiar with the code I saw this and I decided to do a
quick commit to replace a fmt.Printf call with a concatenation (and then
ended up using a stringbuilder)

This is 3x faster, well, we're talking about just 80ns, but still, why
waste time on parsing the format template, etc?
Usually the shard number will be small enough (<100) to be formatted
from a static array.

Also removed the fmt.Sprintf call from astmapper/sharding.go in favor of
ShardSelector{} receiver method call, to make that code cleaner, and
then moved the matcher instantiation to the receiver too so it's now
similar to the ShardSelector.Label() call.


All in all, this is the result of the benchmark comparison:

```
name \ time/op            fmt_printf.txt  concat_itoa.txt  stringbuilder.txt
ShardSelector_LabelValue      109ns ± 1%        38ns ± 1%          27ns ± 2%
```

**Which issue(s) this PR fixes**:

None, really. 

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
