### PR TITLE
Embrace options pattern for integration services

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -83,7 +83,6 @@ func TestAlertmanager(t *testing.T) {
 			AlertmanagerS3Flags(),
 			AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1),
 		),
-		"",
 	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
 	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_config_last_reload_successful"))
@@ -142,7 +141,6 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	am := e2emimir.NewAlertmanager(
 		"alertmanager",
 		flags,
-		"",
 	)
 
 	require.NoError(t, s.StartAndWaitReady(am))
@@ -247,9 +245,9 @@ func TestAlertmanagerSharding(t *testing.T) {
 			flags = mergeFlags(flags, AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), testCfg.replicationFactor))
 
 			// Wait for the Alertmanagers to start.
-			alertmanager1 := e2emimir.NewAlertmanager("alertmanager-1", flags, "")
-			alertmanager2 := e2emimir.NewAlertmanager("alertmanager-2", flags, "")
-			alertmanager3 := e2emimir.NewAlertmanager("alertmanager-3", flags, "")
+			alertmanager1 := e2emimir.NewAlertmanager("alertmanager-1", flags)
+			alertmanager2 := e2emimir.NewAlertmanager("alertmanager-2", flags)
+			alertmanager3 := e2emimir.NewAlertmanager("alertmanager-3", flags)
 
 			alertmanagers := e2emimir.NewCompositeMimirService(alertmanager1, alertmanager2, alertmanager3)
 
@@ -648,7 +646,7 @@ func TestAlertmanagerShardingScaling(t *testing.T) {
 			// Helper to start an instance.
 			startInstance := func() *e2emimir.MimirService {
 				i := len(instances) + 1
-				am := e2emimir.NewAlertmanager(fmt.Sprintf("alertmanager-%d", i), flags, "")
+				am := e2emimir.NewAlertmanager(fmt.Sprintf("alertmanager-%d", i), flags)
 				require.NoError(t, s.StartAndWaitReady(am))
 				instances = append(instances, am)
 				return am

--- a/integration/api_endpoints_test.go
+++ b/integration/api_endpoints_test.go
@@ -41,7 +41,7 @@ func newMimirSingleBinaryWithLocalFilesytemBucket(t *testing.T, name string, fla
 	setFlagIfNotExistingAlready("-blocks-storage.backend", "filesystem")
 	setFlagIfNotExistingAlready("-blocks-storage.filesystem.dir", "./bucket")
 
-	mimir := e2emimir.NewSingleBinaryWithConfigFile(name, mimirConfigFile, flags, "", 9009, 9095)
+	mimir := e2emimir.NewSingleBinary(name, flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 
 	return s, mimir
 }
@@ -81,6 +81,6 @@ func TestConfigAPIEndpoint(t *testing.T) {
 	// Start again Mimir in single binary with the exported config
 	// and ensure it starts (pass the readiness probe).
 	require.NoError(t, writeFileToSharedDir(s, mimirConfigFile, body))
-	mimir2 := e2emimir.NewSingleBinaryWithConfigFile("mimir-2", mimirConfigFile, nil, "", 9009, 9095)
+	mimir2 := e2emimir.NewSingleBinary("mimir-2", nil, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 	require.NoError(t, s.StartAndWaitReady(mimir2))
 }

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -142,6 +142,22 @@ var (
 		}
 	}
 
+	DefaultSingleBinaryFlags = func() map[string]string {
+		return map[string]string{
+			"-auth.multitenancy-enabled": "true",
+			// Query-frontend worker.
+			"-querier.frontend-client.backoff-min-period": "100ms",
+			"-querier.frontend-client.backoff-max-period": "100ms",
+			"-querier.frontend-client.backoff-retries":    "1",
+			"-querier.max-concurrent":                     "1",
+			// Distributor.
+			"-distributor.ring.store": "memberlist",
+			// Ingester.
+			"-ingester.ring.replication-factor": "1",
+			"-ingester.ring.num-tokens":         "512",
+		}
+	}
+
 	BlocksStorageConfig = buildConfigFromTemplate(`
 blocks_storage:
   backend:             s3

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -50,160 +50,101 @@ func buildArgsWithExtra(args []string) []string {
 	return args
 }
 
-func NewDistributor(name string, consulAddress string, flags map[string]string, image string, options ...Option) *MimirService {
-	return NewDistributorWithConfigFile(name, consulAddress, "", flags, image, options...)
-}
-
-func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":                           "distributor",
-		"-log.level":                        "warn",
-		"-auth.multitenancy-enabled":        "true",
-		"-ingester.ring.replication-factor": "1",
-		"-distributor.remote-timeout":       "2s", // Fail fast in integration tests.
-		// Configure the ingesters ring backend
-		"-ingester.ring.store":           "consul",
-		"-ingester.ring.consul.hostname": consulAddress,
-		// Configure the distributor ring backend
-		"-distributor.ring.store": "memberlist",
-	}
-
+func newMimirServiceFromOptions(name string, defaultFlags, flags map[string]string, options ...Option) *MimirService {
 	o := newOptions(options)
 	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
+	binaryName := getBinaryNameForBackwardsCompatibility(o.Image)
 
 	return NewMimirService(
 		name,
-		image,
+		o.Image,
 		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
-	)
-}
-func NewQuerier(name string, consulAddress string, flags map[string]string, image string, options ...Option) *MimirService {
-	return NewQuerierWithConfigFile(name, consulAddress, "", flags, image, options...)
-}
-
-func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":                           "querier",
-		"-log.level":                        "warn",
-		"-ingester.ring.replication-factor": "1",
-		// Ingesters ring backend.
-		"-ingester.ring.store":           "consul",
-		"-ingester.ring.consul.hostname": consulAddress,
-		// Query-frontend worker.
-		"-querier.frontend-client.backoff-min-period": "100ms",
-		"-querier.frontend-client.backoff-max-period": "100ms",
-		"-querier.frontend-client.backoff-retries":    "1",
-		"-querier.max-concurrent":                     "1",
-		// Quickly detect query-frontend and query-scheduler when running it.
-		"-querier.dns-lookup-period": "1s",
-		// Store-gateway ring backend.
-		"-store-gateway.sharding-ring.store":              "consul",
-		"-store-gateway.sharding-ring.consul.hostname":    consulAddress,
-		"-store-gateway.sharding-ring.replication-factor": "1",
-	}
-
-	o := newOptions(options)
-	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
-
-	return NewMimirService(
-		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		e2e.NewHTTPReadinessProbe(o.HTTPPort, "/ready", 200, 299),
+		o.HTTPPort,
+		o.GRPCPort,
+		o.OtherPorts...,
 	)
 }
 
-func NewStoreGateway(name string, consulAddress string, flags map[string]string, image string) *MimirService {
-	return NewStoreGatewayWithConfigFile(name, consulAddress, "", flags, image)
-}
-
-func NewStoreGatewayWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":    "store-gateway",
-		"-log.level": "warn",
-		// Store-gateway ring backend.
-		"-store-gateway.sharding-ring.store":              "consul",
-		"-store-gateway.sharding-ring.consul.hostname":    consulAddress,
-		"-store-gateway.sharding-ring.replication-factor": "1",
-	}
-
-	return NewMimirService(
+func NewDistributor(name string, consulAddress string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(defaultFlags, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		map[string]string{
+			"-target":                           "distributor",
+			"-log.level":                        "warn",
+			"-auth.multitenancy-enabled":        "true",
+			"-ingester.ring.replication-factor": "1",
+			"-distributor.remote-timeout":       "2s", // Fail fast in integration tests.
+			// Configure the ingesters ring backend
+			"-ingester.ring.store":           "consul",
+			"-ingester.ring.consul.hostname": consulAddress,
+			// Configure the distributor ring backend
+			"-distributor.ring.store": "memberlist",
+		},
+		flags,
+		options...,
 	)
 }
 
-func NewIngester(name string, consulAddress string, flags map[string]string, image string, options ...Option) *MimirService {
-	return NewIngesterWithConfigFile(name, consulAddress, "", flags, image, options...)
+func NewQuerier(name string, consulAddress string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
+		name,
+		map[string]string{
+			"-target":                           "querier",
+			"-log.level":                        "warn",
+			"-ingester.ring.replication-factor": "1",
+			// Ingesters ring backend.
+			"-ingester.ring.store":           "consul",
+			"-ingester.ring.consul.hostname": consulAddress,
+			// Query-frontend worker.
+			"-querier.frontend-client.backoff-min-period": "100ms",
+			"-querier.frontend-client.backoff-max-period": "100ms",
+			"-querier.frontend-client.backoff-retries":    "1",
+			"-querier.max-concurrent":                     "1",
+			// Quickly detect query-frontend and query-scheduler when running it.
+			"-querier.dns-lookup-period": "1s",
+			// Store-gateway ring backend.
+			"-store-gateway.sharding-ring.store":              "consul",
+			"-store-gateway.sharding-ring.consul.hostname":    consulAddress,
+			"-store-gateway.sharding-ring.replication-factor": "1",
+		},
+		flags,
+		options...,
+	)
 }
 
-func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":                   "ingester",
-		"-log.level":                "warn",
-		"-ingester.ring.num-tokens": "512",
-		// Configure the ingesters ring backend
-		"-ingester.ring.store":           "consul",
-		"-ingester.ring.consul.hostname": consulAddress,
-		// Speed up the startup.
-		"-ingester.ring.min-ready-duration":          "0s",
-		"-ingester.ring.readiness-check-ring-health": "false",
-	}
-
-	o := newOptions(options)
-	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
-
-	return NewMimirService(
+func NewStoreGateway(name string, consulAddress string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		map[string]string{
+			"-target":    "store-gateway",
+			"-log.level": "warn",
+			// Store-gateway ring backend.
+			"-store-gateway.sharding-ring.store":              "consul",
+			"-store-gateway.sharding-ring.consul.hostname":    consulAddress,
+			"-store-gateway.sharding-ring.replication-factor": "1",
+		},
+		flags,
+		options...,
+	)
+}
+
+func NewIngester(name string, consulAddress string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
+		name,
+		map[string]string{
+			"-target":                   "ingester",
+			"-log.level":                "warn",
+			"-ingester.ring.num-tokens": "512",
+			// Configure the ingesters ring backend
+			"-ingester.ring.store":           "consul",
+			"-ingester.ring.consul.hostname": consulAddress,
+			// Speed up the startup.
+			"-ingester.ring.min-ready-duration":          "0s",
+			"-ingester.ring.readiness-check-ring-health": "false",
+		},
+		flags,
+		options...,
 	)
 }
 
@@ -214,85 +155,36 @@ func getBinaryNameForBackwardsCompatibility(image string) string {
 	return "mimir"
 }
 
-func NewQueryFrontend(name string, flags map[string]string, image string, options ...Option) *MimirService {
-	return NewQueryFrontendWithConfigFile(name, "", flags, image, options...)
-}
-
-func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]string, image string, options ...Option) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":    "query-frontend",
-		"-log.level": "warn",
-		// Quickly detect query-scheduler when running it.
-		"-query-frontend.scheduler-dns-lookup-period": "1s",
-	}
-
-	o := newOptions(options)
-	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags))
-
-	return NewMimirService(
+func NewQueryFrontend(name string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		map[string]string{
+			"-target":    "query-frontend",
+			"-log.level": "warn",
+			// Quickly detect query-scheduler when running it.
+			"-query-frontend.scheduler-dns-lookup-period": "1s",
+		},
+		flags,
+		options...,
 	)
 }
 
-func NewQueryScheduler(name string, flags map[string]string, image string) *MimirService {
-	return NewQuerySchedulerWithConfigFile(name, "", flags, image)
-}
-
-func NewQuerySchedulerWithConfigFile(name, configFile string, flags map[string]string, image string) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	return NewMimirService(
+func NewQueryScheduler(name string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(map[string]string{
+		map[string]string{
 			"-target":    "query-scheduler",
 			"-log.level": "warn",
-		}, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		},
+		flags,
+		options...,
 	)
 }
 
-func NewCompactor(name string, consulAddress string, flags map[string]string, image string) *MimirService {
-	return NewCompactorWithConfigFile(name, consulAddress, "", flags, image)
-}
-
-func NewCompactorWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	return NewMimirService(
+func NewCompactor(name string, consulAddress string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(map[string]string{
+		map[string]string{
 			"-target":    "compactor",
 			"-log.level": "warn",
 			// Store-gateway ring backend.
@@ -301,171 +193,96 @@ func NewCompactorWithConfigFile(name, consulAddress, configFile string, flags ma
 			// Startup quickly.
 			"-compactor.ring.wait-stability-min-duration": "0",
 			"-compactor.ring.wait-stability-max-duration": "0",
-		}, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		},
+		flags,
+		options...,
 	)
 }
 
-func NewSingleBinary(name string, flags map[string]string, image string, otherPorts ...int) *MimirService {
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":                    "all",
-		"-log.level":                 "warn",
-		"-auth.multitenancy-enabled": "true",
-		// Query-frontend worker.
-		"-querier.frontend-client.backoff-min-period": "100ms",
-		"-querier.frontend-client.backoff-max-period": "100ms",
-		"-querier.frontend-client.backoff-retries":    "1",
-		"-querier.max-concurrent":                     "1",
-		// Distributor.
-		"-distributor.ring.store": "memberlist",
-		// Ingester.
-		"-ingester.ring.replication-factor": "1",
-		"-ingester.ring.num-tokens":         "512",
-		// Speed up the startup.
-		"-ingester.ring.min-ready-duration":          "0s",
-		"-ingester.ring.readiness-check-ring-health": "false",
-	}
-
-	return NewMimirService(
+func NewSingleBinary(name string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(defaultFlags, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
-		otherPorts...,
+		map[string]string{
+			// Do not pass any extra default flags (except few used to speed up the test)
+			// because the config could be driven by the config file.
+			"-target":    "all",
+			"-log.level": "warn",
+			// Speed up the startup.
+			"-ingester.ring.min-ready-duration":          "0s",
+			"-ingester.ring.readiness-check-ring-health": "false",
+		},
+		flags,
+		options...,
 	)
 }
 
-func NewSingleBinaryWithConfigFile(name string, configFile string, flags map[string]string, image string, httpPort, grpcPort int, otherPorts ...int) *MimirService {
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		// Do not pass any extra default flags (except few used to speed up the test)
-		// because the config should be drive by the config file.
-		"-target":      "all",
-		"-log.level":   "warn",
-		"-config.file": filepath.Join(e2e.ContainerSharedDir, configFile),
-		// Speed up the startup.
-		"-ingester.ring.min-ready-duration":          "0s",
-		"-ingester.ring.readiness-check-ring-health": "false",
-	}
-
-	return NewMimirService(
+func NewAlertmanager(name string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(defaultFlags, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
-		otherPorts...,
-	)
-}
-
-func NewAlertmanager(name string, flags map[string]string, image string) *MimirService {
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	return NewMimirService(
-		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(map[string]string{
+		map[string]string{
 			"-target":    "alertmanager",
 			"-log.level": "warn",
-		}, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		},
+		flags,
+		options...,
 	)
 }
 
-func NewAlertmanagerWithTLS(name string, flags map[string]string, image string) *MimirService {
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	return NewMimirService(
-		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(map[string]string{
-			"-target":    "alertmanager",
-			"-log.level": "warn",
-		}, flags)))...),
-		e2e.NewTCPReadinessProbe(httpPort),
-		httpPort,
-		grpcPort,
-	)
-}
-
-func NewRuler(name string, consulAddress string, flags map[string]string, image string) *MimirService {
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	defaultFlags := map[string]string{
-		"-target":    "ruler",
+func NewAlertmanagerWithTLS(name string, flags map[string]string, options ...Option) *MimirService {
+	o := newOptions(options)
+	serviceFlags := o.MapFlags(e2e.MergeFlags(map[string]string{
+		"-target":    "alertmanager",
 		"-log.level": "warn",
-		// Configure the ingesters ring backend
-		"-ingester.ring.store":           "consul",
-		"-ingester.ring.consul.hostname": consulAddress,
-	}
+	}, flags))
+	binaryName := getBinaryNameForBackwardsCompatibility(o.Image)
 
 	return NewMimirService(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(defaultFlags, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		o.Image,
+		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(serviceFlags))...),
+		e2e.NewTCPReadinessProbe(o.HTTPPort),
+		o.HTTPPort,
+		o.GRPCPort,
+		o.OtherPorts...,
 	)
 }
 
-func NewPurger(name string, flags map[string]string, image string) *MimirService {
-	return NewPurgerWithConfigFile(name, "", flags, image)
+func NewRuler(name string, consulAddress string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
+		name,
+		map[string]string{
+			"-target":    "ruler",
+			"-log.level": "warn",
+			// Configure the ingesters ring backend
+			"-ingester.ring.store":           "consul",
+			"-ingester.ring.consul.hostname": consulAddress,
+		},
+		flags,
+		options...,
+	)
 }
 
-func NewPurgerWithConfigFile(name, configFile string, flags map[string]string, image string) *MimirService {
-	if configFile != "" {
-		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
-	}
-
-	if image == "" {
-		image = GetDefaultImage()
-	}
-	binaryName := getBinaryNameForBackwardsCompatibility(image)
-
-	return NewMimirService(
+func NewPurger(name string, flags map[string]string, options ...Option) *MimirService {
+	return newMimirServiceFromOptions(
 		name,
-		image,
-		e2e.NewCommandWithoutEntrypoint(binaryName, buildArgsWithExtra(e2e.BuildArgs(e2e.MergeFlags(map[string]string{
+		map[string]string{
 			"-target":                   "purger",
 			"-log.level":                "warn",
 			"-purger.object-store-type": "filesystem",
 			"-local.chunk-directory":    e2e.ContainerSharedDir,
-		}, flags)))...),
-		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
-		httpPort,
-		grpcPort,
+		},
+		flags,
+		options...,
 	)
 }
 
 // Options holds a set of options for running services, they can be altered passing Option funcs.
 type Options struct {
-	MapFlags FlagMapper
+	Image      string
+	MapFlags   FlagMapper
+	OtherPorts []int
+	HTTPPort   int
+	GRPCPort   int
 }
 
 // Option modifies options.
@@ -474,7 +291,10 @@ type Option func(*Options)
 // newOptions creates an Options with default values and applies the options provided.
 func newOptions(options []Option) *Options {
 	o := &Options{
+		Image:    GetDefaultImage(),
 		MapFlags: NoopFlagMapper,
+		HTTPPort: httpPort,
+		GRPCPort: grpcPort,
 	}
 	for _, opt := range options {
 		opt(o)
@@ -490,6 +310,41 @@ func WithFlagMapper(mapFlags FlagMapper) Option {
 		options.MapFlags = ChainFlagMappers(options.MapFlags, mapFlags)
 	}
 }
+
+// WithImage creates an option that overrides the image of the service.
+func WithImage(image string) Option {
+	return func(options *Options) {
+		options.Image = image
+	}
+}
+
+// WithPorts creats an option that overrides the HTTP and gRPC ports.
+func WithPorts(http, grpc int) Option {
+	return func(options *Options) {
+		options.HTTPPort = http
+		options.GRPCPort = grpc
+	}
+}
+
+// WithOtherPorts creates an option that adds other ports to the service.
+func WithOtherPorts(ports ...int) Option {
+	return func(options *Options) {
+		options.OtherPorts = ports
+	}
+}
+
+// WithConfigFile returns an option that sets the config file flag if the provided string is not empty.
+func WithConfigFile(configFile string) Option {
+	if configFile == "" {
+		return WithNoopOption()
+	}
+	return WithFlagMapper(SetFlagMapper(map[string]string{
+		"-config.file": filepath.Join(e2e.ContainerSharedDir, configFile),
+	}))
+}
+
+// WithNoopOption returns an option that doesn't change anything.
+func WithNoopOption() Option { return func(options *Options) {} }
 
 // FlagMapper is the type of function that maps flags, just to reduce some verbosity.
 type FlagMapper func(flags map[string]string) map[string]string

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -45,7 +45,7 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 		"-blocks-storage.s3.insecure":          "true",
 	}
 
-	mimir := e2emimir.NewSingleBinaryWithConfigFile("mimir-1", mimirConfigFile, flags, "", 9009, 9095)
+	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -50,14 +50,14 @@ func TestGettingStartedWithGossipedRing(t *testing.T) {
 	}
 
 	// This mimir will fail to join the cluster configured in yaml file. That's fine.
-	mimir1 := e2emimir.NewSingleBinaryWithConfigFile("mimir-1", "config1.yaml", e2e.MergeFlags(flags, map[string]string{
+	mimir1 := e2emimir.NewSingleBinary("mimir-1", e2e.MergeFlags(flags, map[string]string{
 		"-ingester.ring.instance-addr": networkName + "-mimir-1", // Ingester's hostname in docker setup
-	}), "", 9109, 9195)
+	}), e2emimir.WithPorts(9109, 9095), e2emimir.WithConfigFile("config1.yaml"))
 
-	mimir2 := e2emimir.NewSingleBinaryWithConfigFile("mimir-2", "config2.yaml", e2e.MergeFlags(flags, map[string]string{
+	mimir2 := e2emimir.NewSingleBinary("mimir-2", e2e.MergeFlags(flags, map[string]string{
 		"-ingester.ring.instance-addr": networkName + "-mimir-2", // Ingester's hostname in docker setup
 		"-memberlist.join":             networkName + "-mimir-1:7946",
-	}), "", 9209, 9295)
+	}), e2emimir.WithPorts(9209, 9095), e2emimir.WithConfigFile("config2.yaml"))
 
 	require.NoError(t, s.StartAndWaitReady(mimir1))
 	require.NoError(t, s.StartAndWaitReady(mimir2))

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -29,7 +29,7 @@ func TestGettingStartedWithGrafanaMimir(t *testing.T) {
 
 	require.NoError(t, copyFileToSharedDir(s, "docs/configurations/demo.yaml", "demo.yaml"))
 
-	mimir := e2emimir.NewSingleBinaryWithConfigFile("mimir", "demo.yaml", nil, "", 9009, 9095)
+	mimir := e2emimir.NewSingleBinary("mimir", nil, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile("demo.yaml"))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
 	runTestPushSeriesAndQueryBack(t, mimir)
@@ -68,9 +68,9 @@ func TestPlayWithGrafanaMimirTutorial(t *testing.T) {
 	}
 
 	// Start Mimir (3 replicas).
-	mimir1 := e2emimir.NewSingleBinaryWithConfigFile("mimir-1", "mimir.yaml", flags, "", 8080, 9095)
-	mimir2 := e2emimir.NewSingleBinaryWithConfigFile("mimir-2", "mimir.yaml", flags, "", 8080, 9095)
-	mimir3 := e2emimir.NewSingleBinaryWithConfigFile("mimir-3", "mimir.yaml", flags, "", 8080, 9095)
+	mimir1 := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile("mimir.yaml"))
+	mimir2 := e2emimir.NewSingleBinary("mimir-2", flags, e2emimir.WithConfigFile("mimir.yaml"))
+	mimir3 := e2emimir.NewSingleBinary("mimir-3", flags, e2emimir.WithConfigFile("mimir.yaml"))
 	require.NoError(t, s.StartAndWaitReady(mimir1, mimir2, mimir3))
 
 	// We need that all Mimir instances see each other in the ingesters ring.

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -62,10 +62,10 @@ func TestIngesterGlobalLimits(t *testing.T) {
 			require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 			// Start Mimir components.
-			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags, "")
+			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags)
+			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags)
+			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags)
 			require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3))
 
 			// Wait until distributor has updated the ring.
@@ -181,7 +181,7 @@ overrides:
 				"-ruler-storage.local.directory":                    "/tmp", // Avoid warning "unable to list rules".
 				"-runtime-config.file":                              filepath.Join(e2e.ContainerSharedDir, overridesFile),
 			}
-			cortex1 := e2emimir.NewSingleBinaryWithConfigFile("cortex-1", mimirConfigFile, flags, "", 9009, 9095)
+			cortex1 := e2emimir.NewSingleBinary("cortex-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 			require.NoError(t, s.StartAndWaitReady(cortex1))
 
 			// Populate the overrides we want, then wait long enough for it to be read.

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -59,12 +59,12 @@ func TestIngesterSharding(t *testing.T) {
 			require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 			// Start Mimir components.
-			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags, "")
+			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags)
+			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags)
+			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags)
 			ingesters := e2emimir.NewCompositeMimirService(ingester1, ingester2, ingester3)
-			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 			require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3, querier))
 
 			// Wait until distributor and queriers have updated the ring.

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -141,13 +141,13 @@ func newSingleBinary(name string, servername string, join string, testFlags map[
 	serv := e2emimir.NewSingleBinary(
 		name,
 		mergeFlags(
+			DefaultSingleBinaryFlags(),
 			BlocksStorageFlags(),
 			flags,
 			testFlags,
 			getTLSFlagsWithPrefix("memberlist", servername, servername == ""),
 		),
-		"",
-		8000,
+		e2emimir.WithOtherPorts(8000),
 	)
 
 	backOff := backoff.Config{

--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -111,16 +111,16 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 			require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 			// Start the query-frontend.
-			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, "")
+			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
 			require.NoError(t, s.Start(queryFrontend))
 			flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
 
 			// Start all other Mimir services.
-			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags, "")
-			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags)
+			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags)
+			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags)
+			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 
 			require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3, querier))
 			require.NoError(t, s.WaitReady(queryFrontend))
@@ -332,16 +332,16 @@ func TestQuerierLabelValuesCardinality(t *testing.T) {
 			require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 			// Start the query-frontend.
-			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, "")
+			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
 			require.NoError(t, s.Start(queryFrontend))
 			flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
 
 			// Start all other Mimir services.
-			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags, "")
-			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags, "")
-			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags)
+			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags)
+			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags)
+			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 
 			require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3, querier))
 			require.NoError(t, s.WaitReady(queryFrontend))

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -42,8 +42,8 @@ func TestQuerierRemoteRead(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(minio, consul))
 
 	// Start Mimir components for the write path.
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester))
 
 	// Wait until the distributor has updated the ring.
@@ -61,7 +61,7 @@ func TestQuerierRemoteRead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), BlocksStorageFlags(), "")
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), BlocksStorageFlags())
 	require.NoError(t, s.StartAndWaitReady(querier))
 
 	// Wait until the querier has updated the ring.

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -89,14 +89,14 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	// Start the query-scheduler if enabled.
 	var queryScheduler *e2emimir.MimirService
 	if cfg.querySchedulerEnabled {
-		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags, "")
+		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags)
 		require.NoError(t, s.StartAndWaitReady(queryScheduler))
 		flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
 		flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
 	}
 
 	// Start the query-frontend.
-	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, "")
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
 	require.NoError(t, s.Start(queryFrontend))
 
 	if !cfg.querySchedulerEnabled {
@@ -104,10 +104,10 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	}
 
 	// Start all other services.
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	querier1 := e2emimir.NewQuerier("querier-1", consul.NetworkHTTPEndpoint(), flags, "")
-	querier2 := e2emimir.NewQuerier("querier-2", consul.NetworkHTTPEndpoint(), flags, "")
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	querier1 := e2emimir.NewQuerier("querier-1", consul.NetworkHTTPEndpoint(), flags)
+	querier2 := e2emimir.NewQuerier("querier-2", consul.NetworkHTTPEndpoint(), flags)
 
 	require.NoError(t, s.StartAndWaitReady(querier1, querier2, ingester, distributor))
 	require.NoError(t, s.WaitReady(queryFrontend))

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -76,7 +76,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	// Start the query-scheduler if enabled.
 	var queryScheduler *e2emimir.MimirService
 	if cfg.querySchedulerEnabled {
-		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags, "")
+		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags)
 		require.NoError(t, s.StartAndWaitReady(queryScheduler))
 		flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
 		flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
@@ -91,7 +91,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	// Start the query-frontend.
-	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, "")
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
 	require.NoError(t, s.Start(queryFrontend))
 
 	if !cfg.querySchedulerEnabled {
@@ -99,13 +99,13 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	}
 
 	// Start all other services.
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 
 	var querier2 *e2emimir.MimirService
 	if cfg.shuffleShardingEnabled {
-		querier2 = e2emimir.NewQuerier("querier-2", consul.NetworkHTTPEndpoint(), flags, "")
+		querier2 = e2emimir.NewQuerier("querier-2", consul.NetworkHTTPEndpoint(), flags)
 	}
 
 	require.NoError(t, s.StartAndWaitReady(querier, ingester, distributor))

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -84,8 +84,8 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Start Mimir components in common with all test cases.
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), commonFlags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), commonFlags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), commonFlags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), commonFlags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester))
 
 	// Wait until both the distributor and querier have updated the ring. The querier will also watch
@@ -133,7 +133,7 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 
 	// Start the compactor to have the bucket index created before querying.
 	// This is only required for tests using the bucket index, but doesn't hurt doing it for all of them.
-	compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), commonFlags, "")
+	compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), commonFlags)
 	require.NoError(t, s.StartAndWaitReady(compactor))
 
 	for testName, testCfg := range tests {
@@ -155,14 +155,14 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 			})
 
 			// Start store-gateways.
-			storeGateway1 := e2emimir.NewStoreGateway("store-gateway-1", consul.NetworkHTTPEndpoint(), flags, "")
-			storeGateway2 := e2emimir.NewStoreGateway("store-gateway-2", consul.NetworkHTTPEndpoint(), flags, "")
+			storeGateway1 := e2emimir.NewStoreGateway("store-gateway-1", consul.NetworkHTTPEndpoint(), flags)
+			storeGateway2 := e2emimir.NewStoreGateway("store-gateway-2", consul.NetworkHTTPEndpoint(), flags)
 			storeGateways := e2emimir.NewCompositeMimirService(storeGateway1, storeGateway2)
 			t.Cleanup(func() { require.NoError(t, s.Stop(storeGateway1, storeGateway2)) })
 			require.NoError(t, s.StartAndWaitReady(storeGateway1, storeGateway2))
 
 			// Start the query-frontend but do not check for readiness yet.
-			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, "")
+			queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
 			t.Cleanup(func() { require.NoError(t, s.Stop(queryFrontend)) })
 			require.NoError(t, s.Start(queryFrontend))
 
@@ -170,7 +170,7 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 			flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
 
 			// Start the querier with configuring store-gateway addresses if sharding is disabled.
-			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 			t.Cleanup(func() { require.NoError(t, s.Stop(querier)) })
 			require.NoError(t, s.StartAndWaitReady(querier))
 			require.NoError(t, s.WaitReady(queryFrontend))
@@ -369,8 +369,8 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			})
 
 			// Start Mimir replicas.
-			mimir1 := e2emimir.NewSingleBinary("mimir-1", flags, "")
-			mimir2 := e2emimir.NewSingleBinary("mimir-2", flags, "")
+			mimir1 := e2emimir.NewSingleBinary("mimir-1", e2e.MergeFlags(DefaultSingleBinaryFlags(), flags))
+			mimir2 := e2emimir.NewSingleBinary("mimir-2", e2e.MergeFlags(DefaultSingleBinaryFlags(), flags))
 			cluster := e2emimir.NewCompositeMimirService(mimir1, mimir2)
 			require.NoError(t, s.StartAndWaitReady(mimir1, mimir2))
 
@@ -727,8 +727,8 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Start Mimir components for the write path.
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester))
 
 	// Wait until the distributor has updated the ring.
@@ -766,10 +766,10 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	// have them anyway. We turn down the sync-interval to speed up the test.
 	storeGateway := e2emimir.NewStoreGateway("store-gateway", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
 		"-blocks-storage.bucket-store.sync-interval": "1s",
-	}), "")
+	}))
 	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
 		"-blocks-storage.bucket-store.sync-interval": "1s",
-	}), "")
+	}))
 	require.NoError(t, s.StartAndWaitReady(querier, storeGateway))
 
 	// Wait until the querier and store-gateway have updated the ring
@@ -829,12 +829,12 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	flags["-blocks-storage.bucket-store.index-cache.memcached.addresses"] = "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort)
 
 	// Start Mimir components.
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
-	storeGateway := e2emimir.NewStoreGateway("store-gateway", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	storeGateway := e2emimir.NewStoreGateway("store-gateway", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester, storeGateway))
 
-	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(querier))
 
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
@@ -888,8 +888,8 @@ func TestHashCollisionHandling(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(minio, consul))
 
 	// Start Mimir components for the write path.
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester))
 
 	// Wait until the distributor has updated the ring.
@@ -942,7 +942,7 @@ func TestHashCollisionHandling(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(querier))
 
 	// Wait until the querier has updated the ring.

--- a/integration/query_frontend_cache_test.go
+++ b/integration/query_frontend_cache_test.go
@@ -43,18 +43,18 @@ func TestQueryFrontendUnalignedQuery(t *testing.T) {
 	})
 
 	// Start the query-frontend.
-	queryFrontendAligned := e2emimir.NewQueryFrontendWithConfigFile("query-frontend-aligned", configFile, mergeFlags(flags, map[string]string{"-query-frontend.align-querier-with-step": "true"}), "")
+	queryFrontendAligned := e2emimir.NewQueryFrontend("query-frontend-aligned", mergeFlags(flags, map[string]string{"-query-frontend.align-querier-with-step": "true"}), e2emimir.WithConfigFile(configFile))
 	require.NoError(t, s.Start(queryFrontendAligned))
 
-	queryFrontendUnaligned := e2emimir.NewQueryFrontendWithConfigFile("query-frontend-unaligned", configFile, mergeFlags(flags, map[string]string{"-query-frontend.align-querier-with-step": "false"}), "")
+	queryFrontendUnaligned := e2emimir.NewQueryFrontend("query-frontend-unaligned", mergeFlags(flags, map[string]string{"-query-frontend.align-querier-with-step": "false"}), e2emimir.WithConfigFile(configFile))
 	require.NoError(t, s.Start(queryFrontendUnaligned))
 
-	querierAligned := e2emimir.NewQuerierWithConfigFile("querier-aligned", consul.NetworkHTTPEndpoint(), configFile, mergeFlags(flags, map[string]string{"-querier.frontend-address": queryFrontendAligned.NetworkGRPCEndpoint()}), "")
-	querierUnaligned := e2emimir.NewQuerierWithConfigFile("querier-unaligned", consul.NetworkHTTPEndpoint(), configFile, mergeFlags(flags, map[string]string{"-querier.frontend-address": queryFrontendUnaligned.NetworkGRPCEndpoint()}), "")
+	querierAligned := e2emimir.NewQuerier("querier-aligned", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{"-querier.frontend-address": queryFrontendAligned.NetworkGRPCEndpoint()}), e2emimir.WithConfigFile(configFile))
+	querierUnaligned := e2emimir.NewQuerier("querier-unaligned", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{"-querier.frontend-address": queryFrontendUnaligned.NetworkGRPCEndpoint()}), e2emimir.WithConfigFile(configFile))
 
 	// Start all other services.
-	ingester := e2emimir.NewIngesterWithConfigFile("ingester", consul.NetworkHTTPEndpoint(), configFile, flags, "")
-	distributor := e2emimir.NewDistributorWithConfigFile("distributor", consul.NetworkHTTPEndpoint(), configFile, flags, "")
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
 
 	require.NoError(t, s.StartAndWaitReady(querierAligned, querierUnaligned, ingester, distributor))
 	require.NoError(t, s.WaitReady(queryFrontendAligned, queryFrontendUnaligned))

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -178,14 +178,14 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 	// Start the query-scheduler if enabled.
 	var queryScheduler *e2emimir.MimirService
 	if cfg.querySchedulerEnabled {
-		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags, "")
+		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags)
 		require.NoError(t, s.StartAndWaitReady(queryScheduler))
 		flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
 		flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
 	}
 
 	// Start the query-frontend.
-	queryFrontend := e2emimir.NewQueryFrontendWithConfigFile("query-frontend", configFile, flags, "")
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, e2emimir.WithConfigFile(configFile))
 	require.NoError(t, s.Start(queryFrontend))
 
 	if !cfg.querySchedulerEnabled {
@@ -193,9 +193,9 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 	}
 
 	// Start all other services.
-	ingester := e2emimir.NewIngesterWithConfigFile("ingester", consul.NetworkHTTPEndpoint(), configFile, flags, "")
-	distributor := e2emimir.NewDistributorWithConfigFile("distributor", consul.NetworkHTTPEndpoint(), configFile, flags, "")
-	querier := e2emimir.NewQuerierWithConfigFile("querier", consul.NetworkHTTPEndpoint(), configFile, flags, "")
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
 
 	require.NoError(t, s.StartAndWaitReady(querier, ingester, distributor))
 	require.NoError(t, s.WaitReady(queryFrontend))
@@ -350,15 +350,15 @@ overrides:
 	consul := e2edb.NewConsul()
 	require.NoError(t, s.StartAndWaitReady(consul))
 
-	queryFrontend := e2emimir.NewQueryFrontendWithConfigFile("query-frontend", configFile, flags, "")
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, e2emimir.WithConfigFile(configFile))
 	require.NoError(t, s.Start(queryFrontend))
 
 	flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
 
 	// Start all other services.
-	distributor := e2emimir.NewDistributorWithConfigFile("distributor", consul.NetworkHTTPEndpoint(), configFile, flags, "")
-	ingester := e2emimir.NewIngesterWithConfigFile("ingester", consul.NetworkHTTPEndpoint(), configFile, flags, "")
-	querier := e2emimir.NewQuerierWithConfigFile("querier", consul.NetworkHTTPEndpoint(), configFile, flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
 
 	require.NoError(t, s.StartAndWaitReady(distributor, querier, ingester))
 	require.NoError(t, s.WaitReady(queryFrontend))

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -56,7 +56,7 @@ func TestRulerAPI(t *testing.T) {
 	rulerFlags := mergeFlags(BlocksStorageFlags(), RulerFlags())
 
 	// Start Mimir components.
-	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags, "")
+	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
 	// Create a client with the ruler address configured
@@ -161,7 +161,7 @@ func TestRulerAPISingleBinary(t *testing.T) {
 	// Start Mimir components.
 	require.NoError(t, copyFileToSharedDir(s, "docs/configurations/single-process-config-blocks.yaml", mimirConfigFile))
 	require.NoError(t, writeFileToSharedDir(s, filepath.Join("ruler_configs", user, namespace), []byte(mimirRulerUserConfigYaml)))
-	mimir := e2emimir.NewSingleBinaryWithConfigFile("mimir", mimirConfigFile, flags, "", 9009, 9095)
+	mimir := e2emimir.NewSingleBinary("mimir", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
 	// Create a client with the ruler address configured
@@ -193,7 +193,7 @@ func TestRulerAPISingleBinary(t *testing.T) {
 	require.NoError(t, mimir.Stop())
 
 	// Restart Mimir with identical configs
-	mimirRestarted := e2emimir.NewSingleBinaryWithConfigFile("mimir-restarted", mimirConfigFile, flags, "", 9009, 9095)
+	mimirRestarted := e2emimir.NewSingleBinary("mimir-restarted", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimirRestarted))
 
 	// Wait until the user manager is created
@@ -227,7 +227,7 @@ func TestRulerEvaluationDelay(t *testing.T) {
 	// Start Mimir components.
 	require.NoError(t, copyFileToSharedDir(s, "docs/configurations/single-process-config-blocks.yaml", mimirConfigFile))
 	require.NoError(t, writeFileToSharedDir(s, filepath.Join("ruler_configs", user, namespace), []byte(mimirRulerEvalStaleNanConfigYaml)))
-	mimir := e2emimir.NewSingleBinaryWithConfigFile("mimir", mimirConfigFile, flags, "", 9009, 9095)
+	mimir := e2emimir.NewSingleBinary("mimir", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
 	// Create a client with the ruler address configured
@@ -368,8 +368,8 @@ func TestRulerSharding(t *testing.T) {
 	)
 
 	// Start rulers.
-	ruler1 := e2emimir.NewRuler("ruler-1", consul.NetworkHTTPEndpoint(), rulerFlags, "")
-	ruler2 := e2emimir.NewRuler("ruler-2", consul.NetworkHTTPEndpoint(), rulerFlags, "")
+	ruler1 := e2emimir.NewRuler("ruler-1", consul.NetworkHTTPEndpoint(), rulerFlags)
+	ruler2 := e2emimir.NewRuler("ruler-2", consul.NetworkHTTPEndpoint(), rulerFlags)
 	rulers := e2emimir.NewCompositeMimirService(ruler1, ruler2)
 	require.NoError(t, s.StartAndWaitReady(ruler1, ruler2))
 
@@ -418,8 +418,8 @@ func TestRulerAlertmanager(t *testing.T) {
 
 	// Start Alertmanagers.
 	amFlags := mergeFlags(AlertmanagerFlags(), AlertmanagerS3Flags(), AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1))
-	am1 := e2emimir.NewAlertmanager("alertmanager1", amFlags, "")
-	am2 := e2emimir.NewAlertmanager("alertmanager2", amFlags, "")
+	am1 := e2emimir.NewAlertmanager("alertmanager1", amFlags)
+	am2 := e2emimir.NewAlertmanager("alertmanager2", amFlags)
 	require.NoError(t, s.StartAndWaitReady(am1, am2))
 
 	am1URL := "http://" + am1.HTTPEndpoint()
@@ -436,7 +436,7 @@ func TestRulerAlertmanager(t *testing.T) {
 	)
 
 	// Start Ruler.
-	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags, "")
+	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
 	// Create a client with the ruler address configured
@@ -503,7 +503,7 @@ func TestRulerAlertmanagerTLS(t *testing.T) {
 		AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1),
 		getServerHTTPTLSFlags(),
 	)
-	am1 := e2emimir.NewAlertmanagerWithTLS("alertmanager1", amFlags, "")
+	am1 := e2emimir.NewAlertmanagerWithTLS("alertmanager1", amFlags)
 	require.NoError(t, s.StartAndWaitReady(am1))
 
 	// Configure the ruler.
@@ -517,7 +517,7 @@ func TestRulerAlertmanagerTLS(t *testing.T) {
 	)
 
 	// Start Ruler.
-	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags, "")
+	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
 	// Create a client with the ruler address configured
@@ -572,9 +572,9 @@ func TestRulerMetricsForInvalidQueries(t *testing.T) {
 	const namespace = "test"
 	const user = "user"
 
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester, ruler))
 
 	// Wait until both the distributor and ruler have updated the ring. The querier will also watch
@@ -736,10 +736,10 @@ func TestRulerFederatedRules(t *testing.T) {
 	)
 
 	// Start up services
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags, "")
-	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
-	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester, ruler, querier))
 
 	// Wait until both the distributor and ruler are ready
@@ -882,7 +882,7 @@ func TestRulerEnableAPIs(t *testing.T) {
 			})
 
 			// Start Mimir components.
-			ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags, "")
+			ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
 			require.NoError(t, s.StartAndWaitReady(ruler))
 
 			runTest := func(name, method, path string, shouldBeFound bool) {

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -46,16 +46,16 @@ func TestZoneAwareReplication(t *testing.T) {
 		})
 	}
 
-	ingester1 := e2emimir.NewIngesterWithConfigFile("ingester-1", consul.NetworkHTTPEndpoint(), "", ingesterFlags("zone-a"), "")
-	ingester2 := e2emimir.NewIngesterWithConfigFile("ingester-2", consul.NetworkHTTPEndpoint(), "", ingesterFlags("zone-a"), "")
-	ingester3 := e2emimir.NewIngesterWithConfigFile("ingester-3", consul.NetworkHTTPEndpoint(), "", ingesterFlags("zone-b"), "")
-	ingester4 := e2emimir.NewIngesterWithConfigFile("ingester-4", consul.NetworkHTTPEndpoint(), "", ingesterFlags("zone-b"), "")
-	ingester5 := e2emimir.NewIngesterWithConfigFile("ingester-5", consul.NetworkHTTPEndpoint(), "", ingesterFlags("zone-c"), "")
-	ingester6 := e2emimir.NewIngesterWithConfigFile("ingester-6", consul.NetworkHTTPEndpoint(), "", ingesterFlags("zone-c"), "")
+	ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-a"))
+	ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-a"))
+	ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-b"))
+	ingester4 := e2emimir.NewIngester("ingester-4", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-b"))
+	ingester5 := e2emimir.NewIngester("ingester-5", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-c"))
+	ingester6 := e2emimir.NewIngester("ingester-6", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-c"))
 	require.NoError(t, s.StartAndWaitReady(ingester1, ingester2, ingester3, ingester4, ingester5, ingester6))
 
-	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
-	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(distributor, querier))
 
 	// Wait until distributor and querier have updated the ring.


### PR DESCRIPTION
## What this PR does

[After adding options to allow flag mappers](https://github.com/grafana/mimir/pull/1166), I was annoyed by having 99% of mimir services started with an empty string as an image, so I moved that to an option. Then I saw that we had two constructors just to pass the config file option, so I built a dedicated option for that, then I saw that all the services were started in the same way, so I unified the code.

## Which issue(s) this PR fixes

None, just housekeeping.

## Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
