### PR TITLE
Do not reencode TSDB head chunks when querying ingesters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ replace github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915
 replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20211027085719-c8b86f581c41
+replace github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20211028152210-92833dfb70c1
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -830,8 +830,8 @@ github.com/grafana/dskit v0.0.0-20211015163529-3a65fbdcfc45 h1:MnEo2iaFbjxfkSVc1
 github.com/grafana/dskit v0.0.0-20211015163529-3a65fbdcfc45/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
-github.com/grafana/prometheus-private v0.0.0-20211027085719-c8b86f581c41 h1:XrLoo05JvShszEgLQH5ilQOGskWM0pNlFa7AYTrBsiw=
-github.com/grafana/prometheus-private v0.0.0-20211027085719-c8b86f581c41/go.mod h1:wP6L5BiOZ1JZYadRh17u5RujSS19zNSGZfGUi/MZUpM=
+github.com/grafana/prometheus-private v0.0.0-20211028152210-92833dfb70c1 h1:PeUbmhHltcmCGnHE16aJr7ObnYcVxPRVPDBlCLq+kd8=
+github.com/grafana/prometheus-private v0.0.0-20211028152210-92833dfb70c1/go.mod h1:wP6L5BiOZ1JZYadRh17u5RujSS19zNSGZfGUi/MZUpM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=

--- a/pkg/chunk/encoding/factory.go
+++ b/pkg/chunk/encoding/factory.go
@@ -59,6 +59,8 @@ const (
 	Bigchunk
 	// PrometheusXorChunk is a wrapper around Prometheus XOR-encoded chunk.
 	PrometheusXorChunk
+	// PrometheusXorChunkPartial is a wrapper around Prometheus XOR-encoded partial chunk.
+	PrometheusXorChunkPartial
 )
 
 type encoding struct {
@@ -89,6 +91,12 @@ var encodings = map[Encoding]encoding{
 		Name: "PrometheusXorChunk",
 		New: func() Chunk {
 			return newPrometheusXorChunk()
+		},
+	},
+	PrometheusXorChunkPartial: {
+		Name: "PrometheusXorChunkPartial",
+		New: func() Chunk {
+			return newPrometheusXorChunkPartial()
 		},
 	},
 }

--- a/pkg/chunk/encoding/prometheus_xor_chunk_partial.go
+++ b/pkg/chunk/encoding/prometheus_xor_chunk_partial.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package encoding
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// Wrapper around chunkenc.XORChunkPartial.
+type prometheusXorChunkPartial struct {
+	chunk chunkenc.Chunk
+}
+
+func newPrometheusXorChunkPartial() *prometheusXorChunkPartial {
+	return &prometheusXorChunkPartial{}
+}
+
+func (p *prometheusXorChunkPartial) Add(m model.SamplePair) (Chunk, error) {
+	return nil, errors.New("prometheusXorChunkPartial is read-only")
+}
+
+func (p *prometheusXorChunkPartial) NewIterator(iterator Iterator) Iterator {
+	if p.chunk == nil {
+		return errorIterator("Prometheus chunk is not set")
+	}
+
+	if pit, ok := iterator.(*prometheusChunkIterator); ok {
+		pit.c = p.chunk
+		pit.it = p.chunk.Iterator(pit.it)
+		return pit
+	}
+
+	return &prometheusChunkIterator{c: p.chunk, it: p.chunk.Iterator(nil)}
+}
+
+func (p *prometheusXorChunkPartial) Marshal(i io.Writer) error {
+	if p.chunk == nil {
+		return errors.New("chunk data not set")
+	}
+	_, err := i.Write(p.chunk.Bytes())
+	return err
+}
+
+func (p *prometheusXorChunkPartial) UnmarshalFromBuf(bytes []byte) error {
+	c, err := chunkenc.FromData(chunkenc.EncXORPartial, bytes)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Prometheus XORChunkPartial from bytes")
+	}
+
+	p.chunk = c
+	return nil
+}
+
+func (p *prometheusXorChunkPartial) Encoding() Encoding {
+	return PrometheusXorChunkPartial
+}
+
+func (p *prometheusXorChunkPartial) Utilization() float64 {
+	// Used for reporting when chunk is used to store new data.
+	return 0
+}
+
+func (p *prometheusXorChunkPartial) Slice(_, _ model.Time) Chunk {
+	return p
+}
+
+func (p *prometheusXorChunkPartial) Rebound(from, to model.Time) (Chunk, error) {
+	return nil, errors.New("Rebound not supported by prometheusXorChunkPartial")
+}
+
+func (p *prometheusXorChunkPartial) Len() int {
+	if p.chunk == nil {
+		return 0
+	}
+	return p.chunk.NumSamples()
+}
+
+func (p *prometheusXorChunkPartial) Size() int {
+	if p.chunk == nil {
+		return 0
+	}
+	return len(p.chunk.Bytes())
+}

--- a/vendor/github.com/prometheus/prometheus/storage/interface.go
+++ b/vendor/github.com/prometheus/prometheus/storage/interface.go
@@ -148,6 +148,8 @@ type SelectHints struct {
 
 	ShardIndex uint64 // Current shard index (starts from 0 and up to ShardCount-1).
 	ShardCount uint64 // Total number of shards (0 means sharding is disabled).
+
+	TrimDisabled bool // True to disable chunks trimming (based on query start/end time).
 }
 
 // TODO(bwplotka): Move to promql/engine_test.go?

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/chunk.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/chunk.go
@@ -29,6 +29,8 @@ func (e Encoding) String() string {
 		return "none"
 	case EncXOR:
 		return "XOR"
+	case EncXORPartial:
+		return "XORPartial"
 	}
 	return "<unknown>"
 }
@@ -37,6 +39,7 @@ func (e Encoding) String() string {
 const (
 	EncNone Encoding = iota
 	EncXOR
+	EncXORPartial
 )
 
 // Chunk holds a sequence of sample pairs that can be iterated over and appended to.
@@ -160,6 +163,8 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 	switch e {
 	case EncXOR:
 		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
+	case EncXORPartial:
+		return NewXORPartialChunkFromWire(d)
 	}
 	return nil, errors.Errorf("invalid chunk encoding %q", e)
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/xor_partial.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/xor_partial.go
@@ -1,0 +1,180 @@
+package chunkenc
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+const (
+	// When serialized, the XORPartialChunk has a fixed header:
+	// - numSamples: 2 bytes
+	// - lastSamples: 4 * 16 bytes
+	xorPartialChunkHeaderBytes = 2 + (4 * 16)
+)
+
+type Sample struct {
+	T int64
+	V float64
+}
+
+// XORPartialChunk holds a snapshot of an XORChunk data, created while still appending it.
+// This struct is read-only.
+type XORPartialChunk struct {
+	// Number of samples that can be iterated on.
+	numSamples int
+
+	// (Up to) last 4 samples appended to XORChunk.
+	lastSamples [4]Sample
+
+	// Snapshot of XORChunk underlying bytes when the XORPartialChunk was created.
+	xorChunk []byte
+}
+
+func NewXORPartialChunkFromXORChunk(partial *XORChunk, lastSamples [4]Sample) *XORPartialChunk {
+	return &XORPartialChunk{
+		numSamples:  partial.NumSamples(),
+		xorChunk:    partial.Bytes(),
+		lastSamples: lastSamples,
+	}
+}
+
+func NewXORPartialChunkFromWire(raw []byte) (*XORPartialChunk, error) {
+	c := &XORPartialChunk{}
+	offset := 0
+
+	if len(raw) < xorPartialChunkHeaderBytes {
+		return nil, fmt.Errorf("the serialized XORPartialChunk is %d bytes but should be at least %d bytes", len(raw), xorPartialChunkHeaderBytes)
+	}
+
+	// Read numSamples.
+	c.numSamples = int(binary.BigEndian.Uint16(raw[offset:]))
+	offset += 2
+
+	// Read lastSamples.
+	for idx := range c.lastSamples {
+		c.lastSamples[idx].T = int64(binary.BigEndian.Uint64(raw[offset:]))
+		offset += 8
+
+		c.lastSamples[idx].V = math.Float64frombits(binary.BigEndian.Uint64(raw[offset:]))
+		offset += 8
+	}
+
+	// Read XORChunk underlying bytes.
+	c.xorChunk = raw[offset:]
+
+	return c, nil
+}
+
+// Bytes returns the encoded XORPartialChunk safe to be transferred on wire.
+func (c *XORPartialChunk) Bytes() []byte {
+	serialized := make([]byte, xorPartialChunkHeaderBytes+len(c.xorChunk))
+	offset := 0
+
+	// Write numSamples.
+	binary.BigEndian.PutUint16(serialized[offset:], uint16(c.numSamples))
+	offset += 2
+
+	// Write lastSamples.
+	for _, sample := range c.lastSamples {
+		binary.BigEndian.PutUint64(serialized[offset:], uint64(sample.T))
+		offset += 8
+
+		binary.BigEndian.PutUint64(serialized[offset:], math.Float64bits(sample.V))
+		offset += 8
+	}
+
+	// Copy XORChunk underlying bytes.
+	copy(serialized[offset:], c.xorChunk)
+
+	return serialized
+}
+
+// Encoding returns the encoding type of the chunk.
+func (c *XORPartialChunk) Encoding() Encoding {
+	return EncXORPartial
+}
+
+// Appender returns an appender to append samples to the chunk.
+func (c *XORPartialChunk) Appender() (Appender, error) {
+	return nil, errors.New("XORPartialChunk is read-only")
+}
+
+// The iterator passed as argument is for re-use.
+// Depending on implementation, the iterator can
+// be re-used or a new iterator can be allocated.
+// TODO support Iterator reusing
+func (c *XORPartialChunk) Iterator(_ Iterator) Iterator {
+	xorChunk, err := FromData(EncXOR, c.xorChunk)
+	if err != nil {
+		// Current can't return error, so we panic just in case anything will change in future.
+		panic(err.Error())
+	}
+
+	return &xorPartialChunkIterator{
+		Iterator:    xorChunk.Iterator(nil),
+		total:       c.numSamples,
+		lastSamples: c.lastSamples,
+		i:           -1,
+	}
+}
+
+// NumSamples returns the number of samples in the chunk.
+func (c *XORPartialChunk) NumSamples() int {
+	return c.numSamples
+}
+
+// Compact is called whenever a chunk is expected to be complete (no more
+// samples appended) and the underlying implementation can eventually
+// optimize the chunk.
+// There's no strong guarantee that no samples will be appended once
+// Compact() is called. Implementing this function is optional.
+func (c *XORPartialChunk) Compact() {
+	// Nothing to compact.
+}
+
+type xorPartialChunkIterator struct {
+	// Underlying XORChunk iterator.
+	Iterator
+
+	i           int
+	total       int
+	lastSamples [4]Sample
+}
+
+func (it *xorPartialChunkIterator) Seek(t int64) bool {
+	if it.Err() != nil {
+		return false
+	}
+
+	ts, _ := it.At()
+
+	for t > ts || it.i == -1 {
+		if !it.Next() {
+			return false
+		}
+		ts, _ = it.At()
+	}
+
+	return true
+}
+
+func (it *xorPartialChunkIterator) Next() bool {
+	if it.i+1 >= it.total {
+		return false
+	}
+	it.i++
+	if it.total-it.i > 4 {
+		return it.Iterator.Next()
+	}
+	return true
+}
+
+func (it *xorPartialChunkIterator) At() (int64, float64) {
+	if it.total-it.i > 4 {
+		return it.Iterator.At()
+	}
+	s := it.lastSamples[4-(it.total-it.i)]
+	return s.T, s.V
+}

--- a/vendor/github.com/prometheus/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/compact.go
@@ -808,7 +808,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, minT, maxT int64,
 		}
 		all = indexr.SortedPostings(all)
 		// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
-		sets = append(sets, newBlockChunkSeriesSet(indexr, chunkr, tombsr, all, minT, maxT-1))
+		sets = append(sets, newBlockChunkSeriesSet(indexr, chunkr, tombsr, all, minT, maxT-1, true))
 
 		if len(outBlocks) > 1 {
 			// To iterate series when populating symbols, we cannot reuse postings we just got, but need to get a new copy.
@@ -820,7 +820,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, minT, maxT int64,
 			}
 			all = indexr.SortedPostings(all)
 			// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
-			symbolsSets = append(symbolsSets, newBlockChunkSeriesSet(indexr, chunkr, tombsr, all, minT, maxT-1))
+			symbolsSets = append(symbolsSets, newBlockChunkSeriesSet(indexr, chunkr, tombsr, all, minT, maxT-1, true))
 		} else {
 			syms := indexr.Symbols()
 			if i == 0 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -508,7 +508,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20210914090109-37468d88dce8 => github.com/grafana/prometheus-private v0.0.0-20211027085719-c8b86f581c41
+# github.com/prometheus/prometheus v1.8.2-0.20210914090109-37468d88dce8 => github.com/grafana/prometheus-private v0.0.0-20211028152210-92833dfb70c1
 ## explicit
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -955,7 +955,7 @@ sigs.k8s.io/yaml
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-# github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20211027085719-c8b86f581c41
+# github.com/prometheus/prometheus => github.com/grafana/prometheus-private v0.0.0-20211028152210-92833dfb70c1
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # google.golang.org/grpc => google.golang.org/grpc v1.38.0


### PR DESCRIPTION
**What this PR does**:
This PR builds on top of https://github.com/grafana/mimir/pull/430.

When querying chunks from TSDB head, the chunks which are still open (the ones we're still appending to and not mmap-ed yet) are re-encoded for every single `querier.Select()` call. This puts a significative pressure on ingesters on high query load, both in terms of CPU and memory.

For example, from this profile we can count almost 20% of memory allocations (bytes) in the profiled ingester due to this:

![Screenshot 2021-10-28 at 17 58 42](https://user-images.githubusercontent.com/1701904/139292681-73f54d3c-daa4-4f4e-8c91-44238621ae48.png)

In this PR I'm showing an experiment to avoid having to reencode the TSDB head chunks. TSDB is quite tricky and I'm not sure I'm missing anything (a part from the fact I intentionally didn't support isolation yet, to keep the experiment simpler). TSDB changes are [here](https://github.com/grafana/prometheus-private/compare/experiment-not-reencode-partial-chunks) (on top of changes done for #430 too).

**Benchmark** (including optimization proposed in #430 which is required to have this PR optimization working):

We don't expect any improvement for querying samples:

```
name                                                                                           old time/op    new time/op    delta
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=false-12                868ms ± 2%     803ms ± 2%   -7.43%  (p=0.003 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=true-12                 921ms ± 0%     857ms ± 1%   -6.96%  (p=0.006 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=false-12            174ms ± 0%     171ms ± 3%     ~     (p=0.254 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=true-12             207ms ± 4%     197ms ± 1%     ~     (p=0.151 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=false-12             396ms ± 5%     382ms ± 1%     ~     (p=0.263 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=true-12              427ms ± 2%     413ms ± 3%     ~     (p=0.112 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=false-12     828ms ± 2%     809ms ± 2%     ~     (p=0.149 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=true-12      907ms ± 3%     861ms ± 2%     ~     (p=0.084 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=false-12                 370ms ± 5%     154ms ± 5%  -58.53%  (p=0.001 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=true-12                  414ms ± 2%     205ms ± 2%  -50.55%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=false-12             193ms ± 2%      37ms ± 2%  -80.79%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=true-12              216ms ± 4%      60ms ± 5%  -72.34%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=false-12              471ms ± 2%      49ms ± 3%  -89.67%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=true-12               495ms ± 5%      79ms ± 5%  -84.11%  (p=0.001 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=false-12      501ms ± 7%     141ms ± 1%  -71.81%  (p=0.003 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=true-12       585ms ±15%     204ms ± 1%  -65.09%  (p=0.014 n=3+3)

name                                                                                           old alloc/op   new alloc/op   delta
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=false-12                478MB ± 0%     480MB ± 0%   +0.59%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=true-12                 479MB ± 0%     481MB ± 0%   +0.58%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=false-12            121MB ± 0%     121MB ± 0%     ~     (p=0.640 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=true-12             122MB ± 0%     122MB ± 0%     ~     (p=0.401 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=false-12             239MB ± 0%     239MB ± 0%     ~     (p=0.663 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=true-12              240MB ± 0%     240MB ± 0%     ~     (p=0.202 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=false-12     479MB ± 0%     479MB ± 0%     ~     (p=0.178 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=true-12      480MB ± 0%     480MB ± 0%     ~     (p=0.464 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=false-12                81.2MB ± 0%    69.6MB ± 0%  -14.28%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=true-12                 82.2MB ± 0%    70.6MB ± 0%  -14.11%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=false-12            28.8MB ± 0%    15.6MB ± 0%  -45.80%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=true-12             29.7MB ± 0%    16.5MB ± 0%  -44.51%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=false-12             67.8MB ± 0%    32.1MB ± 0%  -52.64%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=true-12              68.6MB ± 0%    32.9MB ± 0%  -52.01%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=false-12     93.6MB ± 0%    69.6MB ± 0%  -25.64%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=true-12      94.6MB ± 0%    70.6MB ± 0%  -25.37%  (p=0.000 n=3+3)

name                                                                                           old allocs/op  new allocs/op  delta
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=false-12                1.68M ± 0%     1.73M ± 0%   +2.97%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=full_data,_query_sharding=true-12                 1.69M ± 0%     1.74M ± 0%   +2.96%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=false-12             650k ± 0%      650k ± 0%     ~     (p=0.577 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_block,_query_sharding=true-12              651k ± 0%      651k ± 0%     ~     (p=0.457 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=false-12              834k ± 0%      834k ± 0%     ~     (p=0.591 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=partial_head,_query_sharding=true-12               835k ± 0%      835k ± 0%     ~     (p=0.267 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=false-12     1.78M ± 0%     1.78M ± 0%     ~     (p=0.132 n=3+3)
Ingester_V2QueryStream/query_samples/time_range=head_+_partial_block,_query_sharding=true-12      1.79M ± 0%     1.79M ± 0%     ~     (p=0.496 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=false-12                 1.49M ± 0%     1.37M ± 0%   -8.38%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=full_data,_query_sharding=true-12                  1.49M ± 0%     1.37M ± 0%   -8.37%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=false-12              575k ± 0%      350k ± 0%  -39.11%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_block,_query_sharding=true-12               576k ± 0%      351k ± 0%  -39.04%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=false-12               909k ± 0%      442k ± 0%  -51.36%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=partial_head,_query_sharding=true-12                910k ± 0%      443k ± 0%  -51.30%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=false-12      1.72M ± 0%     1.37M ± 0%  -20.38%  (p=0.000 n=3+3)
Ingester_V2QueryStream/query_chunks/time_range=head_+_partial_block,_query_sharding=true-12       1.72M ± 0%     1.37M ± 0%  -20.36%  (p=0.000 n=3+3)
```

**Draft** because:
- Very experimental, just to prove the idea
- Missing a bunch of tests (correctness, race, ...)

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
