### PR TITLE
Renamed distributorConfig jsonnet config to ingesterRingClientConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,6 +612,7 @@
 * [CHANGE] Enabled attributes in-memory cache in store-gateway. #905
 * [CHANGE] Configured store-gateway to not load blocks containing samples more recent than 10h (because such samples are queried from ingesters). #905
 * [CHANGE] Dynamically compute `-compactor.deletion-delay` based on other settings, in order to reduce the deletion delay as much as possible and lower the number of live blocks in the storage. #907
+* [CHANGE] The config field `distributorConfig` has been renamed to `ingesterRingClientConfig`. #997
 * [FEATURE] Added query sharding support. It can be enabled setting `cortex_query_sharding_enabled: true` in the `_config` object. #653
 * [FEATURE] Added shuffle-sharding support. It can be enabled and configured using the following config: #902
    ```

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -147,8 +147,9 @@
       'ring.prefix': '',
     },
 
-    // Some distributor config is shared with the querier.
-    distributorConfig: {
+    // The ingester ring client config that should be shared across all Mimir services
+    // watching the ingester ring.
+    ingesterRingClientConfig: {
       'distributor.replication-factor': $._config.replication_factor,
       'distributor.health-check-ingesters': true,
       'ring.heartbeat-timeout': '10m',

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -5,7 +5,7 @@
   distributor_args::
     $._config.grpcConfig +
     $._config.ringConfig +
-    $._config.distributorConfig +
+    $._config.ingesterRingClientConfig +
     $._config.distributorLimitsConfig +
     {
       target: 'distributor',

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -10,7 +10,7 @@
     $._config.ringConfig +
     $._config.storageConfig +
     $._config.blocksStorageConfig +
-    $._config.distributorConfig +  // This adds the distributor ring flags to the ingester.
+    $._config.ingesterRingClientConfig +
     $._config.ingesterLimitsConfig +
     {
       target: 'ingester',

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -8,7 +8,7 @@
     $._config.blocksStorageConfig +
     $._config.queryConfig +
     $._config.queryEngineConfig +
-    $._config.distributorConfig +
+    $._config.ingesterRingClientConfig +
     $._config.queryBlocksStorageConfig +
     $.blocks_metadata_caching_config +
     $.bucket_index_config

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -8,7 +8,7 @@
     $._config.blocksStorageConfig +
     $._config.queryConfig +
     $._config.queryEngineConfig +
-    $._config.distributorConfig +
+    $._config.ingesterRingClientConfig +
     $._config.rulerClientConfig +
     $._config.rulerLimitsConfig +
     $._config.queryBlocksStorageConfig +


### PR DESCRIPTION
**What this PR does**:
While reviewing a jsonnet PR, I've realised the `distributorConfig` config field is deceiving because it looks like it's used to configure distributors, while it's actually applied to all services internally running the ingesters ring client. The purpose of this config was to have a single place to configure the ingesters ring client, so I propose to rename it to `ingesterRingClientConfig`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
