### PR TITLE
Rename `astmapper.EvalPredicate` to `astmapper.AnyNode`,

### DIFF
--- a/pkg/querier/astmapper/parallel.go
+++ b/pkg/querier/astmapper/parallel.go
@@ -54,7 +54,7 @@ func CanParallelize(node parser.Node, logger log.Logger) bool {
 		}
 
 		// Ensure there are no nested aggregations
-		nestedAggrs, err := AnyNode(n.Expr, isAggregateExpr)
+		nestedAggrs, err := anyNode(n.Expr, isAggregateExpr)
 
 		return err == nil && !nestedAggrs && CanParallelize(n.Expr, logger)
 
@@ -103,7 +103,7 @@ func CanParallelize(node parser.Node, logger log.Logger) bool {
 
 // containsAggregateExpr returns true if the given node contains an aggregate expression within its children.
 func containsAggregateExpr(n parser.Node) bool {
-	containsAggregate, _ := AnyNode(n, isAggregateExpr)
+	containsAggregate, _ := anyNode(n, isAggregateExpr)
 	return containsAggregate
 }
 

--- a/pkg/querier/astmapper/subtree_folder.go
+++ b/pkg/querier/astmapper/subtree_folder.go
@@ -22,7 +22,7 @@ func newSubtreeFolder() ASTMapper {
 
 // MapNode implements NodeMapper.
 func (f *subtreeFolder) MapNode(node parser.Node, _ *MapperStats) (mapped parser.Node, finished bool, err error) {
-	hasEmbeddedQueries, err := AnyNode(node, hasEmbeddedQueries)
+	hasEmbeddedQueries, err := anyNode(node, hasEmbeddedQueries)
 	if err != nil {
 		return nil, true, err
 	}
@@ -32,7 +32,7 @@ func (f *subtreeFolder) MapNode(node parser.Node, _ *MapperStats) (mapped parser
 		return node, false, nil
 	}
 
-	hasVectorSelector, err := AnyNode(node, isVectorSelector)
+	hasVectorSelector, err := anyNode(node, isVectorSelector)
 	if err != nil {
 		return nil, true, err
 	}
@@ -62,9 +62,9 @@ func isVectorSelector(n parser.Node) (bool, error) {
 	return ok, nil
 }
 
-// AnyNode is a helper which walks the input node and returns true if any node in the subtree
+// anyNode is a helper which walks the input node and returns true if any node in the subtree
 // returns true for the specified predicate function.
-func AnyNode(node parser.Node, fn predicate) (bool, error) {
+func anyNode(node parser.Node, fn predicate) (bool, error) {
 	v := &visitor{
 		fn: fn,
 	}

--- a/pkg/querier/astmapper/subtree_folder_test.go
+++ b/pkg/querier/astmapper/subtree_folder_test.go
@@ -59,7 +59,7 @@ func TestEvalPredicate(t *testing.T) {
 			expr, err := parser.ParseExpr(tc.input)
 			require.Nil(t, err)
 
-			res, err := AnyNode(expr.(parser.Node), tc.fn)
+			res, err := anyNode(expr.(parser.Node), tc.fn)
 			if tc.expectedErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
**What this PR does**:

Rename `astmapper.EvalPredicate` to `astmapper.AnyNode`, IMO just reads better everywhere.

I wonder if we really need to have it exported, what's the policy on exporting things?

**Which issue(s) this PR fixes**:

None

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
