### PR TITLE
Strip 'mimir-' prefix from git tag when building image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ BUILD_IMAGE ?= $(IMAGE_PREFIX)mimir-build-image
 # If finding refs/tags/ does not equal emptystring then use
 # the tag we are at as the image tag.
 ifneq (,$(findstring refs/tags/, $(GITHUB_REF)))
-	GIT_TAG := "$(shell git tag --points-at HEAD)"
+	GIT_TAG := $(shell git tag --points-at HEAD)
 	# If the git tag starts with "mimir-" (eg. "mimir-2.0.0") we strip
 	# the "mimir-" prefix in order to keep only the version.
-	IMAGE_TAG_FROM_GIT_TAG := $(patsubst "mimir-%",%,$(GIT_TAG))
+	IMAGE_TAG_FROM_GIT_TAG := $(patsubst mimir-%,%,$(GIT_TAG))
 endif
 IMAGE_TAG ?= $(if $(IMAGE_TAG_FROM_GIT_TAG),$(IMAGE_TAG_FROM_GIT_TAG),$(shell ./tools/image-tag))
 GIT_REVISION := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
#### What this PR does
I've published Mimir 2.0.0-rc.0 docker images and I've noticed the tags are:

```
grafana/mimir:mimir-2.0.0-rc.0
grafana/metaconvert:mimir-2.0.0-rc.0
grafana/mimirtool:mimir-2.0.0-rc.0
grafana/query-tee:mimir-2.0.0-rc.0
```

I think it would be better to strip the `mimir-` prefix from the image tag. This PR does it.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
