### PR TITLE
Log index cache in tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [ENHANCEMENT] Add option (`-querier.label-values-max-cardinality-label-names-per-request`) to configure the maximum number of label names allowed to be queried in a single `<prefix>/api/v1/cardinality/label_values` API call. #332
 * [ENHANCEMENT] Make distributor inflight push requests count include background calls to ingester. #398
 * [ENHANCEMENT] Store-gateway: added an in-memory LRU cache for chunks attributes. Can be enabled setting `-blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=X` where `X` is the max number of items to keep in the in-memory cache. #279 #415
+* [ENHANCEMENT] Store-gateway: log index cache requests to tracing spans. #419
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #207
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16

--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -111,8 +111,13 @@ func newInMemoryIndexCache(cfg InMemoryIndexCacheConfig, logger log.Logger, regi
 func newMemcachedIndexCache(cfg MemcachedClientConfig, logger log.Logger, registerer prometheus.Registerer) (storecache.IndexCache, error) {
 	client, err := cacheutil.NewMemcachedClientWithConfig(logger, "index-cache", cfg.ToMemcachedClientConfig(), registerer)
 	if err != nil {
-		return nil, errors.Wrapf(err, "create index cache memcached client")
+		return nil, errors.Wrap(err, "create index cache memcached client")
 	}
 
-	return storecache.NewMemcachedIndexCache(logger, client, registerer)
+	cache, err := storecache.NewMemcachedIndexCache(logger, client, registerer)
+	if err != nil {
+		return nil, errors.Wrap(err, "create memcached-based index cache")
+	}
+
+	return storecache.NewTracingIndexCache(cache, logger), nil
 }


### PR DESCRIPTION
**What this PR does**:
I propose to log index cache fetch requests to tracing spans like we do for the chunks cache.

**Which issue(s) this PR fixes**:
Fixes #418

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
