### PR TITLE
Use concurrency.ForEachJob() from new dskit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.4
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134
+	github.com/grafana/dskit v0.0.0-20220112093026-95274ccc858d
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/json-iterator/go v1.1.12
 	github.com/leanovate/gopter v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
-github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134 h1:WhDvHde5WYR/dHSFeTfTukgbvVMhO7o9zezACAKfwV0=
-github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134/go.mod h1:M0/dlftwBvH7+hdNNpjMa/CUXD7gsew67mbkCuDlFXE=
+github.com/grafana/dskit v0.0.0-20220112093026-95274ccc858d h1:YwUtZIQFjlH6e2b5dFLfW1h/vTkTXNkZqv9qeU8b5h0=
+github.com/grafana/dskit v0.0.0-20220112093026-95274ccc858d/go.mod h1:M0/dlftwBvH7+hdNNpjMa/CUXD7gsew67mbkCuDlFXE=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
 github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -78,8 +78,8 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 		cfgs   = make(map[string]alertspb.AlertConfigDesc, len(userIDs))
 	)
 
-	err := concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(userIDs), fetchConcurrency, func(ctx context.Context, job interface{}) error {
-		userID := job.(string)
+	err := concurrency.ForEachJob(ctx, len(userIDs), fetchConcurrency, func(ctx context.Context, idx int) error {
+		userID := userIDs[idx]
 
 		cfg, err := s.getAlertConfig(ctx, userID)
 		if s.alertsBucket.IsObjNotFoundErr(err) {

--- a/pkg/querier/queryrange/sharded_queryable.go
+++ b/pkg/querier/queryrange/sharded_queryable.go
@@ -110,8 +110,7 @@ func (q *shardedQuerier) handleEmbeddedQueries(queries []string, hints *storage.
 	streams := make([][]SampleStream, len(queries))
 
 	// Concurrently run each query. It breaks and cancels each worker context on first error.
-	err := concurrency.ForEach(q.ctx, createJobIndexes(len(queries)), len(queries), func(ctx context.Context, job interface{}) error {
-		idx := job.(int)
+	err := concurrency.ForEachJob(q.ctx, len(queries), len(queries), func(ctx context.Context, idx int) error {
 		resp, err := q.handler.Do(ctx, q.req.WithQuery(queries[idx]))
 		if err != nil {
 			return err
@@ -147,14 +146,6 @@ func (q *shardedQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, stor
 // Close implements storage.LabelQuerier.
 func (q *shardedQuerier) Close() error {
 	return nil
-}
-
-func createJobIndexes(l int) []interface{} {
-	jobs := make([]interface{}, l)
-	for j := 0; j < l; j++ {
-		jobs[j] = j
-	}
-	return jobs
 }
 
 type responseHeadersTracker struct {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -772,9 +772,9 @@ func (r *Ruler) getShardedRules(ctx context.Context, userID string) ([]*GroupSta
 
 	// Concurrently fetch rules from all rulers. Since rules are not replicated,
 	// we need all requests to succeed.
-	jobs := concurrency.CreateJobsFromStrings(rulers.GetAddresses())
-	err = concurrency.ForEach(ctx, jobs, len(jobs), func(ctx context.Context, job interface{}) error {
-		addr := job.(string)
+	addrs := rulers.GetAddresses()
+	err = concurrency.ForEachJob(ctx, len(addrs), len(addrs), func(ctx context.Context, idx int) error {
+		addr := addrs[idx]
 
 		rulerClient, err := r.clientsPool.GetClientFor(addr)
 		if err != nil {

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -149,8 +149,8 @@ func fetchDeletionTimes(ctx context.Context, bkt objstore.Bucket, deletionMarker
 	mu := sync.Mutex{}
 	times := map[ulid.ULID]time.Time{}
 
-	return times, concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(deletionMarkers), concurrencyLimit, func(ctx context.Context, job interface{}) error {
-		r, err := bkt.Get(ctx, job.(string))
+	return times, concurrency.ForEachJob(ctx, len(deletionMarkers), concurrencyLimit, func(ctx context.Context, idx int) error {
+		r, err := bkt.Get(ctx, deletionMarkers[idx])
 		if err != nil {
 			if bkt.IsObjNotFoundErr(err) {
 				return nil
@@ -179,8 +179,8 @@ func fetchMetas(ctx context.Context, bkt objstore.Bucket, metaFiles []string) (m
 	mu := sync.Mutex{}
 	metas := map[ulid.ULID]*metadata.Meta{}
 
-	return metas, concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(metaFiles), concurrencyLimit, func(ctx context.Context, job interface{}) error {
-		r, err := bkt.Get(ctx, job.(string))
+	return metas, concurrency.ForEachJob(ctx, len(metaFiles), concurrencyLimit, func(ctx context.Context, idx int) error {
+		r, err := bkt.Get(ctx, metaFiles[idx])
 		if err != nil {
 			if bkt.IsObjNotFoundErr(err) {
 				return nil

--- a/vendor/github.com/grafana/dskit/concurrency/runner.go
+++ b/vendor/github.com/grafana/dskit/concurrency/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/dskit/internal/math"
@@ -62,45 +63,53 @@ func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 
 // ForEach runs the provided jobFunc for each job up to concurrency concurrent workers.
 // The execution breaks on first error encountered.
+//
+// Deprecated: use ForEachJob instead.
 func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc func(ctx context.Context, job interface{}) error) error {
-	if len(jobs) == 0 {
-		return nil
-	}
-
-	// Push all jobs to a channel.
-	ch := make(chan interface{}, len(jobs))
-	for _, job := range jobs {
-		ch <- job
-	}
-	close(ch)
-
-	// Start workers to process jobs.
-	g, ctx := errgroup.WithContext(ctx)
-	for ix := 0; ix < math.Min(concurrency, len(jobs)); ix++ {
-		g.Go(func() error {
-			for job := range ch {
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-
-				if err := jobFunc(ctx, job); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		})
-	}
-
-	// Wait until done (or context has canceled).
-	return g.Wait()
+	return ForEachJob(ctx, len(jobs), concurrency, func(ctx context.Context, idx int) error {
+		return jobFunc(ctx, jobs[idx])
+	})
 }
 
 // CreateJobsFromStrings is an utility to create jobs from an slice of strings.
+//
+// Deprecated: will be removed as it's not needed when using ForEachJob.
 func CreateJobsFromStrings(values []string) []interface{} {
 	jobs := make([]interface{}, len(values))
 	for i := 0; i < len(values); i++ {
 		jobs[i] = values[i]
 	}
 	return jobs
+}
+
+// ForEachJob runs the provided jobFunc for each job index in [0, jobs) up to concurrency concurrent workers.
+// The execution breaks on first error encountered.
+func ForEachJob(ctx context.Context, jobs int, concurrency int, jobFunc func(ctx context.Context, idx int) error) error {
+	if jobs == 0 {
+		return nil
+	}
+
+	// Initialise indexes with -1 so first Inc() returns index 0.
+	indexes := atomic.NewInt64(-1)
+
+	// Start workers to process jobs.
+	g, ctx := errgroup.WithContext(ctx)
+	for ix := 0; ix < math.Min(concurrency, jobs); ix++ {
+		g.Go(func() error {
+			for ctx.Err() == nil {
+				idx := int(indexes.Inc())
+				if idx >= jobs {
+					return nil
+				}
+
+				if err := jobFunc(ctx, idx); err != nil {
+					return err
+				}
+			}
+			return ctx.Err()
+		})
+	}
+
+	// Wait until done (or context has canceled).
+	return g.Wait()
 }

--- a/vendor/github.com/grafana/dskit/ring/ring.go
+++ b/vendor/github.com/grafana/dskit/ring/ring.go
@@ -29,18 +29,6 @@ import (
 const (
 	unhealthy = "Unhealthy"
 
-	// IngesterRingKey is the key under which we store the ingesters ring in the KVStore.
-	IngesterRingKey = "ring"
-
-	// RulerRingKey is the key under which we store the rulers ring in the KVStore.
-	RulerRingKey = "ring"
-
-	// DistributorRingKey is the key under which we store the distributors ring in the KVStore.
-	DistributorRingKey = "distributor"
-
-	// CompactorRingKey is the key under which we store the compactors ring in the KVStore.
-	CompactorRingKey = "compactor"
-
 	// GetBufferSize is the suggested size of buffers passed to Ring.Get(). It's based on
 	// a typical replication factor 3, plus extra room for a JOINING + LEAVING instance.
 	GetBufferSize = 5

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -394,7 +394,7 @@ github.com/googleapis/gax-go/v2/apierror/internal/proto
 # github.com/gorilla/mux v1.8.0
 ## explicit; go 1.12
 github.com/gorilla/mux
-# github.com/grafana/dskit v0.0.0-20220104154758-acbb88132134
+# github.com/grafana/dskit v0.0.0-20220112093026-95274ccc858d
 ## explicit; go 1.16
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/concurrency


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Updates dskit to include https://github.com/grafana/dskit/pull/113

Updated all usages of `concurrency.ForEach()` to use `ForEachJob()` so no type assertion is needed anymore.

**Which issue(s) this PR fixes**:

Follow up on https://github.com/grafana/mimir/pull/707

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
