### PR TITLE
Upgrade Go to 1.17.7

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.3
+          go-version: 1.17.7
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Grafana Mimir - main / unreleased
 
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
+* [ENHANCEMENT] Upgrade Go to 1.17.7. #1347
 
 ### Mixin
 

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.17.7
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.7.3
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM golang:1.17.3-buster
+FROM golang:1.17.7-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev && \


### PR DESCRIPTION
#### What this PR does
Upgrade our Go version to 1.17.7.

#### Which issue(s) this PR fixes or relates to

Fixes #1337.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
