### PR TITLE
Docs: remove old markdown metadata

### DIFF
--- a/docs/internal/contributing/_index.md
+++ b/docs/internal/contributing/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Contributing
-linkTitle: "Contributing"
 weight: 10
-menu:
 ---
 
 Welcome! We're excited that you're interested in contributing. Below are some basic guidelines.

--- a/docs/internal/contributing/how-integration-tests-work.md
+++ b/docs/internal/contributing/how-integration-tests-work.md
@@ -1,8 +1,6 @@
 ---
 title: "How integration tests work"
-linkTitle: "How integration tests work"
 weight: 5
-slug: how-integration-tests-work
 ---
 
 Mimir integration tests are written in Go and based on a [custom framework](https://github.com/grafana/mimir/tree/main/integration/e2e) running Mimir and its dependencies in Docker containers and using the Go [`testing`](https://golang.org/pkg/testing/) package for assertions. Integration tests run in CI for every PR, and can be easily executed locally during development (it just requires Docker).

--- a/docs/internal/contributing/how-to-upgrade-golang-version.md
+++ b/docs/internal/contributing/how-to-upgrade-golang-version.md
@@ -1,8 +1,6 @@
 ---
 title: "How to upgrade Golang version"
-linkTitle: "How to upgrade Golang version"
 weight: 4
-slug: how-to-upgrade-golang-version
 ---
 
 To upgrade the Golang version:

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,10 +1,6 @@
 ---
 title: "Mimir technical documentation"
-linkTitle: "Documentation"
 weight: 1
-menu:
-  main:
-    weight: 1
 ---
 
 Mimir provides horizontally scalable, highly available, multi-tenant, long-term storage for [Prometheus](https://prometheus.io).

--- a/docs/sources/architecture/blocks-storage/_index.md
+++ b/docs/sources/architecture/blocks-storage/_index.md
@@ -1,8 +1,6 @@
 ---
 title: "Blocks storage"
-linkTitle: "Blocks storage"
 weight: 20
-menu:
 ---
 
 The blocks storage is a Mimir storage engine based on [Prometheus TSDB](https://prometheus.io/docs/prometheus/latest/storage/): it stores each tenant's time series into their own TSDB which write out their series to a on-disk block (defaults to 2h block range periods). Each block is composed by chunk files - containing the timestamp-value pairs for multiple series - and an index, which indexes metric names and labels to time series in the chunk files.

--- a/docs/sources/architecture/blocks-storage/binary-index-header.md
+++ b/docs/sources/architecture/blocks-storage/binary-index-header.md
@@ -1,8 +1,6 @@
 ---
 title: "Binary index-header"
-linkTitle: "Binary index-header"
 weight: 10
-slug: binary-index-header
 ---
 
 In order to query series inside blocks from object storage, the [store-gateway](./store-gateway.md) has to know certain initial info from each block index. In order to achieve so, the store-gateway builds an index-header for each block and stores it on local disk; such index-header is built by downloading specific pieces of original block's index and storing them on local disk. Index header is then used by store-gateway at query time.

--- a/docs/sources/architecture/blocks-storage/bucket-index.md
+++ b/docs/sources/architecture/blocks-storage/bucket-index.md
@@ -1,8 +1,6 @@
 ---
 title: "Bucket Index"
-linkTitle: "Bucket Index"
 weight: 10
-slug: bucket-index
 ---
 
 The bucket index is a **per-tenant file containing the list of blocks and block deletion marks** in the storage. The bucket index itself is stored in the backend object storage, is periodically updated by the compactor, and used by queriers, store-gateways and rulers to discover blocks in the storage.

--- a/docs/sources/architecture/blocks-storage/production-tips.md
+++ b/docs/sources/architecture/blocks-storage/production-tips.md
@@ -1,8 +1,6 @@
 ---
 title: "Production tips"
-linkTitle: "Production tips"
 weight: 10
-slug: production-tips
 ---
 
 This page shares some tips and things to take in consideration when setting up a production Cortex cluster based on the blocks storage.


### PR DESCRIPTION
#### What this PR does
Some doc pages still have the old markdown metadata (`linkTitle`, `menu` and `slug`). This PR removes them.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
