### PR TITLE
Split mimir and other tools images building in CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Build Images
         # Build everything except mimir (run by build-mimir job) and build image (not managed by CI).
         run: |
-          make list-images-to-build | grep -v -E '/mimir-build-image/|/cmd/mimir/' | xargs -I {} make BUILD_IN_CONTAINER=false {}
+          make list-image-targets | grep -v -E '/mimir-build-image/|/cmd/mimir/' | xargs -I {} make BUILD_IN_CONTAINER=false {}
 
   integration:
     needs: build-mimir

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool checkin-mixin-playbook build-mixin format-mixin push-multiarch-mimir list-images-to-build
+.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool checkin-mixin-playbook build-mixin format-mixin push-multiarch-mimir list-image-targets
 .DEFAULT_GOAL := all
 
 # Version number
@@ -314,8 +314,8 @@ clean:
 clean-protos:
 	rm -rf $(PROTO_GOS)
 
-# List all images to build.
-list-images-to-build:
+# List all images building make targets.
+list-image-targets:
 	@echo $(UPTODATE_FILES) | tr " " "\n"
 
 save-images:


### PR DESCRIPTION
**What this PR does**:
While working on #592 I've realized that the build job takes about 3m in CI, so integration tests start after that. A reason why it takes 3m to run build job is because we build images for mimir + all our tooling and we store all of them in the artifact, but we actually need only the Mimir image for integration tests.

In this PR I'm experimenting to split image building into two jobs:
- `build-mimir`: build only Mimir image and store it in the artifact
- `build-tools`: build other images (except Mimir and build image), without storing it in the artifact

_Looking at CI, after this change we're able to start integration tests about 1m earlier._

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
