### PR TITLE
Do not trim chunks queried from ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
   * `cortex_cache_memory_items_count`
 * [ENHANCEMENT] Store-gateway: log index cache requests to tracing spans. #419
 * [ENHANCEMENT] Ingester: reduce CPU and memory utilization if remote write requests contains a large amount of "out of bounds" samples. #413
+* [ENHANCEMENT] Ingester: reduce CPU and memory utilization when querying chunks from ingesters. #430
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #207
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -2659,23 +2659,54 @@ func BenchmarkIngester_V2QueryStream(b *testing.B) {
 		require.NoError(b, err)
 	}
 
+	// Benchmark different ranges.
+	ranges := []struct {
+		name       string
+		start, end int64
+	}{
+		{
+			name:  "full data",
+			start: math.MinInt64,
+			end:   math.MaxInt64,
+		},
+		{
+			name:  "partial block",
+			start: 1,
+			end:   numBlockSamples / 3,
+		},
+		{
+			name:  "partial head",
+			start: numBlockSamples + 5,
+			end:   numBlockSamples + numHeadSamples - 5,
+		},
+		{
+			name:  "head + partial block",
+			start: numBlockSamples / 3,
+			end:   numBlockSamples + numHeadSamples,
+		},
+	}
+
 	b.Run("query samples", func(b *testing.B) {
 		streamType = QueryStreamSamples
 
-		for _, queryShardingEnabled := range []bool{false, true} {
-			b.Run(fmt.Sprintf("query sharding=%v", queryShardingEnabled), func(b *testing.B) {
-				benchmarkIngesterV2QueryStream(ctx, b, i, queryShardingEnabled, numShards)
-			})
+		for _, timeRange := range ranges {
+			for _, queryShardingEnabled := range []bool{false, true} {
+				b.Run(fmt.Sprintf("time range=%v, query sharding=%v", timeRange.name, queryShardingEnabled), func(b *testing.B) {
+					benchmarkIngesterV2QueryStream(ctx, b, i, timeRange.start, timeRange.end, queryShardingEnabled, numShards)
+				})
+			}
 		}
 	})
 
 	b.Run("query chunks", func(b *testing.B) {
 		streamType = QueryStreamChunks
 
-		for _, queryShardingEnabled := range []bool{false, true} {
-			b.Run(fmt.Sprintf("query sharding=%v", queryShardingEnabled), func(b *testing.B) {
-				benchmarkIngesterV2QueryStream(ctx, b, i, queryShardingEnabled, numShards)
-			})
+		for _, timeRange := range ranges {
+			for _, queryShardingEnabled := range []bool{false, true} {
+				b.Run(fmt.Sprintf("time range=%v, query sharding=%v", timeRange.name, queryShardingEnabled), func(b *testing.B) {
+					benchmarkIngesterV2QueryStream(ctx, b, i, timeRange.start, timeRange.end, queryShardingEnabled, numShards)
+				})
+			}
 		}
 	})
 }
@@ -2700,7 +2731,7 @@ func getStartedIngesterWithBlocksStorage(t testing.TB, ingesterCfg Config, regis
 	return ingester
 }
 
-func benchmarkIngesterV2QueryStream(ctx context.Context, b *testing.B, i *Ingester, queryShardingEnabled bool, numShards int) {
+func benchmarkIngesterV2QueryStream(ctx context.Context, b *testing.B, i *Ingester, start, end int64, queryShardingEnabled bool, numShards int) {
 	mockStream := &mockQueryStreamServer{ctx: ctx}
 
 	metricMatcher := &client.LabelMatcher{
@@ -2714,8 +2745,8 @@ func benchmarkIngesterV2QueryStream(ctx context.Context, b *testing.B, i *Ingest
 			// Query each shard.
 			for idx := 0; idx < numShards; idx++ {
 				req := &client.QueryRequest{
-					StartTimestampMs: math.MinInt64,
-					EndTimestampMs:   math.MaxInt64,
+					StartTimestampMs: start,
+					EndTimestampMs:   end,
 					Matchers: []*client.LabelMatcher{metricMatcher, {
 						Type:  client.EQUAL,
 						Name:  querysharding.ShardLabel,
@@ -2728,8 +2759,8 @@ func benchmarkIngesterV2QueryStream(ctx context.Context, b *testing.B, i *Ingest
 			}
 		} else {
 			req := &client.QueryRequest{
-				StartTimestampMs: math.MinInt64,
-				EndTimestampMs:   math.MaxInt64,
+				StartTimestampMs: start,
+				EndTimestampMs:   end,
 				Matchers:         []*client.LabelMatcher{metricMatcher},
 			}
 


### PR DESCRIPTION
**What this PR does**:
When querying chunks from TSDB (either head or blocks), TSDB trim chunks whose min/max time is not fully within the query start/end time. Trimming requires to decode + re-encoding the XOR chunks and takes some CPU and much memory in ingesters.

I think we don't need to do it and in this PR I'm proposing to introduce a change in TSDB to allow us to select whether we want to trimming or not.

Reason why I don't think we need it is because PromQL engine should handle it (it `Skip()` to expected timestamp) and we don't actually trim chunks loaded from store-gateway. I've also added a unit test covering it.

This PR is based on a upstream change I did (Prometheus PR 9647).

**Benchmark**:

We don't expect any improvement for querying samples (instead of chunks) and "full data" case:

```
name                                                                                           old time/op    new time/op    delta
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=false-12                842ms ± 4%     772ms ± 0%     ~     (p=0.060 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=true-12                 893ms ± 1%     848ms ± 2%   -5.01%  (p=0.013 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=false-12            161ms ± 4%     154ms ± 1%     ~     (p=0.138 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=true-12             191ms ± 2%     183ms ± 1%   -4.23%  (p=0.044 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=false-12             363ms ± 2%     346ms ± 1%   -4.80%  (p=0.035 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=true-12              403ms ± 2%     399ms ± 4%     ~     (p=0.746 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=false-12     770ms ± 1%     748ms ± 1%     ~     (p=0.051 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=true-12      820ms ± 0%     815ms ± 1%     ~     (p=0.499 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=false-12                 341ms ± 0%     338ms ± 1%     ~     (p=0.145 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=true-12                  414ms ± 2%     404ms ± 2%     ~     (p=0.143 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=false-12             177ms ± 2%      36ms ± 1%  -79.81%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=true-12              207ms ± 1%      64ms ± 2%  -69.19%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=false-12              417ms ± 0%     229ms ± 1%  -44.98%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=true-12               452ms ± 0%     263ms ± 1%  -41.90%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=false-12      441ms ± 1%     334ms ± 1%  -24.07%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=true-12       513ms ± 2%     413ms ± 2%  -19.44%  (p=0.000 n=3+3)

name                                                                                           old alloc/op   new alloc/op   delta
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=false-12                478MB ± 0%     478MB ± 0%     ~     (p=0.403 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=true-12                 479MB ± 0%     479MB ± 0%     ~     (p=0.970 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=false-12            121MB ± 0%     121MB ± 0%     ~     (p=0.517 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=true-12             122MB ± 0%     122MB ± 0%     ~     (p=0.830 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=false-12             239MB ± 0%     239MB ± 0%     ~     (p=0.186 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=true-12              240MB ± 0%     240MB ± 0%     ~     (p=0.595 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=false-12     479MB ± 0%     479MB ± 0%     ~     (p=0.891 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=true-12      480MB ± 0%     480MB ± 0%     ~     (p=0.215 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=false-12                81.2MB ± 0%    81.2MB ± 0%     ~     (p=0.729 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=true-12                 82.2MB ± 0%    82.2MB ± 0%     ~     (p=0.395 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=false-12            28.8MB ± 0%    15.6MB ± 0%  -45.80%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=true-12             29.7MB ± 0%    16.5MB ± 0%  -44.51%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=false-12             67.8MB ± 0%    43.7MB ± 0%  -35.52%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=true-12              68.6MB ± 0%    44.5MB ± 0%  -35.09%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=false-12     93.6MB ± 0%    81.2MB ± 0%  -13.25%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=true-12      94.6MB ± 0%    82.2MB ± 0%  -13.11%  (p=0.000 n=3+3)

name                                                                                           old allocs/op  new allocs/op  delta
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=false-12                1.68M ± 0%     1.68M ± 0%     ~     (p=0.389 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=true-12                 1.69M ± 0%     1.69M ± 0%     ~     (p=0.962 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=false-12             650k ± 0%      650k ± 0%     ~     (p=0.532 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=true-12              651k ± 0%      651k ± 0%     ~     (p=0.876 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=false-12              834k ± 0%      834k ± 0%     ~     (p=0.188 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=true-12               835k ± 0%      835k ± 0%     ~     (p=0.586 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=false-12     1.78M ± 0%     1.78M ± 0%     ~     (p=0.815 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=true-12      1.79M ± 0%     1.79M ± 0%     ~     (p=0.210 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=false-12                 1.49M ± 0%     1.49M ± 0%     ~     (p=0.797 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=true-12                  1.49M ± 0%     1.49M ± 0%     ~     (p=0.428 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=false-12              575k ± 0%      350k ± 0%  -39.11%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=true-12               576k ± 0%      351k ± 0%  -39.04%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=false-12               909k ± 0%      567k ± 0%  -37.61%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=true-12                910k ± 0%      568k ± 0%  -37.57%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=false-12      1.72M ± 0%     1.49M ± 0%  -13.10%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=true-12       1.72M ± 0%     1.49M ± 0%  -13.09%  (p=0.000 n=3+3)
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
