### PR TITLE
Add "Documentation request" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,15 +1,15 @@
 ---
 name: Documentation request
-about: Ask for documentation of a feature
+about: Ask for documentation to be added, changed, or removed
 title: "Docs: ..."
 labels: type/docs
 assignees: ""
 ---
 
-#### Is your documentation request related to a feature? Which one?
+#### Is your documentation request related to a feature? If so, which one?
 
-A clear and concise description of the feature you were trying to use, and what you were trying to achieve.
+A clear and concise description of the feature that you were trying to use, and what you were trying to achieve.
 
-#### Describe the solution you'd like
+#### Describe the solution that you’d like or the expected outcome
 
-A clear and concise description of the documentation you are missing.
+A clear and concise description of the documentation that you want to add, change, or remove.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,15 @@
+---
+name: Documentation request
+about: Ask for documentation of a feature
+title: "Docs: ..."
+labels: type/docs
+assignees: ""
+---
+
+#### Is your documentation request related to a feature? Which one?
+
+A clear and concise description of the feature you were trying to use, and what you were trying to achieve.
+
+#### Describe the solution you'd like
+
+A clear and concise description of the documentation you are missing.


### PR DESCRIPTION
#### What this PR does

Sometimes users just want docs: they don't want to report bugs or add a feature (well, docs are a feature, but you know what I mean).

Those issues have a slighly different structure, and they have to be labeled as `type/docs`.

This makes creating such requests easier.

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
