### PR TITLE
Push images to docker hub

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -261,8 +261,13 @@ jobs:
           if [ -n "$GCR_REGISTRY_PASSWORD" ]; then
             printenv GCR_REGISTRY_PASSWORD | docker login -u "$GCR_REGISTRY_USER" --password-stdin us.gcr.io
           fi
+          if [ -n "$DOCKER_PASSWORD" ]; then
+            printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
+          fi
           export IMAGE_TAG=$(make image-tag)
           ./push-images
         env:
           GCR_REGISTRY_USER: _json_key
           GCR_REGISTRY_PASSWORD: ${{ secrets.gcr_json_key }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/push-images
+++ b/push-images
@@ -4,9 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Filter images to only push query-tee for now
-# TODO: Remove once mimir is becoming a public project
-IMAGES=$(make DOCKER_IMAGE_DIRS=./cmd/query-tee images)
 IMAGE_TAG=${IMAGE_TAG:-$(./tools/image-tag)}
 
 usage() {
@@ -26,12 +23,24 @@ done
 push_image() {
     local image="$1"
     echo "Pushing ${image}:${IMAGE_TAG}"
-    docker push ${image}:${IMAGE_TAG}
+    docker push "${image}:${IMAGE_TAG}"
+
+    # TODO: Check if it is a tag `v[0-9].[0-9].[0-9]` and if it is the latest release push a latest tag
 }
 
-for image in ${IMAGES}; do
-    if [[ "$image" == *"build"* ]]; then
-        continue
-    fi
+# Push images
+for image in $(make images ); do
+    image_name=$(basename "$image")
+    case "$image_name" in
+        mimir-build-image)
+            # skip mimir-build-image
+            continue
+            ;;
+        mimir|mimirtool)
+            old_image="$image"
+            image="docker.io/grafana/${image_name}"
+            docker tag "${old_image}:${IMAGE_TAG}" "${image}:${IMAGE_TAG}"
+            ;;
+    esac
     push_image "${image}"
 done


### PR DESCRIPTION
This ensures that mimirtool and mimir are pushed to Dockerhub grafana/mimirtool and grafana/mimir. The other images are still using the `us.gcr.io/kubernetes-dev` registry

I have actually pushed to the image repos using this test PR:

* https://github.com/grafana/mimir/tree/r000
* https://github.com/grafana/mimir/actions/runs/1761154890

What is left to be done in follow up PRs:

* Determine if the current image push is a new tag to the latest version. This will have to make sure that if you release a new patch version to an older version  it will not overwrite latest,

* Ensure the images pushed are actually multiarch (I don't think they are)
