### PR TITLE
Ring: remove redundant 'LEAVING' status in Operation construction (#4485)

### DIFF
--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -884,7 +884,7 @@ func NewOp(healthyStates []InstanceState, shouldExtendReplicaSet func(s Instance
 	}
 
 	if shouldExtendReplicaSet != nil {
-		for _, s := range []InstanceState{ACTIVE, LEAVING, PENDING, JOINING, LEAVING, LEFT} {
+		for _, s := range []InstanceState{ACTIVE, LEAVING, PENDING, JOINING, LEFT} {
 			if shouldExtendReplicaSet(s) {
 				op |= (0x10000 << s)
 			}


### PR DESCRIPTION
(cherry picked from Cortex commit 1d29897a109aad9ce5ff9d3b31db968164b85201)