### PR TITLE
Fixed instant queries panel in Reads dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Mixin:
 * [ENHANCEMENT] Added "Cortex / Writes Networking" and "Cortex / Reads Networking" dashboards. #405
 * [ENHANCEMENT] Improved "Queue length" panel in "Cortex / Queries" dashboard. #408
 * [ENHANCEMENT] Add `CortexDistributorReachingInflightPushRequestLimit` alert and playbook. #401
+* [BUGFIX] Fixed "Instant queries / sec" in "Cortex / Reads" dashboard. #445
 
 ### Query-tee
 

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -45,8 +45,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 route=~"(prometheus|api_prom)_api_v1_query"
               }[$__rate_interval]
             )
-          ) +
-          sum(
+            or
             rate(
               cortex_prometheus_rule_evaluations_total{
                 %(ruler)s


### PR DESCRIPTION
**What this PR does**:
I noticed the "Instant queries / sec" panel is broken if there are no rule evaluations in the cluster because of how the query has been written:

```
sum(
  rate(
    cortex_request_duration_seconds_count{route=~"(prometheus|api_prom)_api_v1_query"}[$__rate_interval]
  )
) +
sum(
  rate(
    cortex_prometheus_rule_evaluations_total{}[$__rate_interval]
  )
)
```

If there are no rulers / rule evaluations, the `sum(rate(cortex_prometheus_rule_evaluations_total{}[$__rate_interval]))` returns `NaN` and leads to have a `NaN` as well as result of the `+` operation.

This PR fixes that.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
