### PR TITLE
Remove unused Alertmanager sharding_enabled flag from test jsonnet files.

### DIFF
--- a/operations/mimir-tests/test-disable-chunk-streaming.jsonnet
+++ b/operations/mimir-tests/test-disable-chunk-streaming.jsonnet
@@ -17,9 +17,6 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_client_type: 'gcs',
     alertmanager_gcs_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
 
     ingester_stream_chunks_when_using_blocks: false,
   },

--- a/operations/mimir-tests/test-gossip-multikv.jsonnet
+++ b/operations/mimir-tests/test-gossip-multikv.jsonnet
@@ -18,9 +18,6 @@ mimir + gossip {
     alertmanager_enabled: true,
     alertmanager_client_type: 'gcs',
     alertmanager_gcs_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
 
     multikv_migration_enabled: true,
   },

--- a/operations/mimir-tests/test-gossip.jsonnet
+++ b/operations/mimir-tests/test-gossip.jsonnet
@@ -18,8 +18,5 @@ mimir + gossip {
     alertmanager_enabled: true,
     alertmanager_client_type: 'gcs',
     alertmanager_gcs_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
   },
 }

--- a/operations/mimir-tests/test-query-sharding.jsonnet
+++ b/operations/mimir-tests/test-query-sharding.jsonnet
@@ -17,9 +17,6 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_client_type: 'gcs',
     alertmanager_gcs_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
 
     query_sharding_enabled: true,
   },

--- a/operations/mimir-tests/test-shuffle-sharding.jsonnet
+++ b/operations/mimir-tests/test-shuffle-sharding.jsonnet
@@ -17,9 +17,6 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_client_type: 'gcs',
     alertmanager_gcs_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
 
     shuffle_sharding+:: {
       ingester_write_path_enabled: true,

--- a/operations/mimir-tests/test-storage-azure.jsonnet
+++ b/operations/mimir-tests/test-storage-azure.jsonnet
@@ -23,8 +23,5 @@ mimir {
     alertmanager_azure_account_name: 'alerts-account-name',
     alertmanager_azure_account_key: 'alerts-account-key',
     alertmanager_azure_container_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
   },
 }

--- a/operations/mimir-tests/test-storage-gcs.jsonnet
+++ b/operations/mimir-tests/test-storage-gcs.jsonnet
@@ -17,8 +17,5 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_client_type: 'gcs',
     alertmanager_gcs_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
   },
 }

--- a/operations/mimir-tests/test-storage-s3.jsonnet
+++ b/operations/mimir-tests/test-storage-s3.jsonnet
@@ -18,8 +18,5 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_client_type: 's3',
     alertmanager_s3_bucket_name: 'alerts-bucket',
-    alertmanager+: {
-      sharding_enabled: true,
-    },
   },
 }


### PR DESCRIPTION
## What this PR does

This PR removes `alertmanager.sharding_enabled: true` from test jsonnet files.

## Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
