### PR TITLE
query-frontend: Categorize parallelize_shardable_queries as basic

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1128,7 +1128,7 @@ Usage of ./cmd/mimir/mimir:
   -query-frontend.max-retries-per-request int
     	Maximum number of retries for a single request; beyond this, the downstream error is returned. (default 5)
   -query-frontend.parallelize-shardable-queries
-    	[experimental] True to enable query sharding.
+    	True to enable query sharding.
   -query-frontend.querier-forget-delay duration
     	If a querier disconnects without sending notification about graceful shutdown, the query-frontend will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
   -query-frontend.query-sharding-max-sharded-queries int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -349,6 +349,8 @@ Usage of ./cmd/mimir/mimir:
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.max-queriers-per-tenant int
     	Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.
+  -query-frontend.parallelize-shardable-queries
+    	True to enable query sharding.
   -query-frontend.query-sharding-max-sharded-queries int
     	The max number of sharded queries that can be run for a given received query. 0 to disable limit. (default 128)
   -query-frontend.query-sharding-total-shards int

--- a/docs/sources/configuration/reference-configuration-parameters.md
+++ b/docs/sources/configuration/reference-configuration-parameters.md
@@ -1106,7 +1106,7 @@ results_cache:
 # CLI flag: -query-frontend.max-retries-per-request
 [max_retries: <int> | default = 5]
 
-# (experimental) True to enable query sharding.
+# True to enable query sharding.
 # CLI flag: -query-frontend.parallelize-shardable-queries
 [parallelize_shardable_queries: <boolean> | default = false]
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -38,7 +38,7 @@ type Config struct {
 	ResultsCacheConfig     `yaml:"results_cache"`
 	CacheResults           bool `yaml:"cache_results"`
 	MaxRetries             int  `yaml:"max_retries" category:"advanced"`
-	ShardedQueries         bool `yaml:"parallelize_shardable_queries" category:"experimental"`
+	ShardedQueries         bool `yaml:"parallelize_shardable_queries"`
 	CacheUnalignedRequests bool `yaml:"cache_unaligned_requests" category:"advanced"`
 }
 


### PR DESCRIPTION
## What this PR does
Categorize query_frontend.parallelize_shardable_queries as basic, since it shouldn't be considered experimental, as determined by @pracucci.

## Which issue(s) this PR fixes

## Checklist

- [x] Tests updated
- [x] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
