### PR TITLE
Change alerts name prefix from Cortex to Mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,7 @@
 * [CHANGE] The Alertmanager and Ruler compiled dashboards (`alertmanager.json` and `ruler.json`) have been respectively renamed to `mimir-alertmanager.json` and `mimir-ruler.json`. #869
 * [CHANGE] Removed `cortex_overrides_metric` from `_config`. #871
 * [CHANGE] Renamed recording rule groups (`cortex_` prefix changed to `mimir_`). #871
+* [CHANGE] Alerts name prefix has been changed from `Cortex` to `Mimir` (eg. alert `CortexIngesterUnhealthy` has been renamed to `MimirIngesterUnhealthy`). #879
 * [FEATURE] Added `Cortex / Overrides` dashboard, displaying default limits and per-tenant overrides applied to Mimir. #673
 * [FEATURE] Added `Mimir / Tenants` and `Mimir / Top tenants` dashboards, displaying user-based metrics. #776
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. [#317](https://github.com/grafana/cortex-jsonnet/pull/317)

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: cortex_alerts
   rules:
-  - alert: CortexIngesterUnhealthy
+  - alert: MimirIngesterUnhealthy
     annotations:
       message: Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
     expr: |
@@ -9,7 +9,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: CortexRequestErrors
+  - alert: MimirRequestErrors
     annotations:
       message: |
         The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
@@ -21,7 +21,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: CortexRequestLatency
+  - alert: MimirRequestLatency
     annotations:
       message: |
         {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
@@ -32,7 +32,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-  - alert: CortexQueriesIncorrect
+  - alert: MimirQueriesIncorrect
     annotations:
       message: |
         The Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% incorrect query results.
@@ -43,7 +43,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-  - alert: CortexInconsistentRuntimeConfig
+  - alert: MimirInconsistentRuntimeConfig
     annotations:
       message: |
         An inconsistent runtime config file is used across cluster {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -52,7 +52,7 @@ groups:
     for: 1h
     labels:
       severity: critical
-  - alert: CortexBadRuntimeConfig
+  - alert: MimirBadRuntimeConfig
     annotations:
       message: |
         {{ $labels.job }} failed to reload runtime config.
@@ -62,7 +62,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexFrontendQueriesStuck
+  - alert: MimirFrontendQueriesStuck
     annotations:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} query-frontend.
@@ -71,7 +71,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexSchedulerQueriesStuck
+  - alert: MimirSchedulerQueriesStuck
     annotations:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} query-scheduler.
@@ -80,7 +80,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexMemcachedRequestErrors
+  - alert: MimirMemcachedRequestErrors
     annotations:
       message: |
         Memcached {{ $labels.name }} used by Mimir {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
@@ -92,14 +92,14 @@ groups:
     for: 5m
     labels:
       severity: warning
-  - alert: CortexIngesterRestarts
+  - alert: MimirIngesterRestarts
     annotations:
       message: '{{ $labels.job }}/{{ $labels.instance }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.'
     expr: |
       changes(process_start_time_seconds{job=~".+(cortex|ingester.*)"}[30m]) >= 2
     labels:
       severity: warning
-  - alert: CortexKVStoreFailure
+  - alert: MimirKVStoreFailure
     annotations:
       message: |
         Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
@@ -114,7 +114,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexMemoryMapAreasTooHigh
+  - alert: MimirMemoryMapAreasTooHigh
     annotations:
       message: '{{ $labels.job }}/{{ $labels.instance }} has a number of mmap-ed areas close to the limit.'
     expr: |
@@ -124,7 +124,7 @@ groups:
       severity: critical
 - name: cortex_instance_limits_alerts
   rules:
-  - alert: CortexIngesterReachingSeriesLimit
+  - alert: MimirIngesterReachingSeriesLimit
     annotations:
       message: |
         Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its series limit.
@@ -137,7 +137,7 @@ groups:
     for: 3h
     labels:
       severity: warning
-  - alert: CortexIngesterReachingSeriesLimit
+  - alert: MimirIngesterReachingSeriesLimit
     annotations:
       message: |
         Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its series limit.
@@ -150,7 +150,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexIngesterReachingTenantsLimit
+  - alert: MimirIngesterReachingTenantsLimit
     annotations:
       message: |
         Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its tenant limit.
@@ -163,7 +163,7 @@ groups:
     for: 5m
     labels:
       severity: warning
-  - alert: CortexIngesterReachingTenantsLimit
+  - alert: MimirIngesterReachingTenantsLimit
     annotations:
       message: |
         Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its tenant limit.
@@ -176,7 +176,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexReachingTCPConnectionsLimit
+  - alert: MimirReachingTCPConnectionsLimit
     annotations:
       message: |
         Mimir instance {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
@@ -186,7 +186,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexDistributorReachingInflightPushRequestLimit
+  - alert: MimirDistributorReachingInflightPushRequestLimit
     annotations:
       message: |
         Distributor {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
@@ -199,9 +199,9 @@ groups:
     for: 5m
     labels:
       severity: critical
-- name: cortex-rollout-alerts
+- name: mimir-rollout-alerts
   rules:
-  - alert: CortexRolloutStuck
+  - alert: MimirRolloutStuck
     annotations:
       message: |
         The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -227,7 +227,7 @@ groups:
     for: 30m
     labels:
       severity: warning
-  - alert: CortexRolloutStuck
+  - alert: MimirRolloutStuck
     annotations:
       message: |
         The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -245,9 +245,9 @@ groups:
     for: 30m
     labels:
       severity: warning
-- name: cortex-provisioning
+- name: mimir-provisioning
   rules:
-  - alert: CortexProvisioningTooManyActiveSeries
+  - alert: MimirProvisioningTooManyActiveSeries
     annotations:
       message: |
         The number of in-memory series per ingester in {{ $labels.cluster }}/{{ $labels.namespace }} is too high.
@@ -256,7 +256,7 @@ groups:
     for: 2h
     labels:
       severity: warning
-  - alert: CortexProvisioningTooManyWrites
+  - alert: MimirProvisioningTooManyWrites
     annotations:
       message: |
         Ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} ingest too many samples per second.
@@ -265,7 +265,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-  - alert: CortexAllocatingTooMuchMemory
+  - alert: MimirAllocatingTooMuchMemory
     annotations:
       message: |
         Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
@@ -278,7 +278,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-  - alert: CortexAllocatingTooMuchMemory
+  - alert: MimirAllocatingTooMuchMemory
     annotations:
       message: |
         Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
@@ -293,7 +293,7 @@ groups:
       severity: critical
 - name: ruler_alerts
   rules:
-  - alert: CortexRulerTooManyFailedPushes
+  - alert: MimirRulerTooManyFailedPushes
     annotations:
       message: |
         Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
@@ -306,7 +306,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexRulerTooManyFailedQueries
+  - alert: MimirRulerTooManyFailedQueries
     annotations:
       message: |
         Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
@@ -319,7 +319,7 @@ groups:
     for: 5m
     labels:
       severity: warning
-  - alert: CortexRulerMissedEvaluations
+  - alert: MimirRulerMissedEvaluations
     annotations:
       message: |
         Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
@@ -331,7 +331,7 @@ groups:
     for: 5m
     labels:
       severity: warning
-  - alert: CortexRulerFailedRingCheck
+  - alert: MimirRulerFailedRingCheck
     annotations:
       message: |
         Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
@@ -343,7 +343,7 @@ groups:
       severity: critical
 - name: gossip_alerts
   rules:
-  - alert: CortexGossipMembersMismatch
+  - alert: MimirGossipMembersMismatch
     annotations:
       message: Mimir instance {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} sees incorrect number of gossip members.
     expr: |
@@ -383,7 +383,7 @@ groups:
       severity: critical
 - name: alertmanager_alerts
   rules:
-  - alert: CortexAlertmanagerSyncConfigsFailing
+  - alert: MimirAlertmanagerSyncConfigsFailing
     annotations:
       message: |
         Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to read tenant configurations from storage.
@@ -392,7 +392,7 @@ groups:
     for: 30m
     labels:
       severity: critical
-  - alert: CortexAlertmanagerRingCheckFailing
+  - alert: MimirAlertmanagerRingCheckFailing
     annotations:
       message: |
         Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to check tenants ownership via the ring.
@@ -401,7 +401,7 @@ groups:
     for: 10m
     labels:
       severity: critical
-  - alert: CortexAlertmanagerPartialStateMergeFailing
+  - alert: MimirAlertmanagerPartialStateMergeFailing
     annotations:
       message: |
         Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to merge partial state changes received from a replica.
@@ -410,7 +410,7 @@ groups:
     for: 10m
     labels:
       severity: critical
-  - alert: CortexAlertmanagerReplicationFailing
+  - alert: MimirAlertmanagerReplicationFailing
     annotations:
       message: |
         Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to replicating partial state to its replicas.
@@ -419,7 +419,7 @@ groups:
     for: 10m
     labels:
       severity: critical
-  - alert: CortexAlertmanagerPersistStateFailing
+  - alert: MimirAlertmanagerPersistStateFailing
     annotations:
       message: |
         Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to persist full state snaphots to remote storage.
@@ -428,7 +428,7 @@ groups:
     for: 1h
     labels:
       severity: critical
-  - alert: CortexAlertmanagerInitialSyncFailed
+  - alert: MimirAlertmanagerInitialSyncFailed
     annotations:
       message: |
         Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} was unable to obtain some initial state when starting up.
@@ -438,7 +438,7 @@ groups:
       severity: critical
 - name: cortex_blocks_alerts
   rules:
-  - alert: CortexIngesterHasNotShippedBlocks
+  - alert: MimirIngesterHasNotShippedBlocks
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
     expr: |
@@ -457,7 +457,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: CortexIngesterHasNotShippedBlocksSinceStart
+  - alert: MimirIngesterHasNotShippedBlocksSinceStart
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
     expr: |
@@ -467,7 +467,7 @@ groups:
     for: 4h
     labels:
       severity: critical
-  - alert: CortexIngesterHasUnshippedBlocks
+  - alert: MimirIngesterHasUnshippedBlocks
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
     expr: |
@@ -477,7 +477,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: CortexIngesterTSDBHeadCompactionFailed
+  - alert: MimirIngesterTSDBHeadCompactionFailed
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
     expr: |
@@ -485,42 +485,42 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: CortexIngesterTSDBHeadTruncationFailed
+  - alert: MimirIngesterTSDBHeadTruncationFailed
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
     expr: |
       rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
     labels:
       severity: critical
-  - alert: CortexIngesterTSDBCheckpointCreationFailed
+  - alert: MimirIngesterTSDBCheckpointCreationFailed
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
     expr: |
       rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
     labels:
       severity: critical
-  - alert: CortexIngesterTSDBCheckpointDeletionFailed
+  - alert: MimirIngesterTSDBCheckpointDeletionFailed
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
     expr: |
       rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
     labels:
       severity: critical
-  - alert: CortexIngesterTSDBWALTruncationFailed
+  - alert: MimirIngesterTSDBWALTruncationFailed
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
     expr: |
       rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
     labels:
       severity: warning
-  - alert: CortexIngesterTSDBWALCorrupted
+  - alert: MimirIngesterTSDBWALCorrupted
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
     expr: |
       rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
     labels:
       severity: critical
-  - alert: CortexIngesterTSDBWALWritesFailed
+  - alert: MimirIngesterTSDBWALWritesFailed
     annotations:
       message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
     expr: |
@@ -528,7 +528,7 @@ groups:
     for: 3m
     labels:
       severity: critical
-  - alert: CortexQuerierHasNotScanTheBucket
+  - alert: MimirQuerierHasNotScanTheBucket
     annotations:
       message: Mimir Querier {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully scanned the bucket since {{ $value | humanizeDuration }}.
     expr: |
@@ -538,7 +538,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexQuerierHighRefetchRate
+  - alert: MimirQuerierHighRefetchRate
     annotations:
       message: Mimir Queries in {{ $labels.cluster }}/{{ $labels.namespace }} are refetching series from different store-gateways (because of missing blocks) for the {{ printf "%.0f" $value }}% of queries.
     expr: |
@@ -555,7 +555,7 @@ groups:
     for: 10m
     labels:
       severity: warning
-  - alert: CortexStoreGatewayHasNotSyncTheBucket
+  - alert: MimirStoreGatewayHasNotSyncTheBucket
     annotations:
       message: Mimir Store Gateway {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
     expr: |
@@ -565,14 +565,14 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: CortexBucketIndexNotUpdated
+  - alert: MimirBucketIndexNotUpdated
     annotations:
       message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
     expr: |
       min by(cluster, namespace, user) (time() - cortex_bucket_index_last_successful_update_timestamp_seconds) > 7200
     labels:
       severity: critical
-  - alert: CortexTenantHasPartialBlocks
+  - alert: MimirTenantHasPartialBlocks
     annotations:
       message: Mimir tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has {{ $value }} partial blocks.
     expr: |
@@ -582,7 +582,7 @@ groups:
       severity: warning
 - name: cortex_compactor_alerts
   rules:
-  - alert: CortexCompactorHasNotSuccessfullyCleanedUpBlocks
+  - alert: MimirCompactorHasNotSuccessfullyCleanedUpBlocks
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
     expr: |
@@ -590,7 +590,7 @@ groups:
     for: 1h
     labels:
       severity: critical
-  - alert: CortexCompactorHasNotSuccessfullyRunCompaction
+  - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
     expr: |
@@ -600,7 +600,7 @@ groups:
     for: 1h
     labels:
       severity: critical
-  - alert: CortexCompactorHasNotSuccessfullyRunCompaction
+  - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
     expr: |
@@ -608,14 +608,14 @@ groups:
     for: 24h
     labels:
       severity: critical
-  - alert: CortexCompactorHasNotSuccessfullyRunCompaction
+  - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
     expr: |
       increase(cortex_compactor_runs_failed_total[2h]) >= 2
     labels:
       severity: critical
-  - alert: CortexCompactorHasNotUploadedBlocks
+  - alert: MimirCompactorHasNotUploadedBlocks
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
     expr: |
@@ -625,7 +625,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: CortexCompactorHasNotUploadedBlocks
+  - alert: MimirCompactorHasNotUploadedBlocks
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
     expr: |
@@ -633,7 +633,7 @@ groups:
     for: 24h
     labels:
       severity: critical
-  - alert: CortexCompactorSkippedBlocksWithOutOfOrderChunks
+  - alert: MimirCompactorSkippedBlocksWithOutOfOrderChunks
     annotations:
       message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored blocks with out of order chunks.
     expr: |

--- a/operations/mimir-mixin/alerts/alertmanager.libsonnet
+++ b/operations/mimir-mixin/alerts/alertmanager.libsonnet
@@ -1,10 +1,10 @@
-{
+(import 'alerts-utils.libsonnet') {
   groups+: [
     {
       name: 'alertmanager_alerts',
       rules: [
         {
-          alert: 'CortexAlertmanagerSyncConfigsFailing',
+          alert: $.alertName('AlertmanagerSyncConfigsFailing'),
           expr: |||
             rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0
           |||,
@@ -19,7 +19,7 @@
           },
         },
         {
-          alert: 'CortexAlertmanagerRingCheckFailing',
+          alert: $.alertName('AlertmanagerRingCheckFailing'),
           expr: |||
             rate(cortex_alertmanager_ring_check_errors_total[2m]) > 0
           |||,
@@ -34,7 +34,7 @@
           },
         },
         {
-          alert: 'CortexAlertmanagerPartialStateMergeFailing',
+          alert: $.alertName('AlertmanagerPartialStateMergeFailing'),
           expr: |||
             rate(cortex_alertmanager_partial_state_merges_failed_total[2m]) > 0
           |||,
@@ -49,7 +49,7 @@
           },
         },
         {
-          alert: 'CortexAlertmanagerReplicationFailing',
+          alert: $.alertName('AlertmanagerReplicationFailing'),
           expr: |||
             rate(cortex_alertmanager_state_replication_failed_total[2m]) > 0
           |||,
@@ -64,7 +64,7 @@
           },
         },
         {
-          alert: 'CortexAlertmanagerPersistStateFailing',
+          alert: $.alertName('AlertmanagerPersistStateFailing'),
           expr: |||
             rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0
           |||,
@@ -79,7 +79,7 @@
           },
         },
         {
-          alert: 'CortexAlertmanagerInitialSyncFailed',
+          alert: $.alertName('AlertmanagerInitialSyncFailed'),
           expr: |||
             increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[1m]) > 0
           |||,

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -1,0 +1,5 @@
+{
+  // The alert name is prefixed with the product name (eg. AlertName -> MimirAlertName).
+  alertName(name)::
+    $._config.product + name,
+}

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -1,4 +1,4 @@
-{
+(import 'alerts-utils.libsonnet') {
   // simpleRegexpOpt produces a simple regexp that matches all strings in the input array.
   local simpleRegexpOpt(strings) =
     assert std.isArray(strings) : 'simpleRegexpOpt requires that `strings` is an array of strings`';
@@ -15,7 +15,7 @@
       name: 'cortex_alerts',
       rules: [
         {
-          alert: 'CortexIngesterUnhealthy',
+          alert: $.alertName('IngesterUnhealthy'),
           'for': '15m',
           expr: |||
             min by (%s) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
@@ -28,7 +28,7 @@
           },
         },
         {
-          alert: 'CortexRequestErrors',
+          alert: $.alertName('RequestErrors'),
           // Note if alert_aggregation_labels is "job", this will repeat the label. But
           // prometheus seems to tolerate that.
           expr: |||
@@ -51,7 +51,7 @@
           },
         },
         {
-          alert: 'CortexRequestLatency',
+          alert: $.alertName('RequestLatency'),
           expr: |||
             %(group_prefix_jobs)s_route:cortex_request_duration_seconds:99quantile{route!~"%(excluded_routes)s"}
                >
@@ -76,7 +76,7 @@
           },
         },
         {
-          alert: 'CortexQueriesIncorrect',
+          alert: $.alertName('QueriesIncorrect'),
           expr: |||
             100 * sum by (%s) (rate(test_exporter_test_case_result_total{result="fail"}[5m]))
               /
@@ -93,7 +93,7 @@
           },
         },
         {
-          alert: 'CortexInconsistentRuntimeConfig',
+          alert: $.alertName('InconsistentRuntimeConfig'),
           expr: |||
             count(count by(%s, job, sha256) (cortex_runtime_config_hash)) without(sha256) > 1
           ||| % $._config.alert_aggregation_labels,
@@ -108,7 +108,7 @@
           },
         },
         {
-          alert: 'CortexBadRuntimeConfig',
+          alert: $.alertName('BadRuntimeConfig'),
           expr: |||
             # The metric value is reset to 0 on error while reloading the config at runtime.
             cortex_runtime_config_last_reload_successful == 0
@@ -125,7 +125,7 @@
           },
         },
         {
-          alert: 'CortexFrontendQueriesStuck',
+          alert: $.alertName('FrontendQueriesStuck'),
           expr: |||
             sum by (%s) (cortex_query_frontend_queue_length) > 1
           ||| % $._config.alert_aggregation_labels,
@@ -140,7 +140,7 @@
           },
         },
         {
-          alert: 'CortexSchedulerQueriesStuck',
+          alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
             sum by (%s) (cortex_query_scheduler_queue_length) > 1
           ||| % $._config.alert_aggregation_labels,
@@ -155,7 +155,7 @@
           },
         },
         {
-          alert: 'CortexMemcachedRequestErrors',
+          alert: $.alertName('MemcachedRequestErrors'),
           expr: |||
             (
               sum by(%s, name, operation) (rate(thanos_memcached_operation_failures_total[1m])) /
@@ -173,7 +173,7 @@
           },
         },
         {
-          alert: 'CortexIngesterRestarts',
+          alert: $.alertName('IngesterRestarts'),
           expr: |||
             changes(process_start_time_seconds{job=~".+(cortex|ingester.*)"}[30m]) >= 2
           |||,
@@ -188,7 +188,7 @@
           },
         },
         {
-          alert: 'CortexKVStoreFailure',
+          alert: $.alertName('KVStoreFailure'),
           expr: |||
             (
               sum by(%s, pod, status_code, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.+"}[1m]))
@@ -209,7 +209,7 @@
           },
         },
         {
-          alert: 'CortexMemoryMapAreasTooHigh',
+          alert: $.alertName('MemoryMapAreasTooHigh'),
           expr: |||
             process_memory_map_areas{job=~".+(cortex|ingester.*|store-gateway.*)"} / process_memory_map_areas_limit{job=~".+(cortex|ingester.*|store-gateway.*)"} > 0.8
           |||,
@@ -227,7 +227,7 @@
       name: 'cortex_instance_limits_alerts',
       rules: [
         {
-          alert: 'CortexIngesterReachingSeriesLimit',
+          alert: $.alertName('IngesterReachingSeriesLimit'),
           expr: |||
             (
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -246,7 +246,7 @@
           },
         },
         {
-          alert: 'CortexIngesterReachingSeriesLimit',
+          alert: $.alertName('IngesterReachingSeriesLimit'),
           expr: |||
             (
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -265,7 +265,7 @@
           },
         },
         {
-          alert: 'CortexIngesterReachingTenantsLimit',
+          alert: $.alertName('IngesterReachingTenantsLimit'),
           expr: |||
             (
                 (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -284,7 +284,7 @@
           },
         },
         {
-          alert: 'CortexIngesterReachingTenantsLimit',
+          alert: $.alertName('IngesterReachingTenantsLimit'),
           expr: |||
             (
                 (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -303,7 +303,7 @@
           },
         },
         {
-          alert: 'CortexReachingTCPConnectionsLimit',
+          alert: $.alertName('ReachingTCPConnectionsLimit'),
           expr: |||
             cortex_tcp_connections / cortex_tcp_connections_limit > 0.8 and
             cortex_tcp_connections_limit > 0
@@ -319,7 +319,7 @@
           },
         },
         {
-          alert: 'CortexDistributorReachingInflightPushRequestLimit',
+          alert: $.alertName('DistributorReachingInflightPushRequestLimit'),
           expr: |||
             (
                 (cortex_distributor_inflight_push_requests / ignoring(limit) cortex_distributor_instance_limits{limit="max_inflight_push_requests"})
@@ -340,10 +340,10 @@
       ],
     },
     {
-      name: 'cortex-rollout-alerts',
+      name: 'mimir-rollout-alerts',
       rules: [
         {
-          alert: 'CortexRolloutStuck',
+          alert: $.alertName('RolloutStuck'),
           expr: |||
             (
               max without (revision) (
@@ -381,7 +381,7 @@
           },
         },
         {
-          alert: 'CortexRolloutStuck',
+          alert: $.alertName('RolloutStuck'),
           expr: |||
             (
               %(kube_deployment_spec_replicas)s
@@ -411,10 +411,10 @@
       ],
     },
     {
-      name: 'cortex-provisioning',
+      name: 'mimir-provisioning',
       rules: [
         {
-          alert: 'CortexProvisioningTooManyActiveSeries',
+          alert: $.alertName('ProvisioningTooManyActiveSeries'),
           // We target each ingester to 1.5M in-memory series. This alert fires if the average
           // number of series / ingester in a Mimir cluster is > 1.6M for 2h (we compact
           // the TSDB head every 2h).
@@ -432,7 +432,7 @@
           },
         },
         {
-          alert: 'CortexProvisioningTooManyWrites',
+          alert: $.alertName('ProvisioningTooManyWrites'),
           // 80k writes / s per ingester max.
           expr: |||
             avg by (%s) (rate(cortex_ingester_ingested_samples_total[1m])) > 80e3
@@ -448,7 +448,7 @@
           },
         },
         {
-          alert: 'CortexAllocatingTooMuchMemory',
+          alert: $.alertName('AllocatingTooMuchMemory'),
           expr: |||
             (
               container_memory_working_set_bytes{container="ingester"}
@@ -467,7 +467,7 @@
           },
         },
         {
-          alert: 'CortexAllocatingTooMuchMemory',
+          alert: $.alertName('AllocatingTooMuchMemory'),
           expr: |||
             (
               container_memory_working_set_bytes{container="ingester"}
@@ -491,7 +491,7 @@
       name: 'ruler_alerts',
       rules: [
         {
-          alert: 'CortexRulerTooManyFailedPushes',
+          alert: $.alertName('RulerTooManyFailedPushes'),
           expr: |||
             100 * (
             sum by (%s, instance) (rate(cortex_ruler_write_requests_failed_total[1m]))
@@ -510,7 +510,7 @@
           },
         },
         {
-          alert: 'CortexRulerTooManyFailedQueries',
+          alert: $.alertName('RulerTooManyFailedQueries'),
           expr: |||
             100 * (
             sum by (%s, instance) (rate(cortex_ruler_queries_failed_total[1m]))
@@ -529,7 +529,7 @@
           },
         },
         {
-          alert: 'CortexRulerMissedEvaluations',
+          alert: $.alertName('RulerMissedEvaluations'),
           expr: |||
             sum by (%s, instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
@@ -547,7 +547,7 @@
           },
         },
         {
-          alert: 'CortexRulerFailedRingCheck',
+          alert: $.alertName('RulerFailedRingCheck'),
           expr: |||
             sum by (%s, job) (rate(cortex_ruler_ring_check_errors_total[1m]))
                > 0
@@ -568,7 +568,7 @@
       name: 'gossip_alerts',
       rules: [
         {
-          alert: 'CortexGossipMembersMismatch',
+          alert: $.alertName('GossipMembersMismatch'),
           expr:
             |||
               memberlist_client_cluster_members_count

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -1,4 +1,4 @@
-{
+(import 'alerts-utils.libsonnet') {
   groups+: [
     {
       name: 'cortex_blocks_alerts',
@@ -6,7 +6,7 @@
         {
           // Alert if the ingester has not shipped any block in the last 4h. It also checks cortex_ingester_ingested_samples_total
           // to avoid false positives on ingesters not receiving any traffic yet (eg. a newly created cluster).
-          alert: 'CortexIngesterHasNotShippedBlocks',
+          alert: $.alertName('IngesterHasNotShippedBlocks'),
           'for': '15m',
           expr: |||
             (min by(%(alert_aggregation_labels)s, instance) (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester.*"}) > 60 * 60 * 4)
@@ -32,7 +32,7 @@
         {
           // Alert if the ingester has not shipped any block since start. It also checks cortex_ingester_ingested_samples_total
           // to avoid false positives on ingesters not receiving any traffic yet (eg. a newly created cluster).
-          alert: 'CortexIngesterHasNotShippedBlocksSinceStart',
+          alert: $.alertName('IngesterHasNotShippedBlocksSinceStart'),
           'for': '4h',
           expr: |||
             (max by(%(alert_aggregation_labels)s, instance) (thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester.*"}) == 0)
@@ -50,7 +50,7 @@
           // Alert if the ingester has compacted some blocks that haven't been successfully uploaded to the storage yet since
           // more than 1 hour. The metric tracks the time of the oldest unshipped block, measured as the time when the
           // TSDB head has been compacted to a block. The metric is 0 if all blocks have been shipped.
-          alert: 'CortexIngesterHasUnshippedBlocks',
+          alert: $.alertName('IngesterHasUnshippedBlocks'),
           'for': '15m',
           expr: |||
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
@@ -68,7 +68,7 @@
           // Alert if the ingester is failing to compact TSDB head into a block, for any opened TSDB. Once the TSDB head is
           // compactable, the ingester will try to compact it every 1 minute. Repeatedly failing it is a critical condition
           // that should never happen.
-          alert: 'CortexIngesterTSDBHeadCompactionFailed',
+          alert: $.alertName('IngesterTSDBHeadCompactionFailed'),
           'for': '15m',
           expr: |||
             rate(cortex_ingester_tsdb_compactions_failed_total[5m]) > 0
@@ -81,7 +81,7 @@
           },
         },
         {
-          alert: 'CortexIngesterTSDBHeadTruncationFailed',
+          alert: $.alertName('IngesterTSDBHeadTruncationFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
           |||,
@@ -93,7 +93,7 @@
           },
         },
         {
-          alert: 'CortexIngesterTSDBCheckpointCreationFailed',
+          alert: $.alertName('IngesterTSDBCheckpointCreationFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
           |||,
@@ -105,7 +105,7 @@
           },
         },
         {
-          alert: 'CortexIngesterTSDBCheckpointDeletionFailed',
+          alert: $.alertName('IngesterTSDBCheckpointDeletionFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
           |||,
@@ -117,7 +117,7 @@
           },
         },
         {
-          alert: 'CortexIngesterTSDBWALTruncationFailed',
+          alert: $.alertName('IngesterTSDBWALTruncationFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
           |||,
@@ -129,7 +129,7 @@
           },
         },
         {
-          alert: 'CortexIngesterTSDBWALCorrupted',
+          alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
             rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
           |||,
@@ -141,7 +141,7 @@
           },
         },
         {
-          alert: 'CortexIngesterTSDBWALWritesFailed',
+          alert: $.alertName('IngesterTSDBWALWritesFailed'),
           'for': '3m',
           expr: |||
             rate(cortex_ingester_tsdb_wal_writes_failed_total[1m]) > 0
@@ -155,7 +155,7 @@
         },
         {
           // Alert if the querier is not successfully scanning the bucket.
-          alert: 'CortexQuerierHasNotScanTheBucket',
+          alert: $.alertName('QuerierHasNotScanTheBucket'),
           'for': '5m',
           expr: |||
             (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds > 60 * 30)
@@ -172,7 +172,7 @@
         {
           // Alert if the number of queries for which we had to refetch series from different store-gateways
           // (because of missing blocks) is greater than a %.
-          alert: 'CortexQuerierHighRefetchRate',
+          alert: $.alertName('QuerierHighRefetchRate'),
           'for': '10m',
           expr: |||
             100 * (
@@ -195,7 +195,7 @@
         },
         {
           // Alert if the store-gateway is not successfully synching the bucket.
-          alert: 'CortexStoreGatewayHasNotSyncTheBucket',
+          alert: $.alertName('StoreGatewayHasNotSyncTheBucket'),
           'for': '5m',
           expr: |||
             (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
@@ -211,7 +211,7 @@
         },
         {
           // Alert if the bucket index has not been updated for a given user.
-          alert: 'CortexBucketIndexNotUpdated',
+          alert: $.alertName('BucketIndexNotUpdated'),
           expr: |||
             min by(%(alert_aggregation_labels)s, user) (time() - cortex_bucket_index_last_successful_update_timestamp_seconds) > 7200
           ||| % $._config,
@@ -224,7 +224,7 @@
         },
         {
           // Alert if a we consistently find partial blocks for a given tenant over a relatively large time range.
-          alert: 'CortexTenantHasPartialBlocks',
+          alert: $.alertName('TenantHasPartialBlocks'),
           'for': '6h',
           expr: |||
             max by(%(alert_aggregation_labels)s, user) (cortex_bucket_blocks_partials_count) > 0

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -1,11 +1,11 @@
-{
+(import 'alerts-utils.libsonnet') {
   groups+: [
     {
       name: 'cortex_compactor_alerts',
       rules: [
         {
           // Alert if the compactor has not successfully cleaned up blocks in the last 6h.
-          alert: 'CortexCompactorHasNotSuccessfullyCleanedUpBlocks',
+          alert: $.alertName('CompactorHasNotSuccessfullyCleanedUpBlocks'),
           'for': '1h',
           expr: |||
             (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 6)
@@ -19,7 +19,7 @@
         },
         {
           // Alert if the compactor has not successfully run compaction in the last 24h.
-          alert: 'CortexCompactorHasNotSuccessfullyRunCompaction',
+          alert: $.alertName('CompactorHasNotSuccessfullyRunCompaction'),
           'for': '1h',
           expr: |||
             (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
@@ -35,7 +35,7 @@
         },
         {
           // Alert if the compactor has not successfully run compaction in the last 24h since startup.
-          alert: 'CortexCompactorHasNotSuccessfullyRunCompaction',
+          alert: $.alertName('CompactorHasNotSuccessfullyRunCompaction'),
           'for': '24h',
           expr: |||
             cortex_compactor_last_successful_run_timestamp_seconds == 0
@@ -49,7 +49,7 @@
         },
         {
           // Alert if compactor failed to run 2 consecutive compactions.
-          alert: 'CortexCompactorHasNotSuccessfullyRunCompaction',
+          alert: $.alertName('CompactorHasNotSuccessfullyRunCompaction'),
           expr: |||
             increase(cortex_compactor_runs_failed_total[2h]) >= 2
           |||,
@@ -62,7 +62,7 @@
         },
         {
           // Alert if the compactor has not uploaded anything in the last 24h.
-          alert: 'CortexCompactorHasNotUploadedBlocks',
+          alert: $.alertName('CompactorHasNotUploadedBlocks'),
           'for': '15m',
           expr: |||
             (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/%(compactor)s"} > 60 * 60 * 24)
@@ -78,7 +78,7 @@
         },
         {
           // Alert if the compactor has not uploaded anything since its start.
-          alert: 'CortexCompactorHasNotUploadedBlocks',
+          alert: $.alertName('CompactorHasNotUploadedBlocks'),
           'for': '24h',
           expr: |||
             thanos_objstore_bucket_last_successful_upload_time{job=~".+/%(compactor)s"} == 0
@@ -92,7 +92,7 @@
         },
         {
           // Alert if compactor has tried to compact blocks with out-of-order chunks.
-          alert: 'CortexCompactorSkippedBlocksWithOutOfOrderChunks',
+          alert: $.alertName('CompactorSkippedBlocksWithOutOfOrderChunks'),
           'for': '1m',
           expr: |||
             increase(cortex_compactor_blocks_marked_for_no_compaction_total{job=~".+/%(compactor)s", reason="block-index-out-of-order-chunk"}[5m]) > 0

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -7,7 +7,7 @@ This document contains playbooks, or at least a checklist of what to look for, f
 
 ## Alerts
 
-### CortexIngesterRestarts
+### MimirIngesterRestarts
 
 First, check if the alert is for a single ingester or multiple. Even if the alert is only for one ingester, it's best to follow up by checking `kubectl get pods --namespace=<prod/staging/etc.>` every few minutes, or looking at the query `rate(kube_pod_container_status_restarts_total{container="ingester"}[30m]) > 0` just until you're sure there isn't a larger issue causing multiple restarts.
 
@@ -27,7 +27,7 @@ If nothing obvious from the above, check for increased load:
 - If there is an increase in the number of active series and the memory provisioned is not enough, scale up the ingesters horizontally to have the same number of series as before per ingester.
 - If we had an outage and once Mimir is back up, the incoming traffic increases. (or) The clients have their Prometheus remote-write lagging and starts to send samples at a higher rate (again, an increase in traffic but in terms of number of samples). Scale up the ingester horizontally in this case too.
 
-### CortexIngesterReachingSeriesLimit
+### MimirIngesterReachingSeriesLimit
 
 This alert fires when the `max_series` per ingester instance limit is enabled and the actual number of in-memory series in an ingester is reaching the limit. Once the limit is reached, writes to the ingester will fail (5xx) for new series, while appending samples to existing ones will continue to succeed.
 
@@ -95,7 +95,7 @@ How to **fix**:
 3. **Scale up ingesters**<br />
    Scaling up ingesters will lower the number of series per ingester. However, the effect of this change will take up to 4h, because after the scale up we need to wait until all stale series are dropped from memory as the effect of TSDB head compaction, which could take up to 4h (with the default config, TSDB keeps in-memory series up to 3h old and it gets compacted every 2h).
 
-### CortexIngesterReachingTenantsLimit
+### MimirIngesterReachingTenantsLimit
 
 This alert fires when the `max_tenants` per ingester instance limit is enabled and the actual number of tenants in an ingester is reaching the limit. Once the limit is reached, writes to the ingester will fail (5xx) for new tenants, while they will continue to succeed for previously existing ones.
 
@@ -127,7 +127,7 @@ How to **fix**:
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
 
-### CortexDistributorReachingInflightPushRequestLimit
+### MimirDistributorReachingInflightPushRequestLimit
 
 This alert fires when the `cortex_distributor_inflight_push_requests` per distributor instance limit is enabled and the actual number of inflight push requests is approaching the set limit. Once the limit is reached, push requests to the distributor will fail (5xx) for new requests, while existing inflight push requests will continue to succeed.
 
@@ -154,7 +154,7 @@ How to **fix**:
 2. **Scale up distributors**<br />
    Scaling up distributors will lower the number of inflight push requests per distributor.
 
-### CortexRequestLatency
+### MimirRequestLatency
 
 This alert fires when a specific Mimir route is experiencing an high latency.
 
@@ -176,8 +176,8 @@ How to **investigate**:
   - **`ingester`**
     - Typically, ingester p99 latency is in the range 5-50ms. If the ingester latency is higher than this, you should investigate the root cause before scaling up ingesters.
     - Check out the following alerts and fix them if firing:
-      - `CortexProvisioningTooManyActiveSeries`
-      - `CortexProvisioningTooManyWrites`
+      - `MimirProvisioningTooManyActiveSeries`
+      - `MimirProvisioningTooManyWrites`
 
 #### Read Latency
 
@@ -207,7 +207,7 @@ How to **investigate**:
         - If memcached eviction rate is high, then you should scale up memcached replicas. Check the recommendations by `Mimir / Scaling` dashboard and make reasonable adjustments as necessary.
         - If memcached eviction rate is zero or very low, then it may be caused by "first time" queries
 
-### CortexRequestErrors
+### MimirRequestErrors
 
 This alert fires when the rate of 5xx errors of a specific route is > 1% for some time.
 
@@ -223,11 +223,11 @@ How to **investigate**:
 - If the failing service is going OOM (`OOMKilled`): scale up or increase the memory
 - If the failing service is crashing / panicking: look for the stack trace in the logs and investigate from there
 
-### CortexIngesterUnhealthy
+### MimirIngesterUnhealthy
 
 This alert goes off when an ingester is marked as unhealthy. Check the ring web page to see which is marked as unhealthy. You could then check the logs to see if there are any related to that ingester ex: `kubectl logs -f ingester-01 --namespace=prod`. A simple way to resolve this may be to click the "Forgot" button on the ring page, especially if the pod doesn't exist anymore. It might not exist anymore because it was on a node that got shut down, so you could check to see if there are any logs related to the node that pod is/was on, ex: `kubectl get events --namespace=prod | grep cloud-provider-node`.
 
-### CortexMemoryMapAreasTooHigh
+### MimirMemoryMapAreasTooHigh
 
 This alert fires when a Mimir process has a number of memory map areas close to the limit. The limit is a per-process limit imposed by the kernel and this issue is typically caused by a large number of mmap-ed failes.
 
@@ -241,11 +241,11 @@ More information:
 - [Kernel doc](https://www.kernel.org/doc/Documentation/sysctl/vm.txt)
 - [Side effects when increasing `vm.max_map_count`](https://www.suse.com/support/kb/doc/?id=000016692)
 
-### CortexRulerFailedRingCheck
+### MimirRulerFailedRingCheck
 
 This alert occurs when a ruler is unable to validate whether or not it should claim ownership over the evaluation of a rule group. The most likely cause is that one of the rule ring entries is unhealthy. If this is the case proceed to the ring admin http page and forget the unhealth ruler. The other possible cause would be an error returned the ring client. If this is the case look into debugging the ring based on the in-use backend implementation.
 
-### CortexRulerTooManyFailedPushes
+### MimirRulerTooManyFailedPushes
 
 This alert fires when rulers cannot push new samples (result of rule evaluation) to ingesters.
 
@@ -256,7 +256,7 @@ How to **fix**:
 
 - Investigate the ruler logs to find out the reason why ruler cannot write samples. Note that ruler logs all push errors, including "user errors", but those are not causing the alert to fire. Focus on problems with ingesters.
 
-### CortexRulerTooManyFailedQueries
+### MimirRulerTooManyFailedQueries
 
 This alert fires when rulers fail to evaluate rule queries.
 
@@ -268,11 +268,11 @@ How to **fix**:
 
 - Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that ruler logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways.
 
-### CortexRulerMissedEvaluations
+### MimirRulerMissedEvaluations
 
 _TODO: this playbook has not been written yet._
 
-### CortexIngesterHasNotShippedBlocks
+### MimirIngesterHasNotShippedBlocks
 
 This alert fires when a Mimir ingester is not uploading any block to the long-term storage. An ingester is expected to upload a block to the storage every block range period (defaults to 2h) and if a longer time elapse since the last successful upload it means something is not working correctly.
 
@@ -281,7 +281,7 @@ How to **investigate**:
 - Ensure the ingester is receiving write-path traffic (samples to ingest)
 - Look for any upload error in the ingester logs (ie. networking or authentication issues)
 
-_If the alert `CortexIngesterTSDBHeadCompactionFailed` fired as well, then give priority to it because that could be the cause._
+_If the alert `MimirIngesterTSDBHeadCompactionFailed` fired as well, then give priority to it because that could be the cause._
 
 #### Ingester hit the disk capacity
 
@@ -293,11 +293,11 @@ If the ingester hit the disk capacity, any attempt to append samples will fail. 
 - Was the disk just too small?
 - Was there an issue compacting TSDB head and the WAL is increasing indefinitely?
 
-### CortexIngesterHasNotShippedBlocksSinceStart
+### MimirIngesterHasNotShippedBlocksSinceStart
 
-Same as [`CortexIngesterHasNotShippedBlocks`](#CortexIngesterHasNotShippedBlocks).
+Same as [`MimirIngesterHasNotShippedBlocks`](#MimirIngesterHasNotShippedBlocks).
 
-### CortexIngesterHasUnshippedBlocks
+### MimirIngesterHasUnshippedBlocks
 
 This alert fires when a Mimir ingester has compacted some blocks but such blocks haven't been successfully uploaded to the storage yet.
 
@@ -305,7 +305,7 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
-### CortexIngesterTSDBHeadCompactionFailed
+### MimirIngesterTSDBHeadCompactionFailed
 
 This alert fires when a Mimir ingester is failing to compact the TSDB head into a block.
 
@@ -321,7 +321,7 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
-### CortexIngesterTSDBHeadTruncationFailed
+### MimirIngesterTSDBHeadTruncationFailed
 
 This alert fires when a Mimir ingester fails to truncate the TSDB head.
 
@@ -331,16 +331,16 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
-### CortexIngesterTSDBCheckpointCreationFailed
+### MimirIngesterTSDBCheckpointCreationFailed
 
 This alert fires when a Mimir ingester fails to create a TSDB checkpoint.
 
 How to **investigate**:
 
 - Look for details in the ingester logs
-- If the checkpoint fails because of a `corruption in segment`, you can restart the ingester because at next startup TSDB will try to "repair" it. After restart, if the issue is repaired and the ingester is running, you should also get paged by `CortexIngesterTSDBWALCorrupted` to signal you the WAL was corrupted and manual investigation is required.
+- If the checkpoint fails because of a `corruption in segment`, you can restart the ingester because at next startup TSDB will try to "repair" it. After restart, if the issue is repaired and the ingester is running, you should also get paged by `MimirIngesterTSDBWALCorrupted` to signal you the WAL was corrupted and manual investigation is required.
 
-### CortexIngesterTSDBCheckpointDeletionFailed
+### MimirIngesterTSDBCheckpointDeletionFailed
 
 This alert fires when a Mimir ingester fails to delete a TSDB checkpoint.
 
@@ -350,7 +350,7 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
-### CortexIngesterTSDBWALTruncationFailed
+### MimirIngesterTSDBWALTruncationFailed
 
 This alert fires when a Mimir ingester fails to truncate the TSDB WAL.
 
@@ -358,15 +358,15 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
-### CortexIngesterTSDBWALCorrupted
+### MimirIngesterTSDBWALCorrupted
 
 This alert fires when a Mimir ingester finds a corrupted TSDB WAL (stored on disk) while replaying it at ingester startup or when creation of a checkpoint comes across a WAL corruption.
 
 If this alert fires during an **ingester startup**, the WAL should have been auto-repaired, but manual investigation is required. The WAL repair mechanism cause data loss because all WAL records after the corrupted segment are discarded and so their samples lost while replaying the WAL. If this issue happen only on 1 ingester then Mimir doesn't suffer any data loss because of the replication factor, while if it happens on multiple ingesters then some data loss is possible.
 
-If this alert fires during a **checkpoint creation**, you should have also been paged with `CortexIngesterTSDBCheckpointCreationFailed`, and you can follow the steps under that alert.
+If this alert fires during a **checkpoint creation**, you should have also been paged with `MimirIngesterTSDBCheckpointCreationFailed`, and you can follow the steps under that alert.
 
-### CortexIngesterTSDBWALWritesFailed
+### MimirIngesterTSDBWALWritesFailed
 
 This alert fires when a Mimir ingester is failing to log records to the TSDB WAL on disk.
 
@@ -374,7 +374,7 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
-### CortexQuerierHasNotScanTheBucket
+### MimirQuerierHasNotScanTheBucket
 
 This alert fires when a Mimir querier is not successfully scanning blocks in the storage (bucket). A querier is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket since a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.
 
@@ -382,7 +382,7 @@ How to **investigate**:
 
 - Look for any scan error in the querier logs (ie. networking or rate limiting issues)
 
-### CortexQuerierHighRefetchRate
+### MimirQuerierHighRefetchRate
 
 This alert fires when there's an high number of queries for which series have been refetched from a different store-gateway because of missing blocks. This could happen for a short time whenever a store-gateway ring resharding occurs (e.g. during/after an outage or while rolling out store-gateway) but store-gateways should reconcile in a short time. This alert fires if the issue persist for an unexpected long time and thus it should be investigated.
 
@@ -391,7 +391,7 @@ How to **investigate**:
 - Ensure there are no errors related to blocks scan or sync in the queriers and store-gateways
 - Check store-gateway logs to see if all store-gateway have successfully completed a blocks sync
 
-### CortexStoreGatewayHasNotSyncTheBucket
+### MimirStoreGatewayHasNotSyncTheBucket
 
 This alert fires when a Mimir store-gateway is not successfully scanning blocks in the storage (bucket). A store-gateway is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket for a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.
 
@@ -399,7 +399,7 @@ How to **investigate**:
 
 - Look for any scan error in the store-gateway logs (ie. networking or rate limiting issues)
 
-### CortexCompactorHasNotSuccessfullyCleanedUpBlocks
+### MimirCompactorHasNotSuccessfullyCleanedUpBlocks
 
 This alert fires when a Mimir compactor is not successfully deleting blocks marked for deletion for a long time.
 
@@ -408,22 +408,22 @@ How to **investigate**:
 - Ensure the compactor is not crashing during compaction (ie. `OOMKilled`)
 - Look for any error in the compactor logs (ie. bucket Delete API errors)
 
-### CortexCompactorHasNotSuccessfullyCleanedUpBlocksSinceStart
+### MimirCompactorHasNotSuccessfullyCleanedUpBlocksSinceStart
 
-Same as [`CortexCompactorHasNotSuccessfullyCleanedUpBlocks`](#CortexCompactorHasNotSuccessfullyCleanedUpBlocks).
+Same as [`MimirCompactorHasNotSuccessfullyCleanedUpBlocks`](#MimirCompactorHasNotSuccessfullyCleanedUpBlocks).
 
-### CortexCompactorHasNotUploadedBlocks
+### MimirCompactorHasNotUploadedBlocks
 
 This alert fires when a Mimir compactor is not uploading any compacted blocks to the storage since a long time.
 
 How to **investigate**:
 
-- If the alert `CortexCompactorHasNotSuccessfullyRunCompaction` has fired as well, then investigate that issue first
-- If the alert `CortexIngesterHasNotShippedBlocks` or `CortexIngesterHasNotShippedBlocksSinceStart` have fired as well, then investigate that issue first
+- If the alert `MimirCompactorHasNotSuccessfullyRunCompaction` has fired as well, then investigate that issue first
+- If the alert `MimirIngesterHasNotShippedBlocks` or `MimirIngesterHasNotShippedBlocksSinceStart` have fired as well, then investigate that issue first
 - Ensure ingesters are successfully shipping blocks to the storage
 - Look for any error in the compactor logs
 
-### CortexCompactorHasNotSuccessfullyRunCompaction
+### MimirCompactorHasNotSuccessfullyRunCompaction
 
 This alert fires if the compactor is not able to successfully compact all discovered compactable blocks (across all tenants).
 
@@ -434,7 +434,7 @@ How to **investigate**:
 - Look for any error in the compactor logs
   - Corruption: [`not healthy index found`](#compactor-is-failing-because-of-not-healthy-index-found)
 
-### CortexCompactorSkippedBlocksWithOutOfOrderChunks
+### MimirCompactorSkippedBlocksWithOutOfOrderChunks
 
 This alert fires when compactor tries to compact a block, but finds that given block has out-of-order chunks. This indicates a bug in Prometheus TSDB library and should be investigated.
 
@@ -464,7 +464,7 @@ Where:
 - `TENANT` is the tenant id reported in the example error message above as `REDACTED-TENANT`
 - `BLOCK` is the last part of the file path reported as `REDACTED-BLOCK` in the example error message above
 
-### CortexBucketIndexNotUpdated
+### MimirBucketIndexNotUpdated
 
 This alert fires when the bucket index, for a given tenant, is not updated since a long time. The bucket index is expected to be periodically updated by the compactor and is used by queriers and store-gateways to get an almost-updated view over the bucket store.
 
@@ -473,7 +473,7 @@ How to **investigate**:
 - Ensure the compactor is successfully running
 - Look for any error in the compactor logs
 
-### CortexTenantHasPartialBlocks
+### MimirTenantHasPartialBlocks
 
 This alert fires when Mimir finds partial blocks for a given tenant. A partial block is a block missing the `meta.json` and this may usually happen in two circumstances:
 
@@ -491,11 +491,11 @@ How to **investigate**:
 - Safely manually delete the block from the bucket if was a partial delete or an upload failed by a compactor
 - Further investigate if was an upload failed by an ingester but not later retried (ingesters are expected to retry uploads until succeed)
 
-### CortexQueriesIncorrect
+### MimirQueriesIncorrect
 
 _TODO: this playbook has not been written yet._
 
-### CortexInconsistentRuntimeConfig
+### MimirInconsistentRuntimeConfig
 
 This alert fires if multiple replicas of the same Mimir service are using a different runtime config for a longer period of time.
 
@@ -514,7 +514,7 @@ How to **investigate**:
 - Check if the runtime config has been updated on the affected replicas' filesystem. Check `-runtime-config.file` command line argument to find the location of the file.
 - Check the affected replicas logs and look for any error loading the runtime config
 
-### CortexBadRuntimeConfig
+### MimirBadRuntimeConfig
 
 This alert fires if Mimir is unable to reload the runtime config.
 
@@ -525,13 +525,13 @@ How to **investigate**:
 - Check the latest runtime config update (it's likely to be broken)
 - Check Mimir logs to get more details about what's wrong with the config
 
-### CortexFrontendQueriesStuck
+### MimirFrontendQueriesStuck
 
 This alert fires if Mimir is running without query-scheduler and queries are piling up in the query-frontend queue.
 
-The procedure to investigate it is the same as the one for [`CortexSchedulerQueriesStuck`](#CortexSchedulerQueriesStuck): please see the other playbook for more details.
+The procedure to investigate it is the same as the one for [`MimirSchedulerQueriesStuck`](#MimirSchedulerQueriesStuck): please see the other playbook for more details.
 
-### CortexSchedulerQueriesStuck
+### MimirSchedulerQueriesStuck
 
 This alert fires if queries are piling up in the query-scheduler.
 
@@ -562,7 +562,7 @@ How to **investigate**:
     - Verify if the particular queries are hitting edge cases, where query-sharding is not benefical, by getting traces from the `Mimir / Slow Queries` dashboard and then look where time is spent. If time is spent in the query-frontend running PromQL engine, then it means query-sharding is not beneficial for this tenant. Consider disabling query-sharding or reduce the shard count using the `query_sharding_total_shards` override.
     - Otherwise and only if the queries by the tenant are within reason representing normal usage, consider scaling of queriers and potentially store-gateways.
 
-### CortexMemcachedRequestErrors
+### MimirMemcachedRequestErrors
 
 This alert fires if Mimir memcached client is experiencing an high error rate for a specific cache and operation.
 
@@ -591,7 +591,7 @@ How to **investigate**:
   - `other`
     - Check both Mimir and memcached logs to find more details
 
-### CortexProvisioningTooManyActiveSeries
+### MimirProvisioningTooManyActiveSeries
 
 This alert fires if the average number of in-memory series per ingester is above our target (1.5M).
 
@@ -605,7 +605,7 @@ How to **fix**:
     ```
 - After the scale up, the in-memory series are expected to be reduced at the next TSDB head compaction (occurring every 2h)
 
-### CortexProvisioningTooManyWrites
+### MimirProvisioningTooManyWrites
 
 This alert fires if the average number of samples ingested / sec in ingesters is above our target.
 
@@ -617,7 +617,7 @@ How to **fix**:
     sum(rate(cortex_ingester_ingested_samples_total{namespace="<namespace>"}[$__rate_interval])) / (<target> * 0.9)
     ```
 
-### CortexAllocatingTooMuchMemory
+### MimirAllocatingTooMuchMemory
 
 This alert fires when an ingester memory utilization is getting closer to the limit.
 
@@ -641,7 +641,7 @@ How to **fix**:
   - Scale up ingesters
   - Memory is expected to be reclaimed at the next TSDB head compaction (occurring every 2h)
 
-### CortexGossipMembersMismatch
+### MimirGossipMembersMismatch
 
 This alert fires when any instance does not register all other instances as members of the memberlist cluster.
 
@@ -689,7 +689,7 @@ This can be triggered if there are too many HA dedupe keys in etcd. We saw this 
   },
 ```
 
-### CortexAlertmanagerSyncConfigsFailing
+### MimirAlertmanagerSyncConfigsFailing
 
 How it **works**:
 
@@ -709,7 +709,7 @@ How to **investigate**:
 
 Look at the error message that is logged and attempt to understand what is causing the failure. I.e. it could be a networking issue, incorrect configuration for the store, etc.
 
-### CortexAlertmanagerRingCheckFailing
+### MimirAlertmanagerRingCheckFailing
 
 How it **works**:
 
@@ -723,7 +723,7 @@ How to **investigate**:
 
 Look at the error message that is logged and attempt to understand what is causing the failure. In most cases the error will be encountered when attempting to read from the ring, which can fail if there is an issue with in-use backend implementation.
 
-### CortexAlertmanagerPartialStateMergeFailing
+### MimirAlertmanagerPartialStateMergeFailing
 
 How it **works**:
 
@@ -733,9 +733,9 @@ The metric for this alert is cortex_alertmanager_partial_state_merges_failed_tot
 
 How to **investigate**:
 
-The error is not currently logged on the receiver side. If this alert is firing, it is likely that CortexAlertmanagerReplicationFailing is firing also, so instead follow the investigation steps for that alert, with the assumption that the issue is not RPC/communication related.
+The error is not currently logged on the receiver side. If this alert is firing, it is likely that `MimirAlertmanagerReplicationFailing` is firing also, so instead follow the investigation steps for that alert, with the assumption that the issue is not RPC/communication related.
 
-### CortexAlertmanagerReplicationFailing
+### MimirAlertmanagerReplicationFailing
 
 How it **works**:
 
@@ -747,7 +747,7 @@ How to **investigate**:
 
 When state replication fails it gets logged as an error in the alertmanager that attempted the state replication. Check the error message in the log to understand the cause of the error (i.e. was it due to an RPC/communication error or was there an error in the receiving alertmanager).
 
-### CortexAlertmanagerPersistStateFailing
+### MimirAlertmanagerPersistStateFailing
 
 How it **works**:
 
@@ -762,7 +762,7 @@ Each failure to persist state to the remote object storage is logged. Find the r
 - The most probable cause is that remote write failed. Try to investigate why based on the message (network issue, storage issue). If the error indicates the issue might be transient, then you can wait until the next periodic attempt and see if it succeeds.
 - It is also possible that encoding the state failed. This does not depend on external factors as it is just pulling state from the Alertmanager internal state. It may indicate a bug in the encoding method.
 
-### CortexAlertmanagerInitialSyncFailed
+### MimirAlertmanagerInitialSyncFailed
 
 How it **works**:
 
@@ -777,7 +777,7 @@ When an alertmanager cannot read the state for a tenant from storage it gets log
 - The state could not be merged because it might be invalid and could not be decoded. This could indicate data corruption and therefore a bug in the reading or writing of the state, and would need further investigation.
 - The state could not be read from storage. This could be due to a networking issue such as a timeout or an authentication and authorization issue with the remote object store.
 
-### CortexRolloutStuck
+### MimirRolloutStuck
 
 This alert fires when a Mimir service rollout is stuck, which means the number of updated replicas doesn't match the expected one and looks there's no progress in the rollout. The alert monitors services deployed as Kubernetes `StatefulSet` and `Deployment`.
 
@@ -788,7 +788,7 @@ How to **investigate**:
 - Ensure there's no pod `NotReady` (the number of ready containers should match the total number of containers, eg. `1/1` or `2/2`)
 - Run `kubectl -n <namespace> describe statefulset <name>` or `kubectl -n <namespace> describe deployment <name>` and look at "Pod Status" and "Events" to get more information
 
-### CortexKVStoreFailure
+### MimirKVStoreFailure
 
 This alert fires if a Mimir instance is failing to run any operation on a KV store (eg. consul or etcd).
 
@@ -804,7 +804,7 @@ How to **investigate**:
 - Ensure Consul/Etcd is up and running.
 - Investigate the logs of the affected instance to find the specific error occurring when talking to Consul/Etcd.
 
-### CortexReachingTCPConnectionsLimit
+### MimirReachingTCPConnectionsLimit
 
 This alert fires if a Mimir instance is configured with `-server.http-conn-limit` or `-server.grpc-conn-limit` and is reaching the limit.
 


### PR DESCRIPTION
**What this PR does**:
As part of my effort to cleanup jsonnet and mixin, in this PR I've changed all alerts name prefix from Cortex to Mimir (parametrized, so will be changed if you change the product name).

No other "cortex" references are expected to be changed from the mixin (we only left metric names and gRPC methods, which are not going to be changed).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
