### PR TITLE
Provide more convenient workflow for Docs squad development

### DIFF
--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -24,7 +24,9 @@ define docs_docker_run
 	@if [[ -z $${NON_INTERACTIVE} ]]; then \
 		read -p "Press a key to continue"; \
 	fi
-	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \; && touch content/docs/mimir/_index.md && exec $(1)'
+	# The loki _index.md file is intentionally used until the equivalent file in the grafana/website repository is
+	# created for Mimir.
+	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'mv content/docs/loki/_index.md content/docs/$(DOCS_PROJECT)/ && find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \;  && exec $(1)'
 endef
 
 .PHONY: docs-docker-rm


### PR DESCRIPTION
#### What this PR does
- [Expose HUGO_REFLINKSERRORLEVEL environment variable, default to WARNING](https://github.com/grafana/mimir/commit/6d08ac3a7ef8a18e0a6c44f256fcaf2ec0ff28ff)
  This is preferred by the docs squad workflow as it allows them to
  interactively fix links with a running web server.
  CI will still use ERROR to ensure broken links are not merged.
  You can also use the ERROR mode locally with:
  ```console
  $ make docs HUGO_REFLINKSERRORLEVEL=ERROR
  ```
- [Use docs-base server target for consistency with other repos](https://github.com/grafana/mimir/commit/1a257c509097934c1b8988f47b440452cc3ab210)
- [Fix table of contents rendering by borrowing Loki's index file](https://github.com/grafana/mimir/commit/dbd39f7851fefb3ecef64bc2e8340b20593ad36b)
