### PR TITLE
Removed global mint/maxt variables in querier tests

### DIFF
--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/chunkcompat"
 )
 
-const (
-	mint, maxt = 0, 10
-)
-
 func TestDistributorQuerier_SelectShouldHonorQueryIngestersWithin(t *testing.T) {
 	now := time.Now()
 
@@ -130,6 +126,8 @@ func TestDistributorQueryableFilter(t *testing.T) {
 }
 
 func TestIngesterStreaming(t *testing.T) {
+	const mint, maxt = 0, 10
+
 	// We need to make sure that there is atleast one chunk present,
 	// else no series will be selected.
 	promChunk, err := encoding.NewForEncoding(encoding.Bigchunk)
@@ -258,6 +256,8 @@ func TestIngesterStreamingMixedResults(t *testing.T) {
 }
 
 func TestDistributorQuerier_LabelNames(t *testing.T) {
+	const mint, maxt = 0, 10
+
 	someMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 	labelNames := []string{"foo", "job"}
 


### PR DESCRIPTION
**What this PR does**:
This PR is a follow up to #513. Since these mint/maxt global variables are just used in a couple of tests I suggest to remove them at all and define in the tests. Looks there's no good reason to have them globally, but could lead to mistakes given mint/maxt are common variable names in our codebase.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
