### PR TITLE
Remove dead code: astmapper.MapperFunc

### DIFF
--- a/pkg/querier/astmapper/astmapper.go
+++ b/pkg/querier/astmapper/astmapper.go
@@ -65,14 +65,6 @@ type NodeMapper interface {
 	MapNode(node parser.Node, stats *MapperStats) (mapped parser.Node, finished bool, err error)
 }
 
-// NodeMapperFunc is an adapter for NodeMapper
-type NodeMapperFunc func(node parser.Node) (parser.Node, bool, bool, error)
-
-// MapNode applies a NodeMapperFunc as a NodeMapper
-func (f NodeMapperFunc) MapNode(node parser.Node) (parser.Node, bool, bool, error) {
-	return f(node)
-}
-
 // NewASTNodeMapper creates an ASTMapper from a NodeMapper
 func NewASTNodeMapper(mapper NodeMapper) ASTNodeMapper {
 	return ASTNodeMapper{mapper}


### PR DESCRIPTION
It's dead and it's not even compatible with ASTMapper interface anymore.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
