### PR TITLE
Test backward-(in)compatibility

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -8,15 +8,23 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"quay.io/cortexproject/cortex:v1.11.0": e2emimir.ChainFlagMappers(
-		func(flags map[string]string) map[string]string {
-			flags["-store.engine"] = "blocks"
-			flags["-server.http-listen-port"] = "8080"
-			flags["-store-gateway.sharding-enabled"] = "true"
-			return flags
-		},
-		e2emimir.RenameFlagMapper(map[string]string{
-			// Note that we're renaming flags back to their old version.
-			"-query-frontend.scheduler-dns-lookup-period": "-frontend.scheduler-dns-lookup-period",
-		}),
+		cortexFlagMapper,
+		revertRenameFrontendToQueryFrontendFlagMapper,
 	),
 }
+
+var (
+	// cortexFlagMapper sets flags that are needed for cortex.
+	cortexFlagMapper = e2emimir.SetFlagMapper(map[string]string{
+		"-store.engine":                   "blocks",
+		"-server.http-listen-port":        "8080",
+		"-store-gateway.sharding-enabled": "true",
+	})
+
+	// revertRenameFrontendToQueryFrontendFlagMapper reverts the `-frontend` to `-query-frontend` flag renaming that happened in:
+	// https://github.com/grafana/mimir/issues/859
+	revertRenameFrontendToQueryFrontendFlagMapper = e2emimir.RenameFlagMapper(map[string]string{
+		// Note that we're renaming flags back to their old version.
+		"-query-frontend.scheduler-dns-lookup-period": "-frontend.scheduler-dns-lookup-period",
+	})
+)

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -28,19 +28,16 @@ import (
 // then those will be used instead of the default versions. Note that the overriding of flags
 // is not currently possible when overriding the previous image versions via the environment variable.
 func previousVersionImages() map[string]e2emimir.FlagMapper {
-	if os.Getenv("MIMIR_PREVIOUS_IMAGES") != "" {
-		overrideImageVersions := os.Getenv("MIMIR_PREVIOUS_IMAGES")
+	if overrideImageVersions := os.Getenv("MIMIR_PREVIOUS_IMAGES"); overrideImageVersions != "" {
 		previousVersionImages := map[string]e2emimir.FlagMapper{}
 
 		// Overriding of flags is not currently supported when overriding the list of images,
 		// so set all override functions to nil
 		for _, image := range strings.Split(overrideImageVersions, ",") {
-			previousVersionImages[image] = func(flags map[string]string) map[string]string {
-				flags["-store.engine"] = "blocks"
-				flags["-server.http-listen-port"] = "8080"
-				flags["-store-gateway.sharding-enabled"] = "true"
-				return flags
-			}
+			previousVersionImages[image] = e2emimir.ChainFlagMappers(
+				cortexFlagMapper,
+				revertRenameFrontendToQueryFrontendFlagMapper,
+			)
 		}
 
 		return previousVersionImages

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -487,6 +487,9 @@ func WithFlagMapper(mapFlags FlagMapper) Option {
 	}
 }
 
+// FlagMapper is the type of function that maps flags, just to reduce some verbosity.
+type FlagMapper func(flags map[string]string) map[string]string
+
 // NoopFlagMapper is a flag mapper that does not alter the provided flags.
 func NoopFlagMapper(flags map[string]string) map[string]string { return flags }
 
@@ -514,8 +517,15 @@ func RenameFlagMapper(fromTo map[string]string) FlagMapper {
 	}
 }
 
-// FlagMapper is the type of function that maps flags, just to reduce some verbosity.
-type FlagMapper func(flags map[string]string) map[string]string
+// SetFlagMapper builds a flag mapper that sets the provided flags.
+func SetFlagMapper(set map[string]string) FlagMapper {
+	return func(flags map[string]string) map[string]string {
+		for f, v := range set {
+			flags[f] = v
+		}
+		return flags
+	}
+}
 
 // copyFlags provides a copy of the flags map provided.
 func copyFlags(flags map[string]string) map[string]string {


### PR DESCRIPTION
**What this PR does**:

Since some default flags are set when the service is being start, we need to pass the flag mapping function from the backward compatibility definition down to the service starting.

I created an options-like scheme for services (currently supporting only flag mappers, but we could also move other options there, like WithImage() instead of passing in an empty string when we want the default image.

This is intended to be merged into https://github.com/grafana/mimir/pull/1145 in order to fix the tests, I thought this change is worth an explicit PR so it won't get lost in tons of renaming changes.

**Which issue(s) this PR fixes**:

Fixes tests for https://github.com/grafana/mimir/pull/1145

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
