### PR TITLE
Increase CortexKVStoreFailure and CortexRolloutStuck severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@
 
 Mixin:
 
+* [CHANGE] Raised `CortexKVStoreFailure` and `CortexRolloutStuck` alerts severity from warning to critical. #493
+* [CHANGE] Increase `CortexRolloutStuck` alert "for" duration from 15m to 30m. #493
 * [ENHANCEMENT] Added `CortexReachingTCPConnectionsLimit` alert. #403
 * [ENHANCEMENT] Added "Cortex / Writes Networking" and "Cortex / Reads Networking" dashboards. #405
 * [ENHANCEMENT] Improved "Queue length" panel in "Cortex / Queries" dashboard. #408

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -248,7 +248,7 @@
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '5m',
           labels: {
-            severity: 'warning',
+            severity: 'critical',
           },
           annotations: {
             message: |||
@@ -493,9 +493,9 @@
             )
             * on(%s) group_left max by(%s) (cortex_build_info)
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
-          'for': '15m',
+          'for': '30m',
           labels: {
-            severity: 'warning',
+            severity: 'critical',
           },
           annotations: {
             message: |||
@@ -517,9 +517,9 @@
             )
             * on(%s) group_left max by(%s) (cortex_build_info)
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
-          'for': '15m',
+          'for': '30m',
           labels: {
-            severity: 'warning',
+            severity: 'critical',
           },
           annotations: {
             message: |||


### PR DESCRIPTION
**What this PR does**:
When we introduced `CortexKVStoreFailure` (cortex-jsonnet PR 406) and `CortexRolloutStuck` (cortex-jsonnet PR 405) alerts the plan was to have then as warning first, to gain some confidence, and then increase the severity to critical.

I checked the last 4 weeks and I think when they fired there were real issues (eg. wrong config rolling out, issues with Consul, etc...). I propose to increase severity to critical and increase the "for" duration of `CortexRolloutStuck` because sometimes it happens that the operator notices it while doing config changes and just need some time to fix it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
