### PR TITLE
mimirtool config convert: Report Cortex options that are no longer available in Mimir.

### DIFF
--- a/pkg/mimirtool/config/descriptors/cortex-v1.11.0-flags-only.json
+++ b/pkg/mimirtool/config/descriptors/cortex-v1.11.0-flags-only.json
@@ -1,0 +1,35 @@
+{
+  "kind": "block",
+  "name": "",
+  "required": false,
+  "desc": "",
+  "blockEntries": [
+    {
+      "kind": "field",
+      "name": "schema-config-file",
+      "required": false,
+      "desc": "The path to the schema config file. The schema config is used only when running Cortex with the chunks storage.",
+      "fieldValue": "",
+      "fieldFlag": "schema-config-file",
+      "fieldType": "string"
+    },
+    {
+      "kind": "field",
+      "name": "ingester-chunk-encoding",
+      "required": false,
+      "desc": "Encoding version to use for chunks.",
+      "fieldValue": "",
+      "fieldFlag": "ingester.chunk-encoding",
+      "fieldType": "string"
+    },
+    {
+      "kind": "field",
+      "name": "querier-query-parallelism",
+      "required": false,
+      "desc": "Max subqueries run in parallel per higher-level query.",
+      "fieldValue": 100,
+      "fieldFlag": "querier.query-parallelism",
+      "fieldType": "int"
+    }
+  ]
+}

--- a/pkg/mimirtool/config/inspect.go
+++ b/pkg/mimirtool/config/inspect.go
@@ -64,6 +64,11 @@ func (i *InspectedEntry) Set(s string) (err error) {
 	return
 }
 
+// IsBoolFlag is used by flag package to support to setting bool flags without using value.
+func (i *InspectedEntry) IsBoolFlag() bool {
+	return i.FieldType == "boolean"
+}
+
 func (i *InspectedEntry) RegisterFlags(fs *flag.FlagSet, logger log.Logger) {
 	if i.Kind == parse.KindBlock {
 		for _, e := range i.BlockEntries {
@@ -226,8 +231,8 @@ func (i *InspectedEntry) SetValue(path string, val interface{}) error {
 	return nil
 }
 
-// Delete deletes a leaf parameter from the InspectedEntry. Delete also recursively deletes
-// any parent blocks that, because of this delete, now contain no entries.
+// Delete deletes a leaf parameter or entire subtree from the InspectedEntry.
+// Delete also recursively deletes any parent blocks that, because of this delete, now contain no entries.
 // If an error is returned, it's errors.Cause will be ErrParameterNotFound.
 func (i *InspectedEntry) Delete(path string) error {
 	return errors.Wrap(i.delete(path), path)

--- a/pkg/mimirtool/config/inspect_test.go
+++ b/pkg/mimirtool/config/inspect_test.go
@@ -183,6 +183,18 @@ func TestInspectedEntry_Delete(t *testing.T) {
 			pathToDelete:   "api.version",
 			expectedParams: []string{},
 		},
+		{
+			name: "deletes subtree",
+			params: &struct {
+				API struct {
+					Version string `yaml:"version"`
+				} `yaml:"api"`
+				Version string `yaml:"version"`
+			}{},
+
+			pathToDelete:   "api",
+			expectedParams: []string{"version"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/mimirtool/config/removed.go
+++ b/pkg/mimirtool/config/removed.go
@@ -3,7 +3,6 @@
 package config
 
 // YAML Paths for config options removed since Cortex 1.11.0.
-//nolint // not used right now, but will be soon.
 var removedConfigPaths = []string{
 	"flusher.concurrent_flushes",                            // -flusher.concurrent-flushes
 	"flusher.flush_op_timeout",                              // -flusher.flush-op-timeout
@@ -381,7 +380,6 @@ var removedConfigPaths = []string{
 }
 
 // CLI options removed since Cortex 1.11.0. These flags only existed as CLI Flags, and were not included in YAML Config.
-//nolint // not used right now, but will be soon.
 var removedCLIOptions = []string{
 	"schema-config-file",
 	"ingester.chunk-encoding",

--- a/pkg/mimirtool/config/testdata/unsupported-config.yaml
+++ b/pkg/mimirtool/config/testdata/unsupported-config.yaml
@@ -1,0 +1,2 @@
+storage:
+  engine: blocks


### PR DESCRIPTION
#### What this PR does

This PR enhances `mimirtool config convert` to add reporting of Cortex options that are no longer available in Mimir.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
