### PR TITLE
Make ownGroup and ownJob consistent. Previously ownJob didn't honor tenant shard size

### DIFF
--- a/pkg/compactor/default_compactor.go
+++ b/pkg/compactor/default_compactor.go
@@ -10,11 +10,9 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
-
-	"github.com/grafana/mimir/pkg/ring"
 )
 
-func defaultBlocksGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, ring *ring.Ring, instanceAddr string, logger log.Logger, reg prometheus.Registerer) Grouper {
+func defaultBlocksGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, ownJob ownJobFunc, logger log.Logger, reg prometheus.Registerer) Grouper {
 	return NewDefaultGrouper(userID, metadata.NoneFunc)
 }
 


### PR DESCRIPTION
This PR fixes mismatch between `ownGroup` and `ownJob` function... they must behave in the same way. If they don't, jobs that `ownJob` selectes as "owned" by compactor, may be ignored by "ownGroup" and vice-versa. This causes that some compaction jobs will be ignored.

Instead of this PR I think we should proceed with unification of Job and Group. This PR would make extending a compactor difficult.

**Checklist**

- [no] Tests updated
- [no] Documentation added
- [no] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
