### PR TITLE
log: De-duplicate imports of go-kit/log

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -10,7 +10,6 @@ import (
 	"os"
 
 	"github.com/go-kit/log"
-	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/server"
@@ -20,7 +19,7 @@ var (
 	// Logger is a shared go-kit logger.
 	// TODO: Change all components to take a non-global logger via their constructors.
 	// Prefer accepting a non-global logger as an argument.
-	Logger = kitlog.NewNopLogger()
+	Logger = log.NewNopLogger()
 )
 
 // InitLogger initialises the global gokit logger (util_log.Logger) and overrides the

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/go-kit/log"
-	kitlog "github.com/go-kit/log"
 	"github.com/weaveworks/common/tracing"
 
 	"github.com/grafana/mimir/pkg/tenant"
@@ -17,16 +16,16 @@ import (
 
 // WithUserID returns a Logger that has information about the current user in
 // its details.
-func WithUserID(userID string, l kitlog.Logger) kitlog.Logger {
+func WithUserID(userID string, l log.Logger) log.Logger {
 	// See note in WithContext.
-	return kitlog.With(l, "org_id", userID)
+	return log.With(l, "org_id", userID)
 }
 
 // WithTraceID returns a Logger that has information about the traceID in
 // its details.
-func WithTraceID(traceID string, l kitlog.Logger) kitlog.Logger {
+func WithTraceID(traceID string, l log.Logger) log.Logger {
 	// See note in WithContext.
-	return kitlog.With(l, "traceID", traceID)
+	return log.With(l, "traceID", traceID)
 }
 
 // WithContext returns a Logger that has information about the current user in
@@ -35,7 +34,7 @@ func WithTraceID(traceID string, l kitlog.Logger) kitlog.Logger {
 // e.g.
 //   log := util.WithContext(ctx)
 //   log.Errorf("Could not chunk chunks: %v", err)
-func WithContext(ctx context.Context, l kitlog.Logger) kitlog.Logger {
+func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
 	userID, err := tenant.TenantID(ctx)


### PR DESCRIPTION
**What this PR does**:
Just cleaning up duplicate go-kit/log imports in pkg/util/log.

**Which issue(s) this PR fixes**:

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
