### PR TITLE
Allow passing multiple arguments to MIMIR_EXTRA_ARGS

### DIFF
--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -31,20 +31,20 @@ func GetDefaultImage() string {
 }
 
 // GetExtraArgs returns the extra args to pass to the Docker command used to run Mimir.
-func GetExtraArgs() string {
+func GetExtraArgs() []string {
 	// Get extra args from the MIMIR_EXTRA_ARGS env variable
 	// falling back to an empty list
 	if os.Getenv("MIMIR_EXTRA_ARGS") != "" {
-		return os.Getenv("MIMIR_EXTRA_ARGS")
+		return strings.Fields(os.Getenv("MIMIR_EXTRA_ARGS"))
 	}
 
-	return ""
+	return nil
 }
 
 func buildArgsWithExtra(args []string) []string {
 	extraArgs := GetExtraArgs()
 	if len(extraArgs) > 0 {
-		return append([]string{extraArgs}, args...)
+		return append(extraArgs, args...)
 	}
 
 	return args


### PR DESCRIPTION
**What this PR does**:

This PR allows setting multiple flags in the e2e tests via MIMIR_EXTRA_ARGS.
This was the original intent of that variable, but in its current form, the arguments are not correctly split before being used.

**Which issue(s) this PR fixes**:

**Checklist**

- [N/A] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
