### PR TITLE
Makefile: Unexport GOOS and GOARCH.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ VERSION=$(shell cat "./VERSION" 2> /dev/null)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
-# Don't export GOOS and GOARCH as env. variables. We set it at place where we need to (running go build), but
-# we don't want them to be used when running go run.
+# Don't export GOOS and GOARCH as environment variables. They get exported when passed via CLI options,
+# but that breaks tools ran via "go run". We use GOOS/GOARCH explicitly in places where needed.
 unexport GOOS
 unexport GOARCH
 


### PR DESCRIPTION
**What this PR does**: When variables are passed via `make` cli argument (eg. when `make` reruns using build image),
GOOS and GOARCH are automatically exported as env variables. This unfortunately breaks go run commands, eg. running `make doc` (with `BUILD_IN_CONTAINER=true`).

Unexporting fixes it.

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
