### PR TITLE
Build mimirtool binaries for different architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,7 @@ dist/$(UPTODATE):
 			if [ "$$os" = "windows" ]; then \
 				suffix=".exe" ; \
 			fi; \
-			if [ "$$os" = "darwin" ] && [ "$$arch" == "386" ]; then \
+			if [ "$$os" = "darwin" ] && [ "$$arch" = "386" ]; then \
 				continue; \
 			fi; \
 			echo "Building mimirtool for $$os/$$arch"; \


### PR DESCRIPTION
This adds mimirtool to `make dist`, which is a command run during the release process:

https://github.com/grafana/mimir/blob/7edb67d30da022eae7f324fe71cc8485816abc20/RELEASE.md?plain=1#L112

It also adds additional architecture, that are available today for [cortextool](https://github.com/grafana/cortex-tools/releases/tag/v0.10.7)

Fixes #837 