### PR TITLE
e2e test change: make previous image used in backwards compatibility test configurable  for downstream projects

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -31,8 +31,8 @@ var (
 	}
 )
 
-// previousVersionImages returns a list of pervious image version to test backwards
-// compatability against. If MIMIR_PREVIOIS_IMAGES is set to a comma separted list of image versions,
+// previousVersionImages returns a list of previous image version to test backwards
+// compatibility against. If MIMIR_PREVIOIS_IMAGES is set to a comma separted list of image versions,
 // then those will be used instead of the default versions. Note that the overriding of flags
 // is not currently possible when overriding the previous image versions via the environment variable.
 func previousVersionImages() map[string]func(map[string]string) map[string]string {


### PR DESCRIPTION
**What this PR does**:
Make the previous image used by the backwards compatibility test configurable via an environment variable, or default to the existing value.


**Which issue(s) this PR fixes**:

This is related to this previous [PR](https://github.com/grafana/mimir/pull/593) and this [GEM PR](https://github.com/grafana/backend-enterprise/pull/2767). 

GEM runs mimir e2e tests against itself to make sure it's compatible with mimir. Currently, the backwards compatibility test is using a GEM image as the current image, and a mimir image as the "previous image". This is not a situation we currently support, and therefore we'd like to change the test to check against a previous version of GEM instead, which this change will allow us to do.

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
