### PR TITLE
Fix cortex_limits_overrides metric usage and improve CortexIngesterReachingSeriesLimit playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * [CHANGE] Ingester: `-ingester.min-ready-duration` now start counting the delay after the ring's health checks have passed instead of when the ring client was started. #126
 * [CHANGE] Blocks storage: memcached client DNS resolution switched from golang built-in to [`miekg/dns`](https://github.com/miekg/dns). #142
 * [CHANGE] Query-frontend: the `cortex_frontend_mapped_asts_total` metric has been renamed to `cortex_frontend_query_sharding_rewrites_attempted_total`. #150
-* [CHANGE] Renamed metric `cortex_overrides` to `cortex_limits_overrides`. #173
+* [CHANGE] Renamed metric `cortex_overrides` to `cortex_limits_overrides`. #173 #407
 * [CHANGE] Allow experimental ingester max-exemplars setting to be changed dynamically #144
   * CLI flag `-blocks-storage.tsdb.max-exemplars` is renamed to `-ingester.max-global-exemplars-per-user`.
   * YAML `max_exemplars` is moved from `tsdb` to `overrides` and renamed to `max_global_exemplars_per_user`.

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -71,7 +71,7 @@ How to **fix**:
   )
   >
   (
-    max by(user) (cortex_overrides{namespace="<namespace>",limit_name="max_global_series_per_user"})
+    max by(user) (cortex_limits_overrides{namespace="<namespace>",limit_name="max_global_series_per_user"})
     *
     scalar(max(cortex_distributor_replication_factor{namespace="<namespace>"}))
     *
@@ -81,6 +81,12 @@ How to **fix**:
 
   # Decomment the following to show only tenants beloging to a specific ingester's shard.
   # and count by(user) (cortex_ingester_active_series{namespace="<namespace>",pod="ingester-<id>"})
+  ```
+
+- Run the following **instant query** to find tenants that contribute the most to active series on a specific ingester:
+
+  ```
+  topk(10, sum by(user) (cortex_ingester_memory_series_created_total{namespace="<namespace>",pod="ingester-<id>"} - cortex_ingester_memory_series_removed_total{namespace="<namespace>",pod="ingester-<id>"}))
   ```
 
 - Check the current shard size of each tenant in the output and, if they're not already sharded across all ingesters, you may consider to double their shard size

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -6,7 +6,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     max_samples_per_sec_per_ingester: 80e3,
     max_samples_per_sec_per_distributor: 240e3,
     limit_utilisation_target: 0.6,
-    cortex_overrides_metric: 'cortex_overrides',
+    cortex_overrides_metric: 'cortex_limits_overrides',
   } + $._config + $._group_config,
   prometheusRules+:: {
     groups+: [


### PR DESCRIPTION
**What this PR does**:
The PR #173 renamed `cortex_overrides` metric to `cortex_limits_overrides` but the change was not reflected in the mixin. This PR fixes that and improves `CortexIngesterReachingSeriesLimit` playbook (the issue started while following that playbook).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
