### PR TITLE
Mixin: fix container label selector for store-gateway when deployed in multi-zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@ Mixin:
 * [ENHANCEMENT] Improved "Queue length" panel in "Cortex / Queries" dashboard. #408
 * [ENHANCEMENT] Add `CortexDistributorReachingInflightPushRequestLimit` alert and playbook. #401
 * [ENHANCEMENT] Added "Recover accidentally deleted blocks (Google Cloud specific)" playbook. #475
-* [ENHANCEMENT] Added support to multi-zone store-gateway deployments. #608
+* [ENHANCEMENT] Added support to multi-zone store-gateway deployments. #608 #615
 * [BUGFIX] Fixed "Instant queries / sec" in "Cortex / Reads" dashboard. #445
 * [BUGFIX] Fixed and added missing KV store panels in Writes, Reads, Ruler and Compactor dashboards. #448
 

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -261,8 +261,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     { yaxes: $.yaxes('percentunit') },
 
   containerLabelMatcher(containerName)::
-    if containerName == 'ingester'
-    then 'label_name=~"ingester.*"'
+    if containerName == 'ingester' then 'label_name=~"ingester.*"'
+    else if containerName == 'store-gateway' then 'label_name=~"store-gateway.*"'
     else 'label_name="%s"' % containerName,
 
   jobNetworkingRow(title, name)::


### PR DESCRIPTION
**What this PR does**:
We're working to add support for store-gateways deployed in multi-zone. In PR #608 I've added support to the mixin but I didn't address `containerLabelMatcher()` utility function. This PR fixes that.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
