### PR TITLE
Note that all ingesters need to be ACTIVE in the ring for all_users_stats endpoint

### DIFF
--- a/docs/sources/reference-http-api/_index.md
+++ b/docs/sources/reference-http-api/_index.md
@@ -243,6 +243,8 @@ GET /distributor/all_user_stats
 
 This endpoint displays a web page that shows per-tenant statistics updated in real time, including the total number of active series across all ingesters and the current ingestion rate displayed in samples per second.
 
+> **Note:** This endpoint requires all ingesters to be `ACTIVE` in the ring for a successful response.
+
 ### HA tracker status
 
 ```


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

#### Checklist

- [x] Documentation added
