### PR TITLE
Docs: Rename from configuration parameter lifecycle to categories

### DIFF
--- a/docs/sources/configuration/config-param-categories.md
+++ b/docs/sources/configuration/config-param-categories.md
@@ -1,8 +1,8 @@
 ---
-title: "Configuration parameter lifecycle"
-linkTitle: "Configuration parameter lifecycle"
+title: "Configuration parameter categories"
+linkTitle: "Configuration parameter categories"
 weight: 1
-slug: config-param-lifecycle
+slug: config-param-categories
 ---
 
 In order to simplify Mimir configuration, parameters are bucketed into 3 categories according to


### PR DESCRIPTION
**What this PR does**:
In documentation, rename references to configuration parameter lifecycle to categories, since it's become clear that lifecycle is a different dimension and the right term is categories. I was meaning to do it in the original PR to introduce this documentation, but forgot to commit the changes :/

**Which issue(s) this PR fixes**:

**Checklist**

- [na] Tests updated
- [x] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
