### PR TITLE
Speed up TestQueryShardingCorrectness

### DIFF
--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -428,6 +428,9 @@ func TestQueryShardingCorrectness(t *testing.T) {
 	})
 
 	for testName, testData := range tests {
+		// Change scope to ensure it work fine when test cases are executed concurrently.
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
**What this PR does**:
This PR is a follow up of #598, focusing on `TestQueryShardingCorrectness`. Local run of `TestQueryShardingCorrectness` with `-race` takes 115s, while with the changes in this PR it takes 24s.

What has changed:
- Compute expected result only once per query (and not for every shard, since expected result doesn't change)
- For 3 queries whose results are high cardinality (because they test the "no grouping" case), add `{group_1="0"}` to restrict by 10x the number of touched series (the test is not invalidated reducing the series for these cases)
- Run test cases in parallel

_I suggest to review the diff enabling "hide whitespace changes"._

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
