### PR TITLE
Fix the integration test workflow to actually use Go 1.17.3

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -106,13 +106,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Upgrade golang
-        run: |
-          cd /tmp
-          wget https://dl.google.com/go/go1.17.3.linux-amd64.tar.gz
-          tar -zxvf go1.17.3.linux-amd64.tar.gz
-          sudo rm -fr /usr/local/go
-          sudo mv /tmp/go /usr/local/go
-          cd -
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.3
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client
@@ -153,4 +149,5 @@ jobs:
           export MIMIR_IMAGE="us.gcr.io/kubernetes-dev/mimir:$IMAGE_TAG"
           export MIMIR_CHECKOUT_DIR="/go/src/github.com/grafana/mimir"
           echo "Running integration tests with image: $MIMIR_IMAGE"
+          echo "Running integration tests with Go version: $(go version)"
           go test -tags=requires_docker -timeout 2400s -v -count=1 ./integration/...


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix the integration test workflow to actually use Go 1.17.3

The commands to download and install the newer version of Go for running the
integration tests do not work, due to Go actually being installed in a
different location to `/usr/local`, the binary actually used to run the
tests is `/opt/hostedtoolcache/go/1.15.15/x64/bin/go`.

For added confusion, this is not a stock Ubuntu 20.04, but the official GitHub
image with some tools pre-installed or pre-cached. Therefore, it would be
safer to use the officially supported method of updating Go in this container,
which is `actions/setup-go`.

More information:
- https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#cached-tools
- https://github.com/actions/setup-go#usage

Other notes:
- Only the integration test _runner_ is affected, not the code under test.
- If the Go version we want is pre-cached in the image (see above, 1.17.3 currently is), the "install" is near instant.
 
**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes n/a

**Checklist**

- n/a Tests updated
- n/a Documentation added
- n/a `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
