### PR TITLE
Amend CHANGELOG for changes in 821

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
     * `-frontend.memcached.timeout` renamed to `-frontend.results-cache.memcached.timeout`
     * `-frontend.memcached.max-item-size` renamed to `-frontend.results-cache.memcached.max-item-size`
     * `-frontend.memcached.max-idle-conns` renamed to `-frontend.results-cache.memcached.max-idle-connections`
+    * `-frontend.compression` renamed to `-frontend.results-cache.compression`
   * The following CLI flags (and their respective YAML config options) have been removed:
     * `-frontend.memcached.circuit-breaker-consecutive-failures`: feature removed
     * `-frontend.memcached.circuit-breaker-timeout`: feature removed


### PR DESCRIPTION
**What this PR does**:
While testing changes in #821, I've realized the CHANGELOG doesn't mention the rename of `-frontend.compression`. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
