### PR TITLE
Redirect documentation sync to the website publishing branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,7 @@ jobs:
       id: publish
       with:
         repository: grafana/website
-        # Temporarily sync to the mimir branch until we are ready for launch.
-        branch: mimir
+        branch: master
         host: github.com
         github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
         source_folder: docs/sources


### PR DESCRIPTION
#### What this PR does

Reconfigures the destination branch of the documentation sync so that the website publishes it automatically.
