### PR TITLE
Split unit tests into groups to make them faster.

### DIFF
--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd `dirname $0` && pwd)
+MIMIR_DIR=$(realpath "${SCRIPT_DIR}/../../../")
+
+# Parse args.
+INDEX=""
+TOTAL=""
+
+while [[ $# -gt 0 ]]
+do
+  case "$1" in
+    --total)
+      TOTAL="$2"
+      shift # skip --total
+      shift # skip total value
+      ;;
+    --index)
+      INDEX="$2"
+      shift # skip --index
+      shift # skip index value
+      ;;
+    *)  break
+      ;;
+  esac
+done
+
+if [[ -z "$INDEX" ]]; then
+    echo "No --index provided."
+    exit 1
+fi
+
+if [[ -z "$TOTAL" ]]; then
+    echo "No --total provided."
+    exit 1
+fi
+
+# List all tests.
+ALL_TESTS=$(go list "${MIMIR_DIR}/..." | sort)
+
+# Filter tests by the requested group.
+GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX')
+
+echo "This group will run the following tests:"
+echo "$GROUP_TESTS"
+echo ""
+
+# shellcheck disable=SC2086 # we *want* word splitting of GROUP_TESTS.
+exec go test -tags=netgo -timeout 30m -race -count 1 ${GROUP_TESTS}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -87,6 +87,13 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
+    strategy:
+      # Do not abort other groups when one fails.
+      fail-fast: false
+      # Split tests into 4 groups.
+      matrix:
+        test_group_id:    [0, 1, 2, 3]
+        test_group_total: [4]
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
       credentials:
@@ -99,9 +106,11 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      # Note that we're running the 'test-with-race' target here which runs unit tests with the go data race detector
       - name: Run Tests
-        run: make BUILD_IN_CONTAINER=false test-with-race
+        run: |
+          echo "Running unit tests (group ${{ matrix.test_group_id }} of ${{ matrix.test_group_total }}) with Go version: $(go version)"
+          ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
+        
 
   test-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What this PR does
Similar to #592 this PR splits running of unit tests into groups that run in parallel. This should ideally make CI checks faster. 🤞 

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
