### PR TITLE
Include exemplars in e2e test generated series

### DIFF
--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -131,6 +131,11 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 	// Generate the series
 	series = append(series, prompb.TimeSeries{
 		Labels: lbls,
+		Exemplars: []prompb.Exemplar{
+			{Value: value, Timestamp: tsMillis, Labels: []prompb.Label{
+				{Name: "trace_id", Value: "1234"},
+			}},
+		},
 		Samples: []prompb.Sample{
 			{Value: value, Timestamp: tsMillis},
 		},


### PR DESCRIPTION
Include exemplars in series generated by e2e test utility method
which is used by downstream consumers like GEM. This allows us to
easily test interactions between exemplars and GEM features.
    
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
