### PR TITLE
Revert "Distributor Push: re-use decompression buffers in a pool"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 * [ENHANCEMENT] Exemplars are now emitted for all gRPC calls and many operations tracked by histograms. #180
 * [ENHANCEMENT] New options `-server.http-listen-network` and `-server.grpc-listen-network` allow binding as 'tcp4' or 'tcp6'. #180
 * [ENHANCEMENT] Add tags to tracing span for distributor push with user, cluster and replica. #210
-* [ENHANCEMENT] Optimisations to distributor. #212 #217 #242
+* [ENHANCEMENT] Some optimisations to distributor. #212 #242
 * [ENHANCEMENT] Memberlist: Add `-memberlist.advertise-addr` and `-memberlist.advertise-port` options for setting the address to advertise to other members of the cluster to enable NAT traversal. #260
 * [ENHANCEMENT] Compactor: when sharding is enabled, skip already planned compaction jobs if the tenant doesn't belong to the compactor instance anymore. #303
 * [ENHANCEMENT] Query federation: improve performance in MergeQueryable by memoizing labels. #312

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -85,10 +85,10 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 // Push either wraps the distributor push function as configured or returns the distributor push directly.
 func (cfg *Config) wrapDistributorPush(d *distributor.Distributor) push.Func {
 	if cfg.DistributorPushWrapper != nil {
-		return cfg.DistributorPushWrapper(d.PushWithCleanup)
+		return cfg.DistributorPushWrapper(d.Push)
 	}
 
-	return d.PushWithCleanup
+	return d.Push
 }
 
 type API struct {
@@ -249,7 +249,7 @@ type Ingester interface {
 	client.IngesterServer
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)
-	PushWithCleanup(context.Context, *mimirpb.WriteRequest, func()) (*mimirpb.WriteResponse, error)
+	Push(context.Context, *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error)
 }
 
 // RegisterIngester registers the ingesters HTTP and GRPC service
@@ -260,12 +260,12 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 	a.indexPage.AddLink(SectionDangerous, "/ingester/shutdown", "Trigger Ingester Shutdown (Dangerous)")
 	a.RegisterRoute("/ingester/flush", http.HandlerFunc(i.FlushHandler), false, "GET", "POST")
 	a.RegisterRoute("/ingester/shutdown", http.HandlerFunc(i.ShutdownHandler), false, "GET", "POST")
-	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, i.PushWithCleanup), true, "POST") // For testing and debugging.
+	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, i.Push), true, "POST") // For testing and debugging.
 
 	// Legacy Routes
 	a.RegisterRoute("/flush", http.HandlerFunc(i.FlushHandler), false, "GET", "POST")
 	a.RegisterRoute("/shutdown", http.HandlerFunc(i.ShutdownHandler), false, "GET", "POST")
-	a.RegisterRoute("/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, i.PushWithCleanup), true, "POST") // For testing and debugging.
+	a.RegisterRoute("/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, i.Push), true, "POST") // For testing and debugging.
 }
 
 // RegisterChunksPurger registers the endpoints associated with the Purger/DeleteStore. They do not exactly

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -525,19 +525,6 @@ func (d *Distributor) validateSeries(ts mimirpb.PreallocTimeseries, userID strin
 
 // Push implements client.IngesterServer
 func (d *Distributor) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
-	return d.PushWithCleanup(ctx, req, func() { mimirpb.ReuseSlice(req.Timeseries) })
-}
-
-// PushWithCleanup takes a WriteRequest and distributes it to ingesters using the ring.
-// Strings in `req` may be pointers into the gRPC buffer which will be reused, so must be copied if retained.
-func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error) {
-	cleanupInDefer := true
-	defer func() {
-		if cleanupInDefer {
-			cleanup()
-		}
-	}()
-
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
@@ -593,14 +580,15 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 
 	if d.limits.AcceptHASamples(userID) && len(req.Timeseries) > 0 {
 		cluster, replica := findHALabels(d.limits.HAReplicaLabel(userID), d.limits.HAClusterLabel(userID), req.Timeseries[0].Labels)
-		// Make a copy of these, since they may be retained as labels on our metrics, e.g. dedupedSamples.
-		cluster, replica = copyString(cluster), copyString(replica)
 		if span != nil {
 			span.SetTag("cluster", cluster)
 			span.SetTag("replica", replica)
 		}
 		removeReplica, err = d.checkSample(ctx, userID, cluster, replica)
 		if err != nil {
+			// Ensure the request slice is reused if the series get deduped.
+			mimirpb.ReuseSlice(req.Timeseries)
+
 			if errors.Is(err, replicasNotMatchError{}) {
 				// These samples have been deduped.
 				d.dedupedSamples.WithLabelValues(userID, cluster).Add(float64(numSamples))
@@ -711,11 +699,17 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 	d.receivedMetadata.WithLabelValues(userID).Add(float64(len(validatedMetadata)))
 
 	if len(seriesKeys) == 0 && len(metadataKeys) == 0 {
+		// Ensure the request slice is reused if there's no series or metadata passing the validation.
+		mimirpb.ReuseSlice(req.Timeseries)
+
 		return &mimirpb.WriteResponse{}, firstPartialErr
 	}
 
 	totalN := validatedSamples + validatedExemplars + len(validatedMetadata)
 	if !d.ingestionRateLimiter.AllowN(now, userID, totalN) {
+		// Ensure the request slice is reused if the request is rate limited.
+		mimirpb.ReuseSlice(req.Timeseries)
+
 		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedSamples))
 		validation.DiscardedExemplars.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedExemplars))
 		validation.DiscardedMetadata.WithLabelValues(validation.RateLimited, userID).Add(float64(len(validatedMetadata)))
@@ -752,10 +746,6 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 		op = ring.Write
 	}
 
-	// we must not re-use buffers now until all DoBatch goroutines have finished,
-	// so set this flag false and pass cleanup() to DoBatch.
-	cleanupInDefer = false
-
 	err = ring.DoBatch(ctx, op, subRing, keys, func(ingester ring.InstanceDesc, indexes []int) error {
 		timeseries := make([]mimirpb.PreallocTimeseries, 0, len(indexes))
 		var metadata []*mimirpb.MetricMetadata
@@ -769,15 +759,11 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 		}
 
 		return d.send(localCtx, ingester, timeseries, metadata, req.Source)
-	}, func() { cleanup(); cancel() })
+	}, func() { mimirpb.ReuseSlice(req.Timeseries); cancel() })
 	if err != nil {
 		return nil, err
 	}
 	return &mimirpb.WriteResponse{}, firstPartialErr
-}
-
-func copyString(s string) string {
-	return string([]byte(s))
 }
 
 func sortLabelsIfNeeded(labels []mimirpb.LabelAdapter) {

--- a/pkg/ingester/client/client_test.go
+++ b/pkg/ingester/client/client_test.go
@@ -45,9 +45,9 @@ func TestMarshall(t *testing.T) {
 			plentySize   = 1024 * 1024
 		)
 		req := mimirpb.WriteRequest{}
-		_, err := util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), tooSmallSize, nil, &req, util.RawSnappy)
+		err := util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), tooSmallSize, &req, util.RawSnappy)
 		require.Error(t, err)
-		_, err = util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), plentySize, nil, &req, util.RawSnappy)
+		err = util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), plentySize, &req, util.RawSnappy)
 		require.NoError(t, err)
 		require.Equal(t, numSeries, len(req.Timeseries))
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -775,7 +775,8 @@ func (i *Ingester) v2Push(ctx context.Context, req *mimirpb.WriteRequest) (*mimi
 	var firstPartialErr error
 
 	// NOTE: because we use `unsafe` in deserialisation, we must not
-	// retain anything from `req` past the exit from this function.
+	// retain anything from `req` past the call to ReuseSlice
+	defer mimirpb.ReuseSlice(req.Timeseries)
 
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -27,7 +27,7 @@ func RemoteReadHandler(q storage.Queryable, logger log.Logger) http.Handler {
 		ctx := r.Context()
 		var req client.ReadRequest
 		logger := util_log.WithContext(r.Context(), logger)
-		if _, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, nil, &req, util.RawSnappy); err != nil {
+		if err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, &req, util.RawSnappy); err != nil {
 			level.Error(logger).Log("msg", "failed to parse proto", "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -197,7 +197,7 @@ func TestParseProtoReader(t *testing.T) {
 				reader = bytesBuffered{Buffer: &buf}
 			}
 
-			_, err := util.ParseProtoReader(context.Background(), reader, 0, tt.maxSize, nil, &fromWire, tt.compression)
+			err := util.ParseProtoReader(context.Background(), reader, 0, tt.maxSize, &fromWire, tt.compression)
 			if tt.expectErr {
 				assert.NotNil(t, err)
 				return

--- a/pkg/util/push/push.go
+++ b/pkg/util/push/push.go
@@ -8,7 +8,6 @@ package push
 import (
 	"context"
 	"net/http"
-	"sync"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/httpgrpc"
@@ -20,16 +19,7 @@ import (
 )
 
 // Func defines the type of the push. It is similar to http.HandlerFunc.
-type Func func(ctx context.Context, req *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error)
-
-// Wrap a slice in a struct so we can store a pointer in sync.Pool
-type bufHolder struct {
-	buf []byte
-}
-
-var bufferPool = sync.Pool{
-	New: func() interface{} { return &bufHolder{buf: make([]byte, 256*1024)} },
-}
+type Func func(context.Context, *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error)
 
 // Handler is a http.Handler which accepts WriteRequests.
 func Handler(maxRecvMsgSize int, sourceIPs *middleware.SourceIPExtractor, push Func) http.Handler {
@@ -43,23 +33,12 @@ func Handler(maxRecvMsgSize int, sourceIPs *middleware.SourceIPExtractor, push F
 				logger = log.WithSourceIPs(source, logger)
 			}
 		}
-		bufHolder := bufferPool.Get().(*bufHolder)
 		var req mimirpb.PreallocWriteRequest
-		buf, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRecvMsgSize, bufHolder.buf, &req, util.RawSnappy)
+		err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRecvMsgSize, &req, util.RawSnappy)
 		if err != nil {
 			level.Error(logger).Log("err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
-			bufferPool.Put(bufHolder)
 			return
-		}
-		// If decoding allocated a bigger buffer, put that one back in the pool.
-		if len(buf) > len(bufHolder.buf) {
-			bufHolder.buf = buf
-		}
-
-		cleanup := func() {
-			mimirpb.ReuseSlice(req.Timeseries)
-			bufferPool.Put(bufHolder)
 		}
 
 		req.SkipLabelNameValidation = false
@@ -67,7 +46,7 @@ func Handler(maxRecvMsgSize int, sourceIPs *middleware.SourceIPExtractor, push F
 			req.Source = mimirpb.API
 		}
 
-		if _, err := push(ctx, &req.WriteRequest, cleanup); err != nil {
+		if _, err := push(ctx, &req.WriteRequest); err != nil {
 			resp, ok := httpgrpc.HTTPResponseFromError(err)
 			if !ok {
 				http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
This PR reverts grafana/mimir#217, because it creates a conflict in a downstream project (GEM). Since we need to upgrade Mimir in GEM asap (in order to unblock other people) and since fixing the conflict in GEM may take some time, I'm going to revert this PR until we're ready in GEM.