### PR TITLE
Use go install instead of go get

### DIFF
--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -8,7 +8,7 @@ ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN go get -u golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
+RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -37,17 +37,16 @@ RUN GOARCH=$(go env GOARCH) && \
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.27.0
 
 RUN GO111MODULE=on \
-	go get github.com/client9/misspell/cmd/misspell@v0.3.4 && \
-	go get github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
-	go get github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 && \
-	go get github.com/gogo/protobuf/gogoproto@v1.3.0 && \
-	go get github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
-	go get github.com/fatih/faillint@v1.5.0 && \
-	go get github.com/campoy/embedmd@v1.0.0 && \
-	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 && \
-	go get github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066 && \
-	go get github.com/mikefarah/yq/v4@v4.13.4 && \
-	go get github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.17.0 && \
+	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
+	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
+	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 && \
+	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
+	go install github.com/fatih/faillint@v1.5.0 && \
+	go install github.com/campoy/embedmd@v1.0.0 && \
+	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 && \
+	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066 && \
+	go install github.com/mikefarah/yq/v4@v4.13.4 && \
+	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.17.0 && \
 	rm -rf /go/pkg /go/src /root/.cache
 
 ENV NODE_PATH=/usr/lib/node_modules


### PR DESCRIPTION
`go get` is deprecated since Go 1.17 (which is used since #480):

```
go get: installing executables with 'go get' in module mode is deprecated.
```
