### PR TITLE
Fixed latest image tagging

### DIFF
--- a/push-images
+++ b/push-images
@@ -27,7 +27,7 @@ push_image() {
 
     # If image is the latest stable git tag, update the latest docker image tag.
     # Do not tag with latest any release candidate (tag ends with "-rc.*").
-    if [[ "$(git tag | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "${IMAGE_TAG}" ]]; then
+    if [[ "$(git tag | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "mimir-${IMAGE_TAG}" ]]; then
       docker tag "${image}:${IMAGE_TAG}" "${image}:latest"
       docker push "${image}:latest"
     fi


### PR DESCRIPTION
#### What this PR does
I've cut Mimir `2.0.0` but Docker images have **not** been tagged with `latest`. Reason is that `IMAGE_TAG` is `2.0.0` but git tag is `mimir-2.0.0`, so the two don't match when we compare them.

This PR should fix it.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
