### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -112,11 +112,7 @@ func prepareLocalStore(t *testing.T) (store *Store, storeDir string) {
 	var err error
 
 	// Create a temporarily directory for the storage.
-	storeDir, err = ioutil.TempDir(os.TempDir(), "local")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(storeDir))
-	})
+	storeDir = t.TempDir()
 
 	store, err = NewStore(StoreConfig{Path: storeDir})
 	require.NoError(t, err)

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -77,13 +77,7 @@ func mockAlertmanagerConfig(t *testing.T) *MultitenantAlertmanagerConfig {
 	err := externalURL.Set("http://localhost/alertmanager")
 	require.NoError(t, err)
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "alertmanager")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		err := os.RemoveAll(tempDir)
-		require.NoError(t, err)
-	})
+	tempDir := t.TempDir()
 
 	cfg := &MultitenantAlertmanagerConfig{}
 	flagext.DefaultValues(cfg)
@@ -1970,13 +1964,7 @@ func TestSafeTemplateFilepath(t *testing.T) {
 }
 
 func TestStoreTemplateFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "alertmanager")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	})
-
+	tempDir := t.TempDir()
 	testTemplateDir := filepath.Join(tempDir, templatesDir)
 
 	changed, err := storeTemplateFile(filepath.Join(testTemplateDir, "some-template"), "content")

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -447,9 +447,7 @@ type blockgenSpec struct {
 }
 
 func createAndUpload(t testing.TB, bkt objstore.Bucket, blocks []blockgenSpec, blocksWithOutOfOrderChunks []blockgenSpec) (metas []*metadata.Meta) {
-	prepareDir, err := ioutil.TempDir("", "test-compact-prepare")
-	require.NoError(t, err)
-	defer func() { require.NoError(t, os.RemoveAll(prepareDir)) }()
+	prepareDir := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -606,9 +604,7 @@ func foreachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 	t.Run("filesystem", func(t *testing.T) {
 		t.Parallel()
 
-		dir, err := ioutil.TempDir("", "filesystem-foreach-store-test")
-		require.NoError(t, err)
-		defer require.NoError(t, os.RemoveAll(dir))
+		dir := t.TempDir()
 
 		b, err := filesystem.NewBucket(dir)
 		require.NoError(t, err)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1304,14 +1304,10 @@ func TestMultitenantCompactor_ShouldSkipCompactionForJobsNoMoreOwnedAfterPlannin
 
 func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, maxT int64, numSeries int, externalLabels map[string]string) ulid.ULID {
 	// Create a temporary dir for TSDB.
-	tempDir, err := ioutil.TempDir(os.TempDir(), "tsdb")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := t.TempDir()
 
 	// Create a temporary dir for the snapshot.
-	snapshotDir, err := ioutil.TempDir(os.TempDir(), "snapshot")
-	require.NoError(t, err)
-	defer os.RemoveAll(snapshotDir) //nolint:errcheck
+	snapshotDir := t.TempDir()
 
 	// Create a new TSDB.
 	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
@@ -1505,13 +1501,9 @@ func prepareWithConfigProvider(t *testing.T, compactorCfg Config, bucketClient o
 	flagext.DefaultValues(&storageCfg)
 
 	// Create a temporary directory for compactor data.
-	dataDir, err := ioutil.TempDir(os.TempDir(), "compactor-test")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 
 	compactorCfg.DataDir = dataDir
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(dataDir))
-	})
 
 	tsdbCompactor := &tsdbCompactorMock{}
 	tsdbPlanner := &tsdbPlannerMock{}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2846,25 +2846,10 @@ func prepareIngesterWithBlocksStorage(t testing.TB, ingesterCfg Config, register
 func prepareIngesterWithBlocksStorageAndLimits(t testing.TB, ingesterCfg Config, limits validation.Limits, dataDir string, registerer prometheus.Registerer) (*Ingester, error) {
 	// Create a data dir if none has been provided.
 	if dataDir == "" {
-		var err error
-		if dataDir, err = ioutil.TempDir("", "ingester"); err != nil {
-			return nil, err
-		}
-
-		t.Cleanup(func() {
-			require.NoError(t, os.RemoveAll(dataDir))
-		})
+		dataDir = t.TempDir()
 	}
 
-	bucketDir, err := ioutil.TempDir("", "bucket")
-	if err != nil {
-		return nil, err
-	}
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(bucketDir))
-	})
-
+	bucketDir := t.TempDir()
 	clientCfg := defaultClientTestConfig()
 
 	overrides, err := validation.NewOverrides(limits, nil)
@@ -3007,9 +2992,7 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a temporary directory for TSDB
-			tempDir, err := ioutil.TempDir("", "tsdb")
-			require.NoError(t, err)
-			defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 
 			ingesterCfg := defaultIngesterTestConfig(t)
 			ingesterCfg.BlocksStorageConfig.TSDB.Dir = tempDir
@@ -3976,11 +3959,7 @@ func pushSingleSampleAtTime(t *testing.T, i *Ingester, ts int64) {
 
 func TestHeadCompactionOnStartup(t *testing.T) {
 	// Create a temporary directory for TSDB
-	tempDir, err := ioutil.TempDir("", "tsdb")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
-	})
+	tempDir := t.TempDir()
 
 	// Build TSDB for user, with data covering 24 hours.
 	{

--- a/pkg/querier/blocks_finder_bucket_scan_test.go
+++ b/pkg/querier/blocks_finder_bucket_scan_test.go
@@ -8,7 +8,6 @@ package querier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -84,9 +83,7 @@ func TestBucketScanBlocksFinder_InitialScan(t *testing.T) {
 }
 
 func TestBucketScanBlocksFinder_InitialScanFailure(t *testing.T) {
-	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir) //nolint: errcheck
+	cacheDir := t.TempDir()
 
 	ctx := context.Background()
 	bucket := &bucket.ClientMock{}
@@ -152,9 +149,7 @@ func TestBucketScanBlocksFinder_StopWhileRunningTheInitialScanOnManyTenants(t *t
 		bucket.MockExists(path.Join(tenantID, mimir_tsdb.TenantDeletionMarkPath), false, nil)
 	}
 
-	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	cfg := prepareBucketScanBlocksFinderConfig()
 	cfg.CacheDir = cacheDir
@@ -190,12 +185,8 @@ func TestBucketScanBlocksFinder_StopWhileRunningTheInitialScanOnManyBlocks(t *te
 		time.Sleep(time.Second)
 	})
 
-	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
-
 	cfg := prepareBucketScanBlocksFinderConfig()
-	cfg.CacheDir = cacheDir
+	cfg.CacheDir = t.TempDir()
 	cfg.MetasConcurrency = 1
 	cfg.TenantsConcurrency = 1
 
@@ -486,11 +477,7 @@ func TestBucketScanBlocksFinder_GetBlocks(t *testing.T) {
 }
 
 func prepareBucketScanBlocksFinder(t *testing.T, cfg BucketScanBlocksFinderConfig) (*BucketScanBlocksFinder, objstore.Bucket, string, *prometheus.Registry) {
-	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(cacheDir))
-	})
+	cacheDir := t.TempDir()
 
 	bkt, storageDir := mimir_testutil.PrepareFilesystemBucket(t)
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -8,8 +8,6 @@ package querier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -231,12 +229,7 @@ func TestQuerier_QueryableReturnsChunksOutsideQueriedRange(t *testing.T) {
 }
 
 func mockTSDB(t *testing.T, mint model.Time, samples int, step, chunkOffset time.Duration, samplesPerChunk int) (storage.Queryable, model.Time) {
-	dir, err := ioutil.TempDir("", "tsdb")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	opts := tsdb.DefaultHeadOptions()
 	opts.ChunkDirRoot = dir
@@ -322,9 +315,7 @@ func TestQuerier_QueryIngestersWithinConfig(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{
@@ -810,9 +801,7 @@ func TestQuerier_MaxLabelsQueryRange(t *testing.T) {
 }
 
 func testRangeQuery(t testing.TB, queryable storage.Queryable, end model.Time, q query) *promql.Result {
-	dir, err := ioutil.TempDir("", "test_query")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	from, through, step := time.Unix(0, 0), end.Time(), q.step
@@ -955,9 +944,7 @@ func TestQuerier_QueryStoreAfterConfig(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -7,8 +7,6 @@ package ruler
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -25,11 +23,7 @@ import (
 )
 
 func TestSyncRuleGroups(t *testing.T) {
-	dir, err := ioutil.TempDir("", "rules")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	m, err := NewDefaultMultiTenantManager(Config{RulePath: dir}, factory, nil, log.NewNopLogger(), nil)
 	require.NoError(t, err)

--- a/pkg/ruler/rulestore/local/local_test.go
+++ b/pkg/ruler/rulestore/local/local_test.go
@@ -29,9 +29,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	namespace1 := "ns"
 	namespace2 := "z-another" // This test relies on the fact that ioutil.ReadDir() returns files sorted by name.
 
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ruleGroups := rulefmt.RuleGroups{
 		Groups: []rulefmt.RuleGroup{

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -8,7 +8,6 @@ package storegateway
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -424,9 +423,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_e2e")
-		assert.NoError(t, err)
-		defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 
@@ -479,9 +476,7 @@ func TestBucketStore_ManyParts_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_e2e")
-		assert.NoError(t, err)
-		defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, true, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 
@@ -501,9 +496,7 @@ func TestBucketStore_TimePartitioning_e2e(t *testing.T) {
 	defer cancel()
 	bkt := objstore.NewInMemBucket()
 
-	dir, err := ioutil.TempDir("", "test_bucket_time_part_e2e")
-	assert.NoError(t, err)
-	defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+	dir := t.TempDir()
 
 	hourAfter := time.Now().Add(1 * time.Hour)
 	filterMaxTime := model.TimeOrDurationValue{Time: &hourAfter}
@@ -588,9 +581,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			defer cancel()
 			bkt := objstore.NewInMemBucket()
 
-			dir, err := ioutil.TempDir("", "test_bucket_chunks_limiter_e2e")
-			assert.NoError(t, err)
-			defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+			dir := t.TempDir()
 
 			s := prepareStoreWithTestBlocks(t, dir, bkt, false, newCustomChunksLimiterFactory(testData.maxChunksLimit, testData.code), newCustomSeriesLimiterFactory(testData.maxSeriesLimit, testData.code), emptyRelabelConfig, allowAllFilterConf)
 			assert.NoError(t, s.store.SyncBlocks(ctx))
@@ -605,7 +596,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 
 			s.cache.SwapWith(noopCache{})
 			srv := newBucketStoreSeriesServer(ctx)
-			err = s.store.Series(req, srv)
+			err := s.store.Series(req, srv)
 
 			if testData.expectedErr == "" {
 				assert.NoError(t, err)
@@ -625,9 +616,7 @@ func TestBucketStore_LabelNames_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_label_names_e2e")
-		assert.NoError(t, err)
-		defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 		s.cache.SwapWith(noopCache{})
@@ -727,9 +716,7 @@ func TestBucketStore_LabelValues_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		dir, err := ioutil.TempDir("", "test_bucketstore_label_values_e2e")
-		assert.NoError(t, err)
-		defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+		dir := t.TempDir()
 
 		s := prepareStoreWithTestBlocks(t, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), emptyRelabelConfig, allowAllFilterConf)
 		s.cache.SwapWith(noopCache{})
@@ -833,9 +820,7 @@ func foreachStore(t *testing.T, testFn func(t *testing.T, bkt objstore.Bucket)) 
 	t.Run("filesystem", func(t *testing.T) {
 		t.Parallel()
 
-		dir, err := ioutil.TempDir("", "filesystem-foreach-store-test")
-		assert.NoError(t, err)
-		defer assert.NoError(t, os.RemoveAll(dir))
+		dir := t.TempDir()
 
 		b, err := filesystem.NewBucket(dir)
 		assert.NoError(t, err)

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -64,8 +64,7 @@ func TestBucketStores_InitialSync(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareStorageConfig(t)
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "storage-*")
-	require.NoError(t, err)
+	storageDir := t.TempDir()
 
 	for userID, metricName := range userToMetric {
 		generateStorageBlock(t, storageDir, userID, metricName, 10, 100, 15)
@@ -140,8 +139,7 @@ func TestBucketStores_InitialSyncShouldRetryOnFailure(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareStorageConfig(t)
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "storage-*")
-	require.NoError(t, err)
+	storageDir := t.TempDir()
 
 	// Generate a block for the user in the storage.
 	generateStorageBlock(t, storageDir, "user-1", "series_1", 10, 100, 15)
@@ -208,8 +206,7 @@ func TestBucketStores_SyncBlocks(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareStorageConfig(t)
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "storage-*")
-	require.NoError(t, err)
+	storageDir := t.TempDir()
 
 	bucket, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 	require.NoError(t, err)
@@ -336,8 +333,7 @@ func testBucketStoresSeriesShouldCorrectlyQuerySeriesSpanningMultipleChunks(t *t
 	cfg.BucketStore.IndexHeaderLazyLoadingEnabled = lazyLoadingEnabled
 	cfg.BucketStore.IndexHeaderLazyLoadingIdleTimeout = time.Minute
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "storage-*")
-	require.NoError(t, err)
+	storageDir := t.TempDir()
 
 	// Generate a single block with 1 series and a lot of samples.
 	generateStorageBlock(t, storageDir, userID, metricName, 0, 10000, 1)
@@ -504,17 +500,12 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 }
 
 func prepareStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "blocks-sync-*")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
 	cfg.BucketStore.BucketIndex.Enabled = false
 	cfg.BucketStore.SyncDir = tmpDir
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	})
 
 	return cfg
 }
@@ -528,11 +519,7 @@ func generateStorageBlock(t *testing.T, storageDir, userID string, metricName st
 
 	// Create a temporary directory where the TSDB is opened,
 	// then it will be snapshotted to the storage directory.
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "tsdb-*")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	}()
+	tmpDir := t.TempDir()
 
 	db, err := tsdb.Open(tmpDir, log.NewNopLogger(), nil, tsdb.DefaultOptions(), nil)
 	require.NoError(t, err)
@@ -604,11 +591,7 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareStorageConfig(t)
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "storage-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(storageDir))
-	})
+	storageDir := t.TempDir()
 
 	for userID, metricName := range userToMetric {
 		generateStorageBlock(t, storageDir, userID, metricName, 10, 100, 15)
@@ -746,9 +729,7 @@ func BenchmarkBucketStoreLabelValues(tb *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dir, err := ioutil.TempDir("", "bench-label-values")
-	assert.NoError(tb, err)
-	defer func() { assert.NoError(tb, os.RemoveAll(dir)) }()
+	dir := tb.TempDir()
 
 	bkt, err := filesystemstore.NewBucket(filepath.Join(dir, "bkt"))
 	assert.NoError(tb, err)

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -805,9 +805,7 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 	logger := log.NewNopLogger()
 	userID := "user-1"
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "")
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(storageDir)) })
+	storageDir := t.TempDir()
 
 	// Generate 2 TSDB blocks with the same exact series (and data points).
 	numSeries := 2
@@ -1125,9 +1123,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 	logger := log.NewNopLogger()
 	userID := "user-1"
 
-	storageDir, err := ioutil.TempDir(os.TempDir(), "")
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(storageDir)) })
+	storageDir := t.TempDir()
 
 	// Generate 1 TSDB block with chunksQueried series. Since each mocked series contains only 1 sample,
 	// it will also only have 1 chunk.
@@ -1203,11 +1199,7 @@ func mockGatewayConfig() Config {
 }
 
 func mockStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "store-gateway-test-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	})
+	tmpDir := t.TempDir()
 
 	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
@@ -1226,9 +1218,7 @@ func mockStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 func mockTSDB(t *testing.T, dir string, numSeries, numBlocks int, minT, maxT int64) {
 	// Create a new TSDB on a temporary directory. The blocks
 	// will be then snapshotted to the input dir.
-	tempDir, err := ioutil.TempDir(os.TempDir(), "tsdb")
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(tempDir)) })
+	tempDir := t.TempDir()
 
 	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
 		MinBlockDuration:  2 * time.Hour.Milliseconds(),
@@ -1270,9 +1260,7 @@ func mockTSDB(t *testing.T, dir string, numSeries, numBlocks int, minT, maxT int
 func mockTSDBWithGenerator(t *testing.T, dir string, next func() (bool, labels.Labels, int64, float64)) {
 	// Create a new TSDB on a temporary directory. The blocks
 	// will be then snapshotted to the input dir.
-	tempDir, err := ioutil.TempDir(os.TempDir(), "tsdb")
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(tempDir)) })
+	tempDir := t.TempDir()
 
 	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
 		MinBlockDuration:  2 * time.Hour.Milliseconds(),

--- a/pkg/storegateway/postings_codec_test.go
+++ b/pkg/storegateway/postings_codec_test.go
@@ -10,7 +10,6 @@ package storegateway
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -25,11 +24,7 @@ import (
 )
 
 func TestDiffVarintCodec(t *testing.T) {
-	chunksDir, err := ioutil.TempDir("", "diff_varint_codec")
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		assert.NoError(t, os.RemoveAll(chunksDir))
-	})
+	chunksDir := t.TempDir()
 
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = chunksDir

--- a/pkg/util/process/collector_test.go
+++ b/pkg/util/process/collector_test.go
@@ -22,11 +22,7 @@ func TestProcessCollector(t *testing.T) {
 	const pid = 1
 
 	// Create a mocked proc FS.
-	procDir, err := ioutil.TempDir("", "proc")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(procDir))
-	}()
+	procDir := t.TempDir()
 
 	mapsPath := processMapsPath(procDir, pid)
 	mapsLimitPath := vmMapsLimitPath(procDir)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

A testing cleanup. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
