### PR TITLE
Chore: Upgrade Alpine Linux to 3.15.0

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.7
+          go-version: 1.17.3
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
 * [ENHANCEMENT] Upgrade Go to 1.17.7. #1347
+* [ENHANCEMENT] Upgrade Docker base images to `alpine:3.15.0`. #1348
 
 ### Mixin
 

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.13
+FROM       alpine:3.15.0
 RUN        apk add --no-cache ca-certificates
 COPY       metaconvert /
 ENTRYPOINT ["/metaconvert"]

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.13
+FROM       alpine:3.15.0
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM       alpine:3.13
+FROM       alpine:3.15.0
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.13
+FROM       alpine:3.15.0
 RUN        apk add --no-cache ca-certificates
 COPY       query-tee /
 ENTRYPOINT ["/query-tee"]

--- a/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.15.0
 
 RUN     mkdir /mimr
 WORKDIR /mimir

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.17.7
+FROM golang:1.17
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.7.3
 
-FROM alpine:3.13
+FROM alpine:3.15.0
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/tsdb-blocks-storage-swift-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-swift-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.15.0
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM golang:1.17.7-buster
+FROM golang:1.17.3-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev && \


### PR DESCRIPTION
#### What this PR does
Upgrade our Docker images to base themselves on Alpine Linux 3.15.0.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
