### PR TITLE
Mark distributor per-instance limits as advanced settings

### DIFF
--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -245,10 +245,6 @@ Usage of ./cmd/mimir/mimir:
     	Per-tenant ingestion rate limit in samples per second. (default 10000)
   -distributor.ingestion-tenant-shard-size int
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
-  -distributor.instance-limits.max-inflight-push-requests int
-    	Max inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited. (default 2000)
-  -distributor.instance-limits.max-ingestion-rate float
-    	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
   -distributor.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -distributor.ring.etcd.endpoints value

--- a/docs/sources/configuration/reference-configuration-parameters.md
+++ b/docs/sources/configuration/reference-configuration-parameters.md
@@ -617,16 +617,16 @@ ring:
   [instance_addr: <string> | default = ""]
 
 instance_limits:
-  # Max ingestion rate (samples/sec) that this distributor will accept. This
-  # limit is per-distributor, not per-tenant. Additional push requests will be
-  # rejected. Current ingestion rate is computed as exponentially weighted
-  # moving average, updated every second. 0 = unlimited.
+  # (advanced) Max ingestion rate (samples/sec) that this distributor will
+  # accept. This limit is per-distributor, not per-tenant. Additional push
+  # requests will be rejected. Current ingestion rate is computed as
+  # exponentially weighted moving average, updated every second. 0 = unlimited.
   # CLI flag: -distributor.instance-limits.max-ingestion-rate
   [max_ingestion_rate: <float> | default = 0]
 
-  # Max inflight push requests that this distributor can handle. This limit is
-  # per-distributor, not per-tenant. Additional requests will be rejected. 0 =
-  # unlimited.
+  # (advanced) Max inflight push requests that this distributor can handle. This
+  # limit is per-distributor, not per-tenant. Additional requests will be
+  # rejected. 0 = unlimited.
   # CLI flag: -distributor.instance-limits.max-inflight-push-requests
   [max_inflight_push_requests: <int> | default = 2000]
 ```

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -147,8 +147,8 @@ type Config struct {
 }
 
 type InstanceLimits struct {
-	MaxIngestionRate        float64 `yaml:"max_ingestion_rate"`
-	MaxInflightPushRequests int     `yaml:"max_inflight_push_requests"`
+	MaxIngestionRate        float64 `yaml:"max_ingestion_rate" category:"advanced"`
+	MaxInflightPushRequests int     `yaml:"max_inflight_push_requests" category:"advanced"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet


### PR DESCRIPTION
These seemed to have been missed initially and are advanced settings
just like their ingester counterparts.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
