### PR TITLE
Fix flaky TestIngester_inflightPushRequests

### DIFF
--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -4529,12 +4529,12 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 	require.NoError(t, g.Wait())
 }
 
-func generateSamplesForLabel(l labels.Labels, series, samples int) *mimirpb.WriteRequest {
+func generateSamplesForLabel(baseLabels labels.Labels, series, samples int) *mimirpb.WriteRequest {
 	lbls := make([]labels.Labels, 0, series*samples)
 	ss := make([]mimirpb.Sample, 0, series*samples)
 
 	for s := 0; s < series; s++ {
-		l := append(labels.FromStrings("series", strconv.Itoa(s)), l...)
+		l := append(labels.FromStrings("series", strconv.Itoa(s)), baseLabels...)
 		for i := 0; i < samples; i++ {
 			ss = append(ss, mimirpb.Sample{
 				Value:       float64(i),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

My machine is so fast that it can process more than 3600_000 samples in
a second, which means that this test tries to send more than 3600_000
samples, and with 1 millisecond per sample that is more than an hour of
samples so tsdb fails with an "out of bounds" error.

This trades samples for series, so we never send more than an hour of
samples.

**Which issue(s) this PR fixes**:

None

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
