### PR TITLE
Change mimir.Mimir.Cfg to a pointer

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -173,7 +173,7 @@ func main() {
 	// Initialise seed for randomness usage.
 	rand.Seed(time.Now().UnixNano())
 
-	t, err := mimir.New(cfg)
+	t, err := mimir.New(&cfg)
 	util_log.CheckFatal("initializing application", err)
 
 	if printModules {

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -302,7 +302,7 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 
 // Mimir is the root datastructure for Mimir.
 type Mimir struct {
-	Cfg Config
+	Cfg *Config
 
 	// set during initialization
 	ServiceMap    map[string]services.Service
@@ -340,7 +340,7 @@ type Mimir struct {
 }
 
 // New makes a new Mimir.
-func New(cfg Config) (*Mimir, error) {
+func New(cfg *Config) (*Mimir, error) {
 	if cfg.PrintConfig {
 		if err := yaml.NewEncoder(os.Stdout).Encode(&cfg); err != nil {
 			fmt.Println("Error encoding config:", err)

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -91,7 +91,7 @@ func TestMimir(t *testing.T) {
 		Target: []string{All, Compactor},
 	}
 
-	c, err := New(cfg)
+	c, err := New(&cfg)
 	require.NoError(t, err)
 
 	serviceMap, err := c.ModuleManager.InitModuleServices(cfg.Target...)
@@ -170,7 +170,7 @@ func TestGrpcAuthMiddleware(t *testing.T) {
 
 	// Setup server, using Mimir config. This includes authentication middleware.
 	{
-		c, err := New(cfg)
+		c, err := New(&cfg)
 		require.NoError(t, err)
 
 		serv, err := c.initServer()

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -434,7 +434,7 @@ func (t *Mimir) initStoreQueryables() (services.Service, error) {
 	}
 }
 
-func initQueryableForEngine(engine string, cfg Config, chunkStore chunk.Store, limits *validation.Overrides, reg prometheus.Registerer) (prom_storage.Queryable, error) {
+func initQueryableForEngine(engine string, cfg *Config, chunkStore chunk.Store, limits *validation.Overrides, reg prometheus.Registerer) (prom_storage.Queryable, error) {
 	switch engine {
 	case storage.StorageEngineChunks:
 		if chunkStore == nil {

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -21,8 +21,6 @@ func changeTargetConfig(c *Config) {
 }
 
 func TestAPIConfig(t *testing.T) {
-	actualCfg := newDefaultConfig()
-
 	mimir := &Mimir{
 		Server: &server.Server{},
 	}
@@ -83,9 +81,9 @@ func TestAPIConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mimir.Server.HTTP = mux.NewRouter()
 
-			mimir.Cfg = *actualCfg
+			mimir.Cfg = newDefaultConfig()
 			if tc.actualCfg != nil {
-				tc.actualCfg(&mimir.Cfg)
+				tc.actualCfg(mimir.Cfg)
 			}
 
 			_, err := mimir.initAPI()
@@ -144,7 +142,7 @@ func TestMimir_InitRulerStorage(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			mimir := &Mimir{
 				Server: &server.Server{},
-				Cfg:    *testData.config,
+				Cfg:    testData.config,
 			}
 
 			_, err := mimir.initRulerStorage()


### PR DESCRIPTION
**What this PR does**:

Changes to the configuration inside mimir weren't reflected in GEM.
This required copying the changes into GEM. This is brittle and
is difficult to test that config is the same after all modules
have been initialized.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [ n/a ] Tests updated
- [ n/a ] Documentation added
- [ n/a ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
