### PR TITLE
Add documentation for the Alertmanager client code

### DIFF
--- a/pkg/alertmanager/alertmanager_client.go
+++ b/pkg/alertmanager/alertmanager_client.go
@@ -144,6 +144,8 @@ func (c *alertmanagerClient) Close() error {
 	return c.conn.Close()
 }
 
+// String implements the Stringer interface.
+// It returns the remote address of the alertmanager server which is unique for each client.
 func (c *alertmanagerClient) String() string {
 	return c.RemoteAddress()
 }


### PR DESCRIPTION
**What this PR does**

Adds documentation for the Alertmanager client code. Not all documentation may be desirable, and I am happy to drop any that are not useful.
Most are stating the obvious but at least provide editor feedback when the code is referenced from other files.

**Checklist**

- [x] Documentation added