### PR TITLE
Symlink tutorials/ to docs/sources/tutorials/

### DIFF
--- a/tutorials
+++ b/tutorials
@@ -1,0 +1,1 @@
+docs/sources/tutorials


### PR DESCRIPTION
#### What this PR does
In the tutorial video we're saying the tutorial is available at `tutorials/play-with-grafana-mimir/`. After recording (and editing) the tutorial, we've been asked by docs squad to move it under `docs/sources/tutorials/play-with-grafana-mimir/`. To keep the location displayed in the video still working, I suggest to add a symlink.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
