### PR TITLE
Update memcached, minio, etcd, consul and dynamodb e2e images

### DIFF
--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -35,7 +35,7 @@ func NewMinio(port int, bktNames ...string) *e2e.HTTPService {
 		images.Minio,
 		// Create the "mimir" bucket before starting minio
 		e2e.NewCommandWithoutEntrypoint("sh", "-c", strings.Join(commands, " && ")),
-		e2e.NewHTTPReadinessProbe(port, "/minio/health/ready", 200, 200),
+		e2e.NewHTTPReadinessProbe(port, "/minio/health/cluster", 200, 200),
 		port,
 	)
 	m.SetEnvVars(map[string]string{

--- a/integration/e2e/images/images.go
+++ b/integration/e2e/images/images.go
@@ -12,7 +12,7 @@ package images
 
 var (
 	Memcached        = "memcached:1.6.12"
-	Minio            = "minio/minio:RELEASE.2021-11-09T03-21-45Z"
+	Minio            = "minio/minio:RELEASE.2021-02-19T04-38-02Z"
 	Consul           = "consul:1.8.15"
 	ETCD             = "gcr.io/etcd-development/etcd:v3.4.13"
 	DynamoDB         = "amazon/dynamodb-local:1.17.0"


### PR DESCRIPTION
**What this PR does**: Current minio and dynamodb images do not have an arm64 version. Because of this docker desktop on m1 macs complains.

Bumping memcached, etcd and consul versions for good measure since it's only patch releases.


**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
