### PR TITLE
Ensure deploy stage is run for pushes to weekly release branches

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,7 +1,9 @@
 name: ci
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - r[0-9]+ # Trigger builds after a push to weekly branches
     tags:
       - v[0-9]+.[0-9]+.[0-9]+** # Tag filters not as strict due to different regex system on Github Actions
   pull_request:
@@ -217,8 +219,8 @@ jobs:
 
   deploy:
     needs: [build-mimir, build-tools, test, lint, integration]
-    # Only deploy images on tag pushes to the grafana/mimir repo
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'grafana/mimir'
+    # Only deploy images on pushes to the grafana/mimir repo, which either are tag pushes or weekly release branch pushes.
+    if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-20.04
     container:
       image: us.gcr.io/kubernetes-dev/mimir-build-image:import-jsonnet-readme-2418fd778-WIP


### PR DESCRIPTION
This is a follow-up to #652, which only deploys on tags being pushed.

This should enable docker images pushes for all branches `r[0-9]+`