### PR TITLE
Makefile: Fix finding of main.go files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-cmd/cortextool/cortextool
+cmd/mimirtool/mimirtool
 cmd/test-exporter/test-exporter
 cmd/mimir/mimir
 cmd/query-tee/query-tee

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ push-multiarch-build-image:
 
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/grafana/mimir' phase.
-DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name mimir-mixin-tools -prune -o
+DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name mimir-mixin-tools -prune -o -name trafficdump -prune -o
 
 MAKEFILES = $(shell find . $(DONT_FIND) \( -name 'Makefile' -o -name '*.mk' \) -print)
 
@@ -131,10 +131,10 @@ images:
 PROTO_DEFS := $(shell find . $(DONT_FIND) -type f -name '*.proto' -print)
 PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 
-# Building binaries is now automated.  The convention is to build a binary
-# for every directory with main.go in it, in the ./cmd directory.
+# Building binaries is now automated. The convention is to build a binary
+# for every directory with main.go in it.
 MAIN_GO := $(shell find . $(DONT_FIND) -type f -name 'main.go' -print)
-EXES := $(foreach exe, $(patsubst ./cmd/%/main.go, %, $(MAIN_GO)), ./cmd/$(exe)/$(exe))
+EXES := $(foreach exeDir,$(patsubst %/main.go, %, $(MAIN_GO)),$(exeDir)/$(notdir $(exeDir)))
 GO_FILES := $(shell find . $(DONT_FIND) -name cmd -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)
 define dep_exe
 $(1): $(dir $(1))/main.go $(GO_FILES) protos


### PR DESCRIPTION
## What this PR does
In Makefile, fix the detection of main.go files, beneath both cmd and tools directories. Prior to this fix, `make exes` fails due to the `EXES` variable definition expecting only files from beneath ./cmd/:

```Makefile
EXES := $(foreach exe, $(patsubst cmd/%/main.go, %, $(MAIN_GO)), ./cmd/$(exe)/$(exe))
```

## Which issue(s) this PR fixes

## Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
