### PR TITLE
Change default settings for memcached client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,22 @@
 * [CHANGE] Changed the default value of `blocks-storage.bucket-store.ignore-deletion-marks-delay` from 6h to 1h. #892
 * [CHANGE] Querier/ruler/query-frontend: the experimental `-querier.at-modifier-enabled` CLI flag has been removed and the PromQL `@` modifier is always enabled. #941
 * [CHANGE] Ruler: `-ruler.alertmanager-use-v2` now defaults to `true`. #954
+* [CHANGE] Changed default settings for memcached clients: #959
+  * The default value for the following config options has changed from `10000` to `25000`:
+    * `-blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size`
+    * `-blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size`
+    * `-blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size`
+    * `-frontend.results-cache.memcached.max-async-buffer-size`
+  * The default value for the following config options has changed from `0` (unlimited) to `100`:
+    * `-blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size`
+    * `-blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size`
+    * `-blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size`
+    * `-frontend.results-cache.memcached.max-get-multi-batch-size`
+  * The default value for the following config options has changed from `16` to `100`:
+    * `-blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections`
+    * `-blocks-storage.bucket-store.index-cache.memcached.max-idle-connections`
+    * `-blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections`
+    * `-frontend.results-cache.memcached.max-idle-connections`
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -274,15 +274,15 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.chunks-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -blocks-storage.bucket-store.chunks-cache.memcached.timeout duration
@@ -304,15 +304,15 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.index-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -blocks-storage.bucket-store.index-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -blocks-storage.bucket-store.index-cache.memcached.timeout duration
@@ -340,15 +340,15 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.metadata-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -blocks-storage.bucket-store.metadata-cache.memcached.timeout duration
@@ -876,15 +876,15 @@ Usage of ./cmd/mimir/mimir:
   -frontend.results-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -frontend.results-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -frontend.results-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -frontend.results-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -frontend.results-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -frontend.results-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -frontend.results-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -frontend.results-cache.memcached.timeout duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -274,15 +274,15 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.chunks-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -blocks-storage.bucket-store.chunks-cache.memcached.timeout duration
@@ -304,15 +304,15 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.index-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -blocks-storage.bucket-store.index-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -blocks-storage.bucket-store.index-cache.memcached.timeout duration
@@ -340,15 +340,15 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.metadata-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -blocks-storage.bucket-store.metadata-cache.memcached.timeout duration
@@ -808,15 +808,15 @@ Usage of ./cmd/mimir/mimir:
   -frontend.results-cache.memcached.addresses string
     	Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).
   -frontend.results-cache.memcached.max-async-buffer-size int
-    	The maximum number of enqueued asynchronous operations allowed. (default 10000)
+    	The maximum number of enqueued asynchronous operations allowed. (default 25000)
   -frontend.results-cache.memcached.max-async-concurrency int
     	The maximum number of concurrent asynchronous operations can occur. (default 50)
   -frontend.results-cache.memcached.max-get-multi-batch-size int
-    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.
+    	The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited. (default 100)
   -frontend.results-cache.memcached.max-get-multi-concurrency int
     	The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited. (default 100)
   -frontend.results-cache.memcached.max-idle-connections int
-    	The maximum number of idle connections that will be maintained per address. (default 16)
+    	The maximum number of idle connections that will be maintained per address. (default 100)
   -frontend.results-cache.memcached.max-item-size int
     	The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced. (default 1048576)
   -frontend.results-cache.memcached.timeout duration

--- a/docs/sources/configuration/config-file-reference.md
+++ b/docs/sources/configuration/config-file-reference.md
@@ -3529,7 +3529,7 @@ The `memcached_config` configures the Memcached-based caching backend. The suppo
 
 # The maximum number of idle connections that will be maintained per address.
 # CLI flag: -<prefix>.memcached.max-idle-connections
-[max_idle_connections: <int> | default = 16]
+[max_idle_connections: <int> | default = 100]
 
 # The maximum number of concurrent asynchronous operations can occur.
 # CLI flag: -<prefix>.memcached.max-async-concurrency
@@ -3537,7 +3537,7 @@ The `memcached_config` configures the Memcached-based caching backend. The suppo
 
 # The maximum number of enqueued asynchronous operations allowed.
 # CLI flag: -<prefix>.memcached.max-async-buffer-size
-[max_async_buffer_size: <int> | default = 10000]
+[max_async_buffer_size: <int> | default = 25000]
 
 # The maximum number of concurrent connections running get operations. If set to
 # 0, concurrency is unlimited.
@@ -3549,7 +3549,7 @@ The `memcached_config` configures the Memcached-based caching backend. The suppo
 # fetched concurrently, honoring the max concurrency. If set to 0, the max batch
 # size is unlimited.
 # CLI flag: -<prefix>.memcached.max-get-multi-batch-size
-[max_get_multi_batch_size: <int> | default = 0]
+[max_get_multi_batch_size: <int> | default = 100]
 
 # The maximum size of an item stored in memcached. Bigger items are not stored.
 # If set to 0, no maximum size is enforced.

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -747,9 +747,7 @@ spec:
         - -blocks-storage.backend=gcs
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1317,9 +1315,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1327,9 +1323,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1339,9 +1333,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -824,9 +824,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1062,9 +1060,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1646,9 +1642,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1656,9 +1650,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1668,9 +1660,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -823,9 +823,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1065,9 +1063,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1649,9 +1645,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1659,9 +1653,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1671,9 +1663,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -824,9 +824,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1067,9 +1065,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1656,9 +1652,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1666,9 +1660,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1678,9 +1670,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -826,9 +826,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1066,9 +1064,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1660,9 +1656,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1670,9 +1664,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1682,9 +1674,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -823,9 +823,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1061,9 +1059,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1645,9 +1641,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1655,9 +1649,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1667,9 +1659,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -823,9 +823,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1062,9 +1060,7 @@ spec:
         - -blocks-storage.bucket-store.bucket-index.enabled=true
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -1652,9 +1648,7 @@ spec:
         - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
@@ -1662,9 +1656,7 @@ spec:
         - -blocks-storage.bucket-store.ignore-blocks-within=10h
         - -blocks-storage.bucket-store.index-cache.backend=memcached
         - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
@@ -1674,9 +1666,7 @@ spec:
         - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
         - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size=25000
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -408,9 +408,7 @@
         'blocks-storage.bucket-store.index-cache.memcached.addresses': 'dnssrvnoa+memcached-index-queries.%(namespace)s.svc.cluster.local:11211' % $._config,
         'blocks-storage.bucket-store.index-cache.memcached.timeout': '200ms',
         'blocks-storage.bucket-store.index-cache.memcached.max-item-size': $._config.memcached_index_queries_max_item_size_mb * 1024 * 1024,
-        'blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size': '25000',
         'blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency': '50',
-        'blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size': '100',
       } else {}
     ) + (
       if $._config.memcached_chunks_enabled then {
@@ -418,9 +416,7 @@
         'blocks-storage.bucket-store.chunks-cache.memcached.addresses': 'dnssrvnoa+memcached.%(namespace)s.svc.cluster.local:11211' % $._config,
         'blocks-storage.bucket-store.chunks-cache.memcached.timeout': '200ms',
         'blocks-storage.bucket-store.chunks-cache.memcached.max-item-size': $._config.memcached_chunks_max_item_size_mb * 1024 * 1024,
-        'blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size': '25000',
         'blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency': '50',
-        'blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size': '100',
       } else {}
     ),
 
@@ -429,9 +425,7 @@
     'blocks-storage.bucket-store.metadata-cache.memcached.addresses': 'dnssrvnoa+memcached-metadata.%(namespace)s.svc.cluster.local:11211' % $._config,
     'blocks-storage.bucket-store.metadata-cache.memcached.timeout': '200ms',
     'blocks-storage.bucket-store.metadata-cache.memcached.max-item-size': $._config.memcached_metadata_max_item_size_mb * 1024 * 1024,
-    'blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size': '25000',
     'blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency': '50',
-    'blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size': '100',
   } else {},
 
   bucket_index_config:: if $._config.bucket_index_enabled then {

--- a/pkg/cache/memcache_config.go
+++ b/pkg/cache/memcache_config.go
@@ -33,11 +33,11 @@ type MemcachedConfig struct {
 func (cfg *MemcachedConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.StringVar(&cfg.Addresses, prefix+"addresses", "", "Comma separated list of memcached addresses. Supported prefixes are: dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after that).")
 	f.DurationVar(&cfg.Timeout, prefix+"timeout", 100*time.Millisecond, "The socket read/write timeout.")
-	f.IntVar(&cfg.MaxIdleConnections, prefix+"max-idle-connections", 16, "The maximum number of idle connections that will be maintained per address.")
+	f.IntVar(&cfg.MaxIdleConnections, prefix+"max-idle-connections", 100, "The maximum number of idle connections that will be maintained per address.")
 	f.IntVar(&cfg.MaxAsyncConcurrency, prefix+"max-async-concurrency", 50, "The maximum number of concurrent asynchronous operations can occur.")
-	f.IntVar(&cfg.MaxAsyncBufferSize, prefix+"max-async-buffer-size", 10000, "The maximum number of enqueued asynchronous operations allowed.")
+	f.IntVar(&cfg.MaxAsyncBufferSize, prefix+"max-async-buffer-size", 25000, "The maximum number of enqueued asynchronous operations allowed.")
 	f.IntVar(&cfg.MaxGetMultiConcurrency, prefix+"max-get-multi-concurrency", 100, "The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited.")
-	f.IntVar(&cfg.MaxGetMultiBatchSize, prefix+"max-get-multi-batch-size", 0, "The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.")
+	f.IntVar(&cfg.MaxGetMultiBatchSize, prefix+"max-get-multi-batch-size", 100, "The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.")
 	f.IntVar(&cfg.MaxItemSize, prefix+"max-item-size", 1024*1024, "The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced.")
 }
 


### PR DESCRIPTION
**What this PR does**:
We would like to change some default settings for memcached client, based on our production experience:
- Change default `*.memcached.max_get_multi_batch_size` to `100`
- Change default `*.memcached.max_async_buffer_size` to `25000`
- Change default `*.memcached.max_idle_connections` to `100`

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/mimir-squad/issues/490 https://github.com/grafana/mimir-squad/issues/489 https://github.com/grafana/mimir-squad/issues/491

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
