### PR TITLE
Docs: deprecated remove 'chunks storage' references

### DIFF
--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -257,9 +257,9 @@ GET,POST /flush
 
 Triggers a flush of the in-memory time series data (chunks or blocks) to the long-term storage. This endpoint triggers the flush also when `-ingester.flush-on-shutdown-with-wal-enabled` or `-blocks-storage.tsdb.flush-blocks-on-shutdown` are disabled.
 
-When using blocks storage, this endpoint accepts `tenant` parameter to specify tenant whose blocks are compacted and shipped. This parameter may be specified multiple times to select more tenants. If no tenant is specified, all tenants are flushed.
+This endpoint accepts `tenant` parameter to specify tenant whose blocks are compacted and shipped. This parameter may be specified multiple times to select more tenants. If no tenant is specified, all tenants are flushed.
 
-Flush endpoint now also accepts `wait=true` parameter, which makes the call synchronous – it will only return after flushing has finished. Note that returned status code does not reflect the result of flush operation. This parameter is only available when using blocks storage.
+Flush endpoint also accepts `wait=true` parameter, which makes the call synchronous – it will only return after flushing has finished. Note that returned status code does not reflect the result of flush operation.
 
 ### Shutdown
 
@@ -343,8 +343,6 @@ GET,POST <prometheus-http-prefix>/api/v1/series
 GET,POST <legacy-http-prefix>/api/v1/series
 ```
 
-Find series by label matchers. Differently than Prometheus and due to scalability and performances reasons, Cortex currently ignores the `start` and `end` request parameters and always fetches the series from in-memory data stored in the ingesters. There is experimental support to query the long-term store with the _blocks_ storage engine when `-querier.query-store-for-labels-enabled` is set.
-
 _For more information, please check out the Prometheus [series endpoint](https://prometheus.io/docs/prometheus/latest/querying/api/#finding-series-by-label-matchers) documentation._
 
 _Requires [authentication](#authentication)._
@@ -358,8 +356,6 @@ GET,POST <prometheus-http-prefix>/api/v1/labels
 GET,POST <legacy-http-prefix>/api/v1/labels
 ```
 
-Get label names of ingested series. Differently than Prometheus and due to scalability and performances reasons, Cortex currently ignores the `start` and `end` request parameters and always fetches the label names from in-memory data stored in the ingesters. There is experimental support to query the long-term store with the _blocks_ storage engine when `-querier.query-store-for-labels-enabled` is set.
-
 _For more information, please check out the Prometheus [get label names](https://prometheus.io/docs/prometheus/latest/querying/api/#getting-label-names) documentation._
 
 _Requires [authentication](#authentication)._
@@ -372,8 +368,6 @@ GET <prometheus-http-prefix>/api/v1/label/{name}/values
 # Legacy
 GET <legacy-http-prefix>/api/v1/label/{name}/values
 ```
-
-Get label values for a given label name. Differently than Prometheus and due to scalability and performances reasons, Cortex currently ignores the `start` and `end` request parameters and always fetches the label values from in-memory data stored in the ingesters. There is experimental support to query the long-term store with the _blocks_ storage engine when `-querier.query-store-for-labels-enabled` is set.
 
 _For more information, please check out the Prometheus [get label values](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-label-values) documentation._
 
@@ -420,7 +414,6 @@ GET,POST <legacy-http-prefix>/api/v1/cardinality/label_names
 
 Returns realtime label names cardinality across all ingesters, for the authenticated tenant, in `JSON` format.
 It counts distinct label values per label name.
-Works only with blocks storage.
 
 As far as this endpoint generates cardinality report using only values from currently opened TSDBs in ingesters, two subsequent calls may return completely different results, if ingester did a block
 cutting between the calls.
@@ -464,7 +457,6 @@ GET,POST <legacy-http-prefix>/api/v1/cardinality/label_values
 
 Returns realtime label values cardinality associated to request param `label_names[]` across all ingesters, for the authenticated tenant, in `JSON` format.
 It returns the series count per label value associated to request param `label_names[]`.
-Works only with blocks storage.
 
 As far as this endpoint generates cardinality report using only values from currently opened TSDBs in ingesters, two subsequent calls may return completely different results, if ingester did a block
 cutting between the calls.
@@ -940,7 +932,7 @@ The Purger service provides APIs for requesting tenant deletion.
 POST /purger/delete_tenant
 ```
 
-Request deletion of ALL tenant data. Only works with blocks storage. Experimental.
+Request deletion of ALL tenant data. Experimental.
 
 _Requires [authentication](#authentication)._
 

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -49,7 +49,7 @@ Currently experimental features are:
 - gRPC Store.
 - TLS configuration in gRPC and HTTP clients.
 - TLS configuration in Etcd client.
-- OpenStack Swift storage support (both in blocks and chunks storage).
+- OpenStack Swift storage support.
 - Metric relabeling in the distributor.
 - Scalable query-frontend (when using query-scheduler)
 - Distributor: do not extend writes on unhealthy ingesters (`-distributor.extend-writes=false`)

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -33,12 +33,6 @@ The HA Tracker is a feature of Mimir distributor which is used to deduplicate re
 
 For more information, please refer to the guide "[Config for sending HA Pairs data to Mimir](../guides/ha-pair-handling.md)".
 
-### Hand-over
-
-Series hand-over is an operation supported by ingesters to transfer their state, on shutdown, to a new ingester in the `JOINING` state. Hand-over is typically used during [ingesters rollouts](./ingesters-rolling-updates.md) and is only supported by the Mimir chunks storage.
-
-For more information, please refer to the guide "[Ingesters rolling updates](./ingesters-rolling-updates.md)".
-
 ### Hash ring
 
 The hash ring is a distributed data structure used by Mimir for sharding, replication and service discovery. The hash ring data structure gets shared across Mimir replicas via gossip or a key-value store.

--- a/docs/guides/limitations.md
+++ b/docs/guides/limitations.md
@@ -35,11 +35,3 @@ All other characters are not safe to use. In particular, slashes `/` and whitesp
 ### Length
 
 The tenant ID length should not exceed 150 bytes/characters.
-
-## Query without metric name
-
-The Cortex chunks storage doesn't support queries without a metric name, like `count({__name__=~".+"})`. On the contrary, the Cortex [blocks storage](../blocks-storage/_index.md) supports it.
-
-## Query series and labels
-
-When running queries to the `/api/v1/series`, `/api/v1/labels` and `/api/v1/label/{name}/values` endpoints, query's time range is ignored and the data is always fetched from ingesters. There is experimental support to query the long-term store with the _blocks_ storage engine when `-querier.query-store-for-labels-enabled` is set.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -53,7 +53,6 @@ type Config struct {
 	QueryStoreAfter    time.Duration `yaml:"query_store_after"`
 	MaxQueryIntoFuture time.Duration `yaml:"max_query_into_future"`
 
-	// Blocks storage only.
 	StoreGatewayAddresses string       `yaml:"store_gateway_addresses"`
 	StoreGatewayClient    ClientConfig `yaml:"store_gateway_client"`
 


### PR DESCRIPTION
**What this PR does**:
I was looking for "chunks storage" references in repo and I found few references to remove. I've also removed any reference to `-querier.query-store-for-labels-enabled` because it was removed in #518.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
