### PR TITLE
Remove tolerance for long since deprecated ruler flags

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -151,15 +151,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Notifier.RegisterFlags(f)
 	cfg.TenantFederation.RegisterFlags(f)
 
-	// Deprecated Flags that will be maintained to avoid user disruption
-
-	//lint:ignore faillint Need to pass the global logger like this for warning on deprecated methods
-	flagext.DeprecatedFlag(f, "ruler.client-timeout", "This flag has been renamed to ruler.configs.client-timeout", util_log.Logger)
-	//lint:ignore faillint Need to pass the global logger like this for warning on deprecated methods
-	flagext.DeprecatedFlag(f, "ruler.group-timeout", "This flag is no longer functional.", util_log.Logger)
-	//lint:ignore faillint Need to pass the global logger like this for warning on deprecated methods
-	flagext.DeprecatedFlag(f, "ruler.num-workers", "This flag is no longer functional. For increased concurrency horizontal sharding is recommended", util_log.Logger)
-
 	cfg.ExternalURL.URL, _ = url.Parse("") // Must be non-nil
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 1*time.Minute, "How frequently to evaluate rules")


### PR DESCRIPTION
I was looking into flags that were associated with `flagext.DeprecatedFlag` and found these. These flags were removed/renamed in Cortex 0.6.0 on 2020-01-28. In addition, the warning message for `ruler.client-timeout` references a flag that also no longer exists.

I didn't update the CHANGELOG because they were already noted as removed/renamed.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- N/A Tests updated
- N/A Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
