### PR TITLE
Ensure the services status page renders as HTML

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -396,7 +396,7 @@ func (a *API) RegisterQueryScheduler(f *scheduler.Scheduler) {
 // TODO: Refactor this code to be accomplished using the services.ServiceManager
 // or a future module manager #2291
 func (a *API) RegisterServiceMapHandler(handler http.Handler) {
-	a.indexPage.AddLink(SectionAdminEndpoints, "/services", "Service Status")
+	a.indexPage.AddLink(SectionAdminEndpoints, "/services", "Service's status")
 	a.RegisterRoute("/services", handler, false, true, "GET")
 }
 

--- a/pkg/mimir/status.go
+++ b/pkg/mimir/status.go
@@ -19,10 +19,10 @@ const tpl = `
 <html>
 	<head>
 		<meta charset="UTF-8">
-		<title>Services Status</title>
+		<title>Services' status</title>
 	</head>
 	<body>
-		<h1>Services Status</h1>
+		<h1>Services' status</h1>
 		<p>Current time: {{ .Now }}</p>
 		<table border="1">
 			<thead>

--- a/pkg/mimir/status.go
+++ b/pkg/mimir/status.go
@@ -56,7 +56,6 @@ func init() {
 
 func (t *Mimir) servicesHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
-	w.Header().Set("Content-Type", "text/plain")
 
 	svcs := make([]renderService, 0)
 	for mod, s := range t.ServiceMap {

--- a/pkg/mimir/status.go
+++ b/pkg/mimir/status.go
@@ -55,7 +55,7 @@ func init() {
 }
 
 func (t *Mimir) servicesHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "text/html; utf=8")
 
 	svcs := make([]renderService, 0)
 	for mod, s := range t.ServiceMap {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This removes the `text/plain` content type header from the services page

#### Which issue(s) this PR fixes or relates to

This ensures the services page of Mimir renders as HTML. I have noticed that when testing the v2.0.0-rc.0

![scrn-2022-02-22-13-02-32](https://user-images.githubusercontent.com/223048/155146267-52cbd133-98e9-429d-a0e4-b68cddaf1b16.png)

#### Checklist

- ~[ ] Tests updated~
- ~[ ] Documentation added~
- ~[ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
