### PR TITLE
Include per-tenant exemplar limits in overrides-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@
   * `cortex_querier_blocks_queried_total`
   * `cortex_querier_blocks_with_compactor_shard_but_incompatible_query_shard_total`
 * [ENHANCEMENT] Querier&Ruler: reduce cpu usage, latency and peak memory consumption. #459 #463
-* [ENHANCEMENT] Overrides Exporter: Add `max_fetched_chunks_per_query` limit to the default and per-tenant limits exported as metrics. #471
+* [ENHANCEMENT] Overrides Exporter: Add `max_fetched_chunks_per_query` and `max_global_exemplars_per_user` limits to the default and per-tenant limits exported as metrics. #471 #515
 * [ENHANCEMENT] Compactor (blocks cleaner): Delete blocks marked for deletion faster. #490
 * [ENHANCEMENT] Store-gateway: store-gateway can now ignore blocks with minimum time within `-blocks-storage.bucket-store.ignore-blocks-within` duration. Useful when used together with `-querier.query-store-after`. #502
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206

--- a/pkg/util/validation/exporter.go
+++ b/pkg/util/validation/exporter.go
@@ -51,6 +51,7 @@ func (oe *OverridesExporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxLocalSeriesPerMetric), "max_local_series_per_metric")
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxGlobalSeriesPerUser), "max_global_series_per_user")
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxGlobalSeriesPerMetric), "max_global_series_per_metric")
+	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxGlobalExemplarsPerUser), "max_global_exemplars_per_user")
 
 	// Read path limits
 	ch <- prometheus.MustNewConstMetric(oe.defaultsDescription, prometheus.GaugeValue, float64(oe.defaultLimits.MaxChunksPerQuery), "max_fetched_chunks_per_query")
@@ -71,6 +72,7 @@ func (oe *OverridesExporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxLocalSeriesPerMetric), "max_local_series_per_metric", tenant)
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxGlobalSeriesPerUser), "max_global_series_per_user", tenant)
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxGlobalSeriesPerMetric), "max_global_series_per_metric", tenant)
+		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxGlobalExemplarsPerUser), "max_global_exemplars_per_user", tenant)
 
 		// Read path limits
 		ch <- prometheus.MustNewConstMetric(oe.overrideDescription, prometheus.GaugeValue, float64(limits.MaxChunksPerQuery), "max_fetched_chunks_per_query", tenant)

--- a/pkg/util/validation/exporter_test.go
+++ b/pkg/util/validation/exporter_test.go
@@ -21,7 +21,7 @@ func TestOverridesExporter_noConfig(t *testing.T) {
 	assert.Equal(t, 0, count)
 	// The defaults should exist though
 	count = testutil.CollectAndCount(exporter, "cortex_limits_defaults")
-	assert.Equal(t, 12, count)
+	assert.Equal(t, 13, count)
 }
 
 func TestOverridesExporter_withConfig(t *testing.T) {
@@ -33,12 +33,13 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 			MaxLocalSeriesPerMetric:      13,
 			MaxGlobalSeriesPerUser:       14,
 			MaxGlobalSeriesPerMetric:     15,
-			MaxChunksPerQuery:            16,
-			MaxFetchedSeriesPerQuery:     17,
-			MaxFetchedChunkBytesPerQuery: 18,
-			MaxSeriesPerQuery:            19,
-			RulerMaxRulesPerRuleGroup:    20,
-			RulerMaxRuleGroupsPerTenant:  21,
+			MaxGlobalExemplarsPerUser:    16,
+			MaxChunksPerQuery:            17,
+			MaxFetchedSeriesPerQuery:     18,
+			MaxFetchedChunkBytesPerQuery: 19,
+			MaxSeriesPerQuery:            20,
+			RulerMaxRulesPerRuleGroup:    21,
+			RulerMaxRuleGroupsPerTenant:  22,
 		},
 	}
 
@@ -49,12 +50,13 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 		MaxLocalSeriesPerMetric:      25,
 		MaxGlobalSeriesPerUser:       26,
 		MaxGlobalSeriesPerMetric:     27,
-		MaxChunksPerQuery:            28,
-		MaxFetchedSeriesPerQuery:     29,
-		MaxFetchedChunkBytesPerQuery: 30,
-		MaxSeriesPerQuery:            31,
-		RulerMaxRulesPerRuleGroup:    32,
-		RulerMaxRuleGroupsPerTenant:  33,
+		MaxGlobalExemplarsPerUser:    28,
+		MaxChunksPerQuery:            29,
+		MaxFetchedSeriesPerQuery:     30,
+		MaxFetchedChunkBytesPerQuery: 31,
+		MaxSeriesPerQuery:            32,
+		RulerMaxRulesPerRuleGroup:    33,
+		RulerMaxRuleGroupsPerTenant:  34,
 	}, newMockTenantLimits(tenantLimits))
 	limitsMetrics := `
 # HELP cortex_limits_overrides Resource limit overrides applied to tenants
@@ -65,12 +67,13 @@ cortex_limits_overrides{limit_name="max_local_series_per_user",user="tenant-a"} 
 cortex_limits_overrides{limit_name="max_local_series_per_metric",user="tenant-a"} 13
 cortex_limits_overrides{limit_name="max_global_series_per_user",user="tenant-a"} 14
 cortex_limits_overrides{limit_name="max_global_series_per_metric",user="tenant-a"} 15
-cortex_limits_overrides{limit_name="max_fetched_chunks_per_query",user="tenant-a"} 16
-cortex_limits_overrides{limit_name="max_fetched_series_per_query",user="tenant-a"} 17
-cortex_limits_overrides{limit_name="max_fetched_chunk_bytes_per_query",user="tenant-a"} 18
-cortex_limits_overrides{limit_name="max_series_per_query",user="tenant-a"} 19
-cortex_limits_overrides{limit_name="ruler_max_rules_per_rule_group",user="tenant-a"} 20
-cortex_limits_overrides{limit_name="ruler_max_rule_groups_per_tenant",user="tenant-a"} 21
+cortex_limits_overrides{limit_name="max_global_exemplars_per_user",user="tenant-a"} 16
+cortex_limits_overrides{limit_name="max_fetched_chunks_per_query",user="tenant-a"} 17
+cortex_limits_overrides{limit_name="max_fetched_series_per_query",user="tenant-a"} 18
+cortex_limits_overrides{limit_name="max_fetched_chunk_bytes_per_query",user="tenant-a"} 19
+cortex_limits_overrides{limit_name="max_series_per_query",user="tenant-a"} 20
+cortex_limits_overrides{limit_name="ruler_max_rules_per_rule_group",user="tenant-a"} 21
+cortex_limits_overrides{limit_name="ruler_max_rule_groups_per_tenant",user="tenant-a"} 22
 `
 
 	// Make sure each override matches the values from the supplied `Limit`
@@ -86,12 +89,13 @@ cortex_limits_defaults{limit_name="max_local_series_per_user"} 24
 cortex_limits_defaults{limit_name="max_local_series_per_metric"} 25
 cortex_limits_defaults{limit_name="max_global_series_per_user"} 26
 cortex_limits_defaults{limit_name="max_global_series_per_metric"} 27
-cortex_limits_defaults{limit_name="max_fetched_chunks_per_query"} 28
-cortex_limits_defaults{limit_name="max_fetched_series_per_query"} 29
-cortex_limits_defaults{limit_name="max_fetched_chunk_bytes_per_query"} 30
-cortex_limits_defaults{limit_name="max_series_per_query"} 31
-cortex_limits_defaults{limit_name="ruler_max_rules_per_rule_group"} 32
-cortex_limits_defaults{limit_name="ruler_max_rule_groups_per_tenant"} 33
+cortex_limits_defaults{limit_name="max_global_exemplars_per_user"} 28
+cortex_limits_defaults{limit_name="max_fetched_chunks_per_query"} 29
+cortex_limits_defaults{limit_name="max_fetched_series_per_query"} 30
+cortex_limits_defaults{limit_name="max_fetched_chunk_bytes_per_query"} 31
+cortex_limits_defaults{limit_name="max_series_per_query"} 32
+cortex_limits_defaults{limit_name="ruler_max_rules_per_rule_group"} 33
+cortex_limits_defaults{limit_name="ruler_max_rule_groups_per_tenant"} 34
 `
 	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "cortex_limits_defaults")
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
