### PR TITLE
Dashboards: Remove per-user series legends from Tenants dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
     - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
     - `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
-* [CHANGE] Operations: Remove per-user series legends from Tenants dashboard. #1605
+* [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [CHANGE] Default values have changed for the following settings: #1547
     - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
     - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
-- `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
+    - `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
 * [CHANGE] Operations: Remove per-user series legends from Tenants dashboard. #1605
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
     - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
     - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
     - `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
-* [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
@@ -32,8 +31,9 @@
 
 ### Jsonnet
 
-* [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.
+* [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [ENHANCEMENT] Ingester anti-affinity can now be disabled by using `ingester_allow_multiple_replicas_on_same_node` configuration key. #1581
+* [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * [CHANGE] Default values have changed for the following settings: #1547
     - `-alertmanager.alertmanager-client.grpc-max-recv-msg-size` now defaults to 100 MiB (previously was not configurable and set to 16 MiB)
     - `-alertmanager.alertmanager-client.grpc-max-send-msg-size` now defaults to 100 MiB (previously was not configurable and set to 4 MiB)
-    - `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
+- `-alertmanager.max-recv-msg-size` now defaults to 100 MiB (previously was 16 MiB)
+* [CHANGE] Operations: Remove per-user series legends from Tenants dashboard. #1605
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -26,8 +26,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.queryPanel(
           [
             |||
-              sum by (user) (
-                cortex_ingester_active_series{%(ingester)s, user=~"$user"}
+              sum(
+                cortex_ingester_active_series{%(ingester)s, user="$user"}
                 / on(%(group_by_cluster)s) group_left
                 max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
               )
@@ -37,8 +37,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
               group_by_cluster: $._config.group_by_cluster,
             },
             |||
-              sum by (user, name) (
-                cortex_ingester_active_series_custom_tracker{%(ingester)s, user=~"$user"}
+              sum by (name) (
+                cortex_ingester_active_series_custom_tracker{%(ingester)s, user="$user"}
                 / on(%(group_by_cluster)s) group_left
                 max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
               ) > 0
@@ -49,8 +49,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
           ],
           [
-            '{{ user }}',
-            '{{ user }} ({{ name }})',
+            'active',
+            'active ({{ name }})',
           ],
         ) +
         $.panelDescription(
@@ -66,8 +66,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel(title) +
         $.queryPanel(
           |||
-            sum by (user) (
-              cortex_ingester_tsdb_exemplar_series_with_exemplars_in_storage{%(ingester)s, user=~"$user"}
+            sum(
+              cortex_ingester_tsdb_exemplar_series_with_exemplars_in_storage{%(ingester)s, user="$user"}
               / on(%(group_by_cluster)s) group_left
               max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
             )
@@ -76,8 +76,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
             distributor: $.jobMatcher($._config.job_names.distributor),
             group_by_cluster: $._config.group_by_cluster,
           },
-          '{{ user }}',
+          'series',
         ) +
+        {
+          legend: { show: false },
+        } +
         $.panelDescription(
           title,
           |||
@@ -89,11 +92,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Newest seen sample age';
         $.panel(title) +
         $.queryPanel(
-          'time() - max by (user) (cortex_distributor_latest_seen_sample_timestamp_seconds{%(distributor)s, user=~"$user"} > 0)'
+          'time() - max(cortex_distributor_latest_seen_sample_timestamp_seconds{%(distributor)s, user="$user"} > 0)'
           % { distributor: $.jobMatcher($._config.job_names.distributor) },
-          '{{ user }}',
+          'age',
         ) +
-        { yaxes: $.yaxes('s') } +
+        { legend: { show: false }, yaxes: $.yaxes('s') } +
         $.panelDescription(
           title,
           |||
@@ -105,11 +108,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Oldest exemplar age';
         $.panel(title) +
         $.queryPanel(
-          'time() - min by (user) (cortex_ingester_tsdb_exemplar_last_exemplars_timestamp_seconds{%(ingester)s, user=~"$user"} > 0)'
+          'time() - min(cortex_ingester_tsdb_exemplar_last_exemplars_timestamp_seconds{%(ingester)s, user="$user"} > 0)'
           % { ingester: $.jobMatcher($._config.job_names.ingester) },
-          '{{ user }}',
+          'age',
         ) +
-        { yaxes: $.yaxes('s') } +
+        { legend: { show: false }, yaxes: $.yaxes('s') } +
         $.panelDescription(
           title,
           |||
@@ -128,10 +131,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Distributor samples incoming rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user) (rate(cortex_distributor_samples_in_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_distributor_samples_in_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.distributor) },
-          '{{ user }}',
+          'rate',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -143,10 +147,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Distributor samples received (accepted) rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user) (rate(cortex_distributor_received_samples_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_distributor_received_samples_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.distributor) },
-          '{{ user }}',
+          'rate',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -159,14 +164,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel(title) +
         $.queryPanel(
           [
-            'sum by (user) (rate(cortex_distributor_deduped_samples_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+            'sum(rate(cortex_distributor_deduped_samples_total{%(job)s, user="$user"}[$__rate_interval]))'
             % { job: $.jobMatcher($._config.job_names.distributor) },
-            'sum by (user) (rate(cortex_distributor_non_ha_samples_received_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+            'sum(rate(cortex_distributor_non_ha_samples_received_total{%(job)s, user="$user"}[$__rate_interval]))'
             % { job: $.jobMatcher($._config.job_names.distributor) },
           ],
           [
-            '{{ user }}: deduplicated',
-            '{{ user }}: non-HA',
+            'deduplicated',
+            'non-HA',
           ]
         ) +
         $.panelDescription(
@@ -181,14 +186,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel(title) +
         $.queryPanel(
           [
-            'sum by (user, reason) (rate(cortex_discarded_samples_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+            'sum by (reason) (rate(cortex_discarded_samples_total{%(job)s, user="$user"}[$__rate_interval]))'
             % { job: $.jobMatcher($._config.job_names.distributor) },
-            'sum by (user, reason) (rate(cortex_discarded_samples_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+            'sum by (reason) (rate(cortex_discarded_samples_total{%(job)s, user="$user"}[$__rate_interval]))'
             % { job: $.jobMatcher($._config.job_names.ingester) },
           ],
           [
-            '{{ user }}: {{ reason }} (distributor)',
-            '{{ user }}: {{ reason }} (ingester)',
+            '{{ reason }} (distributor)',
+            '{{ reason }} (ingester)',
           ]
         ) +
         $.panelDescription(
@@ -206,10 +211,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Distributor exemplars incoming rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user) (rate(cortex_distributor_exemplars_in_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_distributor_exemplars_in_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.distributor) },
-          '{{ user }}',
+          'rate',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -221,10 +227,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Distributor exemplars received (accepted) rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user) (rate(cortex_distributor_received_exemplars_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_distributor_received_exemplars_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.distributor), group_prefix_users: $._config.group_prefix_users },
-          '{{ user }}',
+          'rate',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -238,9 +245,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Distributor discarded exemplars rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user, reason) (rate(cortex_discarded_exemplars_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum by (reason) (rate(cortex_discarded_exemplars_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.distributor) },
-          '{{ user }}: {{ reason }}',
+          '{{ reason }}',
         ) +
         $.panelDescription(
           title,
@@ -254,8 +261,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel(title) +
         $.queryPanel(
           |||
-            sum by (user) (
-              rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total{%(ingester)s, user=~"$user"}[$__rate_interval])
+            sum(
+              rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total{%(ingester)s, user="$user"}[$__rate_interval])
               / on(%(group_by_cluster)s) group_left
               max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
             )
@@ -264,8 +271,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
             distributor: $.jobMatcher($._config.job_names.distributor),
             group_by_cluster: $._config.group_by_cluster,
           },
-          '{{ user }}',
+          'rate',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -282,9 +290,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Symbol table size for loaded blocks';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user, job) (cortex_ingester_tsdb_symbol_table_size_bytes{%(ingester)s, user=~"$user"})'
+          'sum by (job) (cortex_ingester_tsdb_symbol_table_size_bytes{%(ingester)s, user="$user"})'
           % { ingester: $.jobMatcher($._config.job_names.ingester) },
-          '{{ user }} in {{ job }}',
+          '{{ job }}',
         ) +
         { yaxes: $.yaxes('bytes') } +
         $.panelDescription(
@@ -298,9 +306,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Space used by local blocks';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user, job) (cortex_ingester_tsdb_storage_blocks_bytes{%(ingester)s, user=~"$user"})'
+          'sum by (job) (cortex_ingester_tsdb_storage_blocks_bytes{%(ingester)s, user="$user"})'
           % { ingester: $.jobMatcher($._config.job_names.ingester) },
-          '{{ user }} in {{ job }}',
+          '{{ job }}',
         ) +
         { yaxes: $.yaxes('bytes') } +
         $.panelDescription(
@@ -318,10 +326,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Number of groups';
         $.panel(title) +
         $.queryPanel(
-          'count by (user) (sum by (user, rule_group) (cortex_prometheus_rule_group_rules{%(job)s, user=~"$user"}))'
+          'count(sum by (rule_group) (cortex_prometheus_rule_group_rules{%(job)s, user="$user"}))'
           % { job: $.jobMatcher($._config.job_names.ruler) },
-          '{{ user }}',
+          'groups',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -333,10 +342,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Number of rules';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user) (cortex_prometheus_rule_group_rules{%(job)s, user=~"$user"})'
+          'sum(cortex_prometheus_rule_group_rules{%(job)s, user="$user"})'
           % { job: $.jobMatcher($._config.job_names.ruler) },
-          '{{ user }}',
+          'rules',
         ) +
+        { legend: { show: false } } +
         $.panelDescription(
           title,
           |||
@@ -348,18 +358,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Total evaluations rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user) (rate(cortex_prometheus_rule_evaluations_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_prometheus_rule_evaluations_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.ruler) },
-          '{{ user }}',
-        ),
+          'rate',
+        ) +
+        { legend: { show: false } },
       )
       .addPanel(
         local title = 'Failed evaluations rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (user, rule_group) (rate(cortex_prometheus_rule_group_rules{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum by (rule_group) (rate(cortex_prometheus_rule_group_rules{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.ruler) },
-          '{{ user }}: {{ rule_group }}',
+          '{{ rule_group }}',
         ) + { stack: true },
       )
     )
@@ -371,7 +382,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         { sort: { col: 2, desc: true } } +
         $.tablePanel(
           [
-            'topk($limit, sum by (rule_group) (cortex_prometheus_rule_group_rules{%(job)s, user=~"$user"}))'
+            'topk($limit, sum by (rule_group) (cortex_prometheus_rule_group_rules{%(job)s, user="$user"}))'
             % { job: $.jobMatcher($._config.job_names.ruler) },
           ],
           { 'Value #A': { alias: 'rules' } }
@@ -382,7 +393,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         { sort: { col: 2, desc: true } } +
         $.tablePanel(
           [
-            'topk($limit, sum by (rule_group) (cortex_prometheus_rule_group_last_duration_seconds{%(job)s, user=~"$user"}))'
+            'topk($limit, sum by (rule_group) (cortex_prometheus_rule_group_last_duration_seconds{%(job)s, user="$user"}))'
             % { job: $.jobMatcher($._config.job_names.ruler) },
           ],
           { 'Value #A': { alias: 'seconds' } }
@@ -396,19 +407,21 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Sent notifications rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by(user) (rate(cortex_prometheus_notifications_sent_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_prometheus_notifications_sent_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.ruler) },
-          '{{ user }}',
-        ),
+          'rate',
+        ) +
+        { legend: { show: false } },
       )
       .addPanel(
         local title = 'Failed notifications rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by(user) (rate(cortex_prometheus_notifications_errors_total{%(job)s, user=~"$user"}[$__rate_interval]))'
+          'sum(rate(cortex_prometheus_notifications_errors_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.ruler) },
-          '{{ user }}',
-        ),
+          'rate',
+        ) +
+        { legend: { show: false } },
       )
     ),
 }


### PR DESCRIPTION
The dashboard only allows for selecting a single user, so we can cleanup the
legends and simplify the queries slightly. The secondary motiviation for this
change to make room to add some additional information to the series panels.
