### PR TITLE
Revise store-gateway documentation for mimir launch.

### DIFF
--- a/docs/sources/architecture/store-gateway.md
+++ b/docs/sources/architecture/store-gateway.md
@@ -35,12 +35,7 @@ For more information about the index-header, please refer to [Binary index-heade
 
 ### Bucket index disabled
 
-At startup **store-gateways** iterate over the entire long-term storage to discover blocks to download the `meta.json` metadata file and index-header for each block, skipping blocks that don't belong to users in their shard. During this initial bucket synchronization phase, the store-gateway `/ready` readiness probe endpoint will fail.
-
-Store-gateways periodically scan the long-term storage to discover new or deleted blocks.
-New blocks can be uploaded by [ingesters]({{< relref "./ingester.md" >}}) or by the [compactor]({{< relref "./compactor.md" >}}).
-The compactor additionally may have deleted blocks or marked others for deletion since the last scan.
-The frequency at which this occurs is configured with the `-blocks-storage.bucket-store.sync-interval` flag.
+When bucket index is disabled, the overall workflow is the same, except that the discovery of blocks at startup and during the periodic checks mean iterating over the entire long-term storage to download `meta.json` metadata files while filtering out blocks that don't belong to tenants in their shard.
 
 ## Blocks sharding and replication
 


### PR DESCRIPTION
## What this PR does

References changed to relref format and fixed.
Semi-stateless changed to stateful.
Storage and object storage changed to long-term storage.
The term "option" is replaced by "flag".
Checked that flags exist.
Bucket index is enabled by default.
Sharding is not optional.
Shuffle sharding is the strategy (although one can kind of disable it).
min-wait-ring-stability defaults to 0 now, but production system should use 1m
More metadata is cached.
etc,etc

## Which issue(s) this PR fixes

Relates to https://github.com/grafana/mimir/issues/1084

## Checklist

- [N/A] Tests updated
- [x] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
