### PR TITLE
Move data race detection to separate make target

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -64,9 +64,9 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      # Note that we're running the 'race' target here which runs unit tests with the go data race detector
+      # Note that we're running the 'test-with-race' target here which runs unit tests with the go data race detector
       - name: Run Tests
-        run: CASSANDRA_TEST_ADDRESSES=cassandra:9042 make BUILD_IN_CONTAINER=false race
+        run: CASSANDRA_TEST_ADDRESSES=cassandra:9042 make BUILD_IN_CONTAINER=false test-with-race
 
   build:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test race integration-tests cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool checkin-mixin-playbook build-mixin format-mixin
+.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool checkin-mixin-playbook build-mixin format-mixin
 .DEFAULT_GOAL := all
 
 # Version number
@@ -119,7 +119,7 @@ pkg/alertmanager/alertspb/alerts.pb.go: pkg/alertmanager/alertspb/alerts.proto
 
 all: $(UPTODATE_FILES)
 test: protos
-race: protos
+test-with-race: protos
 mod-check: protos
 lint: lint-packaging-scripts protos
 mimir-build-image/$(UPTODATE): mimir-build-image/*
@@ -144,7 +144,7 @@ GOVOLUMES=	-v $(shell pwd)/.cache:/go/cache:delegated,z \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:delegated,z
 
-exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test race cover shell mod-check check-protos web-build web-pre web-deploy doc format: mimir-build-image/$(UPTODATE)
+exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos web-build web-pre web-deploy doc format: mimir-build-image/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	@mkdir -p $(shell pwd)/.cache
 	@echo
@@ -231,7 +231,7 @@ format:
 test:
 	go test -timeout 30m ./...
 
-race:
+test-with-race:
 	go test -tags netgo -timeout 30m -race -count 1 ./...
 
 cover:


### PR DESCRIPTION
Move data race detection to its own target in the Makefile so that
unit tests can be run quicker. Data race detection as part of unit
tests is still run by CI for pull requests.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
