### PR TITLE
Fix query sharding jsonnet if queriers are autoscaling

### DIFF
--- a/operations/mimir/query-sharding.libsonnet
+++ b/operations/mimir/query-sharding.libsonnet
@@ -26,7 +26,12 @@
 
   // When sharding is enabled, scale the query-frontend to have at least 20% of the replicas of queriers.
   local ensure_replica_ratio_to_queriers = {
-    local min_replicas = std.max(std.floor(0.2 * $.querier_deployment.spec.replicas), 2),
+    // We check if replicas is set because it may be missing if queriers are autoscaling.
+    local min_replicas = if std.objectHas($.querier_deployment.spec, 'replicas') && $.querier_deployment.spec.replicas != null then
+      std.max(std.floor(0.2 * $.querier_deployment.spec.replicas), 2)
+    else
+      2,
+
     spec+: {
       replicas: std.max(super.replicas, min_replicas),
     },


### PR DESCRIPTION
**What this PR does**:
I'm experimenting with autoscaling queriers. When autoscaling is enabled, the replicas field on queriers is set to null so that flux doesn't reconcile it. This makes `ensure_replica_ratio_to_queriers` failing.

In this PR I'm skipping `ensure_replica_ratio_to_queriers` if the replicas on queriers is missing. I will handle it in the autoscaling overrides.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
