### PR TITLE
Speed up TestSplitAndCacheMiddleware_ResultsCacheFuzzy

### DIFF
--- a/pkg/querier/queryrange/promql_test.go
+++ b/pkg/querier/queryrange/promql_test.go
@@ -291,12 +291,12 @@ func Test_FunctionParallelism(t *testing.T) {
 				queryable := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 					return &querierMock{
 						series: []*promql.StorageSeries{
-							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "barr"}}, start.Add(-lookbackDelta), end, factor(5)),
-							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "bazz"}}, start.Add(-lookbackDelta), end, factor(7)),
-							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "buzz"}}, start.Add(-lookbackDelta), end, factor(12)),
-							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bozz"}}, start.Add(-lookbackDelta), end, factor(11)),
-							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "buzz"}}, start.Add(-lookbackDelta), end, factor(8)),
-							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bazz"}}, start.Add(-lookbackDelta), end, arithmeticSequence(10)),
+							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "barr"}}, start.Add(-lookbackDelta), end, step, factor(5)),
+							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "bazz"}}, start.Add(-lookbackDelta), end, step, factor(7)),
+							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "buzz"}}, start.Add(-lookbackDelta), end, step, factor(12)),
+							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bozz"}}, start.Add(-lookbackDelta), end, step, factor(11)),
+							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "buzz"}}, start.Add(-lookbackDelta), end, step, factor(8)),
+							newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bazz"}}, start.Add(-lookbackDelta), end, step, arithmeticSequence(10)),
 						},
 					}, nil
 				})
@@ -431,7 +431,7 @@ func filterSeriesByShard(series []*promql.StorageSeries, shard *sharding.ShardSe
 	return filtered
 }
 
-func newSeries(metric labels.Labels, from, to time.Time, gen generator) *promql.StorageSeries {
+func newSeries(metric labels.Labels, from, to time.Time, step time.Duration, gen generator) *promql.StorageSeries {
 	var (
 		points    []promql.Point
 		prevValue *float64

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -381,25 +381,25 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			gen = stale(start.Add(10*time.Minute), start.Add(20*time.Minute), gen)
 		}
 
-		series = append(series, newSeries(newTestCounterLabels(seriesID), start.Add(-lookbackDelta), end, gen))
+		series = append(series, newSeries(newTestCounterLabels(seriesID), start.Add(-lookbackDelta), end, step, gen))
 		seriesID++
 	}
 
 	// Add a special series whose data points end earlier than the end of the queried time range
 	// and has NO stale marker.
 	series = append(series, newSeries(newTestCounterLabels(seriesID),
-		start.Add(-lookbackDelta), end.Add(-5*time.Minute), factor(2)))
+		start.Add(-lookbackDelta), end.Add(-5*time.Minute), step, factor(2)))
 	seriesID++
 
 	// Add a special series whose data points end earlier than the end of the queried time range
 	// and HAS a stale marker at the end.
 	series = append(series, newSeries(newTestCounterLabels(seriesID),
-		start.Add(-lookbackDelta), end.Add(-5*time.Minute), stale(end.Add(-6*time.Minute), end.Add(-4*time.Minute), factor(2))))
+		start.Add(-lookbackDelta), end.Add(-5*time.Minute), step, stale(end.Add(-6*time.Minute), end.Add(-4*time.Minute), factor(2))))
 	seriesID++
 
 	// Add a special series whose data points start later than the start of the queried time range.
 	series = append(series, newSeries(newTestCounterLabels(seriesID),
-		start.Add(5*time.Minute), end, factor(2)))
+		start.Add(5*time.Minute), end, step, factor(2)))
 	seriesID++
 
 	// Add histogram series.
@@ -413,7 +413,7 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			}
 
 			series = append(series, newSeries(newTestHistogramLabels(seriesID, bucketLe),
-				start.Add(-lookbackDelta), end, gen))
+				start.Add(-lookbackDelta), end, step, gen))
 		}
 
 		// Increase the series ID after all per-bucket series have been created.
@@ -784,7 +784,7 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 		queryable = storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 			return &querierMock{
 				series: []*promql.StorageSeries{
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}}, start.Add(-lookbackDelta), end, factor(5)),
+					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}}, start.Add(-lookbackDelta), end, step, factor(5)),
 				},
 			}, nil
 		})


### PR DESCRIPTION
**What this PR does**:
I was checking the slowest packages to run tests in CI and the slowest package is:
```
github.com/grafana/mimir/pkg/querier/queryrange 789.257s
```

Why the `queryrange` is so slow? I've run it locally with `-race` and I got the following slow tests (times are different because apparently my local machine performs better):
```
ok  	github.com/grafana/mimir/pkg/querier/queryrange	497.323s
--- PASS: TestQueryShardingCorrectness (119.43s)
--- PASS: TestSplitAndCacheMiddleware_ResultsCacheFuzzy (372.66s)
```

So `TestSplitAndCacheMiddleware_ResultsCacheFuzzy` takes 6 minutes on my machine. Why? The investigation lead to the following changes in this PR:
- Process less samples per query (increase step from 30s to 2m)
- Generate the requests upfront and compute the expected results only once (for all test cases)
- Run test cases in parallel

On my machine, these changes reduced the test execution from `372s` to `26s`.

**Update**: in this PR `pkg/querier/queryrange` run in 310.365s compared to  789.257s in other previous PR (without these improvements), so we shaved unit test execution by about 8 minutes.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
