### PR TITLE
Move overrides-exporter.libsonnet from cortex-tools to Mimir overrides-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,7 @@
     * `ingester.max-stale-chunk-idle`
     * `ingester.max-transfer-retries`
     * `ingester.retain-period`
+* [CHANGE] Changed `overrides-exporter.libsonnet` from being based on cortex-tools to Mimir `overrides-exporter` target. #646
 * [CHANGE] Store gateway: set `-blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency`,
   `-blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency`,
   `-blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency`,

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -19,7 +19,6 @@
     store_gateway: self.cortex,
     query_scheduler: self.cortex,
 
-    cortex_tools: 'grafana/cortex-tools:v0.4.0',
     query_tee: 'quay.io/cortexproject/query-tee:v1.9.0',
     testExporter: 'cortexproject/test-exporter:v1.9.0',
   },

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -18,39 +18,23 @@
     ],
   },
 
-  local presets_enabled = std.length($._config.overrides_exporter_presets) > 0,
-
-  local configMap = $.core.v1.configMap,
-  overrides_exporter_presets_configmap:
-    if presets_enabled then
-      configMap.new('overrides-presets') +
-      configMap.withData({
-        'overrides-presets.yaml': $.util.manifestYaml(
-          {
-            presets: {
-              [key]: $._config.overrides[key]
-              for key in $._config.overrides_exporter_presets
-            },
-          }
-        ),
-      }),
-
   local containerPort = $.core.v1.containerPort,
-  overrides_exporter_port:: containerPort.newNamed(name='http-metrics', containerPort=9683),
+  overrides_exporter_port:: containerPort.newNamed(name='http-metrics', containerPort=80),
 
   overrides_exporter_args:: {
-    'overrides-file': '/etc/cortex/overrides.yaml',
-  } + if presets_enabled then {
-    'presets-file': '/etc/cortex_presets/overrides-presets.yaml',
-  } else {},
+    target: 'overrides-exporter',
+
+    'runtime-config.file': '/etc/cortex/overrides.yaml',
+    'distributor.shard-by-all-labels': $._config.distributorConfig['distributor.shard-by-all-labels'],  // Required for ingester.max-global-series-per-user to work.
+  } + $._config.limitsConfig,
 
   local container = $.core.v1.container,
   overrides_exporter_container::
-    container.new(name, $._images.cortex_tools) +
+    container.new(name, $._images.cortex) +
     container.withPorts([
       $.overrides_exporter_port,
     ]) +
-    container.withArgsMixin([name] + $.util.mapToFlags($.overrides_exporter_args, prefix='--')) +
+    container.withArgsMixin($.util.mapToFlags($.overrides_exporter_args)) +
     $.util.resourcesRequests('0.5', '0.5Gi') +
     $.util.readinessProbe +
     container.mixin.readinessProbe.httpGet.withPort($.overrides_exporter_port.name),
@@ -59,7 +43,6 @@
   overrides_exporter_deployment:
     deployment.new(name, 1, [$.overrides_exporter_container], { name: name }) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
-    $.util.configVolumeMount('overrides-presets', '/etc/cortex_presets') +
     deployment.mixin.metadata.withLabels({ name: name }),
 
   overrides_exporter_service:


### PR DESCRIPTION
**What this PR does**:
We have the `overrides-exporter` in Mimir, but our jsonnet is still using the one from cortex-tools. This PR moves it to Mimir one.

I've tested it in our infra and it's a no-op if you were already using the Mimir one except that the `overrides-presets` configmap is now removed (it was a spurious one left there).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
