### PR TITLE
Move TSDB metrics into ingester metrics

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3892,7 +3892,7 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		return len(i.TSDBState.dbs)
 	})
 
-	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbChecks.WithLabelValues(string(tsdbIdleClosed))), float64(0))
+	require.Greater(t, testutil.ToFloat64(i.metrics.idleTsdbChecks.WithLabelValues(string(tsdbIdleClosed))), float64(0))
 	i.updateActiveSeries(time.Now())
 	require.Equal(t, int64(0), i.TSDBState.seriesCount.Load()) // Flushing removed all series from memory.
 


### PR DESCRIPTION
**What this PR does**:

This moves some metrics from `TSDBState` to `ingesterMetrics` to get eventually rid of `TSDBState` altogether (related to #5)
