### PR TITLE
Wait for ruler ring client to self-detect during startup

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -325,6 +325,15 @@ func (r *Ruler) starting(ctx context.Context) error {
 		return errors.Wrap(err, "unable to start ruler subservices")
 	}
 
+	// Wait until the ring client detected this instance in the ACTIVE state to
+	// make sure that when we'll run the initial sync we already know  the tokens
+	// assigned to this instance.
+	level.Info(r.logger).Log("msg", "waiting until ruler is ACTIVE in the ring")
+	if err := ring.WaitInstanceState(ctx, r.ring, r.lifecycler.GetInstanceID(), ring.ACTIVE); err != nil {
+		return err
+	}
+	level.Info(r.logger).Log("msg", "ruler is ACTIVE in the ring")
+
 	// TODO: ideally, ruler would wait until its queryable is finished starting.
 	return nil
 }


### PR DESCRIPTION
**What this PR does**:
I was investigating #989 and I've noticed a race condition in the ruler at startup. The `starting()` function may return before the ring client has detected the updated ring, so the first sync we do in `run()` may have an empty ring. It's not a big deal for the normal case because the next sync will reconcile rules, but this is causing tests flakyness.

In this PR I propose to use the same strategy [we already adopted in the store-gateway](https://github.com/grafana/mimir/blob/744b75db3eecb36253f5284cd2be3ffa2837e5e6/pkg/storegateway/gateway.go#L202-L209), with the only difference that ruler registers in ACTIVE state so we have to wait until ACTIVE and not JOINING.

**Which issue(s) this PR fixes**:
Fixes #989

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
