### PR TITLE
Remove tsdb-blocks-storage-s3 flag from blocks-s3 microservice config mimir.yaml

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -80,7 +80,6 @@ ruler:
         host: consul:8500
 
   alertmanager_url: http://alertmanager-1:8031/alertmanager,http://alertmanager-2:8032/alertmanager,http://alertmanager-3:8033/alertmanager
-  enable_alertmanager_v2: false
 
 ruler_storage:
   backend: s3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
While testing using the docker based development environments I found that we were using a flag that had been removed causing the services to panic on start.

**Which issue(s) this PR fixes**: Removes flags for micro-service tests that were removed from mimir in https://github.com/grafana/mimir/pull/1100

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

**Checklist**

- [X] Tests updated
- [-] Documentation added
- [-] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
