### PR TITLE
Run backward compatibility tests against latest Cortex release only

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -137,9 +137,7 @@ jobs:
           docker pull minio/minio:RELEASE.2021-02-19T04-38-02Z
           docker pull consul:1.8.15
           docker pull gcr.io/etcd-development/etcd:v3.4.13
-          docker pull quay.io/cortexproject/cortex:v1.8.0
-          docker pull quay.io/cortexproject/cortex:v1.9.0
-          docker pull quay.io/cortexproject/cortex:v1.10.0
+          docker pull quay.io/cortexproject/cortex:v1.11.0
           docker pull memcached:1.6.12
       - name: Integration Tests
         run: |

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -25,19 +25,9 @@ var (
 	// by GitHub Actions too (see .github/workflows/test-build-deploy.yml).
 	//nolint:unused
 	previousVersionImages = map[string]func(map[string]string) map[string]string{
-		"quay.io/cortexproject/cortex:v1.8.0":  preCortex110Flags,
-		"quay.io/cortexproject/cortex:v1.9.0":  preCortex110Flags,
-		"quay.io/cortexproject/cortex:v1.10.0": nil,
+		"quay.io/cortexproject/cortex:v1.11.0": nil,
 	}
 )
-
-func preCortex110Flags(flags map[string]string) map[string]string {
-	return e2e.MergeFlagsWithoutRemovingEmpty(flags, map[string]string{
-		// Store-gateway "wait ring stability" has been introduced in 1.10.0
-		"-store-gateway.sharding-ring.wait-stability-min-duration": "",
-		"-store-gateway.sharding-ring.wait-stability-max-duration": "",
-	})
-}
 
 func TestBackwardCompatibility(t *testing.T) {
 	for previousImage, flagsFn := range previousVersionImages {


### PR DESCRIPTION
**What this PR does**:
In Cortex we had a guarantee to support the last N releases while in Mimir we have no policy yet. However, we want to be backward compatible with Cortex to offer a migration path once Mimir will be public.

What's the sentiment if we test for backward compatibility only against latest Cortex release?

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
