### PR TITLE
Chore: Replace pkg/util/net.isPrivate with IP.IsPrivate

### DIFF
--- a/pkg/util/net/firewall_dialer.go
+++ b/pkg/util/net/firewall_dialer.go
@@ -58,7 +58,7 @@ func (d *FirewallDialer) control(_, address string, _ syscall.RawConn) error {
 		return errBlockedAddress
 	}
 
-	if blockPrivateAddresses && (isPrivate(ip) || isLocal(ip)) {
+	if blockPrivateAddresses && (ip.IsPrivate() || isLocal(ip)) {
 		return errBlockedAddress
 	}
 
@@ -73,28 +73,4 @@ func (d *FirewallDialer) control(_, address string, _ syscall.RawConn) error {
 
 func isLocal(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
-}
-
-// isPrivate reports whether ip is a private address, according to
-// RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses).
-//
-// This function has been copied from golang and should be removed once
-// we'll upgrade to go 1.17. See: https://github.com/golang/go/pull/42793
-func isPrivate(ip net.IP) bool {
-	if ip4 := ip.To4(); ip4 != nil {
-		// Following RFC 4193, Section 3. Local IPv6 Unicast Addresses which says:
-		//   The Internet Assigned Numbers Authority (IANA) has reserved the
-		//   following three blocks of the IPv4 address space for private internets:
-		//     10.0.0.0        -   10.255.255.255  (10/8 prefix)
-		//     172.16.0.0      -   172.31.255.255  (172.16/12 prefix)
-		//     192.168.0.0     -   192.168.255.255 (192.168/16 prefix)
-		return ip4[0] == 10 ||
-			(ip4[0] == 172 && ip4[1]&0xf0 == 16) ||
-			(ip4[0] == 192 && ip4[1] == 168)
-	}
-	// Following RFC 4193, Section 3. Private Address Space which says:
-	//   The Internet Assigned Numbers Authority (IANA) has reserved the
-	//   following block of the IPv6 address space for local internets:
-	//     FC00::  -  FDFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF (FC00::/7 prefix)
-	return len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc
 }

--- a/pkg/util/net/firewall_dialer_test.go
+++ b/pkg/util/net/firewall_dialer_test.go
@@ -8,7 +8,6 @@ package net
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 	"testing"
 	"time"
@@ -101,40 +100,6 @@ func TestFirewallDialer(t *testing.T) {
 				})
 			}
 		})
-	}
-}
-
-func TestIsPrivate(t *testing.T) {
-	tests := []struct {
-		ip       net.IP
-		expected bool
-	}{
-		{nil, false},
-		{net.IPv4(1, 1, 1, 1), false},
-		{net.IPv4(9, 255, 255, 255), false},
-		{net.IPv4(10, 0, 0, 0), true},
-		{net.IPv4(10, 255, 255, 255), true},
-		{net.IPv4(11, 0, 0, 0), false},
-		{net.IPv4(172, 15, 255, 255), false},
-		{net.IPv4(172, 16, 0, 0), true},
-		{net.IPv4(172, 16, 255, 255), true},
-		{net.IPv4(172, 23, 18, 255), true},
-		{net.IPv4(172, 31, 255, 255), true},
-		{net.IPv4(172, 31, 0, 0), true},
-		{net.IPv4(172, 32, 0, 0), false},
-		{net.IPv4(192, 167, 255, 255), false},
-		{net.IPv4(192, 168, 0, 0), true},
-		{net.IPv4(192, 168, 255, 255), true},
-		{net.IPv4(192, 169, 0, 0), false},
-		{net.IP{0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, true},
-		{net.IP{0xfc, 0xff, 0x12, 0, 0, 0, 0, 0x44, 0, 0, 0, 0, 0, 0, 0, 0}, true},
-		{net.IP{0xfb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, false},
-		{net.IP{0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, true},
-		{net.IP{0xfe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, false},
-	}
-
-	for _, test := range tests {
-		assert.Equalf(t, test.expected, isPrivate(test.ip), "ip: %s", test.ip.String())
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Replace usage of pkg/util/net.isPrivate with IP.IsPrivate (added in Go 1.17).

#### Which issue(s) this PR fixes or relates to

Fixes #1346.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
