### PR TITLE
Mimir-mixin: adjust ingested exemplars with replication factor

### DIFF
--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -325,8 +325,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Ingester appended exemplars rate';
         $.panel(title) +
         $.queryPanel(
-          'sum(%(group_prefix_jobs)s:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m{%(job)s})'
-          % { job: $.jobMatcher($._config.job_names.ingester), group_prefix_jobs: $._config.group_prefix_jobs },
+          |||
+            sum(
+              %(group_prefix_jobs)s:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m{%(ingester)s}
+              / on(%(group_by_cluster)s) group_left
+              max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
+            )
+          ||| % {
+            ingester: $.jobMatcher($._config.job_names.ingester),
+            distributor: $.jobMatcher($._config.job_names.distributor),
+            group_by_cluster: $._config.group_by_cluster,
+            group_prefix_jobs: $._config.group_prefix_jobs,
+          },
           'appended exemplars',
         ) +
         { yaxes: $.yaxes('ex/s') } +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Fix for already merged https://github.com/grafana/mimir/pull/749
I added ingested exemplars metric, but it has to be divided by replication factor.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
