### PR TITLE
Generate mimir 2.0 config from branch `prepare-2.0.0-rc.4`

### DIFF
--- a/pkg/mimirtool/config/descriptors/mimir-v2.0.0.json
+++ b/pkg/mimirtool/config/descriptors/mimir-v2.0.0.json
@@ -1315,38 +1315,6 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
-        },
-        {
-          "kind": "block",
-          "name": "forwarding",
-          "required": false,
-          "desc": "",
-          "blockEntries": [
-            {
-              "kind": "field",
-              "name": "enabled",
-              "required": false,
-              "desc": "Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.",
-              "fieldValue": null,
-              "fieldDefaultValue": false,
-              "fieldFlag": "distributor.forwarding.enabled",
-              "fieldType": "boolean",
-              "fieldCategory": "experimental"
-            },
-            {
-              "kind": "field",
-              "name": "request_timeout",
-              "required": false,
-              "desc": "Timeout for requests to ingestion endpoints to which we forward metrics.",
-              "fieldValue": null,
-              "fieldDefaultValue": 10000000000,
-              "fieldFlag": "distributor.forwarding.request-timeout",
-              "fieldType": "duration",
-              "fieldCategory": "experimental"
-            }
-          ],
-          "fieldValue": null,
-          "fieldDefaultValue": null
         }
       ],
       "fieldValue": null,
@@ -2982,15 +2950,6 @@
           "fieldDefaultValue": 0,
           "fieldFlag": "alertmanager.max-alerts-size-bytes",
           "fieldType": "int"
-        },
-        {
-          "kind": "field",
-          "name": "forwarding_rules",
-          "required": false,
-          "desc": "Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint.",
-          "fieldValue": null,
-          "fieldDefaultValue": {},
-          "fieldType": "map of string to validation.ForwardingRule"
         }
       ],
       "fieldValue": null,


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Commits a config descriptor for mimir 2.0 that was generated from the release-2.0-rc4 branch.

This effectively removes forwarding rules config that was added after the 2.0 code freeze and are not part of the config set of mimir 2.0

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
