### PR TITLE
Remove unneeded secrets from workflow

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -21,9 +21,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
-      credentials:
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -39,9 +36,6 @@ jobs:
         run: |
           git config --global url."https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/grafana/mimir-prometheus".insteadOf "https://github.com/grafana/mimir-prometheus"
           make BUILD_IN_CONTAINER=false mod-check
-        env:
-          GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}
-          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
       - name: Check Protos
         run: make BUILD_IN_CONTAINER=false check-protos
       - name: Check Generated Documentation
@@ -59,9 +53,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
-      credentials:
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -79,9 +70,6 @@ jobs:
         run: |
           git config --global url."https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/grafana/mimir".insteadOf "https://github.com/grafana/mimir"
           make BUILD_IN_CONTAINER=false check-jsonnet-getting-started
-        env:
-          GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}
-          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
       - name: Check Jsonnet Tests
         run: make BUILD_IN_CONTAINER=false check-jsonnet-tests
 
@@ -96,9 +84,6 @@ jobs:
         test_group_total: [4]
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
-      credentials:
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -125,9 +110,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
-      credentials:
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -157,9 +139,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
-      credentials:
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -240,9 +219,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
-      credentials:
-        username: ${{ secrets.docker_username }}
-        password: ${{ secrets.docker_password }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Lint
         run: make BUILD_IN_CONTAINER=false lint
       - name: Check Vendor Directory
-        run: |
-          git config --global url."https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/grafana/mimir-prometheus".insteadOf "https://github.com/grafana/mimir-prometheus"
-          make BUILD_IN_CONTAINER=false mod-check
+        run: make BUILD_IN_CONTAINER=false mod-check
       - name: Check Protos
         run: make BUILD_IN_CONTAINER=false check-protos
       - name: Check Generated Documentation
@@ -67,9 +65,7 @@ jobs:
       - name: Check Jsonnet Manifests
         run: make BUILD_IN_CONTAINER=false check-jsonnet-manifests
       - name: Check Jsonnet Getting Started
-        run: |
-          git config --global url."https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/grafana/mimir".insteadOf "https://github.com/grafana/mimir"
-          make BUILD_IN_CONTAINER=false check-jsonnet-getting-started
+        run: make BUILD_IN_CONTAINER=false check-jsonnet-getting-started
       - name: Check Jsonnet Tests
         run: make BUILD_IN_CONTAINER=false check-jsonnet-tests
 


### PR DESCRIPTION
#### What this PR does

This PR removes secrets used to access build-image and mimir-prometheus repository, since these are now public. Secrets are not passed to workflows that are triggered by a pull request from a fork, which causes checks from external people to fail.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
