### PR TITLE
Remove -querier.at-modifier-enabled and enable it by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,7 @@
   * `-store-gateway.sharding-strategy` option has been removed store-gateways. Store-gateway now uses shuffle-sharding by default, but respects `store_gateway_tenant_shard_size` for tenant, and this value defaults to 0. #891
 * [CHANGE] Server: `-server.http-listen-port` (yaml: `server.http_listen_port`) now defaults to `8080` (previously `80`). #871
 * [CHANGE] Changed the default value of `blocks-storage.bucket-store.ignore-deletion-marks-delay` from 6h to 1h. #892
+* [CHANGE] Querier/ruler/query-frontend: the experimental `-querier.at-modifier-enabled` CLI flag has been removed and the PromQL `@` modifier is always enabled. #941
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1093,8 +1093,6 @@ Usage of ./cmd/mimir/mimir:
     	Secondary backend storage used by multi-client.
   -print.config
     	Print the config and exit.
-  -querier.at-modifier-enabled
-    	[experimental] Enable the @ modifier in PromQL. This config option should be set on query-frontend too when query sharding is enabled.
   -querier.batch-iterators
     	Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag. (default true)
   -querier.cardinality-analysis-enabled

--- a/docs/sources/blocks-storage/querier.md
+++ b/docs/sources/blocks-storage/querier.md
@@ -189,11 +189,6 @@ querier:
   # CLI flag: -querier.max-samples
   [max_samples: <int> | default = 50000000]
 
-  # Enable the @ modifier in PromQL. This config option should be set on
-  # query-frontend too when query sharding is enabled.
-  # CLI flag: -querier.at-modifier-enabled
-  [at_modifier_enabled: <boolean> | default = false]
-
   # The default evaluation interval or step size for subqueries. This config
   # option should be set on query-frontend too when query sharding is enabled.
   # CLI flag: -querier.default-evaluation-interval

--- a/docs/sources/configuration/config-file-reference.md
+++ b/docs/sources/configuration/config-file-reference.md
@@ -870,11 +870,6 @@ store_gateway_client:
 # CLI flag: -querier.max-samples
 [max_samples: <int> | default = 50000000]
 
-# Enable the @ modifier in PromQL. This config option should be set on
-# query-frontend too when query sharding is enabled.
-# CLI flag: -querier.at-modifier-enabled
-[at_modifier_enabled: <boolean> | default = false]
-
 # The default evaluation interval or step size for subqueries. This config
 # option should be set on query-frontend too when query sharding is enabled.
 # CLI flag: -querier.default-evaluation-interval

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -513,14 +513,6 @@ overrides:
 			expStatusCode: http.StatusBadRequest,
 			expBody:       `{"error": "negative offsets are not supported", "errorType":"bad_data", "status":"error"}`,
 		},
-		{
-			name: "error when at-modifier is unsupported",
-			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
-				return c.QueryRangeRaw(`http_requests_total @ start()`, now.Add(-time.Minute), now, time.Minute)
-			},
-			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"@ modifier is disabled, use -querier.at-modifier-enabled to enable it", "errorType":"bad_data", "status":"error"}`,
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp, body, err := tc.query(cQuerier)

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -758,7 +758,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-address=query-frontend-discovery.default.svc.cluster.local:9095
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -836,7 +836,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
         - -querier.query-ingesters-within=13h
@@ -1076,7 +1075,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -experimental.ruler.enable-api=true
-        - -querier.at-modifier-enabled=true
         - -querier.query-ingesters-within=13h
         - -querier.query-label-names-with-matchers-enabled=true
         - -querier.query-store-after=12h

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -835,7 +835,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-client.grpc-max-send-msg-size=419430400
         - -querier.max-concurrent=16
         - -querier.query-ingesters-within=13h
@@ -931,7 +930,6 @@ spec:
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -frontend.split-queries-by-interval=24h
-        - -querier.at-modifier-enabled=true
         - -querier.max-query-parallelism=240
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=419430400
@@ -1080,7 +1078,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -experimental.ruler.enable-api=true
-        - -querier.at-modifier-enabled=true
         - -querier.query-ingesters-within=13h
         - -querier.query-label-names-with-matchers-enabled=true
         - -querier.query-store-after=12h

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -837,7 +837,6 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
         - -querier.query-ingesters-within=13h
@@ -1082,7 +1081,6 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -distributor.replication-factor=3
         - -experimental.ruler.enable-api=true
-        - -querier.at-modifier-enabled=true
         - -querier.query-ingesters-within=13h
         - -querier.query-label-names-with-matchers-enabled=true
         - -querier.query-store-after=12h

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -837,7 +837,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
         - -querier.query-ingesters-within=13h
@@ -1079,7 +1078,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -experimental.ruler.enable-api=true
-        - -querier.at-modifier-enabled=true
         - -querier.query-ingesters-within=13h
         - -querier.query-label-names-with-matchers-enabled=true
         - -querier.query-store-after=12h

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -835,7 +835,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
         - -querier.query-ingesters-within=13h
@@ -1075,7 +1074,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -experimental.ruler.enable-api=true
-        - -querier.at-modifier-enabled=true
         - -querier.query-ingesters-within=13h
         - -querier.query-label-names-with-matchers-enabled=true
         - -querier.query-store-after=12h

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -836,7 +836,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -mem-ballast-size-bytes=268435456
-        - -querier.at-modifier-enabled=true
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
         - -querier.query-ingesters-within=13h
@@ -1077,7 +1076,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.replication-factor=3
         - -experimental.ruler.enable-api=true
-        - -querier.at-modifier-enabled=true
         - -querier.query-ingesters-within=13h
         - -querier.query-label-names-with-matchers-enabled=true
         - -querier.query-store-after=12h

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -141,9 +141,7 @@
     },
 
     // PromQL query engine config (shared between all services running PromQL engine, like the ruler and querier).
-    queryEngineConfig: {
-      'querier.at-modifier-enabled': true,
-    },
+    queryEngineConfig: {},
 
     ringConfig: {
       'consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/pkg/api/error_translate_query_engine.go
+++ b/pkg/api/error_translate_query_engine.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	errValidationAtModifierDisabled     = errors.New("@ modifier is disabled, use -querier.at-modifier-enabled to enable it")
 	errValidationNegativeOffsetDisabled = errors.New("negative offsets are not supported")
 )
 
@@ -36,8 +35,6 @@ func (qe errorTranslateQueryEngine) NewRangeQuery(q storage.Queryable, qs string
 
 func (qe errorTranslateQueryEngine) translate(err error) error {
 	switch err {
-	case promql.ErrValidationAtModifierDisabled:
-		return errValidationAtModifierDisabled
 	case promql.ErrValidationNegativeOffsetDisabled:
 		return errValidationNegativeOffsetDisabled
 	default:

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -16,10 +16,9 @@ import (
 
 // Config holds the PromQL engine config exposed by Mimir.
 type Config struct {
-	MaxConcurrent     int           `yaml:"max_concurrent"`
-	Timeout           time.Duration `yaml:"timeout"`
-	MaxSamples        int           `yaml:"max_samples"`
-	AtModifierEnabled bool          `yaml:"at_modifier_enabled" category:"experimental"`
+	MaxConcurrent int           `yaml:"max_concurrent"`
+	Timeout       time.Duration `yaml:"timeout"`
+	MaxSamples    int           `yaml:"max_samples"`
 
 	// The default evaluation interval for the promql engine.
 	// Needs to be configured for subqueries to work as it is the default
@@ -43,7 +42,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, sharedWithQueryFrontend("The maximum number of concurrent queries."))
 	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, sharedWithQueryFrontend("The timeout for a query."))
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, sharedWithQueryFrontend("Maximum number of samples a single query can load into memory."))
-	f.BoolVar(&cfg.AtModifierEnabled, "querier.at-modifier-enabled", false, sharedWithQueryFrontend("Enable the @ modifier in PromQL."))
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, sharedWithQueryFrontend("The default evaluation interval or step size for subqueries."))
 	f.DurationVar(&cfg.LookbackDelta, "querier.lookback-delta", 5*time.Minute, sharedWithQueryFrontend("Time since the last sample after which a time series is considered stale and ignored by expression evaluations."))
 }
@@ -57,7 +55,7 @@ func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.Activit
 		MaxSamples:           cfg.MaxSamples,
 		Timeout:              cfg.Timeout,
 		LookbackDelta:        cfg.LookbackDelta,
-		EnableAtModifier:     cfg.AtModifierEnabled,
+		EnableAtModifier:     true,
 		EnableNegativeOffset: false, // If this can be enabled, please change the error mapping in errorTranslateQueryEngine.
 		NoStepSubqueryIntervalFn: func(int64) int64 {
 			return cfg.DefaultEvaluationInterval.Milliseconds()


### PR DESCRIPTION
**What this PR does**:
In the next Prometheus release, the @ modifier will be always on and they removed the option to disable it (see Prometheus PR 10121). Since we have it enabled since a while in our infra and we've noticed no issues, I propose to do the same in Mimir.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
