### PR TITLE
Refactoring: remove logic from compactor's Group

### DIFF
--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -147,7 +147,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		require.NoError(t, sy.GarbageCollect(ctx))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
-		grouper := NewDefaultGrouper("user-1", nil, bkt, false, metadata.NoneFunc)
+		grouper := NewDefaultGrouper("user-1", metadata.NoneFunc)
 		groups, err := grouper.Groups(sy.Metas())
 		require.NoError(t, err)
 
@@ -191,7 +191,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		require.NoError(t, err)
 
 		planner := NewPlanner(logger, []int64{1000, 3000}, noCompactMarkerFilter)
-		grouper := NewDefaultGrouper("user-1", logger, bkt, false, metadata.NoneFunc)
+		grouper := NewDefaultGrouper("user-1", metadata.NoneFunc)
 		metrics := NewBucketCompactorMetrics(blocksMarkedForDeletion, garbageCollectedBlocks, prometheus.NewPedanticRegistry())
 		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true, ownAllGroups, metrics)
 		require.NoError(t, err)

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -61,7 +61,6 @@ type BlocksGrouperFactory func(
 	ctx context.Context,
 	cfg Config,
 	cfgProvider ConfigProvider,
-	bkt objstore.Bucket,
 	userID string,
 	ring *ring.Ring,
 	instanceAddr string,
@@ -663,7 +662,7 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 	compactor, err := NewBucketCompactor(
 		ulogger,
 		syncer,
-		c.blocksGrouperFactory(ctx, c.compactorCfg, c.cfgProvider, bucket, userID, c.ring, instanceAddr, ulogger, reg),
+		c.blocksGrouperFactory(ctx, c.compactorCfg, c.cfgProvider, userID, c.ring, instanceAddr, ulogger, reg),
 		c.blocksPlanner,
 		c.blocksCompactor,
 		path.Join(c.compactorCfg.DataDir, "compact"),

--- a/pkg/compactor/default_compactor.go
+++ b/pkg/compactor/default_compactor.go
@@ -10,18 +10,12 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
-	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/ring"
 )
 
-func defaultBlocksGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, bkt objstore.Bucket, userID string, ring *ring.Ring, instanceAddr string, logger log.Logger, reg prometheus.Registerer) Grouper {
-	return NewDefaultGrouper(
-		userID,
-		logger,
-		bkt,
-		false, // Do not accept malformed indexes
-		metadata.NoneFunc)
+func defaultBlocksGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, ring *ring.Ring, instanceAddr string, logger log.Logger, reg prometheus.Registerer) Grouper {
+	return NewDefaultGrouper(userID, metadata.NoneFunc)
 }
 
 func defaultBlocksCompactorFactory(ctx context.Context, cfg Config, logger log.Logger, reg prometheus.Registerer) (Compactor, Planner, error) {

--- a/pkg/compactor/split_merge_compactor.go
+++ b/pkg/compactor/split_merge_compactor.go
@@ -10,15 +10,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
-	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/ring"
 )
 
-func splitAndMergeGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, bkt objstore.Bucket, userID string, ring *ring.Ring, instanceAddr string, logger log.Logger, reg prometheus.Registerer) Grouper {
+func splitAndMergeGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, ring *ring.Ring, instanceAddr string, logger log.Logger, reg prometheus.Registerer) Grouper {
 	return NewSplitAndMergeGrouper(
 		userID,
-		bkt,
 		cfg.BlockRanges.ToMilliseconds(),
 		uint32(cfgProvider.CompactorSplitAndMergeShards(userID)),
 		createOwnJobFunc(ring, instanceAddr),

--- a/pkg/compactor/split_merge_grouper_test.go
+++ b/pkg/compactor/split_merge_grouper_test.go
@@ -63,7 +63,7 @@ func TestSplitAndMergeGrouper_Groups(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			grouper := NewSplitAndMergeGrouper("test", nil, ranges, 1, testCase.ownJob, log.NewNopLogger())
+			grouper := NewSplitAndMergeGrouper("test", ranges, 1, testCase.ownJob, log.NewNopLogger())
 			res, err := grouper.Groups(blocks)
 			require.NoError(t, err)
 			assert.Len(t, res, testCase.expectedGroups)

--- a/pkg/compactor/split_merge_job.go
+++ b/pkg/compactor/split_merge_job.go
@@ -107,14 +107,6 @@ func (g blocksGroup) overlaps(other blocksGroup) bool {
 	return true
 }
 
-func (g blocksGroup) rangeStartTime() time.Time {
-	return time.Unix(0, g.rangeStart*int64(time.Millisecond)).UTC()
-}
-
-func (g blocksGroup) rangeEndTime() time.Time {
-	return time.Unix(0, g.rangeEnd*int64(time.Millisecond)).UTC()
-}
-
 func (g blocksGroup) rangeLength() int64 {
 	return g.rangeEnd - g.rangeStart
 }


### PR DESCRIPTION
**What this PR does**:
This is a refactoring PR to begin cleaning up the compactor implementation (goal is to simplify it and make design cleaner for our use case).

In this PR I'm removing any logic from compactor's `Group`. I tried to do changes to keep the diff as easiest as possible to review. In different commits:
- Merged Group.Compact() and Group.compact() together (_since this change should be a noop and is contributes the most to the diff, I would suggest to review this commit separately and then other ones_)
- Removed mutex from Group and documented it as not goroutine safe
- Remove any logic from Group

In a follow up PR I would like to merge `Group` and `job` data structures. The idea is that `Group` will disappear and we'll have a planner which return compaction jobs.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
