### PR TITLE
Add configuration for Alertmanager GRPC client and GET request concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [FEATURE] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
 * [ENHANCEMENT] Alertmanager: Added the ability to configure GRPC client settings #1547
-  - `-alertmanager.alertmanager-client.backoff-max-period duration`
-  - `-alertmanager.alertmanager-client.backoff-min-period duration`
+  - `-alertmanager.alertmanager-client.backoff-max-period`
+  - `-alertmanager.alertmanager-client.backoff-min-period`
   - `-alertmanager.alertmanager-client.backoff-on-ratelimits`
   - `-alertmanager.alertmanager-client.backoff-retries`
   - `-alertmanager.alertmanager-client.grpc-client-rate-limit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
-* [ENHANCEMENT] Alertmanager: Added the ability to configure GRPC client settings #1547
+* [ENHANCEMENT] Alertmanager: Added the ability to configure additional gRPC client settings for the Alertmanager distributor #1547
   - `-alertmanager.alertmanager-client.backoff-max-period`
   - `-alertmanager.alertmanager-client.backoff-min-period`
   - `-alertmanager.alertmanager-client.backoff-on-ratelimits`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
-* [FEATURE] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
+* [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
 * [ENHANCEMENT] Alertmanager: Added the ability to configure GRPC client settings #1547
   - `-alertmanager.alertmanager-client.backoff-max-period`
   - `-alertmanager.alertmanager-client.backoff-min-period`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,20 @@
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
-* [FEATURE] Alertmanager: Added the ability to configure GRPC client settings #1547
+* [FEATURE] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
+* [ENHANCEMENT] Alertmanager: Added the ability to configure GRPC client settings #1547
   - `-alertmanager.alertmanager-client.backoff-max-period duration`
   - `-alertmanager.alertmanager-client.backoff-min-period duration`
   - `-alertmanager.alertmanager-client.backoff-on-ratelimits`
-  - `-alertmanager.alertmanager-client.backoff-retries int`
-  - `-alertmanager.alertmanager-client.grpc-client-rate-limit float`
-  - `-alertmanager.alertmanager-client.grpc-client-rate-limit-burst int`
-  - `-alertmanager.alertmanager-client.grpc-compression string`
-  - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size int`
-  - `-alertmanager.alertmanager-client.grpc-max-send-msg-size int`
-* [FEATURE] Alertmanager: Added the ability to configure Alertmanager GET request concurrency #1547
-  - `alertmanager.concurrency`
+  - `-alertmanager.alertmanager-client.backoff-retries`
+  - `-alertmanager.alertmanager-client.grpc-client-rate-limit`
+  - `-alertmanager.alertmanager-client.grpc-client-rate-limit-burst`
+  - `-alertmanager.alertmanager-client.grpc-compression`
+  - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size`
+  - `-alertmanager.alertmanager-client.grpc-max-send-msg-size`
+  - Default values have also changed for the following settings:
+    - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
+    - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
 * [ENHANCEMENT] Ruler: Add more detailed query information to ruler query stats logging. #1411
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Grafana Mimir - main / unreleased
 
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
+* [CHANGE] Default values have changed for the following settings: #1547
+    - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
+    - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
+    - `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
@@ -16,9 +20,6 @@
   - `-alertmanager.alertmanager-client.grpc-compression`
   - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size`
   - `-alertmanager.alertmanager-client.grpc-max-send-msg-size`
-  - Default values have also changed for the following settings:
-    - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
-    - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
 * [ENHANCEMENT] Ruler: Add more detailed query information to ruler query stats logging. #1411
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
+* [FEATURE] Alertmanager: Added the ability to configure GRPC client settings #1547
+  - `-alertmanager.alertmanager-client.backoff-max-period duration`
+  - `-alertmanager.alertmanager-client.backoff-min-period duration`
+  - `-alertmanager.alertmanager-client.backoff-on-ratelimits`
+  - `-alertmanager.alertmanager-client.backoff-retries int`
+  - `-alertmanager.alertmanager-client.grpc-client-rate-limit float`
+  - `-alertmanager.alertmanager-client.grpc-client-rate-limit-burst int`
+  - `-alertmanager.alertmanager-client.grpc-compression string`
+  - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size int`
+  - `-alertmanager.alertmanager-client.grpc-max-send-msg-size int`
+* [FEATURE] Alertmanager: Added the ability to configure Alertmanager GET request concurrency #1547
+  - `alertmanager.concurrency`
 * [ENHANCEMENT] Ruler: Add more detailed query information to ruler query stats logging. #1411
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7953,7 +7953,7 @@
           "required": false,
           "desc": "Maximum size (bytes) of an accepted HTTP request body.",
           "fieldValue": null,
-          "fieldDefaultValue": 16777216,
+          "fieldDefaultValue": 104857600,
           "fieldFlag": "alertmanager.max-recv-msg-size",
           "fieldType": "int",
           "fieldCategory": "advanced"

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8388,6 +8388,17 @@
           "fieldCategory": "advanced"
         },
         {
+          "kind": "field",
+          "name": "concurrency",
+          "required": false,
+          "desc": "Concurrency limit for GET requests. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "alertmanager.concurrency",
+          "fieldType": "int",
+          "fieldCategory": "advanced"
+        },
+        {
           "kind": "block",
           "name": "alertmanager_client",
           "required": false,
@@ -8403,6 +8414,115 @@
               "fieldFlag": "alertmanager.alertmanager-client.remote-timeout",
               "fieldType": "duration",
               "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "max_recv_msg_size",
+              "required": false,
+              "desc": "gRPC client max receive message size (bytes).",
+              "fieldValue": null,
+              "fieldDefaultValue": 104857600,
+              "fieldFlag": "alertmanager.alertmanager-client.grpc-max-recv-msg-size",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "max_send_msg_size",
+              "required": false,
+              "desc": "gRPC client max send message size (bytes).",
+              "fieldValue": null,
+              "fieldDefaultValue": 104857600,
+              "fieldFlag": "alertmanager.alertmanager-client.grpc-max-send-msg-size",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "grpc_compression",
+              "required": false,
+              "desc": "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "alertmanager.alertmanager-client.grpc-compression",
+              "fieldType": "string",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "rate_limit",
+              "required": false,
+              "desc": "Rate limit for gRPC client; 0 means disabled.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "alertmanager.alertmanager-client.grpc-client-rate-limit",
+              "fieldType": "float",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "rate_limit_burst",
+              "required": false,
+              "desc": "Rate limit burst for gRPC client.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "alertmanager.alertmanager-client.grpc-client-rate-limit-burst",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "backoff_on_ratelimits",
+              "required": false,
+              "desc": "Enable backoff and retry when we hit ratelimits.",
+              "fieldValue": null,
+              "fieldDefaultValue": false,
+              "fieldFlag": "alertmanager.alertmanager-client.backoff-on-ratelimits",
+              "fieldType": "boolean",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "block",
+              "name": "backoff_config",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "min_period",
+                  "required": false,
+                  "desc": "Minimum delay when backing off.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 100000000,
+                  "fieldFlag": "alertmanager.alertmanager-client.backoff-min-period",
+                  "fieldType": "duration",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_period",
+                  "required": false,
+                  "desc": "Maximum delay when backing off.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000000000,
+                  "fieldFlag": "alertmanager.alertmanager-client.backoff-max-period",
+                  "fieldType": "duration",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_retries",
+                  "required": false,
+                  "desc": "Number of times to backoff and retry before failing.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10,
+                  "fieldFlag": "alertmanager.alertmanager-client.backoff-retries",
+                  "fieldType": "int",
+                  "fieldCategory": "advanced"
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
             },
             {
               "kind": "field",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8389,12 +8389,12 @@
         },
         {
           "kind": "field",
-          "name": "concurrency",
+          "name": "max_concurrent_get_requests_per_tenant",
           "required": false,
-          "desc": "Concurrency limit for GET requests. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.",
+          "desc": "Maximum number of concurrent GET requests allowed per tenant. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
-          "fieldFlag": "alertmanager.concurrency",
+          "fieldFlag": "alertmanager.max-concurrent-get-requests-per-tenant",
           "fieldType": "int",
           "fieldCategory": "advanced"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -99,6 +99,24 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -alertmanager-storage.swift.username string
     	OpenStack Swift username.
+  -alertmanager.alertmanager-client.backoff-max-period duration
+    	Maximum delay when backing off. (default 10s)
+  -alertmanager.alertmanager-client.backoff-min-period duration
+    	Minimum delay when backing off. (default 100ms)
+  -alertmanager.alertmanager-client.backoff-on-ratelimits
+    	Enable backoff and retry when we hit ratelimits.
+  -alertmanager.alertmanager-client.backoff-retries int
+    	Number of times to backoff and retry before failing. (default 10)
+  -alertmanager.alertmanager-client.grpc-client-rate-limit float
+    	Rate limit for gRPC client; 0 means disabled.
+  -alertmanager.alertmanager-client.grpc-client-rate-limit-burst int
+    	Rate limit burst for gRPC client.
+  -alertmanager.alertmanager-client.grpc-compression string
+    	Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)
+  -alertmanager.alertmanager-client.grpc-max-recv-msg-size int
+    	gRPC client max receive message size (bytes). (default 104857600)
+  -alertmanager.alertmanager-client.grpc-max-send-msg-size int
+    	gRPC client max send message size (bytes). (default 104857600)
   -alertmanager.alertmanager-client.remote-timeout duration
     	Timeout for downstream alertmanagers. (default 2s)
   -alertmanager.alertmanager-client.tls-ca-path string
@@ -113,6 +131,8 @@ Usage of ./cmd/mimir/mimir:
     	Path to the key file for the client certificate. Also requires the client certificate to be configured.
   -alertmanager.alertmanager-client.tls-server-name string
     	Override the expected name on the server certificate.
+  -alertmanager.concurrency int
+    	Concurrency limit for GET requests. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.
   -alertmanager.configs.fallback string
     	Filename of fallback config to use if none specified for instance.
   -alertmanager.configs.poll-interval duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -148,7 +148,7 @@ Usage of ./cmd/mimir/mimir:
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
   -alertmanager.max-recv-msg-size int
-    	Maximum size (bytes) of an accepted HTTP request body. (default 16777216)
+    	Maximum size (bytes) of an accepted HTTP request body. (default 104857600)
   -alertmanager.max-template-size-bytes int
     	Maximum size of single template in tenant's Alertmanager configuration uploaded via Alertmanager API. 0 = no limit.
   -alertmanager.max-templates-count int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -131,8 +131,6 @@ Usage of ./cmd/mimir/mimir:
     	Path to the key file for the client certificate. Also requires the client certificate to be configured.
   -alertmanager.alertmanager-client.tls-server-name string
     	Override the expected name on the server certificate.
-  -alertmanager.concurrency int
-    	Concurrency limit for GET requests. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.
   -alertmanager.configs.fallback string
     	Filename of fallback config to use if none specified for instance.
   -alertmanager.configs.poll-interval duration
@@ -143,6 +141,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of alerts that a single tenant can have. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.
   -alertmanager.max-alerts-size-bytes int
     	Maximum total size of alerts that a single tenant can have, alert size is the sum of the bytes of its labels, annotations and generatorURL. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.
+  -alertmanager.max-concurrent-get-requests-per-tenant int
+    	Maximum number of concurrent GET requests allowed per tenant. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.
   -alertmanager.max-config-size-bytes int
     	Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
   -alertmanager.max-dispatcher-aggregation-groups int

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -1748,11 +1748,12 @@ sharding_ring:
 # CLI flag: -alertmanager.enable-api
 [enable_api: <boolean> | default = true]
 
-# (advanced) Concurrency limit for GET requests. The zero value (and negative
-# values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code
-# 503 is served for GET requests that would exceed the concurrency limit.
-# CLI flag: -alertmanager.concurrency
-[concurrency: <int> | default = 0]
+# (advanced) Maximum number of concurrent GET requests allowed per tenant. The
+# zero value (and negative values) result in a limit of GOMAXPROCS or 8,
+# whichever is larger. Status code 503 is served for GET requests that would
+# exceed the concurrency limit.
+# CLI flag: -alertmanager.max-concurrent-get-requests-per-tenant
+[max_concurrent_get_requests_per_tenant: <int> | default = 0]
 
 alertmanager_client:
   # (advanced) Timeout for downstream alertmanagers.

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -1654,7 +1654,7 @@ The `alertmanager` block configures the alertmanager.
 
 # (advanced) Maximum size (bytes) of an accepted HTTP request body.
 # CLI flag: -alertmanager.max-recv-msg-size
-[max_recv_msg_size: <int> | default = 16777216]
+[max_recv_msg_size: <int> | default = 104857600]
 
 sharding_ring:
   # The key-value store used to share the hash ring across multiple instances.

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -1748,10 +1748,54 @@ sharding_ring:
 # CLI flag: -alertmanager.enable-api
 [enable_api: <boolean> | default = true]
 
+# (advanced) Concurrency limit for GET requests. The zero value (and negative
+# values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code
+# 503 is served for GET requests that would exceed the concurrency limit.
+# CLI flag: -alertmanager.concurrency
+[concurrency: <int> | default = 0]
+
 alertmanager_client:
   # (advanced) Timeout for downstream alertmanagers.
   # CLI flag: -alertmanager.alertmanager-client.remote-timeout
   [remote_timeout: <duration> | default = 2s]
+
+  # (advanced) gRPC client max receive message size (bytes).
+  # CLI flag: -alertmanager.alertmanager-client.grpc-max-recv-msg-size
+  [max_recv_msg_size: <int> | default = 104857600]
+
+  # (advanced) gRPC client max send message size (bytes).
+  # CLI flag: -alertmanager.alertmanager-client.grpc-max-send-msg-size
+  [max_send_msg_size: <int> | default = 104857600]
+
+  # (advanced) Use compression when sending messages. Supported values are:
+  # 'gzip', 'snappy' and '' (disable compression)
+  # CLI flag: -alertmanager.alertmanager-client.grpc-compression
+  [grpc_compression: <string> | default = ""]
+
+  # (advanced) Rate limit for gRPC client; 0 means disabled.
+  # CLI flag: -alertmanager.alertmanager-client.grpc-client-rate-limit
+  [rate_limit: <float> | default = 0]
+
+  # (advanced) Rate limit burst for gRPC client.
+  # CLI flag: -alertmanager.alertmanager-client.grpc-client-rate-limit-burst
+  [rate_limit_burst: <int> | default = 0]
+
+  # (advanced) Enable backoff and retry when we hit ratelimits.
+  # CLI flag: -alertmanager.alertmanager-client.backoff-on-ratelimits
+  [backoff_on_ratelimits: <boolean> | default = false]
+
+  backoff_config:
+    # (advanced) Minimum delay when backing off.
+    # CLI flag: -alertmanager.alertmanager-client.backoff-min-period
+    [min_period: <duration> | default = 100ms]
+
+    # (advanced) Maximum delay when backing off.
+    # CLI flag: -alertmanager.alertmanager-client.backoff-max-period
+    [max_period: <duration> | default = 10s]
+
+    # (advanced) Number of times to backoff and retry before failing.
+    # CLI flag: -alertmanager.alertmanager-client.backoff-retries
+    [max_retries: <int> | default = 10]
 
   # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
   # any other TLS flag is set. If set to false, insecure connection to gRPC

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -72,6 +72,7 @@ type Config struct {
 	Logger      log.Logger
 	PeerTimeout time.Duration
 	Retention   time.Duration
+	Concurrency int
 	ExternalURL *url.URL
 	Limits      Limits
 
@@ -244,9 +245,10 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	}
 
 	am.api, err = api.New(api.Options{
-		Alerts:     am.alerts,
-		Silences:   am.silences,
-		StatusFunc: am.marker.Status,
+		Alerts:      am.alerts,
+		Silences:    am.silences,
+		StatusFunc:  am.marker.Status,
+		Concurrency: cfg.Concurrency,
 		// Mimir should not expose cluster information back to its tenants.
 		Peer:     &NilPeer{},
 		Registry: am.registry,

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -68,13 +68,13 @@ const (
 
 // Config configures an Alertmanager.
 type Config struct {
-	UserID      string
-	Logger      log.Logger
-	PeerTimeout time.Duration
-	Retention   time.Duration
-	Concurrency int
-	ExternalURL *url.URL
-	Limits      Limits
+	UserID                            string
+	Logger                            log.Logger
+	PeerTimeout                       time.Duration
+	Retention                         time.Duration
+	MaxConcurrentGetRequestsPerTenant int
+	ExternalURL                       *url.URL
+	Limits                            Limits
 
 	// Tenant-specific local directory where AM can store its state (notifications, silences, templates). When AM is stopped, entire dir is removed.
 	TenantDataDir string
@@ -248,7 +248,7 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 		Alerts:      am.alerts,
 		Silences:    am.silences,
 		StatusFunc:  am.marker.Status,
-		Concurrency: cfg.Concurrency,
+		Concurrency: cfg.MaxConcurrentGetRequestsPerTenant,
 		// Mimir should not expose cluster information back to its tenants.
 		Peer:     &NilPeer{},
 		Registry: am.registry,

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -79,6 +79,8 @@ type MultitenantAlertmanagerConfig struct {
 
 	EnableAPI bool `yaml:"enable_api" category:"advanced"`
 
+	Concurrency int `yaml:"concurrency" category:"advanced"`
+
 	// For distributor.
 	AlertmanagerClient ClientConfig `yaml:"alertmanager_client"`
 
@@ -103,6 +105,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 	f.DurationVar(&cfg.PollInterval, "alertmanager.configs.poll-interval", 15*time.Second, "How frequently to poll Alertmanager configs.")
 
 	f.BoolVar(&cfg.EnableAPI, "alertmanager.enable-api", true, "Enable the alertmanager config API.")
+	f.IntVar(&cfg.Concurrency, "alertmanager.concurrency", 0, "Concurrency limit for GET requests. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.")
 
 	cfg.AlertmanagerClient.RegisterFlagsWithPrefix("alertmanager.alertmanager-client", f)
 	cfg.Persister.RegisterFlagsWithPrefix("alertmanager", f)
@@ -847,6 +850,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 		Logger:            am.logger,
 		PeerTimeout:       am.cfg.PeerTimeout,
 		Retention:         am.cfg.Retention,
+		Concurrency:       am.cfg.Concurrency,
 		ExternalURL:       am.cfg.ExternalURL.URL,
 		Replicator:        am,
 		ReplicationFactor: am.cfg.ShardingRing.ReplicationFactor,

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -96,7 +96,7 @@ const (
 func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.DataDir, "alertmanager.storage.path", "./data-alertmanager/", "Directory to store Alertmanager state and temporarily configuration files. The content of this directory is not required to be persisted between restarts unless Alertmanager replication has been disabled.")
 	f.DurationVar(&cfg.Retention, "alertmanager.storage.retention", 5*24*time.Hour, "How long to keep data for.")
-	f.Int64Var(&cfg.MaxRecvMsgSize, "alertmanager.max-recv-msg-size", 16<<20, "Maximum size (bytes) of an accepted HTTP request body.")
+	f.Int64Var(&cfg.MaxRecvMsgSize, "alertmanager.max-recv-msg-size", 100<<20, "Maximum size (bytes) of an accepted HTTP request body.")
 
 	_ = cfg.ExternalURL.Set("http://localhost:8080/alertmanager") // set the default
 	f.Var(&cfg.ExternalURL, "alertmanager.web.external-url", "The URL under which Alertmanager is externally reachable (eg. could be different than -http.alertmanager-http-prefix in case Alertmanager is served via a reverse proxy). This setting is used both to configure the internal requests router and to generate links in alert templates. If the external URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager, both the UI and API.")


### PR DESCRIPTION

#### What this PR does

Exposes existing configuration via yaml and CLI flags:
* Alertmanager GRPC Client config is re-used from dskit
* Alertmanager Concurrency is exposed to support running Alertmanager under heavier load

Tuning these parameters is useful when alertmanager is under heavy load

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/578

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
