### PR TITLE
Add "user" label to appended exemplars metric

### DIFF
--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -231,7 +231,7 @@ func TestIngester_Push(t *testing.T) {
 
 				# HELP cortex_ingester_tsdb_exemplar_exemplars_appended_total Total number of TSDB exemplars appended.
 				# TYPE cortex_ingester_tsdb_exemplar_exemplars_appended_total counter
-				cortex_ingester_tsdb_exemplar_exemplars_appended_total 1
+				cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="test"} 1
 
 				# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 				# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge
@@ -548,7 +548,7 @@ func TestIngester_Push(t *testing.T) {
 
 				# HELP cortex_ingester_tsdb_exemplar_exemplars_appended_total Total number of TSDB exemplars appended.
 				# TYPE cortex_ingester_tsdb_exemplar_exemplars_appended_total counter
-				cortex_ingester_tsdb_exemplar_exemplars_appended_total 0
+				cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="test"} 0
 
 				# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 				# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -562,7 +562,7 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 		tsdbExemplarsTotal: prometheus.NewDesc(
 			"cortex_ingester_tsdb_exemplar_exemplars_appended_total",
 			"Total number of TSDB exemplars appended.",
-			nil, nil), // see distributor_exemplars_in for per-user rate
+			[]string{"user"}, nil), // see distributor_exemplars_in for per-user rate
 		tsdbExemplarsInStorage: prometheus.NewDesc(
 			"cortex_ingester_tsdb_exemplar_exemplars_in_storage",
 			"Number of TSDB exemplars currently in storage.",
@@ -681,7 +681,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, sm.checkpointDeleteTotal, "prometheus_tsdb_checkpoint_deletions_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationFail, "prometheus_tsdb_checkpoint_creations_failed_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationTotal, "prometheus_tsdb_checkpoint_creations_total")
-	data.SendSumOfCounters(out, sm.tsdbExemplarsTotal, "prometheus_tsdb_exemplar_exemplars_appended_total")
+	data.SendSumOfCountersPerUser(out, sm.tsdbExemplarsTotal, "prometheus_tsdb_exemplar_exemplars_appended_total")
 	data.SendSumOfGauges(out, sm.tsdbExemplarsInStorage, "prometheus_tsdb_exemplar_exemplars_in_storage")
 	data.SendSumOfGaugesPerUser(out, sm.tsdbExemplarSeriesInStorage, "prometheus_tsdb_exemplar_series_with_exemplars_in_storage")
 	data.SendSumOfGaugesPerUser(out, sm.tsdbExemplarLastTs, "prometheus_tsdb_exemplar_last_exemplars_timestamp_seconds")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -237,7 +237,9 @@ func TestTSDBMetrics(t *testing.T) {
 
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_appended_total Total number of TSDB exemplars appended.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_appended_total counter
-			cortex_ingester_tsdb_exemplar_exemplars_appended_total 300
+			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user1"} 100
+			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user2"} 100
+			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user3"} 100
 
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge
@@ -461,7 +463,8 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_appended_total Total number of TSDB exemplars appended.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_appended_total counter
-			cortex_ingester_tsdb_exemplar_exemplars_appended_total 300
+			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user1"} 100
+			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user2"} 100
 
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Currently there are three metrics on the received exemplars:
- distributed_in: total exemplars received, before deduplication.
- distributor_received: same but without duplicated and rejected.
- ingester_appended: the ones that were actually appended to the
storage, if it's enabled for the user.

The first two have per-user labels, but the last one doesn't, so we can know whether we're receiving exemplars, but we don't know whetherthey're actually being appended (or they're being dropped because of limits configuration).

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/mimir-squad/issues/375

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
