### PR TITLE
Add docs/sources/operations to files in check-doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,14 @@ clean-doc:
 		./docs/sources/guides/encryption-at-rest.md
 
 check-doc: doc
-	@git diff --exit-code -- ./docs/sources/configuration/config-file-reference.md ./docs/sources/blocks-storage/*.md ./docs/sources/configuration/*.md ./operations/mimir/*.md ./operations/mimir-mixin/docs/sources/*.md
+	@git diff --exit-code -- \
+		./docs/sources/configuration/config-file-reference.md \
+		./docs/sources/blocks-storage/*.md \
+		./docs/sources/configuration/*.md \
+		./docs/sources/operations/*.md \
+		./operations/mimir/*.md \
+		./operations/mimir-mixin/docs/sources/*.md \
+	|| (echo "Please update generated documentation by running 'make doc'" && false)
 
 clean-white-noise:
 	@find . -path ./.pkg -prune -o -path ./vendor -prune -o -path ./website -prune -or -type f -name "*.md" -print | \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

`make check-doc` wouldn't catch stale docs in
./docs/sources/operations/\*.md. It also wouldn't give a meaningful help
message, like most of the other make check-\* targets do.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- o Tests updated
- o Documentation added
- o `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
