### PR TITLE
Ensure a stopping ingester is rejecting samples when using blocks

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -648,6 +648,9 @@ func (i *Ingester) stoppingV2ForFlusher(_ error) error {
 
 // runs when V2 ingester is stopping
 func (i *Ingester) stoppingV2(_ error) error {
+	// This will prevent us accepting any more samples
+	i.stopIncomingRequests()
+
 	// It's important to wait until shipper is finished,
 	// because the blocks transfer should start only once it's guaranteed
 	// there's no shipping on-going.


### PR DESCRIPTION
**What this PR does**:

The block store engine of the ingester failed to stop accepting samples as part of the shutdown.

**Which issue(s) this PR fixes**:

Even during shutdown the blocks ingester accepted new samples.

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
