### PR TITLE
Update changelog, fix acl-token flags in help.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Alertmanager: added `insight=true` field to alertmanager dispatch logs. #1379
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 * [BUGFIX] Mimir: services' status content-type is now correctly set to `text/html`. #1575
+* [BUGFIX] Multikv: Fix panic when using using runtime config to set primary KV store used by `multi` KV. #1587
 
 ### Mixin
 

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -87,8 +87,6 @@ Usage of ./cmd/mimir/mimir:
     	Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.
   -alertmanager.receivers-firewall-block-private-addresses
     	True to block private and local addresses in Alertmanager receiver integrations. It blocks private addresses defined by  RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses), as well as loopback, local unicast and local multicast addresses.
-  -alertmanager.sharding-ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -alertmanager.sharding-ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -alertmanager.sharding-ring.etcd.endpoints value
@@ -201,8 +199,6 @@ Usage of ./cmd/mimir/mimir:
     	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
-  -compactor.ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -compactor.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -compactor.ring.etcd.endpoints value
@@ -225,8 +221,6 @@ Usage of ./cmd/mimir/mimir:
     	Configuration file to load.
   -distributor.ha-tracker.cluster string
     	Prometheus label to look for in samples to identify a Prometheus HA cluster. (default "cluster")
-  -distributor.ha-tracker.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -distributor.ha-tracker.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -distributor.ha-tracker.enable
@@ -251,8 +245,6 @@ Usage of ./cmd/mimir/mimir:
     	Per-tenant ingestion rate limit in samples per second. (default 10000)
   -distributor.ingestion-tenant-shard-size int
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
-  -distributor.ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -distributor.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -distributor.ring.etcd.endpoints value
@@ -279,8 +271,6 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of active series per metric name, across the cluster before replication. 0 to disable. (default 20000)
   -ingester.max-global-series-per-user int
     	The maximum number of active series per tenant, across the cluster before replication. 0 to disable. (default 150000)
-  -ingester.ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -ingester.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -ingester.ring.etcd.endpoints value
@@ -453,8 +443,6 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
   -ruler.max-rules-per-rule-group int
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
-  -ruler.ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -ruler.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -ruler.ring.etcd.endpoints value
@@ -483,8 +471,6 @@ Usage of ./cmd/mimir/mimir:
     	HTTP server listen address.
   -server.http-listen-port int
     	HTTP server listen port. (default 8080)
-  -store-gateway.sharding-ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
   -store-gateway.sharding-ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -store-gateway.sharding-ring.etcd.endpoints value

--- a/cmd/mimir/usage.go
+++ b/cmd/mimir/usage.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/grafana/dskit/flagext"
+
 	"github.com/grafana/mimir/pkg/mimir"
 	"github.com/grafana/mimir/pkg/util/fieldcategory"
 )
@@ -131,7 +133,7 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 		fields[fieldValue.Addr().Pointer()] = field
 
 		// Recurse if a struct
-		if field.Type.Kind() != reflect.Struct {
+		if field.Type.Kind() != reflect.Struct || ignoreStructType(field.Type) {
 			continue
 		}
 
@@ -141,6 +143,19 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 	}
 
 	return nil
+}
+
+var ignoredStructTypes = []reflect.Type{
+	reflect.TypeOf(flagext.Secret{}),
+}
+
+func ignoreStructType(fieldType reflect.Type) bool {
+	for _, t := range ignoredStructTypes {
+		if fieldType == t {
+			return true
+		}
+	}
+	return false
 }
 
 func getFlagName(fl *flag.Flag) string {

--- a/cmd/mimir/usage.go
+++ b/cmd/mimir/usage.go
@@ -145,6 +145,9 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 	return nil
 }
 
+// Descending into some structs breaks check for "advanced" category for some fields (eg. flagext.Secret),
+// because field itself is at the same memory address as the internal field in the struct, and advanced-category-check
+// then gets confused.
 var ignoredStructTypes = []reflect.Type{
 	reflect.TypeOf(flagext.Secret{}),
 }


### PR DESCRIPTION
#### What this PR does
This PR updates dskit to commit [6d48ca07ade5.](https://github.com/grafana/dskit/commit/6d48ca07ade59022d5e1467c7f72cbfa01aecfa6). This fixes panic in `multi` KV store implementation when using runtime config to change primary KV store used by `multi`.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
