### PR TITLE
Refactoring: rename compactor Group to Job

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -193,12 +192,12 @@ func (s *Syncer) GarbageCollect(ctx context.Context) error {
 	return nil
 }
 
-// Grouper is responsible to group all known blocks into sub groups which are safe to be
+// Grouper is responsible to group all known blocks into compaction Job which are safe to be
 // compacted concurrently.
 type Grouper interface {
-	// Groups returns the compaction groups for all blocks currently known to the syncer.
-	// It creates all groups from the scratch on every call.
-	Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Group, err error)
+	// Groups returns the compaction jobs for all blocks currently known to the syncer.
+	// It creates all jobs from the scratch on every call.
+	Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Job, err error)
 }
 
 // DefaultGroupKey returns a unique identifier for the group the block belongs to, based on
@@ -211,7 +210,7 @@ func defaultGroupKey(res int64, lbls labels.Labels) string {
 	return fmt.Sprintf("%d@%v", res, lbls.Hash())
 }
 
-// DefaultGrouper is the Thanos built-in grouper. It groups blocks based on downsample
+// DefaultGrouper is the default grouper. It groups blocks based on downsample
 // resolution and block's labels.
 type DefaultGrouper struct {
 	userID   string
@@ -226,16 +225,15 @@ func NewDefaultGrouper(userID string, hashFunc metadata.HashFunc) *DefaultGroupe
 	}
 }
 
-// Groups returns the compaction groups for all blocks currently known to the syncer.
-// It creates all groups from the scratch on every call.
-func (g *DefaultGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Group, err error) {
-	groups := map[string]*Group{}
+// Groups implements Grouper.Groups.
+func (g *DefaultGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Job, err error) {
+	groups := map[string]*Job{}
 	for _, m := range blocks {
 		groupKey := DefaultGroupKey(m.Thanos)
-		group, ok := groups[groupKey]
+		job, ok := groups[groupKey]
 		if !ok {
 			lbls := labels.FromMap(m.Thanos.Labels)
-			group, err = NewGroup(
+			job = NewJob(
 				g.userID,
 				groupKey,
 				lbls,
@@ -245,13 +243,10 @@ func (g *DefaultGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Gro
 				0,     // No splitting shards.
 				"",    // No sharding.
 			)
-			if err != nil {
-				return nil, errors.Wrap(err, "create compaction group")
-			}
-			groups[groupKey] = group
-			res = append(res, group)
+			groups[groupKey] = job
+			res = append(res, job)
 		}
-		if err := group.AppendMeta(m); err != nil {
+		if err := job.AppendMeta(m); err != nil {
 			return nil, errors.Wrap(err, "add compaction group")
 		}
 	}
@@ -259,118 +254,6 @@ func (g *DefaultGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*Gro
 		return res[i].Key() < res[j].Key()
 	})
 	return res, nil
-}
-
-// Group captures a set of blocks that have the same origin labels and downsampling resolution.
-// Those blocks generally contain the same series and can thus efficiently be compacted.
-// Not goroutine safe.
-type Group struct {
-	userID         string
-	key            string
-	labels         labels.Labels
-	resolution     int64
-	metasByMinTime []*metadata.Meta
-	hashFunc       metadata.HashFunc
-	useSplitting   bool
-	shardingKey    string
-
-	// The number of shards to split compacted block into. Not used if splitting is disabled.
-	splitNumShards uint32
-}
-
-// NewGroup returns a new compaction group.
-func NewGroup(
-	userID string,
-	key string,
-	lset labels.Labels,
-	resolution int64,
-	hashFunc metadata.HashFunc,
-	useSplitting bool,
-	splitNumShards uint32,
-	shardingKey string,
-) (*Group, error) {
-	g := &Group{
-		userID:         userID,
-		key:            key,
-		labels:         lset,
-		resolution:     resolution,
-		hashFunc:       hashFunc,
-		useSplitting:   useSplitting,
-		splitNumShards: splitNumShards,
-		shardingKey:    shardingKey,
-	}
-	return g, nil
-}
-
-// UserID returns the user/tenant to which this group belongs to.
-func (cg *Group) UserID() string {
-	return cg.userID
-}
-
-// Key returns an identifier for the group.
-func (cg *Group) Key() string {
-	return cg.key
-}
-
-// AppendMeta the block with the given meta to the group.
-func (cg *Group) AppendMeta(meta *metadata.Meta) error {
-	if !labels.Equal(cg.labels, labels.FromMap(meta.Thanos.Labels)) {
-		return errors.New("block and group labels do not match")
-	}
-	if cg.resolution != meta.Thanos.Downsample.Resolution {
-		return errors.New("block and group resolution do not match")
-	}
-
-	cg.metasByMinTime = append(cg.metasByMinTime, meta)
-	sort.Slice(cg.metasByMinTime, func(i, j int) bool {
-		return cg.metasByMinTime[i].MinTime < cg.metasByMinTime[j].MinTime
-	})
-	return nil
-}
-
-// IDs returns all sorted IDs of blocks in the group.
-func (cg *Group) IDs() (ids []ulid.ULID) {
-	for _, m := range cg.metasByMinTime {
-		ids = append(ids, m.ULID)
-	}
-	sort.Slice(ids, func(i, j int) bool {
-		return ids[i].Compare(ids[j]) < 0
-	})
-	return ids
-}
-
-// MinTime returns the min time across all group's blocks.
-func (cg *Group) MinTime() int64 {
-	if len(cg.metasByMinTime) > 0 {
-		return cg.metasByMinTime[0].MinTime
-	}
-	return math.MaxInt64
-}
-
-// MaxTime returns the max time across all group's blocks.
-func (cg *Group) MaxTime() int64 {
-	max := int64(math.MinInt64)
-	for _, m := range cg.metasByMinTime {
-		if m.MaxTime > max {
-			max = m.MaxTime
-		}
-	}
-	return max
-}
-
-// Labels returns the labels that all blocks in the group share.
-func (cg *Group) Labels() labels.Labels {
-	return cg.labels
-}
-
-// Resolution returns the common downsampling resolution of blocks in the group.
-func (cg *Group) Resolution() int64 {
-	return cg.resolution
-}
-
-// ShardingKey returns the key used to shard this group across multiple instances.
-func (cg *Group) ShardingKey() string {
-	return cg.shardingKey
 }
 
 func minTime(metas []*metadata.Meta) time.Time {
@@ -434,11 +317,11 @@ type Compactor interface {
 	CompactWithSplitting(dest string, dirs []string, open []*tsdb.Block, shardCount uint64) (result []ulid.ULID, _ error)
 }
 
-// CompactGroup plans and runs a single compaction against the provided group. The compacted result
+// runCompactionJob plans and runs a single compaction against the provided job. The compacted result
 // is uploaded into the bucket the blocks were retrieved from.
-func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir string, planner Planner, comp Compactor, blocksMarkedForDeletion, garbageCollectedBlocks prometheus.Counter) (shouldRerun bool, compIDs []ulid.ULID, rerr error) {
-	groupLogger := log.With(c.logger, "groupKey", cg.Key())
-	subDir := filepath.Join(dir, cg.Key())
+func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job, dir string, planner Planner, comp Compactor, blocksMarkedForDeletion, garbageCollectedBlocks prometheus.Counter) (shouldRerun bool, compIDs []ulid.ULID, rerr error) {
+	jobLogger := log.With(c.logger, "groupKey", job.Key())
+	subDir := filepath.Join(dir, job.Key())
 
 	defer func() {
 		// Leave the compact directory for inspection if it is a halt error
@@ -447,15 +330,15 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 			return
 		}
 		if err := os.RemoveAll(subDir); err != nil {
-			level.Error(groupLogger).Log("msg", "failed to remove compaction group work directory", "path", subDir, "err", err)
+			level.Error(jobLogger).Log("msg", "failed to remove compaction group work directory", "path", subDir, "err", err)
 		}
 	}()
 
 	if err := os.MkdirAll(subDir, 0750); err != nil {
-		return false, nil, errors.Wrap(err, "create compaction group dir")
+		return false, nil, errors.Wrap(err, "create compaction job dir")
 	}
 
-	toCompact, err := planner.Plan(ctx, cg.metasByMinTime)
+	toCompact, err := planner.Plan(ctx, job.metasByMinTime)
 	if err != nil {
 		return false, nil, errors.Wrap(err, "plan compaction")
 	}
@@ -466,9 +349,9 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 
 	// The planner returned some blocks to compact, so we can enrich the logger
 	// with the min/max time between all blocks to compact.
-	groupLogger = log.With(groupLogger, "minTime", minTime(toCompact).String(), "maxTime", maxTime(toCompact).String())
+	jobLogger = log.With(jobLogger, "minTime", minTime(toCompact).String(), "maxTime", maxTime(toCompact).String())
 
-	level.Info(groupLogger).Log("msg", "compaction available and planned; downloading blocks", "plan", fmt.Sprintf("%v", toCompact))
+	level.Info(jobLogger).Log("msg", "compaction available and planned; downloading blocks", "plan", fmt.Sprintf("%v", toCompact))
 
 	// Due to #183 we verify that none of the blocks in the plan have overlapping sources.
 	// This is one potential source of how we could end up with duplicated chunks.
@@ -487,12 +370,12 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 			uniqueSources[s] = struct{}{}
 		}
 
-		if err := block.Download(ctx, groupLogger, c.bkt, meta.ULID, bdir); err != nil {
+		if err := block.Download(ctx, jobLogger, c.bkt, meta.ULID, bdir); err != nil {
 			return false, nil, retry(errors.Wrapf(err, "download block %s", meta.ULID))
 		}
 
 		// Ensure all input blocks are valid.
-		stats, err := block.GatherIndexHealthStats(groupLogger, filepath.Join(bdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
+		stats, err := block.GatherIndexHealthStats(jobLogger, filepath.Join(bdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
 		if err != nil {
 			return false, nil, errors.Wrapf(err, "gather index issues for block %s", bdir)
 		}
@@ -514,12 +397,12 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 		}
 		toCompactDirs = append(toCompactDirs, bdir)
 	}
-	level.Info(groupLogger).Log("msg", "downloaded and verified blocks; compacting blocks", "plan", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
+	level.Info(jobLogger).Log("msg", "downloaded and verified blocks; compacting blocks", "plan", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	begin = time.Now()
 
-	if cg.useSplitting {
-		compIDs, err = comp.CompactWithSplitting(dir, toCompactDirs, nil, uint64(cg.splitNumShards))
+	if job.UseSplitting() {
+		compIDs, err = comp.CompactWithSplitting(dir, toCompactDirs, nil, uint64(job.SplittingShards()))
 	} else {
 		var compID ulid.ULID
 		compID, err = comp.Compact(dir, toCompactDirs, nil)
@@ -531,11 +414,11 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 
 	if !hasNonZeroULIDs(compIDs) {
 		// Prometheus compactor found that the compacted block would have no samples.
-		level.Info(groupLogger).Log("msg", "compacted block would have no samples, deleting source blocks", "blocks", fmt.Sprintf("%v", toCompactDirs))
+		level.Info(jobLogger).Log("msg", "compacted block would have no samples, deleting source blocks", "blocks", fmt.Sprintf("%v", toCompactDirs))
 		for _, meta := range toCompact {
 			if meta.Stats.NumSamples == 0 {
-				if err := deleteBlock(c.bkt, meta.ULID, filepath.Join(dir, meta.ULID.String()), groupLogger, blocksMarkedForDeletion); err != nil {
-					level.Warn(groupLogger).Log("msg", "failed to mark for deletion an empty block found during compaction", "block", meta.ULID, "err", err)
+				if err := deleteBlock(c.bkt, meta.ULID, filepath.Join(dir, meta.ULID.String()), jobLogger, blocksMarkedForDeletion); err != nil {
+					level.Warn(jobLogger).Log("msg", "failed to mark for deletion an empty block found during compaction", "block", meta.ULID, "err", err)
 				}
 			}
 		}
@@ -543,15 +426,15 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 		return true, nil, nil
 	}
 
-	level.Info(groupLogger).Log("msg", "compacted blocks", "new", fmt.Sprintf("%v", compIDs), "blocks", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
+	level.Info(jobLogger).Log("msg", "compacted blocks", "new", fmt.Sprintf("%v", compIDs), "blocks", fmt.Sprintf("%v", toCompactDirs), "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds())
 
 	for shardID, compID := range compIDs {
 		// Skip if it's an empty block.
 		if compID == (ulid.ULID{}) {
-			if cg.useSplitting {
-				level.Info(groupLogger).Log("msg", "compaction produced an empty block", "shard_id", formatShardIDLabelValue(uint32(shardID), cg.splitNumShards))
+			if job.UseSplitting() {
+				level.Info(jobLogger).Log("msg", "compaction produced an empty block", "shard_id", formatShardIDLabelValue(uint32(shardID), job.SplittingShards()))
 			} else {
-				level.Info(groupLogger).Log("msg", "compaction produced an empty block")
+				level.Info(jobLogger).Log("msg", "compaction produced an empty block")
 			}
 
 			continue
@@ -561,14 +444,14 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 		index := filepath.Join(bdir, block.IndexFilename)
 
 		// When splitting is enabled, we need to inject the shard ID as external label.
-		newLabels := cg.labels.Map()
-		if cg.useSplitting {
-			newLabels[ShardIDLabelName] = formatShardIDLabelValue(uint32(shardID), cg.splitNumShards)
+		newLabels := job.Labels().Map()
+		if job.UseSplitting() {
+			newLabels[ShardIDLabelName] = formatShardIDLabelValue(uint32(shardID), job.SplittingShards())
 		}
 
-		newMeta, err := metadata.InjectThanos(groupLogger, bdir, metadata.Thanos{
+		newMeta, err := metadata.InjectThanos(jobLogger, bdir, metadata.Thanos{
 			Labels:       newLabels,
-			Downsample:   metadata.ThanosDownsample{Resolution: cg.resolution},
+			Downsample:   metadata.ThanosDownsample{Resolution: job.Resolution()},
 			Source:       metadata.CompactorSource,
 			SegmentFiles: block.GetSegmentFiles(bdir),
 		}, nil)
@@ -581,24 +464,24 @@ func (c *BucketCompactor) CompactGroup(ctx context.Context, cg *Group, dir strin
 		}
 
 		// Ensure the output block is valid.
-		if err := block.VerifyIndex(groupLogger, index, newMeta.MinTime, newMeta.MaxTime); err != nil {
+		if err := block.VerifyIndex(jobLogger, index, newMeta.MinTime, newMeta.MaxTime); err != nil {
 			return false, nil, halt(errors.Wrapf(err, "invalid result block %s", bdir))
 		}
 
 		begin = time.Now()
 
-		if err := block.Upload(ctx, groupLogger, c.bkt, bdir, cg.hashFunc); err != nil {
+		if err := block.Upload(ctx, jobLogger, c.bkt, bdir, job.hashFunc); err != nil {
 			return false, nil, retry(errors.Wrapf(err, "upload of %s failed", compID))
 		}
 
-		level.Info(groupLogger).Log("msg", "uploaded block", "result_block", compID, "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds(), "external_labels", labels.FromMap(newLabels))
+		level.Info(jobLogger).Log("msg", "uploaded block", "result_block", compID, "duration", time.Since(begin), "duration_ms", time.Since(begin).Milliseconds(), "external_labels", labels.FromMap(newLabels))
 	}
 
-	// Mark for deletion the blocks we just compacted from the group and bucket so they do not get included
+	// Mark for deletion the blocks we just compacted from the job and bucket so they do not get included
 	// into the next planning cycle.
-	// Eventually the block we just uploaded should get synced into the group again (including sync-delay).
+	// Eventually the block we just uploaded should get synced into the job again (including sync-delay).
 	for _, meta := range toCompact {
-		if err := deleteBlock(c.bkt, meta.ULID, filepath.Join(dir, meta.ULID.String()), groupLogger, blocksMarkedForDeletion); err != nil {
+		if err := deleteBlock(c.bkt, meta.ULID, filepath.Join(dir, meta.ULID.String()), jobLogger, blocksMarkedForDeletion); err != nil {
 			return false, nil, retry(errors.Wrapf(err, "mark old block for deletion from bucket"))
 		}
 		garbageCollectedBlocks.Inc()
@@ -820,10 +703,10 @@ func NewBucketCompactorMetrics(blocksMarkedForDeletion, garbageCollectedBlocks p
 	}
 }
 
-type ownGroupFunc func(group *Group) (bool, error)
+type ownCompactionJobFunc func(job *Job) (bool, error)
 
-// ownAllGroups is a ownGroupFunc that always return true.
-var ownAllGroups = func(group *Group) (bool, error) {
+// ownAllJobs is a ownCompactionJobFunc that always return true.
+var ownAllJobs = func(job *Job) (bool, error) {
 	return true, nil
 }
 
@@ -838,7 +721,7 @@ type BucketCompactor struct {
 	bkt                            objstore.Bucket
 	concurrency                    int
 	skipBlocksWithOutOfOrderChunks bool
-	ownGroup                       func(group *Group) (bool, error)
+	ownJob                         func(job *Job) (bool, error)
 	metrics                        *BucketCompactorMetrics
 }
 
@@ -853,7 +736,7 @@ func NewBucketCompactor(
 	bkt objstore.Bucket,
 	concurrency int,
 	skipBlocksWithOutOfOrderChunks bool,
-	ownGroup ownGroupFunc,
+	ownJob ownCompactionJobFunc,
 	metrics *BucketCompactorMetrics,
 ) (*BucketCompactor, error) {
 	if concurrency <= 0 {
@@ -869,7 +752,7 @@ func NewBucketCompactor(
 		bkt:                            bkt,
 		concurrency:                    concurrency,
 		skipBlocksWithOutOfOrderChunks: skipBlocksWithOutOfOrderChunks,
-		ownGroup:                       ownGroup,
+		ownJob:                         ownJob,
 		metrics:                        metrics,
 	}, nil
 }
@@ -893,43 +776,43 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 		var (
 			wg                     sync.WaitGroup
 			workCtx, workCtxCancel = context.WithCancel(ctx)
-			groupChan              = make(chan *Group)
+			jobChan                = make(chan *Job)
 			errChan                = make(chan error, c.concurrency)
-			finishedAllGroups      = true
+			finishedAllJobs        = true
 			mtx                    sync.Mutex
 		)
 		defer workCtxCancel()
 
-		// Set up workers who will compact the groups when the groups are ready.
-		// They will compact available groups until they encounter an error, after which they will stop.
+		// Set up workers who will compact the jobs when the jobs are ready.
+		// They will compact available jobs until they encounter an error, after which they will stop.
 		for i := 0; i < c.concurrency; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				for g := range groupChan {
-					// Ensure the group is still owned by the current compactor instance.
+				for g := range jobChan {
+					// Ensure the job is still owned by the current compactor instance.
 					// If not, we shouldn't run it because another compactor instance may already
 					// process it (or will do it soon).
-					if ok, err := c.ownGroup(g); err != nil {
-						level.Info(c.logger).Log("msg", "skipped compaction because unable to check whether the group is owned by the compactor instance", "group", g.Key(), "err", err)
+					if ok, err := c.ownJob(g); err != nil {
+						level.Info(c.logger).Log("msg", "skipped compaction because unable to check whether the job is owned by the compactor instance", "groupKey", g.Key(), "err", err)
 						continue
 					} else if !ok {
-						level.Info(c.logger).Log("msg", "skipped compaction because group is not owned by the compactor instance anymore", "group", g.Key())
+						level.Info(c.logger).Log("msg", "skipped compaction because job is not owned by the compactor instance anymore", "groupKey", g.Key())
 						continue
 					}
 
 					c.metrics.groupCompactionRunsStarted.Inc()
 
-					shouldRerunGroup, compactedBlockIDs, err := c.CompactGroup(workCtx, g, c.compactDir, c.planner, c.comp, c.metrics.blocksMarkedForDeletion, c.metrics.garbageCollectedBlocks)
+					shouldRerunJob, compactedBlockIDs, err := c.runCompactionJob(workCtx, g, c.compactDir, c.planner, c.comp, c.metrics.blocksMarkedForDeletion, c.metrics.garbageCollectedBlocks)
 					if err == nil {
 						c.metrics.groupCompactionRunsCompleted.Inc()
 						if hasNonZeroULIDs(compactedBlockIDs) {
 							c.metrics.groupCompactions.Inc()
 						}
 
-						if shouldRerunGroup {
+						if shouldRerunJob {
 							mtx.Lock()
-							finishedAllGroups = false
+							finishedAllJobs = false
 							mtx.Unlock()
 						}
 						continue
@@ -941,7 +824,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 					if IsIssue347Error(err) {
 						if err := RepairIssue347(workCtx, c.logger, c.bkt, c.sy.metrics.blocksMarkedForDeletion, err); err == nil {
 							mtx.Lock()
-							finishedAllGroups = false
+							finishedAllJobs = false
 							mtx.Unlock()
 							continue
 						}
@@ -958,7 +841,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 							metadata.OutOfOrderChunksNoCompactReason,
 							"OutofOrderChunk: marking block with out-of-order series/chunks to as no compact to unblock compaction", c.metrics.blocksMarkedForNoCompact); err == nil {
 							mtx.Lock()
-							finishedAllGroups = false
+							finishedAllJobs = false
 							mtx.Unlock()
 							continue
 						}
@@ -981,51 +864,51 @@ func (c *BucketCompactor) Compact(ctx context.Context) (rerr error) {
 			return errors.Wrap(err, "garbage")
 		}
 
-		groups, err := c.grouper.Groups(c.sy.Metas())
+		jobs, err := c.grouper.Groups(c.sy.Metas())
 		if err != nil {
-			return errors.Wrap(err, "build compaction groups")
+			return errors.Wrap(err, "build compaction jobs")
 		}
 
 		ignoreDirs := []string{}
-		for _, gr := range groups {
+		for _, gr := range jobs {
 			for _, grID := range gr.IDs() {
 				ignoreDirs = append(ignoreDirs, filepath.Join(gr.Key(), grID.String()))
 			}
 		}
 
 		if err := runutil.DeleteAll(c.compactDir, ignoreDirs...); err != nil {
-			level.Warn(c.logger).Log("msg", "failed deleting non-compaction group directories/files, some disk space usage might have leaked. Continuing", "err", err, "dir", c.compactDir)
+			level.Warn(c.logger).Log("msg", "failed deleting non-compaction job directories/files, some disk space usage might have leaked. Continuing", "err", err, "dir", c.compactDir)
 		}
 
 		level.Info(c.logger).Log("msg", "start of compactions")
 
-		// Send all groups found during this pass to the compaction workers.
-		var groupErrs errutil.MultiError
-	groupLoop:
-		for _, g := range groups {
+		// Send all jobs found during this pass to the compaction workers.
+		var jobErrs errutil.MultiError
+	jobLoop:
+		for _, g := range jobs {
 			select {
-			case groupErr := <-errChan:
-				groupErrs.Add(groupErr)
-				break groupLoop
-			case groupChan <- g:
+			case jobErr := <-errChan:
+				jobErrs.Add(jobErr)
+				break jobLoop
+			case jobChan <- g:
 			}
 		}
-		close(groupChan)
+		close(jobChan)
 		wg.Wait()
 
 		// Collect any other error reported by the workers, or any error reported
-		// while we were waiting for the last batch of groups to run the compaction.
+		// while we were waiting for the last batch of jobs to run the compaction.
 		close(errChan)
-		for groupErr := range errChan {
-			groupErrs.Add(groupErr)
+		for jobErr := range errChan {
+			jobErrs.Add(jobErr)
 		}
 
 		workCtxCancel()
-		if len(groupErrs) > 0 {
-			return groupErrs.Err()
+		if len(jobErrs) > 0 {
+			return jobErrs.Err()
 		}
 
-		if finishedAllGroups {
+		if finishedAllJobs {
 			break
 		}
 	}

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -193,7 +193,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		planner := NewPlanner(logger, []int64{1000, 3000}, noCompactMarkerFilter)
 		grouper := NewDefaultGrouper("user-1", metadata.NoneFunc)
 		metrics := NewBucketCompactorMetrics(blocksMarkedForDeletion, garbageCollectedBlocks, prometheus.NewPedanticRegistry())
-		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true, ownAllGroups, metrics)
+		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true, ownAllJobs, metrics)
 		require.NoError(t, err)
 
 		// Compaction on empty should not fail.

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -116,7 +116,7 @@ func TestGroupKey(t *testing.T) {
 }
 
 func TestGroupMaxMinTime(t *testing.T) {
-	g := &Group{
+	g := &Job{
 		metasByMinTime: []*metadata.Meta{
 			{BlockMeta: tsdb.BlockMeta{MinTime: 0, MaxTime: 10}},
 			{BlockMeta: tsdb.BlockMeta{MinTime: 1, MaxTime: 20}},

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -686,7 +686,7 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 		bucket,
 		c.compactorCfg.CompactionConcurrency,
 		false, // Do not skip blocks with out of order chunks.
-		c.shardingStrategy.ownGroup,
+		c.shardingStrategy.ownJob,
 		c.bucketCompactorMetrics,
 	)
 	if err != nil {
@@ -734,11 +734,11 @@ func (c *MultitenantCompactor) discoverUsers(ctx context.Context) ([]string, err
 	return users, err
 }
 
-// shardingStrategy describes whether compactor "owns" given user or group.
+// shardingStrategy describes whether compactor "owns" given user or job.
 type shardingStrategy interface {
 	compactorOwnUser(userID string) (bool, error)
 	blocksCleanerOwnUser(userID string) (bool, error)
-	ownGroup(group *Group) (bool, error)
+	ownJob(job *Job) (bool, error)
 }
 
 // No sharding of users. Each compactor will process any user.
@@ -762,8 +762,8 @@ func (n *noShardingStrategy) compactorOwnUser(userID string) (bool, error) {
 	return n.ownUser(userID), nil
 }
 
-func (n *noShardingStrategy) ownGroup(group *Group) (bool, error) {
-	return n.ownUser(group.UserID()), nil
+func (n *noShardingStrategy) ownJob(job *Job) (bool, error) {
+	return n.ownUser(job.UserID()), nil
 }
 
 // defaultShardingStrategy is used with default compaction strategy. Only one compactor
@@ -798,13 +798,13 @@ func (d *defaultShardingStrategy) compactorOwnUser(userID string) (bool, error) 
 	return d.ownUser(userID)
 }
 
-func (d *defaultShardingStrategy) ownGroup(group *Group) (bool, error) {
-	return d.ownUser(group.UserID())
+func (d *defaultShardingStrategy) ownJob(job *Job) (bool, error) {
+	return d.ownUser(job.UserID())
 }
 
 // splitAndMergeShardingStrategy is used with split-and-merge compaction strategy.
 // All compactors from user's shard own the user for compaction purposes, and plan jobs.
-// Each job (group) is only owned and executed by single compactor.
+// Each job is only owned and executed by single compactor.
 // Only one of compactors from user's shard will do cleanup.
 type splitAndMergeShardingStrategy struct {
 	allowedTenants *util.AllowedTenants
@@ -844,16 +844,16 @@ func (s *splitAndMergeShardingStrategy) compactorOwnUser(userID string) (bool, e
 	return r.HasInstance(s.ringLifecycler.ID), nil
 }
 
-// Only single compactor should execute the job (group).
-func (s *splitAndMergeShardingStrategy) ownGroup(group *Group) (bool, error) {
-	ok, err := s.compactorOwnUser(group.UserID())
+// Only single compactor should execute the job.
+func (s *splitAndMergeShardingStrategy) ownJob(job *Job) (bool, error) {
+	ok, err := s.compactorOwnUser(job.UserID())
 	if err != nil || !ok {
 		return ok, err
 	}
 
-	r := s.ring.ShuffleShard(group.UserID(), s.configProvider.CompactorTenantShardSize(group.UserID()))
+	r := s.ring.ShuffleShard(job.UserID(), s.configProvider.CompactorTenantShardSize(job.UserID()))
 
-	return instanceOwnsTokenInRing(r, s.ringLifecycler.Addr, group.ShardingKey())
+	return instanceOwnsTokenInRing(r, s.ringLifecycler.Addr, job.ShardingKey())
 }
 
 func instanceOwnsTokenInRing(r ring.ReadRing, instanceAddr string, key string) (bool, error) {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1055,7 +1055,7 @@ func TestMultitenantCompactor_ShouldSkipCompactionForJobsNoMoreOwnedAfterPlannin
 		`level=debug component=compactor org_id=user-1 msg="grouper found a compactable blocks group" groupKey=0@17241709254077376921-split-1_of_4-1574863200000-1574870400000 job="stage: split, range start: 1574863200000, range end: 1574870400000, shard: 1_of_4, blocks: 01DTVP434PA9VFXSW2JK000002 (min time: 2019-11-27 14:00:00 +0000 UTC, max time: 2019-11-27 16:00:00 +0000 UTC)"`,
 		// The ownership check is failing because, to keep this test simple, we've just switched
 		// the instance state to LEAVING and there are no other instances in the ring.
-		`level=info component=compactor org_id=user-1 msg="skipped compaction because unable to check whether the group is owned by the compactor instance" group=0@17241709254077376921-split-1_of_4-1574863200000-1574870400000 err="at least 1 live replicas required, could only find 0"`,
+		`level=info component=compactor org_id=user-1 msg="skipped compaction because unable to check whether the job is owned by the compactor instance" groupKey=0@17241709254077376921-split-1_of_4-1574863200000-1574870400000 err="at least 1 live replicas required, could only find 0"`,
 		`level=info component=compactor org_id=user-1 msg="compaction iterations done"`,
 		`level=info component=compactor msg="successfully compacted user blocks" user=user-1`,
 	}, removeIgnoredLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))

--- a/pkg/compactor/job.go
+++ b/pkg/compactor/job.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package compactor
+
+import (
+	"errors"
+	"math"
+	"sort"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+// Job holds a compaction job, which consists of a group of blocks that should be compacted together.
+// Not goroutine safe.
+type Job struct {
+	userID         string
+	key            string
+	labels         labels.Labels
+	resolution     int64
+	metasByMinTime []*metadata.Meta
+	hashFunc       metadata.HashFunc
+	useSplitting   bool
+	shardingKey    string
+
+	// The number of shards to split compacted block into. Not used if splitting is disabled.
+	splitNumShards uint32
+}
+
+// NewJob returns a new compaction Job.
+func NewJob(userID string, key string, lset labels.Labels, resolution int64, hashFunc metadata.HashFunc, useSplitting bool, splitNumShards uint32, shardingKey string) *Job {
+	return &Job{
+		userID:         userID,
+		key:            key,
+		labels:         lset,
+		resolution:     resolution,
+		hashFunc:       hashFunc,
+		useSplitting:   useSplitting,
+		splitNumShards: splitNumShards,
+		shardingKey:    shardingKey,
+	}
+}
+
+// UserID returns the user/tenant to which this job belongs to.
+func (job *Job) UserID() string {
+	return job.userID
+}
+
+// Key returns an identifier for the job.
+func (job *Job) Key() string {
+	return job.key
+}
+
+// AppendMeta the block with the given meta to the job.
+func (job *Job) AppendMeta(meta *metadata.Meta) error {
+	if !labels.Equal(job.labels, labels.FromMap(meta.Thanos.Labels)) {
+		return errors.New("block and group labels do not match")
+	}
+	if job.resolution != meta.Thanos.Downsample.Resolution {
+		return errors.New("block and group resolution do not match")
+	}
+
+	job.metasByMinTime = append(job.metasByMinTime, meta)
+	sort.Slice(job.metasByMinTime, func(i, j int) bool {
+		return job.metasByMinTime[i].MinTime < job.metasByMinTime[j].MinTime
+	})
+	return nil
+}
+
+// IDs returns all sorted IDs of blocks in the job.
+func (job *Job) IDs() (ids []ulid.ULID) {
+	for _, m := range job.metasByMinTime {
+		ids = append(ids, m.ULID)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].Compare(ids[j]) < 0
+	})
+	return ids
+}
+
+// MinTime returns the min time across all job's blocks.
+func (job *Job) MinTime() int64 {
+	if len(job.metasByMinTime) > 0 {
+		return job.metasByMinTime[0].MinTime
+	}
+	return math.MaxInt64
+}
+
+// MaxTime returns the max time across all job's blocks.
+func (job *Job) MaxTime() int64 {
+	max := int64(math.MinInt64)
+	for _, m := range job.metasByMinTime {
+		if m.MaxTime > max {
+			max = m.MaxTime
+		}
+	}
+	return max
+}
+
+// Labels returns the external labels for the output block(s) of this job.
+func (job *Job) Labels() labels.Labels {
+	return job.labels
+}
+
+// Resolution returns the common downsampling resolution of blocks in the job.
+func (job *Job) Resolution() int64 {
+	return job.resolution
+}
+
+// UseSplitting returns whether blocks should be splitted into multiple shards when compacted.
+func (job *Job) UseSplitting() bool {
+	return job.useSplitting
+}
+
+// SplittingShards returns the number of output shards to build if splitting is enabled.
+func (job *Job) SplittingShards() uint32 {
+	return job.splitNumShards
+}
+
+// ShardingKey returns the key used to shard this job across multiple instances.
+func (job *Job) ShardingKey() string {
+	return job.shardingKey
+}

--- a/pkg/compactor/split_merge_grouper_test.go
+++ b/pkg/compactor/split_merge_grouper_test.go
@@ -34,22 +34,22 @@ func TestSplitAndMergeGrouper_Groups(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		ownJob         ownJobFunc
-		expectedGroups int
+		ownJob       ownJobFunc
+		expectedJobs int
 	}{
-		"should return all planned groups if the compactor instance owns all of them": {
+		"should return all planned jobs if the compactor instance owns all of them": {
 			ownJob: func(job *job) (bool, error) {
 				return true, nil
 			},
-			expectedGroups: 4,
+			expectedJobs: 4,
 		},
-		"should return no groups if the compactor instance owns none of them": {
+		"should return no jobs if the compactor instance owns none of them": {
 			ownJob: func(job *job) (bool, error) {
 				return false, nil
 			},
-			expectedGroups: 0,
+			expectedJobs: 0,
 		},
-		"should return some groups if the compactor instance owns some of them": {
+		"should return some jobs if the compactor instance owns some of them": {
 			ownJob: func() ownJobFunc {
 				count := 0
 				return func(job *job) (bool, error) {
@@ -57,7 +57,7 @@ func TestSplitAndMergeGrouper_Groups(t *testing.T) {
 					return count%2 == 0, nil
 				}
 			}(),
-			expectedGroups: 2,
+			expectedJobs: 2,
 		},
 	}
 
@@ -66,7 +66,7 @@ func TestSplitAndMergeGrouper_Groups(t *testing.T) {
 			grouper := NewSplitAndMergeGrouper("test", ranges, 1, testCase.ownJob, log.NewNopLogger())
 			res, err := grouper.Groups(blocks)
 			require.NoError(t, err)
-			assert.Len(t, res, testCase.expectedGroups)
+			assert.Len(t, res, testCase.expectedJobs)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:
I would like to do a little cleanup in the compactor, including merging `Group` and `job`. This is a first PR going into that direction.

In this PR I'm just renaming `Group` to `Job`, moving it to a dedicate file and renaming related functions/variables accordingly. Logic shouldn't have changed.

_I haven't addressed "groupKey" because I would like to address it in a dedicated PR._

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
