### PR TITLE
Add a span for each day split in the query-frontend.

### DIFF
--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -381,7 +381,7 @@ func (s resultsCache) handleHit(ctx context.Context, r Request, extents []Extent
 		return response, nil, err
 	}
 
-	reqResps, err = DoRequests(ctx, s.next, requests, s.limits)
+	reqResps, err = DoRequests(ctx, s.next, requests, s.limits, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -55,7 +55,7 @@ func (s splitByInterval) Do(ctx context.Context, r Request) (Response, error) {
 	}
 	s.splitByCounter.Add(float64(len(reqs)))
 
-	reqResps, err := DoRequests(ctx, s.next, reqs, s.limits)
+	reqResps, err := DoRequests(ctx, s.next, reqs, s.limits, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/queryrange/util.go
+++ b/pkg/querier/queryrange/util.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/mimir/pkg/tenant"
@@ -22,7 +23,7 @@ type RequestResponse struct {
 }
 
 // DoRequests executes a list of requests in parallel. The limits parameters is used to limit parallelism per single request.
-func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
+func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits, recordSpan bool) ([]RequestResponse, error) {
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, "%s", err)
@@ -49,7 +50,22 @@ func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits 
 	for i := 0; i < parallelism; i++ {
 		go func() {
 			for req := range intermediate {
-				resp, err := downstream.Do(ctx, req)
+
+				var (
+					span     opentracing.Span
+					childCtx = ctx
+				)
+
+				if recordSpan {
+					span, childCtx = opentracing.StartSpanFromContext(ctx, "DoRequests")
+					req.LogToSpan(span)
+				}
+
+				resp, err := downstream.Do(childCtx, req)
+
+				if span != nil {
+					span.Finish()
+				}
 				if err != nil {
 					errChan <- err
 				} else {


### PR DESCRIPTION

**What this PR does**:

This will logs all parameters for each split allowing to see which span is which day.

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
