### PR TITLE
Fix rendering of sections

### DIFF
--- a/docs/sources/architecture/_index.md
+++ b/docs/sources/architecture/_index.md
@@ -21,7 +21,7 @@ Some microservices are stateful and rely on non-volatile storage to prevent data
 
 A dedicate page describes each microservice in detail.
 
-`{{< section >}}`
+{{< section >}}
 
 <!-- START from blocks-storage/_index.md -->
 

--- a/docs/sources/operations/_index.md
+++ b/docs/sources/operations/_index.md
@@ -6,4 +6,4 @@ weight: 2000
 
 # Operating Grafana Mimir
 
-`{{< section >}}`
+{{< section >}}

--- a/docs/sources/tools/_index.md
+++ b/docs/sources/tools/_index.md
@@ -4,4 +4,4 @@ description: ""
 weight: 3000
 ---
 
-`{{< section >}}`
+{{< section >}}


### PR DESCRIPTION
They were incorrectly wrapped in backticks that was causing them to be mis-rendered.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>