### PR TITLE
indexed+diff+varint+snappy postings encoding

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -2314,7 +2314,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 				compressions++
 				s := time.Now()
 				bep := newBigEndianPostings(pBytes[4:])
-				data, err := diffVarintSnappyEncode(bep, bep.length())
+				data, err := indexedDiffVarintSnappyEncode(bep, bep.length())
 				compressionTime = time.Since(s)
 				if err == nil {
 					dataToCache = data
@@ -2354,7 +2354,15 @@ func (r *bucketIndexReader) decodePostings(b []byte) (index.Postings, error) {
 		l   index.Postings
 		err error
 	)
-	if isDiffVarintSnappyEncodedPostings(b) {
+	if isIndexedDiffVarintSnappyEncodedPostings(b) {
+		s := time.Now()
+		l, err = indexedDiffVarintSnappyDecode(b)
+		r.stats.cachedPostingsDecompressions++
+		r.stats.cachedPostingsDecompressionTimeSum += time.Since(s)
+		if err != nil {
+			r.stats.cachedPostingsDecompressionErrors++
+		}
+	} else if isDiffVarintSnappyEncodedPostings(b) {
 		s := time.Now()
 		l, err = diffVarintSnappyDecode(b)
 		r.stats.cachedPostingsDecompressions++

--- a/pkg/storegateway/postings_codec_test.go
+++ b/pkg/storegateway/postings_codec_test.go
@@ -10,6 +10,7 @@ package storegateway
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -22,9 +23,10 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestDiffVarintCodec(t *testing.T) {
+func TestDiffVarintCodecs(t *testing.T) {
 	chunksDir, err := ioutil.TempDir("", "diff_varint_codec")
 	assert.NoError(t, err)
 	t.Cleanup(func() {
@@ -67,8 +69,10 @@ func TestDiffVarintCodec(t *testing.T) {
 		codingFunction   func(index.Postings, int) ([]byte, error)
 		decodingFunction func([]byte) (index.Postings, error)
 	}{
-		"raw":    {codingFunction: diffVarintEncodeNoHeader, decodingFunction: func(bytes []byte) (index.Postings, error) { return newDiffVarintPostings(bytes), nil }},
-		"snappy": {codingFunction: diffVarintSnappyEncode, decodingFunction: diffVarintSnappyDecode},
+		"raw":            {codingFunction: diffVarintEncodeNoHeader, decodingFunction: func(bytes []byte) (index.Postings, error) { return newDiffVarintPostings(bytes), nil }},
+		"snappy":         {codingFunction: diffVarintSnappyEncode, decodingFunction: diffVarintSnappyDecode},
+		"indexed_raw":    {codingFunction: indexedDiffVarintEncodeNoHeader, decodingFunction: func(bytes []byte) (index.Postings, error) { return newIndexedDiffVarintPostings(bytes) }},
+		"indexed_snappy": {codingFunction: indexedDiffVarintSnappyEncode, decodingFunction: indexedDiffVarintSnappyDecode},
 	}
 
 	for postingName, postings := range postingsMap {
@@ -97,6 +101,81 @@ func TestDiffVarintCodec(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestIndexedDiffVarintPostings_Seek(t *testing.T) {
+	for i, tc := range []struct {
+		input []storage.SeriesRef
+		test  func(t *testing.T, p index.Postings)
+	}{
+		{
+			test: func(t *testing.T, p index.Postings) {
+				require.True(t, p.Seek(1))
+				require.Equal(t, storage.SeriesRef(1), p.At())
+			},
+		},
+		{
+			test: func(t *testing.T, p index.Postings) {
+				require.True(t, p.Seek(indexedDiffVarintPageSize-1))
+				require.Equal(t, storage.SeriesRef(indexedDiffVarintPageSize-1), p.At())
+			},
+		},
+
+		{
+			test: func(t *testing.T, p index.Postings) {
+				require.True(t, p.Seek(indexedDiffVarintPageSize))
+				require.Equal(t, storage.SeriesRef(indexedDiffVarintPageSize), p.At())
+			},
+		},
+		{
+			test: func(t *testing.T, p index.Postings) {
+				require.True(t, p.Seek(indexedDiffVarintPageSize+1))
+				require.Equal(t, storage.SeriesRef(indexedDiffVarintPageSize+1), p.At())
+				require.True(t, p.Seek(indexedDiffVarintPageSize+1))
+				require.Equal(t, storage.SeriesRef(indexedDiffVarintPageSize+1), p.At())
+			},
+		},
+		{
+			test: func(t *testing.T, p index.Postings) {
+				require.True(t, p.Seek(indexedDiffVarintPageSize-1))
+				require.Equal(t, storage.SeriesRef(indexedDiffVarintPageSize-1), p.At())
+				require.True(t, p.Seek(indexedDiffVarintPageSize+1))
+				require.Equal(t, storage.SeriesRef(indexedDiffVarintPageSize+1), p.At())
+			},
+		},
+		{
+			input: []storage.SeriesRef{},
+			test: func(t *testing.T, p index.Postings) {
+				require.False(t, p.Seek(1))
+				require.False(t, p.Next())
+				require.Nil(t, p.Err())
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ids := tc.input
+			if ids == nil {
+				for i := 1; i <= indexedDiffVarintPageSize*2; i++ {
+					ids = append(ids, storage.SeriesRef(i))
+				}
+			}
+
+			enc, err := indexedDiffVarintEncodeNoHeader(index.NewListPostings(ids), indexedDiffVarintPageSize*2)
+			require.NoError(t, err)
+
+			diffVarintChunked, err := newIndexedDiffVarintPostings(enc)
+			require.NoError(t, err)
+
+			// run the test on the list too, just to validate that our test is actually correct
+			t.Run("index.ListPostings", func(t *testing.T) {
+				tc.test(t, index.NewListPostings(ids))
+			})
+			t.Run("indexedDiffVarintPostings", func(t *testing.T) {
+				tc.test(t, diffVarintChunked)
+			})
+		})
+	}
+
 }
 
 func comparePostings(t *testing.T, p1, p2 index.Postings) {


### PR DESCRIPTION
**What this PR does**:

[Profiles have shown](https://github.com/grafana/mimir/issues/337#issuecomment-940177387) that a lot of time of `ExpandedPostings()` is spent decoding `diff+varint+snappy` postings, to be more specific, time is spent doing the `varint` decoding. In the current diff+varint encoding we have to decode all previous values in order to `Seek()` to a given position.

This is a new codec, that encodes `diff+varint` into pages of a given size (const defined, like 256), and stores an index of offsets of those pages with their first value. So when calling `Seek()` we can skip entire chunks if the next chunk's first value is still lower than the one we're seeking for.

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/mimir/issues/337 and https://github.com/grafana/cortex-squad/issues/293

**Benchmarks**

**TL;DR**: 250ms -> 45ms improvement in an `ExpandedPostings()` call with two matchers that results in 28k series. ~20% memory increase (both allocs and used memory)

I downloaded a 24h-long block and run some `ExpandedPostings` checks on it, like this:
```go
func BenchmarkOpsBlockExpandedPostingsCached(b *testing.B) {
	const expectedPostings = 28058
	ctx := context.Background()
	logger := log.NewNopLogger()

	blk := loadDownloadedBlock(b, ctx, logger)

	matchers := []*labels.Matcher{
		labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "go_gc_duration_seconds_count"),
		labels.MustNewMatcher(labels.MatchRegexp, "job", ".*/.*"),
	}

	ids, err := blk.indexReader().ExpandedPostings(ctx, matchers)
	require.NoError(b, err)
	require.Len(b, ids, expectedPostings)

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		ids, err := blk.indexReader().ExpandedPostings(ctx, matchers)
		require.NoError(b, err)
		require.Len(b, ids, expectedPostings)
	}
}
```

This are the results of the benchmark, `diff-varint` is the current codec, `chunk-N` are results of the new codec with pageSize=N. I also tested with pageSize=32 and doing a binary search inside of `Seek()` which resulted to be suboptimal.

```
name \ time/op                     diff-varint  chunk-32     chunk-64     chunk-128    chunk-256    chunk-32-binary
OpsBlockExpandedPostingsCached-12   251ms ± 1%    62ms ± 0%    51ms ± 1%    45ms ± 2%    42ms ± 0%       290ms ± 1%

name \ alloc/op                    diff-varint  chunk-32     chunk-64     chunk-128    chunk-256    chunk-32-binary
OpsBlockExpandedPostingsCached-12  42.1MB ± 0%  64.7MB ± 0%  53.6MB ± 0%  47.9MB ± 0%  45.2MB ± 0%      64.8MB ± 0%

name \ allocs/op                   diff-varint  chunk-32     chunk-64     chunk-128    chunk-256    chunk-32-binary
OpsBlockExpandedPostingsCached-12   5.06k ± 0%   6.05k ± 0%   6.05k ± 0%   6.05k ± 0%   6.05k ± 0%       6.06k ± 0%
```

**Checklist**

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
