### PR TITLE
WIP: Add app.kubernetes.io labels to pods

### DIFF
--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # Start from a clean setup.
-rm -rf jsonnet-tests && mkdir jsonnet-tests
+#rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.18
+#tk init --k8s=1.18
 
 # Install Mimir jsonnet from this branch.
-jb install ../operations/mimir
+#jb install ../operations/mimir
 
 # Copy tests to dedicated environments and build them.
 export PAGER=cat

--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # Start from a clean setup.
-#rm -rf jsonnet-tests && mkdir jsonnet-tests
+rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-#tk init --k8s=1.18
+tk init --k8s=1.18
 
 # Install Mimir jsonnet from this branch.
-#jb install ../operations/mimir
+jb install ../operations/mimir
 
 # Copy tests to dedicated environments and build them.
 export PAGER=cat

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -642,8 +642,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -728,8 +726,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -826,8 +822,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -905,8 +899,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1001,8 +993,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1320,8 +1310,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -642,6 +642,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -650,6 +652,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -724,6 +728,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -732,6 +738,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -818,6 +826,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -826,6 +836,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -893,11 +905,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -985,11 +1001,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1300,11 +1320,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -718,6 +718,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -726,6 +728,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -800,6 +804,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -808,6 +814,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -896,6 +904,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -904,6 +914,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -971,6 +983,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -979,6 +993,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/part-of: mimir
         name: query-scheduler
     spec:
       affinity:
@@ -1034,6 +1050,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1042,6 +1060,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: mimir
         name: ruler
     spec:
       affinity:
@@ -1135,11 +1155,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: mimir
         name: alertmanager
     spec:
       containers:
@@ -1219,11 +1243,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -1311,11 +1339,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1626,11 +1658,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -718,8 +718,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -804,8 +802,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -904,8 +900,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -983,8 +977,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-scheduler
-      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -1050,8 +1042,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1155,8 +1145,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
@@ -1243,8 +1231,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1339,8 +1325,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1658,8 +1642,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-overrides-exporter-generated.yaml
+++ b/operations/mimir-tests/test-overrides-exporter-generated.yaml
@@ -1,0 +1,1527 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ingester-pdb
+  name: ingester-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ingester
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: store-gateway-pdb
+  name: store-gateway-pdb
+  namespace: default
+spec:
+  maxUnavailable: 2
+  selector:
+    matchLabels:
+      name: store-gateway
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: consul-sidekick
+  namespace: default
+---
+apiVersion: v1
+data:
+  consul-config.json: '{"leave_on_terminate": true, "raft_snapshot_threshold": 128,
+    "raft_trailing_logs": 10000, "telemetry": {"dogstatsd_addr": "127.0.0.1:9125"}}'
+  mapping: |
+    mappings:
+    - match: consul.*.runtime.*
+      name: consul_runtime
+      labels:
+        type: $2
+    - match: consul.runtime.total_gc_pause_ns
+      name: consul_runtime_total_gc_pause_ns
+      labels:
+        type: $2
+    - match: consul.consul.health.service.query-tag.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3
+    - match: consul.consul.health.service.query-tag.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9.$10
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9.$10.$11
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9.$10.$11.$12
+    - match: consul.consul.catalog.deregister
+      name: consul_catalog_deregister
+      labels: {}
+    - match: consul.consul.dns.domain_query.*.*.*.*.*
+      name: consul_dns_domain_query
+      labels:
+        query: $1.$2.$3.$4.$5
+    - match: consul.consul.health.service.not-found.*
+      name: consul_health_service_not_found
+      labels:
+        query: $1
+    - match: consul.consul.health.service.query.*
+      name: consul_health_service_query
+      labels:
+        query: $1
+    - match: consul.*.memberlist.health.score
+      name: consul_memberlist_health_score
+      labels: {}
+    - match: consul.serf.queue.*
+      name: consul_serf_events
+      labels:
+        type: $1
+    - match: consul.serf.snapshot.appendLine
+      name: consul_serf_snapshot_appendLine
+      labels:
+        type: $1
+    - match: consul.serf.coordinate.adjustment-ms
+      name: consul_serf_coordinate_adjustment_ms
+      labels: {}
+    - match: consul.consul.rpc.query
+      name: consul_rpc_query
+      labels: {}
+    - match: consul.*.consul.session_ttl.active
+      name: consul_session_ttl_active
+      labels: {}
+    - match: consul.raft.rpc.*
+      name: consul_raft_rpc
+      labels:
+        type: $1
+    - match: consul.raft.rpc.appendEntries.storeLogs
+      name: consul_raft_rpc_appendEntries_storeLogs
+      labels:
+        type: $1
+    - match: consul.consul.fsm.persist
+      name: consul_fsm_persist
+      labels: {}
+    - match: consul.raft.fsm.apply
+      name: consul_raft_fsm_apply
+      labels: {}
+    - match: consul.raft.leader.lastContact
+      name: consul_raft_leader_lastcontact
+      labels: {}
+    - match: consul.raft.leader.dispatchLog
+      name: consul_raft_leader_dispatchLog
+      labels: {}
+    - match: consul.raft.commitTime
+      name: consul_raft_commitTime
+      labels: {}
+    - match: consul.raft.replication.appendEntries.logs.*.*.*.*
+      name: consul_raft_replication_appendEntries_logs
+      labels:
+        query: ${1}.${2}.${3}.${4}
+    - match: consul.raft.replication.appendEntries.rpc.*.*.*.*
+      name: consul_raft_replication_appendEntries_rpc
+      labels:
+        query: ${1}.${2}.${3}.${4}
+    - match: consul.raft.replication.heartbeat.*.*.*.*
+      name: consul_raft_replication_heartbeat
+      labels:
+        query: ${1}.${2}.${3}.${4}
+    - match: consul.consul.rpc.request
+      name: consul_rpc_requests
+      labels: {}
+    - match: consul.consul.rpc.accept_conn
+      name: consul_rpc_accept_conn
+      labels: {}
+    - match: consul.memberlist.udp.*
+      name: consul_memberlist_udp
+      labels:
+        type: $1
+    - match: consul.memberlist.tcp.*
+      name: consul_memberlist_tcp
+      labels:
+        type: $1
+    - match: consul.memberlist.gossip
+      name: consul_memberlist_gossip
+      labels: {}
+    - match: consul.memberlist.probeNode
+      name: consul_memberlist_probenode
+      labels: {}
+    - match: consul.memberlist.pushPullNode
+      name: consul_memberlist_pushpullnode
+      labels: {}
+    - match: consul.http.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /
+    - match: consul.http.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2
+    - match: consul.http.*.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2/$3
+    - match: consul.http.*.*.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2/$3/$4
+    - match: consul.http.*.*.*.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2/$3/$4/$5
+    - match: consul.consul.leader.barrier
+      name: consul_leader_barrier
+      labels: {}
+    - match: consul.consul.leader.reconcileMember
+      name: consul_leader_reconcileMember
+      labels: {}
+    - match: consul.consul.leader.reconcile
+      name: consul_leader_reconcile
+      labels: {}
+    - match: consul.consul.fsm.coordinate.batch-update
+      name: consul_fsm_coordinate_batch_update
+      labels: {}
+    - match: consul.consul.fsm.autopilot
+      name: consul_fsm_autopilot
+      labels: {}
+    - match: consul.consul.fsm.kvs.cas
+      name: consul_fsm_kvs_cas
+      labels: {}
+    - match: consul.consul.fsm.register
+      name: consul_fsm_register
+      labels: {}
+    - match: consul.consul.fsm.deregister
+      name: consul_fsm_deregister
+      labels: {}
+    - match: consul.consul.fsm.tombstone.reap
+      name: consul_fsm_tombstone_reap
+      labels: {}
+    - match: consul.consul.catalog.register
+      name: consul_catalog_register
+      labels: {}
+    - match: consul.consul.catalog.deregister
+      name: consul_catalog_deregister
+      labels: {}
+    - match: consul.consul.leader.reapTombstones
+      name: consul_leader_reapTombstones
+      labels: {}
+kind: ConfigMap
+metadata:
+  name: consul
+  namespace: default
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides: {}
+kind: ConfigMap
+metadata:
+  name: overrides
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: consul-sidekick
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  - extensions
+  - apps
+  resources:
+  - pods
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: consul-sidekick
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: consul-sidekick
+subjects:
+- kind: ServiceAccount
+  name: consul-sidekick
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: consul
+  name: consul
+  namespace: default
+spec:
+  ports:
+  - name: consul-server
+    port: 8300
+    targetPort: 8300
+  - name: consul-serf
+    port: 8301
+    targetPort: 8301
+  - name: consul-client
+    port: 8400
+    targetPort: 8400
+  - name: consul-api
+    port: 8500
+    targetPort: 8500
+  - name: statsd-exporter-http-metrics
+    port: 8000
+    targetPort: 8000
+  - name: consul-exporter-http-metrics
+    port: 9107
+    targetPort: 9107
+  selector:
+    name: consul
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: distributor
+  name: distributor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: distributor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: distributor-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: distributor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ingester
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: overrides-exporter
+  name: overrides-exporter
+  namespace: default
+spec:
+  ports:
+  - name: overrides-exporter-http-metrics
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: overrides-exporter
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  ports:
+  - name: querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: querier-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: store-gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consul
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: consul
+  template:
+    metadata:
+      annotations:
+        consul-hash: e56ef6821a3557604caccaf6d5820239
+      labels:
+        name: consul
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: consul
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchLabels:
+                name: ingester
+            namespaces:
+            - default
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - agent
+        - -ui
+        - -server
+        - -client=0.0.0.0
+        - -config-file=/etc/config/consul-config.json
+        - -bootstrap-expect=1
+        - -ui-content-path=/default/consul/
+        env:
+        - name: CHECKPOINT_DISABLE
+          value: "1"
+        image: consul:1.5.3
+        imagePullPolicy: IfNotPresent
+        name: consul
+        ports:
+        - containerPort: 8300
+          name: server
+        - containerPort: 8301
+          name: serf
+        - containerPort: 8400
+          name: client
+        - containerPort: 8500
+          name: api
+        resources:
+          requests:
+            cpu: "4"
+            memory: 4Gi
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      - args:
+        - --namespace=$(POD_NAMESPACE)
+        - --pod-name=$(POD_NAME)
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: weaveworks/consul-sidekick:master-f18ad13
+        imagePullPolicy: IfNotPresent
+        name: sidekick
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      - args:
+        - --web.listen-address=:8000
+        - --statsd.mapping-config=/etc/config/mapping
+        image: prom/statsd-exporter:v0.12.2
+        imagePullPolicy: IfNotPresent
+        name: statsd-exporter
+        ports:
+        - containerPort: 8000
+          name: http-metrics
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      - args:
+        - --consul.server=localhost:8500
+        - --web.listen-address=:9107
+        - --consul.timeout=1s
+        - --no-consul.health-summary
+        - --consul.allow_stale
+        image: prom/consul-exporter:v0.5.0
+        imagePullPolicy: IfNotPresent
+        name: consul-exporter
+        ports:
+        - containerPort: 9107
+          name: http-metrics
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      serviceAccount: consul-sidekick
+      volumes:
+      - configMap:
+          name: consul
+        name: consul
+      - emptyDir:
+          medium: Memory
+        name: data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: distributor
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
+      name: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
+        name: distributor
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: distributor
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.extend-writes=true
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.etcd.endpoints=etcd-client.default.svc.cluster.local.:2379
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=etcd
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.remote-timeout=20s
+        - -distributor.replication-factor=3
+        - -distributor.ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.ring.prefix=
+        - -mem-ballast-size-bytes=1073741824
+        - -ring.heartbeat-timeout=10m
+        - -ring.prefix=
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=distributor
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overrides-exporter
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: overrides-exporter
+      app.kubernetes.io/part-of: mimir
+      name: overrides-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: overrides-exporter
+        app.kubernetes.io/part-of: mimir
+        name: overrides-exporter
+    spec:
+      containers:
+      - args:
+        - -compactor.blocks-retention-period=0
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -ingester.max-global-series-per-metric=20000
+        - -ingester.max-global-series-per-user=150000
+        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rules-per-rule-group=20
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.http-listen-port=8080
+        - -target=overrides-exporter
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: overrides-exporter
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http-metrics
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: 0.5Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 6
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
+      name: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
+        name: querier
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: querier
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.health-check-ingesters=true
+        - -distributor.replication-factor=3
+        - -mem-ballast-size-bytes=268435456
+        - -querier.frontend-address=query-frontend-discovery.default.svc.cluster.local:9095
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.query-ingesters-within=13h
+        - -querier.query-label-names-with-matchers-enabled=true
+        - -querier.query-store-after=12h
+        - -querier.query-store-for-labels-enabled=true
+        - -ring.heartbeat-timeout=10m
+        - -ring.prefix=
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -server.http-write-timeout=1m
+        - -store-gateway.sharding-enabled=true
+        - -store-gateway.sharding-ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=consul
+        - -store.max-query-length=768h
+        - -target=querier
+        env:
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1024"
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
+      name: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
+        name: query-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: query-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -api.response-compression-enabled=true
+        - -frontend.align-querier-with-step=false
+        - -frontend.cache-results=true
+        - -frontend.max-cache-freshness=10m
+        - -frontend.results-cache.backend=memcached
+        - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
+        - -frontend.results-cache.memcached.timeout=500ms
+        - -frontend.split-queries-by-interval=24h
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-recv-msg-size-bytes=104857600
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -server.http-write-timeout=1m
+        - -store.max-query-length=12000h
+        - -target=query-frontend
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 1200Mi
+          requests:
+            cpu: "2"
+            memory: 600Mi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
+      name: compactor
+  serviceName: compactor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
+        name: compactor
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data
+        - -compactor.deletion-delay=2h
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=consul
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: compactor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 6Gi
+          requests:
+            cpu: 1
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
+      name: ingester
+  serviceName: ingester
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
+        name: ingester
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ingester
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.close-idle-tsdb-timeout=13h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.isolation-enabled=false
+        - -blocks-storage.tsdb.retention-period=24h
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.health-check-ingesters=true
+        - -distributor.replication-factor=3
+        - -ingester.heartbeat-period=15s
+        - -ingester.join-after=0s
+        - -ingester.max-global-series-per-metric=20000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.num-tokens=512
+        - -ingester.tokens-file-path=/data/tokens
+        - -ingester.unregister-on-shutdown=true
+        - -ring.heartbeat-timeout=10m
+        - -ring.prefix=
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=10000
+        - -server.grpc-max-recv-msg-size-bytes=10485760
+        - -server.grpc-max-send-msg-size-bytes=10485760
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached
+  serviceName: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-frontend
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-frontend
+  serviceName: memcached-frontend
+  template:
+    metadata:
+      labels:
+        name: memcached-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 1024
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1329Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+  serviceName: memcached-index-queries
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1329Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata
+  serviceName: memcached-metadata
+  template:
+    metadata:
+      labels:
+        name: memcached-metadata
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 512
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 768Mi
+          requests:
+            cpu: 500m
+            memory: 715Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
+      name: store-gateway
+  serviceName: store-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
+        name: store-gateway
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.ignore-blocks-within=10h
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.index-header-lazy-loading-enabled=true
+        - -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout=60m
+        - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-enabled=true
+        - -store-gateway.sharding-ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=consul
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -target=store-gateway
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+metadata:
+  annotations:
+    etcd.database.coreos.com/scope: clusterwide
+  name: etcd
+  namespace: default
+spec:
+  pod:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              etcd_cluster: etcd
+          topologyKey: kubernetes.io/hostname
+    annotations:
+      prometheus.io/port: "2379"
+      prometheus.io/scrape: "true"
+    etcdEnv:
+    - name: ETCD_AUTO_COMPACTION_RETENTION
+      value: 1h
+    labels:
+      name: etcd
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  size: 3
+  version: 3.3.13

--- a/operations/mimir-tests/test-overrides-exporter-generated.yaml
+++ b/operations/mimir-tests/test-overrides-exporter-generated.yaml
@@ -657,8 +657,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -746,8 +744,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: overrides-exporter
-      app.kubernetes.io/part-of: mimir
       name: overrides-exporter
   template:
     metadata:
@@ -803,8 +799,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -901,8 +895,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -980,8 +972,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1076,8 +1066,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1395,8 +1383,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-overrides-exporter-generated.yaml
+++ b/operations/mimir-tests/test-overrides-exporter-generated.yaml
@@ -688,7 +688,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
-        - -distributor.remote-timeout=20s
         - -distributor.replication-factor=3
         - -distributor.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-overrides-exporter-generated.yaml
+++ b/operations/mimir-tests/test-overrides-exporter-generated.yaml
@@ -736,6 +736,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    name: overrides-exporter
   name: overrides-exporter
   namespace: default
 spec:

--- a/operations/mimir-tests/test-overrides-exporter.jsonnet
+++ b/operations/mimir-tests/test-overrides-exporter.jsonnet
@@ -1,0 +1,12 @@
+local mimir = import 'mimir/mimir.libsonnet';
+local overrides_exporter = import 'mimir/overrides-exporter.libsonnet';
+
+overrides_exporter + mimir + {
+  _config+:: {
+    namespace: 'default',
+    external_url: 'http://test',
+
+    blocks_storage_backend: 'gcs',
+    blocks_storage_bucket_name: 'blocks-bucket',
+  },
+}

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -717,6 +717,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -725,6 +727,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -799,6 +803,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -807,6 +813,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -895,6 +903,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -903,6 +913,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -974,6 +986,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -982,6 +996,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/part-of: mimir
         name: query-scheduler
     spec:
       affinity:
@@ -1037,6 +1053,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1045,6 +1063,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: mimir
         name: ruler
     spec:
       affinity:
@@ -1138,11 +1158,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: mimir
         name: alertmanager
     spec:
       containers:
@@ -1222,11 +1246,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -1314,11 +1342,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1629,11 +1661,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -717,8 +717,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -803,8 +801,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -903,8 +899,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -986,8 +980,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-scheduler
-      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -1053,8 +1045,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1158,8 +1148,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
@@ -1246,8 +1234,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1342,8 +1328,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1661,8 +1645,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-query-tee-generated.yaml
+++ b/operations/mimir-tests/test-query-tee-generated.yaml
@@ -1,0 +1,1508 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ingester-pdb
+  name: ingester-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ingester
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: store-gateway-pdb
+  name: store-gateway-pdb
+  namespace: default
+spec:
+  maxUnavailable: 2
+  selector:
+    matchLabels:
+      name: store-gateway
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: consul-sidekick
+  namespace: default
+---
+apiVersion: v1
+data:
+  consul-config.json: '{"leave_on_terminate": true, "raft_snapshot_threshold": 128,
+    "raft_trailing_logs": 10000, "telemetry": {"dogstatsd_addr": "127.0.0.1:9125"}}'
+  mapping: |
+    mappings:
+    - match: consul.*.runtime.*
+      name: consul_runtime
+      labels:
+        type: $2
+    - match: consul.runtime.total_gc_pause_ns
+      name: consul_runtime_total_gc_pause_ns
+      labels:
+        type: $2
+    - match: consul.consul.health.service.query-tag.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3
+    - match: consul.consul.health.service.query-tag.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9.$10
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9.$10.$11
+    - match: consul.consul.health.service.query-tag.*.*.*.*.*.*.*.*.*.*.*.*
+      name: consul_health_service_query_tag
+      labels:
+        query: $1.$2.$3.$4.$5.$6.$7.$8.$9.$10.$11.$12
+    - match: consul.consul.catalog.deregister
+      name: consul_catalog_deregister
+      labels: {}
+    - match: consul.consul.dns.domain_query.*.*.*.*.*
+      name: consul_dns_domain_query
+      labels:
+        query: $1.$2.$3.$4.$5
+    - match: consul.consul.health.service.not-found.*
+      name: consul_health_service_not_found
+      labels:
+        query: $1
+    - match: consul.consul.health.service.query.*
+      name: consul_health_service_query
+      labels:
+        query: $1
+    - match: consul.*.memberlist.health.score
+      name: consul_memberlist_health_score
+      labels: {}
+    - match: consul.serf.queue.*
+      name: consul_serf_events
+      labels:
+        type: $1
+    - match: consul.serf.snapshot.appendLine
+      name: consul_serf_snapshot_appendLine
+      labels:
+        type: $1
+    - match: consul.serf.coordinate.adjustment-ms
+      name: consul_serf_coordinate_adjustment_ms
+      labels: {}
+    - match: consul.consul.rpc.query
+      name: consul_rpc_query
+      labels: {}
+    - match: consul.*.consul.session_ttl.active
+      name: consul_session_ttl_active
+      labels: {}
+    - match: consul.raft.rpc.*
+      name: consul_raft_rpc
+      labels:
+        type: $1
+    - match: consul.raft.rpc.appendEntries.storeLogs
+      name: consul_raft_rpc_appendEntries_storeLogs
+      labels:
+        type: $1
+    - match: consul.consul.fsm.persist
+      name: consul_fsm_persist
+      labels: {}
+    - match: consul.raft.fsm.apply
+      name: consul_raft_fsm_apply
+      labels: {}
+    - match: consul.raft.leader.lastContact
+      name: consul_raft_leader_lastcontact
+      labels: {}
+    - match: consul.raft.leader.dispatchLog
+      name: consul_raft_leader_dispatchLog
+      labels: {}
+    - match: consul.raft.commitTime
+      name: consul_raft_commitTime
+      labels: {}
+    - match: consul.raft.replication.appendEntries.logs.*.*.*.*
+      name: consul_raft_replication_appendEntries_logs
+      labels:
+        query: ${1}.${2}.${3}.${4}
+    - match: consul.raft.replication.appendEntries.rpc.*.*.*.*
+      name: consul_raft_replication_appendEntries_rpc
+      labels:
+        query: ${1}.${2}.${3}.${4}
+    - match: consul.raft.replication.heartbeat.*.*.*.*
+      name: consul_raft_replication_heartbeat
+      labels:
+        query: ${1}.${2}.${3}.${4}
+    - match: consul.consul.rpc.request
+      name: consul_rpc_requests
+      labels: {}
+    - match: consul.consul.rpc.accept_conn
+      name: consul_rpc_accept_conn
+      labels: {}
+    - match: consul.memberlist.udp.*
+      name: consul_memberlist_udp
+      labels:
+        type: $1
+    - match: consul.memberlist.tcp.*
+      name: consul_memberlist_tcp
+      labels:
+        type: $1
+    - match: consul.memberlist.gossip
+      name: consul_memberlist_gossip
+      labels: {}
+    - match: consul.memberlist.probeNode
+      name: consul_memberlist_probenode
+      labels: {}
+    - match: consul.memberlist.pushPullNode
+      name: consul_memberlist_pushpullnode
+      labels: {}
+    - match: consul.http.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /
+    - match: consul.http.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2
+    - match: consul.http.*.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2/$3
+    - match: consul.http.*.*.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2/$3/$4
+    - match: consul.http.*.*.*.*.*
+      name: consul_http_request
+      labels:
+        method: $1
+        path: /$2/$3/$4/$5
+    - match: consul.consul.leader.barrier
+      name: consul_leader_barrier
+      labels: {}
+    - match: consul.consul.leader.reconcileMember
+      name: consul_leader_reconcileMember
+      labels: {}
+    - match: consul.consul.leader.reconcile
+      name: consul_leader_reconcile
+      labels: {}
+    - match: consul.consul.fsm.coordinate.batch-update
+      name: consul_fsm_coordinate_batch_update
+      labels: {}
+    - match: consul.consul.fsm.autopilot
+      name: consul_fsm_autopilot
+      labels: {}
+    - match: consul.consul.fsm.kvs.cas
+      name: consul_fsm_kvs_cas
+      labels: {}
+    - match: consul.consul.fsm.register
+      name: consul_fsm_register
+      labels: {}
+    - match: consul.consul.fsm.deregister
+      name: consul_fsm_deregister
+      labels: {}
+    - match: consul.consul.fsm.tombstone.reap
+      name: consul_fsm_tombstone_reap
+      labels: {}
+    - match: consul.consul.catalog.register
+      name: consul_catalog_register
+      labels: {}
+    - match: consul.consul.catalog.deregister
+      name: consul_catalog_deregister
+      labels: {}
+    - match: consul.consul.leader.reapTombstones
+      name: consul_leader_reapTombstones
+      labels: {}
+kind: ConfigMap
+metadata:
+  name: consul
+  namespace: default
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides: {}
+kind: ConfigMap
+metadata:
+  name: overrides
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: consul-sidekick
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  - extensions
+  - apps
+  resources:
+  - pods
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: consul-sidekick
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: consul-sidekick
+subjects:
+- kind: ServiceAccount
+  name: consul-sidekick
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: consul
+  name: consul
+  namespace: default
+spec:
+  ports:
+  - name: consul-server
+    port: 8300
+    targetPort: 8300
+  - name: consul-serf
+    port: 8301
+    targetPort: 8301
+  - name: consul-client
+    port: 8400
+    targetPort: 8400
+  - name: consul-api
+    port: 8500
+    targetPort: 8500
+  - name: statsd-exporter-http-metrics
+    port: 8000
+    targetPort: 8000
+  - name: consul-exporter-http-metrics
+    port: 9107
+    targetPort: 9107
+  selector:
+    name: consul
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: distributor
+  name: distributor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: distributor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: distributor-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: distributor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ingester
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  ports:
+  - name: querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: querier-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: query-tee
+  namespace: default
+spec:
+  ports:
+  - name: http
+    nodePort: 1234
+    port: 80
+    targetPort: 80
+  selector:
+    name: query-tee
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: store-gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consul
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: consul
+  template:
+    metadata:
+      annotations:
+        consul-hash: e56ef6821a3557604caccaf6d5820239
+      labels:
+        name: consul
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: consul
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchLabels:
+                name: ingester
+            namespaces:
+            - default
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - agent
+        - -ui
+        - -server
+        - -client=0.0.0.0
+        - -config-file=/etc/config/consul-config.json
+        - -bootstrap-expect=1
+        - -ui-content-path=/default/consul/
+        env:
+        - name: CHECKPOINT_DISABLE
+          value: "1"
+        image: consul:1.5.3
+        imagePullPolicy: IfNotPresent
+        name: consul
+        ports:
+        - containerPort: 8300
+          name: server
+        - containerPort: 8301
+          name: serf
+        - containerPort: 8400
+          name: client
+        - containerPort: 8500
+          name: api
+        resources:
+          requests:
+            cpu: "4"
+            memory: 4Gi
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      - args:
+        - --namespace=$(POD_NAMESPACE)
+        - --pod-name=$(POD_NAME)
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: weaveworks/consul-sidekick:master-f18ad13
+        imagePullPolicy: IfNotPresent
+        name: sidekick
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      - args:
+        - --web.listen-address=:8000
+        - --statsd.mapping-config=/etc/config/mapping
+        image: prom/statsd-exporter:v0.12.2
+        imagePullPolicy: IfNotPresent
+        name: statsd-exporter
+        ports:
+        - containerPort: 8000
+          name: http-metrics
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      - args:
+        - --consul.server=localhost:8500
+        - --web.listen-address=:9107
+        - --consul.timeout=1s
+        - --no-consul.health-summary
+        - --consul.allow_stale
+        image: prom/consul-exporter:v0.5.0
+        imagePullPolicy: IfNotPresent
+        name: consul-exporter
+        ports:
+        - containerPort: 9107
+          name: http-metrics
+        volumeMounts:
+        - mountPath: /etc/config
+          name: consul
+        - mountPath: /consul/data/
+          name: data
+      serviceAccount: consul-sidekick
+      volumes:
+      - configMap:
+          name: consul
+        name: consul
+      - emptyDir:
+          medium: Memory
+        name: data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: distributor
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
+      name: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
+        name: distributor
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: distributor
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.extend-writes=true
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.etcd.endpoints=etcd-client.default.svc.cluster.local.:2379
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=etcd
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.remote-timeout=20s
+        - -distributor.replication-factor=3
+        - -distributor.ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.ring.prefix=
+        - -mem-ballast-size-bytes=1073741824
+        - -ring.heartbeat-timeout=10m
+        - -ring.prefix=
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=distributor
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 6
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
+      name: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
+        name: querier
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: querier
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.health-check-ingesters=true
+        - -distributor.replication-factor=3
+        - -mem-ballast-size-bytes=268435456
+        - -querier.frontend-address=query-frontend-discovery.default.svc.cluster.local:9095
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.query-ingesters-within=13h
+        - -querier.query-label-names-with-matchers-enabled=true
+        - -querier.query-store-after=12h
+        - -querier.query-store-for-labels-enabled=true
+        - -ring.heartbeat-timeout=10m
+        - -ring.prefix=
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -server.http-write-timeout=1m
+        - -store-gateway.sharding-enabled=true
+        - -store-gateway.sharding-ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=consul
+        - -store.max-query-length=768h
+        - -target=querier
+        env:
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1024"
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
+      name: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
+        name: query-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: query-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -api.response-compression-enabled=true
+        - -frontend.align-querier-with-step=false
+        - -frontend.cache-results=true
+        - -frontend.max-cache-freshness=10m
+        - -frontend.results-cache.backend=memcached
+        - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
+        - -frontend.results-cache.memcached.timeout=500ms
+        - -frontend.split-queries-by-interval=24h
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-recv-msg-size-bytes=104857600
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -server.http-write-timeout=1m
+        - -store.max-query-length=12000h
+        - -target=query-frontend
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 1200Mi
+          requests:
+            cpu: "2"
+            memory: 600Mi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-tee
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-tee
+      app.kubernetes.io/part-of: mimir
+      name: query-tee
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-tee
+        app.kubernetes.io/part-of: mimir
+        name: query-tee
+    spec:
+      containers:
+      - args:
+        - -backend.endpoints=
+        - -backend.preferred=
+        image: quay.io/cortexproject/query-tee:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: query-tee
+        ports:
+        - containerPort: 80
+          name: http
+        - containerPort: 9900
+          name: http-metrics
+        resources:
+          requests:
+            cpu: "1"
+            memory: 512Mi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
+      name: compactor
+  serviceName: compactor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
+        name: compactor
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data
+        - -compactor.deletion-delay=2h
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=consul
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: compactor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 6Gi
+          requests:
+            cpu: 1
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
+      name: ingester
+  serviceName: ingester
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
+        name: ingester
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ingester
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.close-idle-tsdb-timeout=13h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.isolation-enabled=false
+        - -blocks-storage.tsdb.retention-period=24h
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -consul.hostname=consul.default.svc.cluster.local:8500
+        - -distributor.health-check-ingesters=true
+        - -distributor.replication-factor=3
+        - -ingester.heartbeat-period=15s
+        - -ingester.join-after=0s
+        - -ingester.max-global-series-per-metric=20000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.num-tokens=512
+        - -ingester.tokens-file-path=/data/tokens
+        - -ingester.unregister-on-shutdown=true
+        - -ring.heartbeat-timeout=10m
+        - -ring.prefix=
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=10000
+        - -server.grpc-max-recv-msg-size-bytes=10485760
+        - -server.grpc-max-send-msg-size-bytes=10485760
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached
+  serviceName: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-frontend
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-frontend
+  serviceName: memcached-frontend
+  template:
+    metadata:
+      labels:
+        name: memcached-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 1024
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1329Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+  serviceName: memcached-index-queries
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1329Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata
+  serviceName: memcached-metadata
+  template:
+    metadata:
+      labels:
+        name: memcached-metadata
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 512
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.9-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 768Mi
+          requests:
+            cpu: 500m
+            memory: 715Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
+      name: store-gateway
+  serviceName: store-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
+        name: store-gateway
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.ignore-blocks-within=10h
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.index-header-lazy-loading-enabled=true
+        - -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout=60m
+        - -blocks-storage.bucket-store.max-chunk-pool-bytes=12884901888
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.metadata-cache.memcached.timeout=200ms
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-enabled=true
+        - -store-gateway.sharding-ring.consul.hostname=consul.default.svc.cluster.local:8500
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=consul
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -target=store-gateway
+        image: cortexproject/cortex:v1.9.0
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+metadata:
+  annotations:
+    etcd.database.coreos.com/scope: clusterwide
+  name: etcd
+  namespace: default
+spec:
+  pod:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              etcd_cluster: etcd
+          topologyKey: kubernetes.io/hostname
+    annotations:
+      prometheus.io/port: "2379"
+      prometheus.io/scrape: "true"
+    etcdEnv:
+    - name: ETCD_AUTO_COMPACTION_RETENTION
+      value: 1h
+    labels:
+      name: etcd
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  size: 3
+  version: 3.3.13

--- a/operations/mimir-tests/test-query-tee-generated.yaml
+++ b/operations/mimir-tests/test-query-tee-generated.yaml
@@ -657,8 +657,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -744,8 +742,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -842,8 +838,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -920,8 +914,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-tee
-      app.kubernetes.io/part-of: mimir
       name: query-tee
   template:
     metadata:
@@ -959,8 +951,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1055,8 +1045,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1374,8 +1362,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-query-tee-generated.yaml
+++ b/operations/mimir-tests/test-query-tee-generated.yaml
@@ -688,7 +688,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
-        - -distributor.remote-timeout=20s
         - -distributor.replication-factor=3
         - -distributor.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-query-tee.jsonnet
+++ b/operations/mimir-tests/test-query-tee.jsonnet
@@ -1,0 +1,15 @@
+local mimir = import 'mimir/mimir.libsonnet';
+local query_tee = import 'mimir/query-tee.libsonnet';
+
+query_tee + mimir + {
+  _config+:: {
+    namespace: 'default',
+    external_url: 'http://test',
+
+    blocks_storage_backend: 'gcs',
+    blocks_storage_bucket_name: 'blocks-bucket',
+
+    query_tee_enabled: true,
+    query_tee_node_port: 1234,
+  },
+}

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -717,6 +717,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -725,6 +727,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -800,6 +804,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -808,6 +814,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -899,6 +907,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -907,6 +917,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -975,6 +987,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -983,6 +997,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/part-of: mimir
         name: query-scheduler
     spec:
       affinity:
@@ -1039,6 +1055,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1047,6 +1065,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: mimir
         name: ruler
     spec:
       affinity:
@@ -1144,11 +1164,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: mimir
         name: alertmanager
     spec:
       containers:
@@ -1228,11 +1252,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -1320,11 +1348,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1636,11 +1668,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -717,8 +717,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -804,8 +802,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -907,8 +903,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -987,8 +981,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-scheduler
-      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -1055,8 +1047,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1164,8 +1154,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
@@ -1252,8 +1240,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1348,8 +1334,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1668,8 +1652,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -717,8 +717,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -803,8 +801,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -905,8 +901,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -984,8 +978,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-scheduler
-      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -1051,8 +1043,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1160,8 +1150,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
@@ -1250,8 +1238,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1348,8 +1334,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1669,8 +1653,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -717,6 +717,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -725,6 +727,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -799,6 +803,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -807,6 +813,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -897,6 +905,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -905,6 +915,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -972,6 +984,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -980,6 +994,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/part-of: mimir
         name: query-scheduler
     spec:
       affinity:
@@ -1035,6 +1051,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1043,6 +1061,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: mimir
         name: ruler
     spec:
       affinity:
@@ -1140,11 +1160,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: mimir
         name: alertmanager
     spec:
       containers:
@@ -1226,11 +1250,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -1320,11 +1348,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1637,11 +1669,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -717,6 +717,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -725,6 +727,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -799,6 +803,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -807,6 +813,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -895,6 +903,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -903,6 +913,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -970,6 +982,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -978,6 +992,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/part-of: mimir
         name: query-scheduler
     spec:
       affinity:
@@ -1033,6 +1049,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1041,6 +1059,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: mimir
         name: ruler
     spec:
       affinity:
@@ -1134,11 +1154,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: mimir
         name: alertmanager
     spec:
       containers:
@@ -1218,11 +1242,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -1310,11 +1338,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1625,11 +1657,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -717,8 +717,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -803,8 +801,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -903,8 +899,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -982,8 +976,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-scheduler
-      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -1049,8 +1041,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1154,8 +1144,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
@@ -1242,8 +1230,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1338,8 +1324,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1657,8 +1641,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -717,8 +717,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -803,8 +801,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -904,8 +900,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-frontend
-      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -983,8 +977,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: query-scheduler
-      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -1050,8 +1042,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: ruler
-      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1158,8 +1148,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
@@ -1247,8 +1235,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: compactor
-      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
@@ -1344,8 +1330,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
@@ -1664,8 +1648,6 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: store-gateway
-      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -717,6 +717,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/part-of: mimir
       name: distributor
   strategy:
     rollingUpdate:
@@ -725,6 +727,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: mimir
         name: distributor
     spec:
       affinity:
@@ -799,6 +803,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/part-of: mimir
       name: querier
   strategy:
     rollingUpdate:
@@ -807,6 +813,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: mimir
         name: querier
     spec:
       affinity:
@@ -896,6 +904,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/part-of: mimir
       name: query-frontend
   strategy:
     rollingUpdate:
@@ -904,6 +914,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: mimir
         name: query-frontend
     spec:
       affinity:
@@ -971,6 +983,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/part-of: mimir
       name: query-scheduler
   strategy:
     rollingUpdate:
@@ -979,6 +993,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/part-of: mimir
         name: query-scheduler
     spec:
       affinity:
@@ -1034,6 +1050,8 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
+      app.kubernetes.io/component: ruler
+      app.kubernetes.io/part-of: mimir
       name: ruler
   strategy:
     rollingUpdate:
@@ -1042,6 +1060,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: mimir
         name: ruler
     spec:
       affinity:
@@ -1138,11 +1158,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/part-of: mimir
       name: alertmanager
   serviceName: alertmanager
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: mimir
         name: alertmanager
     spec:
       containers:
@@ -1223,11 +1247,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/part-of: mimir
       name: compactor
   serviceName: compactor
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: mimir
         name: compactor
     spec:
       containers:
@@ -1316,11 +1344,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/part-of: mimir
       name: ingester
   serviceName: ingester
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: mimir
         name: ingester
     spec:
       affinity:
@@ -1632,11 +1664,15 @@ spec:
   replicas: 3
   selector:
     matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/part-of: mimir
       name: store-gateway
   serviceName: store-gateway
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: mimir
         name: store-gateway
     spec:
       containers:

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -122,12 +122,13 @@
 
   alertmanager_statefulset:
     if $._config.alertmanager_enabled then
-      statefulSet.new('alertmanager', $._config.alertmanager.replicas, [$.alertmanager_container], $.alertmanager_pvc, $.alertmanager_deployment_labels) +
+      statefulSet.new('alertmanager', $._config.alertmanager.replicas, [$.alertmanager_container], $.alertmanager_pvc) +
       statefulSet.mixin.spec.withServiceName('alertmanager') +
       statefulSet.mixin.metadata.withNamespace($._config.namespace) +
       statefulSet.mixin.metadata.withLabels({ name: 'alertmanager' }) +
       statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
       statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
+      statefulSet.mixin.spec.template.metadata.withLabelsMixin($.alertmanager_deployment_labels) +
       statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
       $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
       statefulSet.mixin.spec.template.spec.withVolumesMixin(

--- a/operations/mimir/compactor.libsonnet
+++ b/operations/mimir/compactor.libsonnet
@@ -105,13 +105,18 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
+  compactor_deployment_labels:: {
+    'app.kubernetes.io/component': 'compactor',
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
+
+  compactor_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
+
   newCompactorStatefulSet(name, container)::
-    statefulSet.new(name, 1, [container], compactor_data_pvc) +
+    statefulSet.new(name, 1, [container], compactor_data_pvc, $.compactor_deployment_labels) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: name }) +
-    statefulSet.mixin.spec.template.metadata.withLabels({ name: name }) +
-    statefulSet.mixin.spec.selector.withMatchLabels({ name: name }) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +

--- a/operations/mimir/compactor.libsonnet
+++ b/operations/mimir/compactor.libsonnet
@@ -113,11 +113,12 @@
   compactor_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
 
   newCompactorStatefulSet(name, container)::
-    statefulSet.new(name, 1, [container], compactor_data_pvc, $.compactor_deployment_labels) +
+    statefulSet.new(name, 1, [container], compactor_data_pvc) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: name }) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin($.compactor_deployment_labels) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
     // Parallelly scale up/down compactor instances instead of starting them

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -5,6 +5,9 @@
     replication_factor: 3,
     external_url: error 'must define external url for cluster',
 
+    // kubernetes_part_of is used to set the app.kubernetes.io/part-of label on all pods in this mimir cluster
+    kubernetes_part_of: 'mimir',
+
     aws_region: error 'must specify AWS region',
 
     // If false, ingesters are not unregistered on shutdown and left in the ring with

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -50,7 +50,10 @@
 
   local deployment = $.apps.v1.deployment,
 
-  distributor_deployment_labels:: {},
+  distributor_deployment_labels:: {
+    'app.kubernetes.io/component': 'distributor',
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
 
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container], $.distributor_deployment_labels) +
@@ -61,7 +64,7 @@
 
   local service = $.core.v1.service,
 
-  distributor_service_ignored_labels:: [],
+  distributor_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
 
   distributor_service:
     $.util.serviceFor($.distributor_deployment, $.distributor_service_ignored_labels) +

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -56,9 +56,10 @@
   },
 
   distributor_deployment:
-    deployment.new('distributor', 3, [$.distributor_container], $.distributor_deployment_labels) +
+    deployment.new('distributor', 3, [$.distributor_container]) +
     (if $._config.distributor_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
+    deployment.spec.template.metadata.withLabelsMixin($.distributor_deployment_labels) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
 

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -78,10 +78,11 @@
       container + $.core.v1.container.withVolumeMountsMixin([
         volumeMount.new('ingester-data', '/data'),
       ]),
-    ], ingester_data_pvc, $.ingester_deployment_labels) +
+    ], ingester_data_pvc) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: name }) +
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin($.ingester_deployment_labels) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     // When the ingester needs to flush blocks to the storage, it may take quite a lot of time.
     // For this reason, we grant an high termination period (80 minutes).

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -49,9 +49,10 @@
 
   local deployment = $.apps.v1.deployment,
   overrides_exporter_deployment:
-    deployment.new(name, 1, [$.overrides_exporter_container], $.overries_exporter_deployment_labels) +
+    deployment.new(name, 1, [$.overrides_exporter_container]) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
-    deployment.mixin.metadata.withLabels({ name: name }),
+    deployment.mixin.metadata.withLabels({ name: name }) +
+    deployment.spec.template.metadata.withLabelsMixin($.overries_exporter_deployment_labels),
 
   overrides_exporter_service:
     $.util.serviceFor($.overrides_exporter_deployment, $.overries_exporter_service_ignored_labels),

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -50,7 +50,8 @@
   local deployment = $.apps.v1.deployment,
   overrides_exporter_deployment:
     deployment.new(name, 1, [$.overrides_exporter_container], $.overries_exporter_deployment_labels) +
-    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint),
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
+    deployment.mixin.metadata.withLabels({ name: name }),
 
   overrides_exporter_service:
     $.util.serviceFor($.overrides_exporter_deployment, $.overries_exporter_service_ignored_labels),

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -29,6 +29,13 @@
     'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
   } + $._config.limitsConfig,
 
+  overries_exporter_deployment_labels:: {
+    'app.kubernetes.io/component': name,
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
+
+  overries_exporter_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
+
   local container = $.core.v1.container,
   overrides_exporter_container::
     container.new(name, $._images.overrides_exporter) +
@@ -42,10 +49,9 @@
 
   local deployment = $.apps.v1.deployment,
   overrides_exporter_deployment:
-    deployment.new(name, 1, [$.overrides_exporter_container], { name: name }) +
-    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
-    deployment.mixin.metadata.withLabels({ name: name }),
+    deployment.new(name, 1, [$.overrides_exporter_container], $.overries_exporter_deployment_labels) +
+    $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint),
 
   overrides_exporter_service:
-    $.util.serviceFor($.overrides_exporter_deployment),
+    $.util.serviceFor($.overrides_exporter_deployment, $.overries_exporter_service_ignored_labels),
 }

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -58,11 +58,12 @@
   },
 
   newQuerierDeployment(name, container)::
-    deployment.new(name, $._config.querier.replicas, [container], $.querier_deployment_labels) +
+    deployment.new(name, $._config.querier.replicas, [container]) +
     (if $._config.querier_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    deployment.spec.template.metadata.withLabelsMixin($.querier_deployment_labels),
 
   querier_deployment:
     self.newQuerierDeployment('querier', $.querier_container),

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -52,7 +52,10 @@
 
   local deployment = $.apps.v1.deployment,
 
-  querier_deployment_labels: {},
+  querier_deployment_labels:: {
+    'app.kubernetes.io/component': 'querier',
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
 
   newQuerierDeployment(name, container)::
     deployment.new(name, $._config.querier.replicas, [container], $.querier_deployment_labels) +
@@ -66,7 +69,7 @@
 
   local service = $.core.v1.service,
 
-  querier_service_ignored_labels:: [],
+  querier_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
 
   querier_service:
     $.util.serviceFor($.querier_deployment, $.querier_service_ignored_labels),

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -56,11 +56,12 @@
   query_frontend_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
 
   newQueryFrontendDeployment(name, container)::
-    deployment.new(name, $._config.queryFrontend.replicas, [container], $.query_frontend_deployment_labels) +
+    deployment.new(name, $._config.queryFrontend.replicas, [container]) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     (if $._config.query_frontend_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    deployment.spec.template.metadata.withLabelsMixin($.query_frontend_deployment_labels),
 
   query_frontend_deployment: self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container),
 

--- a/operations/mimir/query-scheduler.libsonnet
+++ b/operations/mimir/query-scheduler.libsonnet
@@ -30,12 +30,13 @@
   query_scheduler_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
 
   newQuerySchedulerDeployment(name, container)::
-    deployment.new(name, 2, [container], $.query_scheduler_deployment_labels) +
+    deployment.new(name, 2, [container]) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     $.util.antiAffinity +
     // Do not run more query-schedulers than expected.
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    deployment.spec.template.metadata.withLabelsMixin($.query_scheduler_deployment_labels),
 
   query_scheduler_deployment: if !$._config.query_scheduler_enabled then {} else
     self.newQuerySchedulerDeployment('query-scheduler', $.query_scheduler_container),

--- a/operations/mimir/query-tee.libsonnet
+++ b/operations/mimir/query-tee.libsonnet
@@ -20,8 +20,14 @@
     $.util.resourcesRequests('1', '512Mi') +
     $.jaeger_mixin,
 
+
+  query_tee_deployment_labels:: {
+    'app.kubernetes.io/component': 'query-tee',
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
+
   query_tee_deployment: if !($._config.query_tee_enabled) then {} else
-    deployment.new('query-tee', 2, [$.query_tee_container]),
+    deployment.new('query-tee', 2, [$.query_tee_container], $.query_tee_deployment_labels),
 
   query_tee_service: if !($._config.query_tee_enabled) then {} else
     service.new('query-tee', { name: 'query-tee' }, [

--- a/operations/mimir/query-tee.libsonnet
+++ b/operations/mimir/query-tee.libsonnet
@@ -27,7 +27,8 @@
   },
 
   query_tee_deployment: if !($._config.query_tee_enabled) then {} else
-    deployment.new('query-tee', 2, [$.query_tee_container], $.query_tee_deployment_labels),
+    deployment.new('query-tee', 2, [$.query_tee_container]) +
+    deployment.spec.template.metadata.withLabelsMixin($.query_tee_deployment_labels),
 
   query_tee_service: if !($._config.query_tee_enabled) then {} else
     service.new('query-tee', { name: 'query-tee' }, [

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -47,11 +47,19 @@
       $.jaeger_mixin
     else {},
 
+
+  ruler_deployment_labels:: {
+    'app.kubernetes.io/component': 'ruler',
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
+
+  ruler_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
+
   local deployment = $.apps.v1.deployment,
 
   ruler_deployment:
     if $._config.ruler_enabled then
-      deployment.new('ruler', 2, [$.ruler_container]) +
+      deployment.new('ruler', 2, [$.ruler_container], $.ruler_deployment_labels) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
@@ -63,6 +71,6 @@
 
   ruler_service:
     if $._config.ruler_enabled then
-      $.util.serviceFor($.ruler_deployment)
+      $.util.serviceFor($.ruler_deployment, $.ruler_service_ignored_labels)
     else {},
 }

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -59,12 +59,13 @@
 
   ruler_deployment:
     if $._config.ruler_enabled then
-      deployment.new('ruler', 2, [$.ruler_container], $.ruler_deployment_labels) +
+      deployment.new('ruler', 2, [$.ruler_container]) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
       (if $._config.ruler_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
-      $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint)
+      $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
+      deployment.spec.template.metadata.withLabelsMixin($.ruler_deployment_labels)
     else {},
 
   local service = $.core.v1.service,

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -81,10 +81,11 @@
   store_gateway_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
 
   newStoreGatewayStatefulSet(name, container)::
-    statefulSet.new(name, 3, [container], store_gateway_data_pvc, $.store_gateway_deployment_labels) +
+    statefulSet.new(name, 3, [container], store_gateway_data_pvc) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: name }) +
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin($.store_gateway_deployment_labels) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -73,13 +73,18 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
+  store_gateway_deployment_labels:: {
+    'app.kubernetes.io/component': 'store-gateway',
+    'app.kubernetes.io/part-of': $._config.kubernetes_part_of,
+  },
+
+  store_gateway_service_ignored_labels:: ['app.kubernetes.io/component', 'app.kubernetes.io/part-of'],
+
   newStoreGatewayStatefulSet(name, container)::
-    statefulSet.new(name, 3, [container], store_gateway_data_pvc) +
+    statefulSet.new(name, 3, [container], store_gateway_data_pvc, $.store_gateway_deployment_labels) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: name }) +
-    statefulSet.mixin.spec.template.metadata.withLabels({ name: name }) +
-    statefulSet.mixin.spec.selector.withMatchLabels({ name: name }) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
@@ -93,7 +98,7 @@
   store_gateway_statefulset: self.newStoreGatewayStatefulSet('store-gateway', $.store_gateway_container),
 
   store_gateway_service:
-    $.util.serviceFor($.store_gateway_statefulset),
+    $.util.serviceFor($.store_gateway_statefulset, $.store_gateway_service_ignored_labels),
 
   store_gateway_pdb:
     podDisruptionBudget.new() +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds some [standard kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) to pod templates.

##### Labels
* `app.kubernetes.io/component` (e.g. `compactor`)
* `app.kubernetes.io/part-of` (configured with `$._config.kubernetes_part_of`, default `mimir`)

##### Services
The labels are ignored in all services, so that on deployment of this change the matched pods of a service do not change.

##### Deployments/stateful sets

The selector label of these haven't been modified because selector labels are immutable.

#### Considerations before deployment

Changing the labels of a deployment or a stateful set will create a new `ReplicaSet` for deployments, and will replace existing pods in a `StatefulSet`

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
