### PR TITLE
Update operations/mimir/images.libsonnet wrt. Docker registry

### DIFF
--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -687,7 +687,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -779,7 +779,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -851,7 +851,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -924,7 +924,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1026,7 +1026,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1344,7 +1344,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -763,7 +763,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -855,7 +855,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -928,7 +928,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -991,7 +991,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1086,7 +1086,7 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1153,7 +1153,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1242,7 +1242,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1344,7 +1344,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1662,7 +1662,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-gossip-generated.yaml
+++ b/operations/mimir-tests/test-gossip-generated.yaml
@@ -789,7 +789,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -886,7 +886,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -961,7 +961,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -1024,7 +1024,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1119,7 +1119,7 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1186,7 +1186,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1277,7 +1277,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1383,7 +1383,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1705,7 +1705,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-gossip-multikv-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-generated.yaml
@@ -795,7 +795,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -894,7 +894,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -969,7 +969,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -1032,7 +1032,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1130,7 +1130,7 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1197,7 +1197,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1289,7 +1289,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1396,7 +1396,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1719,7 +1719,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -762,7 +762,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -854,7 +854,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -931,7 +931,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -994,7 +994,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1089,7 +1089,7 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1156,7 +1156,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1245,7 +1245,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1347,7 +1347,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1665,7 +1665,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -763,7 +763,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -858,7 +858,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -932,7 +932,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -996,7 +996,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1095,7 +1095,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1162,7 +1162,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1251,7 +1251,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1354,7 +1354,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1673,7 +1673,7 @@ spec:
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.tenant-shard-size=3
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -762,7 +762,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -856,7 +856,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -929,7 +929,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -992,7 +992,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1091,7 +1091,7 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1160,7 +1160,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1251,7 +1251,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1355,7 +1355,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1675,7 +1675,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -762,7 +762,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -854,7 +854,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -927,7 +927,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -990,7 +990,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1085,7 +1085,7 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1152,7 +1152,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1241,7 +1241,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1343,7 +1343,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1661,7 +1661,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -762,7 +762,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -855,7 +855,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -928,7 +928,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -991,7 +991,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1089,7 +1089,7 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -store.max-query-length=768h
         - -target=ruler
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1157,7 +1157,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1247,7 +1247,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1350,7 +1350,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1669,7 +1669,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: cortexproject/cortex:v1.9.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -5,7 +5,7 @@
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.
-    mimir: 'cortexproject/cortex:v1.9.0',
+    mimir: 'grafana/mimir:mimir-2.0.0',
 
     alertmanager: self.mimir,
     distributor: self.mimir,
@@ -19,6 +19,6 @@
     query_scheduler: self.mimir,
     overrides_exporter: self.mimir,
 
-    query_tee: 'quay.io/cortexproject/query-tee:v1.9.0',
+    query_tee: 'grafana/query-tee:mimir-2.0.0',
   },
 }


### PR DESCRIPTION
## What this PR does
Update operations/mimir/images.libsonnet wrt. Docker registry, which is now `grafana` and not respectively `cortexproject` and `quay.io/cortexproject`.

## Which issue(s) this PR fixes

## Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
