### PR TITLE
Add more detailed query stats to ruler query logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
 * [ENHANCEMENT] Upgrade Go to 1.17.8. #1347 #1381
 * [ENHANCEMENT] Upgrade Docker base images to `alpine:3.15.0`. #1348
+* [ENHANCEMENT] Ruler: Add more detailed query information to ruler query stats logging. #1411
 
 ### Mixin
 


### PR DESCRIPTION
#### What this PR does

Use the same stats that query-frontends use to record performance information
about queries performed (series fetched, chunk bytes loaded, etc) for queries
performed by the ruler.

Fixes #1285

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
