### PR TITLE
Alertmanager: Remove ability to run without clustering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,7 @@
   * `prometheus_sd_dns_lookup_failures_total` replaced by `cortex_dns_failures_total{component="ruler"}`
 * [CHANGE] Memberlist: the `name` label on metrics `cortex_dns_failures_total`, `cortex_dns_lookups_total` and `cortex_dns_provider_results` was renamed to `component`. #993
 * [CHANGE] Changed the default value of `-blocks-storage.bucket-store.bucket-index.enabled` to `true`. The default configuration must now run the compactor in order to write the bucket index or else queries to long term storage will fail. #924
+* [CHANGE] Alertmanager: remove ability to run alertmanager with clustering disabled. The `-alertmanager.cluster.listen-address` must be provided if `-alertmanager.sharding-enabled=false`. #1044
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -118,7 +118,7 @@ Usage of ./cmd/mimir/mimir:
   -alertmanager.cluster.gossip-interval duration
     	The interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across cluster more quickly at the expense of increased bandwidth usage. (default 200ms)
   -alertmanager.cluster.listen-address string
-    	Listen address and port for the cluster. Not specifying this flag disables high-availability mode. (default "0.0.0.0:9094")
+    	Listen address and port for the cluster. (default "0.0.0.0:9094")
   -alertmanager.cluster.peer-timeout duration
     	Time to wait between peers to send notifications. (default 15s)
   -alertmanager.cluster.peers value

--- a/docs/sources/configuration/config-file-reference.md
+++ b/docs/sources/configuration/config-file-reference.md
@@ -1638,8 +1638,7 @@ sharding_ring:
 [fallback_config_file: <string> | default = ""]
 
 cluster:
-  # [advanced] Listen address and port for the cluster. Not specifying this flag
-  # disables high-availability mode.
+  # [advanced] Listen address and port for the cluster.
   # CLI flag: -alertmanager.cluster.listen-address
   [listen_address: <string> | default = "0.0.0.0:9094"]
 

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -10,10 +10,8 @@
   // The Alertmanager has three operational modes.
   local haType = if $._config.alertmanager.sharding_enabled then
     'sharding'
-  else if $._config.alertmanager.replicas > 1 then
-    'gossip_multi_replica'
   else
-    'gossip_single_replica',
+    'gossip',
   // mode represents which operational mode the alertmanager runs in.
   // ports: array of container ports used for gossiping.
   // args: arguments that are eventually converted to flags on the container
@@ -33,7 +31,7 @@
         $.util.serviceFor($.alertmanager_statefulset, $._config.service_ignored_labels) +
         service.mixin.spec.withClusterIp('None'),
     },
-    gossip_multi_replica: {
+    gossip: {
       ports: [
         $.core.v1.containerPort.newUDP('gossip-udp', $._config.alertmanager.gossip_port),
         $.core.v1.containerPort.new('gossip-tcp', $._config.alertmanager.gossip_port),
@@ -46,12 +44,6 @@
       service:
         $.util.serviceFor($.alertmanager_statefulset, $._config.service_ignored_labels) +
         service.mixin.spec.withClusterIp('None'),
-    },
-    gossip_single_replica: {
-      ports: [],
-      args: {},
-      flags: ['--alertmanager.cluster.listen-address=""'],
-      service: $.util.serviceFor($.alertmanager_statefulset, $._config.service_ignored_labels),
     },
   }[haType],
   local hasFallbackConfig = std.length($._config.alertmanager.fallback_config) > 0,

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
-	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -711,10 +710,7 @@ receivers:
 	// Create the Multitenant Alertmanager.
 	reg := prometheus.NewPedanticRegistry()
 	cfg := mockAlertmanagerConfig(t)
-	am, err := createMultitenantAlertmanager(cfg, nil, nil, alertStore, nil, nil, log.NewNopLogger(), reg)
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), am))
-	defer services.StopAndAwaitTerminated(context.Background(), am) //nolint:errcheck
+	am := setupSingleMultitenantAlertmanager(t, cfg, alertStore, nil, log.NewNopLogger(), reg)
 
 	err = am.loadAndSyncConfigs(context.Background(), reasonPeriodic)
 	require.NoError(t, err)

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -109,6 +109,9 @@ func TestMimir(t *testing.T) {
 		Compactor: compactor.Config{CompactionJobsOrder: compactor.CompactionOrderOldestFirst},
 		Alertmanager: alertmanager.MultitenantAlertmanagerConfig{
 			DataDir: t.TempDir(),
+			Cluster: alertmanager.ClusterConfig{
+				ListenAddr: "127.0.0.1:0",
+			},
 		},
 		AlertmanagerStorage: alertstore.Config{
 			Config: bucket.Config{


### PR DESCRIPTION
**What this PR does**:

This change removes the ability for Alertmanager to run without clustering
enabled if sharding is not enabled. Tests have been updated to run with
sharding enabled where necessary, though I have decided against a full
clean-up of the tests to avoid polluting the significant test changes.

To keep this change small and easier to review, a follow up commit will remove
the ability to run without sharding enabled. I've also not made effort to add
configuration validation for `listen-address`, because it will soon be removed.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Which issue(s) this PR fixes**:

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Part of: #856

**Checklist**

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
