### PR TITLE
Add OoO instructions for playbook MimirCompactorHasNotSuccessfullyRunCompaction

### DIFF
--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -468,7 +468,13 @@ How to **investigate**:
           - Find source blocks for the compaction job: search for `msg="compact blocks"` and a mention of the result block ID.
           - Upload a JSON file to the markers directory of the compactor: `<tenant_id>/markers/<faulty_source_block>-no-compact-mark.json`. The format of the file follows. Replace the `id` and `no_compact_time`:
             ```json
-            {"id":"01FYAFBE9F0VH6555R3J1CFPHP","version":1,"details":"When compacting with other blocks is leading to out-of-order chunks","no_compact_time":1647514725,"reason":"manual"}
+            {
+              "id": "01FYAFBE9F0VH6555R3J1CFPHP",
+              "version": 1,
+              "details": "When compacting with other blocks is leading to out-of-order chunks",
+              "no_compact_time": 1647514725,
+              "reason": "manual"
+            }
             ```
 
 ### MimirCompactorSkippedBlocksWithOutOfOrderChunks


### PR DESCRIPTION
#### What this PR does

Add mitigation steps for `MimirCompactorHasNotSuccessfullyRunCompaction` when the compactor produces out-of-order chunks.

#### Which issue(s) this PR fixes or relates to

<!-- Please make sure you don't reference cortex issues here, as the references can be publicly seen under certain conditions -->

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
