### PR TITLE
mimirtool config: GEM config extensions

### DIFF
--- a/pkg/mimirtool/config/descriptors/gem-v1.7.0.json
+++ b/pkg/mimirtool/config/descriptors/gem-v1.7.0.json
@@ -9923,6 +9923,16 @@
           "fieldDefaultValue": "smallest-range-oldest-blocks-first",
           "fieldFlag": "compactor.compaction-jobs-order",
           "fieldType": "string"
+        },
+        {
+          "kind": "field",
+          "name": "sharding_strategy",
+          "required": false,
+          "desc": "The sharding strategy to use. Supported values are: default, time-sharding.",
+          "fieldValue": null,
+          "fieldDefaultValue": "default",
+          "fieldFlag": "compactor.sharding-strategy",
+          "fieldType": "string"
         }
       ],
       "fieldValue": null,

--- a/pkg/mimirtool/config/descriptors/gem-v2.0.0.json
+++ b/pkg/mimirtool/config/descriptors/gem-v2.0.0.json
@@ -14175,6 +14175,38 @@
       ],
       "fieldValue": null,
       "fieldDefaultValue": null
+    },
+    {
+      "kind": "block",
+      "name": "usage_reporting",
+      "required": false,
+      "desc": "",
+      "blockEntries": [
+        {
+          "kind": "field",
+          "name": "collect_interval",
+          "required": false,
+          "desc": "How often to collect usage to internal buffer",
+          "fieldValue": null,
+          "fieldDefaultValue": 900000000000,
+          "fieldFlag": "usage-reporting.collect-interval",
+          "fieldType": "duration",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
+          "name": "report_interval",
+          "required": false,
+          "desc": "How often to report usage and store reports",
+          "fieldValue": null,
+          "fieldDefaultValue": 3600000000000,
+          "fieldFlag": "usage-reporting.report-interval",
+          "fieldType": "duration",
+          "fieldCategory": "advanced"
+        }
+      ],
+      "fieldValue": null,
+      "fieldDefaultValue": null
     }
   ],
   "fieldValue": null,


### PR DESCRIPTION
#### What this PR does

* adds GEM JSON config descriptors for GEM extensions - these are additional structs that GEM unmarshals YAML into in addition to `mimir.Config` and `gem.Config`. The haven't been added yet because the generation process is slightly different.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
