### PR TITLE
[HOTFIX]fixed configuration of replicationSet when ZoneAwareness is enabled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,8 @@
 * [FEATURE] Ingester: can expose metrics on active series matching custom trackers configured via `-ingester.active-series-custom-trackers` (or its respective YAML config option). When configured, active series for custom trackers are exposed by the `cortex_ingester_active_series_custom_tracker` metric. #42
 * [FEATURE] Ingester: Enable snapshotting of in-memory TSDB on disk during shutdown via `-blocks-storage.tsdb.memory-snapshot-on-shutdown`. #249
 * [FEATURE] Compactor: added support for a new compaction strategy `-compactor.compaction-strategy=split-and-merge`. When the `split-and-merge` compactor is used, source blocks for a given tenant are split into `-compactor.split-and-merge-shards` shards (configurable on a per-tenant basis) and compaction of each tenant shards can be horizontally scaled. Number of compactors that work on jobs for single tenant can be limited by using `-compactor.compactor-tenant-shard-size` parameter, or per-tenant `compactor_tenant_shard_size` override.  #275 #281 #282 #283 #288 #290 #303 #307 #317 #323 #324 #328 #353 #368
-* [FEATURE] Querier: Added label names cardinality endpoint `<prefix>/api/v1/cardinality/label_names` that is disabled by default. Can be enabled/disabled via the CLI flag `-querier.cardinality-analysis-enabled` or its respective YAML config option. Configurable on a per-tenant basis. #301 #377
-* [FEATURE] Querier: Added label values cardinality endpoint `<prefix>/api/v1/cardinality/label_values` that is disabled by default. Can be enabled/disabled via the CLI flag `-querier.cardinality-analysis-enabled` or its respective YAML config option. Configurable on a per-tenant basis. #332 #395
+* [FEATURE] Querier: Added label names cardinality endpoint `<prefix>/api/v1/cardinality/label_names` that is disabled by default. Can be enabled/disabled via the CLI flag `-querier.cardinality-analysis-enabled` or its respective YAML config option. Configurable on a per-tenant basis. #301 #377 #474
+* [FEATURE] Querier: Added label values cardinality endpoint `<prefix>/api/v1/cardinality/label_values` that is disabled by default. Can be enabled/disabled via the CLI flag `-querier.cardinality-analysis-enabled` or its respective YAML config option. Configurable on a per-tenant basis. #332 #395 #474
 * [FEATURE] Query-Frontend: Added `-query-frontend.cache-unaligned-requests` option to cache responses for requests that do not have step-aligned start and end times. This can improve speed of repeated queries, but can also pollute cache with results that are never reused. #432
 * [ENHANCEMENT] Add a flag (`--proxy.compare-use-relative-error`) in the query-tee to compare floating point values using relative error. #208
 * [ENHANCEMENT] Add a flag (`--proxy.compare-skip-recent-samples`) in the query-tee to skip comparing recent samples. By default samples not older than 1 minute are skipped. #234
@@ -119,6 +119,7 @@
 * [BUGFIX] Query-tee: Ensure POST requests are handled correctly #286
 * [BUGFIX] Query-frontend: Ensure query_range requests handled by the query-frontend return JSON formatted errors. #360
 * [BUGFIX] Query-frontend: don't reuse cached results for queries that are not step-aligned. #424
+* [BUGFIX] Querier: fixed UserStats endpoint. When zone-aware replication is enabled, `MaxUnavailableZones` param is used instead of `MaxErrors`, so setting `MaxErrors = 0` doesn't make the Querier wait for all Ingesters responses. #474
 
 Mixin:
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -936,6 +936,10 @@ func toLabelNamesCardinalityRequest(matchers []*labels.Matcher) (*ingester_clien
 
 // toLabelNamesAndValuesResponses converts map with distinct label values to `ingester_client.LabelNamesAndValuesResponse`.
 func (m *labelNamesAndValuesResponseMerger) toLabelNamesAndValuesResponses() *ingester_client.LabelNamesAndValuesResponse {
+	// we need to acquire the lock to prevent concurrent read/write to the map because it might be a case that some ingesters responses are
+	// still being processed if replicationSet.Do() returned execution to this method when it decided that it got enough responses from the quorum of instances.
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	responses := make([]*ingester_client.LabelValues, 0, len(m.result))
 	for name, values := range m.result {
 		labelValues := make([]string, 0, len(values))
@@ -1039,6 +1043,7 @@ func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []m
 
 	// Make sure we get a successful response from all the ingesters
 	replicationSet.MaxErrors = 0
+	replicationSet.MaxUnavailableZones = 0
 
 	cardinalityConcurrentMap := &labelValuesCardinalityConcurrentMap{
 		cardinalityMap: map[string]map[string]uint64{},
@@ -1061,25 +1066,7 @@ func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []m
 	if err != nil {
 		return nil, err
 	}
-
-	cardinalityItems := make([]*ingester_client.LabelValueSeriesCount, 0, len(labelNames))
-
-	// Adjust label values' series count based on the ingester's replication factor
-	for labelName, labelValueSeriesCountMap := range cardinalityConcurrentMap.cardinalityMap {
-		for labelValue, seriesCount := range labelValueSeriesCountMap {
-			labelValueSeriesCountMap[labelValue] = seriesCount / uint64(d.ingestersRing.ReplicationFactor())
-		}
-		cardinalityItems = append(cardinalityItems, &ingester_client.LabelValueSeriesCount{
-			LabelName:        labelName,
-			LabelValueSeries: labelValueSeriesCountMap,
-		})
-	}
-
-	cardinalityResponse := &ingester_client.LabelValuesCardinalityResponse{
-		Items: cardinalityItems,
-	}
-
-	return cardinalityResponse, nil
+	return cardinalityConcurrentMap.toLabelValuesCardinalityResponse(d.ingestersRing.ReplicationFactor()), nil
 }
 
 func toLabelValuesCardinalityRequest(labelNames []model.LabelName, matchers []*labels.Matcher) (*ingester_client.LabelValuesCardinalityRequest, error) {
@@ -1138,6 +1125,30 @@ func (cm *labelValuesCardinalityConcurrentMap) processLabelValuesCardinalityMess
 			// Label name existent
 			cm.cardinalityMap[item.LabelName][labelValue] += seriesCount
 		}
+	}
+}
+
+// toLabelValuesCardinalityResponse adjust count of series to the replication factor and converts the map to `ingester_client.LabelValuesCardinalityResponse`.
+func (cm *labelValuesCardinalityConcurrentMap) toLabelValuesCardinalityResponse(replicationFactor int) *ingester_client.LabelValuesCardinalityResponse {
+	// we need to acquire the lock to prevent concurrent read/write to the map
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	cardinalityItems := make([]*ingester_client.LabelValueSeriesCount, 0, len(cm.cardinalityMap))
+	// Adjust label values' series count based on the ingester's replication factor
+	for labelName, labelValueSeriesCountMap := range cm.cardinalityMap {
+		adjustedSeriesCountMap := make(map[string]uint64, len(labelValueSeriesCountMap))
+		for labelValue, seriesCount := range labelValueSeriesCountMap {
+			adjustedSeriesCountMap[labelValue] = seriesCount / uint64(replicationFactor)
+		}
+		cardinalityItems = append(cardinalityItems, &ingester_client.LabelValueSeriesCount{
+			LabelName:        labelName,
+			LabelValueSeries: adjustedSeriesCountMap,
+		})
+	}
+
+	return &ingester_client.LabelValuesCardinalityResponse{
+		Items: cardinalityItems,
 	}
 }
 
@@ -1262,6 +1273,7 @@ func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
 
 	// Make sure we get a successful response from all of them.
 	replicationSet.MaxErrors = 0
+	replicationSet.MaxUnavailableZones = 0
 
 	req := &ingester_client.UserStatsRequest{}
 	resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {


### PR DESCRIPTION
1. fixed race condition in cardinality analysis endpoints when ZoneAw awareness feature is enabled and covered it with test 

2. fixed UserStats endpoint. MaxErrors is ignored if MaxUnavailableZones > 0. When zone-aware replication is enabled, MaxUnavailableZones is used instead of MaxErrors, so setting MaxErrors = 0 doesn't have the desired effect if multi-zone is used. We need both set to 0 to prevent cases when we return stats from a quorum of Ingesters but not from all.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #474

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
