### PR TITLE
mimir-mixin: Change CortexRolloutStuck severity to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@
 
 Mixin:
 
-* [CHANGE] Raised `CortexKVStoreFailure` and `CortexRolloutStuck` alerts severity from warning to critical. #493
+* [CHANGE] Raised `CortexKVStoreFailure` alert severity from warning to critical. #493
 * [CHANGE] Increase `CortexRolloutStuck` alert "for" duration from 15m to 30m. #493
 * [ENHANCEMENT] Added `CortexReachingTCPConnectionsLimit` alert. #403
 * [ENHANCEMENT] Added "Cortex / Writes Networking" and "Cortex / Reads Networking" dashboards. #405

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -495,7 +495,7 @@
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '30m',
           labels: {
-            severity: 'critical',
+            severity: 'warning',
           },
           annotations: {
             message: |||
@@ -519,7 +519,7 @@
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '30m',
           labels: {
-            severity: 'critical',
+            severity: 'warning',
           },
           annotations: {
             message: |||


### PR DESCRIPTION
**What this PR does**:
In operations/mimir-mixin, change `CortexRolloutStuck` alert severity to warning.

**Which issue(s) this PR fixes**:

**Checklist**

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
