### PR TITLE
Reorder "Migrating to Grafana Mimir" pages

### DIFF
--- a/docs/sources/migrating/_index.md
+++ b/docs/sources/migrating/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating to Grafana Mimir"
 description: ""
-weight: 1
+weight: 40
 ---
 
 # Migrating to Grafana Mimir

--- a/docs/sources/migrating/migrating-from-thanos-or-prometheus.md
+++ b/docs/sources/migrating/migrating-from-thanos-or-prometheus.md
@@ -14,7 +14,7 @@ Each project stores blocks in different places use different block metadata file
 
 ## Configuring remote write to Grafana Mimir
 
-For configuration of remote write to Grafana Mimir, refer to [Configuring Prometheus remote write]({{<relref "../about-authentication-and-authorization.md#configuring-prometheus-remote-write" >}}).
+For configuration of remote write to Grafana Mimir, refer to [Configuring Prometheus remote write]({{< relref "../about-authentication-and-authorization.md#configuring-prometheus-remote-write" >}}).
 
 ## Uploading historic blocks to the Grafana Mimir storage bucket
 


### PR DESCRIPTION
#### What this PR does
- Reorder _index.md to be fourth in the top level table of contents
- Rename the directory to remove the grafana-mimir name

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
