### PR TITLE
Allow mixin dashboard prefix to be customized

### DIFF
--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -6,6 +6,9 @@
     // The product name used when building dashboards.
     product: 'Mimir',
 
+    // The prefix including product name used when building dashboards.
+    dashboard_prefix: '%(product)s / ' % $._config.product,
+
     // Tags for dashboards.
     tags: ['mimir'],
 

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -8,8 +8,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   // - default tags,
   // - some links that propagate the selectred cluster.
   dashboard(title)::
-    // Prefix the dashboard title with "<product> /".
-    super.dashboard('%(product)s / %(title)s' % { product: $._config.product, title: title }) + {
+    // Prefix the dashboard title with "<product> /" unless configured otherwise.
+    super.dashboard('%(prefix)s%(title)s' % { prefix: $._config.dashboard_prefix, title: title }) + {
       addRowIf(condition, row)::
         if condition
         then self.addRow(row)


### PR DESCRIPTION
Allow the prefix used for dashboards (default "Mimir /") to be
customized. This is useful for consumers of the mixin that require
more control over how dashboards are named (like GEM self-monitoring).

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
