### PR TITLE
Upgrade to latest dskit and pass empty service name to dskit/grpcutil.Resolver.Resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@
 * [BUGFIX] Distributor: fix bug in query-exemplar where some results would get dropped. #583
 * [BUGFIX] Azure storage: only create HTTP client once, to reduce memory utilization. #605
 * [BUGFIX] Ruler: fix formatting of rule groups in `/ruler/rule_groups` endpoint. #655
+* [BUGFIX] Querier: Disable query scheduler SRV DNS lookup. #689
 
 ### Mixin (changes since `grafana/cortex-jsonnet` `1.9.0`)
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.4
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/dskit v0.0.0-20211229145507-fded26153e7b
+	github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/json-iterator/go v1.1.12
 	github.com/leanovate/gopter v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -848,8 +848,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
-github.com/grafana/dskit v0.0.0-20211229145507-fded26153e7b h1:6pTR2oUZ03Y/0++l6qOjB8tjVZDXuQ235/oUay02L9o=
-github.com/grafana/dskit v0.0.0-20211229145507-fded26153e7b/go.mod h1:M0/dlftwBvH7+hdNNpjMa/CUXD7gsew67mbkCuDlFXE=
+github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134 h1:WhDvHde5WYR/dHSFeTfTukgbvVMhO7o9zezACAKfwV0=
+github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134/go.mod h1:M0/dlftwBvH7+hdNNpjMa/CUXD7gsew67mbkCuDlFXE=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
 github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=

--- a/pkg/util/dns_watcher.go
+++ b/pkg/util/dns_watcher.go
@@ -38,7 +38,8 @@ func NewDNSWatcher(address string, dnsLookupPeriod time.Duration, notifications 
 		return nil, err
 	}
 
-	watcher, err := resolver.Resolve(address)
+	// Pass empty string for service argument, since we don't intend to lookup any SRV record
+	watcher, err := resolver.Resolve(address, "")
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/grafana/dskit/grpcutil/naming.go
+++ b/vendor/github.com/grafana/dskit/grpcutil/naming.go
@@ -24,13 +24,7 @@ type Update struct {
 	Metadata interface{}
 }
 
-// Resolver creates a Watcher for a target to track its resolution changes.
-type Resolver interface {
-	// Resolve creates a Watcher for target.
-	Resolve(target string) (Watcher, error)
-}
-
-// Watcher watches for the updates on the specified target.
+// Watcher watches for SRV updates on the specified target.
 type Watcher interface {
 	// Next blocks until an update or error happens. It may return one or more
 	// updates. The first call should get the full set of the results. It should

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -394,7 +394,7 @@ github.com/googleapis/gax-go/v2/apierror/internal/proto
 # github.com/gorilla/mux v1.8.0
 ## explicit; go 1.12
 github.com/gorilla/mux
-# github.com/grafana/dskit v0.0.0-20211229145507-fded26153e7b
+# github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134
 ## explicit; go 1.16
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/concurrency


### PR DESCRIPTION
**What this PR does**:
Upgrade to latest dskit, which most importantly takes a new argument, `service`, to `dskit/grpcutil.Resolver.Resolve`. This argument configures the service part of the SRV DNS record to try and resolve. The PR passes an empty string for the aforementioned argument, so SRV lookup is disabled.

Should the SRV service string possibly be user configurable?

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
