### PR TITLE
Correct substitution for determining docs version from release tags

### DIFF
--- a/tools/release-docs
+++ b/tools/release-docs
@@ -54,6 +54,9 @@ readonly WEBSITE_BRANCH="${WEBSITE_BRANCH:-mimir-release-${VERSION}}"
 # WEBSITE_REMOTE is the name the configured remote in the
 # grafana/website repository.
 readonly WEBSITE_REMOTE="${WEBSITE_REMOTE:-origin}"
+# WEBSITE_BASE_BRANCH is the name of the branch in the
+# grafana/website repository from which to base the changes.
+readonly WEBSITE_BASE_BRANCH="${WEBSITE_BASE_BRANCH:-master}"
 
 # ensure_cloned clones a repository $2 if it does not already exist
 # in directory $1.
@@ -91,7 +94,7 @@ git checkout "${TAG}" || (echo "Release tag '${TAG}' does not exist locally. Ref
 
 cd "${WEBSITE_DIR}"
 # Create a new branch for the changes.
-git checkout -B "${WEBSITE_BRANCH}" "${WEBSITE_REMOTE}"/master
+git checkout -B "${WEBSITE_BRANCH}" "${WEBSITE_REMOTE}"/"${WEBSITE_BASE_BRANCH}"
 # Move unreleased documentation aside to allow the `docs-release.sh` script
 # to update aliases and perform any future changes that it does.
 mv content/docs/mimir/next content/docs/mimir/next.main


### PR DESCRIPTION
#### What this PR does
- [Correct substition for determining version from release tags](https://github.com/grafana/mimir/commit/984ead1a92f519e50ac5cd94242d0cd02bcca048)[](https://github.com/jdbaldry) 
- [Make base branch configurable](https://github.com/grafana/mimir/commit/e5edf581f558f3e7e4a48d393eea7b2dfb51941e)[](https://github.com/jdbaldry)
