### PR TITLE
Don't merge last two splits for big steps.

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -86,10 +86,9 @@ func splitQueryByInterval(r Request, interval time.Duration) ([]Request, error) 
 			end = r.GetEnd()
 		}
 
-		// If step isn't too big, and adding another step saves us one extra request, do it.
-		// For bigger steps, we don't do this, so that we still benefit from running split subrequests
-		// concurrently.
-		if r.GetStep() < interval.Milliseconds()/2 && end+r.GetStep() == r.GetEnd() {
+		// If step isn't too big, and adding another step saves us one extra request,
+		// then extend the current request to cover the extra step too.
+		if end+r.GetStep() == r.GetEnd() && r.GetStep() <= 5*time.Minute.Milliseconds() {
 			end = r.GetEnd()
 		}
 

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -137,6 +137,21 @@ func TestSplitQueryByInterval(t *testing.T) {
 			interval: 3 * time.Hour,
 		},
 		{
+			input: &PrometheusRequest{Start: timeToMillis(t, "2021-10-14T23:48:00Z"), End: timeToMillis(t, "2021-10-15T00:03:00Z"), Step: 5 * time.Minute.Milliseconds(), Query: "foo"},
+			expected: []Request{
+				&PrometheusRequest{Start: timeToMillis(t, "2021-10-14T23:48:00Z"), End: timeToMillis(t, "2021-10-15T00:03:00Z"), Step: 5 * time.Minute.Milliseconds(), Query: "foo"},
+			},
+			interval: day,
+		},
+		{
+			input: &PrometheusRequest{Start: timeToMillis(t, "2021-10-14T23:48:00Z"), End: timeToMillis(t, "2021-10-15T00:00:00Z"), Step: 6 * time.Minute.Milliseconds(), Query: "foo"},
+			expected: []Request{
+				&PrometheusRequest{Start: timeToMillis(t, "2021-10-14T23:48:00Z"), End: timeToMillis(t, "2021-10-14T23:54:00Z"), Step: 6 * time.Minute.Milliseconds(), Query: "foo"},
+				&PrometheusRequest{Start: timeToMillis(t, "2021-10-15T00:00:00Z"), End: timeToMillis(t, "2021-10-15T00:00:00Z"), Step: 6 * time.Minute.Milliseconds(), Query: "foo"},
+			},
+			interval: day,
+		},
+		{
 			input: &PrometheusRequest{Start: timeToMillis(t, "2021-10-14T22:00:00Z"), End: timeToMillis(t, "2021-10-17T22:00:00Z"), Step: 24 * time.Hour.Milliseconds(), Query: "foo"},
 			expected: []Request{
 				&PrometheusRequest{Start: timeToMillis(t, "2021-10-14T22:00:00Z"), End: timeToMillis(t, "2021-10-14T22:00:00Z"), Step: 24 * time.Hour.Milliseconds(), Query: "foo"},
@@ -195,17 +210,15 @@ func TestSplitQueryByInterval(t *testing.T) {
 			},
 			interval: day,
 		},
-
-		// TODO: Marco thinks this should pass. It looks reasonable, question is how to design the condition for split/no-split decision that works for all cases.
-		//{
-		//	input: &PrometheusRequest{Start: timeToMillis(t, "2021-10-15T06:00:00Z"), End: timeToMillis(t, "2021-10-17T08:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
-		//	expected: []Request{
-		//		&PrometheusRequest{Start: timeToMillis(t, "2021-10-15T06:00:00Z"), End: timeToMillis(t, "2021-10-15T16:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
-		//		&PrometheusRequest{Start: timeToMillis(t, "2021-10-16T02:00:00Z"), End: timeToMillis(t, "2021-10-16T22:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
-		//		&PrometheusRequest{Start: timeToMillis(t, "2021-10-17T08:00:00Z"), End: timeToMillis(t, "2021-10-17T08:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
-		//	},
-		//	interval: day,
-		//},
+		{
+			input: &PrometheusRequest{Start: timeToMillis(t, "2021-10-15T06:00:00Z"), End: timeToMillis(t, "2021-10-17T08:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
+			expected: []Request{
+				&PrometheusRequest{Start: timeToMillis(t, "2021-10-15T06:00:00Z"), End: timeToMillis(t, "2021-10-15T16:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
+				&PrometheusRequest{Start: timeToMillis(t, "2021-10-16T02:00:00Z"), End: timeToMillis(t, "2021-10-16T22:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
+				&PrometheusRequest{Start: timeToMillis(t, "2021-10-17T08:00:00Z"), End: timeToMillis(t, "2021-10-17T08:00:00Z"), Step: 10 * time.Hour.Milliseconds(), Query: "foo"},
+			},
+			interval: day,
+		},
 	} {
 		t.Run(fmt.Sprintf("%d: start: %v, end: %v, step: %v", i, tc.input.GetStart(), tc.input.GetEnd(), tc.input.GetStep()), func(t *testing.T) {
 			days, err := splitQueryByInterval(tc.input, tc.interval)


### PR DESCRIPTION
**What this PR does**: Splitting middleware splits incoming request into subrequests within predefined intervals. If last subrequest has only single step, then splitting includes it in the previous subrequest. That works fine for small steps, but for bigger steps, we lose the benfit of running subrequests concurrently.

As an example, before this PR, request with `start=2021-10-14T22:00:00Z`, end=`2021-10-17T22:00:00Z` and `step=24h` while using 24h interval would generate following subrequests:

| start | end |
|----|----|
| 2021-10-14T22:00:00Z | 2021-10-14T22:00:00Z |
| 2021-10-15T22:00:00Z | 2021-10-15T22:00:00Z | 
| 2021-10-16T22:00:00Z | 2021-10-17T22:00:00Z | 

Notice how the last subrequest covers two separate days.

After this fix, last subrequest will be replaced with:

| start | end |
|----|----|
| 2021-10-16T22:00:00Z | 2021-10-16T22:00:00Z | 
| 2021-10-17T22:00:00Z | 2021-10-17T22:00:00Z | 

Allowing the subrequests for two days running concurrently.

(Note: start=end looks weird, but it is correct. End is computed as (next interval start - step), aligned on step. Both start/end are inclusive.)

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
