### PR TITLE
tools/trafficdump: Add Makefile and ignore binary output.

### DIFF
--- a/tools/trafficdump/.gitignore
+++ b/tools/trafficdump/.gitignore
@@ -1,0 +1,1 @@
+trafficdump

--- a/tools/trafficdump/Makefile
+++ b/tools/trafficdump/Makefile
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# This tool uses requires_libpcap tag to avoid compilation problems on machines that
+# don't have libpcap installed (eg. when running "go test ./..." from Mimir root).
+build:
+	go build -tags requires_libpcap .


### PR DESCRIPTION
**What this PR does**: This PR adds `Makefile` for `trafficdump` tool, to make sure people can build it easily, as it requires `-tags` option which may not be obvious. Binary output is also ignored.

**Checklist**

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
