### PR TITLE
WIP: compactor: Change compaction concurrency default to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,7 @@
 * [CHANGE] Alertmanager: `-experimental.alertmanager.enable-api` flag has been renamed to `-alertmanager.enable-api` and is now stable. #913
 * [CHANGE] Ingester: changed default value of `-blocks-storage.tsdb.retention-period` from `6h` to `24h`. #966
 * [CHANGE] Changed default value of `-querier.query-ingesters-within` and `-blocks-storage.tsdb.close-idle-tsdb-timeout` from `0` to `13h`. #966
+* [CHANGE] Change default value of `-compactor.compaction-concurrency` to 4. #1025
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -506,7 +506,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.cleanup-interval duration
     	How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index. (default 15m0s)
   -compactor.compaction-concurrency int
-    	Max number of concurrent compactions running. (default 1)
+    	Max number of concurrent compactions running. (default 4)
   -compactor.compaction-interval duration
     	The frequency at which the compaction runs (default 1h0m0s)
   -compactor.compaction-jobs-order string

--- a/docs/sources/architecture/compactor.md
+++ b/docs/sources/architecture/compactor.md
@@ -182,7 +182,7 @@ compactor:
 
   # [advanced] Max number of concurrent compactions running.
   # CLI flag: -compactor.compaction-concurrency
-  [compaction_concurrency: <int> | default = 1]
+  [compaction_concurrency: <int> | default = 4]
 
   # [advanced] How frequently compactor should run blocks cleanup and
   # maintenance, as well as update the bucket index.

--- a/docs/sources/configuration/config-file-reference.md
+++ b/docs/sources/configuration/config-file-reference.md
@@ -3272,7 +3272,7 @@ The `compactor_config` configures the compactor service.
 
 # [advanced] Max number of concurrent compactions running.
 # CLI flag: -compactor.compaction-concurrency
-[compaction_concurrency: <int> | default = 1]
+[compaction_concurrency: <int> | default = 4]
 
 # [advanced] How frequently compactor should run blocks cleanup and maintenance,
 # as well as update the bucket index.

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -134,7 +134,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CompactionInterval, "compactor.compaction-interval", time.Hour, "The frequency at which the compaction runs")
 	f.DurationVar(&cfg.MaxCompactionTime, "compactor.max-compaction-time", 0, "Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled.")
 	f.IntVar(&cfg.CompactionRetries, "compactor.compaction-retries", 3, "How many times to retry a failed compaction within a single compaction run.")
-	f.IntVar(&cfg.CompactionConcurrency, "compactor.compaction-concurrency", 1, "Max number of concurrent compactions running.")
+	f.IntVar(&cfg.CompactionConcurrency, "compactor.compaction-concurrency", 4, "Max number of concurrent compactions running.")
 	f.DurationVar(&cfg.CleanupInterval, "compactor.cleanup-interval", 15*time.Minute, "How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index.")
 	f.IntVar(&cfg.CleanupConcurrency, "compactor.cleanup-concurrency", 20, "Max number of tenants for which blocks cleanup and maintenance should run concurrently.")
 	f.StringVar(&cfg.CompactionJobsOrder, "compactor.compaction-jobs-order", CompactionOrderOldestFirst, fmt.Sprintf("The sorting to use when deciding which compaction jobs should run first for a given tenant. Supported values are: %s.", strings.Join(CompactionOrders, ", ")))


### PR DESCRIPTION
**What this PR does**:
Change compaction concurrency default to 4. 4 was proposed as the new default during our recent config audit.

**Which issue(s) this PR fixes**:

**Checklist**

- [na] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
