### PR TITLE
Add ability to configure `docker network` in `e2e.Scenario`

### DIFF
--- a/integration/e2e/scenario.go
+++ b/integration/e2e/scenario.go
@@ -49,8 +49,19 @@ func NewScenario(networkName string) (*Scenario, error) {
 	// the previous tests run didn't cleanup correctly.
 	s.shutdown()
 
+	args := []string{
+		"network", "create", networkName,
+	}
+
+	if extraArgs := os.Getenv("DOCKER_NETWORK_CREATE_EXTRA_ARGS"); extraArgs != "" {
+		args = append(
+			args,
+			strings.Split(extraArgs, ",")...,
+		)
+	}
+
 	// Setup the docker network.
-	if out, err := RunCommandAndGetOutput("docker", "network", "create", networkName); err != nil {
+	if out, err := RunCommandAndGetOutput("docker", args...); err != nil {
 		logger.Log(string(out))
 		s.clean()
 		return nil, errors.Wrapf(err, "create docker network '%s'", networkName)


### PR DESCRIPTION
**What this PR does**:

This allows to run integration tests with specific settings for the temporary created network interface e.g. a lower MTU by setting this environment variable:

```
export DOCKER_NETWORK_CREATE_EXTRA_ARGS=--opt,com.docker.network.driver.mtu=1420
```
**Which issue(s) this PR fixes**:

In my dev cloud instance I can't successfully run the integration tests, as the Internet connection has a reduced MTU, so many integration tests fail. This MTU can't be set somewhere else as the docker setting for MTU is only applying to the default network not the one created by an integration tests `Scenario`.

Note: I haven't added any docs yet, happy to do that once I get a sense that is something that we would consider merging.