### PR TITLE
Disable gzip encoding in e2e tests querier client

### DIFF
--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -56,10 +56,15 @@ func NewClient(
 	rulerAddress string,
 	orgID string,
 ) (*Client, error) {
+	// Disable compression in querier client so it's easier to debug issue looking at the HTTP responses
+	// logged by the querier.
+	querierTransport := http.DefaultTransport.(*http.Transport).Clone()
+	querierTransport.DisableCompression = true
+
 	// Create querier API client
 	querierAPIClient, err := promapi.NewClient(promapi.Config{
 		Address:      "http://" + querierAddress + "/api/prom",
-		RoundTripper: &addOrgIDRoundTripper{orgID: orgID, next: http.DefaultTransport},
+		RoundTripper: &addOrgIDRoundTripper{orgID: orgID, next: querierTransport},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does**:
I was looking at https://github.com/grafana/mimir/issues/861 but we can't easily why the querier returned 500 considering the logged response is the gzipped one:

```
13:35:14 querier: level=warn ts=2022-01-24T13:35:14.195961768Z caller=logging.go:72 traceID=28c5d234e6835c86 msg="POST /api/prom/api/v1/query (500) 4.621262ms Response: \"\\x1f\\x8b\\b\\x00\\x00\\x00\\x00\\x00\\x00\\xff<\\x8e\\xc1j\\xf30\\x10\\x84_e\\xd091\\xb6\\xf9#c\\xddB\\xc0\\xfc\\x14z)9\\xf4\\xba\\xb56\\xb6\\xa8X\\xb9ҚԔ\\xbe{1%=\\r\\f\\xdf\\fߗ)J\\xba\\x16\\xe3\\f眲9\\xfc\\xe6u[\\xd88\\x13D9\\v\\xc5G\\xbdc\\x9f\\v\\x89\\x0f2\\xa1p\\x0e\\\\\\x1cn\\x14\\\"{h\\xc2Ċ\\xa2)\\xf3q\\\"\\xe5;mȼ\\xc40\\x92\\x86$(\\xacHw٧:3\\xdeb\\x1a\\xdfQ7\\xc3\\xd5\\xfe{\\xb9\\xbc\\xb6]\\xf7t\\xb6\\xfd\\xff\\xc1\\xf6\\x17;\\x9c\\x9fk\\aRD\\xa6\\xa2h03E\\x9d\\xff\\xfe\\x90\\xf9c\\r\\x99\\xfd\\x01cZ\\xa3G\\x92\\xb8\\xe1\\x16ģ\\xc6\\x11\\xab<\\xf8 EI\\xc6]\\xb3\\xe9ڪ=Uue]_\\xf7'\\xf3\\xfd\\x03\\x00\\x00\\xff\\xff\\x01\\x00\\x00\\xff\\xff~vb9\\xfc\\x00\\x00\\x00\" ws: false; Accept-Encoding: gzip; Content-Length: 37; Content-Type: application/x-www-form-urlencoded; User-Agent: Go-http-client/1.1; X-Scope-Orgid: user-1; "
```

I tried to decode it with no success. To simplify debugging in e2e tests I propose to disable gzip encoding in the querier client used by e2e tests.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
