### PR TITLE
Update backward compatibility test after Mimir 2.0.0 launch

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -200,6 +200,15 @@ jobs:
         run: |
           sudo mkdir -p /go/src/github.com/grafana/mimir
           sudo ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
+      # TODO Remove "Docker login" step after Mimir Docker Hub repo is public.
+      - name: Docker login
+        run: |
+          if [ -n "$DOCKER_PASSWORD" ]; then
+            printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
+          fi
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Download Docker Images Mimir Artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -200,15 +200,6 @@ jobs:
         run: |
           sudo mkdir -p /go/src/github.com/grafana/mimir
           sudo ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      # TODO Remove "Docker login" step after Mimir Docker Hub repo is public.
-      - name: Docker login
-        run: |
-          if [ -n "$DOCKER_PASSWORD" ]; then
-            printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
-          fi
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Download Docker Images Mimir Artifacts
         uses: actions/download-artifact@v2
         with:

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,12 +7,7 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"quay.io/cortexproject/cortex:v1.11.0": e2emimir.ChainFlagMappers(
-		cortexFlagMapper,
-		revertRenameFrontendToQueryFrontendFlagMapper,
-		ingesterRingRename,
-		ingesterRingNewFeatures,
-	),
+	"grafana/mimir:2.0.0": e2emimir.NoopFlagMapper,
 }
 
 var (

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -149,9 +149,6 @@ func NewIngester(name string, consulAddress string, flags map[string]string, opt
 }
 
 func getBinaryNameForBackwardsCompatibility(image string) string {
-	if strings.Contains(image, "quay.io/cortexproject/cortex") {
-		return "cortex"
-	}
 	return "mimir"
 }
 


### PR DESCRIPTION
#### What this PR does
Mimir 2.0.0 guarantees backward compatibility with Cortex. After 2.0.0 we'll keep testing backward compatibility against Mimir previous versions, so in this PR I'm changing the integration test to run against Mimir 2.0.0.

**Draft PR** until Mimir launch. After that we can remove the "Docker login" step.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
