### PR TITLE
Remove max_series_per_query from jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 * [CHANGE] Compactor: removed overlapping sources detection. Overlapping sources may exist due to edge cases (timing issues) when horizontally sharding compactor with `split-and-merge` strategy, but are correctly handled by compactor. #494
 * [CHANGE] Rename metric `cortex_query_fetched_chunks_bytes_total` to `cortex_query_fetched_chunk_bytes_total` to be consistent with the limit name. #476
 * [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #537
-* [CHANGE] Remove chunks storage engine. #510 #545 #743 #744 #748 #753 #755 #757 #758 #759 #760 #762 #764 #789
+* [CHANGE] Remove chunks storage engine. #510 #545 #743 #744 #748 #753 #755 #757 #758 #759 #760 #762 #764 #789 #813
   * The following CLI flags (and their respective YAML config options) have been removed:
     * `-store.engine`
     * `-ingester.checkpoint-duration`
@@ -70,7 +70,7 @@
     * `-ingester.flush-period`
     * `-ingester.max-chunk-age`
     * `-ingester.max-chunk-idle`
-    * `-ingester.max-series-per-query`
+    * `-ingester.max-series-per-query` (and `max_series_per_query` from runtime config)
     * `-ingester.max-stale-chunk-idle`
     * `-ingester.max-transfer-retries`
     * `-ingester.min-chunk-length`
@@ -265,7 +265,7 @@
 
 ### Mixin (changes since `grafana/cortex-jsonnet` `1.9.0`)
 
-* [CHANGE] Removed chunks storage support from mixin. #641 #643 #645 #811
+* [CHANGE] Removed chunks storage support from mixin. #641 #643 #645 #811 #813
   * Removed `tsdb.libsonnet`: no need to import it anymore (its content is already automatically included when using Jsonnet)
   * Removed the following fields from `_config`:
     * `storage_engine` (defaults to `blocks`)

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -313,10 +313,8 @@ Example runtime configuration file:
 overrides:
   tenant1:
     ingestion_rate: 10000
-    max_series_per_metric: 100000
   tenant2:
     max_samples_per_query: 1000000
-    max_series_per_metric: 100000
 
 multi_kv_config:
   mirror_enabled: false
@@ -341,10 +339,8 @@ The `overrides` field is a map of tenant ID (same values as passed in the `X-Sco
 overrides:
   tenant1:
     ingestion_rate: 10000
-    max_series_per_metric: 100000
   tenant2:
     max_samples_per_query: 1000000
-    max_series_per_metric: 100000
 ```
 
 Valid per-tenant limits are (with their corresponding flags for default values):

--- a/docs/guides/overrides-exporter-runtime.yaml
+++ b/docs/guides/overrides-exporter-runtime.yaml
@@ -6,6 +6,4 @@ overrides:
     ingestion_rate: 350000
     max_global_series_per_metric: 300000
     max_global_series_per_user: 300000
-    max_series_per_metric: 0
-    max_series_per_user: 0
     max_samples_per_query: 100000

--- a/docs/guides/overrides-exporter.md
+++ b/docs/guides/overrides-exporter.md
@@ -35,8 +35,6 @@ overrides:
     ingestion_rate: 350000
     max_global_series_per_metric: 300000
     max_global_series_per_user: 300000
-    max_series_per_metric: 0
-    max_series_per_user: 0
     max_samples_per_query: 100000
 ```
 <!-- prettier-ignore-end -->

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -1363,7 +1363,6 @@ spec:
         - -ingester.join-after=0s
         - -ingester.max-global-series-per-metric=20000
         - -ingester.max-global-series-per-user=150000
-        - -ingester.max-series-per-query=100000
         - -ingester.num-tokens=512
         - -ingester.tokens-file-path=/data/tokens
         - -ingester.unregister-on-shutdown=true

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1366,7 +1366,6 @@ spec:
         - -ingester.join-after=0s
         - -ingester.max-global-series-per-metric=20000
         - -ingester.max-global-series-per-user=150000
-        - -ingester.max-series-per-query=100000
         - -ingester.num-tokens=512
         - -ingester.tokens-file-path=/data/tokens
         - -ingester.unregister-on-shutdown=true

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1374,7 +1374,6 @@ spec:
         - -ingester.join-after=0s
         - -ingester.max-global-series-per-metric=20000
         - -ingester.max-global-series-per-user=150000
-        - -ingester.max-series-per-query=100000
         - -ingester.num-tokens=512
         - -ingester.tokens-file-path=/data/tokens
         - -ingester.unregister-on-shutdown=true

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1362,7 +1362,6 @@ spec:
         - -ingester.join-after=0s
         - -ingester.max-global-series-per-metric=20000
         - -ingester.max-global-series-per-user=150000
-        - -ingester.max-series-per-query=100000
         - -ingester.num-tokens=512
         - -ingester.tokens-file-path=/data/tokens
         - -ingester.unregister-on-shutdown=true

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1369,7 +1369,6 @@ spec:
         - -ingester.join-after=0s
         - -ingester.max-global-series-per-metric=20000
         - -ingester.max-global-series-per-user=150000
-        - -ingester.max-series-per-query=100000
         - -ingester.num-tokens=512
         - -ingester.tokens-file-path=/data/tokens
         - -ingester.unregister-on-shutdown=true

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -236,7 +236,6 @@
     ingesterLimitsConfig: {
       'ingester.max-global-series-per-user': $._config.limits.max_global_series_per_user,
       'ingester.max-global-series-per-metric': $._config.limits.max_global_series_per_metric,
-      'ingester.max-series-per-query': $._config.limits.max_series_per_query,
     },
     rulerLimitsConfig: {
       'ruler.max-rules-per-rule-group': $._config.limits.ruler_max_rules_per_rule_group,
@@ -256,8 +255,6 @@
         max_global_series_per_user: 150000,
         max_global_series_per_metric: 20000,
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 10000,
         ingestion_burst_size: 200000,
 
@@ -273,8 +270,6 @@
         max_global_series_per_user: 300000,
         max_global_series_per_metric: 30000,
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 30000,
         ingestion_burst_size: 300000,
 
@@ -286,8 +281,6 @@
       small_user:: {
         max_global_series_per_user: 1000000,
         max_global_series_per_metric: 100000,
-
-        max_series_per_query: 100000,
 
         ingestion_rate: 100000,
         ingestion_burst_size: 1000000,
@@ -301,8 +294,6 @@
         max_global_series_per_user: 3000000,  // 3M
         max_global_series_per_metric: 300000,  // 300K
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 350000,  // 350K
         ingestion_burst_size: 3500000,  // 3.5M
 
@@ -312,8 +303,6 @@
       },
 
       big_user:: {
-        max_series_per_query: 100000,
-
         max_global_series_per_user: 6000000,  // 6M
         max_global_series_per_metric: 600000,  // 600K
 
@@ -329,8 +318,6 @@
         max_global_series_per_user: 12000000,  // 12M
         max_global_series_per_metric: 1200000,  // 1.2M
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 1500000,  // 1.5M
         ingestion_burst_size: 15000000,  // 15M
 
@@ -343,8 +330,6 @@
       mega_user+:: {
         max_global_series_per_user: 16000000,  // 16M
         max_global_series_per_metric: 1600000,  // 1.6M
-
-        max_series_per_query: 100000,
 
         ingestion_rate: 2250000,  // 2.25M
         ingestion_burst_size: 22500000,  // 22.5M


### PR DESCRIPTION
**What this PR does**:
When I removed `max_series_per_query` support in #764 I forgot to remove it from jsonnet. This PR does it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
