### PR TITLE
Improved 'Queue length' panels in queries dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Mixin:
 
 * [ENHANCEMENT] Added `CortexReachingTCPConnectionsLimit` alert. #403
 * [ENHANCEMENT] Added "Cortex / Writes Networking" and "Cortex / Reads Networking" dashboards. #405
+* [ENHANCEMENT] Improved "Queue length" panel in "Cortex / Queries" dashboard. #408
 
 ### Query-tee
 

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -17,8 +17,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
         { yaxes: $.yaxes('short') },
       )
       .addPanel(
-        $.panel('Queue Length') +
-        $.queryPanel('cortex_query_frontend_queue_length{%s}' % $.jobMatcher($._config.job_names.query_frontend), '{{cluster}} / {{namespace}} / {{%s}}' % $._config.per_instance_label),
+        $.panel('Queue Length (per %s)' % $._config.per_instance_label) +
+        $.queryPanel(
+          'sum by(%s) (cortex_query_frontend_queue_length{%s})' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.query_frontend)],
+          '{{%s}}' % $._config.per_instance_label
+        ),
+      )
+      .addPanel(
+        $.panel('Queue Length (per user)') +
+        $.queryPanel(
+          'sum by(user) (cortex_query_frontend_queue_length{%s}) > 0' % [$.jobMatcher($._config.job_names.query_frontend)],
+          '{{user}}'
+        ),
       )
     )
     .addRow(
@@ -28,8 +38,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.latencyPanel('cortex_query_scheduler_queue_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.query_scheduler)),
       )
       .addPanel(
-        $.panel('Queue Length') +
-        $.queryPanel('cortex_query_scheduler_queue_length{%s}' % $.jobMatcher($._config.job_names.query_scheduler), '{{cluster}} / {{namespace}} / {{%s}}' % $._config.per_instance_label),
+        $.panel('Queue Length (per %s)' % $._config.per_instance_label) +
+        $.queryPanel(
+          'sum by(%s) (cortex_query_scheduler_queue_length{%s})' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.query_scheduler)],
+          '{{%s}}' % $._config.per_instance_label
+        ),
+      )
+      .addPanel(
+        $.panel('Queue Length (per user)') +
+        $.queryPanel(
+          'sum by(user) (cortex_query_scheduler_queue_length{%s}) > 0' % [$.jobMatcher($._config.job_names.query_scheduler)],
+          '{{user}}'
+        ),
       )
     )
     .addRow(


### PR DESCRIPTION
**What this PR does**:
While handling the `CortexSchedulerQueriesStuck` alert I've noticed the "Queue length" panel in the "Cortex / Queries" dashboard is not helping much. I propose to split into:
- Queue length per pod
- Queue length per user

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
