### PR TITLE
Fix rendering of table of contents using the local web server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -583,5 +583,6 @@ packaging/deb/debian-systemd/$(UPTODATE): packaging/deb/debian-systemd/Dockerfil
 test-packages: packages packaging/rpm/centos-systemd/$(UPTODATE) packaging/deb/debian-systemd/$(UPTODATE)
 	./tools/packaging/test-packages $(IMAGE_PREFIX) $(VERSION)
 
-include docs.mk
+include docs/docs.mk
+DOCS_DIR = docs/sources
 docs: doc

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,10 @@
+.DEFAULT_GOAL: help
+
+# Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
+.PHONY: help
+help: ## Display this help.
+help:
+	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+include docs.mk
+

--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -2,7 +2,7 @@ SHELL = /usr/bin/env bash
 
 DOCS_IMAGE   = grafana/docs-base:latest
 DOCS_PROJECT = mimir
-DOCS_DIR     = docs/sources
+DOCS_DIR     = sources
 
 # This allows ports and base URL to be overridden, so services like ngrok.io can
 # be used to share a local running docs instances.


### PR DESCRIPTION
[Ensure Mimir has an index file for proper table of contents rendering](https://github.com/grafana/mimir/commit/2eb650c3431f7bf88ebc6c4601ba311ef6268c8e)[](https://github.com/jdbaldry) 
  
[Ensure make docs can be run from the /docs directory](https://github.com/grafana/mimir/commit/be0f318fc6b429d2cd3a67cd4c56445480f4e3d1) 

This is consistent with other Grafana labs project. The include in the
top-level Makefile is updated to allow it to also be run from the root
of the repository.

Supersedes #1041.

Fixes https://github.com/grafana/mimir-squad/issues/523