### PR TITLE
distributor-queryable tests: make time go forward

### DIFF
--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	maxt, mint = 0, 10
+	mint, maxt = 0, 10
 )
 
 func TestDistributorQuerier_SelectShouldHonorQueryIngestersWithin(t *testing.T) {


### PR DESCRIPTION
Conventionally the minimum time would be before the maximum.
Apparently none of the tests were depending on this.

**Checklist**

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - test-only change
