### PR TITLE
Experimental unsafe way to reuse Marshal() []byte

### DIFF
--- a/pkg/ingester/client/custom.go
+++ b/pkg/ingester/client/custom.go
@@ -5,6 +5,14 @@
 
 package client
 
+import (
+	"sync"
+)
+
+var (
+	queryStreamResponseDataPool = sync.Pool{}
+)
+
 // ChunksCount returns the number of chunks in response.
 func (m *QueryStreamResponse) ChunksCount() int {
 	if len(m.Chunkseries) == 0 {
@@ -31,4 +39,59 @@ func (m *QueryStreamResponse) ChunksSize() int {
 		}
 	}
 	return size
+}
+
+func SendQueryStream(stream Ingester_QueryStreamServer, m *QueryStreamResponse) error {
+	res := &reuseResponse{res: m}
+
+	err := sendWithContextErrChecking(stream.Context(), func() error {
+		return stream.SendMsg(res)
+	})
+
+	// TODO This is unsafe! The marshalled payload is enqueued in transpont control flow component (http2 transport) and
+	// it's still retained after SendMsg() is returned.
+	queryStreamResponseDataPool.Put(res.data[:0])
+	return err
+}
+
+type reuseResponse struct {
+	res  *QueryStreamResponse
+	data []byte
+}
+
+func (r *reuseResponse) Marshal() (dAtA []byte, err error) {
+	size := r.res.Size()
+
+	dataFromPool := queryStreamResponseDataPool.Get()
+	if dataFromPool == nil {
+		dAtA = make([]byte, size)
+	} else {
+		dAtA = dataFromPool.([]byte)
+		if cap(dAtA) < size {
+			dAtA = make([]byte, size)
+		}
+	}
+	r.data = dAtA
+
+	n, err := r.res.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (r *reuseResponse) Unmarshal(dAtA []byte) error {
+	return r.res.Unmarshal(dAtA)
+}
+
+func (r *reuseResponse) Reset() {
+	r.res.Reset()
+}
+
+func (r *reuseResponse) String() string {
+	return r.res.String()
+}
+
+func (r *reuseResponse) ProtoMessage() {
+	r.res.ProtoMessage()
 }

--- a/pkg/ingester/client/mimir_util.go
+++ b/pkg/ingester/client/mimir_util.go
@@ -9,14 +9,6 @@ import (
 	context "context"
 )
 
-// SendQueryStream wraps the stream's Send() checking if the context is done
-// before calling Send().
-func SendQueryStream(s Ingester_QueryStreamServer, m *QueryStreamResponse) error {
-	return sendWithContextErrChecking(s.Context(), func() error {
-		return s.Send(m)
-	})
-}
-
 // SendTimeSeriesChunk wraps the stream's Send() checking if the context is done
 // before calling Send().
 func SendTimeSeriesChunk(s Ingester_TransferChunksClient, m *TimeSeriesChunk) error {


### PR DESCRIPTION
**What this PR does**:
_This PR is to show how to NOT reuse `Marshal()` ` []byte` and sparkle a discussion whether there's any way to do it._

I'm profiling ingesters on high query load. Among other things, I've noticed 20% of memory is allocated by `QueryStreamResponse.Marshal()`. For a given `Ingester.v2QueryStreamChunks()` call we may end up sending multiple responses (gRPC stream messages) containing series chunks, each response is sent once we hit 1MB size.

![Screenshot 2021-10-28 at 10 42 23](https://user-images.githubusercontent.com/1701904/139220694-cbd59d33-f5ec-4bfc-b091-0b019d8385f5.png)

After the response is sent to the wire, we should recycle the `[]byte` returned by `Marshal()` into a pool, in order to reduce memory allocations. However, I haven't find any safe way to do it and I'm opening this PR to show how to NOT do it and sparkle a discussion whether anyone has a smart idea. The potential impact is huge.

There was this attempt in gRPC but then it was rolled back:
https://github.com/grpc/grpc-go/pull/3167

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
