### PR TITLE
Updated mimir-build-image after update of Go to 1.17.7.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container:
-      image: grafana/mimir-build-image:chore-publish-images-to-dockerhub-771364985
+      image: grafana/mimir-build-image:main-c6d7d5f5b
       credentials:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
@@ -56,7 +56,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-20.04
     container:
-      image: grafana/mimir-build-image:chore-publish-images-to-dockerhub-771364985
+      image: grafana/mimir-build-image:main-c6d7d5f5b
       credentials:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
@@ -86,7 +86,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: grafana/mimir-build-image:chore-publish-images-to-dockerhub-771364985
+      image: grafana/mimir-build-image:main-c6d7d5f5b
       credentials:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
@@ -113,7 +113,7 @@ jobs:
   build-mimir:
     runs-on: ubuntu-20.04
     container:
-      image: grafana/mimir-build-image:chore-publish-images-to-dockerhub-771364985
+      image: grafana/mimir-build-image:main-c6d7d5f5b
       credentials:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
@@ -145,7 +145,7 @@ jobs:
   build-tools:
     runs-on: ubuntu-20.04
     container:
-      image: grafana/mimir-build-image:chore-publish-images-to-dockerhub-771364985
+      image: grafana/mimir-build-image:main-c6d7d5f5b
       credentials:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
@@ -228,7 +228,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-20.04
     container:
-      image: grafana/mimir-build-image:chore-publish-images-to-dockerhub-771364985
+      image: grafana/mimir-build-image:main-c6d7d5f5b
       credentials:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
-LATEST_BUILD_IMAGE_TAG ?= chore-publish-images-to-dockerhub-771364985
+LATEST_BUILD_IMAGE_TAG ?= main-c6d7d5f5b
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden


### PR DESCRIPTION
#### What this PR does

PR #1347 updated build image, but we forgot to rebuild it and update references. This PR fixes that.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
