### PR TITLE
Fix BenchmarkDistributor_Push

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/common/user"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -1706,8 +1707,9 @@ func BenchmarkDistributor_Push(b *testing.B) {
 			var clientConfig client.Config
 			limits := validation.Limits{}
 			flagext.DefaultValues(&distributorCfg, &clientConfig, &limits)
+			distributorCfg.DistributorRing.KVStore.Store = "inmemory"
 
-			limits.IngestionRate = 0 // Unlimited.
+			limits.IngestionRate = float64(rate.Inf) // Unlimited.
 			testData.prepareConfig(&limits)
 
 			distributorCfg.IngesterClientFactory = func(addr string) (ring_client.PoolClient, error) {


### PR DESCRIPTION
This benchmark was broken by #725, but appears to have been broken
before that as well

**What this PR does**:

This PR updates the noted benchmark in two ways:

1. Set the distributor ring to use an inmemory kvstore (now required after #725)
2. Use `rate.Inf` to enable unlimited ingestion rate instead of `0`

**Which issue(s) this PR fixes**:

Found while working on #554 

**Checklist**

- [N/A] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
