### PR TITLE
Fix KV store panels in dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Mixin:
 * [ENHANCEMENT] Improved "Queue length" panel in "Cortex / Queries" dashboard. #408
 * [ENHANCEMENT] Add `CortexDistributorReachingInflightPushRequestLimit` alert and playbook. #401
 * [BUGFIX] Fixed "Instant queries / sec" in "Cortex / Reads" dashboard. #445
+* [BUGFIX] Fixed and added missing KV store panels in Writes, Reads, Ruler and Compactor dashboards. #448
 
 ### Query-tee
 

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -116,5 +116,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.latencyPanel('cortex_compactor_meta_sync_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.compactor)),
       )
     )
-    .addRows($.getObjectStoreRows('Object Store', 'compactor')),
+    .addRows($.getObjectStoreRows('Object Store', 'compactor'))
+    .addRow(
+      $.kvStoreRow('Key-value store for compactors ring', 'compactor', '.+')
+    ),
 }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -287,6 +287,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { fill: 0 }
     ),
 
+  kvStoreRow(title, jobName, kvName)::
+    super.row(title)
+    .addPanel(
+      $.panel('Requests / sec') +
+      $.qpsPanel('cortex_kv_request_duration_seconds_count{%s, kv_name=~"%s"}' % [$.jobMatcher($._config.job_names[jobName]), kvName])
+    )
+    .addPanel(
+      $.panel('Latency') +
+      $.latencyPanel('cortex_kv_request_duration_seconds', '{%s, kv_name=~"%s"}' % [$.jobMatcher($._config.job_names[jobName]), kvName])
+    ),
+
   goHeapInUsePanel(title, jobName)::
     $.panel(title) +
     $.queryPanel(

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -216,6 +216,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
+      std.member($._config.storage_engine, 'blocks'),
+      $.kvStoreRow('Store-gateway - Key-value store for store-gateways ring', 'store_gateway', 'store-gateway')
+    )
+    .addRowIf(
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Index')
       .addPanel(

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -144,6 +144,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.latencyPanel('cortex_ingester_client_request_duration_seconds', '{%s, operation="/cortex.Ingester/QueryStream"}' % $.jobMatcher('ruler'))
       )
     )
+    .addRow(
+      $.kvStoreRow('Ruler - Key-value store for rulers ring', 'ruler', 'ruler')
+    )
     .addRowIf(
       std.member($._config.storage_engine, 'chunks'),
       $.row('Ruler - Chunks storage - Index Cache')

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -109,17 +109,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      $.row('Key-value store for high-availability (HA) deduplication')
-      .addPanel(
-        $.panel('Requests / sec') +
-        $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.distributor))
-      )
-      .addPanel(
-        $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_kv_request_duration_seconds', $.jobSelector($._config.job_names.distributor))
-      )
-    )
-    .addRow(
       $.row('Ingester')
       .addPanel(
         $.panel('Requests / sec') +
@@ -138,15 +127,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      $.row('Key-value store for the ingesters ring')
-      .addPanel(
-        $.panel('Requests / sec') +
-        $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester))
-      )
-      .addPanel(
-        $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_kv_request_duration_seconds', $.jobSelector($._config.job_names.ingester))
-      )
+      $.kvStoreRow('Distributor - Key-value store for high-availability (HA) deduplication', 'distributor', 'distributor-hatracker')
+    )
+    .addRow(
+      $.kvStoreRow('Distributor - Key-value store for distributors ring', 'distributor', 'distributor-(lifecycler|ring)')
+    )
+    .addRow(
+      $.kvStoreRow('Ingester - Key-value store for the ingesters ring', 'ingester', 'ingester-.*')
     )
     .addRowIf(
       std.member($._config.storage_engine, 'chunks'),


### PR DESCRIPTION
**What this PR does**:
The KV panels for distributor we have in the "Writes" dashboard is inaccurate because the panel "Key-value store for high-availability (HA) deduplication" includes both HA store and distributors ring (which could also be on two different KV store backends, like etcd and consul).

In this PR I propose to fix it, while also adding the KV store panels for other rings we have.

I manually tested it and the following is a screenshot of "Writes" dashboard after changes:
![Screenshot 2021-11-04 at 13 15 54](https://user-images.githubusercontent.com/1701904/140312255-914d8837-2901-4184-9ab2-397fb6db2b70.png)



**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
