### PR TITLE
mimirtool config: Add hidden usage_reporting block to GEM 1.7 descriptors

### DIFF
--- a/pkg/mimirtool/config/descriptors/gem-v1.7.0.json
+++ b/pkg/mimirtool/config/descriptors/gem-v1.7.0.json
@@ -18877,6 +18877,36 @@
       ],
       "fieldValue": null,
       "fieldDefaultValue": null
+    },
+    {
+      "kind": "block",
+      "name": "usage_reporting",
+      "required": false,
+      "desc": "",
+      "blockEntries": [
+        {
+          "kind": "field",
+          "name": "collect_interval",
+          "required": false,
+          "desc": "How often to collect usage to internal buffer",
+          "fieldValue": null,
+          "fieldDefaultValue": 900000000000,
+          "fieldFlag": "usage-reporting.collect-interval",
+          "fieldType": "duration"
+        },
+        {
+          "kind": "field",
+          "name": "report_interval",
+          "required": false,
+          "desc": "How often to report usage and store reports",
+          "fieldValue": null,
+          "fieldDefaultValue": 3600000000000,
+          "fieldFlag": "usage-reporting.report-interval",
+          "fieldType": "duration"
+        }
+      ],
+      "fieldValue": null,
+      "fieldDefaultValue": null
     }
   ],
   "fieldValue": null,


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

These exist in the GEM 2.0 descriptors, but I forgot to remove the `doc:"hidden"` tag in GEM 1.7 when generating the descriptors. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
