### PR TITLE
Drop forwarding rules from GEM 2.0 config descriptor

### DIFF
--- a/pkg/mimirtool/config/descriptors/gem-v2.0.0.json
+++ b/pkg/mimirtool/config/descriptors/gem-v2.0.0.json
@@ -1315,38 +1315,6 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
-        },
-        {
-          "kind": "block",
-          "name": "forwarding",
-          "required": false,
-          "desc": "",
-          "blockEntries": [
-            {
-              "kind": "field",
-              "name": "enabled",
-              "required": false,
-              "desc": "Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.",
-              "fieldValue": null,
-              "fieldDefaultValue": false,
-              "fieldFlag": "distributor.forwarding.enabled",
-              "fieldType": "boolean",
-              "fieldCategory": "experimental"
-            },
-            {
-              "kind": "field",
-              "name": "request_timeout",
-              "required": false,
-              "desc": "Timeout for requests to ingestion endpoints to which we forward metrics.",
-              "fieldValue": null,
-              "fieldDefaultValue": 10000000000,
-              "fieldFlag": "distributor.forwarding.request-timeout",
-              "fieldType": "duration",
-              "fieldCategory": "experimental"
-            }
-          ],
-          "fieldValue": null,
-          "fieldDefaultValue": null
         }
       ],
       "fieldValue": null,
@@ -2982,15 +2950,6 @@
           "fieldDefaultValue": 0,
           "fieldFlag": "alertmanager.max-alerts-size-bytes",
           "fieldType": "int"
-        },
-        {
-          "kind": "field",
-          "name": "forwarding_rules",
-          "required": false,
-          "desc": "Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint.",
-          "fieldValue": null,
-          "fieldDefaultValue": {},
-          "fieldType": "map of string to validation.ForwardingRule"
         }
       ],
       "fieldValue": null,


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This change affects only `mimirtool config convert` command. So far the descsriptors have been generated from the master branch. This used to be accurate enough, but the config of master started drifting from the config of 2.0. So this PR

* removes forwarding rules from the GEM 2.0 config descriptor. These are changes that will not be part of GEM 2.0, so they should be removed from the config descriptor

This wasn't generated, I manually removed the JSON entries because I couldn't easily vendor mimir 2.0 into GEM. These descriptors will change again in the coming days. This change is so that mimi 2.0 RC4 can be cut.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
