### PR TITLE
Docs: revisit shuffle sharding

### DIFF
--- a/docs/sources/operating-grafana-mimir/configure-shuffle-sharding.md
+++ b/docs/sources/operating-grafana-mimir/configure-shuffle-sharding.md
@@ -112,7 +112,7 @@ The current shuffle sharding implementation in Grafana Mimir has a limitation th
 
 The problem is that if a tenant’s shard decreases in size, there is currently no way for the queriers and rulers to know how big the tenant shard was previously, and hence they will potentially miss an ingester with data for that tenant. In other words, the lookback mechanism, used to select the ingesters which may have received series since 'now - lookback period', doesn't work correctly if the tenant shard size is decreased.
 
-Decreasing the tenant shard size is not supported because deemed to be an infrequent operation, but a workaround still exists:
+> **Note:** Decreasing the tenant shard size is not supported because it is something that you would rarely need to do, but a workaround still exists:
 
 1. Disable shuffle sharding on the read path.
 2. Decrease the configured tenant shard size.


### PR DESCRIPTION
## What this PR does
In this PR I'm revising the shuffle sharding doc. From a tech perspective there were 2 things to fix:
1. Fix ruler doc (now ruler sharding is always enabled)
2. Add compactor shuffle sharding (introduced just recently, doc was missing)

I've also took the opportunity to do some other small changes.

## Which issue(s) this PR relates to
Relates to #1092

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

[Edit by Ursula] Change "Fixes" to "Relates to".