### PR TITLE
Speed up memberlist integration tests not waiting to observe tokens for the 1st instance

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -123,7 +123,6 @@ func newSingleBinary(name string, servername string, join string, testFlags map[
 		"-ingester.join-after":               "0s", // join quickly
 		"-ingester.min-ready-duration":       "0s",
 		"-ingester.num-tokens":               "512",
-		"-ingester.observe-period":           "5s", // to avoid conflicts in tokens
 		"-ring.store":                        "memberlist",
 		"-memberlist.bind-port":              "8000",
 		"-memberlist.left-ingesters-timeout": "600s", // effectively disable
@@ -131,6 +130,9 @@ func newSingleBinary(name string, servername string, join string, testFlags map[
 
 	if join != "" {
 		flags["-memberlist.join"] = join
+		flags["-ingester.observe-period"] = "5s" // Observe ring tokens to avoid conflicts.
+	} else {
+		flags["-ingester.observe-period"] = "0s" // No need to observe tokens because we're going to be the first instance.
 	}
 
 	serv := e2emimir.NewSingleBinary(


### PR DESCRIPTION
**What this PR does**:
Memberlist integration tests set a 5s observe period for tokens in order to avoid conflicts (wouldn't be a big deal if we have conflicts on few tokens but we have assertions on the exact number of tokens and if we have conflicts we would end up with flaky tests).

However, we don't need to wait 5s for the 1st instance we add to the memberlist cluster for each tests, so this PR does this little improvement.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
