### PR TITLE
Cleanup chunks attributes in-memory cache config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 * [ENHANCEMENT] Compactor: added `-compactor.compaction-jobs-order` support to configure which compaction jobs should run first for a given tenant (in case there are multiple ones). Supported values are: `smallest-range-oldest-blocks-first` (default), `newest-blocks-first` (not supported by `default` compaction strategy). #364
 * [ENHANCEMENT] Add option (`-querier.label-values-max-cardinality-label-names-per-request`) to configure the maximum number of label names allowed to be queried in a single `<prefix>/api/v1/cardinality/label_values` API call. #332
 * [ENHANCEMENT] Make distributor inflight push requests count include background calls to ingester. #398
+* [ENHANCEMENT] Store-gateway: added an in-memory LRU cache for chunks attributes. Can be enabled setting `-blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=X` where `X` is the max number of items to keep in the in-memory cache. #279 #415
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #207
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16
@@ -328,7 +329,6 @@ Mixin:
 * [CHANGE] Ingester: return error code 400 instead of 429 when per-user/per-tenant series/metadata limits are reached. #3833
 * [CHANGE] Compactor: add `reason` label to `cortex_compactor_blocks_marked_for_deletion_total` metric. Source blocks marked for deletion by compactor are labelled as `compaction`, while blocks passing the retention period are labelled as `retention`. #3879
 * [CHANGE] Alertmanager: the `DELETE /api/v1/alerts` is now idempotent. No error is returned if the alertmanager config doesn't exist. #3888
-* [FEATURE] Store Gateway: Adds a LRU cache for attributes. (`-blocks-storage.bucket-store.metadata-cache.lru-enabled=true` to activate) #279
 * [FEATURE] Experimental Ruler Storage: Add a separate set of configuration options to configure the ruler storage backend under the `-ruler-storage.` flag prefix. All blocks storage bucket clients and the config service are currently supported. Clients using this implementation will only be enabled if the existing `-ruler.storage` flags are left unset. #3805 #3864
 * [FEATURE] Experimental Alertmanager Storage: Add a separate set of configuration options to configure the alertmanager storage backend under the `-alertmanager-storage.` flag prefix. All blocks storage bucket clients and the config service are currently supported. Clients using this implementation will only be enabled if the existing `-alertmanager.storage` flags are left unset. #3888
 * [FEATURE] Adds support to S3 server-side encryption using KMS. The S3 server-side encryption config can be overridden on a per-tenant basis for the blocks storage, ruler and alertmanager. Deprecated `-<prefix>.s3.sse-encryption`, please use the following CLI flags that have been added. #3651 #3810 #3811 #3870 #3886 #3906

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -587,6 +587,12 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-ttl
       [attributes_ttl: <duration> | default = 168h]
 
+      # Maximum number of object attribute items to keep in a first level
+      # in-memory LRU cache. Metadata will be stored and fetched in-memory
+      # before hitting the cache backend. 0 to disable the in-memory cache.
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items
+      [attributes_in_memory_max_items: <int> | default = 0]
+
       # TTL for caching individual chunks subranges.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-ttl
       [subrange_ttl: <duration> | default = 24h]
@@ -691,16 +697,6 @@ blocks_storage:
       # this limit to the same limit in the caching backend).
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
       [bucket_index_max_size_bytes: <int> | default = 1048576]
-
-      # Use a first level in memory LRU cache for metadata cache. Metadata will
-      # be stored and fetched in memory before hiting the cache backend.
-      # **Experimental**
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.lru-enabled
-      [lru_enabled: <boolean> | default = false]
-
-      # Maximum number of items in the first level in memory LRU cache.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.lru-max-items
-      [lru_max_items: <int> | default = 10000]
 
     # Duration after which the blocks marked for deletion will be filtered out
     # while fetching blocks. The idea of ignore-deletion-marks-delay is to

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -640,6 +640,12 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-ttl
       [attributes_ttl: <duration> | default = 168h]
 
+      # Maximum number of object attribute items to keep in a first level
+      # in-memory LRU cache. Metadata will be stored and fetched in-memory
+      # before hitting the cache backend. 0 to disable the in-memory cache.
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items
+      [attributes_in_memory_max_items: <int> | default = 0]
+
       # TTL for caching individual chunks subranges.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-ttl
       [subrange_ttl: <duration> | default = 24h]
@@ -744,16 +750,6 @@ blocks_storage:
       # this limit to the same limit in the caching backend).
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
       [bucket_index_max_size_bytes: <int> | default = 1048576]
-
-      # Use a first level in memory LRU cache for metadata cache. Metadata will
-      # be stored and fetched in memory before hiting the cache backend.
-      # **Experimental**
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.lru-enabled
-      [lru_enabled: <boolean> | default = false]
-
-      # Maximum number of items in the first level in memory LRU cache.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.lru-max-items
-      [lru_max_items: <int> | default = 10000]
 
     # Duration after which the blocks marked for deletion will be filtered out
     # while fetching blocks. The idea of ignore-deletion-marks-delay is to

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4814,6 +4814,12 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-ttl
     [attributes_ttl: <duration> | default = 168h]
 
+    # Maximum number of object attribute items to keep in a first level
+    # in-memory LRU cache. Metadata will be stored and fetched in-memory before
+    # hitting the cache backend. 0 to disable the in-memory cache.
+    # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items
+    [attributes_in_memory_max_items: <int> | default = 0]
+
     # TTL for caching individual chunks subranges.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-ttl
     [subrange_ttl: <duration> | default = 24h]
@@ -4918,16 +4924,6 @@ bucket_store:
     # same limit in the caching backend).
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
     [bucket_index_max_size_bytes: <int> | default = 1048576]
-
-    # Use a first level in memory LRU cache for metadata cache. Metadata will be
-    # stored and fetched in memory before hiting the cache backend.
-    # **Experimental**
-    # CLI flag: -blocks-storage.bucket-store.metadata-cache.lru-enabled
-    [lru_enabled: <boolean> | default = false]
-
-    # Maximum number of items in the first level in memory LRU cache.
-    # CLI flag: -blocks-storage.bucket-store.metadata-cache.lru-max-items
-    [lru_max_items: <int> | default = 10000]
 
   # Duration after which the blocks marked for deletion will be filtered out
   # while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore


### PR DESCRIPTION
**What this PR does**:
This is a follow up to #279. I'm proposing to move the in-memory cache config to chunks cache (since it applies only to attributes used by chunks cache) and rename the CLI flag / YAML option to make it clear. I've also fixed the CHANGELOG entry moving it up.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
