### PR TITLE
Replace calls to strings.Compare

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -772,7 +772,7 @@ func sortLabelsIfNeeded(labels []mimirpb.LabelAdapter) {
 	sorted := true
 	last := ""
 	for _, l := range labels {
-		if strings.Compare(last, l.Name) > 0 {
+		if last > l.Name {
 			sorted = false
 			break
 		}
@@ -784,7 +784,7 @@ func sortLabelsIfNeeded(labels []mimirpb.LabelAdapter) {
 	}
 
 	sort.Slice(labels, func(i, j int) bool {
-		return strings.Compare(labels[i].Name, labels[j].Name) < 0
+		return labels[i].Name < labels[j].Name
 	})
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2717,7 +2717,7 @@ func TestSortLabels(t *testing.T) {
 	sortLabelsIfNeeded(unsorted)
 
 	sort.SliceIsSorted(unsorted, func(i, j int) bool {
-		return strings.Compare(unsorted[i].Name, unsorted[j].Name) < 0
+		return unsorted[i].Name < unsorted[j].Name
 	})
 }
 

--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 	"unsafe"
 
@@ -155,7 +154,7 @@ func FromPointsToSamples(points []promql.Point) []Sample {
 type byLabel []LabelAdapter
 
 func (s byLabel) Len() int           { return len(s) }
-func (s byLabel) Less(i, j int) bool { return strings.Compare(s[i].Name, s[j].Name) < 0 }
+func (s byLabel) Less(i, j int) bool { return s[i].Name < s[j].Name }
 func (s byLabel) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // MetricMetadataMetricTypeToMetricType converts a metric type from our internal client

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -345,7 +345,7 @@ func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 		s.advLabelSets = append(s.advLabelSets, labelpb.ZLabelSet{Labels: labelpb.ZLabelsFromPromLabels(append(storeLabels, bs.labels...))})
 	}
 	sort.Slice(s.advLabelSets, func(i, j int) bool {
-		return strings.Compare(s.advLabelSets[i].String(), s.advLabelSets[j].String()) < 0
+		return s.advLabelSets[i].String() < s.advLabelSets[j].String()
 	})
 	s.mtx.Unlock()
 	return nil

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -7,7 +7,6 @@ package validation
 
 import (
 	"net/http"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -205,12 +204,10 @@ func ValidateLabels(cfg LabelValidationConfig, userID string, ls []mimirpb.Label
 		} else if len(l.Value) > maxLabelValueLength {
 			DiscardedSamples.WithLabelValues(labelValueTooLong, userID).Inc()
 			return newLabelValueTooLongError(ls, l.Value)
-		} else if cmp := strings.Compare(lastLabelName, l.Name); cmp >= 0 {
-			if cmp == 0 {
-				DiscardedSamples.WithLabelValues(duplicateLabelNames, userID).Inc()
-				return newDuplicatedLabelError(ls, l.Name)
-			}
-
+		} else if lastLabelName == l.Name {
+			DiscardedSamples.WithLabelValues(duplicateLabelNames, userID).Inc()
+			return newDuplicatedLabelError(ls, l.Name)
+		} else if lastLabelName > l.Name {
 			DiscardedSamples.WithLabelValues(labelsNotSorted, userID).Inc()
 			return newLabelsNotSortedError(ls, l.Name)
 		}


### PR DESCRIPTION
`<` is clearer and faster. As the documentation says, "Basically no one should use strings.Compare."

**Checklist**

- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated