### PR TITLE
Refactoring: decouple isResponseCachable() from isRequestCachable() and check max cache freshness too

### DIFF
--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -236,24 +236,34 @@ func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
 	return response, err
 }
 
-// isResponseCachable says whether the response should be cached or not.
-func isResponseCachable(ctx context.Context, req Request, r Response, maxCacheTime int64, cacheGenNumberLoader CacheGenNumberLoader, logger log.Logger) bool {
+// isRequestCachable says whether the request is eligible for caching.
+func isRequestCachable(req Request, maxCacheTime int64, logger log.Logger) bool {
 	// We can run with step alignment disabled because Grafana does it already. Mimir automatically aligning start and end is not
 	// PromQL compatible. But this means we cannot cache queries that do not have their start and end aligned.
 	if !isRequestStepAligned(req) {
 		return false
 	}
 
+	// Do not cache it at all if the query time range is more recent than the configured max cache freshness.
+	if req.GetStart() > maxCacheTime {
+		return false
+	}
+
+	if !isAtModifierCachable(req, maxCacheTime, logger) {
+		return false
+	}
+
+	return true
+}
+
+// isResponseCachable says whether the response should be cached or not.
+func isResponseCachable(ctx context.Context, r Response, cacheGenNumberLoader CacheGenNumberLoader, logger log.Logger) bool {
 	headerValues := getHeaderValuesWithName(r, cacheControlHeader)
 	for _, v := range headerValues {
 		if v == noStoreValue {
 			level.Debug(logger).Log("msg", fmt.Sprintf("%s header in response is equal to %s, not caching the response", cacheControlHeader, noStoreValue))
 			return false
 		}
-	}
-
-	if !isAtModifierCachable(req, maxCacheTime, logger) {
-		return false
 	}
 
 	if cacheGenNumberLoader == nil {
@@ -348,7 +358,7 @@ func (s resultsCache) handleMiss(ctx context.Context, r Request, maxCacheTime in
 		return nil, nil, err
 	}
 
-	if !isResponseCachable(ctx, r, response, maxCacheTime, s.cacheGenNumberLoader, s.logger) {
+	if !isRequestCachable(r, maxCacheTime, s.logger) || !isResponseCachable(ctx, response, s.cacheGenNumberLoader, s.logger) {
 		return response, []Extent{}, nil
 	}
 
@@ -388,7 +398,7 @@ func (s resultsCache) handleHit(ctx context.Context, r Request, extents []Extent
 
 	for _, reqResp := range reqResps {
 		responses = append(responses, reqResp.Response)
-		if !isResponseCachable(ctx, r, reqResp.Response, maxCacheTime, s.cacheGenNumberLoader, s.logger) {
+		if !isRequestCachable(r, maxCacheTime, s.logger) || !isResponseCachable(ctx, reqResp.Response, s.cacheGenNumberLoader, s.logger) {
 			continue
 		}
 		extent, err := toExtent(ctx, reqResp.Request, s.extractor.ResponseWithoutHeaders(reqResp.Response))


### PR DESCRIPTION
**What this PR does**:
I'm working on https://github.com/grafana/mimir/issues/378. As a preliminary step, I would like to submit a 2nd refactoring, which is extracting `isRequestCachable()` into a dedicated function out of `isResponseCachable()`. Reason is that in the upcoming new implementation it more handy if these checks are separated.

Compared to the previous logic, I've added the following check to `isRequestCachable()`. This check is done anyway by `resultsCache` but new implementation will leverage on `isRequestCachable()` only. I've intentionally not changed `resultsCache` logic to reduce risk of introducing any regression there.

```
	// Do not cache it at all if the query time range is more recent than the configured max cache freshness.
	if req.GetStart() > maxCacheTime {
		return false
	}
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
