### PR TITLE
Run storage config sanity check at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -468,6 +468,7 @@
 * [ENHANCEMENT] Ingester: Expose ingester ring page on ingesters. #654
 * [ENHANCEMENT] Querier: retry store-gateway in case of unexpected failure, instead of failing the query. #1003
 * [ENHANCEMENT] Added a new metric `mimir_build_info` to coincide with `cortex_build_info`. #1022
+* [ENHANCEMENT] Mimir runs a sanity check of storage config at startup and will fail to start if the sanity check doesn't pass. This is done to find potential config issues before starting up. #1180
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #206
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #207
 * [BUGFIX] Upgrade Prometheus. TSDB now waits for pending readers before truncating Head block, fixing the `chunk not found` error and preventing wrong query results. #16

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -351,7 +351,7 @@ func TestRulerSharding(t *testing.T) {
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, rulestoreBucketName)
+	minio := e2edb.NewMinio(9000, rulestoreBucketName, bucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Configure the ruler.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -212,6 +212,16 @@ func (c *Config) isModuleEnabled(m string) bool {
 	return util.StringsContain(c.Target, m)
 }
 
+func (c *Config) isAnyModuleEnabled(modules ...string) bool {
+	for _, m := range modules {
+		if c.isModuleEnabled(m) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // validateYAMLEmptyNodes ensure that no empty node has been specified in the YAML config file.
 // When an empty node is defined in YAML, the YAML parser sets the whole struct to its zero value
 // and so we loose all default values. It's very difficult to detect this case for the user, so we

--- a/pkg/mimir/sanity_check.go
+++ b/pkg/mimir/sanity_check.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package mimir
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/multierror"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	alertstorelocal "github.com/grafana/mimir/pkg/alertmanager/alertstore/local"
+	rulestorelocal "github.com/grafana/mimir/pkg/ruler/rulestore/local"
+	"github.com/grafana/mimir/pkg/storage/bucket"
+)
+
+var (
+	errObjectStorage = "unable to successfully send a request to object storage"
+)
+
+func runSanityCheck(ctx context.Context, cfg Config, logger log.Logger) error {
+	level.Info(logger).Log("msg", "Checking object storage config")
+	if err := checkObjectStoresConfigWithRetries(ctx, cfg, logger); err != nil {
+		level.Error(logger).Log("msg", "Unable to successfully connect to configured object storage", "err", err)
+		return err
+	}
+	level.Info(logger).Log("msg", "Object storage config successfully checked")
+
+	return nil
+}
+
+func checkObjectStoresConfigWithRetries(ctx context.Context, cfg Config, logger log.Logger) (err error) {
+	const maxRetries = 20
+
+	backoff := backoff.New(ctx, backoff.Config{
+		MinBackoff: time.Second,
+		MaxBackoff: 5 * time.Second,
+		MaxRetries: maxRetries,
+	})
+
+	for backoff.Ongoing() {
+		err = checkObjectStoresConfig(ctx, cfg, logger)
+		if err == nil {
+			return nil
+		}
+
+		if backoff.NumRetries() < maxRetries-1 {
+			level.Warn(logger).Log("msg", "Unable to successfully connect to configured object storage (will retry)", "err", err)
+		} else {
+			level.Warn(logger).Log("msg", "Unable to successfully connect to configured object storage", "err", err)
+		}
+
+		backoff.Wait()
+	}
+
+	return err
+}
+
+func checkObjectStoresConfig(ctx context.Context, cfg Config, logger log.Logger) error {
+	errs := multierror.New()
+
+	// Check blocks storage config only if running at least one component using it.
+	if cfg.isAnyModuleEnabled(All, Ingester, Querier, Ruler, StoreGateway) {
+		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.BlocksStorage.Bucket, logger), "blocks storage"))
+	}
+
+	// Check alertmanager storage config.
+	if cfg.isAnyModuleEnabled(AlertManager) && cfg.AlertmanagerStorage.Backend != alertstorelocal.Name {
+		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.AlertmanagerStorage.Config, logger), "alertmanager storage"))
+	}
+
+	// Check ruler storage config.
+	if cfg.isAnyModuleEnabled(All, Ruler) && cfg.RulerStorage.Backend != rulestorelocal.Name {
+		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.RulerStorage.Config, logger), "ruler storage"))
+	}
+
+	return errs.Err()
+}
+
+func checkObjectStoreConfig(ctx context.Context, cfg bucket.Config, logger log.Logger) error {
+	// Hardcoded but relatively high timeout.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	client, err := bucket.NewClient(ctx, cfg, "sanity-check", logger, nil)
+	if err != nil {
+		return errors.Wrap(err, errObjectStorage)
+	}
+
+	defer func() {
+		// Ensure the client gets closed. Ignore the returned error here.
+		_ = client.Close()
+	}()
+
+	// Read an object we don't expect to exist, just to check if the object storage
+	// replies with the expected error.
+	reader, err := client.Get(ctx, "sanity-check-at-startup")
+	if err != nil {
+		if client.IsObjNotFoundErr(err) {
+			return nil
+		}
+		return errors.Wrap(err, errObjectStorage)
+	}
+
+	runutil.ExhaustCloseWithErrCapture(&err, reader, "error while reading from object store")
+	return err
+}

--- a/pkg/mimir/sanity_check_test.go
+++ b/pkg/mimir/sanity_check_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package mimir
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/bucket"
+)
+
+func TestCheckObjectStoresConfig(t *testing.T) {
+	tests := map[string]struct {
+		setup    func(cfg *Config)
+		expected string
+	}{
+		"should succeed with the default config": {
+			setup:    nil,
+			expected: "",
+		},
+		"should succeed with the default config running Alertmanager along with target=all": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("all,alertmanager"))
+			},
+			expected: "",
+		},
+		"should succeed with filesystem backend and non-existent directory (components create the dir at startup)": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("all,alertmanager"))
+
+				for _, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.Filesystem
+					bucketCfg.Filesystem.Directory = "/does/not/exists"
+				}
+			},
+			expected: "",
+		},
+		"should check only blocks storage config when target=ingester": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("ingester"))
+
+				// Configure alertmanager and ruler storage to fail, but expect to succeed.
+				for _, bucketCfg := range []*bucket.Config{&cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.GCS
+					bucketCfg.GCS.BucketName = "invalid"
+				}
+			},
+			expected: "",
+		},
+		"should check only alertmanager storage config when target=alertmanager": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("alertmanager"))
+
+				// Configure blocks storage and ruler storage to fail, but expect to succeed.
+				for _, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.GCS
+					bucketCfg.GCS.BucketName = "invalid"
+				}
+			},
+			expected: "",
+		},
+		"should check blocks and ruler storage config when target=ruler": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("ruler"))
+
+				// Configure alertmanager storage to fail, but expect to succeed.
+				cfg.AlertmanagerStorage.Config.Backend = bucket.GCS
+				cfg.AlertmanagerStorage.Config.GCS.BucketName = "invalid"
+			},
+			expected: "",
+		},
+		"should fail on invalid AWS S3 config": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("all,alertmanager"))
+
+				for _, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.S3
+					bucketCfg.S3.Region = "us-east-1"
+					bucketCfg.S3.Endpoint = "s3.dualstack.us-east-1.amazonaws.com"
+					bucketCfg.S3.BucketName = "invalid"
+					bucketCfg.S3.AccessKeyID = "xxx"
+					bucketCfg.S3.SecretAccessKey = flagext.Secret{Value: "yyy"}
+				}
+			},
+			expected: errObjectStorage,
+		},
+		"should fail on invalid GCS config": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("all,alertmanager"))
+
+				for _, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.GCS
+					bucketCfg.GCS.BucketName = "invalid"
+				}
+			},
+			expected: errObjectStorage,
+		},
+		"should fail on invalid Azure config": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("all,alertmanager"))
+
+				for _, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.Azure
+					bucketCfg.Azure.ContainerName = "invalid"
+					bucketCfg.Azure.StorageAccountName = "xxx"
+					bucketCfg.Azure.StorageAccountKey = flagext.Secret{Value: "eHh4"}
+				}
+			},
+			expected: errObjectStorage,
+		},
+		"should fail on invalid Swift config": {
+			setup: func(cfg *Config) {
+				require.NoError(t, cfg.Target.Set("all,alertmanager"))
+
+				for _, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
+					bucketCfg.Backend = bucket.Swift
+					bucketCfg.Swift.AuthURL = "http://127.0.0.1/"
+				}
+			},
+			expected: errObjectStorage,
+		},
+	}
+
+	for testName, testData := range tests {
+		// Change scope since we're running each test in parallel.
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{}
+			flagext.DefaultValues(&cfg)
+
+			if testData.setup != nil {
+				testData.setup(&cfg)
+			}
+
+			require.NoError(t, cfg.Validate(log.NewNopLogger()), "pre-condition: the config static validation should pass")
+
+			actual := checkObjectStoresConfig(context.Background(), cfg, log.NewNopLogger())
+			if testData.expected == "" {
+				require.NoError(t, actual)
+			} else {
+				require.Error(t, actual)
+				require.Contains(t, actual.Error(), testData.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## What this PR does
In this PR I propose to run a sanity check on storage config startup and fail to start if such sanity check fails. The idea is to find some (not all) config issues before starting Mimir, and is a follow up of a conversation I had last week with Tom.

The current situation is that some Mimir components already fail to start if storage is misconfigured, while others dont. For example, Alertmanager will fail to start, while ingesters don't.

As a nice side effect, this should also solve a problem we have in the tutorial I'm working on #1049 where Mimir `-target=all,alertmanager` fails to start if Minio is not ready yet.

## Which issue(s) this PR fixes
N/A

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
