### PR TITLE
Allow flag renaming in backwards (in)compatibility tests

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -2,13 +2,21 @@
 
 package integration
 
+import "github.com/grafana/mimir/integration/e2emimir"
+
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
-var DefaultPreviousVersionImages = map[string]func(map[string]string) map[string]string{
-	"quay.io/cortexproject/cortex:v1.11.0": func(flags map[string]string) map[string]string {
-		flags["-store.engine"] = "blocks"
-		flags["-server.http-listen-port"] = "8080"
-		flags["-store-gateway.sharding-enabled"] = "true"
-		return flags
-	},
+var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
+	"quay.io/cortexproject/cortex:v1.11.0": e2emimir.ChainFlagMappers(
+		cortexFlagMapper,
+	),
 }
+
+var (
+	// cortexFlagMapper sets flags that are needed for cortex.
+	cortexFlagMapper = e2emimir.SetFlagMapper(map[string]string{
+		"-store.engine":                   "blocks",
+		"-server.http-listen-port":        "8080",
+		"-store-gateway.sharding-enabled": "true",
+	})
+)

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -27,20 +27,16 @@ import (
 // compatibility against. If MIMIR_PREVIOUS_IMAGES is set to a comma separted list of image versions,
 // then those will be used instead of the default versions. Note that the overriding of flags
 // is not currently possible when overriding the previous image versions via the environment variable.
-func previousVersionImages() map[string]func(map[string]string) map[string]string {
-	if os.Getenv("MIMIR_PREVIOUS_IMAGES") != "" {
-		overrideImageVersions := os.Getenv("MIMIR_PREVIOUS_IMAGES")
-		previousVersionImages := map[string]func(map[string]string) map[string]string{}
+func previousVersionImages() map[string]e2emimir.FlagMapper {
+	if overrideImageVersions := os.Getenv("MIMIR_PREVIOUS_IMAGES"); overrideImageVersions != "" {
+		previousVersionImages := map[string]e2emimir.FlagMapper{}
 
 		// Overriding of flags is not currently supported when overriding the list of images,
 		// so set all override functions to nil
 		for _, image := range strings.Split(overrideImageVersions, ",") {
-			previousVersionImages[image] = func(flags map[string]string) map[string]string {
-				flags["-store.engine"] = "blocks"
-				flags["-server.http-listen-port"] = "8080"
-				flags["-store-gateway.sharding-enabled"] = "true"
-				return flags
-			}
+			previousVersionImages[image] = e2emimir.ChainFlagMappers(
+				cortexFlagMapper,
+			)
 		}
 
 		return previousVersionImages
@@ -50,32 +46,22 @@ func previousVersionImages() map[string]func(map[string]string) map[string]strin
 }
 
 func TestBackwardCompatibility(t *testing.T) {
-	for previousImage, flagsFn := range previousVersionImages() {
+	for previousImage, oldFlagsMapper := range previousVersionImages() {
 		t.Run(fmt.Sprintf("Backward compatibility upgrading from %s", previousImage), func(t *testing.T) {
-			flags := BlocksStorageFlags()
-			if flagsFn != nil {
-				flags = flagsFn(flags)
-			}
-
-			runBackwardCompatibilityTest(t, previousImage, flags)
+			runBackwardCompatibilityTest(t, previousImage, oldFlagsMapper)
 		})
 	}
 }
 
 func TestNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T) {
-	for previousImage, flagsFn := range previousVersionImages() {
+	for previousImage, oldFlagsMapper := range previousVersionImages() {
 		t.Run(fmt.Sprintf("Backward compatibility upgrading from %s", previousImage), func(t *testing.T) {
-			flags := BlocksStorageFlags()
-			if flagsFn != nil {
-				flags = flagsFn(flags)
-			}
-
-			runNewDistributorsCanPushToOldIngestersWithReplication(t, previousImage, flags)
+			runNewDistributorsCanPushToOldIngestersWithReplication(t, previousImage, oldFlagsMapper)
 		})
 	}
 }
 
-func runBackwardCompatibilityTest(t *testing.T, previousImage string, flagsForOldImage map[string]string) {
+func runBackwardCompatibilityTest(t *testing.T, previousImage string, oldFlagsMapper e2emimir.FlagMapper) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
@@ -84,23 +70,18 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, flagsForOl
 		"-blocks-storage.tsdb.dir": e2e.ContainerSharedDir + "/tsdb-shared",
 	}
 
-	flagsNew := mergeFlags(
+	flags := mergeFlags(
 		BlocksStorageFlags(),
-		flagTSDBPath,
-	)
-
-	flagsForOldImage = mergeFlags(
-		flagsForOldImage,
 		flagTSDBPath,
 	)
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, flagsNew["-blocks-storage.s3.bucket-name"])
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Start other Mimir components (ingester running on previous version).
-	ingester := e2emimir.NewIngester("ingester-old", consul.NetworkHTTPEndpoint(), flagsForOldImage, previousImage)
+	ingester := e2emimir.NewIngester("ingester-old", consul.NetworkHTTPEndpoint(), flags, previousImage, e2emimir.WithFlagMapper(oldFlagsMapper))
 	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), BlocksStorageFlags(), "")
 	assert.NoError(t, s.StartAndWaitReady(distributor, ingester))
 
@@ -122,7 +103,7 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, flagsForOl
 	// Stop ingester on old version
 	require.NoError(t, s.Stop(ingester))
 
-	ingester = e2emimir.NewIngester("ingester-new", consul.NetworkHTTPEndpoint(), flagsNew, "")
+	ingester = e2emimir.NewIngester("ingester-new", consul.NetworkHTTPEndpoint(), flags, "")
 	require.NoError(t, s.StartAndWaitReady(ingester))
 
 	// Wait until the distributor has updated the ring.
@@ -133,8 +114,8 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, flagsForOl
 		consul,
 		expectedVector,
 		previousImage,
-		flagsForOldImage,
-		BlocksStorageFlags(),
+		flags,
+		oldFlagsMapper,
 		now,
 		s,
 		1,
@@ -142,25 +123,25 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, flagsForOl
 }
 
 // Check for issues like https://github.com/cortexproject/cortex/issues/2356
-func runNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T, previousImage string, flagsForPreviousImage map[string]string) {
+func runNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T, previousImage string, oldFlagsMapper e2emimir.FlagMapper) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
-	flagsForNewImage := mergeFlags(BlocksStorageFlags(), map[string]string{
+	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
 		"-distributor.replication-factor": "3",
 	})
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, flagsForNewImage["-blocks-storage.s3.bucket-name"])
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Start other Mimir components (ingester running on previous version).
-	ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flagsForPreviousImage, previousImage)
-	ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flagsForPreviousImage, previousImage)
-	ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flagsForPreviousImage, previousImage)
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flagsForNewImage, "")
+	ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags, previousImage, e2emimir.WithFlagMapper(oldFlagsMapper))
+	ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags, previousImage, e2emimir.WithFlagMapper(oldFlagsMapper))
+	ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags, previousImage, e2emimir.WithFlagMapper(oldFlagsMapper))
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3))
 
 	// Wait until the distributor has updated the ring.
@@ -181,8 +162,8 @@ func runNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T, previo
 	checkQueries(t, consul,
 		expectedVector,
 		previousImage,
-		flagsForPreviousImage,
-		flagsForNewImage,
+		flags,
+		oldFlagsMapper,
 		now,
 		s,
 		3,
@@ -194,35 +175,42 @@ func checkQueries(
 	consul *e2e.HTTPService,
 	expectedVector model.Vector,
 	previousImage string,
-	flagsForOldImage, flagsForNewImage map[string]string,
+	flags map[string]string,
+	oldFlagsMapper e2emimir.FlagMapper,
 	now time.Time,
 	s *e2e.Scenario,
 	numIngesters int,
 ) {
 	cases := map[string]struct {
-		queryFrontendImage string
-		queryFrontendFlags map[string]string
-		querierImage       string
-		querierFlags       map[string]string
+		queryFrontendImage      string
+		queryFrontendFlags      map[string]string
+		queryFrontendFlagMapper e2emimir.FlagMapper
+		querierImage            string
+		querierFlags            map[string]string
+		querierFlagMapper       e2emimir.FlagMapper
 	}{
 		"old query-frontend, new querier": {
-			queryFrontendImage: previousImage,
-			queryFrontendFlags: flagsForOldImage,
-			querierImage:       "",
-			querierFlags:       flagsForNewImage,
+			queryFrontendImage:      previousImage,
+			queryFrontendFlags:      flags,
+			queryFrontendFlagMapper: oldFlagsMapper,
+			querierImage:            "",
+			querierFlags:            flags,
+			querierFlagMapper:       e2emimir.NoopFlagMapper,
 		},
 		"new query-frontend, old querier": {
-			queryFrontendImage: "",
-			queryFrontendFlags: flagsForNewImage,
-			querierImage:       previousImage,
-			querierFlags:       flagsForOldImage,
+			queryFrontendImage:      "",
+			queryFrontendFlags:      flags,
+			queryFrontendFlagMapper: e2emimir.NoopFlagMapper,
+			querierImage:            previousImage,
+			querierFlags:            flags,
+			querierFlagMapper:       oldFlagsMapper,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			// Start query-frontend.
-			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", c.queryFrontendFlags, c.queryFrontendImage)
+			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", c.queryFrontendFlags, c.queryFrontendImage, e2emimir.WithFlagMapper(c.queryFrontendFlagMapper))
 			require.NoError(t, s.Start(queryFrontend))
 			defer func() {
 				require.NoError(t, s.Stop(queryFrontend))
@@ -231,7 +219,7 @@ func checkQueries(
 			// Start querier.
 			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), e2e.MergeFlagsWithoutRemovingEmpty(c.querierFlags, map[string]string{
 				"-querier.frontend-address": queryFrontend.NetworkGRPCEndpoint(),
-			}), c.querierImage)
+			}), c.querierImage, e2emimir.WithFlagMapper(c.querierFlagMapper))
 
 			require.NoError(t, s.Start(querier))
 			defer func() {

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -50,11 +50,11 @@ func buildArgsWithExtra(args []string) []string {
 	return args
 }
 
-func NewDistributor(name string, consulAddress string, flags map[string]string, image string) *MimirService {
-	return NewDistributorWithConfigFile(name, consulAddress, "", flags, image)
+func NewDistributor(name string, consulAddress string, flags map[string]string, image string, options ...Option) *MimirService {
+	return NewDistributorWithConfigFile(name, consulAddress, "", flags, image, options...)
 }
 
-func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *MimirService {
+func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
 	if configFile != "" {
 		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
 	}
@@ -64,32 +64,36 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 	}
 	binaryName := getBinaryNameForBackwardsCompatibility(image)
 
+	defaultFlags := map[string]string{
+		"-target":                         "distributor",
+		"-log.level":                      "warn",
+		"-auth.multitenancy-enabled":      "true",
+		"-distributor.replication-factor": "1",
+		"-distributor.remote-timeout":     "2s", // Fail fast in integration tests.
+		// Configure the ingesters ring backend
+		"-ring.store":      "consul",
+		"-consul.hostname": consulAddress,
+		// Configure the distributor ring backend
+		"-distributor.ring.store": "memberlist",
+	}
+
+	o := newOptions(options)
+	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
+
 	return NewMimirService(
 		name,
 		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(
-			e2e.MergeFlags(map[string]string{
-				"-target":                         "distributor",
-				"-log.level":                      "warn",
-				"-auth.multitenancy-enabled":      "true",
-				"-distributor.replication-factor": "1",
-				"-distributor.remote-timeout":     "2s", // Fail fast in integration tests.
-				// Configure the ingesters ring backend
-				"-ring.store":      "consul",
-				"-consul.hostname": consulAddress,
-				// Configure the distributor ring backend
-				"-distributor.ring.store": "memberlist",
-			}, flags)))...),
+		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
 		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
 		httpPort,
 		grpcPort,
 	)
 }
-func NewQuerier(name string, consulAddress string, flags map[string]string, image string) *MimirService {
-	return NewQuerierWithConfigFile(name, consulAddress, "", flags, image)
+func NewQuerier(name string, consulAddress string, flags map[string]string, image string, options ...Option) *MimirService {
+	return NewQuerierWithConfigFile(name, consulAddress, "", flags, image, options...)
 }
 
-func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *MimirService {
+func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
 	if configFile != "" {
 		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
 	}
@@ -119,10 +123,13 @@ func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[
 		"-store-gateway.sharding-ring.replication-factor": "1",
 	}
 
+	o := newOptions(options)
+	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
+
 	return NewMimirService(
 		name,
 		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(defaultFlags, flags)))...),
+		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
 		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
 		httpPort,
 		grpcPort,
@@ -162,11 +169,11 @@ func NewStoreGatewayWithConfigFile(name, consulAddress, configFile string, flags
 	)
 }
 
-func NewIngester(name string, consulAddress string, flags map[string]string, image string) *MimirService {
-	return NewIngesterWithConfigFile(name, consulAddress, "", flags, image)
+func NewIngester(name string, consulAddress string, flags map[string]string, image string, options ...Option) *MimirService {
+	return NewIngesterWithConfigFile(name, consulAddress, "", flags, image, options...)
 }
 
-func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *MimirService {
+func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
 	if configFile != "" {
 		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
 	}
@@ -175,20 +182,25 @@ func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map
 	}
 	binaryName := getBinaryNameForBackwardsCompatibility(image)
 
+	defaultFlags := map[string]string{
+		"-target":                      "ingester",
+		"-log.level":                   "warn",
+		"-ingester.final-sleep":        "0s",
+		"-ingester.join-after":         "0s",
+		"-ingester.min-ready-duration": "0s",
+		"-ingester.num-tokens":         "512",
+		// Configure the ingesters ring backend
+		"-ring.store":      "consul",
+		"-consul.hostname": consulAddress,
+	}
+
+	o := newOptions(options)
+	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
+
 	return NewMimirService(
 		name,
 		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(map[string]string{
-			"-target":                      "ingester",
-			"-log.level":                   "warn",
-			"-ingester.final-sleep":        "0s",
-			"-ingester.join-after":         "0s",
-			"-ingester.min-ready-duration": "0s",
-			"-ingester.num-tokens":         "512",
-			// Configure the ingesters ring backend
-			"-ring.store":      "consul",
-			"-consul.hostname": consulAddress,
-		}, flags)))...),
+		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
 		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
 		httpPort,
 		grpcPort,
@@ -202,11 +214,11 @@ func getBinaryNameForBackwardsCompatibility(image string) string {
 	return "mimir"
 }
 
-func NewQueryFrontend(name string, flags map[string]string, image string) *MimirService {
-	return NewQueryFrontendWithConfigFile(name, "", flags, image)
+func NewQueryFrontend(name string, flags map[string]string, image string, options ...Option) *MimirService {
+	return NewQueryFrontendWithConfigFile(name, "", flags, image, options...)
 }
 
-func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]string, image string) *MimirService {
+func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
 	if configFile != "" {
 		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
 	}
@@ -223,10 +235,13 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 		"-frontend.scheduler-dns-lookup-period": "1s",
 	}
 
+	o := newOptions(options)
+	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
+
 	return NewMimirService(
 		name,
 		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(defaultFlags, flags)))...),
+		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
 		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
 		httpPort,
 		grpcPort,
@@ -442,4 +457,81 @@ func NewPurgerWithConfigFile(name, configFile string, flags map[string]string, i
 		httpPort,
 		grpcPort,
 	)
+}
+
+// Options holds a set of options for running services, they can be altered passing Option funcs.
+type Options struct {
+	MapFlags FlagMapper
+}
+
+// Option modifies options.
+type Option func(*Options)
+
+// newOptions creates an Options with default values and applies the options provided.
+func newOptions(options []Option) *Options {
+	o := &Options{
+		MapFlags: NoopFlagMapper,
+	}
+	for _, opt := range options {
+		opt(o)
+	}
+	return o
+}
+
+// WithFlagMapper creates an option that sets a FlagMapper.
+// Multiple flag mappers can be set, each one maps the output of the previous one.
+// Flag mappers added using this option act on a copy of the flags, so they don't alter the input.
+func WithFlagMapper(mapFlags FlagMapper) Option {
+	return func(options *Options) {
+		options.MapFlags = ChainFlagMappers(options.MapFlags, mapFlags)
+	}
+}
+
+// FlagMapper is the type of function that maps flags, just to reduce some verbosity.
+type FlagMapper func(flags map[string]string) map[string]string
+
+// NoopFlagMapper is a flag mapper that does not alter the provided flags.
+func NoopFlagMapper(flags map[string]string) map[string]string { return flags }
+
+// ChainFlagMappers chains multiple flag mappers, each flag mapper gets a copy of the flags so it can safely modify the values.
+// ChainFlagMappers(a, b)(flags) == b(copy(a(copy(flags)
+func ChainFlagMappers(mappers ...FlagMapper) FlagMapper {
+	return func(flags map[string]string) map[string]string {
+		for _, mapFlags := range mappers {
+			flags = mapFlags(copyFlags(flags))
+		}
+		return flags
+	}
+}
+
+// RenameFlagMapper builds a flag mapper that renames flags.
+func RenameFlagMapper(fromTo map[string]string) FlagMapper {
+	return func(flags map[string]string) map[string]string {
+		for name, renamed := range fromTo {
+			if v, ok := flags[name]; ok {
+				flags[renamed] = v
+				delete(flags, name)
+			}
+		}
+		return flags
+	}
+}
+
+// SetFlagMapper builds a flag mapper that sets the provided flags.
+func SetFlagMapper(set map[string]string) FlagMapper {
+	return func(flags map[string]string) map[string]string {
+		for f, v := range set {
+			flags[f] = v
+		}
+		return flags
+	}
+}
+
+// copyFlags provides a copy of the flags map provided.
+func copyFlags(flags map[string]string) map[string]string {
+	cp := make(map[string]string)
+	for f, v := range flags {
+		cp[f] = v
+	}
+	return cp
 }


### PR DESCRIPTION
**What this PR does**:

This is the same as https://github.com/grafana/mimir/pull/1156 but to be merged to `main` and without the query-frontend flags renaming. 

This way we can unblock several changes without having to wait for https://github.com/grafana/mimir/pull/1145 (which we all know that will take more than expected because of Murphy's law)

> Since some default flags are set when the service is being start, we need to pass the flag mapping function from the backward compatibility definition down to the service starting.
>
> I created an options-like scheme for services (currently supporting only flag mappers, but e could also move other options there, like WithImage() instead of passing in an empty string hen we want the default image.

**Which issue(s) this PR fixes**:

None, test refactor to make other PRs easier.

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
