### PR TITLE
Fix mimir-mixin-tools/screenshots/Dockerfile

### DIFF
--- a/operations/mimir-mixin-tools/screenshots/Dockerfile
+++ b/operations/mimir-mixin-tools/screenshots/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install sources and dependencies.
 RUN mkdir /app
-COPY package*.json app.js /app
+COPY package*.json app.js /app/
 RUN cd /app && npm ci
 
 WORKDIR /app


### PR DESCRIPTION
**What this PR does**:
Given `/app` is a directory it should end with `/` according to [Dockerfile reference doc](https://docs.docker.com/engine/reference/builder/#copy). I don't know why it was working to me, but Mauro report it doesn't to him.

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
