### PR TITLE
Remove unused flush config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 * [CHANGE] Compactor: removed overlapping sources detection. Overlapping sources may exist due to edge cases (timing issues) when horizontally sharding compactor with `split-and-merge` strategy, but are correctly handled by compactor. #494
 * [CHANGE] Rename metric `cortex_query_fetched_chunks_bytes_total` to `cortex_query_fetched_chunk_bytes_total` to be consistent with the limit name. #476
 * [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #537
-* [CHANGE] Remove chunks storage engine. #510 #545 #743 #744 #748 #753 #755 #757 #758
+* [CHANGE] Remove chunks storage engine. #510 #545 #743 #744 #748 #753 #755 #757 #758 #759
   * The following CLI flags (and their respective YAML config options) have been removed:
     * `-store.engine`
     * `-ingester.checkpoint-duration`
@@ -80,6 +80,9 @@
     * `-querier.query-parallelism`
     * `-querier.second-store-engine`
     * `-querier.use-second-store-before-time`
+    * `-flusher.wal-dir`
+    * `-flusher.concurrent-flushes`
+    * `-flusher.flush-op-timeout`
     * All `-table-manager.*` flags
     * All `-deletes.*` flags
     * All `-purger.*` flags

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -301,17 +301,6 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
 - `distributor.ha-tracker.update-timeout`
   Update the timestamp in the KV store for a given cluster/replica only after this amount of time has passed since the current stored timestamp. (default 15s)
 
-#### Flusher
-
-- `-flusher.wal-dir`
-  Directory where the WAL data should be recovered from.
-
-- `-flusher.concurrent-flushes`
-  Number of concurrent flushes.
-
-- `-flusher.flush-op-timeout`
-  Duration after which a flush should timeout.
-
 ## Runtime configuration file
 
 Mimir has a concept of "runtime config" file, which is simply a file that is reloaded while Mimir is running. It is used by some Mimir components to allow operator to change some aspects of Mimir configuration without restarting it. File is specified by using `-runtime-config.file=<filename>` flag and reload period (which defaults to 10 seconds) can be changed by `-runtime-config.reload-period=<duration>` flag. Previously this mechanism was only used by limits overrides, and flags were called `-limits.per-user-override-config=<filename>` and `-limits.per-user-override-period=10s` respectively. These are still used, if `-runtime-config.file=<filename>` is not specified.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1979,19 +1979,6 @@ local:
 The `flusher_config` configures the WAL flusher target, used to manually run one-time flushes when scaling down ingesters.
 
 ```yaml
-# Directory to read WAL from (chunks storage engine only).
-# CLI flag: -flusher.wal-dir
-[wal_dir: <string> | default = "wal"]
-
-# Number of concurrent goroutines flushing to storage (chunks storage engine
-# only).
-# CLI flag: -flusher.concurrent-flushes
-[concurrent_flushes: <int> | default = 50]
-
-# Timeout for individual flush operations (chunks storage engine only).
-# CLI flag: -flusher.flush-op-timeout
-[flush_op_timeout: <duration> | default = 2m]
-
 # Stop after flush has finished. If false, process will keep running, doing
 # nothing.
 # CLI flag: -flusher.exit-after-flush

--- a/pkg/flusher/flusher.go
+++ b/pkg/flusher/flusher.go
@@ -23,17 +23,11 @@ import (
 
 // Config for an Ingester.
 type Config struct {
-	WALDir            string        `yaml:"wal_dir"`
-	ConcurrentFlushes int           `yaml:"concurrent_flushes"`
-	FlushOpTimeout    time.Duration `yaml:"flush_op_timeout"`
-	ExitAfterFlush    bool          `yaml:"exit_after_flush"`
+	ExitAfterFlush bool `yaml:"exit_after_flush"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.WALDir, "flusher.wal-dir", "wal", "Directory to read WAL from (chunks storage engine only).")
-	f.IntVar(&cfg.ConcurrentFlushes, "flusher.concurrent-flushes", 50, "Number of concurrent goroutines flushing to storage (chunks storage engine only).")
-	f.DurationVar(&cfg.FlushOpTimeout, "flusher.flush-op-timeout", 2*time.Minute, "Timeout for individual flush operations (chunks storage engine only).")
 	f.BoolVar(&cfg.ExitAfterFlush, "flusher.exit-after-flush", true, "Stop after flush has finished. If false, process will keep running, doing nothing.")
 }
 


### PR DESCRIPTION
**What this PR does**:
When we removed chunks storage support from ingester/flusher we unintentionally left some unused config. This PR removes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
