### PR TITLE
Sync latest docs to support backporting documentation

### DIFF
--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -1,15 +1,14 @@
-name: "publish_docs"
+name: "publish-technical-documentation"
 
 on:
   push:
     branches:
     - "main"
-    - "mimir-*"
+    - "release-*"
     tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    - "mimir-[0-9]+.[0-9]+.[0-9]+"
     paths:
     - "docs/sources/**"
-
 jobs:
   test:
     runs-on: "ubuntu-latest"
@@ -18,7 +17,7 @@ jobs:
       uses: "actions/checkout@v3"
     - name: "Build website"
       run: |
-        docker run -v "${PWD}/docs/sources:/hugo/content/docs/mimir/next" --rm grafana/docs-base:latest /bin/bash -c 'make hugo
+        docker run -v "${PWD}/docs/sources:/hugo/content/docs/mimir/next" --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"
@@ -27,6 +26,8 @@ jobs:
 
     - name: "Checkout Mimir repo"
       uses: "actions/checkout@v3"
+      with:
+        fetch-depth: 0
 
     - name: "Checkout Actions library"
       uses: "actions/checkout@v3"
@@ -43,12 +44,30 @@ jobs:
       with:
         ref_name: "${{ github.ref_name }}"
 
+    - name: "Determine latest release tag"
+      id: "latest-released"
+      shell: "bash"
+      run: |
+        tag="$(./tools/latest-tag '^mimir-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$')"
+        echo "::set-output name=tag::${tag}"
+
+    - name: "Determine latest release tag target"
+      uses: "./actions/docs-target"
+      id: "latest-released-target"
+      with:
+        ref_name: "${{ steps.latest-released.outputs.tag }}"
+
     - name: "Clone website-sync Action"
       run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
     - name: "Publish to website repository"
       uses: "./.github/actions/website-sync"
       id: "publish"
+      # Only publish if the target of the latest release tag matches the target of this reference.
+      # For release tags the tag and reference are the same.
+      # For release branches, this guard prevents publishing documentation before a tag
+      # has been pushed that has officially "released" that documentation.
+      if: "steps.latest-released-target.outputs.target == steps.target.outputs.target"
       with:
         repository: "grafana/website"
         branch: "master"
@@ -56,8 +75,10 @@ jobs:
         github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
         source_folder: "docs/sources"
         # Append ".x" to target to produce a v<major>.<minor>.x directory.
-        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}".x
-    - shell: "bash"
+        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}.x"
+
+    - name: "Validate successful publishing"
+      shell: "bash"
       run: |
         test -n "${{ steps.publish.outputs.commit_hash }}"
         test -n "${{ steps.publish.outputs.working_directory }}"

--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -17,7 +17,7 @@ jobs:
       uses: "actions/checkout@v3"
     - name: "Build website"
       run: |
-        docker run -v "${PWD}/docs/sources:/hugo/content/docs/mimir/next" --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+        docker run -v ${PWD}/docs/sources:/hugo/content/docs/mimir/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -71,7 +71,7 @@ jobs:
         host: "github.com"
         github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
         source_folder: "docs/sources"
-        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}"
+        target_folder: "content/docs/mimir/next"
 
     - name: "Publish to website repository (release)"
       uses: "./.github/actions/website-sync"

--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -67,7 +67,7 @@ jobs:
       # For release tags the tag and reference are the same.
       # For release branches, this guard prevents publishing documentation before a tag
       # has been pushed that has officially "released" that documentation.
-      if: "steps.latest-released-target.outputs.target == steps.target.outputs.target"
+      if: "(github.ref == 'refs/heads/main' || (steps.latest-released-target.outputs.target == steps.target.outputs.target)"
       with:
         repository: "grafana/website"
         branch: "master"

--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -48,7 +48,7 @@ jobs:
       id: "latest-released"
       shell: "bash"
       run: |
-        tag="$(./tools/latest-tag '^mimir-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$')"
+        tag="$(git tag --sort=-v:refname | grep -E '^mimir-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | head -n1)"
         echo "::set-output name=tag::${tag}"
 
     - name: "Determine latest release tag target"

--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -60,14 +60,27 @@ jobs:
     - name: "Clone website-sync Action"
       run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
-    - name: "Publish to website repository"
+    - name: "Publish to website repository (next)"
       uses: "./.github/actions/website-sync"
-      id: "publish"
+      id: "publish-next"
+      # Only publish on main branch.
+      if: "github.ref == 'refs/heads/main'"
+      with:
+        repository: "grafana/website"
+        branch: "master"
+        host: "github.com"
+        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        source_folder: "docs/sources"
+        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}"
+
+    - name: "Publish to website repository (release)"
+      uses: "./.github/actions/website-sync"
+      id: "publish-release"
       # Only publish if the target of the latest release tag matches the target of this reference.
       # For release tags the tag and reference are the same.
       # For release branches, this guard prevents publishing documentation before a tag
       # has been pushed that has officially "released" that documentation.
-      if: "(github.ref == 'refs/heads/main' || (steps.latest-released-target.outputs.target == steps.target.outputs.target)"
+      if: "steps.latest-released-target.outputs.target == steps.target.outputs.target"
       with:
         repository: "grafana/website"
         branch: "master"

--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -89,9 +89,3 @@ jobs:
         source_folder: "docs/sources"
         # Append ".x" to target to produce a v<major>.<minor>.x directory.
         target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}.x"
-
-    - name: "Validate successful publishing"
-      shell: "bash"
-      run: |
-        test -n "${{ steps.publish.outputs.commit_hash }}"
-        test -n "${{ steps.publish.outputs.working_directory }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,12 @@ jobs:
   test:
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v3"
-      - name: "Build website"
-        run: |
-          docker run -v ${PWD}/sources:/hugo/content/docs/mimir --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+    - name: "Check out code"
+      uses: "actions/checkout@v3"
+    - name: "Build website"
+      run: |
+        docker run -v "${PWD}/docs/sources:/hugo/content/docs/mimir/next" --rm grafana/docs-base:latest /bin/bash -c 'make hugo
+
   sync:
     runs-on: "ubuntu-latest"
     needs: "test"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,8 @@ jobs:
         host: "github.com"
         github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
         source_folder: "docs/sources"
-        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}"
+        # Append ".x" to target to produce a v<major>.<minor>.x directory.
+        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}".x
     - shell: "bash"
       run: |
         test -n "${{ steps.publish.outputs.commit_hash }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,61 @@
-name: publish_docs
+name: "publish_docs"
 
 on:
   push:
     branches:
-    - main
+    - "main"
+    - "mimir-*"
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
     paths:
-    - 'docs/sources/**'
+    - "docs/sources/**"
 
 jobs:
-  sync:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v1
-    - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
-    - name: publish-to-git
-      uses: ./.github/actions/website-sync
-      id: publish
+      - name: "Check out code"
+        uses: "actions/checkout@v3"
+      - name: "Build website"
+        run: |
+          docker run -v ${PWD}/sources:/hugo/content/docs/mimir --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+  sync:
+    runs-on: "ubuntu-latest"
+    needs: "test"
+    steps:
+
+    - name: "Checkout Mimir repo"
+      uses: "actions/checkout@v3"
+
+    - name: "Checkout Actions library"
+      uses: "actions/checkout@v3"
       with:
-        repository: grafana/website
-        branch: master
-        host: github.com
-        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
-        source_folder: docs/sources
-        target_folder: content/docs/mimir/next
-    - shell: bash
+        repository: "grafana/grafana-github-actions"
+        path: "./actions"
+
+    - name: "Install Actions from library"
+      run: "npm install --production --prefix ./actions"
+
+    - name: "Determine technical documentation version"
+      uses: "./actions/docs-target"
+      id: "target"
+      with:
+        ref_name: "${{ github.ref_name }}"
+
+    - name: "Clone website-sync Action"
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
+    - name: "Publish to website repository"
+      uses: "./.github/actions/website-sync"
+      id: "publish"
+      with:
+        repository: "grafana/website"
+        branch: "master"
+        host: "github.com"
+        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        source_folder: "docs/sources"
+        target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}"
+    - shell: "bash"
       run: |
         test -n "${{ steps.publish.outputs.commit_hash }}"
         test -n "${{ steps.publish.outputs.working_directory }}"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -96,11 +96,11 @@ jobs:
   test-docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v1
-      - name: Build Website
+      - name: "Check out code"
+        uses: "actions/checkout@v3"
+      - name: "Build website"
         run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/mimir/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'mkdir -p content/docs/grafana/latest/ && touch content/docs/grafana/latest/menu.yaml && make prod'
+          docker run -v ${PWD}/docs/sources:/hugo/content/docs/mimir/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   build-mimir:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
#### What this PR does
Pushes to main are published to the `next` directory and release
branches and tags are published to the a versioned directory.

The `Determine technical documentation version` step coerces the git
reference into a version string of the form `v.<major>.<minor>` which
matches the versioned documentation structure on the website.

Release branches are published to a `v.<major>.<minor>.x` directory 
on the website and the website orders these directories and determines
what is to become the "latest" directory automatically.

Release branches are only published if there is a release tag that, when
coerced using the same process as for the technical documentation version,
matches the release branch version. This ensures that docs on release branches
are only published after the actual release has happened.

Syncing both latest and next documentation facilitates backporting
documentation fixes to release branches in order to update latest
documentation.

Also introduces the `test` job to ensure broken documentation is not
synced the to the website.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
