### PR TITLE
Removed chunks cache panels from querier row in 'Mimir / Queries' dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,7 +265,7 @@
 
 ### Mixin (changes since `grafana/cortex-jsonnet` `1.9.0`)
 
-* [CHANGE] Removed chunks storage support from mixin. #641 #643 #645
+* [CHANGE] Removed chunks storage support from mixin. #641 #643 #645 #811
   * Removed `tsdb.libsonnet`: no need to import it anymore (its content is already automatically included when using Jsonnet)
   * Removed the following fields from `_config`:
     * `storage_engine` (defaults to `blocks`)

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -111,14 +111,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
         { yaxes: $.yaxes('ms') } +
         $.stack,
       )
-      .addPanel(
-        $.panel('Chunk cache misses') +
-        $.queryPanel('sum(rate(cortex_cache_fetched_keys{%s,name="chunksmemcache"}[1m])) - sum(rate(cortex_cache_hits{%s,name="chunksmemcache"}[1m]))' % [$.jobMatcher($._config.job_names.querier), $.jobMatcher($._config.job_names.querier)], 'Hit rate'),
-      )
-      .addPanel(
-        $.panel('Chunk cache corruptions') +
-        $.queryPanel('sum(rate(cortex_cache_corrupt_chunks_total{%s}[1m]))' % $.jobMatcher($._config.job_names.querier), 'Corrupt chunks'),
-      )
     )
     .addRow(
       $.row('Ingester')


### PR DESCRIPTION
**What this PR does**:
The `Mimir / Queries` dashboard has a couple of panels showing the chunks cache in the querier row, querying metrics which were related to chunks storage. With blocks storage the querier doesn't hit the chunks cache anymore (it's the store-gateway and we already have panels for that), so I'm just removing it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
