### PR TITLE
Adding a small page for deployment instructions that references Helm and Jsonnet

### DIFF
--- a/docs/sources/operators-guide/deploying-grafana-mimir/_index.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/_index.md
@@ -10,7 +10,7 @@ keywords:
 
 # Deploying Grafana Mimir on Kubernetes
 
-You can use Helm or Tanka to deploy Grafana Mimir on Kubernetes. 
+You can use Helm or Tanka to deploy Grafana Mimir on Kubernetes.
 
 ## Helm
 
@@ -18,6 +18,6 @@ A [mimir-distributed](https://github.com/grafana/helm-charts/tree/main/charts/mi
 
 ## Tanka
 
-Grafana Labs also publishes [jsonnet](https://jsonnet.org/) files that you can use to deploy Grafana Mimir in [microservices mode]({{< relref "../architecture/deployment-modes.md#microservices-mode" >}}). To locate the Jsonnet files and a README file, refer to [Jsonnet for Mimir on Kubernetes](https://github.com/grafana/mimir/tree/main/operations/mimir). 
+Grafana Labs also publishes [jsonnet](https://jsonnet.org/) files that you can use to deploy Grafana Mimir in [microservices mode]({{< relref "../architecture/deployment-modes.md#microservices-mode" >}}). To locate the Jsonnet files and a README file, refer to [Jsonnet for Mimir on Kubernetes](https://github.com/grafana/mimir/tree/main/operations/mimir).
 
-The README explains how to use [tanka](https://tanka.dev/) and [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) to generate Kubernetes YAML manifests from the jsonnet files. Alternatively, if you are familiar with tanka, you can use it directly to deploy Grafana Mimir. 
+The README explains how to use [tanka](https://tanka.dev/) and [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) to generate Kubernetes YAML manifests from the jsonnet files. Alternatively, if you are familiar with tanka, you can use it directly to deploy Grafana Mimir.


### PR DESCRIPTION
Relates to #1488 