### PR TITLE
Cancel running CI workflows when more commits are pushed

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -13,8 +13,6 @@ concurrency:
   group: "${{ github.ref_name }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
-# Works?
-
 jobs:
   lint:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
**What this PR does**:
Sometimes it happens that we push more commits to a PR when a CI workflow for that PR is still running. Right now previous runs are not canceled, but we typically just wanna see the CI run for the latest commit. With this PR, CI cancels any previous run for the same PR/branch commit/tag.

I tested it with a couple of commits on this PR. You can see a canceled run here:
https://github.com/grafana/mimir/actions/runs/1588463753

The documentation for the `concurrency` config I've used is [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
