### PR TITLE
Explicitly set SHELL to bash as the Makefile recipes are not written POSIX sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /usr/bin/env bash
+
 # Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
 .PHONY: help
 help: ## Display this help and any documented user-facing targets. Other undocumented targets may be present in the Makefile.


### PR DESCRIPTION
Without this declaration, users with alternative shells (like `dash`)
can have trouble with our Makefile.

Specifically our use of `read` in `make docs` is problematic for non-bash shells.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>