### PR TITLE
Consistently use fetched_chunk_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [CHANGE] Flag `-querier.parallelise-shardable-queries` has been renamed to `-query-frontend.parallelize-shardable-queries` #284
 * [CHANGE] Update Go version to 1.17.3. #480
 * [CHANGE] Compactor: removed overlapping sources detection. Overlapping sources may exist due to edge cases (timing issues) when horizontally sharding compactor with `split-and-merge` strategy, but are correctly handled by compactor. #494
+* [CHANGE] Rename metric `cortex_query_fetched_chunks_bytes_total` to `cortex_query_fetched_chunk_bytes_total` to be consistent with the limit name. #476
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage. You can now enabled querysharding for blocks storage (`-store.engine=blocks`) by setting `-query-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458
   * New config options:

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -92,8 +92,8 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 		}, []string{"user"})
 
 		h.queryBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_query_fetched_chunks_bytes_total",
-			Help: "Size of all chunks fetched to execute a query in bytes.",
+			Name: "cortex_query_fetched_chunk_bytes_total",
+			Help: "Number of chunk bytes fetched to execute a query.",
 		}, []string{"user"})
 
 		h.queryChunks = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
@@ -215,7 +215,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 		"response_time", queryResponseTime,
 		"query_wall_time_seconds", wallTime.Seconds(),
 		"fetched_series_count", numSeries,
-		"fetched_chunks_bytes", numBytes,
+		"fetched_chunk_bytes", numBytes,
 		"fetched_chunks_count", numChunks,
 		"sharded_queries", stats.LoadShardedQueries(),
 	}, formatQueryString(queryString)...)

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -88,7 +88,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				reg,
 				"cortex_query_seconds_total",
 				"cortex_query_fetched_series_total",
-				"cortex_query_fetched_chunks_bytes_total",
+				"cortex_query_fetched_chunk_bytes_total",
 				"cortex_query_fetched_chunks_total",
 			)
 

--- a/tools/blocksconvert/builder/builder.go
+++ b/tools/blocksconvert/builder/builder.go
@@ -96,7 +96,7 @@ func NewBuilder(cfg Config, scfg blocksconvert.SharedConfig, l log.Logger, reg p
 			Help: "Fetched chunks",
 		}),
 		fetchedChunksSize: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_blocksconvert_builder_fetched_chunks_bytes_total",
+			Name: "cortex_blocksconvert_builder_fetched_chunk_bytes_total",
 			Help: "Fetched chunks bytes",
 		}),
 		processedSeries: promauto.With(reg).NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This changes the name of metrics and some log output to consistently use the fetched_chunk_bytes instead of fetched_chunks_bytes.

The related limit e.g. was always called max_fetched_chunk_bytes:

**Checklist**

- ~[ ] Tests updated~
- ~[ ] Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
