### PR TITLE
Fix latest tag

### DIFF
--- a/push-images
+++ b/push-images
@@ -25,8 +25,9 @@ push_image() {
     echo "Pushing ${image}:${IMAGE_TAG}"
     docker push "${image}:${IMAGE_TAG}"
 
-    # If image is the latest stable git tag, update the latest docker image tag
-    if [[ "$(git tag | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "${IMAGE_TAG}" ]]; then
+    # If image is the latest stable git tag, update the latest docker image tag.
+    # Do not tag with latest any release candidate (tag ends with "-rc.*").
+    if [[ "$(git tag | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "${IMAGE_TAG}" ]]; then
       docker tag "${image}:${IMAGE_TAG}" "${image}:latest"
       docker push "${image}:latest"
     fi


### PR DESCRIPTION
#### What this PR does

The release tag is something like `mimir-2.0.0` so we need to fix the regex used for checking if the image should be tag with "latest".

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
