### PR TITLE
Add federated rules to buildinfo endpoint

### DIFF
--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -109,6 +109,7 @@ func (t *Mimir) initAPI() (services.Service, error) {
 			AlertmanagerConfigAPI: strconv.FormatBool(t.Cfg.Alertmanager.EnableAPI),
 			QuerySharding:         strconv.FormatBool(t.Cfg.Frontend.QueryMiddleware.ShardedQueries),
 			RulerConfigAPI:        strconv.FormatBool(t.Cfg.Ruler.EnableAPI),
+			FederatedRules:        strconv.FormatBool(t.Cfg.Ruler.TenantFederation.Enabled),
 		})
 
 	t.API = a

--- a/pkg/util/version/info_handler.go
+++ b/pkg/util/version/info_handler.go
@@ -26,6 +26,7 @@ type BuildInfoFeatures struct {
 	RulerConfigAPI        string `json:"ruler_config_api,omitempty"`
 	AlertmanagerConfigAPI string `json:"alertmanager_config_api,omitempty"`
 	QuerySharding         string `json:"query_sharding,omitempty"`
+	FederatedRules        string `json:"federated_rules,omitempty"`
 }
 
 func BuildInfoHandler(application string, features interface{}) http.Handler {


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

> **Note:** This should be cherry-picked into 2.0. This will allow grafana alerting to properly handle federated rules. I am not sure how to cherry-pick it in the RC/create new RC.

#### Which issue(s) this PR fixes or relates to

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
