### PR TITLE
add store.engine flag for GEM

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -35,7 +35,10 @@ func previousVersionImages() map[string]func(map[string]string) map[string]strin
 		// Overriding of flags is not currently supported when overriding the list of images,
 		// so set all override functions to nil
 		for _, image := range strings.Split(overrideImageVersions, ",") {
-			previousVersionImages[image] = nil
+			previousVersionImages[image] = func(flags map[string]string) map[string]string {
+				flags["-store.engine"] = "blocks"
+				return flags
+			}
 		}
 
 		return previousVersionImages


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

https://github.com/grafana/mimir/pull/758 removed the storage engine config option, but it is still needed for older version of GEM when running the backwards compatibility test. This PR adds these whenever a previous image is set via the env var, which GEM currently has to do to run these tests against previous GEM versions rather than Mimir ones.

This is likely temporary until https://github.com/grafana/backend-enterprise/issues/2951 is figured out.

**Which issue(s) this PR fixes**:

Related to: https://github.com/grafana/backend-enterprise/issues/2951

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
