### PR TITLE
Rename the default overrides mountpoint from /etc/cortex to /etc/mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,7 @@
     * `cortex_ruler_allow_multiple_replicas_on_same_node` renamed to `ruler_allow_multiple_replicas_on_same_node`
     * `cortex_store_gateway_data_disk_class` renamed to `store_gateway_data_disk_class`
     * `cortex_store_gateway_data_disk_size` renamed to `store_gateway_data_disk_size`
+* [CHANGE] The overrides configmap default mountpoint has changed from `/etc/cortex` to `/etc/mimir`. It can be customized via the `overrides_configmap_mountpoint` config field. #899
 * [FEATURE] Added query sharding support. It can be enabled setting `cortex_query_sharding_enabled: true` in the `_config` object. #653
 * [ENHANCEMENT] Add overrides config to compactor. This allows setting retention configs per user. [#386](https://github.com/grafana/cortex-jsonnet/pull/386)
 * [ENHANCEMENT] Added 256MB memory ballast to querier. [#369](https://github.com/grafana/cortex-jsonnet/pull/369)

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -12,7 +12,7 @@
 
   groups+: [
     {
-      name: 'cortex_alerts',
+      name: 'mimir_alerts',
       rules: [
         {
           alert: $.alertName('IngesterUnhealthy'),

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -754,7 +754,7 @@ spec:
         - -mem-ballast-size-bytes=1073741824
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
@@ -782,7 +782,7 @@ spec:
             cpu: "2"
             memory: 2Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -845,7 +845,7 @@ spec:
         - -querier.worker-match-max-concurrent=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -880,7 +880,7 @@ spec:
             cpu: "1"
             memory: 12Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -927,7 +927,7 @@ spec:
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -frontend.split-queries-by-interval=24h
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -955,7 +955,7 @@ spec:
             cpu: "2"
             memory: 600Mi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1018,7 +1018,7 @@ spec:
             cpu: "2"
             memory: 1Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1085,7 +1085,7 @@ spec:
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1119,7 +1119,7 @@ spec:
             cpu: "1"
             memory: 6Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
       volumes:
@@ -1157,7 +1157,7 @@ spec:
         - -alertmanager.web.external-url=http://test/alertmanager
         - -experimental.alertmanager.enable-api=true
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=alertmanager
@@ -1187,7 +1187,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: alertmanager-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1249,7 +1249,7 @@ spec:
         - -compactor.split-and-merge-shards=0
         - -compactor.split-groups=1
         - -compactor.symbols-flushers-concurrency=4
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1276,7 +1276,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: compactor-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1346,7 +1346,7 @@ spec:
         - -ingester.unregister-on-shutdown=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1376,7 +1376,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: ingester-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1669,7 +1669,7 @@ spec:
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true
@@ -1702,7 +1702,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: store-gateway-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -753,7 +753,7 @@ spec:
         - -mem-ballast-size-bytes=1073741824
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
@@ -781,7 +781,7 @@ spec:
             cpu: "2"
             memory: 2Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -844,7 +844,7 @@ spec:
         - -querier.worker-match-max-concurrent=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -879,7 +879,7 @@ spec:
             cpu: "1"
             memory: 12Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -930,7 +930,7 @@ spec:
         - -frontend.split-queries-by-interval=24h
         - -log.level=debug
         - -querier.max-query-parallelism=240
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=419430400
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -958,7 +958,7 @@ spec:
             cpu: "2"
             memory: 600Mi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1021,7 +1021,7 @@ spec:
             cpu: "2"
             memory: 1Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1088,7 +1088,7 @@ spec:
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1122,7 +1122,7 @@ spec:
             cpu: "1"
             memory: 6Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
       volumes:
@@ -1160,7 +1160,7 @@ spec:
         - -alertmanager.web.external-url=http://test/alertmanager
         - -experimental.alertmanager.enable-api=true
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=alertmanager
@@ -1190,7 +1190,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: alertmanager-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1252,7 +1252,7 @@ spec:
         - -compactor.split-and-merge-shards=0
         - -compactor.split-groups=1
         - -compactor.symbols-flushers-concurrency=4
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1279,7 +1279,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: compactor-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1349,7 +1349,7 @@ spec:
         - -ingester.unregister-on-shutdown=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1379,7 +1379,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: ingester-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1672,7 +1672,7 @@ spec:
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true
@@ -1705,7 +1705,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: store-gateway-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -753,7 +753,7 @@ spec:
         - -mem-ballast-size-bytes=1073741824
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
@@ -781,7 +781,7 @@ spec:
             cpu: "2"
             memory: 2Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -846,7 +846,7 @@ spec:
         - -querier.worker-match-max-concurrent=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -881,7 +881,7 @@ spec:
             cpu: "1"
             memory: 12Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -928,7 +928,7 @@ spec:
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -frontend.split-queries-by-interval=24h
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -956,7 +956,7 @@ spec:
             cpu: "2"
             memory: 600Mi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1019,7 +1019,7 @@ spec:
             cpu: "2"
             memory: 1Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1090,7 +1090,7 @@ spec:
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1124,7 +1124,7 @@ spec:
             cpu: "1"
             memory: 6Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
       volumes:
@@ -1164,7 +1164,7 @@ spec:
         - -alertmanager.web.external-url=http://test/alertmanager
         - -experimental.alertmanager.enable-api=true
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=alertmanager
@@ -1194,7 +1194,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: alertmanager-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1258,7 +1258,7 @@ spec:
         - -compactor.split-and-merge-shards=0
         - -compactor.split-groups=1
         - -compactor.symbols-flushers-concurrency=4
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1285,7 +1285,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: compactor-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1357,7 +1357,7 @@ spec:
         - -ingester.unregister-on-shutdown=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1387,7 +1387,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: ingester-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1682,7 +1682,7 @@ spec:
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true
@@ -1715,7 +1715,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: store-gateway-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -753,7 +753,7 @@ spec:
         - -mem-ballast-size-bytes=1073741824
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
@@ -781,7 +781,7 @@ spec:
             cpu: "2"
             memory: 2Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -844,7 +844,7 @@ spec:
         - -querier.worker-match-max-concurrent=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -879,7 +879,7 @@ spec:
             cpu: "1"
             memory: 12Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -926,7 +926,7 @@ spec:
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -frontend.split-queries-by-interval=24h
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -954,7 +954,7 @@ spec:
             cpu: "2"
             memory: 600Mi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1017,7 +1017,7 @@ spec:
             cpu: "2"
             memory: 1Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1084,7 +1084,7 @@ spec:
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1118,7 +1118,7 @@ spec:
             cpu: "1"
             memory: 6Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
       volumes:
@@ -1156,7 +1156,7 @@ spec:
         - -alertmanager.web.external-url=http://test/alertmanager
         - -experimental.alertmanager.enable-api=true
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=alertmanager
@@ -1186,7 +1186,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: alertmanager-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1248,7 +1248,7 @@ spec:
         - -compactor.split-and-merge-shards=0
         - -compactor.split-groups=1
         - -compactor.symbols-flushers-concurrency=4
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1275,7 +1275,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: compactor-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1345,7 +1345,7 @@ spec:
         - -ingester.unregister-on-shutdown=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1375,7 +1375,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: ingester-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1668,7 +1668,7 @@ spec:
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true
@@ -1701,7 +1701,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: store-gateway-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -753,7 +753,7 @@ spec:
         - -mem-ballast-size-bytes=1073741824
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
@@ -781,7 +781,7 @@ spec:
             cpu: "2"
             memory: 2Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -845,7 +845,7 @@ spec:
         - -querier.worker-match-max-concurrent=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-write-timeout=1m
@@ -880,7 +880,7 @@ spec:
             cpu: "1"
             memory: 12Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -927,7 +927,7 @@ spec:
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -frontend.split-queries-by-interval=24h
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -955,7 +955,7 @@ spec:
             cpu: "2"
             memory: 600Mi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1018,7 +1018,7 @@ spec:
             cpu: "2"
             memory: 1Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       volumes:
       - configMap:
@@ -1088,7 +1088,7 @@ spec:
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1122,7 +1122,7 @@ spec:
             cpu: "1"
             memory: 6Gi
         volumeMounts:
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
       volumes:
@@ -1161,7 +1161,7 @@ spec:
         - -alertmanager.web.external-url=http://test/alertmanager
         - -experimental.alertmanager.enable-api=true
         - -log.level=debug
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=alertmanager
@@ -1191,7 +1191,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: alertmanager-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1254,7 +1254,7 @@ spec:
         - -compactor.split-and-merge-shards=0
         - -compactor.split-groups=1
         - -compactor.symbols-flushers-concurrency=4
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -target=compactor
@@ -1281,7 +1281,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: compactor-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1352,7 +1352,7 @@ spec:
         - -ingester.unregister-on-shutdown=true
         - -ring.heartbeat-timeout=10m
         - -ring.prefix=
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=10000
         - -server.grpc-max-recv-msg-size-bytes=10485760
         - -server.grpc-max-send-msg-size-bytes=10485760
@@ -1382,7 +1382,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: ingester-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0
@@ -1676,7 +1676,7 @@ spec:
         - -blocks-storage.bucket-store.sync-interval=15m
         - -blocks-storage.s3.bucket-name=blocks-bucket
         - -blocks-storage.s3.endpoint=s3.dualstack.us-east-1.amazonaws.com
-        - -runtime-config.file=/etc/cortex/overrides.yaml
+        - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -store-gateway.sharding-enabled=true
@@ -1709,7 +1709,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: store-gateway-data
-        - mountPath: /etc/cortex
+        - mountPath: /etc/mimir
           name: overrides
       securityContext:
         runAsUser: 0

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -66,7 +66,7 @@
     {
       target: 'alertmanager',
       'log.level': 'debug',
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
       'experimental.alertmanager.enable-api': 'true',
       'alertmanager.storage.path': '/data',
       'alertmanager.web.external-url': '%s/alertmanager' % $._config.external_url,
@@ -123,7 +123,7 @@
       statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
       statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
       statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
-      $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+      $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
       statefulSet.mixin.spec.template.spec.withVolumesMixin(
         if hasFallbackConfig then
           [volume.fromConfigMap('alertmanager-fallback-config', 'alertmanager-fallback-config')]

--- a/operations/mimir/compactor.libsonnet
+++ b/operations/mimir/compactor.libsonnet
@@ -38,7 +38,7 @@
       'compactor.ring.prefix': '',
 
       // Limits config.
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
     },
 
   // The compactor runs a statefulset with a single replica, because
@@ -78,7 +78,7 @@
     // rolled out one by one (the next pod will be rolled out once the previous is
     // ready).
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel') +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex'),
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint),
 
   compactor_statefulset:
     $.newCompactorStatefulSet('compactor', $.compactor_container),

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -123,7 +123,7 @@
 
     // Querier component config (shared between the ruler and querier).
     queryConfig: {
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
 
       // Don't allow individual queries of longer than 32days.  Due to day query
       // splitting in the frontend, the reality is this only limits rate(foo[32d])
@@ -246,6 +246,7 @@
     limitsConfig: self.distributorLimitsConfig + self.ingesterLimitsConfig + self.rulerLimitsConfig + self.compactorLimitsConfig,
 
     overrides_configmap: 'overrides',
+    overrides_configmap_mountpoint: '/etc/mimir',
 
     overrides: {
       extra_small_user:: {

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -10,7 +10,7 @@
     {
       target: 'distributor',
 
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
       'distributor.remote-timeout': '20s',
 
       'distributor.ha-tracker.enable': true,
@@ -55,7 +55,7 @@
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container], $.distributor_deployment_labels) +
     (if $._config.distributor_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
 

--- a/operations/mimir/flusher-job-blocks.libsonnet
+++ b/operations/mimir/flusher-job-blocks.libsonnet
@@ -44,6 +44,6 @@
     job.mixin.spec.template.metadata.withLabels({ name: 'flusher' }) +
     job.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     job.mixin.spec.template.spec.withTerminationGracePeriodSeconds(300) +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     $.util.podPriority('high'),
 }

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -22,7 +22,7 @@
       'ingester.unregister-on-shutdown': $._config.unregister_ingesters_on_shutdown,
 
       // Limits config.
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
       'server.grpc-max-concurrent-streams': 10000,
       'server.grpc-max-send-msg-size-bytes': 10 * 1024 * 1024,
       'server.grpc-max-recv-msg-size-bytes': 10 * 1024 * 1024,
@@ -78,7 +78,7 @@
     // For this reason, we grant an high termination period (80 minutes).
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(1200) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     $.util.podPriority('high') +
     // Parallelly scale up/down ingester instances instead of starting them
     // one by one. This does NOT affect rolling updates: they will continue to be

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -24,7 +24,7 @@
   overrides_exporter_args:: {
     target: 'overrides-exporter',
 
-    'runtime-config.file': '/etc/cortex/overrides.yaml',
+    'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
   } + $._config.limitsConfig,
 
   local container = $.core.v1.container,
@@ -41,7 +41,7 @@
   local deployment = $.apps.v1.deployment,
   overrides_exporter_deployment:
     deployment.new(name, 1, [$.overrides_exporter_container], { name: name }) +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     deployment.mixin.metadata.withLabels({ name: name }),
 
   overrides_exporter_service:

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -57,7 +57,7 @@
   newQuerierDeployment(name, container)::
     deployment.new(name, $._config.querier.replicas, [container], $.querier_deployment_labels) +
     (if $._config.querier_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
 

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -35,7 +35,7 @@
 
       // Limit queries to 500 days, allow this to be override per-user.
       'store.max-query-length': '12000h',  // 500 Days
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
     },
 
   query_frontend_container::
@@ -51,7 +51,7 @@
 
   newQueryFrontendDeployment(name, container)::
     deployment.new(name, $._config.queryFrontend.replicas, [container]) +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     (if $._config.query_frontend_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),

--- a/operations/mimir/query-scheduler.libsonnet
+++ b/operations/mimir/query-scheduler.libsonnet
@@ -24,7 +24,7 @@
 
   newQuerySchedulerDeployment(name, container)::
     deployment.new(name, 2, [container]) +
-    $.util.configVolumeMount('overrides', '/etc/cortex') +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     $.util.antiAffinity +
     // Do not run more query-schedulers than expected.
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -54,7 +54,7 @@
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
       (if $._config.ruler_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
-      $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex')
+      $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint)
     else {},
 
   local service = $.core.v1.service,

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -20,7 +20,7 @@
     $._config.queryBlocksStorageConfig +
     {
       target: 'store-gateway',
-      'runtime-config.file': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
 
       // Persist ring tokens so that when the store-gateway will be restarted
       // it will pick the same tokens
@@ -77,7 +77,7 @@
     // rolled out one by one (the next pod will be rolled out once the previous is
     // ready).
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel') +
-    $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex'),
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint),
 
   store_gateway_statefulset: self.newStoreGatewayStatefulSet('store-gateway', $.store_gateway_container),
 


### PR DESCRIPTION
**What this PR does**:
This should be the very last PR to cleanup our jsonnet/mixin, removing "cortex" references (except for metric names and default image until we'll have a public image for Mimir). In this PR I've changed the default overrides mountpoint from `/etc/cortex` to `/etc/mimir` but I've left it configurable (as it already was the configmap name).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
