### PR TITLE
Fix TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod flakyness

### DIFF
--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -96,10 +96,11 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 	require.NoError(t, bucketClient.Upload(context.Background(), user4DebugMetaFile, strings.NewReader("some random content here")))
 
 	cfg := BlocksCleanerConfig{
-		DeletionDelay:      deletionDelay,
-		CleanupInterval:    time.Minute,
-		CleanupConcurrency: options.concurrency,
-		TenantCleanupDelay: options.tenantDeletionDelay,
+		DeletionDelay:           deletionDelay,
+		CleanupInterval:         time.Minute,
+		CleanupConcurrency:      options.concurrency,
+		TenantCleanupDelay:      options.tenantDeletionDelay,
+		DeleteBlocksConcurrency: 1,
 	}
 
 	reg := prometheus.NewPedanticRegistry()
@@ -231,9 +232,10 @@ func TestBlocksCleaner_ShouldContinueOnBlockDeletionFailure(t *testing.T) {
 	}
 
 	cfg := BlocksCleanerConfig{
-		DeletionDelay:      deletionDelay,
-		CleanupInterval:    time.Minute,
-		CleanupConcurrency: 1,
+		DeletionDelay:           deletionDelay,
+		CleanupInterval:         time.Minute,
+		CleanupConcurrency:      1,
+		DeleteBlocksConcurrency: 1,
 	}
 
 	logger := log.NewNopLogger()
@@ -290,9 +292,10 @@ func TestBlocksCleaner_ShouldRebuildBucketIndexOnCorruptedOne(t *testing.T) {
 	require.NoError(t, bucketClient.Upload(ctx, path.Join(userID, bucketindex.IndexCompressedFilename), strings.NewReader("invalid!}")))
 
 	cfg := BlocksCleanerConfig{
-		DeletionDelay:      deletionDelay,
-		CleanupInterval:    time.Minute,
-		CleanupConcurrency: 1,
+		DeletionDelay:           deletionDelay,
+		CleanupInterval:         time.Minute,
+		CleanupConcurrency:      1,
+		DeleteBlocksConcurrency: 1,
 	}
 
 	logger := log.NewNopLogger()
@@ -338,9 +341,10 @@ func TestBlocksCleaner_ShouldRemoveMetricsForTenantsNotBelongingAnymoreToTheShar
 	createTSDBBlock(t, bucketClient, "user-2", 30, 40, 2, nil)
 
 	cfg := BlocksCleanerConfig{
-		DeletionDelay:      time.Hour,
-		CleanupInterval:    time.Minute,
-		CleanupConcurrency: 1,
+		DeletionDelay:           time.Hour,
+		CleanupInterval:         time.Minute,
+		CleanupConcurrency:      1,
+		DeleteBlocksConcurrency: 1,
 	}
 
 	ctx := context.Background()
@@ -405,9 +409,10 @@ func TestBlocksCleaner_ShouldNotCleanupUserThatDoesntBelongToShardAnymore(t *tes
 	createTSDBBlock(t, bucketClient, "user-2", 20, 30, 2, nil)
 
 	cfg := BlocksCleanerConfig{
-		DeletionDelay:      time.Hour,
-		CleanupInterval:    time.Minute,
-		CleanupConcurrency: 1,
+		DeletionDelay:           time.Hour,
+		CleanupInterval:         time.Minute,
+		CleanupConcurrency:      1,
+		DeleteBlocksConcurrency: 1,
 	}
 
 	ctx := context.Background()
@@ -518,9 +523,10 @@ func TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod(t *testing.T) {
 	block4 := createTSDBBlock(t, bucketClient, "user-2", ts(-8), ts(-6), 2, nil)
 
 	cfg := BlocksCleanerConfig{
-		DeletionDelay:      time.Hour,
-		CleanupInterval:    time.Minute,
-		CleanupConcurrency: 1,
+		DeletionDelay:           time.Hour,
+		CleanupInterval:         time.Minute,
+		CleanupConcurrency:      1,
+		DeleteBlocksConcurrency: 1,
 	}
 
 	ctx := context.Background()

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -454,10 +454,11 @@ func (c *MultitenantCompactor) starting(ctx context.Context) error {
 
 	// Create the blocks cleaner (service).
 	c.blocksCleaner = NewBlocksCleaner(BlocksCleanerConfig{
-		DeletionDelay:      c.compactorCfg.DeletionDelay,
-		CleanupInterval:    util.DurationWithJitter(c.compactorCfg.CleanupInterval, 0.1),
-		CleanupConcurrency: c.compactorCfg.CleanupConcurrency,
-		TenantCleanupDelay: c.compactorCfg.TenantCleanupDelay,
+		DeletionDelay:           c.compactorCfg.DeletionDelay,
+		CleanupInterval:         util.DurationWithJitter(c.compactorCfg.CleanupInterval, 0.1),
+		CleanupConcurrency:      c.compactorCfg.CleanupConcurrency,
+		TenantCleanupDelay:      c.compactorCfg.TenantCleanupDelay,
+		DeleteBlocksConcurrency: defaultDeleteBlocksConcurrency,
 	}, c.bucketClient, c.shardingStrategy.blocksCleanerOwnUser, c.cfgProvider, c.parentLogger, c.registerer)
 
 	// Start blocks cleaner asynchronously, don't wait until initial cleanup is finished.


### PR DESCRIPTION
**What this PR does**:
`TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod` (like other tests) uses the filesystem-based object store. I found this suffers a race condition in the [deletion of an empty dir](https://github.com/thanos-io/thanos/blob/ce82cf3499d7a22af10013348c44185ee85313d8/pkg/objstore/filesystem/filesystem.go#L219): basically, if 2 goroutines delete an object in the same folder at the same time and, after their deletion, both of them detect that the dir is empty, the 2nd one trying to delete the empty dir will return error.

I will submit a fix to Thanos, but in the meanwhile I suggest to disable the blocks deletion concurrency in our tests.

**Which issue(s) this PR fixes**:
Fixes #824

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
