### PR TITLE
metaconvert: Fix usage string

### DIFF
--- a/cmd/metaconvert/main.go
+++ b/cmd/metaconvert/main.go
@@ -47,7 +47,7 @@ func main() {
 	flag.BoolVar(&cfg.DryRun, "dry-run", false, "Don't make changes; only report what needs to be done")
 	flag.StringVar(&cfg.Tenant, "tenant", "", "Tenant to process")
 	flag.Usage = func() {
-		fmt.Fprintln(flag.CommandLine.Output(), os.Args[0], "%s is a tool to update meta.json files to conform to Mimir requirements.")
+		fmt.Fprintln(flag.CommandLine.Output(), os.Args[0], "is a tool to update meta.json files to conform to Mimir requirements.")
 		fmt.Fprintln(flag.CommandLine.Output(), "Flags:")
 		flag.PrintDefaults()
 	}


### PR DESCRIPTION
## What this PR does
Fix metaconvert usage string.

Before: `./cmd/metaconvert/metaconvert %s is a tool to update meta.json files to conform to Mimir requirements.`
After: `./cmd/metaconvert/metaconvert is a tool to update meta.json files to conform to Mimir requirements.`


## Which issue(s) this PR fixes

## Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
