### PR TITLE
Correct help text when neither flags nor config is provided

### DIFF
--- a/pkg/mimirtool/commands/config.go
+++ b/pkg/mimirtool/commands/config.go
@@ -69,11 +69,11 @@ func (c *ConfigCommand) prepareInputs() ([]byte, []string, error) {
 	)
 
 	if c.flagsFile == "" && c.yamlFile == "" {
-		return nil, nil, errors.New("provide at least one of --config-file or --flags-file")
+		return nil, nil, errors.New("provide at least one of --yaml-file or --flags-file")
 	}
 	yamlContents, err = os.ReadFile(c.yamlFile)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return nil, nil, errors.Wrap(err, "could not read config-file")
+		return nil, nil, errors.Wrap(err, "could not read yaml-file")
 	}
 
 	flagsContents, err := os.ReadFile(c.flagsFile)


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
