### PR TITLE
Docs: improve internal doc and fix link

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -1,8 +1,3 @@
----
-title: Contributing
-weight: 10
----
-
 Welcome! We're excited that you're interested in contributing. Below are some basic guidelines.
 
 ## Workflow

--- a/docs/internal/contributing/design-patterns-and-conventions.md
+++ b/docs/internal/contributing/design-patterns-and-conventions.md
@@ -1,9 +1,3 @@
----
-title: "Design patterns and code conventions"
-description: ""
-weight: 10
----
-
 # Design patterns and code conventions
 
 Grafana Mimir adopts some design patterns and code conventions that we ask you to follow when contributing to the project. These conventions have been adopted based on the experience gained over the time and aim to enforce good coding practices and keep a consistent UX (ie. config).

--- a/docs/internal/contributing/how-integration-tests-work.md
+++ b/docs/internal/contributing/how-integration-tests-work.md
@@ -1,8 +1,3 @@
----
-title: "How integration tests work"
-weight: 5
----
-
 Mimir integration tests are written in Go and based on a [custom framework](https://github.com/grafana/mimir/tree/main/integration/e2e) running Mimir and its dependencies in Docker containers and using the Go [`testing`](https://golang.org/pkg/testing/) package for assertions. Integration tests run in CI for every PR, and can be easily executed locally during development (it just requires Docker).
 
 ## How to run integration tests

--- a/docs/internal/contributing/how-to-upgrade-golang-version.md
+++ b/docs/internal/contributing/how-to-upgrade-golang-version.md
@@ -1,8 +1,3 @@
----
-title: "How to upgrade Golang version"
-weight: 4
----
-
 To upgrade the Golang version:
 
 1. Upgrade build image version

--- a/docs/internal/contributing/how-to-write-documentation.md
+++ b/docs/internal/contributing/how-to-write-documentation.md
@@ -1,7 +1,3 @@
----
-title: "How to write documentation"
----
-
 # How to write documentation
 
 ## Style guide

--- a/docs/internal/how-to-update-the-build-image.md
+++ b/docs/internal/how-to-update-the-build-image.md
@@ -1,7 +1,3 @@
----
-title: "How to update the build image"
----
-
 The build image currently can only be updated by a Grafana Mimir maintainer. If you're not a maintainer you can still open a PR with the changes, asking a maintainer to assist you publishing the updated image. The procedure is:
 
 1. Update `mimir-build-image/Dockerfile`.

--- a/docs/internal/tools/compaction-planner.md
+++ b/docs/internal/tools/compaction-planner.md
@@ -1,9 +1,3 @@
----
-title: "Compaction planner tool"
-description: ""
-weight: 100
----
-
 # Compaction planner tool
 
 You can use the compaction planner tool to troubleshoot the Grafana Mimir compactor.

--- a/docs/internal/tools/list-deduplicated-blocks.md
+++ b/docs/internal/tools/list-deduplicated-blocks.md
@@ -1,9 +1,3 @@
----
-title: "List deduplicated blocks"
-description: ""
-weight: 100
----
-
 # List deduplicated blocks
 
 `list-deduplicated-blocks` downloads all `meta.json` files from tenants' debug/metas directory, removes duplicates

--- a/docs/internal/tools/query-step-alignment-analysis.md
+++ b/docs/internal/tools/query-step-alignment-analysis.md
@@ -1,9 +1,3 @@
----
-title: "Query Step Alignment analysis"
-description: ""
-weight: 100
----
-
 # Query Step Alignment analysis
 
 This tools allow to parse the query stats log messages of query-frontends to

--- a/docs/internal/tools/trafficdump.md
+++ b/docs/internal/tools/trafficdump.md
@@ -1,9 +1,3 @@
----
-title: "Trafficdump"
-description: ""
-weight: 100
----
-
 # Trafficdump
 
 Trafficdump is a tool that can read packets from captured `tcpdump` output, reassemble them into TCP streams

--- a/docs/internal/tools/tsdb-tools.md
+++ b/docs/internal/tools/tsdb-tools.md
@@ -1,9 +1,3 @@
----
-title: "TSDB Tools"
-description: ""
-weight: 100
----
-
 # TSDB Tools
 
 Grafana Mimir has multiple tools useful for inspecting or debugging TSDB blocks.

--- a/docs/internal/tools/ulidtime.md
+++ b/docs/internal/tools/ulidtime.md
@@ -1,9 +1,3 @@
----
-title: "ULID time"
-description: ""
-weight: 100
----
-
 # ULID time
 
 `ulidtime` is a tiny tool to parse [ULID](https://github.com/ulid/spec) and print the time embedded in it.

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,3 +1,3 @@
 # Grafana Mimir integration tests
 
-See "[How integration tests work](https://github.com/grafana/mimir/blob/main/docs/sources/contributing/how-integration-tests-work.md)".
+See "[How integration tests work](https://github.com/grafana/mimir/blob/main/docs/internal/contributing/how-integration-tests-work.md)".


### PR DESCRIPTION
#### What this PR does
The internal doc is not meant to be published to grafana.com, so in this PR:
- Remove frontmatter
- Rename `contributing/_index.md` to `contributing/README.md` so that it gets automatically displayed by GitHub
- Fix link in `integration/README.md`

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
