### PR TITLE
Use ULID time for filtering out blocks that don't have correct minTime.

### DIFF
--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -61,7 +61,7 @@ func main() {
 	flag.IntVar(&cfg.splitCount, "split-count", 0, "It not 0, shows split number that would be used for grouping blocks during split compaction")
 	flag.Var(&cfg.minTime, "min-time", "If set, only blocks with MinTime >= this value are printed")
 	flag.Var(&cfg.maxTime, "max-time", "If set, only blocks with MaxTime <= this value are printed")
-	flag.BoolVar(&cfg.useUlidTimeForMinTimeCheck, "use-ulid-time-for-min-time-check", true, "If true, meta.json files for blocks with ULID time before min-time are not loaded. This may incorrectly skip blocks that have data from the future (minT/maxT higher than ULID).")
+	flag.BoolVar(&cfg.useUlidTimeForMinTimeCheck, "use-ulid-time-for-min-time-check", false, "If true, meta.json files for blocks with ULID time before min-time are not loaded. This may incorrectly skip blocks that have data from the future (minT/maxT higher than ULID).")
 	flag.Parse()
 
 	if cfg.userID == "" {


### PR DESCRIPTION
**What this PR does**: This PR modifies `listblocks` tool to use ULID time to filter out blocks that are too old and don't have correct minTime. This works for most blocks, but it's possible to disable this filter, just in case.

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
