### PR TITLE
pkg/ruler: fix usage string of tenant federation

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1481,8 +1481,8 @@ Usage of ./cmd/mimir/mimir:
     	file path to store temporary rule files for the prometheus rule managers (default "/rules")
   -ruler.search-pending-for duration
     	Time to spend searching for a pending ruler when shutting down. (default 5m0s)
-  -ruler.tenant-federation.enabled source_tenants
-    	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's source_tenants field. If this flag is set to `false` when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
+  -ruler.tenant-federation.enabled
+    	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's `source_tenants` field. If this flag is set to `false` when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
   -ruler.tenant-shard-size int
     	The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.
   -runtime-config.file string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -1477,8 +1477,8 @@ Usage of ./cmd/mimir/mimir:
     	file path to store temporary rule files for the prometheus rule managers (default "/rules")
   -ruler.search-pending-for duration
     	Time to spend searching for a pending ruler when shutting down. (default 5m0s)
-  -ruler.tenant-federation.enabled source_tenants
-    	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's source_tenants field. If this flag is set to `false` when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
+  -ruler.tenant-federation.enabled
+    	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's `source_tenants` field. If this flag is set to `false` when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
   -ruler.tenant-shard-size int
     	The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.
   -runtime-config.file string

--- a/pkg/ruler/tenant_federation.go
+++ b/pkg/ruler/tenant_federation.go
@@ -20,7 +20,7 @@ type TenantFederationConfig struct {
 }
 
 func (cfg *TenantFederationConfig) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, "ruler.tenant-federation.enabled", false, "Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's `source_tenants` field. If this flag is set to `false` when there are already created federated rule groups, then these rules groups will be skipped during evaluations.")
+	f.BoolVar(&cfg.Enabled, "ruler.tenant-federation.enabled", false, "Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's ```source_tenants` field. If this flag is set to `false` when there are already created federated rule groups, then these rules groups will be skipped during evaluations.")
 }
 
 type contextKey int


### PR DESCRIPTION
**What this PR does**:

Because of https://pkg.go.dev/flag#UnquoteUsage , the rendered flag in the
output becomes "-ruler.tenant-federation.enabled source_tenants" but we
do not want text after the flag for boolean flags.

Fix by adding backticks to protect the emphasized part.

**Which issue(s) this PR fixes**:

N/A

**Checklist**

- [x] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
