### PR TITLE
Added test for using correct compaction dir.

### DIFF
--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -179,13 +179,8 @@ func TestGroupCompactE2E(t *testing.T) {
 				}
 
 				for _, fi := range fs {
-					// Used by Prometheus LeveledCompactor when doing compaction.
-					const tmpForCreationBlockDirSuffix = ".tmp-for-creation"
-
-					toCheck := fi.Name()
-					if strings.HasSuffix(toCheck, tmpForCreationBlockDirSuffix) {
-						toCheck = toCheck[:len(toCheck)-len(tmpForCreationBlockDirSuffix)]
-					}
+					// Suffix used by Prometheus LeveledCompactor when doing compaction.
+					toCheck := strings.TrimSuffix(fi.Name(), ".tmp-for-creation")
 
 					_, err := ulid.Parse(toCheck)
 					if err == nil {


### PR DESCRIPTION
This PR adds test for https://github.com/grafana/mimir/pull/349. It works by checking that main compaction directory passed to `BucketCompactor` doesn't contain any filenames/directories with ULIDs in them, as was the case that #349 is fixing.