### PR TITLE
distributor: Make MaxIngestionRate and MaxInflightPushRequests basic

### DIFF
--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -659,6 +659,10 @@ Usage of ./cmd/mimir/mimir:
     	Per-user ingestion rate limit in samples per second. (default 10000)
   -distributor.ingestion-tenant-shard-size int
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
+  -distributor.instance-limits.max-inflight-push-requests int
+    	Max inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.
+  -distributor.instance-limits.max-ingestion-rate float
+    	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
   -distributor.replication-factor int
     	The number of ingesters to write to and read from. (default 3)
   -distributor.ring.consul.acl-token string

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -149,8 +149,8 @@ type Config struct {
 }
 
 type InstanceLimits struct {
-	MaxIngestionRate        float64 `yaml:"max_ingestion_rate" category:"advanced"`
-	MaxInflightPushRequests int     `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxIngestionRate        float64 `yaml:"max_ingestion_rate"`
+	MaxInflightPushRequests int     `yaml:"max_inflight_push_requests"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet


### PR DESCRIPTION
**What this PR does**:
Make distributor configuration parameters max_ingestion_rate and max_inflight_push_requests basic, on advice from @pracucci.

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
