### PR TITLE
Set new default rule group limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@
   * `-querier.cache-results` renamed to `-frontend.cache-results`
   * `-query-frontend.parallelize-shardable-queries` renamed to `-frontend.parallelize-shardable-queries`
   * `-query-frontend.cache-unaligned-requests` renamed to `-frontend.cache-unaligned-requests`
+* [CHANGE] Ruler: set new default limits for rule groups: `ruler.max_rules_per_rule_group` to 20 (previously 0, disabled) and `ruler.max_rule_groups_per_tenant` to 70 (previously 0, disabled). #847
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2578,11 +2578,11 @@ The `limits_config` configures default and per-tenant limits imposed by services
 
 # Maximum number of rules per rule group per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rules-per-rule-group
-[ruler_max_rules_per_rule_group: <int> | default = 0]
+[ruler_max_rules_per_rule_group: <int> | default = 20]
 
 # Maximum number of rule groups per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rule-groups-per-tenant
-[ruler_max_rule_groups_per_tenant: <int> | default = 0]
+[ruler_max_rule_groups_per_tenant: <int> | default = 70]
 
 # The tenant's shard size when the shuffle-sharding strategy is used. Must be
 # set when the store-gateway sharding is enabled with the shuffle-sharding

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -372,6 +372,8 @@ func TestRulerSharding(t *testing.T) {
 			"-querier.store-gateway-addresses": "localhost:12345",
 			// Enable the bucket index so we can skip the initial bucket scan.
 			"-blocks-storage.bucket-store.bucket-index.enabled": "true",
+			// Disable rule group limit
+			"-ruler.max-rule-groups-per-tenant": "0",
 		},
 	)
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -156,8 +156,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.Var(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The tenant's shard size when the shuffle-sharding strategy is used by ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
-	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 0, "Maximum number of rules per rule group per-tenant. 0 to disable.")
-	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
+	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 20, "Maximum number of rules per rule group per-tenant. 0 to disable.")
+	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 70, "Maximum number of rule groups per-tenant. 0 to disable.")
 
 	f.Var(&l.CompactorBlocksRetentionPeriod, "compactor.blocks-retention-period", "Delete blocks containing samples older than the specified retention period. 0 to disable.")
 	f.IntVar(&l.CompactorSplitAndMergeShards, "compactor.split-and-merge-shards", 0, "The number of shards to use when splitting blocks. This config option is used only when split-and-merge compaction strategy is in use. 0 to disable splitting but keep using the split-and-merge compaction strategy.")


### PR DESCRIPTION
**What this PR does**:

Previously the default for both of these limits was 0, which disabled them. It is usually recommended to set limits then gradually increase them as needed, so it would be nice to set some defaults

These changes:
- Default `-ruler.max_rules_per_rule_group` to 20 (previously 0).
- Default `-ruler.max_rule_groups_per_tenant` to 70 (previously 0).

These values were chosen as they were the ones ultimately recommended to customers in the latest configuration audit.

For reference, the current publicly recommended GEM limits can be found here:
https://grafana.com/docs/metrics-enterprise/latest/setup/limits/#ruler-max-rules-per-rule-group

`-ruler_max_rules_per_rule_group` set to 20 is the same as that recommendation.
`-ruler_max_rule_groups_per_tenant` is not the same, and is 70 here instead of 10.

From my recollection, these values weren't scientifically chosen and were more of a best guess at what a reasonable value would be that didn't impede users initially, but offered them some assurance.

**Which issue(s) this PR fixes**:

N/A (Mimir launch prep)

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
