### PR TITLE
Mimir: Tweak help output

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -105,7 +105,7 @@ func main() {
 	flag.CommandLine.Init(flag.CommandLine.Name(), flag.ContinueOnError)
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
-		fmt.Fprintln(flag.CommandLine.Output(), "Run with -help to get list of available parameters")
+		fmt.Fprintln(flag.CommandLine.Output(), "Run with -help to get a list of available parameters")
 		if !testMode {
 			os.Exit(2)
 		}

--- a/cmd/mimir/main_test.go
+++ b/cmd/mimir/main_test.go
@@ -49,7 +49,7 @@ func TestFlagParsing(t *testing.T) {
 
 		"unknown flag": {
 			arguments:      []string{"-unknown.flag"},
-			stderrMessage:  "Run with -help to get list of available parameters",
+			stderrMessage:  "Run with -help to get a list of available parameters",
 			stdoutExcluded: "Usage of", // No usage description on unknown flag.
 			stderrExcluded: "Usage of",
 		},


### PR DESCRIPTION
**What this PR does**:
Tweak help output when an unrecognized flag is provided, based on @KMiller-Grafana feedback.

**Which issue(s) this PR fixes**:

**Checklist**

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
