### PR TITLE
Add MaxChunksPerQuery limit to overrides-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
   * `cortex_querier_blocks_queried_total`
   * `cortex_querier_blocks_with_compactor_shard_but_incompatible_query_shard_total`
 * [ENHANCEMENT] Querier&Ruler: reduce cpu usage, latency and peak memory consumption. #459 #463
+* [ENHANCEMENT] Overrides Exporter: Add `max_fetched_chunks_per_query` limit to the default and per-tenant limits exported as metrics. #471
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #207
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16

--- a/pkg/util/validation/exporter.go
+++ b/pkg/util/validation/exporter.go
@@ -53,6 +53,7 @@ func (oe *OverridesExporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxGlobalSeriesPerMetric), "max_global_series_per_metric")
 
 	// Read path limits
+	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxChunksPerQuery), "max_fetched_chunks_per_query")
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxFetchedSeriesPerQuery), "max_fetched_series_per_query")
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxFetchedChunkBytesPerQuery), "max_fetched_chunk_bytes_per_query")
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxSeriesPerQuery), "max_series_per_query")
@@ -72,6 +73,7 @@ func (oe *OverridesExporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxGlobalSeriesPerMetric), "max_global_series_per_metric", tenant)
 
 		// Read path limits
+		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxChunksPerQuery), "max_fetched_chunks_per_query", tenant)
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxFetchedSeriesPerQuery), "max_fetched_series_per_query", tenant)
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxFetchedChunkBytesPerQuery), "max_fetched_chunk_bytes_per_query", tenant)
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxSeriesPerQuery), "max_series_per_query", tenant)

--- a/pkg/util/validation/exporter_test.go
+++ b/pkg/util/validation/exporter_test.go
@@ -21,7 +21,7 @@ func TestOverridesExporter_noConfig(t *testing.T) {
 	assert.Equal(t, 0, count)
 	// The defaults should exist though
 	count = testutil.CollectAndCount(exporter, "cortex_limits_defaults")
-	assert.Equal(t, 11, count)
+	assert.Equal(t, 12, count)
 }
 
 func TestOverridesExporter_withConfig(t *testing.T) {
@@ -33,9 +33,10 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 			MaxLocalSeriesPerMetric:      13,
 			MaxGlobalSeriesPerUser:       14,
 			MaxGlobalSeriesPerMetric:     15,
-			MaxFetchedSeriesPerQuery:     16,
-			MaxFetchedChunkBytesPerQuery: 17,
-			MaxSeriesPerQuery:            18,
+			MaxChunksPerQuery:            16,
+			MaxFetchedSeriesPerQuery:     17,
+			MaxFetchedChunkBytesPerQuery: 18,
+			MaxSeriesPerQuery:            19,
 			RulerMaxRulesPerRuleGroup:    20,
 			RulerMaxRuleGroupsPerTenant:  21,
 		},
@@ -48,9 +49,10 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 		MaxLocalSeriesPerMetric:      25,
 		MaxGlobalSeriesPerUser:       26,
 		MaxGlobalSeriesPerMetric:     27,
-		MaxFetchedSeriesPerQuery:     28,
-		MaxFetchedChunkBytesPerQuery: 29,
-		MaxSeriesPerQuery:            30,
+		MaxChunksPerQuery:            28,
+		MaxFetchedSeriesPerQuery:     29,
+		MaxFetchedChunkBytesPerQuery: 30,
+		MaxSeriesPerQuery:            31,
 		RulerMaxRulesPerRuleGroup:    32,
 		RulerMaxRuleGroupsPerTenant:  33,
 	}, newMockTenantLimits(tenantLimits))
@@ -63,9 +65,10 @@ cortex_limits_overrides{limit_name="max_local_series_per_user",user="tenant-a"} 
 cortex_limits_overrides{limit_name="max_local_series_per_metric",user="tenant-a"} 13
 cortex_limits_overrides{limit_name="max_global_series_per_user",user="tenant-a"} 14
 cortex_limits_overrides{limit_name="max_global_series_per_metric",user="tenant-a"} 15
-cortex_limits_overrides{limit_name="max_fetched_series_per_query",user="tenant-a"} 16
-cortex_limits_overrides{limit_name="max_fetched_chunk_bytes_per_query",user="tenant-a"} 17
-cortex_limits_overrides{limit_name="max_series_per_query",user="tenant-a"} 18
+cortex_limits_overrides{limit_name="max_fetched_chunks_per_query",user="tenant-a"} 16
+cortex_limits_overrides{limit_name="max_fetched_series_per_query",user="tenant-a"} 17
+cortex_limits_overrides{limit_name="max_fetched_chunk_bytes_per_query",user="tenant-a"} 18
+cortex_limits_overrides{limit_name="max_series_per_query",user="tenant-a"} 19
 cortex_limits_overrides{limit_name="ruler_max_rules_per_rule_group",user="tenant-a"} 20
 cortex_limits_overrides{limit_name="ruler_max_rule_groups_per_tenant",user="tenant-a"} 21
 `
@@ -83,9 +86,10 @@ cortex_limits_defaults{limit_name="max_local_series_per_user"} 24
 cortex_limits_defaults{limit_name="max_local_series_per_metric"} 25
 cortex_limits_defaults{limit_name="max_global_series_per_user"} 26
 cortex_limits_defaults{limit_name="max_global_series_per_metric"} 27
-cortex_limits_defaults{limit_name="max_fetched_series_per_query"} 28
-cortex_limits_defaults{limit_name="max_fetched_chunk_bytes_per_query"} 29
-cortex_limits_defaults{limit_name="max_series_per_query"} 30
+cortex_limits_defaults{limit_name="max_fetched_chunks_per_query"} 28
+cortex_limits_defaults{limit_name="max_fetched_series_per_query"} 29
+cortex_limits_defaults{limit_name="max_fetched_chunk_bytes_per_query"} 30
+cortex_limits_defaults{limit_name="max_series_per_query"} 31
 cortex_limits_defaults{limit_name="ruler_max_rules_per_rule_group"} 32
 cortex_limits_defaults{limit_name="ruler_max_rule_groups_per_tenant"} 33
 `


### PR DESCRIPTION
This adds the read path MaxChunksPerQuery limit to the overrides
exporter which makes per-tenant limits available as metrics.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
