### PR TITLE
Add "by in-memory series growth" to Top Tenants

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -247,7 +247,7 @@
                   ],
                   "targets": [
                      {
-                        "expr": "topk($limit,\n  sum by (user) (\n    (\n        sum by (user, cluster, namespace) (cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"})\n        -\n        sum by (user, cluster, namespace) (cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"})\n    )\n    / on(cluster, namespace) group_left\n    max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"})\n  )\n)\n",
+                        "expr": "topk($limit, sum by (user) (\n  (\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} )\n      -\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} )\n  )\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"} )\n)\n)",
                         "format": "table",
                         "instant": true,
                         "intervalFactor": 2,
@@ -313,6 +313,95 @@
                   "datasource": "$datasource",
                   "fill": 1,
                   "id": 4,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 12,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by (user) (\n  (\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} )\n      -\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} )\n  )\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"} )\n)\n\nand\ntopk($limit, sum by (user) (\n  (\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} @ end())\n      -\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} @ end())\n  )\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"} @ end())\n)\n - sum by (user) (\n  (\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} @ start())\n      -\n      sum by (user, cluster, namespace) (cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"} @ start())\n  )\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"} @ start())\n)\n)\n",
+                        "format": "time_series",
+                        "interval": "15s",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{ user }}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Top $limit users by in-memory series (series created - series removed) that grew the most between query range start and query range end",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "By in-memory series growth",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": true,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "id": 5,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -440,7 +529,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 5,
+                  "id": 6,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -568,7 +657,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 6,
+                  "id": 7,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin/dashboards/top-tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/top-tenants.libsonnet
@@ -1,6 +1,23 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
+  local in_memory_series_per_user_query(at='') = |||
+    sum by (user) (
+      (
+          sum by (user, %(group_by_cluster)s) (cortex_ingester_memory_series_created_total{%(ingester)s} %(at)s)
+          -
+          sum by (user, %(group_by_cluster)s) (cortex_ingester_memory_series_removed_total{%(ingester)s} %(at)s)
+      )
+      / on(%(group_by_cluster)s) group_left
+      max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s} %(at)s)
+    )
+  ||| % {
+    at: at,
+    ingester: $.jobMatcher($._config.job_names.ingester),
+    distributor: $.jobMatcher($._config.job_names.distributor),
+    group_by_cluster: $._config.group_by_cluster,
+  },
+
   'mimir-top-tenants.json':
     ($.dashboard('Top tenants') + { uid: 'bc6e12d4fe540e4a1785b9d3ca0ffdd9' })
     .addClusterSelectorTemplates()
@@ -52,25 +69,29 @@ local utils = import 'mixin-utils/utils.libsonnet';
         { sort: { col: 2, desc: true } } +
         $.tablePanel(
           [
-            |||
-              topk($limit,
-                sum by (user) (
-                  (
-                      sum by (user, %(group_by_cluster)s) (cortex_ingester_memory_series_created_total{%(ingester)s})
-                      -
-                      sum by (user, %(group_by_cluster)s) (cortex_ingester_memory_series_removed_total{%(ingester)s})
-                  )
-                  / on(%(group_by_cluster)s) group_left
-                  max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
-                )
-              )
-            ||| % {
-              ingester: $.jobMatcher($._config.job_names.ingester),
-              distributor: $.jobMatcher($._config.job_names.distributor),
-              group_by_cluster: $._config.group_by_cluster,
-            },
+            'topk($limit, %(in_memory_series_per_user)s)' % { in_memory_series_per_user: in_memory_series_per_user_query() },
           ],
           { 'Value #A': { alias: 'series' } }
+        )
+      ),
+    )
+
+    .addRow(
+      ($.row('By in-memory series growth') + { collapse: true })
+      .addPanel(
+        local title = 'Top $limit users by in-memory series (series created - series removed) that grew the most between query range start and query range end';
+        $.panel(title) +
+        $.queryPanel(
+          |||
+            %(in_memory_series_per_user)s
+            and
+            topk($limit, %(in_memory_series_per_user_at_end)s - %(in_memory_series_per_user_at_start)s)
+          ||| % {
+            in_memory_series_per_user: in_memory_series_per_user_query(),
+            in_memory_series_per_user_at_end: in_memory_series_per_user_query(at='@ end()'),
+            in_memory_series_per_user_at_start: in_memory_series_per_user_query(at='@ start()'),
+          },
+          '{{ user }}',
         )
       ),
     )


### PR DESCRIPTION
## What this PR does

Sometimes the tenant we're worried the most in a cluster is not the one that has the largest number of series, but the one that's growing too fast.

This adds a panel to Top Tenants dashboard that filters the tenants by in-memory series growth between start() and end().

## Which issue(s) this PR fixes

None, just saw the need in a recent oncall issue.

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
