### PR TITLE
Avoid overflow converting time to/from milliseconds

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -16,17 +16,13 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 )
 
-const (
-	nanosecondsInMillisecond = int64(time.Millisecond / time.Nanosecond)
-)
-
 func TimeToMillis(t time.Time) int64 {
-	return t.UnixNano() / nanosecondsInMillisecond
+	return t.Unix()*1000 + int64(t.Nanosecond())/int64(time.Millisecond)
 }
 
 // TimeFromMillis is a helper to turn milliseconds -> time.Time
 func TimeFromMillis(ms int64) time.Time {
-	return time.Unix(0, ms*nanosecondsInMillisecond)
+	return time.Unix(ms/1000, (ms%1000)*int64(time.Millisecond)).UTC()
 }
 
 // FormatTimeMillis returns a human readable version of the input time (in milliseconds).


### PR DESCRIPTION
Previous implementation overflowed at 2^63 nanoseconds since 1/1/1970, around 240 years into the future.

Which is not normally a huge problem, but it has showed up at least once: Prometheus very large milliseconds values to denote "no end-time specified", which overflows this conversion.

https://github.com/prometheus/prometheus/blob/0eac720468cf1b4bfee5cf3a4587cb5a409c1607/web/api/v1/api.go#L682-L683

Example, seen while testing #507 (the end-time is in year 292277025, which overflows to 1754):
```
$ curl -H "X-Scope-OrgID: 9960" "http://localhost:8080/api/prom/api/v1/series?start=$(date +%s --date '31 days ago')&match%5B%5D=alertmanager_build_info"
...
ts=2021-11-19T13:38:58.542891904Z caller=spanlogger.go:80 org_id=9960 level=debug msg="the end time of the query has been manipulated because of the 'max query into future' setting" original="1754-08-30 22:43:40.319654848 +0000 UTC" updated="2021-11-19 13:48:58.542 +0000 UTC"
```

The new code is likely slower; I haven't investigated whether we call this function in any tight loops.

**Checklist**

- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - I don't think this is significant enough to mention.
