### PR TITLE
Chore: cleanup ruler tests

### DIFF
--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -26,11 +26,9 @@ import (
 )
 
 func TestRuler_rules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(mockRules))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(mockRules))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -83,11 +81,9 @@ func TestRuler_rules(t *testing.T) {
 }
 
 func TestRuler_rules_special_characters(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(mockSpecialCharRules))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(mockSpecialCharRules))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -140,11 +136,9 @@ func TestRuler_rules_special_characters(t *testing.T) {
 }
 
 func TestRuler_alerts(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(mockRules))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(mockRules))
 	defer r.StopAsync()
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -176,11 +170,9 @@ func TestRuler_alerts(t *testing.T) {
 }
 
 func TestRuler_Create(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -267,11 +259,9 @@ rules:
 }
 
 func TestRuler_DeleteNamespace(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(mockRulesNamespaces))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(mockRulesNamespaces))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -306,11 +296,9 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 }
 
 func TestRuler_LimitsPerGroup(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
@@ -361,11 +349,9 @@ rules:
 }
 
 func TestRuler_RulerGroupLimits(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t)
-	defer cleanup()
+	cfg := defaultRulerConfig(t)
 
-	r, rcleanup := newTestRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	defer rcleanup()
+	r := newTestRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -25,12 +25,8 @@ import (
 func TestRulerShutdown(t *testing.T) {
 	ctx := context.Background()
 
-	config, cleanup := defaultRulerConfig(t)
-	defer cleanup()
-
-	r, rcleanup := buildRuler(t, config, newMockRuleStore(mockRules), nil)
-	defer rcleanup()
-
+	config := defaultRulerConfig(t)
+	r := buildRuler(t, config, newMockRuleStore(mockRules), nil)
 	r.cfg.EnableSharding = true
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
@@ -61,10 +57,8 @@ func TestRuler_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 	const heartbeatTimeout = time.Minute
 
 	ctx := context.Background()
-	config, cleanup := defaultRulerConfig(t)
-	defer cleanup()
-	r, rcleanup := buildRuler(t, config, newMockRuleStore(mockRules), nil)
-	defer rcleanup()
+	config := defaultRulerConfig(t)
+	r := buildRuler(t, config, newMockRuleStore(mockRules), nil)
 	r.cfg.EnableSharding = true
 	r.cfg.Ring.HeartbeatPeriod = 100 * time.Millisecond
 	r.cfg.Ring.HeartbeatTimeout = heartbeatTimeout


### PR DESCRIPTION
**What this PR does**:
While working on #628 I noticed we can simplify a bit ruler tests using `t.TempDir()`. This PR does that.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
