### PR TITLE
Set server port in backwards compatibility tests

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -37,6 +37,7 @@ func previousVersionImages() map[string]func(map[string]string) map[string]strin
 		for _, image := range strings.Split(overrideImageVersions, ",") {
 			previousVersionImages[image] = func(flags map[string]string) map[string]string {
 				flags["-store.engine"] = "blocks"
+				flags["-server.http-listen-port"] = "8080"
 				return flags
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This complements the change by #871 to `backward_compatibility.go`:

https://github.com/grafana/mimir/blob/fa71733208e8da11b14cd7707b19aa565a20f6a6/integration/backward_compatibility.go#L10

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
