### PR TITLE
tsdb-symbols: Continue on errors.

### DIFF
--- a/tools/tsdb-symbols/main.go
+++ b/tools/tsdb-symbols/main.go
@@ -41,7 +41,7 @@ func main() {
 	for _, blockDir := range flag.Args() {
 		err := analyseSymbols(blockDir, uniqueSymbols, uniqueSymbolsPerShard)
 		if err != nil {
-			log.Fatalln("failed to analyse symbols for", blockDir, "due to error:", err)
+			log.Println("failed to analyse symbols for", blockDir, "due to error:", err)
 		}
 		fmt.Println()
 	}


### PR DESCRIPTION
**What this PR does**: This PR makes tsdb-symbols continue on errors. It's useful eg. when running `tsdb-symbols *`, and some of the supplied arguments are not TSDB blocks.

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
