### PR TITLE
Speed up tests in `github.com/grafana/mimir/pkg/mimirtool/config`

### DIFF
--- a/pkg/mimirtool/config/inspect.go
+++ b/pkg/mimirtool/config/inspect.go
@@ -644,7 +644,9 @@ var mimirConfigFlagsOnly []byte
 //go:embed descriptors/mimir-v2.0.0.json
 var mimirConfig []byte
 
-func DefaultMimirConfig() *InspectedEntry {
+var mimirConfigDeserialized = loadDefaultMimirConfig()
+
+func loadDefaultMimirConfig() *InspectedEntry {
 	cfg := &InspectedEntry{}
 	if err := json.Unmarshal(mimirConfig, cfg); err != nil {
 		panic(err)
@@ -665,13 +667,19 @@ func DefaultMimirConfig() *InspectedEntry {
 	return cfg
 }
 
+func DefaultMimirConfig() *InspectedEntry {
+	return mimirConfigDeserialized.Clone()
+}
+
 //go:embed descriptors/cortex-v1.11.0.json
 var oldCortexConfig []byte
 
 //go:embed descriptors/cortex-v1.11.0-flags-only.json
 var oldCortexConfigFlagsOnly []byte
 
-func DefaultCortexConfig() *InspectedEntry {
+var oldCortexConfigDeserialized = loadDefaultCortexConfig()
+
+func loadDefaultCortexConfig() *InspectedEntry {
 	cfg := &InspectedEntry{}
 	if err := json.Unmarshal(oldCortexConfig, cfg); err != nil {
 		panic(err)
@@ -692,13 +700,19 @@ func DefaultCortexConfig() *InspectedEntry {
 	return cfg
 }
 
+func DefaultCortexConfig() *InspectedEntry {
+	return oldCortexConfigDeserialized.Clone()
+}
+
 //go:embed descriptors/gem-v1.7.0.json
 var gem170CortexConfig []byte
 
 //go:embed descriptors/gem-v1.7.0-flags-only.json
 var gem170CortexConfigFlagsOnly []byte
 
-func DefaultGEM170Config() *InspectedEntry {
+var gem170CortexConfigDeserialized = loadDefaultGEM170Config()
+
+func loadDefaultGEM170Config() *InspectedEntry {
 	cfg := &InspectedEntry{}
 	if err := json.Unmarshal(gem170CortexConfig, cfg); err != nil {
 		panic(err)
@@ -719,13 +733,19 @@ func DefaultGEM170Config() *InspectedEntry {
 	return cfg
 }
 
+func DefaultGEM170Config() *InspectedEntry {
+	return gem170CortexConfigDeserialized.Clone()
+}
+
 //go:embed descriptors/gem-v2.0.0.json
 var gem200CortexConfig []byte
 
 //go:embed descriptors/gem-v2.0.0-flags-only.json
 var gem200CortexConfigFlagsOnly []byte
 
-func DefaultGEM200COnfig() *InspectedEntry {
+var gem200CortexConfigDeserialized = loadDefaultGEM200COnfig()
+
+func loadDefaultGEM200COnfig() *InspectedEntry {
 	cfg := &InspectedEntry{}
 	if err := json.Unmarshal(gem200CortexConfig, cfg); err != nil {
 		panic(err)
@@ -744,4 +764,8 @@ func DefaultGEM200COnfig() *InspectedEntry {
 		BlockEntries: cfgFlagsOnly.BlockEntries,
 	})
 	return cfg
+}
+
+func DefaultGEM200COnfig() *InspectedEntry {
+	return gem200CortexConfigDeserialized.Clone()
 }


### PR DESCRIPTION
#### What this PR does

This PR improves speed of tests in `github.com/grafana/mimir/pkg/mimirtool/config` package. Instead of each test doing JSON-unmarshalling of config files, we now do it once, and then make in-memory clone for each test.

This improves speed of tests in this package from `25.59s` to `3s` on my machine when running `go test -v -parallel 1 github.com/grafana/mimir/pkg/mimirtool/config`. (I'm running with `-parallel 1` to make tests slower. On my multicore machine they are normally plenty fast, but we see them being slow in CI).

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
