### PR TITLE
Don't hardcode BUILD_IN_CONTAINER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
-BUILD_IN_CONTAINER := true
+BUILD_IN_CONTAINER ?= true
 LATEST_BUILD_IMAGE_TAG ?= update-go-1.17.8-8a996bb57
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,


### PR DESCRIPTION
#### What this PR does

This PR allows BUILD_IN_CONTAINER variable to be set by environment variable as well (in shell-profile script, or `BUILD_IN_CONTAINER=false make ...`) and not just as variable override (`make BUILD_IN_CONTAINER=false ...`)

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
