### PR TITLE
Update gRPC settings in example config

### DIFF
--- a/docs/configurations/single-process-config-blocks-gossip-1.yaml
+++ b/docs/configurations/single-process-config-blocks-gossip-1.yaml
@@ -20,13 +20,6 @@ distributor:
   pool:
     health_check_ingesters: true
 
-ingester_client:
-  grpc_client_config:
-    # Configure the client to allow messages up to 100MB.
-    max_recv_msg_size: 104857600
-    max_send_msg_size: 104857600
-    grpc_compression: gzip
-
 ingester:
   ring:
     # The address to advertise for this ingester.  Will be autodiscovered by

--- a/docs/configurations/single-process-config-blocks-gossip-2.yaml
+++ b/docs/configurations/single-process-config-blocks-gossip-2.yaml
@@ -20,13 +20,6 @@ distributor:
   pool:
     health_check_ingesters: true
 
-ingester_client:
-  grpc_client_config:
-    # Configure the client to allow messages up to 100MB.
-    max_recv_msg_size: 104857600
-    max_send_msg_size: 104857600
-    grpc_compression: gzip
-
 ingester:
   ring:
     # The address to advertise for this ingester.  Will be autodiscovered by

--- a/docs/configurations/single-process-config-blocks-tls.yaml
+++ b/docs/configurations/single-process-config-blocks-tls.yaml
@@ -27,10 +27,6 @@ distributor:
 
 ingester_client:
   grpc_client_config:
-    # Configure the client to allow messages up to 100MB.
-    max_recv_msg_size: 104857600
-    max_send_msg_size: 104857600
-    grpc_compression: gzip
     tls_cert_path: "client.crt"
     tls_key_path: "client.key"
     tls_ca_path: "root.crt"

--- a/docs/configurations/single-process-config-blocks.yaml
+++ b/docs/configurations/single-process-config-blocks.yaml
@@ -22,13 +22,6 @@ distributor:
   pool:
     health_check_ingesters: true
 
-ingester_client:
-  grpc_client_config:
-    # Configure the client to allow messages up to 100MB.
-    max_recv_msg_size: 104857600
-    max_send_msg_size: 104857600
-    grpc_compression: gzip
-
 ingester:
   ring:
     # The address to advertise for this ingester.  Will be autodiscovered by


### PR DESCRIPTION
#### What this PR does
Triggered by a question from Bryan, I propose to change gRPC settings in example config as follows:
- Remove `max_recv_msg_size` and `max_send_msg_size` overrides because now they default to 100MB
- Remove `grpc_compression: gzip` because that's not how we recommend to run it (eg. not enabled in our jsonnet)

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
