### PR TITLE
Ignore ./ folders with prettier.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 CHANGELOG.md
 vendor
+.*/


### PR DESCRIPTION
vscode plugin (history and go) uses for cache and it's always failing and super slow for me.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

