### PR TITLE
distributor: count requests inflight for longer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 * [ENHANCEMENT] Query-frontend: added `cortex_query_frontend_non_step_aligned_queries_total` to track the total number of range queries with start/end not aligned to step. #347 #357
 * [ENHANCEMENT] Compactor: added `-compactor.compaction-jobs-order` support to configure which compaction jobs should run first for a given tenant (in case there are multiple ones). Supported values are: `smallest-range-oldest-blocks-first` (default), `newest-blocks-first` (not supported by `default` compaction strategy). #364
 * [ENHANCEMENT] Add option (`-querier.label-values-max-cardinality-label-names-per-request`) to configure the maximum number of label names allowed to be queried in a single `<prefix>/api/v1/cardinality/label_values` API call. #332
+* [ENHANCEMENT] Make distributor inflight push requests count include background calls to ingester. #398
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #207
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16


### PR DESCRIPTION
Distributor will return from its call once a majority of ingester writes have completed, but at this point some ingester calls are still running in the background.

**What this PR does**:

Move the inflight counter decrement into the cleanup routine so they remain in the count until the background call has finished or been cancelled.

This way the limit will work better at capping the amount of work running inside a distributor.

**Checklist**

- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
