### PR TITLE
Fix returned status code on max samples limit hit when query sharding is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@
 * [BUGFIX] Ingester: don't create TSDB or appender if no samples are sent by a tenant. #162
 * [BUGFIX] Alertmanager: don't replace user configurations with blank fallback configurations (when enabled), particularly during scaling up/down instances when sharding is enabled. #224
 * [BUGFIX] Query-tee: Ensure POST requests are handled correctly #286
-* [BUGFIX] Query-frontend: Ensure query_range requests handled by the query-frontend return JSON formatted errors. #360
+* [BUGFIX] Query-frontend: Ensure query_range requests handled by the query-frontend return JSON formatted errors. #360 #499
 * [BUGFIX] Query-frontend: don't reuse cached results for queries that are not step-aligned. #424
 * [BUGFIX] Querier: fixed UserStats endpoint. When zone-aware replication is enabled, `MaxUnavailableZones` param is used instead of `MaxErrors`, so setting `MaxErrors = 0` doesn't make the Querier wait for all Ingesters responses. #474
 

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -174,6 +174,8 @@ func mapEngineError(err error) error {
 		errorType = apierror.TypeTimeout
 	case promql.ErrStorage:
 		errorType = apierror.TypeInternal
+	case promql.ErrTooManySamples:
+		errorType = apierror.TypeExec
 	}
 
 	return apierror.New(errorType, err.Error())

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -814,7 +814,7 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 			name:             "downstream - sample limit",
 			engineDownstream: engineSampleLimit,
 			engineSharding:   engine,
-			expError:         apierror.New(apierror.TypeInternal, "query processing would load too many samples into memory in query execution"),
+			expError:         apierror.New(apierror.TypeExec, "query processing would load too many samples into memory in query execution"),
 		},
 		{
 			name:             "sharding - timeout",
@@ -822,12 +822,6 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 			engineSharding:   engineTimeout,
 			expError:         apierror.New(apierror.TypeTimeout, "query timed out in expression evaluation"),
 			queryable:        queryableSlow,
-		},
-		{
-			name:             "downstream - sample limit",
-			engineDownstream: engine,
-			engineSharding:   engineSampleLimit,
-			expError:         apierror.New(apierror.TypeInternal, "query processing would load too many samples into memory in query execution"),
 		},
 		{
 			name:             "downstream - storage",


### PR DESCRIPTION
**What this PR does**:
While running some tests in a cluster with query sharding enabled, I've noticed that when the "max samples limit" is reached the returned status code is 5xx instead of 422 (as done by Prometheus). The API errors mapping was fixed in https://github.com/grafana/mimir/pull/360 but we forgot to handle the `promql.ErrTooManySamples` so this PR fixes that case.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
