### PR TITLE
Fix ruler dashboard row title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@
 
 ### Mixin (changes since `grafana/cortex-jsonnet` `1.9.0`)
 
-* [CHANGE] Removed chunks storage support from mixin. #641
+* [CHANGE] Removed chunks storage support from mixin. #641 #643
   * Removed the following fields from `_config`:
     * `storage_engine` (defaults to `blocks`)
     * `chunk_index_backend`

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -148,7 +148,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.kvStoreRow('Ruler - Key-value store for rulers ring', 'ruler', 'ruler')
     )
     .addRow(
-      $.row('Ruler')
+      $.row('Ruler - Blocks storage')
       .addPanel(
         $.panel('Number of store-gateways hit per Query') +
         $.latencyPanel('cortex_querier_storegateway_instances_hit_per_query', '{%s}' % $.jobMatcher($._config.job_names.ruler), multiplier=1) +


### PR DESCRIPTION
**What this PR does**:
In #641 I've changed the title of a row in the ruler dashboard ([see here](https://github.com/grafana/mimir/pull/641/files#diff-54336c33342992fac8630ab5e3719c14ca940128aa99c934d88a2788b8ef3a09L191-R151)) but I just realised that since we have multiple ruler rows it was correct to name it "Ruler - Blocks Storage" because that row contains some panels on storage metrics.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
