### PR TITLE
Remove --quiet on some git diff's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,12 +345,12 @@ clean-white-noise:
 	SED_BIN="$(SED)" xargs ./tools/cleanup-white-noise.sh
 
 check-white-noise: clean-white-noise
-	@git diff --exit-code --quiet -- '*.md' || (echo "Please remove trailing whitespaces running 'make clean-white-noise'" && false)
+	@git diff --exit-code -- '*.md' || (echo "Please remove trailing whitespaces running 'make clean-white-noise'" && false)
 
 check-mixin: format-mixin check-mixin-jb check-mixin-mixtool check-mixin-playbook
 	@echo "Checking diff:"
 	git diff
-	@git diff --exit-code --quiet -- $(MIXIN_PATH) || (echo "Please format mixin by running 'make format-mixin'" && false)
+	@git diff --exit-code -- $(MIXIN_PATH) || (echo "Please format mixin by running 'make format-mixin'" && false)
 
 	@cd $(MIXIN_PATH) && \
 	jb install && \

--- a/development/tsdb-blocks-storage-s3/Makefile
+++ b/development/tsdb-blocks-storage-s3/Makefile
@@ -10,4 +10,4 @@ docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
 check: docker-compose.yml
-	@git diff --exit-code --quiet -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)
+	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)


### PR DESCRIPTION
**What this PR does**: Linter failures like this one https://github.com/grafana/mimir/runs/4507253663?check_suite_focus=true
are difficult to trace back to the file that caused them. This is
usually not a problem if the remediating `make` command actually works.
But in the case above, the GH actions workflow is probably working on a
stale commit. Being able to view the diff that's causing the workflow to
 fail will help to diagnose this.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->



**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
