### PR TITLE
Do not log 'unable to read rules directory' at startup if directory hasn't been created yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,6 +423,7 @@
 * [BUGFIX] Compactor: compactor should now be able to correctly mark blocks for deletion and no-compaction, if such marking was previously interrupted. #1015
 * [BUGFIX] Overrides-exporter: successfully startup even if runtime config is not set. #1056
 * [BUGFIX] Multi-KV: runtime config changes are now propagated to all rings, not just ingester ring. #1047
+* [BUGFIX] Ruler: do not log `unable to read rules directory` at startup if the directory hasn't been created yet. #1058
 
 ### Mixin (changes since `grafana/cortex-jsonnet` `1.9.0`)
 

--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -8,6 +8,7 @@ package ruler
 import (
 	"crypto/md5"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -65,6 +66,12 @@ func (m *mapper) users() ([]string, error) {
 	var result []string
 
 	dirs, err := afero.ReadDir(m.FS, m.Path)
+	if os.IsNotExist(err) {
+		// The directory may have not been created yet. With regards to this function
+		// it's like the ruler has no tenants and it shouldn't be considered an error.
+		return nil, nil
+	}
+
 	for _, u := range dirs {
 		if u.IsDir() {
 			result = append(result, u.Name())

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -389,6 +389,18 @@ func Test_mapper_MapRulesSpecialCharNamespace(t *testing.T) {
 	})
 }
 
+func Test_mapper_CleanupShouldNotFailIfPathDoesNotExist(t *testing.T) {
+	m := &mapper{
+		Path:   "/path-does-not-exist",
+		FS:     afero.NewMemMapFs(),
+		logger: log.NewNopLogger(),
+	}
+
+	actual, err := m.users()
+	require.NoError(t, err)
+	require.Empty(t, actual)
+}
+
 func sliceContains(t *testing.T, find string, in []string) bool {
 	t.Helper()
 


### PR DESCRIPTION
**What this PR does**:
While working on https://github.com/grafana/mimir/issues/991 I've noticed that a brand new ruler logs the following at startup:
```
level=error ts=2022-02-04T14:39:18.20755899Z caller=mapper.go:55 msg="unable to read rules directory" path=/rules err="open /rules: no such file or directory"
```

The reason is that when we create the mapper we also call `cleanup()` but the `/rules` directory hasn't been created yet. In this PR I'm proposing a PR to fix this.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
