### PR TITLE
Add multiarch make target for mimir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 	@echo Please use push-multiarch-build-image to build and push build image for all supported architectures.
 	touch $@
 
-
+# This target compiles mimir in amd64 and arm64 then builds and pushes a multiarch image
 push-multiarch-mimir:
 	@echo
 	# Build image for each platform separately... it tends to generate fewer errors.
@@ -61,7 +61,6 @@ push-multiarch-mimir:
 	# This command will run the same build as above, but it will reuse existing platform-specific images,
 	# put them together and push to registry.
 	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)mimir:$(IMAGE_TAG) cmd/mimir
-
 
 # This target fetches current build image, and tags it with "latest" tag. It can be used instead of building the image locally.
 fetch-build-image:


### PR DESCRIPTION
**What this PR does**: This makes it easier for people on non-linux/amd64 machines to push
local mimir images

This is an image pushed with this target: https://console.cloud.google.com/gcr/images/kubernetes-dev/us/mimir@sha256:6b6fd00287082e72df5fc1614af9c0e0202fa5471fa62eb21dbd46aa3a2e17fd/details?tab=pull


Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->



**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
