### PR TITLE
Remove schema config from jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,10 @@
 * [CHANGE] Compactor: removed overlapping sources detection. Overlapping sources may exist due to edge cases (timing issues) when horizontally sharding compactor with `split-and-merge` strategy, but are correctly handled by compactor. #494
 * [CHANGE] Rename metric `cortex_query_fetched_chunks_bytes_total` to `cortex_query_fetched_chunk_bytes_total` to be consistent with the limit name. #476
 * [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #537
-* [CHANGE] Remove chunks storage engine. #510 #545 #743 #744 #748 #753 #755 #757 #758 #759 #760 #762 #764 #789 #813
+* [CHANGE] Remove chunks storage engine. #510 #545 #743 #744 #748 #753 #755 #757 #758 #759 #760 #762 #764 #789 #812 #813
   * The following CLI flags (and their respective YAML config options) have been removed:
     * `-store.engine`
+    * `-schema-config-file`
     * `-ingester.checkpoint-duration`
     * `-ingester.checkpoint-enabled`
     * `-ingester.chunk-encoding`
@@ -265,12 +266,13 @@
 
 ### Mixin (changes since `grafana/cortex-jsonnet` `1.9.0`)
 
-* [CHANGE] Removed chunks storage support from mixin. #641 #643 #645 #811 #813
+* [CHANGE] Removed chunks storage support from mixin. #641 #643 #645 #811 #812 #813
   * Removed `tsdb.libsonnet`: no need to import it anymore (its content is already automatically included when using Jsonnet)
   * Removed the following fields from `_config`:
     * `storage_engine` (defaults to `blocks`)
     * `chunk_index_backend`
     * `chunk_store_backend`
+  * Removed schema config map
   * Removed the following dashboards:
     * "Cortex / Chunks"
     * "Cortex / WAL"

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -258,15 +258,6 @@ metadata:
   name: overrides
   namespace: default
 ---
-apiVersion: v1
-data:
-  config.yaml: |
-    configs: []
-kind: ConfigMap
-metadata:
-  name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-  namespace: default
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -818,8 +809,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: querier
     spec:
@@ -859,7 +848,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -896,15 +884,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1062,8 +1045,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: ruler
     spec:
@@ -1107,7 +1088,6 @@ spec:
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1143,16 +1123,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1271,7 +1246,6 @@ spec:
         - -compactor.ring.store=consul
         - -compactor.sharding-enabled=true
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1369,7 +1343,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1693,7 +1666,6 @@ spec:
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -257,15 +257,6 @@ metadata:
   name: overrides
   namespace: default
 ---
-apiVersion: v1
-data:
-  config.yaml: |
-    configs: []
-kind: ConfigMap
-metadata:
-  name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-  namespace: default
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -817,8 +808,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: querier
     spec:
@@ -858,7 +847,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -895,15 +883,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1065,8 +1048,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: ruler
     spec:
@@ -1110,7 +1091,6 @@ spec:
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1146,16 +1126,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1274,7 +1249,6 @@ spec:
         - -compactor.ring.store=consul
         - -compactor.sharding-enabled=true
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1372,7 +1346,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1696,7 +1669,6 @@ spec:
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -257,15 +257,6 @@ metadata:
   name: overrides
   namespace: default
 ---
-apiVersion: v1
-data:
-  config.yaml: |
-    configs: []
-kind: ConfigMap
-metadata:
-  name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-  namespace: default
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -817,8 +808,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: querier
     spec:
@@ -860,7 +849,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -897,15 +885,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1063,8 +1046,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: ruler
     spec:
@@ -1112,7 +1093,6 @@ spec:
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1148,16 +1128,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1280,7 +1255,6 @@ spec:
         - -compactor.ring.store=consul
         - -compactor.sharding-enabled=true
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1380,7 +1354,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1706,7 +1679,6 @@ spec:
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -257,15 +257,6 @@ metadata:
   name: overrides
   namespace: default
 ---
-apiVersion: v1
-data:
-  config.yaml: |
-    configs: []
-kind: ConfigMap
-metadata:
-  name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-  namespace: default
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -817,8 +808,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: querier
     spec:
@@ -858,7 +847,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -895,15 +883,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1061,8 +1044,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: ruler
     spec:
@@ -1106,7 +1087,6 @@ spec:
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1142,16 +1122,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1270,7 +1245,6 @@ spec:
         - -compactor.ring.store=consul
         - -compactor.sharding-enabled=true
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1368,7 +1342,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1692,7 +1665,6 @@ spec:
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -257,15 +257,6 @@ metadata:
   name: overrides
   namespace: default
 ---
-apiVersion: v1
-data:
-  config.yaml: |
-    configs: []
-kind: ConfigMap
-metadata:
-  name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-  namespace: default
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -817,8 +808,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: querier
     spec:
@@ -859,7 +848,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -896,15 +884,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1062,8 +1045,6 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
-      annotations:
-        schemaID: fa9497f5acccafcc3e6019657bdc5eb1
       labels:
         name: ruler
     spec:
@@ -1110,7 +1091,6 @@ spec:
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1146,16 +1126,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/cortex
           name: overrides
-        - mountPath: /etc/cortex/schema
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
           name: overrides
         name: overrides
-      - configMap:
-          name: schema-fa9497f5acccafcc3e6019657bdc5eb1
-        name: schema-fa9497f5acccafcc3e6019657bdc5eb1
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1276,7 +1251,6 @@ spec:
         - -compactor.ring.store=consul
         - -compactor.sharding-enabled=true
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1375,7 +1349,6 @@ spec:
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1700,7 +1673,6 @@ spec:
         - -blocks-storage.s3.bucket-name=blocks-bucket
         - -blocks-storage.s3.endpoint=s3.dualstack.us-east-1.amazonaws.com
         - -runtime-config.file=/etc/cortex/overrides.yaml
-        - -schema-config-file=/etc/cortex/schema/config.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -86,7 +86,7 @@
     },
 
     storageConfig:
-      { 'schema-config-file': '/etc/cortex/schema/config.yaml' },
+      {},
 
     genericBlocksStorageConfig:: {},
     queryBlocksStorageConfig:: {
@@ -343,9 +343,6 @@
     // if not empty, passed to overrides.yaml as another top-level field
     multi_kv_config: {},
 
-    // TODO This should be removed but we're still keeping the schema for backward compatibility.
-    schemaID: std.md5(std.toString([])),
-
     enable_pod_priorities: true,
 
     alertmanager_enabled: false,
@@ -380,19 +377,6 @@
         + (if $._config.ingester_instance_limits != null then { ingester_limits: $._config.ingester_instance_limits } else {}),
       ),
     }),
-
-  storage_config:
-    configMap.new('schema-' + $._config.schemaID) +
-    configMap.withData({
-      'config.yaml': $.util.manifestYaml({
-        configs: [],
-      }),
-    }),
-
-  local deployment = $.apps.v1.deployment,
-  storage_config_mixin::
-    deployment.mixin.spec.template.metadata.withAnnotationsMixin({ schemaID: $._config.schemaID },) +
-    $.util.configVolumeMount('schema-' + $._config.schemaID, '/etc/cortex/schema'),
 
   // This removed the CPU limit from the config.  NB won't show up in subset
   // diffs, but ks apply will do the right thing.

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -59,8 +59,7 @@
     (if $._config.cortex_querier_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
-    $.storage_config_mixin,
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
 
   querier_deployment:
     self.newQuerierDeployment('querier', $.querier_container),

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -54,8 +54,7 @@
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
       (if $._config.cortex_ruler_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
-      $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
-      $.storage_config_mixin
+      $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex')
     else {},
 
   local service = $.core.v1.service,


### PR DESCRIPTION
**What this PR does**:
This PR removes the schema config from jsonnet (was used only by chunks storage).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
