### PR TITLE
Remove more cortex references from mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,8 @@
 * [CHANGE] Raised `CortexKVStoreFailure` alert severity from warning to critical. #493
 * [CHANGE] Increase `CortexRolloutStuck` alert "for" duration from 15m to 30m. #493 #573
 * [CHANGE] The Alertmanager and Ruler compiled dashboards (`alertmanager.json` and `ruler.json`) have been respectively renamed to `mimir-alertmanager.json` and `mimir-ruler.json`. #869
+* [CHANGE] Removed `cortex_overrides_metric` from `_config`. #871
+* [CHANGE] Renamed recording rule groups (`cortex_` prefix changed to `mimir_`). #871
 * [FEATURE] Added `Cortex / Overrides` dashboard, displaying default limits and per-tenant overrides applied to Mimir. #673
 * [FEATURE] Added `Mimir / Tenants` and `Mimir / Top tenants` dashboards, displaying user-based metrics. #776
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. [#317](https://github.com/grafana/cortex-jsonnet/pull/317)

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: CortexIngesterUnhealthy
     annotations:
-      message: Cortex cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
+      message: Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
     expr: |
       min by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
     for: 15m
@@ -35,7 +35,7 @@ groups:
   - alert: CortexQueriesIncorrect
     annotations:
       message: |
-        The Cortex cluster {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% incorrect query results.
+        The Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% incorrect query results.
     expr: |
       100 * sum by (cluster, namespace) (rate(test_exporter_test_case_result_total{result="fail"}[5m]))
         /
@@ -83,7 +83,7 @@ groups:
   - alert: CortexMemcachedRequestErrors
     annotations:
       message: |
-        Memcached {{ $labels.name }} used by Cortex {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
+        Memcached {{ $labels.name }} used by Mimir {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
     expr: |
       (
         sum by(cluster, namespace, name, operation) (rate(thanos_memcached_operation_failures_total[1m])) /
@@ -102,7 +102,7 @@ groups:
   - alert: CortexKVStoreFailure
     annotations:
       message: |
-        Cortex {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
+        Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
     expr: |
       (
         sum by(cluster, namespace, pod, status_code, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.+"}[1m]))
@@ -179,7 +179,7 @@ groups:
   - alert: CortexReachingTCPConnectionsLimit
     annotations:
       message: |
-        Cortex instance {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
+        Mimir instance {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
     expr: |
       cortex_tcp_connections / cortex_tcp_connections_limit > 0.8 and
       cortex_tcp_connections_limit > 0
@@ -296,7 +296,7 @@ groups:
   - alert: CortexRulerTooManyFailedPushes
     annotations:
       message: |
-        Cortex Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
+        Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
     expr: |
       100 * (
       sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total[1m]))
@@ -309,7 +309,7 @@ groups:
   - alert: CortexRulerTooManyFailedQueries
     annotations:
       message: |
-        Cortex Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
+        Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
     expr: |
       100 * (
       sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total[1m]))
@@ -322,7 +322,7 @@ groups:
   - alert: CortexRulerMissedEvaluations
     annotations:
       message: |
-        Cortex Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+        Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
     expr: |
       sum by (cluster, namespace, instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
         /
@@ -334,7 +334,7 @@ groups:
   - alert: CortexRulerFailedRingCheck
     annotations:
       message: |
-        Cortex Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
+        Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
     expr: |
       sum by (cluster, namespace, job) (rate(cortex_ruler_ring_check_errors_total[1m]))
          > 0
@@ -345,7 +345,7 @@ groups:
   rules:
   - alert: CortexGossipMembersMismatch
     annotations:
-      message: Cortex instance {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} sees incorrect number of gossip members.
+      message: Mimir instance {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} sees incorrect number of gossip members.
     expr: |
       memberlist_client_cluster_members_count
         != on (cluster, namespace) group_left
@@ -386,7 +386,7 @@ groups:
   - alert: CortexAlertmanagerSyncConfigsFailing
     annotations:
       message: |
-        Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to read tenant configurations from storage.
+        Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to read tenant configurations from storage.
     expr: |
       rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0
     for: 30m
@@ -395,7 +395,7 @@ groups:
   - alert: CortexAlertmanagerRingCheckFailing
     annotations:
       message: |
-        Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to check tenants ownership via the ring.
+        Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to check tenants ownership via the ring.
     expr: |
       rate(cortex_alertmanager_ring_check_errors_total[2m]) > 0
     for: 10m
@@ -404,7 +404,7 @@ groups:
   - alert: CortexAlertmanagerPartialStateMergeFailing
     annotations:
       message: |
-        Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to merge partial state changes received from a replica.
+        Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to merge partial state changes received from a replica.
     expr: |
       rate(cortex_alertmanager_partial_state_merges_failed_total[2m]) > 0
     for: 10m
@@ -413,7 +413,7 @@ groups:
   - alert: CortexAlertmanagerReplicationFailing
     annotations:
       message: |
-        Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to replicating partial state to its replicas.
+        Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to replicating partial state to its replicas.
     expr: |
       rate(cortex_alertmanager_state_replication_failed_total[2m]) > 0
     for: 10m
@@ -422,7 +422,7 @@ groups:
   - alert: CortexAlertmanagerPersistStateFailing
     annotations:
       message: |
-        Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to persist full state snaphots to remote storage.
+        Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to persist full state snaphots to remote storage.
     expr: |
       rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0
     for: 1h
@@ -431,7 +431,7 @@ groups:
   - alert: CortexAlertmanagerInitialSyncFailed
     annotations:
       message: |
-        Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} was unable to obtain some initial state when starting up.
+        Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} was unable to obtain some initial state when starting up.
     expr: |
       increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[1m]) > 0
     labels:
@@ -440,7 +440,7 @@ groups:
   rules:
   - alert: CortexIngesterHasNotShippedBlocks
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
     expr: |
       (min by(cluster, namespace, instance) (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester.*"}) > 60 * 60 * 4)
       and
@@ -459,7 +459,7 @@ groups:
       severity: critical
   - alert: CortexIngesterHasNotShippedBlocksSinceStart
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
     expr: |
       (max by(cluster, namespace, instance) (thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester.*"}) == 0)
       and
@@ -469,7 +469,7 @@ groups:
       severity: critical
   - alert: CortexIngesterHasUnshippedBlocks
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
     expr: |
       (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
       and
@@ -479,7 +479,7 @@ groups:
       severity: critical
   - alert: CortexIngesterTSDBHeadCompactionFailed
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
     expr: |
       rate(cortex_ingester_tsdb_compactions_failed_total[5m]) > 0
     for: 15m
@@ -487,42 +487,42 @@ groups:
       severity: critical
   - alert: CortexIngesterTSDBHeadTruncationFailed
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
     expr: |
       rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
     labels:
       severity: critical
   - alert: CortexIngesterTSDBCheckpointCreationFailed
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
     expr: |
       rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
     labels:
       severity: critical
   - alert: CortexIngesterTSDBCheckpointDeletionFailed
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
     expr: |
       rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
     labels:
       severity: critical
   - alert: CortexIngesterTSDBWALTruncationFailed
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
     expr: |
       rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
     labels:
       severity: warning
   - alert: CortexIngesterTSDBWALCorrupted
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
     expr: |
       rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
     labels:
       severity: critical
   - alert: CortexIngesterTSDBWALWritesFailed
     annotations:
-      message: Cortex Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
     expr: |
       rate(cortex_ingester_tsdb_wal_writes_failed_total[1m]) > 0
     for: 3m
@@ -530,7 +530,7 @@ groups:
       severity: critical
   - alert: CortexQuerierHasNotScanTheBucket
     annotations:
-      message: Cortex Querier {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully scanned the bucket since {{ $value | humanizeDuration }}.
+      message: Mimir Querier {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully scanned the bucket since {{ $value | humanizeDuration }}.
     expr: |
       (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds > 60 * 30)
       and
@@ -540,7 +540,7 @@ groups:
       severity: critical
   - alert: CortexQuerierHighRefetchRate
     annotations:
-      message: Cortex Queries in {{ $labels.cluster }}/{{ $labels.namespace }} are refetching series from different store-gateways (because of missing blocks) for the {{ printf "%.0f" $value }}% of queries.
+      message: Mimir Queries in {{ $labels.cluster }}/{{ $labels.namespace }} are refetching series from different store-gateways (because of missing blocks) for the {{ printf "%.0f" $value }}% of queries.
     expr: |
       100 * (
         (
@@ -557,7 +557,7 @@ groups:
       severity: warning
   - alert: CortexStoreGatewayHasNotSyncTheBucket
     annotations:
-      message: Cortex Store Gateway {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
+      message: Mimir Store Gateway {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
     expr: |
       (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
       and
@@ -567,14 +567,14 @@ groups:
       severity: critical
   - alert: CortexBucketIndexNotUpdated
     annotations:
-      message: Cortex bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
+      message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
     expr: |
       min by(cluster, namespace, user) (time() - cortex_bucket_index_last_successful_update_timestamp_seconds) > 7200
     labels:
       severity: critical
   - alert: CortexTenantHasPartialBlocks
     annotations:
-      message: Cortex tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has {{ $value }} partial blocks.
+      message: Mimir tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has {{ $value }} partial blocks.
     expr: |
       max by(cluster, namespace, user) (cortex_bucket_blocks_partials_count) > 0
     for: 6h
@@ -584,7 +584,7 @@ groups:
   rules:
   - alert: CortexCompactorHasNotSuccessfullyCleanedUpBlocks
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
     expr: |
       (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 6)
     for: 1h
@@ -592,7 +592,7 @@ groups:
       severity: critical
   - alert: CortexCompactorHasNotSuccessfullyRunCompaction
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
     expr: |
       (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
       and
@@ -602,7 +602,7 @@ groups:
       severity: critical
   - alert: CortexCompactorHasNotSuccessfullyRunCompaction
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
     expr: |
       cortex_compactor_last_successful_run_timestamp_seconds == 0
     for: 24h
@@ -610,14 +610,14 @@ groups:
       severity: critical
   - alert: CortexCompactorHasNotSuccessfullyRunCompaction
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
     expr: |
       increase(cortex_compactor_runs_failed_total[2h]) >= 2
     labels:
       severity: critical
   - alert: CortexCompactorHasNotUploadedBlocks
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
     expr: |
       (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 60 * 60 * 24)
       and
@@ -627,7 +627,7 @@ groups:
       severity: critical
   - alert: CortexCompactorHasNotUploadedBlocks
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
     expr: |
       thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} == 0
     for: 24h
@@ -635,7 +635,7 @@ groups:
       severity: critical
   - alert: CortexCompactorSkippedBlocksWithOutOfOrderChunks
     annotations:
-      message: Cortex Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored blocks with out of order chunks.
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored blocks with out of order chunks.
     expr: |
       increase(cortex_compactor_blocks_marked_for_no_compaction_total{job=~".+/compactor.*", reason="block-index-out-of-order-chunk"}[5m]) > 0
     for: 1m

--- a/operations/mimir-mixin-compiled/rules.yaml
+++ b/operations/mimir-mixin-compiled/rules.yaml
@@ -1,5 +1,5 @@
 groups:
-- name: cortex_api_1
+- name: mimir_api_1
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster, job))
     record: cluster_job:cortex_request_duration_seconds:99quantile
@@ -13,7 +13,7 @@ groups:
     record: cluster_job:cortex_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster, job)
     record: cluster_job:cortex_request_duration_seconds_count:sum_rate
-- name: cortex_api_2
+- name: mimir_api_2
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
     record: cluster_job_route:cortex_request_duration_seconds:99quantile
@@ -27,7 +27,7 @@ groups:
     record: cluster_job_route:cortex_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster, job, route)
     record: cluster_job_route:cortex_request_duration_seconds_count:sum_rate
-- name: cortex_api_3
+- name: mimir_api_3
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route))
     record: cluster_namespace_job_route:cortex_request_duration_seconds:99quantile
@@ -41,7 +41,7 @@ groups:
     record: cluster_namespace_job_route:cortex_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster, namespace, job, route)
     record: cluster_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
-- name: cortex_querier_api
+- name: mimir_querier_api
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job))
     record: cluster_job:cortex_querier_request_duration_seconds:99quantile
@@ -79,7 +79,7 @@ groups:
     record: cluster_namespace_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster, namespace, job, route)
     record: cluster_namespace_job_route:cortex_querier_request_duration_seconds_count:sum_rate
-- name: cortex_cache
+- name: mimir_cache
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket[1m])) by (le, cluster, job, method))
     record: cluster_job_method:cortex_memcache_request_duration_seconds:99quantile
@@ -117,7 +117,7 @@ groups:
     record: cluster_job_method:cortex_cache_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(cortex_cache_request_duration_seconds_count[1m])) by (cluster, job, method)
     record: cluster_job_method:cortex_cache_request_duration_seconds_count:sum_rate
-- name: cortex_storage
+- name: mimir_storage
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster, job))
     record: cluster_job:cortex_kv_request_duration_seconds:99quantile
@@ -131,7 +131,7 @@ groups:
     record: cluster_job:cortex_kv_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster, job)
     record: cluster_job:cortex_kv_request_duration_seconds_count:sum_rate
-- name: cortex_queries
+- name: mimir_queries
   rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster, job))
     record: cluster_job:cortex_query_frontend_retries:99quantile
@@ -193,32 +193,32 @@ groups:
     record: cluster_job:cortex_ingester_queried_exemplars_sum:sum_rate
   - expr: sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster, job)
     record: cluster_job:cortex_ingester_queried_exemplars_count:sum_rate
-- name: cortex_received_samples
+- name: mimir_received_samples
   rules:
   - expr: |
       sum by (cluster, namespace, job) (rate(cortex_distributor_received_samples_total[5m]))
     record: cluster_namespace_job:cortex_distributor_received_samples:rate5m
-- name: cortex_exemplars_in
+- name: mimir_exemplars_in
   rules:
   - expr: |
       sum by (cluster, namespace, job) (rate(cortex_distributor_exemplars_in_total[5m]))
     record: cluster_namespace_job:cortex_distributor_exemplars_in:rate5m
-- name: cortex_received_exemplars
+- name: mimir_received_exemplars
   rules:
   - expr: |
       sum by (cluster, namespace, job) (rate(cortex_distributor_received_exemplars_total[5m]))
     record: cluster_namespace_job:cortex_distributor_received_exemplars:rate5m
-- name: cortex_exemplars_ingested
+- name: mimir_exemplars_ingested
   rules:
   - expr: |
       sum by (cluster, namespace, job) (rate(cortex_ingester_ingested_exemplars_total[5m]))
     record: cluster_namespace_job:cortex_ingester_ingested_exemplars:rate5m
-- name: cortex_exemplars_appended
+- name: mimir_exemplars_appended
   rules:
   - expr: |
       sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total[5m]))
     record: cluster_namespace_job:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m
-- name: cortex_scaling_rules
+- name: mimir_scaling_rules
   rules:
   - expr: |
       sum by (cluster, namespace, deployment) (
@@ -438,7 +438,7 @@ groups:
     labels:
       reason: memory_usage
     record: cluster_namespace_deployment_reason:required_replicas:count
-- name: cortex_alertmanager_rules
+- name: mimir_alertmanager_rules
   rules:
   - expr: |
       sum by (cluster, job, pod) (cortex_alertmanager_alerts)

--- a/operations/mimir-mixin/alerts/alertmanager.libsonnet
+++ b/operations/mimir-mixin/alerts/alertmanager.libsonnet
@@ -14,8 +14,8 @@
           },
           annotations: {
             message: |||
-              Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to read tenant configurations from storage.
-            |||,
+              %(product)s Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to read tenant configurations from storage.
+            ||| % $._config,
           },
         },
         {
@@ -29,8 +29,8 @@
           },
           annotations: {
             message: |||
-              Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to check tenants ownership via the ring.
-            |||,
+              %(product)s Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to check tenants ownership via the ring.
+            ||| % $._config,
           },
         },
         {
@@ -44,8 +44,8 @@
           },
           annotations: {
             message: |||
-              Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to merge partial state changes received from a replica.
-            |||,
+              %(product)s Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to merge partial state changes received from a replica.
+            ||| % $._config,
           },
         },
         {
@@ -59,8 +59,8 @@
           },
           annotations: {
             message: |||
-              Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to replicating partial state to its replicas.
-            |||,
+              %(product)s Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to replicating partial state to its replicas.
+            ||| % $._config,
           },
         },
         {
@@ -74,8 +74,8 @@
           },
           annotations: {
             message: |||
-              Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to persist full state snaphots to remote storage.
-            |||,
+              %(product)s Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to persist full state snaphots to remote storage.
+            ||| % $._config,
           },
         },
         {
@@ -88,8 +88,8 @@
           },
           annotations: {
             message: |||
-              Cortex Alertmanager {{ $labels.job }}/{{ $labels.instance }} was unable to obtain some initial state when starting up.
-            |||,
+              %(product)s Alertmanager {{ $labels.job }}/{{ $labels.instance }} was unable to obtain some initial state when starting up.
+            ||| % $._config,
           },
         },
       ],

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -24,7 +24,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex cluster %(alert_aggregation_variables)s has {{ printf "%%f" $value }} unhealthy ingester(s).' % $._config,
+            message: '%(product)s cluster %(alert_aggregation_variables)s has {{ printf "%%f" $value }} unhealthy ingester(s).' % $._config,
           },
         },
         {
@@ -88,7 +88,7 @@
           },
           annotations: {
             message: |||
-              The Cortex cluster %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% incorrect query results.
+              The %(product)s cluster %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% incorrect query results.
             ||| % $._config,
           },
         },
@@ -168,7 +168,7 @@
           },
           annotations: {
             message: |||
-              Memcached {{ $labels.name }} used by Cortex %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% errors for {{ $labels.operation }} operation.
+              Memcached {{ $labels.name }} used by %(product)s %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% errors for {{ $labels.operation }} operation.
             ||| % $._config,
           },
         },
@@ -204,7 +204,7 @@
           },
           annotations: {
             message: |||
-              Cortex {{ $labels.pod }} in  %(alert_aggregation_variables)s is failing to talk to the KV store {{ $labels.kv_name }}.
+              %(product)s {{ $labels.pod }} in  %(alert_aggregation_variables)s is failing to talk to the KV store {{ $labels.kv_name }}.
             ||| % $._config,
           },
         },
@@ -314,8 +314,8 @@
           },
           annotations: {
             message: |||
-              Cortex instance {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
-            |||,
+              %(product)s instance {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
+            ||| % $._config,
           },
         },
         {
@@ -416,7 +416,7 @@
         {
           alert: 'CortexProvisioningTooManyActiveSeries',
           // We target each ingester to 1.5M in-memory series. This alert fires if the average
-          // number of series / ingester in a Cortex cluster is > 1.6M for 2h (we compact
+          // number of series / ingester in a Mimir cluster is > 1.6M for 2h (we compact
           // the TSDB head every 2h).
           expr: |||
             avg by (%s) (cortex_ingester_memory_series) > 1.6e6
@@ -505,7 +505,7 @@
           },
           annotations: {
             message: |||
-              Cortex Ruler {{ $labels.instance }} in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% write (push) errors.
+              %(product)s Ruler {{ $labels.instance }} in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% write (push) errors.
             ||| % $._config,
           },
         },
@@ -524,7 +524,7 @@
           },
           annotations: {
             message: |||
-              Cortex Ruler {{ $labels.instance }} in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% errors while evaluating rules.
+              %(product)s Ruler {{ $labels.instance }} in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% errors while evaluating rules.
             ||| % $._config,
           },
         },
@@ -542,7 +542,7 @@
           },
           annotations: {
             message: |||
-              Cortex Ruler {{ $labels.instance }} in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% missed iterations for the rule group {{ $labels.rule_group }}.
+              %(product)s Ruler {{ $labels.instance }} in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% missed iterations for the rule group {{ $labels.rule_group }}.
             ||| % $._config,
           },
         },
@@ -558,7 +558,7 @@
           },
           annotations: {
             message: |||
-              Cortex Rulers in %(alert_aggregation_variables)s are experiencing errors when checking the ring for rule group ownership.
+              %(product)s Rulers in %(alert_aggregation_variables)s are experiencing errors when checking the ring for rule group ownership.
             ||| % $._config,
           },
         },
@@ -580,7 +580,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: 'Cortex instance {{ $labels.instance }} in %(alert_aggregation_variables)s sees incorrect number of gossip members.' % $._config,
+            message: '%(product)s instance {{ $labels.instance }} in %(alert_aggregation_variables)s sees incorrect number of gossip members.' % $._config,
           },
         },
       ],

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -26,7 +26,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s has not shipped any block in the last 4 hours.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s has not shipped any block in the last 4 hours.' % $._config,
           },
         },
         {
@@ -43,7 +43,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s has not shipped any block in the last 4 hours.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s has not shipped any block in the last 4 hours.' % $._config,
           },
         },
         {
@@ -61,7 +61,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: "Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet." % $._config,
+            message: "%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet." % $._config,
           },
         },
         {
@@ -77,7 +77,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to compact TSDB head.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to compact TSDB head.' % $._config,
           },
         },
         {
@@ -89,7 +89,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to truncate TSDB head.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to truncate TSDB head.' % $._config,
           },
         },
         {
@@ -101,7 +101,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to create TSDB checkpoint.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to create TSDB checkpoint.' % $._config,
           },
         },
         {
@@ -113,7 +113,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to delete TSDB checkpoint.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to delete TSDB checkpoint.' % $._config,
           },
         },
         {
@@ -125,7 +125,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to truncate TSDB WAL.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to truncate TSDB WAL.' % $._config,
           },
         },
         {
@@ -137,7 +137,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s got a corrupted TSDB WAL.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s got a corrupted TSDB WAL.' % $._config,
           },
         },
         {
@@ -150,7 +150,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to write to TSDB WAL.' % $._config,
+            message: '%(product)s Ingester {{ $labels.instance }} in %(alert_aggregation_variables)s is failing to write to TSDB WAL.' % $._config,
           },
         },
         {
@@ -166,7 +166,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Querier {{ $labels.instance }} in %(alert_aggregation_variables)s has not successfully scanned the bucket since {{ $value | humanizeDuration }}.' % $._config,
+            message: '%(product)s Querier {{ $labels.instance }} in %(alert_aggregation_variables)s has not successfully scanned the bucket since {{ $value | humanizeDuration }}.' % $._config,
           },
         },
         {
@@ -190,7 +190,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: 'Cortex Queries in %(alert_aggregation_variables)s are refetching series from different store-gateways (because of missing blocks) for the {{ printf "%%.0f" $value }}%% of queries.' % $._config,
+            message: '%(product)s Queries in %(alert_aggregation_variables)s are refetching series from different store-gateways (because of missing blocks) for the {{ printf "%%.0f" $value }}%% of queries.' % $._config,
           },
         },
         {
@@ -206,7 +206,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Store Gateway {{ $labels.instance }} in %(alert_aggregation_variables)s has not successfully synched the bucket since {{ $value | humanizeDuration }}.' % $._config,
+            message: '%(product)s Store Gateway {{ $labels.instance }} in %(alert_aggregation_variables)s has not successfully synched the bucket since {{ $value | humanizeDuration }}.' % $._config,
           },
         },
         {
@@ -219,7 +219,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex bucket index for tenant {{ $labels.user }} in %(alert_aggregation_variables)s has not been updated since {{ $value | humanizeDuration }}.' % $._config,
+            message: '%(product)s bucket index for tenant {{ $labels.user }} in %(alert_aggregation_variables)s has not been updated since {{ $value | humanizeDuration }}.' % $._config,
           },
         },
         {
@@ -233,7 +233,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: 'Cortex tenant {{ $labels.user }} in %(alert_aggregation_variables)s has {{ $value }} partial blocks.' % $._config,
+            message: '%(product)s tenant {{ $labels.user }} in %(alert_aggregation_variables)s has {{ $value }} partial blocks.' % $._config,
           },
         },
       ],

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -14,7 +14,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not successfully cleaned up blocks in the last 6 hours.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not successfully cleaned up blocks in the last 6 hours.' % $._config,
           },
         },
         {
@@ -30,7 +30,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
           },
         },
         {
@@ -44,7 +44,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
           },
         },
         {
@@ -57,7 +57,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s failed to run 2 consecutive compactions.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s failed to run 2 consecutive compactions.' % $._config,
           },
         },
         {
@@ -73,7 +73,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not uploaded any block in the last 24 hours.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not uploaded any block in the last 24 hours.' % $._config,
           },
         },
         {
@@ -87,7 +87,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not uploaded any block in the last 24 hours.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has not uploaded any block in the last 24 hours.' % $._config,
           },
         },
         {
@@ -101,7 +101,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has found and ignored blocks with out of order chunks.' % $._config,
+            message: '%(product)s Compactor {{ $labels.instance }} in %(alert_aggregation_variables)s has found and ignored blocks with out of order chunks.' % $._config,
           },
         },
       ],

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -14,7 +14,7 @@
     singleBinary: false,
 
     // These are used by the dashboards and allow for the simultaneous display of
-    // microservice and single binary cortex clusters.
+    // microservice and single binary Mimir clusters.
     job_names: {
       ingester: '(ingester.*|cortex$)',  // Match also custom and per-zone ingester deployments.
       distributor: '(distributor|cortex$)',

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -669,7 +669,7 @@ How to **investigate**:
   - `memberlist_tcp_transport_packets_sent_errors_total`
   - `memberlist_tcp_transport_packets_received_errors_total`
   - These errors (and others) can be found by searching for messages prefixed with `TCPTransport:`.
-- Logs coming directly from memberlist are also logged by Cortex; they may indicate where to investigate further. These can be identified as such due to being tagged with `caller=memberlist_logger.go:xyz`.
+- Logs coming directly from memberlist are also logged by Mimir; they may indicate where to investigate further. These can be identified as such due to being tagged with `caller=memberlist_logger.go:xyz`.
 
 ### EtcdAllocatingTooMuchMemory
 
@@ -889,7 +889,7 @@ The blocks retained in the ingesters can be used in case the compactor generates
 
 How to manually blocks from ingesters to the bucket:
 
-1. Ensure [`gsutil`](https://cloud.google.com/storage/docs/gsutil) is installed in the Mimir pod. If not, [install it](#install-gsutil-in-the-cortex-pod)
+1. Ensure [`gsutil`](https://cloud.google.com/storage/docs/gsutil) is installed in the Mimir pod. If not, [install it](#install-gsutil-in-the-mimir-pod)
 2. Run `cd /data/tsdb && /path/to/gsutil -m rsync -n -r -x 'thanos.shipper.json|chunks_head|wal' . gs://<bucket>/recovered/`
    - `-n` enabled the **dry run** (remove it once you've verified the output matches your expectations)
    - `-m` enables parallel mode

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -6,46 +6,45 @@ local utils = import 'mixin-utils/utils.libsonnet';
     max_samples_per_sec_per_ingester: 80e3,
     max_samples_per_sec_per_distributor: 240e3,
     limit_utilisation_target: 0.6,
-    cortex_overrides_metric: 'cortex_limits_overrides',
   } + $._config + $._group_config,
   prometheusRules+:: {
     groups+: [
       {
-        name: 'cortex_api_1',
+        name: 'mimir_api_1',
         rules:
           utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'job']),
       },
       {
-        name: 'cortex_api_2',
+        name: 'mimir_api_2',
         rules:
           utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'job', 'route']),
       },
       {
-        name: 'cortex_api_3',
+        name: 'mimir_api_3',
         rules:
           utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'namespace', 'job', 'route']),
       },
       {
-        name: 'cortex_querier_api',
+        name: 'mimir_querier_api',
         rules:
           utils.histogramRules('cortex_querier_request_duration_seconds', ['cluster', 'job']) +
           utils.histogramRules('cortex_querier_request_duration_seconds', ['cluster', 'job', 'route']) +
           utils.histogramRules('cortex_querier_request_duration_seconds', ['cluster', 'namespace', 'job', 'route']),
       },
       {
-        name: 'cortex_cache',
+        name: 'mimir_cache',
         rules:
           utils.histogramRules('cortex_memcache_request_duration_seconds', ['cluster', 'job', 'method']) +
           utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job']) +
           utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job', 'method']),
       },
       {
-        name: 'cortex_storage',
+        name: 'mimir_storage',
         rules:
           utils.histogramRules('cortex_kv_request_duration_seconds', ['cluster', 'job']),
       },
       {
-        name: 'cortex_queries',
+        name: 'mimir_queries',
         rules:
           utils.histogramRules('cortex_query_frontend_retries', ['cluster', 'job']) +
           utils.histogramRules('cortex_query_frontend_queue_duration_seconds', ['cluster', 'job']) +
@@ -54,7 +53,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           utils.histogramRules('cortex_ingester_queried_exemplars', ['cluster', 'job']),
       },
       {
-        name: 'cortex_received_samples',
+        name: 'mimir_received_samples',
         rules: [
           {
             record: '%(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m' % _config,
@@ -65,7 +64,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ],
       },
       {
-        name: 'cortex_exemplars_in',
+        name: 'mimir_exemplars_in',
         rules: [
           {
             record: '%(group_prefix_jobs)s:cortex_distributor_exemplars_in:rate5m' % _config,
@@ -76,7 +75,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ],
       },
       {
-        name: 'cortex_received_exemplars',
+        name: 'mimir_received_exemplars',
         rules: [
           {
             record: '%(group_prefix_jobs)s:cortex_distributor_received_exemplars:rate5m' % _config,
@@ -87,7 +86,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ],
       },
       {
-        name: 'cortex_exemplars_ingested',
+        name: 'mimir_exemplars_ingested',
         rules: [
           {
             record: '%(group_prefix_jobs)s:cortex_ingester_ingested_exemplars:rate5m' % _config,
@@ -98,7 +97,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ],
       },
       {
-        name: 'cortex_exemplars_appended',
+        name: 'mimir_exemplars_appended',
         rules: [
           {
             record: '%(group_prefix_jobs)s:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m' % _config,
@@ -109,7 +108,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ],
       },
       {
-        name: 'cortex_scaling_rules',
+        name: 'mimir_scaling_rules',
         rules: [
           {
             // Convenience rule to get the number of replicas for both a deployment and a statefulset.
@@ -158,7 +157,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
             expr: |||
               ceil(
-                sum by (cluster, namespace) (%(cortex_overrides_metric)s{limit_name="ingestion_rate"})
+                sum by (cluster, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
                 * %(limit_utilisation_target)s / %(max_samples_per_sec_per_distributor)s
               )
             ||| % _config,
@@ -210,7 +209,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
             expr: |||
               ceil(
-                sum by (cluster, namespace) (%(cortex_overrides_metric)s{limit_name="max_global_series_per_user"})
+                sum by (cluster, namespace) (cortex_limits_overrides{limit_name="max_global_series_per_user"})
                 * 3 * %(limit_utilisation_target)s / %(max_series_per_ingester)s
               )
             ||| % _config,
@@ -225,7 +224,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
             expr: |||
               ceil(
-                sum by (cluster, namespace) (%(cortex_overrides_metric)s{limit_name="ingestion_rate"})
+                sum by (cluster, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
                 * %(limit_utilisation_target)s / %(max_samples_per_sec_per_ingester)s
               )
             ||| % _config,
@@ -410,7 +409,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ],
       },
       {
-        name: 'cortex_alertmanager_rules',
+        name: 'mimir_alertmanager_rules',
         rules: [
           // Aggregations of per-user Alertmanager metrics used in dashboards.
           {


### PR DESCRIPTION
**What this PR does**:
In this PR I'm removing more cortex references from the mixin (excluding alert and metric names):
- Cleanup references from playbooks
- Cleanup references from recording rules
- Use the parametrized "product" in alert messages
- Remove `cortex_overrides_metric` config (was used during the migration to the "new" overrides exported)

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
