### PR TITLE
Mixin: Show in-memory series and the per-user limit on Tenants dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Jsonnet
 
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
+* [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
 * [ENHANCEMENT] Ingester anti-affinity can now be disabled by using `ingester_allow_multiple_replicas_on_same_node` configuration key. #1581
 * [ENHANCEMENT] Microservices: Ability to add NodeSelector. #1596
 * [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@
 
 ### Mixin
 
-### Jsonnet
-
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
+
+### Jsonnet
+
 * [ENHANCEMENT] Ingester anti-affinity can now be disabled by using `ingester_allow_multiple_replicas_on_same_node` configuration key. #1581
 * [ENHANCEMENT] Microservices: Ability to add NodeSelector. #1596
 * [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -92,7 +92,7 @@
                         "format": "time_series",
                         "interval": "15s",
                         "intervalFactor": 2,
-                        "legendFormat": "memory",
+                        "legendFormat": "in-memory",
                         "legendLink": null,
                         "step": 10
                      },
@@ -381,7 +381,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Series & exemplars",
+            "title": "Series and exemplars",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -55,7 +55,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Active series\nNumber of active series per user, and active series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "description": "### Series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                   "fill": 1,
                   "id": 2,
                   "legend": {
@@ -75,12 +75,36 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [ ],
+                  "seriesOverrides": [
+                     {
+                        "alias": "limit",
+                        "dashes": true,
+                        "fill": 0
+                     }
+                  ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
+                     {
+                        "expr": "sum(\n  (\n    cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\", user=\"$user\"}\n    - cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\", user=\"$user\"}\n  )\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"})\n)\n",
+                        "format": "time_series",
+                        "interval": "15s",
+                        "intervalFactor": 2,
+                        "legendFormat": "memory",
+                        "legendLink": null,
+                        "step": 10
+                     },
+                     {
+                        "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/(overrides-exporter)\", limit_name=\"max_global_series_per_user\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/(overrides-exporter)\", limit_name=\"max_global_series_per_user\"})\n",
+                        "format": "time_series",
+                        "interval": "15s",
+                        "intervalFactor": 2,
+                        "legendFormat": "limit",
+                        "legendLink": null,
+                        "step": 10
+                     },
                      {
                         "expr": "sum(\n  cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir))\"})\n)\n",
                         "format": "time_series",
@@ -103,7 +127,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Active series",
+                  "title": "Series",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -357,7 +381,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Active series & exemplars",
+            "title": "Series & exemplars",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -32,6 +32,7 @@
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*|cortex|mimir',  // Match also custom compactor deployments.
       alertmanager: 'alertmanager|cortex|mimir',
+      overrides_exporter: 'overrides-exporter',
     },
 
     // Grouping labels, to uniquely identify and group by {jobs, clusters}

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -19,12 +19,33 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
 
     .addRow(
-      $.row('Active series & exemplars')
+      $.row('Series & exemplars')
       .addPanel(
-        local title = 'Active series';
+        local title = 'Series';
         $.panel(title) +
         $.queryPanel(
           [
+            |||
+              sum(
+                (
+                  cortex_ingester_memory_series_created_total{%(ingester)s, user="$user"}
+                  - cortex_ingester_memory_series_removed_total{%(ingester)s, user="$user"}
+                )
+                / on(%(group_by_cluster)s) group_left
+                max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
+              )
+            ||| % {
+              ingester: $.jobMatcher($._config.job_names.ingester),
+              distributor: $.jobMatcher($._config.job_names.distributor),
+              group_by_cluster: $._config.group_by_cluster,
+            },
+            |||
+              max(cortex_limits_overrides{%(overrides_exporter)s, limit_name="max_global_series_per_user", user="$user"})
+              or
+              max(cortex_limits_defaults{%(overrides_exporter)s, limit_name="max_global_series_per_user"})
+            ||| % {
+              overrides_exporter: $.jobMatcher($._config.job_names.overrides_exporter),
+            },
             |||
               sum(
                 cortex_ingester_active_series{%(ingester)s, user="$user"}
@@ -49,14 +70,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
           ],
           [
+            'memory',
+            'limit',
             'active',
             'active ({{ name }})',
           ],
         ) +
+        {
+          seriesOverrides: [
+            {
+              alias: 'limit',
+              fill: 0,
+              dashes: true,
+            },
+          ],
+        } +
         $.panelDescription(
           title,
           |||
-            Number of active series per user, and active series matching custom trackers (in parenthesis).
+            Number of active and in-memory series per user, and active series matching custom trackers (in parenthesis).
             Note that active series matching custom trackers are included in the total active series count.
           |||
         ),

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -19,7 +19,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
 
     .addRow(
-      $.row('Series & exemplars')
+      $.row('Series and exemplars')
       .addPanel(
         local title = 'Series';
         $.panel(title) +
@@ -70,7 +70,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
           ],
           [
-            'memory',
+            'in-memory',
             'limit',
             'active',
             'active ({{ name }})',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Changes the "Active series" panel on the "Tenants" dashboard to show:

- Current number of in-memory series for the tenant
- The current in-memory series limit (either from overrides or the default)

This information is extremely valuable to operators tasked with troubleshooting when tenants are hitting limits, or whether they are close to hitting limits. Looking at only active series often causes confusion because limits are applied to the number of in-memory series, not active series.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- n/a Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
