### PR TITLE
Add ExpandedPostings MC hit ratio panel to mixin

### DIFF
--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -283,7 +283,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
       )
       .addPanel(
-        $.panel('ExpandedPostings memcache hit ratio') +
+        $.panel('ExpandedPostings cache hit ratio') +
         $.queryPanel(|||
           sum(rate(thanos_store_index_cache_hits_total{item_type="ExpandedPostings",%s}[$__rate_interval]))
           /


### PR DESCRIPTION
**What this PR does**:

Added MC hit ratio for ExpandedPostings cache to the bundled mixin.

**Which issue(s) this PR fixes**:

Ref: https://github.com/grafana/mimir/pull/371

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
