### PR TITLE
Accept exemplars in ToWriteRequest convenience method

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1789,7 +1789,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 			b.ResetTimer()
 
 			for n := 0; n < b.N; n++ {
-				_, err := distributor.Push(ctx, mimirpb.ToWriteRequest(metrics, samples, nil, mimirpb.API))
+				_, err := distributor.Push(ctx, mimirpb.ToWriteRequest(metrics, samples, nil, nil, mimirpb.API))
 
 				if testData.expectedErr == "" && err != nil {
 					b.Fatalf("no error expected but got %v", err)
@@ -2522,7 +2522,7 @@ func mockWriteRequest(lbls labels.Labels, value float64, timestampMs int64) *mim
 		},
 	}
 
-	return mimirpb.ToWriteRequest([]labels.Labels{lbls}, samples, nil, mimirpb.API)
+	return mimirpb.ToWriteRequest([]labels.Labels{lbls}, samples, nil, nil, mimirpb.API)
 }
 
 type prepConfig struct {
@@ -3331,7 +3331,7 @@ func TestDistributorValidation(t *testing.T) {
 				limits:           &limits,
 			})
 
-			_, err := ds[0].Push(ctx, mimirpb.ToWriteRequest(tc.labels, tc.samples, tc.metadata, mimirpb.API))
+			_, err := ds[0].Push(ctx, mimirpb.ToWriteRequest(tc.labels, tc.samples, nil, tc.metadata, mimirpb.API))
 			require.Equal(t, tc.err, err)
 		})
 	}

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -77,7 +77,7 @@ func (a *PusherAppender) Commit() error {
 
 	// Since a.pusher is distributor, client.ReuseSlice will be called in a.pusher.Push.
 	// We shouldn't call client.ReuseSlice here.
-	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), mimirpb.ToWriteRequest(a.labels, a.samples, nil, mimirpb.RULE))
+	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), mimirpb.ToWriteRequest(a.labels, a.samples, nil, nil, mimirpb.RULE))
 
 	if err != nil {
 		// Don't report errors that ended with 4xx HTTP status code (series limits, duplicate samples, out of order, etc.)


### PR DESCRIPTION
Allow a matched slice of exemplars to be used along with samples and
labels to build distributor write requests.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
