### PR TITLE
Export UploadAlertmanagerConfig and fix it

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -37,32 +37,6 @@ const simpleAlertmanagerConfig = `route:
 receivers:
   - name: dummy`
 
-func uploadAlertmanagerConfig(minio *e2e.HTTPService, user, config string) error {
-	client, err := s3.NewBucketClient(s3.Config{
-		Endpoint:        minio.HTTPEndpoint(),
-		Insecure:        true,
-		BucketName:      alertsBucketName,
-		AccessKeyID:     e2edb.MinioAccessKey,
-		SecretAccessKey: flagext.Secret{Value: e2edb.MinioSecretKey},
-	}, "test", log.NewNopLogger())
-	if err != nil {
-		return err
-	}
-
-	desc := alertspb.AlertConfigDesc{
-		RawConfig: mimirAlertmanagerUserConfigYaml,
-		User:      user,
-		Templates: []*alertspb.TemplateDesc{},
-	}
-
-	d, err := desc.Marshal()
-	if err != nil {
-		return err
-	}
-
-	return client.Upload(context.Background(), fmt.Sprintf("/alerts/%s", user), bytes.NewReader(d))
-}
-
 func TestAlertmanager(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
@@ -72,7 +46,7 @@ func TestAlertmanager(t *testing.T) {
 	minio := e2edb.NewMinio(9000, alertsBucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
-	require.NoError(t, uploadAlertmanagerConfig(minio, "user-1", mimirAlertmanagerUserConfigYaml))
+	require.NoError(t, UploadAlertmanagerConfig(minio, "user-1", mimirAlertmanagerUserConfigYaml))
 
 	alertmanager := e2emimir.NewAlertmanager(
 		"alertmanager",

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -8,13 +8,21 @@
 package integration
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"text/template"
 
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
+
+	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
+	"github.com/grafana/mimir/pkg/storage/bucket/s3"
 )
 
 const (
@@ -185,4 +193,32 @@ func buildConfigFromTemplate(tmpl string, data interface{}) string {
 	}
 
 	return w.String()
+}
+
+// UploadAlertmanagerConfig uploads the provided config to the minio bucket for the specified user.
+// Uses default test minio credentials.
+func UploadAlertmanagerConfig(minio *e2e.HTTPService, user, config string) error {
+	client, err := s3.NewBucketClient(s3.Config{
+		Endpoint:        minio.HTTPEndpoint(),
+		Insecure:        true,
+		BucketName:      alertsBucketName,
+		AccessKeyID:     e2edb.MinioAccessKey,
+		SecretAccessKey: flagext.Secret{Value: e2edb.MinioSecretKey},
+	}, "test", log.NewNopLogger())
+	if err != nil {
+		return err
+	}
+
+	desc := alertspb.AlertConfigDesc{
+		RawConfig: config,
+		User:      user,
+		Templates: []*alertspb.TemplateDesc{},
+	}
+
+	d, err := desc.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return client.Upload(context.Background(), fmt.Sprintf("/alerts/%s", user), bytes.NewReader(d))
 }

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -414,7 +414,7 @@ func TestRulerAlertmanager(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Have at least one alertmanager configuration.
-	require.NoError(t, uploadAlertmanagerConfig(minio, "user-1", mimirAlertmanagerUserConfigYaml))
+	require.NoError(t, UploadAlertmanagerConfig(minio, "user-1", mimirAlertmanagerUserConfigYaml))
 
 	// Start Alertmanagers.
 	amFlags := mergeFlags(AlertmanagerFlags(), AlertmanagerS3Flags(), AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1))
@@ -494,7 +494,7 @@ func TestRulerAlertmanagerTLS(t *testing.T) {
 	))
 
 	// Have at least one alertmanager configuration.
-	require.NoError(t, uploadAlertmanagerConfig(minio, "user-1", mimirAlertmanagerUserConfigYaml))
+	require.NoError(t, UploadAlertmanagerConfig(minio, "user-1", mimirAlertmanagerUserConfigYaml))
 
 	// Start Alertmanagers.
 	amFlags := mergeFlags(


### PR DESCRIPTION

## What this PR does

Exports UploadAlertmanagerConfig and fixes it: it was using a global variable instead of the provided `config`.

Exported it to use it in other projects (i.e. GEM).


## Which issue(s) this PR fixes

None

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
