### PR TITLE
Use GOOS=linux when building for docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 	@echo
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG) $(@D)/
 	@echo
-	@echo Go binaries were built using "GOOS=$(GOOS) and GOARCH=$(GOARCH)"
+	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)
 	@echo
 	@echo Please use '"make push-multiarch-build-image"' to build and push build image.
 	@echo Please use '"make push-multiarch-mimir"' to build and push Mimir image.


### PR DESCRIPTION
**What this PR does**: This PR modifies Makefile to use GOOS=linux when building binary to be included in Docker (eg. via `make cmd/mimir/.uptodate`). This doesn't set GOARCH, which really depends on whether image is going to be used locally (then GOARCH should be set based on host architecture, and this is the default value), or pushed remotely. Ideally one would use one of `push-multiarch-*` targets instead in that case.

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
