### PR TITLE
Chore: extract HTML templates to .gohtml files

### DIFF
--- a/pkg/alertmanager/alertmanager_http.go
+++ b/pkg/alertmanager/alertmanager_http.go
@@ -6,7 +6,7 @@
 package alertmanager
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"net/http"
 	"text/template"
 

--- a/pkg/alertmanager/alertmanager_http.go
+++ b/pkg/alertmanager/alertmanager_http.go
@@ -6,6 +6,7 @@
 package alertmanager
 
 import (
+	_ "embed"
 	"net/http"
 	"text/template"
 
@@ -16,34 +17,26 @@ import (
 )
 
 var (
-	ringStatusPageTemplate = template.Must(template.New("ringStatusPage").Parse(`
-	<!DOCTYPE html>
-	<html>
-		<head>
-			<meta charset="UTF-8">
-			<title>Alertmanager Ring</title>
-		</head>
-		<body>
-			<h1>Alertmanager Ring</h1>
-			<p>{{ .Message }}</p>
-		</body>
-	</html>`))
+	//go:embed ring_status.gohtml
+	ringStatusPageHTML     string
+	ringStatusPageTemplate = template.Must(template.New("ringStatusPage").Parse(ringStatusPageHTML))
 
-	statusTemplate = template.Must(template.New("statusPage").Parse(`
-    <!doctype html>
-    <html>
-        <head><title>Alertmanager Status</title></head>
-        <body>
-            <h1>Alertmanager Status: {{ .State }}</h1>
-        </body>
-    </html>`))
+	//go:embed status.gohtml
+	statusPageHTML     string
+	statusPageTemplate = template.Must(template.New("statusPage").Parse(statusPageHTML))
 )
+
+type ringStatusPageContents struct {
+	Message string
+}
+
+type statusPageContents struct {
+	State string
+}
 
 func writeRingStatusMessage(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusOK)
-	err := ringStatusPageTemplate.Execute(w, struct {
-		Message string
-	}{Message: message})
+	err := ringStatusPageTemplate.Execute(w, ringStatusPageContents{Message: message})
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "unable to serve alertmanager ring page", "err", err)
 	}
@@ -75,9 +68,7 @@ type StatusHandler struct {
 
 // ServeHTTP serves the status of the alertmanager.
 func (s StatusHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	err := statusTemplate.Execute(w, struct {
-		State string
-	}{
+	err := statusPageTemplate.Execute(w, statusPageContents{
 		State: s.am.State().String(),
 	})
 	if err != nil {

--- a/pkg/alertmanager/ring_status.gohtml
+++ b/pkg/alertmanager/ring_status.gohtml
@@ -1,0 +1,12 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/alertmanager.ringStatusPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Alertmanager Ring</title>
+</head>
+<body>
+<h1>Alertmanager Ring</h1>
+<p>{{ .Message }}</p>
+</body>
+</html>

--- a/pkg/alertmanager/status.gohtml
+++ b/pkg/alertmanager/status.gohtml
@@ -1,0 +1,11 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/alertmanager.statusPageContents*/ -}}
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Alertmanager Status</title>
+</head>
+<body>
+<h1>Alertmanager Status: {{ .State }}</h1>
+</body>
+</html>

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -49,7 +49,6 @@ type IndexPageContent struct {
 type IndexPageLinkGroup struct {
 	weight int
 	Desc   string
-	Path   string
 	Links  []IndexPageLink
 }
 
@@ -92,7 +91,11 @@ func (pc *IndexPageContent) GetContent() []IndexPageLinkGroup {
 }
 
 //go:embed index.gohtml
-var indexPageTemplate string
+var indexPageHTML string
+
+type indexPageContents struct {
+	LinkGroups []IndexPageLinkGroup
+}
 
 //go:embed static
 var staticFiles embed.FS
@@ -104,10 +107,10 @@ func indexHandler(httpPathPrefix string, content *IndexPageContent) http.Handler
 			return path.Join(httpPathPrefix, link)
 		},
 	})
-	template.Must(templ.Parse(indexPageTemplate))
+	template.Must(templ.Parse(indexPageHTML))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := templ.Execute(w, content.GetContent())
+		err := templ.Execute(w, indexPageContents{LinkGroups: content.GetContent()})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/pkg/api/index.gohtml
+++ b/pkg/api/index.gohtml
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/api.indexPageContents */ -}}
 <!DOCTYPE html>
 <html>
 <head>
@@ -20,19 +21,18 @@
         </h1>
     </div>
     <dl class="dl-horizontal">
-    {{ range $i, $ := . }}
-        {{- /*gotype: github.com/grafana/mimir/pkg/api.IndexPageLinkGroup */ -}}
-        {{ if $i }}
-            <hr>
-        {{ end }}
-            <dt><h2>{{ .Desc }}</h2></dt>
-            {{ range .Links }}
+        {{ range $i, $ := .LinkGroups }}
+            {{ if $i }}
+                <hr>
+            {{ end }}
+            <dt><h2>{{ $.Desc }}</h2></dt>
+            {{ range $.Links }}
                 <dd>
                     <a href="{{ AddPathPrefix .Path }}">{{ .Desc }}</a>
                     {{ if .Dangerous }}<span class="label label-danger">Dangerous</span>{{ end }}
                 </dd>
             {{ end }}
-    {{ end }}
+        {{ end }}
     </dl>
 </div>
 

--- a/pkg/compactor/compactor_http.go
+++ b/pkg/compactor/compactor_http.go
@@ -6,7 +6,7 @@
 package compactor
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"html/template"
 	"net/http"
 

--- a/pkg/compactor/compactor_http.go
+++ b/pkg/compactor/compactor_http.go
@@ -6,6 +6,7 @@
 package compactor
 
 import (
+	_ "embed"
 	"html/template"
 	"net/http"
 
@@ -16,25 +17,18 @@ import (
 )
 
 var (
-	compactorStatusPageTemplate = template.Must(template.New("main").Parse(`
-	<!DOCTYPE html>
-	<html>
-		<head>
-			<meta charset="UTF-8">
-			<title>Compactor Ring</title>
-		</head>
-		<body>
-			<h1>Compactor Ring</h1>
-			<p>{{ .Message }}</p>
-		</body>
-	</html>`))
+	//go:embed status.gohtml
+	statusPageHTML     string
+	statusPageTemplate = template.Must(template.New("main").Parse(statusPageHTML))
 )
+
+type statusPageContents struct {
+	Message string
+}
 
 func writeMessage(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusOK)
-	err := compactorStatusPageTemplate.Execute(w, struct {
-		Message string
-	}{Message: message})
+	err := statusPageTemplate.Execute(w, statusPageContents{Message: message})
 
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "unable to serve compactor ring page", "err", err)

--- a/pkg/compactor/status.gohtml
+++ b/pkg/compactor/status.gohtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Compactor Ring</title>
+</head>
+<body>
+<h1>Compactor Ring</h1>
+<p>{{ .Message }}</p>
+</body>
+</html>

--- a/pkg/distributor/ha_tracker_http.go
+++ b/pkg/distributor/ha_tracker_http.go
@@ -6,7 +6,7 @@
 package distributor
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"html/template"
 	"net/http"
 	"sort"

--- a/pkg/distributor/ha_tracker_http.go
+++ b/pkg/distributor/ha_tracker_http.go
@@ -6,6 +6,7 @@
 package distributor
 
 import (
+	_ "embed"
 	"html/template"
 	"net/http"
 	"sort"
@@ -16,65 +17,32 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-const trackerTpl = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>HA Tracker Status</title>
-	</head>
-	<body>
-		<h1>HA Tracker Status</h1>
-		<p>Current time: {{ .Now }}</p>
-		<table width="100%" border="1">
-			<thead>
-				<tr>
-					<th>User ID</th>
-					<th>Cluster</th>
-					<th>Replica</th>
-					<th>Elected Time</th>
-					<th>Time Until Update</th>
-					<th>Time Until Failover</th>
-				</tr>
-			</thead>
-			<tbody>
-				{{ range .Elected }}
-				<tr>
-					<td>{{ .UserID }}</td>
-					<td>{{ .Cluster }}</td>
-					<td>{{ .Replica }}</td>
-					<td>{{ .ElectedAt }}</td>
-					<td>{{ .UpdateTime }}</td>
-					<td>{{ .FailoverTime }}</td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-	</body>
-</html>`
+//go:embed ha_tracker_status.gohtml
+var haTrackerStatusPageHTML string
+var haTrackerStatusPageTemplate = template.Must(template.New("ha-tracker").Parse(haTrackerStatusPageHTML))
 
-var trackerTmpl *template.Template
+type haTrackerStatusPageContents struct {
+	Elected []haTrackerReplica `json:"elected"`
+	Now     time.Time          `json:"now"`
+}
 
-func init() {
-	trackerTmpl = template.Must(template.New("ha-tracker").Parse(trackerTpl))
+type haTrackerReplica struct {
+	UserID       string        `json:"userID"`
+	Cluster      string        `json:"cluster"`
+	Replica      string        `json:"replica"`
+	ElectedAt    time.Time     `json:"electedAt"`
+	UpdateTime   time.Duration `json:"updateDuration"`
+	FailoverTime time.Duration `json:"failoverDuration"`
 }
 
 func (h *haTracker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.electedLock.RLock()
-	type replica struct {
-		UserID       string        `json:"userID"`
-		Cluster      string        `json:"cluster"`
-		Replica      string        `json:"replica"`
-		ElectedAt    time.Time     `json:"electedAt"`
-		UpdateTime   time.Duration `json:"updateDuration"`
-		FailoverTime time.Duration `json:"failoverDuration"`
-	}
 
-	electedReplicas := []replica{}
+	var electedReplicas []haTrackerReplica
 	for userID, clusters := range h.clusters {
 		for cluster, entry := range clusters {
 			desc := &entry.elected
-			electedReplicas = append(electedReplicas, replica{
+			electedReplicas = append(electedReplicas, haTrackerReplica{
 				UserID:       userID,
 				Cluster:      cluster,
 				Replica:      desc.Replica,
@@ -96,11 +64,8 @@ func (h *haTracker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return first.Cluster < second.Cluster
 	})
 
-	util.RenderHTTPResponse(w, struct {
-		Elected []replica `json:"elected"`
-		Now     time.Time `json:"now"`
-	}{
+	util.RenderHTTPResponse(w, haTrackerStatusPageContents{
 		Elected: electedReplicas,
 		Now:     time.Now(),
-	}, trackerTmpl, req)
+	}, haTrackerStatusPageTemplate, req)
 }

--- a/pkg/distributor/ha_tracker_status.gohtml
+++ b/pkg/distributor/ha_tracker_status.gohtml
@@ -1,0 +1,36 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/distributor.haTrackerStatusPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>HA Tracker Status</title>
+</head>
+<body>
+<h1>HA Tracker Status</h1>
+<p>Current time: {{ .Now }}</p>
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>User ID</th>
+        <th>Cluster</th>
+        <th>Replica</th>
+        <th>Elected Time</th>
+        <th>Time Until Update</th>
+        <th>Time Until Failover</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{ range .Elected }}
+        <tr>
+            <td>{{ .UserID }}</td>
+            <td>{{ .Cluster }}</td>
+            <td>{{ .Replica }}</td>
+            <td>{{ .ElectedAt }}</td>
+            <td>{{ .UpdateTime }}</td>
+            <td>{{ .FailoverTime }}</td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/pkg/distributor/http_admin.go
+++ b/pkg/distributor/http_admin.go
@@ -6,6 +6,7 @@
 package distributor
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -17,49 +18,14 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-const tpl = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>Ingester Stats</title>
-	</head>
-	<body>
-		<h1>Ingester Stats</h1>
-		<p>Current time: {{ .Now }}</p>
-		<p><b>NB stats do not account for replication factor, which is currently set to {{ .ReplicationFactor }}</b></p>
-		<form action="" method="POST">
-			<input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
-			<table border="1">
-				<thead>
-					<tr>
-						<th>User</th>
-						<th># Series</th>
-						<th>Total Ingest Rate</th>
-						<th>API Ingest Rate</th>
-						<th>Rule Ingest Rate</th>
-					</tr>
-				</thead>
-				<tbody>
-					{{ range .Stats }}
-					<tr>
-						<td>{{ .UserID }}</td>
-						<td align='right'>{{ .UserStats.NumSeries }}</td>
-						<td align='right'>{{ printf "%.2f" .UserStats.IngestionRate }}</td>
-						<td align='right'>{{ printf "%.2f" .UserStats.APIIngestionRate }}</td>
-						<td align='right'>{{ printf "%.2f" .UserStats.RuleIngestionRate }}</td>
-					</tr>
-					{{ end }}
-				</tbody>
-			</table>
-		</form>
-	</body>
-</html>`
+//go:embed ingester_stats.gohtml
+var ingesterStatsPageHTML string
+var ingesterStatsPageTemplate = template.Must(template.New("webpage").Parse(ingesterStatsPageHTML))
 
-var tmpl *template.Template
-
-func init() {
-	tmpl = template.Must(template.New("webpage").Parse(tpl))
+type ingesterStatsPageContents struct {
+	Now               time.Time     `json:"now"`
+	Stats             []UserIDStats `json:"stats"`
+	ReplicationFactor int           `json:"replicationFactor"`
 }
 
 type userStatsByTimeseries []UserIDStats
@@ -90,13 +56,9 @@ func (d *Distributor) AllUserStatsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	util.RenderHTTPResponse(w, struct {
-		Now               time.Time     `json:"now"`
-		Stats             []UserIDStats `json:"stats"`
-		ReplicationFactor int           `json:"replicationFactor"`
-	}{
+	util.RenderHTTPResponse(w, ingesterStatsPageContents{
 		Now:               time.Now(),
 		Stats:             stats,
 		ReplicationFactor: d.ingestersRing.ReplicationFactor(),
-	}, tmpl, r)
+	}, ingesterStatsPageTemplate, r)
 }

--- a/pkg/distributor/http_admin.go
+++ b/pkg/distributor/http_admin.go
@@ -6,7 +6,7 @@
 package distributor
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"encoding/json"
 	"fmt"
 	"html/template"

--- a/pkg/distributor/ingester_stats.gohtml
+++ b/pkg/distributor/ingester_stats.gohtml
@@ -1,0 +1,38 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/distributor.ingesterStatsPageContents */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ingester Stats</title>
+</head>
+<body>
+<h1>Ingester Stats</h1>
+<p>Current time: {{ .Now }}</p>
+<p><b>NB stats do not account for replication factor, which is currently set to {{ .ReplicationFactor }}</b></p>
+<form action="" method="POST">
+    <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+    <table border="1">
+        <thead>
+        <tr>
+            <th>User</th>
+            <th># Series</th>
+            <th>Total Ingest Rate</th>
+            <th>API Ingest Rate</th>
+            <th>Rule Ingest Rate</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{ range .Stats }}
+            <tr>
+                <td>{{ .UserID }}</td>
+                <td align='right'>{{ .UserStats.NumSeries }}</td>
+                <td align='right'>{{ printf "%.2f" .UserStats.IngestionRate }}</td>
+                <td align='right'>{{ printf "%.2f" .UserStats.APIIngestionRate }}</td>
+                <td align='right'>{{ printf "%.2f" .UserStats.RuleIngestionRate }}</td>
+            </tr>
+        {{ end }}
+        </tbody>
+    </table>
+</form>
+</body>
+</html>

--- a/pkg/mimir/status.go
+++ b/pkg/mimir/status.go
@@ -6,7 +6,7 @@
 package mimir
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"html/template"
 	"net/http"
 	"sort"

--- a/pkg/mimir/status.go
+++ b/pkg/mimir/status.go
@@ -6,6 +6,7 @@
 package mimir
 
 import (
+	_ "embed"
 	"html/template"
 	"net/http"
 	"sort"
@@ -14,44 +15,18 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-const tpl = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>Services Status</title>
-	</head>
-	<body>
-		<h1>Services Status</h1>
-		<p>Current time: {{ .Now }}</p>
-		<table border="1">
-			<thead>
-				<tr>
-					<th>Service</th>
-					<th>Status</th>
-				</tr>
-			</thead>
-			<tbody>
-				{{ range .Services }}
-				<tr>
-					<td>{{ .Name }}</td>
-					<td>{{ .Status }}</td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-	</body>
-</html>`
+//go:embed status.gohtml
+var statusPageHTML string
+var statusPageTemplate = template.Must(template.New("webpage").Parse(statusPageHTML))
 
-var tmpl *template.Template
+type statusPageContents struct {
+	Now      time.Time       `json:"now"`
+	Services []renderService `json:"services"`
+}
 
 type renderService struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
-}
-
-func init() {
-	tmpl = template.Must(template.New("webpage").Parse(tpl))
 }
 
 func (t *Mimir) servicesHandler(w http.ResponseWriter, r *http.Request) {
@@ -70,11 +45,8 @@ func (t *Mimir) servicesHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// TODO: this could be extended to also print sub-services, if given service has any
-	util.RenderHTTPResponse(w, struct {
-		Now      time.Time       `json:"now"`
-		Services []renderService `json:"services"`
-	}{
+	util.RenderHTTPResponse(w, statusPageContents{
 		Now:      time.Now(),
 		Services: svcs,
-	}, tmpl, r)
+	}, statusPageTemplate, r)
 }

--- a/pkg/mimir/status.gohtml
+++ b/pkg/mimir/status.gohtml
@@ -1,0 +1,28 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/mimir.statusPageContents */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Services Status</title>
+</head>
+<body>
+<h1>Services Status</h1>
+<p>Current time: {{ .Now }}</p>
+<table border="1">
+    <thead>
+    <tr>
+        <th>Service</th>
+        <th>Status</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{ range .Services }}
+        <tr>
+            <td>{{ .Name }}</td>
+            <td>{{ .Status }}</td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/pkg/storegateway/blocks.gohtml
+++ b/pkg/storegateway/blocks.gohtml
@@ -1,0 +1,85 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.blocksContents */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Store-gateway: bucket tenant blocks</title>
+    </script>
+</head>
+<body>
+<h1>Store-gateway: bucket tenant blocks</h1>
+<p>Current time: {{ .Now }}</p>
+<p>Showing blocks for tenant: {{ .Tenant }}</p>
+<p>
+    {{ if not .ShowDeleted }}
+        <a href="{{ .ShowDeletedQuery }}">Show Deleted</a>
+    {{ end }}
+    {{ if not .ShowSources }}
+        <a href="{{ .ShowSourcesQuery }}">Show Sources</a>
+    {{ end }}
+    {{ if not .ShowParents }}
+        <a href="{{ .ShowParentsQuery }}">Show Parents</a>
+    {{ end }}
+</p>
+<p>
+    Use ?split_count= query param to show split compactor count preview.
+</p>
+<table border="1" cellpadding="5" style="border-collapse: collapse">
+    <thead>
+    <tr>
+        <th>Block ID</th>
+        {{ if .ShowSplitCount }}
+        <th>Split ID</th>{{ end }}
+        <th>ULID Time</th>
+        <th>Min Time</th>
+        <th>Max Time</th>
+        <th>Duration</th>
+        {{ if .ShowDeleted }}
+        <th>Deletion Time</th>{{ end }}
+        <th>Lvl</th>
+        <th>Size</th>
+        <th>Labels (excl. {{ .TSDBTenantIDExternalLabel }})</th>
+        {{ if .ShowSources }}
+        <th>Sources</th>{{ end }}
+        {{ if .ShowParents }}
+        <th>Parents</th>{{ end }}
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ $page := . }}
+    {{ range .FormattedBlocks }}
+        <tr>
+            <td>{{ .ULID }}</td>
+            {{ if $page.ShowSplitCount }}
+            <td>{{ .SplitCount }}</td>{{ end }}
+            <td>{{ .ULIDTime }}</td>
+            <td>{{ .MinTime }}</td>
+            <td>{{ .MaxTime }}</td>
+            <td>{{ .Duration }}</td>
+            {{ if $page.ShowDeleted }}
+            <td>{{ .DeletedTime }}</td>{{ end }}
+            <td>{{ .CompactionLevel }}</td>
+            <td>{{ .BlockSize }}</td>
+            <td>{{ .Labels }}</td>
+            {{ if $page.ShowSources }}
+                <td>
+                    {{ range $i, $source := .Sources }}
+                        {{ if $i }}<br>{{ end }}
+                        {{ . }}
+                    {{ end }}
+                </td>
+            {{ end }}
+            {{ if $page.ShowParents }}
+                <td>
+                    {{ range $i, $source := .Parents }}
+                        {{ if $i }}<br>{{ end }}
+                        {{ . }}
+                    {{ end }}
+                </td>
+            {{ end }}
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -3,6 +3,7 @@
 package storegateway
 
 import (
+	_ "embed"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -19,87 +20,47 @@ import (
 	"github.com/grafana/mimir/pkg/util/listblocks"
 )
 
-const blocksPageTemplate = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>Store-gateway: bucket tenant blocks</title>
-		</script>
-	</head>
-	<body>
-		<h1>Store-gateway: bucket tenant blocks</h1>
-		<p>Current time: {{ .Now }}</p>
-		<p>Showing blocks for tenant: {{ .Tenant }}</p>
-		<p>
-			{{ if not .ShowDeleted }}
-				<a href="{{ .ShowDeletedQuery }}">Show Deleted</a>
-			{{ end }}
-			{{ if not .ShowSources }}
-				<a href="{{ .ShowSourcesQuery }}">Show Sources</a>
-			{{ end }}
-			{{ if not .ShowParents }}
-				<a href="{{ .ShowParentsQuery }}">Show Parents</a>
-			{{ end }}
-		</p>
-		<p>
-			Use ?split_count= query param to show split compactor count preview.
-		</p>
-		<table border="1" cellpadding="5" style="border-collapse: collapse">
-			<thead>
-				<tr>
-					<th>Block ID</th>
-					{{ if .ShowSplitCount }}<th>Split ID</th>{{ end }}
-					<th>ULID Time</th>
-					<th>Min Time</th>
-					<th>Max Time</th>
-					<th>Duration</th>
-					{{ if .ShowDeleted }}<th>Deletion Time</th>{{ end }}
-					<th>Lvl</th>
-					<th>Size</th>
-					<th>Labels (excl. {{ .TSDBTenantIDExternalLabel }})</th>
-					{{ if .ShowSources }}<th>Sources</th>{{ end }}
-					{{ if .ShowParents }}<th>Parents</th>{{ end }}
-				</tr>
-			</thead>
-			<tbody style="font-family: monospace;">
-				{{ $page := . }}
-				{{ range .FormattedBlocks }}
-				<tr>
-					<td>{{ .ULID }}</td>
-					{{ if $page.ShowSplitCount }}<td>{{ .SplitCount }}</td>{{ end }}
-					<td>{{ .ULIDTime }}</td>
-					<td>{{ .MinTime }}</td>
-					<td>{{ .MaxTime }}</td>
-					<td>{{ .Duration }}</td>
-					{{ if $page.ShowDeleted }}<td>{{ .DeletedTime }}</td>{{ end }}
-					<td>{{ .CompactionLevel }}</td>
-					<td>{{ .BlockSize }}</td>
-					<td>{{ .Labels }}</td>
-					{{ if $page.ShowSources }}
-						<td>
-							{{ range $i, $source := .Sources }}
-								{{ if $i }}<br>{{ end }}
-								{{ . }}
-							{{ end }}
-						</td>
-					{{ end }}
-					{{ if $page.ShowParents }}
-						<td>
-							{{ range $i, $source := .Parents }}
-								{{ if $i }}<br>{{ end }}
-								{{ . }}
-							{{ end }}
-						</td>
-					{{ end }}
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-	</body>
-</html>`
+//go:embed blocks.gohtml
+var blocksPageHTML string
+var blocksPageTemplate = template.Must(template.New("webpage").Parse(blocksPageHTML))
 
-var blocksTemplate = template.Must(template.New("webpage").Parse(blocksPageTemplate))
+type blocksPageContents struct {
+	Now             time.Time            `json:"now"`
+	Tenant          string               `json:"tenant,omitempty"`
+	RichMetas       []richMeta           `json:"metas"`
+	FormattedBlocks []formattedBlockData `json:"-"`
+	ShowDeleted     bool                 `json:"-"`
+	ShowSplitCount  bool                 `json:"-"`
+	ShowSources     bool                 `json:"-"`
+	ShowParents     bool                 `json:"-"`
+
+	ShowDeletedQuery string `json:"-"`
+	ShowSourcesQuery string `json:"-"`
+	ShowParentsQuery string `json:"-"`
+
+	TSDBTenantIDExternalLabel string `json:"-"`
+}
+
+type formattedBlockData struct {
+	ULID            string
+	ULIDTime        string
+	SplitCount      *uint32
+	MinTime         string
+	MaxTime         string
+	Duration        string
+	DeletedTime     string
+	CompactionLevel int
+	BlockSize       string
+	Labels          string
+	Sources         []string
+	Parents         []string
+}
+
+type richMeta struct {
+	*metadata.Meta
+	DeletedTime *int64  `json:"deletedTime,omitempty"`
+	SplitID     *uint32 `json:"splitId,omitempty"`
+}
 
 func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
@@ -133,27 +94,6 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	metas := listblocks.SortBlocks(metasMap)
-
-	type formattedBlockData struct {
-		ULID            string
-		ULIDTime        string
-		SplitCount      *uint32
-		MinTime         string
-		MaxTime         string
-		Duration        string
-		DeletedTime     string
-		CompactionLevel int
-		BlockSize       string
-		Labels          string
-		Sources         []string
-		Parents         []string
-	}
-
-	type richMeta struct {
-		*metadata.Meta
-		DeletedTime *int64  `json:"deletedTime,omitempty"`
-		SplitID     *uint32 `json:"splitId,omitempty"`
-	}
 
 	formattedBlocks := make([]formattedBlockData, 0, len(metas))
 	richMetas := make([]richMeta, 0, len(metas))
@@ -202,22 +142,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 
-	util.RenderHTTPResponse(w, struct {
-		Now             time.Time            `json:"now"`
-		Tenant          string               `json:"tenant,omitempty"`
-		RichMetas       []richMeta           `json:"metas"`
-		FormattedBlocks []formattedBlockData `json:"-"`
-		ShowDeleted     bool                 `json:"-"`
-		ShowSplitCount  bool                 `json:"-"`
-		ShowSources     bool                 `json:"-"`
-		ShowParents     bool                 `json:"-"`
-
-		ShowDeletedQuery string `json:"-"`
-		ShowSourcesQuery string `json:"-"`
-		ShowParentsQuery string `json:"-"`
-
-		TSDBTenantIDExternalLabel string `json:"-"`
-	}{
+	util.RenderHTTPResponse(w, blocksPageContents{
 		Now:             time.Now(),
 		Tenant:          tenantID,
 		RichMetas:       richMetas,
@@ -233,7 +158,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		ShowParentsQuery: queryWithTrueBoolParam(*req.URL, req.Form, "show_parents"),
 
 		TSDBTenantIDExternalLabel: tsdb.TenantIDExternalLabel,
-	}, blocksTemplate, req)
+	}, blocksPageTemplate, req)
 }
 
 func queryWithTrueBoolParam(u url.URL, form url.Values, boolParam string) string {

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -3,7 +3,7 @@
 package storegateway
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"fmt"
 	"html/template"
 	"net/http"

--- a/pkg/storegateway/gateway_ring_http.go
+++ b/pkg/storegateway/gateway_ring_http.go
@@ -6,6 +6,7 @@
 package storegateway
 
 import (
+	_ "embed"
 	"net/http"
 	"text/template"
 
@@ -16,25 +17,18 @@ import (
 )
 
 var (
-	statusPageTemplate = template.Must(template.New("main").Parse(`
-	<!DOCTYPE html>
-	<html>
-		<head>
-			<meta charset="UTF-8">
-			<title>Store Gateway Ring</title>
-		</head>
-		<body>
-			<h1>Store Gateway Ring</h1>
-			<p>{{ .Message }}</p>
-		</body>
-	</html>`))
+	//go:embed ring_status.gohtml
+	ringStatusPageHTML     string
+	ringStatusPageTemplate = template.Must(template.New("main").Parse(ringStatusPageHTML))
 )
+
+type ringStatusPageContents struct {
+	Message string
+}
 
 func writeMessage(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusOK)
-	err := statusPageTemplate.Execute(w, struct {
-		Message string
-	}{Message: message})
+	err := ringStatusPageTemplate.Execute(w, ringStatusPageContents{Message: message})
 
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "unable to serve store gateway ring page", "err", err)

--- a/pkg/storegateway/gateway_ring_http.go
+++ b/pkg/storegateway/gateway_ring_http.go
@@ -6,7 +6,7 @@
 package storegateway
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"net/http"
 	"text/template"
 

--- a/pkg/storegateway/gateway_tenants_http.go
+++ b/pkg/storegateway/gateway_tenants_http.go
@@ -3,6 +3,7 @@
 package storegateway
 
 import (
+	_ "embed"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -11,34 +12,14 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-const tenantsPageTemplate = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>Store-gateway: bucket tenants</title>
-	</head>
-	<body>
-		<h1>Store-gateway: bucket tenants</h1>
-		<p>Current time: {{ .Now }}</p>
-		<table border="1" cellpadding="5" style="border-collapse: collapse">
-			<thead>
-				<tr>
-					<th>Tenant</th>
-				</tr>
-			</thead>
-			<tbody style="font-family: monospace;">
-				{{ range .Tenants }}
-				<tr>
-					<td><a href="tenant/{{ . }}/blocks">{{ . }}</a></td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-	</body>
-</html>`
+//go:embed tenants.gohtml
+var tenantsPageHTML string
+var tenantsTemplate = template.Must(template.New("webpage").Parse(tenantsPageHTML))
 
-var tenantsTemplate = template.Must(template.New("webpage").Parse(tenantsPageTemplate))
+type tenantsPageContents struct {
+	Now     time.Time `json:"now"`
+	Tenants []string  `json:"tenants,omitempty"`
+}
 
 func (s *StoreGateway) TenantsHandler(w http.ResponseWriter, req *http.Request) {
 	tenantIDs, err := s.stores.scanUsers(req.Context())
@@ -47,10 +28,7 @@ func (s *StoreGateway) TenantsHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	util.RenderHTTPResponse(w, struct {
-		Now     time.Time `json:"now"`
-		Tenants []string  `json:"tenants,omitempty"`
-	}{
+	util.RenderHTTPResponse(w, tenantsPageContents{
 		Now:     time.Now(),
 		Tenants: tenantIDs,
 	}, tenantsTemplate, req)

--- a/pkg/storegateway/gateway_tenants_http.go
+++ b/pkg/storegateway/gateway_tenants_http.go
@@ -3,7 +3,7 @@
 package storegateway
 
 import (
-	_ "embed"
+	_ "embed" // Used to embed html template
 	"fmt"
 	"html/template"
 	"net/http"

--- a/pkg/storegateway/ring_status.gohtml
+++ b/pkg/storegateway/ring_status.gohtml
@@ -1,0 +1,12 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.ringStatusPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Store Gateway Ring</title>
+</head>
+<body>
+<h1>Store Gateway Ring</h1>
+<p>{{ .Message }}</p>
+</body>
+</html>

--- a/pkg/storegateway/tenants.gohtml
+++ b/pkg/storegateway/tenants.gohtml
@@ -1,0 +1,26 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.tenantsPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Store-gateway: bucket tenants</title>
+</head>
+<body>
+<h1>Store-gateway: bucket tenants</h1>
+<p>Current time: {{ .Now }}</p>
+<table border="1" cellpadding="5" style="border-collapse: collapse">
+    <thead>
+    <tr>
+        <th>Tenant</th>
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ range .Tenants }}
+        <tr>
+            <td><a href="tenant/{{ . }}/blocks">{{ . }}</a></td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
#### What this PR does

Instead of having HTML in constants, extract them to `.gohtml` files, properly annotated with the type they expect to be rendering, and then embed them using the `//go:embed` directive.

Also standarize the usage across projects, variable for the HTML of page `foo` is called `fooPageHTML`, the template is `fooPageTemplate` and the struct that is being rendered is called `fooPageContents`.

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

Not needed, only moving code.

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
