### PR TITLE
Add doc tasks to org-wide project for Docs Squad.

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "label",
+    "name": "type/docs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/69"
+    }
+  }
+]


### PR DESCRIPTION
Add doc tasks to org-wide project for Docs Squad.