### PR TITLE
pgk/storegateway/gateway_test: increase min stability timeout

### DIFF
--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -362,7 +362,7 @@ func TestStoreGateway_InitialSyncWithWaitRingTokensStability(t *testing.T) {
 					gatewayCfg.ShardingRing.InstanceID = instanceID
 					gatewayCfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
 					gatewayCfg.ShardingRing.RingCheckPeriod = time.Hour // Do not check the ring topology changes in this test. We want the initial sync only.
-					gatewayCfg.ShardingRing.WaitStabilityMinDuration = 2 * time.Second
+					gatewayCfg.ShardingRing.WaitStabilityMinDuration = 4 * time.Second
 					gatewayCfg.ShardingRing.WaitStabilityMaxDuration = 30 * time.Second
 					gatewayCfg.ShardingEnabled = true
 					gatewayCfg.ShardingStrategy = testData.shardingStrategy


### PR DESCRIPTION
**What this PR does**:

The test TestStoreGateway_InitialSyncWithWaitRingTokensStability
is flaky in our CI env, but it works fine on local machine.
I've run the test hundreds of times locally.

Increase the timeout to account for the fact that CI build VM is slower.

**Which issue(s) this PR fixes**:

Fixes #668

**Checklist**

- [x] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
