### PR TITLE
Fix 'make docs' to show doc compilation errors

### DIFF
--- a/docs.mk
+++ b/docs.mk
@@ -13,23 +13,14 @@ DOCS_VERSION = next
 DOCS_DOCKER_RUN_FLAGS = -ti -v $(CURDIR)/$(DOCS_DIR):/hugo/content/docs/$(DOCS_PROJECT)/$(DOCS_VERSION):ro,z -p $(DOCS_HOST_PORT):$(DOCS_LISTEN_PORT) --rm $(DOCS_IMAGE)
 DOCS_DOCKER_CONTAINER = $(DOCS_PROJECT)-docs
 
-# This wrapper will delete the pre-existing Grafana and Loki docs, which
-# significantly slows down the build process, due to the duplication of pages
-# through versioning.
+# This wrapper will serve documentation on a local webserver.
 define docs_docker_run
-	@docker run --name $(DOCS_DOCKER_CONTAINER) -d $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \; && exec $(1)'; \
-	until curl -sLw '%{http_code}' http://localhost:$(DOCS_HOST_PORT)/docs/$(DOCS_PROJECT)/ | grep -q 200; do \
-		echo "Waiting for docs container to be ready..."; \
-		sleep 1; \
-	done; \
-	docker logs $(DOCS_DOCKER_CONTAINER); \
-	echo ; \
-	echo ------------------------- ; \
-	echo Serving documentation at: ; \
-	echo http://$(DOCS_BASE_URL)/docs/$(DOCS_PROJECT)/$(DOCS_VERSION)/; \
-	echo ------------------------- ; \
-	echo ; \
-	docker attach $(DOCS_DOCKER_CONTAINER)
+	@echo "Documentation will be served at:"
+	@echo "http://$(DOCS_BASE_URL)/docs/$(DOCS_PROJECT)/$(DOCS_VERSION)/"
+	@echo ""
+	@read -p "Press a key to continue"
+
+	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \; && exec $(1)'
 endef
 
 .PHONY: docs-docker-rm


### PR DESCRIPTION
**What this PR does**:
While working on #925 I tried `make docs` and it looped forever in `Waiting for docs container to be ready...`. Why? Because if there's an issue in the markdown (eg. with links) and the compilation fails, the container immediately terminates, the health check run via `curl` will never succeed and, more importantly, the compilation error never displayed.

I suggest to keep it simple and just run the container without detaching it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
