### PR TITLE
Fix "Services' status" page content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482 #1549
 * [ENHANCEMENT] Alertmanager: added `insight=true` field to alertmanager dispatch logs. #1379
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
+* [BUGFIX] Mimir: services' status content-type is now correctly set to `text/html`. #1575
 
 ### Mixin
 

--- a/pkg/mimir/status.go
+++ b/pkg/mimir/status.go
@@ -55,9 +55,6 @@ func init() {
 }
 
 func (t *Mimir) servicesHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(200)
-	w.Header().Set("Content-Type", "text/plain")
-
 	svcs := make([]renderService, 0)
 	for mod, s := range t.ServiceMap {
 		svcs = append(svcs, renderService{

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -83,7 +83,7 @@ func WriteYAMLResponse(w http.ResponseWriter, v interface{}) {
 	_, _ = w.Write(data)
 }
 
-// Sends message as text/plain response with 200 status code.
+// WriteTextResponse sends message as text/plain response with 200 status code.
 func WriteTextResponse(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "text/plain")
 
@@ -91,7 +91,7 @@ func WriteTextResponse(w http.ResponseWriter, message string) {
 	_, _ = w.Write([]byte(message))
 }
 
-// Sends message as text/html response with 200 status code.
+// WriteHTMLResponse sends message as text/html response with 200 status code.
 func WriteHTMLResponse(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -99,8 +99,8 @@ func WriteHTMLResponse(w http.ResponseWriter, message string) {
 	_, _ = w.Write([]byte(message))
 }
 
-// RenderHTTPResponse either responds with json or a rendered html page using the passed in template
-// by checking the Accepts header
+// RenderHTTPResponse either responds with JSON or a rendered HTML page using the passed in template
+// by checking the Accepts header.
 func RenderHTTPResponse(w http.ResponseWriter, v interface{}, t *template.Template, r *http.Request) {
 	accept := r.Header.Get("Accept")
 	if strings.Contains(accept, "application/json") {
@@ -108,6 +108,7 @@ func RenderHTTPResponse(w http.ResponseWriter, v interface{}, t *template.Templa
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/html; utf=8")
 	err := t.Execute(w, v)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -108,7 +108,7 @@ func RenderHTTPResponse(w http.ResponseWriter, v interface{}, t *template.Templa
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html; utf=8")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	err := t.Execute(w, v)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
#### What this PR does

It was forced to be `text/plain` for some reason. Removed that forcing, and added an explicit setting of `text/html` in RenderHTTPResponse when it's not YAML (comment says it will render HTML, so it's safe).

#### Which issue(s) this PR fixes or relates to

A new take to https://github.com/grafana/mimir/pull/1265

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
