### PR TITLE
Fix flaky TestQuerierLabelNamesAndValues 

### DIFF
--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -27,8 +27,6 @@ var cardinalityEnvLabelValues = []string{"prod", "staging", "dev"}
 var cardinalityJobLabelValues = []string{"distributor", "ingester", "store-gateway", "querier", "compactor"}
 
 func TestQuerierLabelNamesAndValues(t *testing.T) {
-	t.Skip("Flaky, see https://github.com/grafana/mimir/issues/426")
-
 	const numSeriesToPush = 1000
 
 	// Define response types.
@@ -173,16 +171,6 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 			res, err := client.LabelNamesAndValues(tc.selector, tc.limit)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, res.StatusCode)
-
-			// Ensure all ingesters have been invoked.
-			ingesters := []*e2emimir.MimirService{ingester1, ingester2, ingester3}
-			for _, ing := range ingesters {
-				require.NoError(t, ing.WaitSumMetricsWithOptions(
-					e2e.Equals(1),
-					[]string{"cortex_request_duration_seconds"},
-					e2e.WithMetricCount,
-					e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "route", "/cortex.Ingester/LabelNamesAndValues"))))
-			}
 
 			// Test results.
 			var lbNamesAndValuesResp labelNamesAndValuesResponse


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix flaky `TestQuerierLabelNamesAndValues` by removing  wrong assertion, since we only enforce all ingesters to be invoked for  `LabelValuesCardinality` method. 

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #426 

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
