### PR TITLE
Mark querier tenant federation as stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,7 +300,7 @@
 * [FEATURE] Mimir: Added "Activity tracker" feature which can log ongoing activities from previous Mimir run in case of the crash. It is enabled by default and controlled by the `-activity-tracker.filepath` flag. It can be disabled by setting this path to an empty string. Currently, the Store-gateway, Ruler, Querier, and Query-frontend components uses this feature. #631 #782 #822
 * [FEATURE] Mimir: Divide configuration parameters into categories "basic", "advanced", and "experimental". Only flags in the basic category are shown when invoking `-help`, whereas `-help-all` will include flags in all categories (basic, advanced, experimental). #840
 * [FEATURE] Store-gateway: Added `/store-gateway/tenants` and `/store-gateway/tenant/{tenant}/blocks` endpoints that provide functionality that was provided by `tools/listblocks`. #911
-* [FEATURE] The following features have been moved from experimental to stable: #913
+* [FEATURE] The following features have been moved from experimental to stable: #913 #1002
   * Alertmanager API
   * Alertmanager receiver firewall
   * Alertmanager sharding
@@ -314,6 +314,7 @@
   * OpenStack Swift storage support
   * Query-frontend: query stats tracking
   * Query-scheduler
+  * Querier: tenant federation
   * Ruler API
   * S3 Server Side Encryption (SSE) using KMS
   * TLS configuration for gRPC, HTTP and etcd clients

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1624,7 +1624,7 @@ Usage of ./cmd/mimir/mimir:
   -target value
     	Comma-separated list of modules to load. The alias 'all' can be used in the list to load a number of core modules and will enable single-binary mode. Use '-modules' command line flag to get a list of available modules, and to see which modules are included in 'all'. (default all)
   -tenant-federation.enabled
-    	[experimental] If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.
+    	If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.
   -validation.create-grace-period value
     	Duration which table will be created/deleted before/after it's needed; we won't accept sample from before this time. (default 10m)
   -validation.enforce-metadata-metric-name

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -863,6 +863,8 @@ Usage of ./cmd/mimir/mimir:
     	Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
   -target value
     	Comma-separated list of modules to load. The alias 'all' can be used in the list to load a number of core modules and will enable single-binary mode. Use '-modules' command line flag to get a list of available modules, and to see which modules are included in 'all'. (default all)
+  -tenant-federation.enabled
+    	If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.
   -validation.create-grace-period value
     	Duration which table will be created/deleted before/after it's needed; we won't accept sample from before this time. (default 10m)
   -validation.enforce-metadata-metric-name

--- a/docs/sources/configuration/config-file-reference.md
+++ b/docs/sources/configuration/config-file-reference.md
@@ -129,9 +129,9 @@ api:
 [store_gateway: <store_gateway_config>]
 
 tenant_federation:
-  # [experimental] If enabled on all services, queries can be federated across
-  # multiple tenants. The tenant IDs involved need to be specified separated by
-  # a '|' character in the 'X-Scope-OrgID' header.
+  # If enabled on all services, queries can be federated across multiple
+  # tenants. The tenant IDs involved need to be specified separated by a '|'
+  # character in the 'X-Scope-OrgID' header.
   # CLI flag: -tenant-federation.enabled
   [enabled: <boolean> | default = false]
 

--- a/docs/sources/configuration/v1-guarantees.md
+++ b/docs/sources/configuration/v1-guarantees.md
@@ -33,7 +33,6 @@ Grafana Mimir is an actively developed project and we want to encourage the intr
 
 Currently experimental features are:
 
-- Querier: tenant federation.
 - Ruler: tenant federation.
 - Distributor: metrics relabeling.
 - Purger: tenant deletion API.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -309,7 +309,6 @@ func New(cfg Config) (*Mimir, error) {
 
 	// Swap out the default resolver to support multiple tenant IDs separated by a '|'
 	if cfg.TenantFederation.Enabled {
-		util_log.WarnExperimentalUse("tenant-federation")
 		tenant.WithDefaultResolver(tenant.NewMultiResolver())
 
 		if cfg.Ruler.TenantFederation.Enabled {

--- a/pkg/querier/tenantfederation/tenant_federation.go
+++ b/pkg/querier/tenantfederation/tenant_federation.go
@@ -11,7 +11,7 @@ import (
 
 type Config struct {
 	// Enabled switches on support for multi tenant query federation
-	Enabled bool `yaml:"enabled" category:"experimental"`
+	Enabled bool `yaml:"enabled"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does**:
As agreed, in this PR I'm marking the querier tenant federation (but not the ruler one) as stable. The flag to enable it has been classified as basic since it's a core feature.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/mimir-squad/issues/516

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
