### PR TITLE
Pass primary and secondary multiKV stores via CLI parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Jsonnet
 
+* [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.
+
 ### Mimirtool
 
 ### Tools

--- a/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
@@ -800,7 +800,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -902,7 +902,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -977,7 +977,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -1040,7 +1040,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1145,7 +1145,7 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -store.max-query-length=768h
         - -target=ruler
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1212,7 +1212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1309,7 +1309,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1420,7 +1420,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1746,7 +1746,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: grafana/mimir:mimir-2.0.0
+        image: grafana/mimir:2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
@@ -253,7 +253,7 @@ data:
   overrides.yaml: |
     multi_kv_config:
         mirror_enabled: false
-        primary: consul
+        primary: memberlist
     overrides: {}
 kind: ConfigMap
 metadata:
@@ -800,7 +800,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=distributor
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:
@@ -902,7 +902,7 @@ spec:
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: querier
         ports:
@@ -977,7 +977,7 @@ spec:
         - -server.http-write-timeout=1m
         - -store.max-query-length=12000h
         - -target=query-frontend
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:
@@ -1040,7 +1040,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=query-scheduler
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: query-scheduler
         ports:
@@ -1145,7 +1145,7 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -store.max-query-length=768h
         - -target=ruler
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ruler
         ports:
@@ -1212,7 +1212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: alertmanager
         ports:
@@ -1309,7 +1309,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=compactor
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:
@@ -1420,7 +1420,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -target=ingester
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: ingester
         ports:
@@ -1746,7 +1746,7 @@ spec:
         - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -target=store-gateway
-        image: grafana/mimir:2.0.0
+        image: grafana/mimir:mimir-2.0.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
         ports:

--- a/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary.jsonnet
+++ b/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary.jsonnet
@@ -1,0 +1,26 @@
+local mimir = import 'mimir/mimir.libsonnet';
+
+mimir {
+  _config+:: {
+    namespace: 'default',
+    external_url: 'http://test',
+
+    memberlist_ring_enabled: true,
+
+    blocks_storage_backend: 'gcs',
+    blocks_storage_bucket_name: 'blocks-bucket',
+    bucket_index_enabled: true,
+    query_scheduler_enabled: true,
+
+    ruler_enabled: true,
+    ruler_client_type: 'gcs',
+    ruler_storage_bucket_name: 'rules-bucket',
+
+    alertmanager_enabled: true,
+    alertmanager_client_type: 'gcs',
+    alertmanager_gcs_bucket_name: 'alerts-bucket',
+
+    multikv_migration_enabled: true,
+    multikv_switch_primary_secondary: true,
+  },
+}


### PR DESCRIPTION
#### What this PR does

This PR fixes passing of primary and secondary stores to `multi` KV config. These need to be passed via CLI, and not runtime config. 

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
