### PR TITLE
Remove storage engine from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,11 +23,6 @@ A clear and concise description of what you expected to happen.
 - Infrastructure: [e.g., Kubernetes, bare-metal, laptop]
 - Deployment tool: [e.g., helm, jsonnet]
 
-**Storage Engine**
-
-- [ ] Blocks
-- [ ] Chunks
-
 **Additional Context**
 
 <!--  Additional relevant info which can help us debug this issue easily like Logs, Configuration etc. -->


### PR DESCRIPTION
**What this PR does**:
We now have only 1 storage engine, so no need to ask for it in the bug report template.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
