### PR TITLE
Revert spanlogger.New() breaking change

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -37,7 +37,6 @@ import (
 	chunk_util "github.com/grafana/mimir/pkg/chunk/util"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/log"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -374,7 +373,7 @@ type chunksPlusError struct {
 
 // GetChunks implements chunk.Client.
 func (a dynamoDBStorageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "GetChunks.DynamoDB", ot.Tag{Key: "numChunks", Value: len(chunks)})
+	log, ctx := spanlogger.New(ctx, "GetChunks.DynamoDB", ot.Tag{Key: "numChunks", Value: len(chunks)})
 	defer log.Span.Finish()
 	level.Debug(log).Log("chunks requested", len(chunks))
 
@@ -423,7 +422,7 @@ var placeholder = []byte{'c'}
 // Structure is identical to BatchWrite(), but operating on different datatypes
 // so cannot share implementation.  If you fix a bug here fix it there too.
 func (a dynamoDBStorageClient) getDynamoDBChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "getDynamoDBChunks", ot.Tag{Key: "numChunks", Value: len(chunks)})
+	log, ctx := spanlogger.New(ctx, "getDynamoDBChunks", ot.Tag{Key: "numChunks", Value: len(chunks)})
 	defer log.Span.Finish()
 	outstanding := dynamoDBReadRequest{}
 	chunksByKey := map[string]chunk.Chunk{}

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -141,7 +141,7 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 	var items map[string]*memcache.Item
 	const method = "Memcache.GetMulti"
 	err := instr.CollectedRequest(ctx, method, c.requestDuration, memcacheStatusCode, func(innerCtx context.Context) error {
-		log, _ := spanlogger.New(innerCtx, c.logger, method)
+		log, _ := spanlogger.NewWithLogger(innerCtx, c.logger, method)
 		defer log.Finish()
 		log.LogFields(otlog.Int("keys requested", len(keys)))
 

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -65,7 +65,7 @@ func (c *RedisCache) Fetch(ctx context.Context, keys []string) (found []string, 
 	var items [][]byte
 	// Run a tracked request, using c.requestDuration to monitor requests.
 	err := instr.CollectedRequest(ctx, method, c.requestDuration, redisStatusCode, func(ctx context.Context) error {
-		log, _ := spanlogger.New(ctx, c.logger, method)
+		log, _ := spanlogger.NewWithLogger(ctx, c.logger, method)
 		defer log.Finish()
 		log.LogFields(otlog.Int("keys requested", len(keys)))
 

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -155,7 +155,7 @@ func (c *store) Put(ctx context.Context, chunks []Chunk) error {
 
 // PutOne implements Store
 func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.PutOne")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.PutOne")
 	defer log.Finish()
 	chunks := []Chunk{chunk}
 
@@ -205,7 +205,7 @@ func (c *store) calculateIndexEntries(userID string, from, through model.Time, c
 
 // Get implements Store
 func (c *store) Get(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([]Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.Get")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.Get")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "matchers", len(allMatchers))
 
@@ -227,7 +227,7 @@ func (c *store) GetChunkRefs(ctx context.Context, userID string, from, through m
 
 // LabelValuesForMetricName retrieves all label values for a single label name and metric name.
 func (c *baseStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName, labelName string) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.LabelValues")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.LabelValues")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "metricName", metricName, "labelName", labelName)
 
@@ -261,7 +261,7 @@ func (c *baseStore) LabelValuesForMetricName(ctx context.Context, userID string,
 
 // LabelNamesForMetricName retrieves all label names for a metric name.
 func (c *store) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.LabelNamesForMetricName")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.LabelNamesForMetricName")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "metricName", metricName)
 
@@ -294,7 +294,7 @@ func (c *store) LabelNamesForMetricName(ctx context.Context, userID string, from
 
 func (c *baseStore) validateQueryTimeRange(ctx context.Context, userID string, from *model.Time, through *model.Time) (bool, error) {
 	//nolint:ineffassign,staticcheck //Leaving ctx even though we don't currently use it, we want to make it available for when we might need it and hopefully will ensure us using the correct context at that time
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "store.validateQueryTimeRange")
+	log, ctx := spanlogger.New(ctx, "store.validateQueryTimeRange")
 	defer log.Span.Finish()
 
 	if *through < *from {
@@ -324,7 +324,7 @@ func (c *baseStore) validateQueryTimeRange(ctx context.Context, userID string, f
 }
 
 func (c *baseStore) validateQuery(ctx context.Context, userID string, from *model.Time, through *model.Time, matchers []*labels.Matcher) (string, []*labels.Matcher, bool, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "store.validateQuery")
+	log, ctx := spanlogger.New(ctx, "store.validateQuery")
 	defer log.Span.Finish()
 
 	shortcut, err := c.validateQueryTimeRange(ctx, userID, from, through)
@@ -345,7 +345,7 @@ func (c *baseStore) validateQuery(ctx context.Context, userID string, from *mode
 }
 
 func (c *store) getMetricNameChunks(ctx context.Context, userID string, from, through model.Time, allMatchers []*labels.Matcher, metricName string) ([]Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.getMetricNameChunks")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.getMetricNameChunks")
 	defer log.Finish()
 	level.Debug(log).Log("from", from, "through", through, "metricName", metricName, "matchers", len(allMatchers))
 
@@ -380,7 +380,7 @@ func (c *store) getMetricNameChunks(ctx context.Context, userID string, from, th
 }
 
 func (c *store) lookupChunksByMetricName(ctx context.Context, userID string, from, through model.Time, matchers []*labels.Matcher, metricName string) ([]Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.lookupChunksByMetricName")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.lookupChunksByMetricName")
 	defer log.Finish()
 
 	// Just get chunks for metric if there are no matchers
@@ -448,7 +448,7 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, userID string, fro
 
 func (c *baseStore) lookupIdsByMetricNameMatcher(ctx context.Context, from, through model.Time, userID, metricName string, matcher *labels.Matcher) ([]string, error) {
 	formattedMatcher := formatMatcher(matcher)
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "Store.lookupIdsByMetricNameMatcher", "metricName", metricName, "matcher", formattedMatcher)
+	log, ctx := spanlogger.New(ctx, "Store.lookupIdsByMetricNameMatcher", "metricName", metricName, "matcher", formattedMatcher)
 	defer log.Span.Finish()
 
 	var err error
@@ -498,7 +498,7 @@ func formatMatcher(matcher *labels.Matcher) string {
 }
 
 func (c *baseStore) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "store.lookupEntriesByQueries")
+	log, ctx := spanlogger.New(ctx, "store.lookupEntriesByQueries")
 	defer log.Span.Finish()
 
 	// Nothing to do if there are no queries.

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -145,7 +145,7 @@ func (c *Fetcher) worker() {
 // FetchChunks fetches a set of chunks from cache and store. Note that the keys passed in must be
 // lexicographically sorted, while the returned chunks are not in the same order as the passed in chunks.
 func (c *Fetcher) FetchChunks(ctx context.Context, chunks []Chunk, keys []string) ([]Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "ChunkStore.FetchChunks")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.FetchChunks")
 	defer log.Span.Finish()
 
 	// Now fetch the actual chunk data from Memcache / S3
@@ -205,7 +205,7 @@ func (c *Fetcher) processCacheResponse(ctx context.Context, chunks []Chunk, keys
 		responses = make(chan decodeResponse)
 		missing   []Chunk
 	)
-	log, _ := spanlogger.New(ctx, util_log.Logger, "Fetcher.processCacheResponse")
+	log, _ := spanlogger.New(ctx, "Fetcher.processCacheResponse")
 	defer log.Span.Finish()
 
 	i, j := 0, 0

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/grafana/mimir/pkg/chunk"
 	chunk_util "github.com/grafana/mimir/pkg/chunk/util"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -338,7 +337,7 @@ func (s *storageClientV1) QueryPages(ctx context.Context, queries []chunk.IndexQ
 func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, callback chunk_util.Callback) error {
 	const null = string('\xff')
 
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
+	log, ctx := spanlogger.New(ctx, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
 	defer log.Finish()
 
 	table := s.client.Open(query.TableName)

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/mimir/pkg/chunk/cache"
 	"github.com/grafana/mimir/pkg/querier/querysharding"
 	"github.com/grafana/mimir/pkg/util"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
@@ -101,7 +100,7 @@ func newSeriesStore(cfg StoreConfig, schema SeriesStoreSchema, index IndexClient
 
 // Get implements Store
 func (c *seriesStore) Get(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([]Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.Get")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.Get")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "matchers", len(allMatchers))
 
@@ -148,7 +147,7 @@ func (c *seriesStore) Get(ctx context.Context, userID string, from, through mode
 }
 
 func (c *seriesStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.GetChunkRefs")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.GetChunkRefs")
 	defer log.Span.Finish()
 
 	// Validate the query is within reasonable bounds.
@@ -198,7 +197,7 @@ func (c *seriesStore) GetChunkRefs(ctx context.Context, userID string, from, thr
 
 // LabelNamesForMetricName retrieves all label names for a metric name.
 func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.LabelNamesForMetricName")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.LabelNamesForMetricName")
 	defer log.Span.Finish()
 
 	shortcut, err := c.validateQueryTimeRange(ctx, userID, &from, &through)
@@ -232,7 +231,7 @@ func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, userID string
 }
 
 func (c *seriesStore) lookupLabelNamesByChunks(ctx context.Context, from, through model.Time, userID string, seriesIDs []string) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.lookupLabelNamesByChunks")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupLabelNamesByChunks")
 	defer log.Span.Finish()
 
 	// Lookup the series in the index to get the chunks.
@@ -265,7 +264,7 @@ func (c *seriesStore) lookupLabelNamesByChunks(ctx context.Context, from, throug
 	return labelNamesFromChunks(allChunks), nil
 }
 func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from, through model.Time, userID, metricName string, matchers []*labels.Matcher) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.lookupSeriesByMetricNameMatchers", "metricName", metricName, "matchers", len(matchers))
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupSeriesByMetricNameMatchers", "metricName", metricName, "matchers", len(matchers))
 	defer log.Span.Finish()
 
 	// Just get series for metric if there are no matchers
@@ -343,7 +342,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 }
 
 func (c *seriesStore) lookupChunksBySeries(ctx context.Context, from, through model.Time, userID string, seriesIDs []string) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.lookupChunksBySeries")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupChunksBySeries")
 	defer log.Span.Finish()
 
 	level.Debug(log).Log("seriesIDs", len(seriesIDs))
@@ -369,7 +368,7 @@ func (c *seriesStore) lookupChunksBySeries(ctx context.Context, from, through mo
 }
 
 func (c *seriesStore) lookupLabelNamesBySeries(ctx context.Context, from, through model.Time, userID string, seriesIDs []string) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.lookupLabelNamesBySeries")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupLabelNamesBySeries")
 	defer log.Span.Finish()
 
 	level.Debug(log).Log("seriesIDs", len(seriesIDs))
@@ -413,7 +412,7 @@ func (c *seriesStore) Put(ctx context.Context, chunks []Chunk) error {
 
 // PutOne implements Store
 func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "SeriesStore.PutOne")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.PutOne")
 	defer log.Finish()
 	writeChunk := true
 

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/mimir/pkg/chunk/cache"
 	chunk_util "github.com/grafana/mimir/pkg/chunk/util"
 	"github.com/grafana/mimir/pkg/tenant"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
@@ -245,7 +244,7 @@ func (s *cachingIndexClient) cacheStore(ctx context.Context, keys []string, batc
 }
 
 func (s *cachingIndexClient) cacheFetch(ctx context.Context, keys []string) (batches []ReadBatch, missed []string) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "cachingIndexClient.cacheFetch")
+	log, ctx := spanlogger.New(ctx, "cachingIndexClient.cacheFetch")
 	defer log.Finish()
 
 	cacheGets.Add(float64(len(keys)))

--- a/pkg/chunk/util/parallel_chunk_fetch.go
+++ b/pkg/chunk/util/parallel_chunk_fetch.go
@@ -12,7 +12,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/grafana/mimir/pkg/chunk"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
@@ -26,7 +25,7 @@ var decodeContextPool = sync.Pool{
 
 // GetParallelChunks fetches chunks in parallel (up to maxParallel).
 func GetParallelChunks(ctx context.Context, chunks []chunk.Chunk, f func(context.Context, *chunk.DecodeContext, chunk.Chunk) (chunk.Chunk, error)) ([]chunk.Chunk, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "GetParallelChunks")
+	log, ctx := spanlogger.New(ctx, "GetParallelChunks")
 	defer log.Finish()
 	log.LogFields(otlog.Int("chunks requested", len(chunks)))
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -800,7 +800,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	spanLog, ctx := spanlogger.New(stream.Context(), i.logger, "QueryStream")
+	spanLog, ctx := spanlogger.NewWithLogger(stream.Context(), i.logger, "QueryStream")
 	defer spanLog.Finish()
 
 	from, through, matchers, err := client.FromQueryRequest(req)

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1336,7 +1336,7 @@ func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingeste
 		return err
 	}
 
-	spanlog, ctx := spanlogger.New(stream.Context(), i.logger, "v2QueryStream")
+	spanlog, ctx := spanlogger.NewWithLogger(stream.Context(), i.logger, "v2QueryStream")
 	defer spanlog.Finish()
 
 	userID, err := tenant.TenantID(ctx)

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -319,7 +319,7 @@ func (u *userState) forSeriesMatching(ctx context.Context, allMatchers []*labels
 	add func(context.Context, model.Fingerprint, *memorySeries) error,
 	send func(context.Context) error, batchSize int,
 ) error {
-	log, ctx := spanlogger.New(ctx, u.logger, "forSeriesMatching")
+	log, ctx := spanlogger.NewWithLogger(ctx, u.logger, "forSeriesMatching")
 	defer log.Finish()
 
 	filters, matchers := util.SplitFiltersAndMatchers(allMatchers)

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -332,7 +332,7 @@ func (q *blocksStoreQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 }
 
 func (q *blocksStoreQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	spanLog, spanCtx := spanlogger.New(q.ctx, q.logger, "blocksStoreQuerier.LabelNames")
+	spanLog, spanCtx := spanlogger.NewWithLogger(q.ctx, q.logger, "blocksStoreQuerier.LabelNames")
 	defer spanLog.Span.Finish()
 
 	minT, maxT := q.minT, q.maxT
@@ -367,7 +367,7 @@ func (q *blocksStoreQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, 
 }
 
 func (q *blocksStoreQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	spanLog, spanCtx := spanlogger.New(q.ctx, q.logger, "blocksStoreQuerier.LabelValues")
+	spanLog, spanCtx := spanlogger.NewWithLogger(q.ctx, q.logger, "blocksStoreQuerier.LabelValues")
 	defer spanLog.Span.Finish()
 
 	minT, maxT := q.minT, q.maxT
@@ -406,7 +406,7 @@ func (q *blocksStoreQuerier) Close() error {
 }
 
 func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	spanLog, spanCtx := spanlogger.New(q.ctx, q.logger, "blocksStoreQuerier.selectSorted")
+	spanLog, spanCtx := spanlogger.NewWithLogger(q.ctx, q.logger, "blocksStoreQuerier.selectSorted")
 	defer spanLog.Span.Finish()
 
 	minT, maxT := q.minT, q.maxT

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -92,7 +92,7 @@ type distributorQuerier struct {
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
 func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	log, ctx := spanlogger.New(q.ctx, q.logger, "distributorQuerier.Select")
+	log, ctx := spanlogger.NewWithLogger(q.ctx, q.logger, "distributorQuerier.Select")
 	defer log.Span.Finish()
 
 	// Kludge: Prometheus passes nil SelectParams if it is doing a 'series' operation,
@@ -195,7 +195,7 @@ func (q *distributorQuerier) LabelValues(name string, matchers ...*labels.Matche
 }
 
 func (q *distributorQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	log, ctx := spanlogger.New(q.ctx, q.logger, "distributorQuerier.LabelNames")
+	log, ctx := spanlogger.NewWithLogger(q.ctx, q.logger, "distributorQuerier.LabelNames")
 	defer log.Span.Finish()
 
 	if len(matchers) > 0 && !q.queryLabelNamesWithMatchers {
@@ -210,7 +210,7 @@ func (q *distributorQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, 
 // this is used when the LabelNames with matchers feature is first deployed, and some ingesters may have not been updated yet, so they could be ignoring
 // the matchers, leading to wrong results.
 func (q *distributorQuerier) legacyLabelNamesWithMatchersThroughMetricsCall(ctx context.Context, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	log, ctx := spanlogger.New(ctx, q.logger, "distributorQuerier.legacyLabelNamesWithMatchersThroughMetricsCall")
+	log, ctx := spanlogger.NewWithLogger(ctx, q.logger, "distributorQuerier.legacyLabelNamesWithMatchersThroughMetricsCall")
 	defer log.Span.Finish()
 	ms, err := q.distributor.MetricsForLabelMatchers(ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
 	if err != nil {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -264,7 +264,7 @@ type querier struct {
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
 func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	log, ctx := spanlogger.New(q.ctx, q.logger, "querier.Select")
+	log, ctx := spanlogger.NewWithLogger(q.ctx, q.logger, "querier.Select")
 	defer log.Span.Finish()
 
 	if sp != nil {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -62,7 +62,7 @@ func NewLimitsMiddleware(l Limits, logger log.Logger) Middleware {
 }
 
 func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
-	log, ctx := spanlogger.New(ctx, l.logger, "limits")
+	log, ctx := spanlogger.NewWithLogger(ctx, l.logger, "limits")
 	defer log.Finish()
 
 	tenantIDs, err := tenant.TenantIDs(ctx)

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -261,7 +261,7 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ R
 		body, _ := ioutil.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
-	log, ctx := spanlogger.New(ctx, logger, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
+	log, ctx := spanlogger.NewWithLogger(ctx, logger, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
 	buf, err := bodyBuffer(r)

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -91,7 +91,7 @@ func NewQueryShardingMiddleware(
 }
 
 func (s *querySharding) Do(ctx context.Context, r Request) (Response, error) {
-	log, ctx := spanlogger.New(ctx, s.logger, "querySharding.Do")
+	log, ctx := spanlogger.NewWithLogger(ctx, s.logger, "querySharding.Do")
 	defer log.Span.Finish()
 
 	tenantIDs, err := tenant.TenantIDs(ctx)

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -362,7 +362,7 @@ func (s resultsCache) handleHit(ctx context.Context, r Request, extents []Extent
 		reqResps []RequestResponse
 		err      error
 	)
-	log, ctx := spanlogger.New(ctx, s.logger, "handleHit")
+	log, ctx := spanlogger.NewWithLogger(ctx, s.logger, "handleHit")
 	defer log.Finish()
 
 	requests, responses, err := s.partition(r, extents)
@@ -570,7 +570,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	}
 
 	var resp CachedResponse
-	log, ctx := spanlogger.New(ctx, s.logger, "unmarshal-extent") //nolint:ineffassign,staticcheck
+	log, ctx := spanlogger.NewWithLogger(ctx, s.logger, "unmarshal-extent") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
 	log.LogFields(otlog.Int("bytes", len(bufs[0])))

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -147,7 +147,7 @@ type mergeQuerier struct {
 // For the label "original_" + `idLabelName it will return all the values
 // of the underlying queriers for `idLabelName`.
 func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	log, _ := spanlogger.New(m.ctx, m.logger, "mergeQuerier.LabelValues")
+	log, _ := spanlogger.NewWithLogger(m.ctx, m.logger, "mergeQuerier.LabelValues")
 	defer log.Span.Finish()
 
 	matchedTenants, filteredMatchers := filterValuesByMatchers(m.idLabelName, m.ids, matchers...)
@@ -177,7 +177,7 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 // queriers. It also adds the `idLabelName` and if present in the original
 // results the original `idLabelName`.
 func (m *mergeQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	log, _ := spanlogger.New(m.ctx, m.logger, "mergeQuerier.LabelNames")
+	log, _ := spanlogger.NewWithLogger(m.ctx, m.logger, "mergeQuerier.LabelNames")
 	defer log.Span.Finish()
 
 	matchedTenants, filteredMatchers := filterValuesByMatchers(m.idLabelName, m.ids, matchers...)
@@ -309,7 +309,7 @@ type selectJob struct {
 // matching. The forwarded labelSelector is not containing those that operate
 // on `idLabelName`.
 func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	log, ctx := spanlogger.New(m.ctx, m.logger, "mergeQuerier.Select")
+	log, ctx := spanlogger.NewWithLogger(m.ctx, m.logger, "mergeQuerier.Select")
 	defer log.Span.Finish()
 	matchedValues, filteredMatchers := filterValuesByMatchers(m.idLabelName, m.ids, matchers...)
 	var jobs = make([]interface{}, len(matchedValues))

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -170,7 +170,7 @@ func (m *mockSeriesSet) Warnings() storage.Warnings {
 
 // Select implements the storage.Querier interface.
 func (m mockTenantQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	log, _ := spanlogger.New(m.ctx, m.logger, "mockTenantQuerier.select")
+	log, _ := spanlogger.NewWithLogger(m.ctx, m.logger, "mockTenantQuerier.select")
 	defer log.Span.Finish()
 	var matrix model.Matrix
 

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -296,7 +296,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 
 // Series makes a series request to the underlying user bucket store.
 func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	spanLog, spanCtx := spanlogger.New(srv.Context(), u.logger, "BucketStores.Series")
+	spanLog, spanCtx := spanlogger.NewWithLogger(srv.Context(), u.logger, "BucketStores.Series")
 	defer spanLog.Span.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
@@ -317,7 +317,7 @@ func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_Seri
 
 // LabelNames implements the Storegateway proto service.
 func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
-	spanLog, spanCtx := spanlogger.New(ctx, u.logger, "BucketStores.LabelNames")
+	spanLog, spanCtx := spanlogger.NewWithLogger(ctx, u.logger, "BucketStores.LabelNames")
 	defer spanLog.Span.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
@@ -335,7 +335,7 @@ func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 
 // LabelValues implements the Storegateway proto service.
 func (u *BucketStores) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
-	spanLog, spanCtx := spanlogger.New(ctx, u.logger, "BucketStores.LabelValues")
+	spanLog, spanCtx := spanlogger.NewWithLogger(ctx, u.logger, "BucketStores.LabelValues")
 	defer spanLog.Span.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)

--- a/pkg/testexporter/correctness/runner.go
+++ b/pkg/testexporter/correctness/runner.go
@@ -24,7 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/weaveworks/common/user"
 
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
@@ -185,7 +184,7 @@ func (r *Runner) runRandomTest() {
 	r.mtx.Unlock()
 
 	ctx := context.Background()
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "runRandomTest")
+	log, ctx := spanlogger.New(ctx, "runRandomTest")
 	span, trace := opentracing.SpanFromContext(ctx), "<none>"
 	if span != nil {
 		trace = fmt.Sprintf("%s", span.Context())

--- a/pkg/testexporter/correctness/simple.go
+++ b/pkg/testexporter/correctness/simple.go
@@ -97,7 +97,7 @@ func (tc *simpleTestCase) ExpectedValueAt(t time.Time) float64 {
 }
 
 func (tc *simpleTestCase) Query(ctx context.Context, client v1.API, selectors string, start time.Time, duration time.Duration) ([]model.SamplePair, error) {
-	log, ctx := spanlogger.New(ctx, util_log.Logger, "simpleTestCase.Query")
+	log, ctx := spanlogger.New(ctx, "simpleTestCase.Query")
 	defer log.Finish()
 
 	metricName := prometheus.BuildFQName(namespace, subsystem, tc.name)

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/dskit/spanlogger"
 
 	"github.com/grafana/mimir/pkg/tenant"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
 const (
@@ -21,7 +22,12 @@ type SpanLogger = spanlogger.SpanLogger
 
 // New makes a new SpanLogger with a log.Logger to send logs to. The provided context will have the logger attached
 // to it and can be retrieved with FromContext.
-func New(ctx context.Context, logger log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
+func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
+	return spanlogger.New(ctx, util_log.Logger, method, tenant.DefaultResolver, kvps...)
+}
+
+// NewWithLogger is like New but allows to pass a logger.
+func NewWithLogger(ctx context.Context, logger log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
 	return spanlogger.New(ctx, logger, method, tenant.DefaultResolver, kvps...)
 }
 


### PR DESCRIPTION
**What this PR does**:
In https://github.com/grafana/mimir/pull/322 we introduced a breaking change to `spanlogger.New()` (requires a logger now). This is making very hard to upgrade Mimir in downstream projects due to their usage of `spanlogger.New()` and some circular dependencies between projects.

To solve this issue, I'm proposing to revert the breaking change from `spanlogger.New()`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
