### PR TITLE
Added range query support to write-read-series-test in mimir-continuous-test tool

### DIFF
--- a/pkg/continuoustest/client_test.go
+++ b/pkg/continuoustest/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -48,6 +49,7 @@ func TestClient_WriteSeries(t *testing.T) {
 	flagext.DefaultValues(&cfg)
 	cfg.WriteBatchSize = 10
 	require.NoError(t, cfg.WriteBaseEndpoint.Set(server.URL))
+	require.NoError(t, cfg.ReadBaseEndpoint.Set(server.URL))
 
 	c, err := NewClient(cfg, log.NewNopLogger())
 	require.NoError(t, err)
@@ -112,4 +114,9 @@ type ClientMock struct {
 func (m *ClientMock) WriteSeries(ctx context.Context, series []prompb.TimeSeries) (int, error) {
 	args := m.Called(ctx, series)
 	return args.Int(0), args.Error(1)
+}
+
+func (m *ClientMock) QueryRange(ctx context.Context, query string, start, end time.Time, step time.Duration) (model.Matrix, error) {
+	args := m.Called(ctx, query, start, end, step)
+	return args.Get(0).(model.Matrix), args.Error(1)
 }

--- a/pkg/continuoustest/metrics.go
+++ b/pkg/continuoustest/metrics.go
@@ -10,8 +10,12 @@ import (
 // TestMetrics holds generic metrics tracked by tests. The common metrics are used to enforce the same
 // metric names and labels to track the same information across different tests.
 type TestMetrics struct {
-	writesTotal       prometheus.Counter
-	writesFailedTotal *prometheus.CounterVec
+	writesTotal                  prometheus.Counter
+	writesFailedTotal            *prometheus.CounterVec
+	queriesTotal                 prometheus.Counter
+	queriesFailedTotal           prometheus.Counter
+	queryResultChecksTotal       prometheus.Counter
+	queryResultChecksFailedTotal prometheus.Counter
 }
 
 func NewTestMetrics(testName string, reg prometheus.Registerer) *TestMetrics {
@@ -26,5 +30,25 @@ func NewTestMetrics(testName string, reg prometheus.Registerer) *TestMetrics {
 			Help:        "Total number of failed write requests.",
 			ConstLabels: map[string]string{"test": testName},
 		}, []string{"status_code"}),
+		queriesTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "mimir_continuous_test_queries_total",
+			Help:        "Total number of attempted query requests.",
+			ConstLabels: map[string]string{"test": testName},
+		}),
+		queriesFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "mimir_continuous_test_queries_failed_total",
+			Help:        "Total number of failed query requests.",
+			ConstLabels: map[string]string{"test": testName},
+		}),
+		queryResultChecksTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "mimir_continuous_test_query_result_checks_total",
+			Help:        "Total number of query results checked for correctness.",
+			ConstLabels: map[string]string{"test": testName},
+		}),
+		queryResultChecksFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "mimir_continuous_test_query_result_checks_failed_total",
+			Help:        "Total number of query results failed when checking for correctness.",
+			ConstLabels: map[string]string{"test": testName},
+		}),
 	}
 }

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -3,15 +3,41 @@
 package continuoustest
 
 import (
+	"fmt"
 	"math"
+	"math/rand"
 	"strconv"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
+)
+
+const (
+	maxComparisonDelta = 0.001
 )
 
 func alignTimestampToInterval(ts time.Time, interval time.Duration) time.Time {
 	return ts.Truncate(interval)
+}
+
+// getQueryStep returns the query step to use to run a test query. The returned step
+// is a guaranteed to be a multiple of alignInterval.
+func getQueryStep(start, end time.Time, alignInterval time.Duration) time.Duration {
+	const maxSamples = 1000
+
+	// Compute the number of samples that we would have if we query every single sample.
+	actualSamples := end.Sub(start) / alignInterval
+	if actualSamples <= maxSamples {
+		return alignInterval
+	}
+
+	// Adjust the query step based on the max steps spread over the query time range,
+	// rounding it to alignInterval.
+	step := end.Sub(start) / time.Duration(maxSamples)
+	step = ((step / alignInterval) + 1) * alignInterval
+
+	return step
 }
 
 func generateSineWaveSeries(name string, t time.Time, numSeries int) []prompb.TimeSeries {
@@ -41,4 +67,67 @@ func generateSineWaveValue(t time.Time) float64 {
 	period := 10 * time.Minute
 	radians := 2 * math.Pi * float64(t.UnixNano()) / float64(period.Nanoseconds())
 	return math.Sin(radians)
+}
+
+// verifySineWaveSamplesSum assumes the input matrix is the result of a range query summing the values
+// of expectedSeries sine wave series and checks whether the actual values match the expected ones.
+// Returns error if values don't match.
+func verifySineWaveSamplesSum(matrix model.Matrix, expectedSeries int, expectedStep time.Duration) error {
+	if len(matrix) != 1 {
+		return fmt.Errorf("expected 1 series in the result but got %d", len(matrix))
+	}
+
+	samples := matrix[0].Values
+
+	for idx, sample := range samples {
+		ts := time.UnixMilli(int64(sample.Timestamp)).UTC()
+
+		// Assert on value.
+		expectedValue := generateSineWaveValue(ts)
+		if !compareSampleValues(float64(sample.Value), expectedValue*float64(expectedSeries)) {
+			return fmt.Errorf("sample at timestamp %d (%s) has value %f while was expecting %f", sample.Timestamp, ts.String(), sample.Value, expectedValue)
+		}
+
+		// Assert on sample timestamp. We expect no gaps.
+		if idx > 0 {
+			prevTs := time.UnixMilli(int64(samples[idx-1].Timestamp)).UTC()
+			expectedTs := prevTs.Add(expectedStep)
+
+			if ts.UnixMilli() != expectedTs.UnixMilli() {
+				return fmt.Errorf("sample at timestamp %d (%s) was expected to have timestamp %d (%s) because previous sample had timestamp %d (%s)",
+					sample.Timestamp, ts.String(), expectedTs.UnixMilli(), expectedTs.String(), prevTs.UnixMilli(), prevTs.String())
+			}
+		}
+	}
+
+	return nil
+}
+
+func compareSampleValues(actual, expected float64) bool {
+	delta := math.Abs((actual - expected) / maxComparisonDelta)
+	return delta < maxComparisonDelta
+}
+
+func minTime(first, second time.Time) time.Time {
+	if first.After(second) {
+		return second
+	}
+	return first
+}
+
+func maxTime(first, second time.Time) time.Time {
+	if first.After(second) {
+		return first
+	}
+	return second
+}
+
+func randTime(min, max time.Time) time.Time {
+	delta := max.Unix() - min.Unix()
+	if delta <= 0 {
+		return min
+	}
+
+	sec := rand.Int63n(delta) + min.Unix()
+	return time.Unix(sec, 0)
 }

--- a/pkg/continuoustest/util_test.go
+++ b/pkg/continuoustest/util_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAlignTimestampToInterval(t *testing.T) {
@@ -14,4 +16,132 @@ func TestAlignTimestampToInterval(t *testing.T) {
 	assert.Equal(t, time.Unix(30, 0), alignTimestampToInterval(time.Unix(31, 0), 10*time.Second))
 	assert.Equal(t, time.Unix(30, 0), alignTimestampToInterval(time.Unix(39, 0), 10*time.Second))
 	assert.Equal(t, time.Unix(40, 0), alignTimestampToInterval(time.Unix(40, 0), 10*time.Second))
+}
+
+func TestGetQueryStep(t *testing.T) {
+	tests := map[string]struct {
+		start         time.Time
+		end           time.Time
+		writeInterval time.Duration
+		expectedStep  time.Duration
+	}{
+		"should return write interval if expected number of samples is < 1000": {
+			start:         time.UnixMilli(0),
+			end:           time.UnixMilli(3600 * 1000),
+			writeInterval: 10 * time.Second,
+			expectedStep:  10 * time.Second,
+		},
+		"should align step to write interval and guarantee no more than 1000 samples": {
+			start:         time.UnixMilli(0),
+			end:           time.UnixMilli(86400 * 1000),
+			writeInterval: 10 * time.Second,
+			expectedStep:  90 * time.Second,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualStep := getQueryStep(testData.start, testData.end, testData.writeInterval)
+			assert.Equal(t, testData.expectedStep, actualStep)
+		})
+	}
+}
+
+func TestVerifySineWaveSamplesSums(t *testing.T) {
+	// Round to millis since that's the precision of Prometheus timestamps.
+	now := time.UnixMilli(time.Now().UnixMilli()).UTC()
+
+	tests := map[string]struct {
+		samples        []model.SamplePair
+		expectedSeries int
+		expectedStep   time.Duration
+		expectedErr    string
+	}{
+		"should return no error if all samples value and timestamp match the expected one (1 series)": {
+			samples: []model.SamplePair{
+				newSamplePair(now.Add(10*time.Second), generateSineWaveValue(now.Add(10*time.Second))),
+				newSamplePair(now.Add(20*time.Second), generateSineWaveValue(now.Add(20*time.Second))),
+				newSamplePair(now.Add(30*time.Second), generateSineWaveValue(now.Add(30*time.Second))),
+			},
+			expectedSeries: 1,
+			expectedStep:   10 * time.Second,
+			expectedErr:    "",
+		},
+		"should return no error if all samples value and timestamp match the expected one (multiple series)": {
+			samples: []model.SamplePair{
+				newSamplePair(now.Add(10*time.Second), 5*generateSineWaveValue(now.Add(10*time.Second))),
+				newSamplePair(now.Add(20*time.Second), 5*generateSineWaveValue(now.Add(20*time.Second))),
+				newSamplePair(now.Add(30*time.Second), 5*generateSineWaveValue(now.Add(30*time.Second))),
+			},
+			expectedSeries: 5,
+			expectedStep:   10 * time.Second,
+			expectedErr:    "",
+		},
+		"should return error if there's a missing series": {
+			samples: []model.SamplePair{
+				newSamplePair(now.Add(10*time.Second), 4*generateSineWaveValue(now.Add(10*time.Second))),
+				newSamplePair(now.Add(20*time.Second), 4*generateSineWaveValue(now.Add(20*time.Second))),
+				newSamplePair(now.Add(30*time.Second), 4*generateSineWaveValue(now.Add(30*time.Second))),
+			},
+			expectedSeries: 5,
+			expectedStep:   10 * time.Second,
+			expectedErr:    "sample at timestamp .* has value .* while was expecting .*",
+		},
+		"should return error if there's a missing sample": {
+			samples: []model.SamplePair{
+				newSamplePair(now.Add(10*time.Second), 5*generateSineWaveValue(now.Add(10*time.Second))),
+				newSamplePair(now.Add(30*time.Second), 5*generateSineWaveValue(now.Add(30*time.Second))),
+			},
+			expectedSeries: 5,
+			expectedStep:   10 * time.Second,
+			expectedErr:    "sample at timestamp .* was expected to have timestamp .*",
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			matrix := model.Matrix{{Values: testData.samples}}
+			actual := verifySineWaveSamplesSum(matrix, testData.expectedSeries, testData.expectedStep)
+			if testData.expectedErr == "" {
+				assert.NoError(t, actual)
+			} else {
+				assert.Error(t, actual)
+				assert.Regexp(t, testData.expectedErr, actual.Error())
+			}
+		})
+	}
+}
+
+func TestMinTime(t *testing.T) {
+	first := time.Now()
+	second := first.Add(time.Second)
+
+	assert.Equal(t, first, minTime(first, second))
+	assert.Equal(t, first, minTime(second, first))
+}
+
+func TestMaxTime(t *testing.T) {
+	first := time.Now()
+	second := first.Add(time.Second)
+
+	assert.Equal(t, second, maxTime(first, second))
+	assert.Equal(t, second, maxTime(second, first))
+}
+
+func TestRandTime(t *testing.T) {
+	min := time.Unix(1000, 0)
+	max := time.Unix(10000, 0)
+
+	for i := 0; i < 100; i++ {
+		actual := randTime(min, max)
+		require.GreaterOrEqual(t, actual.Unix(), min.Unix())
+		require.LessOrEqual(t, actual.Unix(), max.Unix())
+	}
+}
+
+func newSamplePair(ts time.Time, value float64) model.SamplePair {
+	return model.SamplePair{
+		Timestamp: model.Time(ts.UnixMilli()),
+		Value:     model.SampleValue(value),
+	}
 }

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -5,6 +5,7 @@ package continuoustest
 import (
 	"context"
 	"flag"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -19,11 +20,13 @@ const (
 )
 
 type WriteReadSeriesTestConfig struct {
-	NumSeries int
+	NumSeries   int
+	MaxQueryAge time.Duration
 }
 
 func (cfg *WriteReadSeriesTestConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.NumSeries, "tests.write-read-series-test.num-series", 10000, "Number of series used for the test.")
+	f.DurationVar(&cfg.MaxQueryAge, "tests.write-read-series-test.max-query-age", 7*24*time.Hour, "How back in the past metrics can be queried at most.")
 }
 
 type WriteReadSeriesTest struct {
@@ -81,8 +84,6 @@ func (t *WriteReadSeriesTest) Run(ctx context.Context, now time.Time) {
 		// assert on query results due to possible gaps.
 		if statusCode/100 == 4 {
 			t.lastWrittenTimestamp = timestamp
-
-			// TODO The following reset is related to the read path (not implemented yet), but was added to ensure we don't forget about it.
 			t.queryMinTime = time.Time{}
 			t.queryMaxTime = time.Time{}
 			continue
@@ -96,9 +97,93 @@ func (t *WriteReadSeriesTest) Run(ctx context.Context, now time.Time) {
 
 		// The write request succeeded.
 		t.lastWrittenTimestamp = timestamp
+		t.queryMaxTime = timestamp
+		if t.queryMinTime.IsZero() {
+			t.queryMinTime = timestamp
+		}
 	}
 
-	// TODO Here we should query the written data and assert on correctness.
+	for _, timeRange := range t.getRangeQueryTimeRanges(now) {
+		t.runRangeQueryAndVerifyResult(ctx, timeRange[0], timeRange[1])
+	}
+}
+
+// getRangeQueryTimeRanges returns the start/end time ranges to use to run test range queries.
+func (t *WriteReadSeriesTest) getRangeQueryTimeRanges(now time.Time) (ranges [][2]time.Time) {
+	// The min and max allowed query timestamps are zero if there's no successfully written data yet.
+	if t.queryMinTime.IsZero() || t.queryMaxTime.IsZero() {
+		level.Info(t.logger).Log("msg", "Skipped range queries because there's no valid time range to query")
+		return nil
+	}
+
+	// Honor the configured max age.
+	adjustedQueryMinTime := maxTime(t.queryMinTime, now.Add(-t.cfg.MaxQueryAge))
+	if t.queryMaxTime.Before(adjustedQueryMinTime) {
+		level.Info(t.logger).Log("msg", "Skipped range queries because there's no valid time range to query after honoring configured max query age", "min_valid_time", t.queryMinTime, "max_valid_time", t.queryMaxTime, "max_query_age", t.cfg.MaxQueryAge)
+		return
+	}
+
+	// Last 1h.
+	if t.queryMaxTime.After(now.Add(-1 * time.Hour)) {
+		ranges = append(ranges, [2]time.Time{
+			maxTime(adjustedQueryMinTime, now.Add(-1*time.Hour)),
+			minTime(t.queryMaxTime, now),
+		})
+	}
+
+	// Last 24h (only if the actual time range is not already covered by "Last 1h").
+	if t.queryMaxTime.After(now.Add(-24*time.Hour)) && adjustedQueryMinTime.Before(now.Add(-1*time.Hour)) {
+		ranges = append(ranges, [2]time.Time{
+			maxTime(adjustedQueryMinTime, now.Add(-24*time.Hour)),
+			minTime(t.queryMaxTime, now),
+		})
+	}
+
+	// From last 23h to last 24h.
+	if adjustedQueryMinTime.Before(now.Add(-23*time.Hour)) && t.queryMaxTime.After(now.Add(-23*time.Hour)) {
+		ranges = append(ranges, [2]time.Time{
+			maxTime(adjustedQueryMinTime, now.Add(-24*time.Hour)),
+			minTime(t.queryMaxTime, now.Add(-23*time.Hour)),
+		})
+	}
+
+	// A random time range.
+	randMinTime := randTime(adjustedQueryMinTime, t.queryMaxTime)
+	ranges = append(ranges, [2]time.Time{randMinTime, randTime(randMinTime, t.queryMaxTime)})
+
+	return ranges
+}
+
+func (t *WriteReadSeriesTest) runRangeQueryAndVerifyResult(ctx context.Context, start, end time.Time) {
+	// We align start, end and step to write interval in order to avoid any false positives
+	// when checking results correctness. The min/max query time is always aligned.
+	start = maxTime(t.queryMinTime, alignTimestampToInterval(start, writeInterval))
+	end = minTime(t.queryMaxTime, alignTimestampToInterval(end, writeInterval))
+	if end.Before(start) {
+		return
+	}
+
+	step := getQueryStep(start, end, writeInterval)
+	query := fmt.Sprintf("sum(%s)", metricName)
+
+	logger := log.With(t.logger, "query", query, "start", start.Unix(), "end", end.Unix(), "step", step)
+	level.Debug(logger).Log("msg", "Running range query")
+
+	t.metrics.queriesTotal.Inc()
+	matrix, err := t.client.QueryRange(ctx, query, start, end, step)
+	if err != nil {
+		t.metrics.queriesFailedTotal.Inc()
+		level.Warn(logger).Log("msg", "Failed to execute range query", "err", err)
+		return
+	}
+
+	t.metrics.queryResultChecksTotal.Inc()
+	err = verifySineWaveSamplesSum(matrix, t.cfg.NumSeries, step)
+	if err != nil {
+		t.metrics.queryResultChecksFailedTotal.Inc()
+		level.Warn(logger).Log("msg", "Range query result check failed", "err", err)
+		return
+	}
 }
 
 func (t *WriteReadSeriesTest) nextWriteTimestamp(now time.Time) time.Time {

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -166,7 +166,7 @@ func (t *WriteReadSeriesTest) runRangeQueryAndVerifyResult(ctx context.Context, 
 	step := getQueryStep(start, end, writeInterval)
 	query := fmt.Sprintf("sum(%s)", metricName)
 
-	logger := log.With(t.logger, "query", query, "start", start.Unix(), "end", end.Unix(), "step", step)
+	logger := log.With(t.logger, "query", query, "start", start.UnixMilli(), "end", end.UnixMilli(), "step", step)
 	level.Debug(logger).Log("msg", "Running range query")
 
 	t.metrics.queriesTotal.Inc()


### PR DESCRIPTION
#### What this PR does
In this PR I'm adding support to query back written series (using range query) to write-read-series-test in mimir-continuous-test tool.

At each interval, after writing series the tool query back the time range successfully written until that point in time. The queried time ranges are:
- Last 1h
- Last 24h
- From last 23h to last 24h
- Random time range (up until the configured max query age)

**Out of the scope of this PR** (will be done in follow up PRs):
- Test instant query
- Query results cache disabled too
- Find the previously written samples at startup, so that it can continue write and read after a restart
- CHANGELOG
- Doc

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
