### PR TITLE
Fix query sharding when subquery is outside a shardable aggregation function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [ENHANCEMENT] Ruler: Add more detailed query information to ruler query stats logging. #1411
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482
+* [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -385,6 +385,16 @@ func TestQueryShardingCorrectness(t *testing.T) {
 					)`,
 			expectedShardedQueries: 0,
 		},
+		"outer subquery on top of sum": {
+			query:                  `sum(metric_counter) by (group_1)[5m:1m]`,
+			expectedShardedQueries: 0,
+			noRangeQuery:           true,
+		},
+		"outer subquery on top of avg": {
+			query:                  `avg(metric_counter) by (group_1)[5m:1m]`,
+			expectedShardedQueries: 0,
+			noRangeQuery:           true,
+		},
 		"stddev()": {
 			query:                  `stddev(metric_counter{const="fixed"})`,
 			expectedShardedQueries: 0,


### PR DESCRIPTION
#### What this PR does
This PR introduce a change to **not** shard queries with subquery **outside** a shardable aggregation function. The issue is described in #1539.

To fix #1539 keeping the query sharding working I think we need to fix #255. I've got an idea for #255 but need to spend more time experimenting it. In the meanwhile, I suggest to fix #1539 just disabling query sharding for that cases.

#### Which issue(s) this PR fixes or relates to

Fixes #1539

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
