### PR TITLE
Create a small docs page on custom trackers

### DIFF
--- a/docs/sources/operators-guide/configuring/configuring-custom-trackers.md
+++ b/docs/sources/operators-guide/configuring/configuring-custom-trackers.md
@@ -21,13 +21,13 @@ active_series_custom_trackers:
 
 If you configure a custom tracker for an ingester, the ingester exposes a `cortex_ingester_active_series_custom_tracker` gauge metric on its [/metrics endpoint](({{< relref "../reference-http-api#metrics" >}})).
 
-Each custom tracker counts the active series matching its label pattern on a per-tenant basis, which means that each custom tracker generates as many as `# of tenants` series with metric name `cortex_ingester_active_series_custom_tracker`. To reduce the cardinality of this metric, only custom trackers that have matched at least one series are exposed on the metric, and they are removed if they become 0 again.
+Each custom tracker counts the active series matching its label pattern on a per-tenant basis, which means that each custom tracker generates as many as `# of tenants` series with metric name `cortex_ingester_active_series_custom_tracker`. To reduce the cardinality of this metric, only custom trackers that have matched at least one series are exposed on the metric, and they are removed if they become `0`.
 
-Series with metric name `cortex_ingester_active_series_custom_tracker` will have 2 labels applied: `name` and `user`. The value of the `name` label is the name of the custom tracker specified in the configuration. The value of the `user` label is the tenant-id for which the series count applies.
+Series with metric name `cortex_ingester_active_series_custom_tracker` have two labels applied: `name` and `user`. The value of the `name` label is the name of the custom tracker specified in the configuration. The value of the `user` label is the tenant-id for which the series count applies.
 
-Assume two custom trackers are configured as in the example above, and that your Grafana Mimir cluster has 3 tenants: `tenant_1`, `tenant_2`, and `tenant_with_only_prod_metrics`. Assume all series within `tenant_with_only_prod_metrics` have labels that match the pattern `{namespace=~"prod-.*"}` and none that match `{namespace=~"dev-.*"}`.
+Assume two custom trackers are configured as in the example above, and that your Grafana Mimir cluster has three tenants: `tenant_1`, `tenant_2`, and `tenant_with_only_prod_metrics`. Assume all series within `tenant_with_only_prod_metrics` have labels that match the pattern `{namespace=~"prod-.*"}` and none that match `{namespace=~"dev-.*"}`.
 
-You'd see the following output when the `/metrics` endpoint for the ingester component is scraped:
+In this example, the following output appears when the `/metrics` endpoint for the ingester component is scraped:
 
 ```
 cortex_ingester_active_series_custom_tracker{name="dev", user="tenant_1"}


### PR DESCRIPTION
Right now the only docs this feature has are in the changelog and in the configuration file itself, making it hard to discover. 

Relates to #1494 