### PR TITLE
integration tests: Replace regex for prefix matching with strings.HasPrefix

### DIFF
--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -77,7 +77,11 @@ func assertServiceMetricsPrefixes(t *testing.T, serviceType ServiceType, service
 				break
 			}
 
-			assert.NotRegexp(t, "^"+prefix, metricLine, "service: %s endpoint: %s", service.Name(), service.HTTPEndpoint())
+			assert.Falsef(
+				t, strings.HasPrefix(metricLine, prefix),
+				"service: %s endpoint: %s prefix: %s metric: %s",
+				service.Name(), service.HTTPEndpoint(), prefix, metricLine,
+			)
 		}
 	}
 }


### PR DESCRIPTION
Constant compilation of regex just to do prefix matching showed up in profiling
some e2e tests. Probably not significant compared to the various services being
run but it was about 35% of CPU time of the supervisor process.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
