### PR TITLE
Remove low level ingester client settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,10 @@
   * `-querier.frontend-client.grpc-max-send-msg-size`
   * `-query-scheduler.grpc-client-config.grpc-max-send-msg-size`
   * `-ruler.client.grpc-max-send-msg-size`
+* [CHANGE] The following ingester low level settings have been removed: #1153
+  * `-ingester-client.expected-labels`
+  * `-ingester-client.expected-samples-per-series`
+  * `-ingester-client.expected-timeseries`
 * [FEATURE] Query Frontend: Add `cortex_query_fetched_chunks_total` per-user counter to expose the number of chunks fetched as part of queries. This metric can be enabled with the `-frontend.query-stats-enabled` flag (or its respective YAML config option `query_stats_enabled`). #31
 * [FEATURE] Query Frontend: Add experimental querysharding for the blocks storage (instant and range queries). You can now enable querysharding for blocks storage (`-store.engine=blocks`) by setting `-frontend.parallelize-shardable-queries` to `true`. The following additional config and exported metrics have been added. #79 #80 #100 #124 #140 #148 #150 #151 #153 #154 #155 #156 #157 #158 #159 #160 #163 #169 #172 #196 #205 #225 #226 #227 #228 #230 #235 #240 #239 #246 #244 #319 #330 #371 #385 #400 #458 #586 #630 #660 #707
   * New config options:

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -903,12 +903,6 @@ Usage of ./cmd/mimir/mimir:
     	HTTP path prefix for API. (default "/api/prom")
   -http.prometheus-http-prefix string
     	HTTP URL path under which the Prometheus api will be served. (default "/prometheus")
-  -ingester-client.expected-labels int
-    	Expected number of labels per timeseries, used for preallocations. (default 20)
-  -ingester-client.expected-samples-per-series int
-    	Expected number of samples per timeseries, used for preallocations. (default 10)
-  -ingester-client.expected-timeseries int
-    	Expected number of timeseries per request, used for preallocations. (default 100)
   -ingester.active-series-custom-trackers value
     	Additional active series metrics, matching the provided matchers. Matchers should be in form <name>:<matcher>, like 'foobar:{foo="bar"}'. Multiple matchers can be provided either providing the flag multiple times or providing multiple semicolon-separated values to a single flag.
   -ingester.active-series-metrics-enabled

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -347,12 +347,6 @@ Usage of ./cmd/mimir/mimir:
     	Print help, also including advanced and experimental parameters.
   -http.prefix string
     	HTTP path prefix for API. (default "/api/prom")
-  -ingester-client.expected-labels int
-    	Expected number of labels per timeseries, used for preallocations. (default 20)
-  -ingester-client.expected-samples-per-series int
-    	Expected number of samples per timeseries, used for preallocations. (default 10)
-  -ingester-client.expected-timeseries int
-    	Expected number of timeseries per request, used for preallocations. (default 100)
   -ingester.active-series-custom-trackers value
     	Additional active series metrics, matching the provided matchers. Matchers should be in form <name>:<matcher>, like 'foobar:{foo="bar"}'. Multiple matchers can be provided either providing the flag multiple times or providing multiple semicolon-separated values to a single flag.
   -ingester.active-series-metrics-enabled

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -44,7 +44,6 @@ import (
 	frontendv1 "github.com/grafana/mimir/pkg/frontend/v1"
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/ingester/client"
-	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/querier/tenantfederation"
 	querier_worker "github.com/grafana/mimir/pkg/querier/worker"
@@ -99,7 +98,6 @@ type Config struct {
 	Ingester         ingester.Config                 `yaml:"ingester"`
 	Flusher          flusher.Config                  `yaml:"flusher"`
 	LimitsConfig     validation.Limits               `yaml:"limits"`
-	Prealloc         mimirpb.PreallocConfig          `yaml:"prealloc" doc:"hidden"`
 	Worker           querier_worker.Config           `yaml:"frontend_worker"`
 	Frontend         frontend.CombinedFrontendConfig `yaml:"frontend"`
 	BlocksStorage    tsdb.BlocksStorageConfig        `yaml:"blocks_storage"`
@@ -142,7 +140,6 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.Ingester.RegisterFlags(f)
 	c.Flusher.RegisterFlags(f)
 	c.LimitsConfig.RegisterFlags(f)
-	c.Prealloc.RegisterFlags(f)
 	c.Worker.RegisterFlags(f)
 	c.Frontend.RegisterFlags(f)
 	c.BlocksStorage.RegisterFlags(f)

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -6,7 +6,6 @@
 package mimirpb
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"strings"
@@ -16,11 +15,14 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-var (
+const (
 	expectedTimeseries         = 100
 	expectedLabels             = 20
 	expectedSamplesPerSeries   = 10
 	expectedExemplarsPerSeries = 1
+)
+
+var (
 
 	/*
 		We cannot pool these as pointer-to-slice because the place we use them is in WriteRequest which is generated from Protobuf
@@ -43,17 +45,6 @@ var (
 		},
 	}
 )
-
-// PreallocConfig configures how structures will be preallocated to optimise
-// proto unmarshalling.
-type PreallocConfig struct{}
-
-// RegisterFlags registers configuration settings.
-func (PreallocConfig) RegisterFlags(f *flag.FlagSet) {
-	f.IntVar(&expectedTimeseries, "ingester-client.expected-timeseries", expectedTimeseries, "Expected number of timeseries per request, used for preallocations.")
-	f.IntVar(&expectedLabels, "ingester-client.expected-labels", expectedLabels, "Expected number of labels per timeseries, used for preallocations.")
-	f.IntVar(&expectedSamplesPerSeries, "ingester-client.expected-samples-per-series", expectedSamplesPerSeries, "Expected number of samples per timeseries, used for preallocations.")
-}
 
 // PreallocWriteRequest is a WriteRequest which preallocs slices on Unmarshal.
 type PreallocWriteRequest struct {


### PR DESCRIPTION
**What this PR does**:
We have 3 low level settings which we don't set in our jsonnet. I propose to just get rid of them and keep using the hardcoded defaults:
- `-ingester-client.expected-labels`
- `-ingester-client.expected-samples-per-series`
- `-ingester-client.expected-timeseries`

**Which issue(s) this PR fixes**:
N/A

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
