### PR TITLE
Disable query range step alignment if cache is disabled on the request

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1130,7 +1130,9 @@ The `query_range_config` configures the query splitting and caching in the query
 # CLI flag: -querier.split-queries-by-interval
 [split_queries_by_interval: <duration> | default = 0s]
 
-# Mutate incoming queries to align their start and end with their step.
+# Mutate incoming queries to align their start and end with their step. Can be
+# disabled on a per-request basis setting 'Cache-Control: no-store' header (will
+# disable results cache too).
 # CLI flag: -querier.align-querier-with-step
 [align_queries_with_step: <boolean> | default = false]
 

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -53,7 +53,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRetries, "querier.max-retries-per-request", 5, "Maximum number of retries for a single request; beyond this, the downstream error is returned.")
 	f.DurationVar(&cfg.SplitQueriesByInterval, "querier.split-queries-by-interval", 0, "Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled")
-	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", false, "Mutate incoming queries to align their start and end with their step.")
+	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", false, "Mutate incoming queries to align their start and end with their step. Can be disabled on a per-request basis setting 'Cache-Control: no-store' header (will disable results cache too).")
 	f.BoolVar(&cfg.CacheResults, "querier.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelise-shardable-queries", false, "Perform query parallelisations based on storage sharding configuration and query ASTs. This feature is supported only by the blocks storage engine.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)

--- a/pkg/querier/queryrange/step_align.go
+++ b/pkg/querier/queryrange/step_align.go
@@ -22,6 +22,12 @@ type stepAlign struct {
 }
 
 func (s stepAlign) Do(ctx context.Context, r Request) (Response, error) {
+	// No need to align step if results cache is disabled. Moreover, we want to provide customers
+	// a way to disable step alignment too on a per-request basis (ie. used by PromQL compliance test).
+	if r.GetOptions().CacheDisabled {
+		return s.next.Do(ctx, r)
+	}
+
 	start := (r.GetStart() / r.GetStep()) * r.GetStep()
 	end := (r.GetEnd() / r.GetStep()) * r.GetStep()
 	return s.next.Do(ctx, r.WithStartEnd(start, end))


### PR DESCRIPTION
**What this PR does**:
We need an easy way to disable step alignment on a per-request basis. Given step alignment is done to make queries cachable, I suggest to disable it when results cache is disabled in the request.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
