### PR TITLE
Fix parallel tests execution bug introduced in PR 598

### DIFF
--- a/pkg/querier/queryrange/split_and_cache_test.go
+++ b/pkg/querier/queryrange/split_and_cache_test.go
@@ -602,6 +602,10 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 
 	for testName, testData := range tests {
 		for _, maxConcurrency := range []int{1, numQueries} {
+			// Change scope to ensure tests work fine when run concurrently.
+			testData := testData
+			maxConcurrency := maxConcurrency
+
 			t.Run(fmt.Sprintf("%s (concurrency: %d)", testName, maxConcurrency), func(t *testing.T) {
 				t.Parallel()
 


### PR DESCRIPTION
**What this PR does**:
I just realized that in PR #598 I've introduced a bug causing only last test case to be executed because of the variables scoping. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
