### PR TITLE
Include compactor shard ID in the bucket index.

### DIFF
--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -24,8 +24,8 @@ const (
 	IndexFilename           = "bucket-index.json"
 	IndexCompressedFilename = IndexFilename + ".gz"
 	IndexVersion1           = 1
-
-	SegmentsFormatUnknown = ""
+	IndexVersion2           = 2 // Added CompactorShardID field.
+	SegmentsFormatUnknown   = ""
 
 	// SegmentsFormat1Based6Digits defined segments numbered with 6 digits numbers in a sequence starting from number 1
 	// eg. (000001, 000002, 000003).
@@ -88,6 +88,9 @@ type Block struct {
 	// UploadedAt is a unix timestamp (seconds precision) of when the block has been completed to be uploaded
 	// to the storage.
 	UploadedAt int64 `json:"uploaded_at"`
+
+	// Block's compactor shard ID, copied from tsdb.CompactorShardIDExternalLabel label.
+	CompactorShardID string `json:"compactor_shard_id,omitempty"`
 }
 
 // Within returns whether the block contains samples within the provided range.
@@ -143,11 +146,12 @@ func BlockFromThanosMeta(meta metadata.Meta) *Block {
 	segmentsFormat, segmentsNum := detectBlockSegmentsFormat(meta)
 
 	return &Block{
-		ID:             meta.ULID,
-		MinTime:        meta.MinTime,
-		MaxTime:        meta.MaxTime,
-		SegmentsFormat: segmentsFormat,
-		SegmentsNum:    segmentsNum,
+		ID:               meta.ULID,
+		MinTime:          meta.MinTime,
+		MaxTime:          meta.MaxTime,
+		SegmentsFormat:   segmentsFormat,
+		SegmentsNum:      segmentsNum,
+		CompactorShardID: meta.Thanos.Labels[mimir_tsdb.CompactorShardIDExternalLabel],
 	}
 }
 

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -51,8 +51,8 @@ func (w *Updater) UpdateIndex(ctx context.Context, old *Index) (*Index, map[ulid
 	var oldBlocks []*Block
 	var oldBlockDeletionMarks []*BlockDeletionMark
 
-	// Read the old index, if provided.
-	if old != nil {
+	// Use the old index if provided, and it is using the latest version format.
+	if old != nil && old.Version == IndexVersion2 {
 		oldBlocks = old.Blocks
 		oldBlockDeletionMarks = old.BlockDeletionMarks
 	}
@@ -68,7 +68,7 @@ func (w *Updater) UpdateIndex(ctx context.Context, old *Index) (*Index, map[ulid
 	}
 
 	return &Index{
-		Version:            IndexVersion1,
+		Version:            IndexVersion2,
 		Blocks:             blocks,
 		BlockDeletionMarks: blockDeletionMarks,
 		UpdatedAt:          time.Now().Unix(),

--- a/pkg/storage/tsdb/bucketindex/updater_test.go
+++ b/pkg/storage/tsdb/bucketindex/updater_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/block"
@@ -23,6 +22,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
 )
 
@@ -36,26 +36,26 @@ func TestUpdater_UpdateIndex(t *testing.T) {
 
 	// Generate the initial index.
 	bkt = BucketWithGlobalMarkers(bkt)
-	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
-	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
-	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+	block1 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 10, 20, nil)
+	block2 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 20, 30, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "1_of_5"})
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2.BlockMeta)
 
 	w := NewUpdater(bkt, userID, nil, logger)
 	returnedIdx, _, err := w.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	assertBucketIndexEqual(t, returnedIdx, bkt, userID,
-		[]tsdb.BlockMeta{block1, block2},
+		[]metadata.Meta{block1, block2},
 		[]*metadata.DeletionMark{block2Mark})
 
 	// Create new blocks, and update the index.
-	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
-	block4 := testutil.MockStorageBlock(t, bkt, userID, 40, 50)
-	block4Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block4)
+	block3 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 30, 40, map[string]string{"aaa": "bbb"})
+	block4 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 40, 50, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "2_of_5"})
+	block4Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block4.BlockMeta)
 
 	returnedIdx, _, err = w.UpdateIndex(ctx, returnedIdx)
 	require.NoError(t, err)
 	assertBucketIndexEqual(t, returnedIdx, bkt, userID,
-		[]tsdb.BlockMeta{block1, block2, block3, block4},
+		[]metadata.Meta{block1, block2, block3, block4},
 		[]*metadata.DeletionMark{block2Mark, block4Mark})
 
 	// Hard delete a block and update the index.
@@ -64,7 +64,7 @@ func TestUpdater_UpdateIndex(t *testing.T) {
 	returnedIdx, _, err = w.UpdateIndex(ctx, returnedIdx)
 	require.NoError(t, err)
 	assertBucketIndexEqual(t, returnedIdx, bkt, userID,
-		[]tsdb.BlockMeta{block1, block3, block4},
+		[]metadata.Meta{block1, block3, block4},
 		[]*metadata.DeletionMark{block4Mark})
 }
 
@@ -78,10 +78,10 @@ func TestUpdater_UpdateIndex_ShouldSkipPartialBlocks(t *testing.T) {
 
 	// Mock some blocks in the storage.
 	bkt = BucketWithGlobalMarkers(bkt)
-	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
-	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
-	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
-	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+	block1 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 10, 20, map[string]string{"hello": "world"})
+	block2 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 20, 30, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "3_of_10"})
+	block3 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 30, 40, nil)
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2.BlockMeta)
 
 	// Delete a block's meta.json to simulate a partial block.
 	require.NoError(t, bkt.Delete(ctx, path.Join(userID, block3.ULID.String(), metadata.MetaFilename)))
@@ -90,7 +90,7 @@ func TestUpdater_UpdateIndex_ShouldSkipPartialBlocks(t *testing.T) {
 	idx, partials, err := w.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	assertBucketIndexEqual(t, idx, bkt, userID,
-		[]tsdb.BlockMeta{block1, block2},
+		[]metadata.Meta{block1, block2},
 		[]*metadata.DeletionMark{block2Mark})
 
 	assert.Len(t, partials, 1)
@@ -107,10 +107,10 @@ func TestUpdater_UpdateIndex_ShouldSkipBlocksWithCorruptedMeta(t *testing.T) {
 
 	// Mock some blocks in the storage.
 	bkt = BucketWithGlobalMarkers(bkt)
-	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
-	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
-	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
-	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+	block1 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 10, 20, nil)
+	block2 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 20, 30, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "55_of_64"})
+	block3 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 30, 40, nil)
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2.BlockMeta)
 
 	// Overwrite a block's meta.json with invalid data.
 	require.NoError(t, bkt.Upload(ctx, path.Join(userID, block3.ULID.String(), metadata.MetaFilename), bytes.NewReader([]byte("invalid!}"))))
@@ -119,7 +119,7 @@ func TestUpdater_UpdateIndex_ShouldSkipBlocksWithCorruptedMeta(t *testing.T) {
 	idx, partials, err := w.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	assertBucketIndexEqual(t, idx, bkt, userID,
-		[]tsdb.BlockMeta{block1, block2},
+		[]metadata.Meta{block1, block2},
 		[]*metadata.DeletionMark{block2Mark})
 
 	assert.Len(t, partials, 1)
@@ -136,10 +136,10 @@ func TestUpdater_UpdateIndex_ShouldSkipCorruptedDeletionMarks(t *testing.T) {
 
 	// Mock some blocks in the storage.
 	bkt = BucketWithGlobalMarkers(bkt)
-	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
-	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
-	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
-	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+	block1 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 10, 20, nil)
+	block2 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 20, 30, nil)
+	block3 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 30, 40, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "2_of_7"})
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2.BlockMeta)
 
 	// Overwrite a block's deletion-mark.json with invalid data.
 	require.NoError(t, bkt.Upload(ctx, path.Join(userID, block2Mark.ID.String(), metadata.DeletionMarkFilename), bytes.NewReader([]byte("invalid!}"))))
@@ -148,7 +148,7 @@ func TestUpdater_UpdateIndex_ShouldSkipCorruptedDeletionMarks(t *testing.T) {
 	idx, partials, err := w.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	assertBucketIndexEqual(t, idx, bkt, userID,
-		[]tsdb.BlockMeta{block1, block2, block3},
+		[]metadata.Meta{block1, block2, block3},
 		[]*metadata.DeletionMark{})
 	assert.Empty(t, partials)
 }
@@ -164,12 +164,65 @@ func TestUpdater_UpdateIndex_NoTenantInTheBucket(t *testing.T) {
 		idx, partials, err := w.UpdateIndex(ctx, oldIdx)
 
 		require.NoError(t, err)
-		assert.Equal(t, IndexVersion1, idx.Version)
+		assert.Equal(t, IndexVersion2, idx.Version)
 		assert.InDelta(t, time.Now().Unix(), idx.UpdatedAt, 2)
 		assert.Len(t, idx.Blocks, 0)
 		assert.Len(t, idx.BlockDeletionMarks, 0)
 		assert.Empty(t, partials)
 	}
+}
+
+func TestUpdater_UpdateIndexFromVersion1ToVersion2(t *testing.T) {
+	const userID = "user-1"
+
+	bkt, _ := testutil.PrepareFilesystemBucket(t)
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	// Generate blocks with compactor shard ID.
+	bkt = BucketWithGlobalMarkers(bkt)
+	block1 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 10, 20, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "1_of_4"})
+	block2 := testutil.MockStorageBlockWithExtLabels(t, bkt, userID, 20, 30, map[string]string{mimir_tsdb.CompactorShardIDExternalLabel: "3_of_4"})
+
+	block1WithoutCompactorShardID := block1
+	block1WithoutCompactorShardID.Thanos.Labels = nil
+
+	block2WithoutCompactorShardID := block2
+	block2WithoutCompactorShardID.Thanos.Labels = nil
+
+	// Double check that original block1 and block2 still have compactor shards set.
+	require.Equal(t, "1_of_4", block1.Thanos.Labels[mimir_tsdb.CompactorShardIDExternalLabel])
+	require.Equal(t, "3_of_4", block2.Thanos.Labels[mimir_tsdb.CompactorShardIDExternalLabel])
+
+	// Generate index (this produces V2 index, with compactor shard IDs).
+	w := NewUpdater(bkt, userID, nil, logger)
+	returnedIdx, _, err := w.UpdateIndex(ctx, nil)
+	require.NoError(t, err)
+	assertBucketIndexEqual(t, returnedIdx, bkt, userID,
+		[]metadata.Meta{block1, block2},
+		[]*metadata.DeletionMark{})
+
+	// Now remove Compactor Shard ID from index.
+	for _, b := range returnedIdx.Blocks {
+		b.CompactorShardID = ""
+	}
+
+	// Try to update existing index. Since we didn't change the version, updater will reuse the index, and not update CompactorShardID field.
+	returnedIdx, _, err = w.UpdateIndex(ctx, returnedIdx)
+	require.NoError(t, err)
+	assertBucketIndexEqual(t, returnedIdx, bkt, userID,
+		[]metadata.Meta{block1WithoutCompactorShardID, block2WithoutCompactorShardID}, // No compactor shards in bucket index.
+		[]*metadata.DeletionMark{})
+
+	// Now set index version to old version 1. Rerunning updater should rebuild index from scratch.
+	returnedIdx.Version = IndexVersion1
+
+	returnedIdx, _, err = w.UpdateIndex(ctx, returnedIdx)
+	require.NoError(t, err)
+	assertBucketIndexEqual(t, returnedIdx, bkt, userID,
+		[]metadata.Meta{block1, block2}, // Compactor shards are back.
+		[]*metadata.DeletionMark{})
 }
 
 func getBlockUploadedAt(t testing.TB, bkt objstore.Bucket, userID string, blockID ulid.ULID) int64 {
@@ -181,18 +234,19 @@ func getBlockUploadedAt(t testing.TB, bkt objstore.Bucket, userID string, blockI
 	return attrs.LastModified.Unix()
 }
 
-func assertBucketIndexEqual(t testing.TB, idx *Index, bkt objstore.Bucket, userID string, expectedBlocks []tsdb.BlockMeta, expectedDeletionMarks []*metadata.DeletionMark) {
-	assert.Equal(t, IndexVersion1, idx.Version)
+func assertBucketIndexEqual(t testing.TB, idx *Index, bkt objstore.Bucket, userID string, expectedBlocks []metadata.Meta, expectedDeletionMarks []*metadata.DeletionMark) {
+	assert.Equal(t, IndexVersion2, idx.Version)
 	assert.InDelta(t, time.Now().Unix(), idx.UpdatedAt, 2)
 
 	// Build the list of expected block index entries.
 	var expectedBlockEntries []*Block
 	for _, b := range expectedBlocks {
 		expectedBlockEntries = append(expectedBlockEntries, &Block{
-			ID:         b.ULID,
-			MinTime:    b.MinTime,
-			MaxTime:    b.MaxTime,
-			UploadedAt: getBlockUploadedAt(t, bkt, userID, b.ULID),
+			ID:               b.ULID,
+			MinTime:          b.MinTime,
+			MaxTime:          b.MaxTime,
+			UploadedAt:       getBlockUploadedAt(t, bkt, userID, b.ULID),
+			CompactorShardID: b.Thanos.Labels[mimir_tsdb.CompactorShardIDExternalLabel],
 		})
 	}
 

--- a/pkg/storage/tsdb/testutil/block_mock.go
+++ b/pkg/storage/tsdb/testutil/block_mock.go
@@ -22,18 +22,28 @@ import (
 )
 
 func MockStorageBlock(t testing.TB, bucket objstore.Bucket, userID string, minT, maxT int64) tsdb.BlockMeta {
+	m := MockStorageBlockWithExtLabels(t, bucket, userID, minT, maxT, nil)
+	return m.BlockMeta
+}
+
+func MockStorageBlockWithExtLabels(t testing.TB, bucket objstore.Bucket, userID string, minT, maxT int64, externalLabels map[string]string) metadata.Meta {
 	// Generate a block ID whose timestamp matches the maxT (for simplicity we assume it
 	// has been compacted and shipped in zero time, even if not realistic).
 	id := ulid.MustNew(uint64(maxT), rand.Reader)
 
-	meta := tsdb.BlockMeta{
-		Version: 1,
-		ULID:    id,
-		MinTime: minT,
-		MaxTime: maxT,
-		Compaction: tsdb.BlockMetaCompaction{
-			Level:   1,
-			Sources: []ulid.ULID{id},
+	meta := metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			Version: 1,
+			ULID:    id,
+			MinTime: minT,
+			MaxTime: maxT,
+			Compaction: tsdb.BlockMetaCompaction{
+				Level:   1,
+				Sources: []ulid.ULID{id},
+			},
+		},
+		Thanos: metadata.Thanos{
+			Labels: externalLabels,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**: This PR updates bucket-index format to include value of compactor shard ID external label. This will be used by querier to further optimise sharded queries when querier finds sharded blocks (see https://github.com/grafana/mimir/issues/406).

No changelog entry yet, will be added after finishing the optimization feature.

**Checklist**

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
