### PR TITLE
Mimir: Tweak -help-all flag description

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -902,7 +902,7 @@ Usage of ./cmd/mimir/mimir:
   -help
     	Print basic help.
   -help-all
-    	Print help including also advanced and experimental flags.
+    	Print help, also including advanced and experimental parameters.
   -http.alertmanager-http-prefix string
     	HTTP URL path under which the Alertmanager ui and api will be served. (default "/alertmanager")
   -http.prefix string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -900,7 +900,7 @@ Usage of ./cmd/mimir/mimir:
   -help
     	Print basic help.
   -help-all
-    	Print help including also advanced and experimental flags.
+    	Print help, also including advanced and experimental parameters.
   -http.alertmanager-http-prefix string
     	HTTP URL path under which the Alertmanager ui and api will be served. (default "/alertmanager")
   -http.prefix string

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -99,7 +99,7 @@ func main() {
 	flag.BoolVar(&printModules, "modules", false, "List available values that can be used as target.")
 	flag.BoolVar(&printHelp, "help", false, "Print basic help.")
 	flag.BoolVar(&printHelp, "h", false, "Print basic help.")
-	flag.BoolVar(&printHelpAll, "help-all", false, "Print help including also advanced and experimental flags.")
+	flag.BoolVar(&printHelpAll, "help-all", false, "Print help, also including advanced and experimental parameters.")
 
 	flag.CommandLine.Usage = func() { /* don't do anything by default, we will print usage ourselves, but only when requested. */ }
 	flag.CommandLine.Init(flag.CommandLine.Name(), flag.ContinueOnError)


### PR DESCRIPTION
**What this PR does**:
Tweak `-help-all` flag description, from @KMiller-Grafana feedback.

While _flags_ isn't the wrong term per se, change to _parameters_ to be consistent with rest of help output.

**Which issue(s) this PR fixes**:

**Checklist**

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
