### PR TITLE
Make doc-generator root blocks injectable

### DIFF
--- a/pkg/mimirtool/config/inspect.go
+++ b/pkg/mimirtool/config/inspect.go
@@ -481,7 +481,7 @@ func InspectConfig(cfg flagext.RegistererWithLogger) (*InspectedEntry, error) {
 // InspectConfigWithFlags does the same as InspectConfig while allowing to provide custom CLI flags. This is
 // useful when the configuration struct does not implement flagext.RegistererWithLogger.
 func InspectConfigWithFlags(cfg interface{}, flags map[uintptr]*flag.Flag) (*InspectedEntry, error) {
-	blocks, err := parse.Config(nil, cfg, flags)
+	blocks, err := parse.Config(cfg, flags, parse.RootBlocks)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't generate parsed config")
 	}

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -146,7 +146,7 @@ func main() {
 	flags := parse.Flags(cfg, util_log.Logger)
 
 	// Parse the config, mapping each config field with the related CLI flag.
-	blocks, err := parse.Config(nil, cfg, flags)
+	blocks, err := parse.Config(cfg, flags, parse.RootBlocks)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "An error occurred while generating the doc: %s\n", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

  * In order to reuse the parse package in GEM we need to be able to inject the root blocks into the config. An alternative to this change is to introduce an interface 
  
    ```go
    type RootBlocker interface {
      IsRootBlock(reflect.Type) (name, description string, isRootBlock bool)
    }
    ```
  
    But I don't see that as a much better alternative - the implementations will be backed by the same logic as now.



  * This also changes the signature of `parse.Config` to drop the `block *ConfigBlock` arg, which was always `nil` when passed from outside the package.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
