### PR TITLE
Fix "Services' status" spelling

### DIFF
--- a/docs/sources/operators-guide/reference-http-api/index.md
+++ b/docs/sources/operators-guide/reference-http-api/index.md
@@ -149,7 +149,7 @@ GET /runtime_config?mode=diff
 
 This endpoint displays the differences between the Grafana Mimir default runtime configuration and the current runtime configuration.
 
-### Services status
+### Services' status
 
 ```
 GET /services

--- a/docs/sources/operators-guide/reference-http-api/index.md
+++ b/docs/sources/operators-guide/reference-http-api/index.md
@@ -26,7 +26,7 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Index page](#index-page)                                                             | _All services_          | `GET /`                                                                   |
 | [Configuration](#configuration)                                                       | _All services_          | `GET /config`                                                             |
 | [Runtime Configuration](#runtime-configuration)                                       | _All services_          | `GET /runtime_config`                                                     |
-| [Services status](#services-status)                                                   | _All services_          | `GET /services`                                                           |
+| [Services' status](#services-status)                                                  | _All services_          | `GET /services`                                                           |
 | [Readiness probe](#readiness-probe)                                                   | _All services_          | `GET /ready`                                                              |
 | [Metrics](#metrics)                                                                   | _All services_          | `GET /metrics`                                                            |
 | [Pprof](#pprof)                                                                       | _All services_          | `GET /debug/pprof`                                                        |

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -418,7 +418,7 @@ func (a *API) RegisterQueryScheduler(f *scheduler.Scheduler) {
 // or a future module manager #2291
 func (a *API) RegisterServiceMapHandler(handler http.Handler) {
 	a.indexPage.AddLinks(serviceStatusWeight, "Overview", []IndexPageLink{
-		{Desc: "Service status", Path: "/services"},
+		{Desc: "Services' status", Path: "/services"},
 	})
 	a.RegisterRoute("/services", handler, false, true, "GET")
 }

--- a/pkg/mimir/status.gohtml
+++ b/pkg/mimir/status.gohtml
@@ -3,10 +3,10 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Services Status</title>
+    <title>Services' status</title>
 </head>
 <body>
-<h1>Services Status</h1>
+<h1>Services' status</h1>
 <p>Current time: {{ .Now }}</p>
 <table border="1">
     <thead>


### PR DESCRIPTION
#### What this PR does

As @osg-grafana pointed out, this page is listing the status information about more than one service, so this is the correct spelling.

#### Which issue(s) this PR fixes or relates to

See: https://github.com/grafana/mimir/pull/1265#issuecomment-1047841452

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

_I don't think this deserves a changelog entry, right?_
