### PR TITLE
Makefile: fix docs related targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ clean-doc:
 	rm -f $(DOC_TEMPLATES:.template=.md)
 
 check-doc: doc
-	@git diff --exit-code -- $(DOC_TEMPLATES:.template=.md) $(DOC_EMBED) \
+	@find . -name "*.md" | xargs git diff --exit-code -- \
 	|| (echo "Please update generated documentation by running 'make doc' and committing the changes" && false)
 
 .PHONY: reference-help


### PR DESCRIPTION
## What this PR does

doc, clean-doc targets: remove repetitions and use a single variable
    for defining templates in use.

check-doc target: fix wrong file reference and missing architecture folder.

## Which issue(s) this PR fixes

Fixes N/A

## Checklist

Not applicable.

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
