### PR TITLE
Fix unit tests in CI

### DIFF
--- a/pkg/mimir/sanity_check_test.go
+++ b/pkg/mimir/sanity_check_test.go
@@ -121,7 +121,7 @@ func TestCheckObjectStoresConfig(t *testing.T) {
 				for i, bucketCfg := range []*bucket.Config{&cfg.BlocksStorage.Bucket, &cfg.AlertmanagerStorage.Config, &cfg.RulerStorage.Config} {
 					bucketCfg.Backend = bucket.Azure
 					bucketCfg.Azure.ContainerName = "invalid"
-					bucketCfg.Azure.StorageAccountName = "xxx"
+					bucketCfg.Azure.StorageAccountName = ""
 					bucketCfg.Azure.StorageAccountKey = flagext.Secret{Value: "eHh4"}
 
 					// Set a different container name for blocks storage to avoid config validation error.


### PR DESCRIPTION
#### What this PR does
We have some PRs blocked because unit tests are failing in CI (unit tests timeout). After some debugging, I think it's caused by the Azure storage sanity check test. The problem looks caused by the fact that if the storage account name doesn't exist then the Azure library apparently looks infinitely. My wild guess is that previously `xxx` was existing, but now it has been removed.

This PR sets an empty container name, making if fail earlier in the check.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
