### PR TITLE
Changed -frontend.split-queries-by-interval default from 0s to 24h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,7 @@
   * `-alertmanager.storage.path` default value changed to `./data-alertmanager/`
   * `-compactor.data-dir` default value changed to `./data-compactor/`
   * `-ruler.rule-path` default value changed to `./data-ruler/`
+* [CHANGE] Query-frontend: the default value of `-frontend.split-queries-by-interval` has changed from `0` to `24h`. #1131
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -890,7 +890,7 @@ Usage of ./cmd/mimir/mimir:
   -frontend.scheduler-worker-concurrency int
     	Number of concurrent workers forwarding queries to single query-scheduler. (default 5)
   -frontend.split-queries-by-interval duration
-    	Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled.
+    	Split queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it. (default 24h0m0s)
   -h
     	Print basic help.
   -help

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -357,8 +357,6 @@ Usage of ./cmd/mimir/mimir:
     	The socket read/write timeout. (default 200ms)
   -frontend.scheduler-address string
     	DNS hostname used for finding query-schedulers.
-  -frontend.split-queries-by-interval duration
-    	Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled.
   -h
     	Print basic help.
   -help

--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -135,7 +135,6 @@ store_gateway:
 
 frontend:
   query_stats_enabled: true
-  split_queries_by_interval: 24h
   parallelize_shardable_queries: true
   align_queries_with_step: true
   cache_results: true

--- a/docs/sources/configuration/reference-configuration-parameters.md
+++ b/docs/sources/configuration/reference-configuration-parameters.md
@@ -1035,12 +1035,10 @@ grpc_client_config:
 # CLI flag: -frontend.instance-port
 [port: <int> | default = 0]
 
-# Split queries by an interval and execute in parallel, 0 disables it. You
-# should use an a multiple of 24 hours (same as the storage bucketing scheme),
-# to avoid queriers downloading and processing the same chunks. This also
-# determines how cache keys are chosen when result caching is enabled.
+# (advanced) Split queries by an interval and execute in parallel. You should
+# use a multiple of 24 hours to optimize querying blocks. 0 to disable it.
 # CLI flag: -frontend.split-queries-by-interval
-[split_queries_by_interval: <duration> | default = 0s]
+[split_queries_by_interval: <duration> | default = 24h]
 
 # Mutate incoming queries to align their start and end with their step.
 # CLI flag: -frontend.align-querier-with-step

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -71,7 +71,6 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 
 	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
 		"-frontend.cache-results":                      "true",
-		"-frontend.split-queries-by-interval":          "24h",
 		"-querier.query-ingesters-within":              "12h", // Required by the test on query /series out of ingesters time range
 		"-frontend.results-cache.backend":              "memcached",
 		"-frontend.results-cache.memcached.addresses":  "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -66,7 +66,6 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 
 	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
 		"-frontend.cache-results":                     "true",
-		"-frontend.split-queries-by-interval":         "24h",
 		"-querier.query-ingesters-within":             "12h", // Required by the test on query /series out of ingesters time range
 		"-frontend.results-cache.backend":             "memcached",
 		"-frontend.results-cache.memcached.addresses": "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -169,7 +169,6 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 	flags = mergeFlags(flags, map[string]string{
 		"-frontend.cache-results":                     "true",
-		"-frontend.split-queries-by-interval":         "24h",
 		"-querier.query-ingesters-within":             "12h", // Required by the test on query /series out of ingesters time range
 		"-frontend.results-cache.backend":             "memcached",
 		"-frontend.results-cache.memcached.addresses": "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
@@ -343,9 +342,7 @@ overrides:
 `)))
 
 	flags = mergeFlags(flags, map[string]string{
-		"-frontend.split-queries-by-interval": "24h",
-		"-querier.max-samples":                "20", // Very low limit so that we can easily hit it, but high enough to test other features.
-
+		"-querier.max-samples":                    "20",                                                 // Very low limit so that we can easily hit it, but high enough to test other features.
 		"-frontend.parallelize-shardable-queries": "true",                                               // Allow queries to be parallized (query-sharding)
 		"-frontend.query-sharding-total-shards":   "0",                                                  // Disable query-sharding by default
 		"-runtime-config.file":                    filepath.Join(e2e.ContainerSharedDir, runtimeConfig), // Read per tenant runtime config

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -845,7 +845,6 @@ spec:
         - -frontend.results-cache.backend=memcached
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -922,7 +922,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-gossip-generated.yaml
+++ b/operations/mimir-tests/test-gossip-generated.yaml
@@ -955,7 +955,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-gossip-multikv-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-generated.yaml
@@ -963,7 +963,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -924,7 +924,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -querier.max-query-parallelism=240
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=419430400

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -926,7 +926,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -923,7 +923,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -921,7 +921,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -922,7 +922,6 @@ spec:
         - -frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local:11211
         - -frontend.results-cache.memcached.timeout=500ms
         - -frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
-        - -frontend.split-queries-by-interval=24h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-recv-msg-size-bytes=104857600
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -12,9 +12,6 @@
       // queries that return a lot of data timeing out.
       'server.http-write-timeout': '1m',
 
-      // Split long queries up into multiple day-long queries.
-      'frontend.split-queries-by-interval': '24h',
-
       // Cache query results.
       'frontend.align-querier-with-step': false,
       'frontend.cache-results': true,

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -33,7 +33,7 @@ const (
 
 // Config for query_range middleware chain.
 type Config struct {
-	SplitQueriesByInterval time.Duration `yaml:"split_queries_by_interval"`
+	SplitQueriesByInterval time.Duration `yaml:"split_queries_by_interval" category:"advanced"`
 	AlignQueriesWithStep   bool          `yaml:"align_queries_with_step"`
 	ResultsCacheConfig     `yaml:"results_cache"`
 	CacheResults           bool `yaml:"cache_results"`
@@ -45,7 +45,7 @@ type Config struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRetries, "frontend.max-retries-per-request", 5, "Maximum number of retries for a single request; beyond this, the downstream error is returned.")
-	f.DurationVar(&cfg.SplitQueriesByInterval, "frontend.split-queries-by-interval", 0, "Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled.")
+	f.DurationVar(&cfg.SplitQueriesByInterval, "frontend.split-queries-by-interval", 24*time.Hour, "Split queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it.")
 	f.BoolVar(&cfg.AlignQueriesWithStep, "frontend.align-querier-with-step", false, "Mutate incoming queries to align their start and end with their step.")
 	f.BoolVar(&cfg.CacheResults, "frontend.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.ShardedQueries, "frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
@@ -57,7 +57,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) Validate() error {
 	if cfg.CacheResults {
 		if cfg.SplitQueriesByInterval <= 0 {
-			return errors.New("frontend.cache-results may only be enabled in conjunction with frontend.split-queries-by-interval. Please set the latter")
+			return errors.New("-frontend.cache-results may only be enabled in conjunction with -frontend.split-queries-by-interval. Please set the latter")
 		}
 		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config")


### PR DESCRIPTION
**What this PR does**:
`-frontend.split-queries-by-interval` default is still 0 (disabled) but we recommend to run it with `24h`. In this I'm changing default to 24h and marking the param as advanced (nearly zero good reasons to change it).

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
