### PR TITLE
Added networking dashboards to mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 Mixin:
 
 * [ENHANCEMENT] Added `CortexReachingTCPConnectionsLimit` alert. #403
+* [ENHANCEMENT] Added "Cortex / Writes Networking" and "Cortex / Reads Networking" dashboards. #405
 
 ### Query-tee
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -55,6 +55,14 @@
     instance_names: {
       compactor: 'compactor.*',
       alertmanager: 'alertmanager.*',
+      ingester: 'ingester.*',
+      distributor: 'distributor.*',
+      querier: 'querier.*',
+      ruler: 'ruler.*',
+      query_frontend: 'query-frontend.*',
+      query_scheduler: 'query-scheduler.*',
+      store_gateway: 'store-gateway.*',
+      gateway: '(gateway|cortex-gw|cortex-gw).*',
     },
 
     // The label used to differentiate between different nodes (i.e. servers).

--- a/operations/mimir-mixin/dashboards.libsonnet
+++ b/operations/mimir-mixin/dashboards.libsonnet
@@ -28,7 +28,9 @@
 
     (if !$._config.resources_dashboards_enabled then {} else
        (import 'dashboards/reads-resources.libsonnet') +
+       (import 'dashboards/reads-networking.libsonnet') +
        (import 'dashboards/writes-resources.libsonnet') +
+       (import 'dashboards/writes-networking.libsonnet') +
        (import 'dashboards/alertmanager-resources.libsonnet')) +
 
     { _config:: $._config + $._group_config },

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -265,6 +265,28 @@ local utils = import 'mixin-utils/utils.libsonnet';
     then 'label_name=~"ingester.*"'
     else 'label_name="%s"' % containerName,
 
+  jobNetworkingRow(title, name)::
+    super.row(title)
+    .addPanel($.containerNetworkReceiveBytesPanel($._config.instance_names[name]))
+    .addPanel($.containerNetworkTransmitBytesPanel($._config.instance_names[name]))
+    .addPanel(
+      $.panel('Inflight Requests (per pod)') +
+      $.queryPanel([
+        'avg(cortex_inflight_requests{%s})' % $.jobMatcher($._config.job_names[name]),
+        'max(cortex_inflight_requests{%s})' % $.jobMatcher($._config.job_names[name]),
+      ], ['avg', 'highest']) +
+      { fill: 0 }
+    )
+    .addPanel(
+      $.panel('TCP Connections (per pod)') +
+      $.queryPanel([
+        'avg(sum by(pod) (cortex_tcp_connections{%s}))' % $.jobMatcher($._config.job_names[name]),
+        'max(sum by(pod) (cortex_tcp_connections{%s}))' % $.jobMatcher($._config.job_names[name]),
+        'min(cortex_tcp_connections_limit{%s})' % $.jobMatcher($._config.job_names[name]),
+      ], ['avg', 'highest', 'limit']) +
+      { fill: 0 }
+    ),
+
   goHeapInUsePanel(title, jobName)::
     $.panel(title) +
     $.queryPanel(

--- a/operations/mimir-mixin/dashboards/reads-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-networking.libsonnet
@@ -1,0 +1,22 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+  'cortex-reads-networking.json':
+    ($.dashboard('Cortex / Reads Networking') + { uid: 'c0464f0d8bd026f776c9006b05910000' })
+    .addClusterSelectorTemplates(false)
+    .addRow($.jobNetworkingRow('Gateway', 'gateway'))
+    .addRow($.jobNetworkingRow('Query-frontend', 'query_frontend'))
+    .addRow($.jobNetworkingRow('Query-scheduler', 'query_scheduler'))
+    .addRow($.jobNetworkingRow('Querier', 'querier'))
+    .addRow($.jobNetworkingRow('Store-gateway', 'store_gateway'))
+    .addRow($.jobNetworkingRow('Ruler', 'ruler'))
+    + {
+      templating+: {
+        list: [
+          // Do not allow to include all clusters/namespaces.
+          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          for l in super.list
+        ],
+      },
+    },
+}

--- a/operations/mimir-mixin/dashboards/writes-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-networking.libsonnet
@@ -1,0 +1,19 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+  'cortex-writes-networking.json':
+    ($.dashboard('Cortex / Writes Networking') + { uid: '681cd62b680b7154811fe73af55dcfd4' })
+    .addClusterSelectorTemplates(false)
+    .addRow($.jobNetworkingRow('Gateway', 'gateway'))
+    .addRow($.jobNetworkingRow('Distributor', 'distributor'))
+    .addRow($.jobNetworkingRow('Ingester', 'ingester'))
+    + {
+      templating+: {
+        list: [
+          // Do not allow to include all clusters/namespaces.
+          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          for l in super.list
+        ],
+      },
+    },
+}


### PR DESCRIPTION
**What this PR does**:
I propose to add a couple of more dashboards to have an overview over networking usage both on read and write path. The following screenshot shows an example for the write path:

![Screenshot 2021-10-25 at 15 23 59](https://user-images.githubusercontent.com/1701904/138704974-03d59b7e-92fa-4532-b55f-837a2dfc2894.png)

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
