### PR TITLE
mimir-mixins: dashboards: compactor: Add "last successful run" compactor panels

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -243,7 +243,7 @@
                                           "from": "-Infinity",
                                           "result": {
                                              "color": "text",
-                                             "text": "No successful runs"
+                                             "text": "No successful runs since startup yet"
                                           },
                                           "to": 0
                                        },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -210,7 +210,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica that has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages might appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none\n  of them were successfully executed yet.\n\nThese might be expected - for example, if you just recently restarted your compactors, they might not\nyet be broadcasting metrics, or they might not have had a chance to complete their first compaction run.\nHowever, if these messages persist, you should check the health of your compactors.\n\n",
+                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica that has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages might appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none\n  of them were successfully executed yet.\n\nThese might be expected - for example, if you just recently restarted your compactors,\nthey might not have had a chance to complete their first compaction run.\nHowever, if these messages persist, you should check the health of your compactors.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "color": {
@@ -321,7 +321,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}, !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"},\n)\n",
+                        "expr": "max by(pod)\n(\n  (time() * (max_over_time(cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}[1h]) !=bool 0))\n  -\n  max_over_time(cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}[1h])\n)\n",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -560,7 +560,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}, !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"},\n)\n",
+                        "expr": "max by(pod)\n(\n  (time() * (max_over_time(cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}[1h]) !=bool 0))\n  -\n  max_over_time(cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}[1h])\n)\n",
                         "format": "table",
                         "instant": true,
                         "interval": "15s",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -210,7 +210,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica which has the longest time since its\nlast successful run, relative to its compaction interval.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages may appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none \n  of them were successfully executed yet.\n\nThese may be expected - for example, if you just recently restarted your compactors, they may not \nyet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. \nHowever, if these messages persist, you should check the health of your compactors.\n\n",
+                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica which has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages may appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none \n  of them were successfully executed yet.\n\nThese may be expected - for example, if you just recently restarted your compactors, they may not \nyet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. \nHowever, if these messages persist, you should check the health of your compactors.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "color": {
@@ -254,7 +254,31 @@
                               {
                                  "id": "color",
                                  "value": {
-                                    "mode": "continuous-GrYlRd"
+                                    "mode": "thresholds"
+                                 }
+                              },
+                              {
+                                 "id": "thresholds",
+                                 "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                       {
+                                          "color": "green",
+                                          "value": 0
+                                       },
+                                       {
+                                          "color": "yellow",
+                                          "value": 7200
+                                       },
+                                       {
+                                          "color": "orange",
+                                          "value": 21600
+                                       },
+                                       {
+                                          "color": "red",
+                                          "value": 43200
+                                       }
+                                    ]
                                  }
                               }
                            ]
@@ -302,20 +326,8 @@
                         "instant": true,
                         "interval": "",
                         "intervalFactor": null,
-                        "legendFormat": "Last run",
+                        "legendFormat": "",
                         "legendLink": null,
-                        "refId": "Last run",
-                        "step": null
-                     },
-                     {
-                        "expr": "max by (pod) \n(\n  cortex_compactor_compaction_interval_seconds\n)\n",
-                        "format": "table",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": null,
-                        "legendFormat": "Interval",
-                        "legendLink": null,
-                        "refId": "Interval",
                         "step": null
                      }
                   ],
@@ -330,15 +342,10 @@
                   },
                   "transformations": [
                      {
-                        "id": "merge",
-                        "options": { }
-                     },
-                     {
                         "id": "organize",
                         "options": {
                            "renameByName": {
-                              "Value #Interval": "Interval",
-                              "Value #Last run": "Last run",
+                              "Value": "Last run",
                               "pod": "Compactor"
                            }
                         }
@@ -349,8 +356,8 @@
                            "alias": "Status",
                            "binary": {
                               "left": "Last run",
-                              "operator": "/",
-                              "right": "Interval"
+                              "operator": "*",
+                              "right": 1
                            },
                            "mode": "binary",
                            "replaceFields": false
@@ -362,22 +369,9 @@
                            "sort": [
                               {
                                  "desc": true,
-                                 "field": "Status"
+                                 "field": "Last run"
                               }
                            ]
-                        }
-                     },
-                     {
-                        "id": "calculateField",
-                        "options": {
-                           "alias": "Maximum of threshold",
-                           "binary": {
-                              "left": "Interval",
-                              "operator": "*",
-                              "right": "9"
-                           },
-                           "mode": "binary",
-                           "replaceFields": false
                         }
                      }
                   ],
@@ -414,7 +408,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Last successful run per-compactor replica\nDisplays the compactor replicas, and for each, shows how long it has been since\nits last successful compaction run.\n\nThe value in status column is based on how long it has been since the last compaction, \nrelative to the compaction interval (which is by default, one hour long).\n\n- Delayed: more than 3 times the interval\n- Late: more than 6 times the interval\n- Very late: more than 9 times the interval\n\nIf the status of any compactor replicas are late, you should check their health.\n\n",
+                  "description": "### Last successful run per-compactor replica\nDisplays the compactor replicas, and for each, shows how long it has been since\nits last successful compaction run.\n\nThe value in status column is based on how long it has been since the last successful compaction.\n\n- Delayed: more than 2 hours\n- Late: more than 6 hours\n- Very late: more than 12 hours\n\nIf the status of any compactor replicas are late, you should check their health.\n\n",
                   "fieldConfig": {
                      "overrides": [
                         {
@@ -448,35 +442,35 @@
                                              "color": "green",
                                              "text": "Ok"
                                           },
-                                          "to": 3
+                                          "to": 7200
                                        },
                                        "type": "range"
                                     },
                                     {
                                        "options": {
-                                          "from": 3,
+                                          "from": 7200,
                                           "result": {
                                              "color": "yellow",
                                              "text": "Delayed"
                                           },
-                                          "to": 6
+                                          "to": 21600
                                        },
                                        "type": "range"
                                     },
                                     {
                                        "options": {
-                                          "from": 6,
+                                          "from": 21600,
                                           "result": {
                                              "color": "orange",
                                              "text": "Late"
                                           },
-                                          "to": 9
+                                          "to": 43200
                                        },
                                        "type": "range"
                                     },
                                     {
                                        "options": {
-                                          "from": 9,
+                                          "from": 43200,
                                           "result": {
                                              "color": "red",
                                              "text": "Very late"
@@ -573,18 +567,6 @@
                         "intervalFactor": 2,
                         "legendFormat": "Last run",
                         "legendLink": null,
-                        "refId": "Last run",
-                        "step": 10
-                     },
-                     {
-                        "expr": "max by (pod) \n(\n  cortex_compactor_compaction_interval_seconds\n)\n",
-                        "format": "table",
-                        "instant": true,
-                        "interval": "15s",
-                        "intervalFactor": 2,
-                        "legendFormat": "Interval",
-                        "legendLink": null,
-                        "refId": "Interval",
                         "step": 10
                      }
                   ],
@@ -599,17 +581,10 @@
                   },
                   "transformations": [
                      {
-                        "id": "seriesToColumns",
-                        "options": {
-                           "byField": "instance"
-                        }
-                     },
-                     {
                         "id": "organize",
                         "options": {
                            "renameByName": {
-                              "Value #Interval": "Interval",
-                              "Value #Last run": "Last run",
+                              "Value": "Last run",
                               "pod": "Compactor"
                            }
                         }
@@ -620,8 +595,8 @@
                            "alias": "Status",
                            "binary": {
                               "left": "Last run",
-                              "operator": "/",
-                              "right": "Interval"
+                              "operator": "*",
+                              "right": 1
                            },
                            "mode": "binary",
                            "replaceFields": false
@@ -633,7 +608,7 @@
                            "sort": [
                               {
                                  "desc": true,
-                                 "field": "Status"
+                                 "field": "Last run"
                               }
                            ]
                         }
@@ -648,21 +623,6 @@
                                  "Status"
                               ]
                            }
-                        }
-                     },
-                     {
-                        "id": "filterByValue",
-                        "options": {
-                           "filters": [
-                              {
-                                 "config": {
-                                    "id": "isNull"
-                                 },
-                                 "fieldName": "Last run"
-                              }
-                           ],
-                           "match": "any",
-                           "type": "exclude"
                         }
                      }
                   ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -210,7 +210,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica that has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages might appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none \n  of them were successfully executed yet.\n\nThese might be expected - for example, if you just recently restarted your compactors, they might not \nyet be broadcasting metrics, or they might not have had a chance to complete their first compaction run. \nHowever, if these messages persist, you should check the health of your compactors.\n\n",
+                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica that has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages might appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none\n  of them were successfully executed yet.\n\nThese might be expected - for example, if you just recently restarted your compactors, they might not\nyet be broadcasting metrics, or they might not have had a chance to complete their first compaction run.\nHowever, if these messages persist, you should check the health of your compactors.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "color": {
@@ -321,7 +321,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  - \n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
+                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -560,7 +560,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  - \n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
+                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
                         "format": "table",
                         "instant": true,
                         "interval": "15s",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -321,7 +321,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
+                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}, !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"},\n)\n",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -560,7 +560,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
+                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"}, !=bool 0))\n  -\n  cortex_compactor_last_successful_run_timestamp_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(compactor.*|cortex|mimir)\"},\n)\n",
                         "format": "table",
                         "instant": true,
                         "interval": "15s",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -210,7 +210,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica which has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages may appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none \n  of them were successfully executed yet.\n\nThese may be expected - for example, if you just recently restarted your compactors, they may not \nyet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. \nHowever, if these messages persist, you should check the health of your compactors.\n\n",
+                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica that has the longest time since its\nlast successful run.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages might appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none \n  of them were successfully executed yet.\n\nThese might be expected - for example, if you just recently restarted your compactors, they might not \nyet be broadcasting metrics, or they might not have had a chance to complete their first compaction run. \nHowever, if these messages persist, you should check the health of your compactors.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "color": {
@@ -408,7 +408,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Last successful run per-compactor replica\nDisplays the compactor replicas, and for each, shows how long it has been since\nits last successful compaction run.\n\nThe value in status column is based on how long it has been since the last successful compaction.\n\n- Delayed: more than 2 hours\n- Late: more than 6 hours\n- Very late: more than 12 hours\n\nIf the status of any compactor replicas are late, you should check their health.\n\n",
+                  "description": "### Last successful run per-compactor replica\nDisplays the compactor replicas, and for each, shows how long it has been since\nits last successful compaction run.\n\nThe value in the status column is based on how long it has been since the last successful compaction.\n\n- Okay: less than 2 hours\n- Delayed: more than 2 hours\n- Late: more than 6 hours\n- Very late: more than 12 hours\n\nIf the status of any compactor replicas are *Late* or *Very late*, check their health.\n\n",
                   "fieldConfig": {
                      "overrides": [
                         {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -58,7 +58,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 6,
+                  "span": 3,
                   "stack": true,
                   "steppedLine": false,
                   "targets": [
@@ -154,7 +154,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 6,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -203,6 +203,495 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Longest time since last successful run\nDisplays the amount of time since the most recent successful execution\nof the compactor.\nThe value shown will be for the compactor replica which has the longest time since its\nlast successful run, relative to its compaction interval.\nThe table to the right shows a summary for all compactor replicas.\n\nIf there is no time value, one of the following messages may appear:\n\n- If you see \"No compactor data\" in this panel, that means that no compactors are active yet.\n\n- If you see \"No successful runs\" in this panel, that means that compactors are active, but none \n  of them were successfully executed yet.\n\nThese may be expected - for example, if you just recently restarted your compactors, they may not \nyet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. \nHowever, if these messages persist, you should check the health of your compactors.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "color": {
+                           "mode": "thresholds"
+                        },
+                        "decimals": 1,
+                        "noValue": "No compactor data",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "s"
+                     },
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Last run"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.width",
+                                 "value": 74
+                              },
+                              {
+                                 "id": "mappings",
+                                 "value": [
+                                    {
+                                       "options": {
+                                          "from": "-Infinity",
+                                          "result": {
+                                             "color": "text",
+                                             "text": "No successful runs"
+                                          },
+                                          "to": 0
+                                       },
+                                       "type": "range"
+                                    }
+                                 ]
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "mode": "continuous-GrYlRd"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "fill": 1,
+                  "id": 3,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "options": {
+                     "reduceOptions": {
+                        "calcs": [
+                           "first"
+                        ],
+                        "fields": "/^Last run$/",
+                        "values": false
+                     },
+                     "textMode": "value"
+                  },
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 3,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  - \n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "intervalFactor": null,
+                        "legendFormat": "Last run",
+                        "legendLink": null,
+                        "refId": "Last run",
+                        "step": null
+                     },
+                     {
+                        "expr": "max by (pod) \n(\n  cortex_compactor_compaction_interval_seconds\n)\n",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "intervalFactor": null,
+                        "legendFormat": "Interval",
+                        "legendLink": null,
+                        "refId": "Interval",
+                        "step": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Longest time since last successful run",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "transformations": [
+                     {
+                        "id": "merge",
+                        "options": { }
+                     },
+                     {
+                        "id": "organize",
+                        "options": {
+                           "renameByName": {
+                              "Value #Interval": "Interval",
+                              "Value #Last run": "Last run",
+                              "pod": "Compactor"
+                           }
+                        }
+                     },
+                     {
+                        "id": "calculateField",
+                        "options": {
+                           "alias": "Status",
+                           "binary": {
+                              "left": "Last run",
+                              "operator": "/",
+                              "right": "Interval"
+                           },
+                           "mode": "binary",
+                           "replaceFields": false
+                        }
+                     },
+                     {
+                        "id": "sortBy",
+                        "options": {
+                           "sort": [
+                              {
+                                 "desc": true,
+                                 "field": "Status"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "id": "calculateField",
+                        "options": {
+                           "alias": "Maximum of threshold",
+                           "binary": {
+                              "left": "Interval",
+                              "operator": "*",
+                              "right": "9"
+                           },
+                           "mode": "binary",
+                           "replaceFields": false
+                        }
+                     }
+                  ],
+                  "type": "stat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Last successful run per-compactor replica\nDisplays the compactor replicas, and for each, shows how long it has been since\nits last successful compaction run.\n\nThe value in status column is based on how long it has been since the last compaction, \nrelative to the compaction interval (which is by default, one hour long).\n\n- Delayed: more than 3 times the interval\n- Late: more than 6 times the interval\n- Very late: more than 9 times the interval\n\nIf the status of any compactor replicas are late, you should check their health.\n\n",
+                  "fieldConfig": {
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Status"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.displayMode",
+                                 "value": "color-background"
+                              },
+                              {
+                                 "id": "mappings",
+                                 "value": [
+                                    {
+                                       "options": {
+                                          "from": "-Infinity",
+                                          "result": {
+                                             "color": "transparent",
+                                             "text": "N/A"
+                                          },
+                                          "to": 0
+                                       },
+                                       "type": "range"
+                                    },
+                                    {
+                                       "options": {
+                                          "from": 0,
+                                          "result": {
+                                             "color": "green",
+                                             "text": "Ok"
+                                          },
+                                          "to": 3
+                                       },
+                                       "type": "range"
+                                    },
+                                    {
+                                       "options": {
+                                          "from": 3,
+                                          "result": {
+                                             "color": "yellow",
+                                             "text": "Delayed"
+                                          },
+                                          "to": 6
+                                       },
+                                       "type": "range"
+                                    },
+                                    {
+                                       "options": {
+                                          "from": 6,
+                                          "result": {
+                                             "color": "orange",
+                                             "text": "Late"
+                                          },
+                                          "to": 9
+                                       },
+                                       "type": "range"
+                                    },
+                                    {
+                                       "options": {
+                                          "from": 9,
+                                          "result": {
+                                             "color": "red",
+                                             "text": "Very late"
+                                          },
+                                          "to": "Infinity"
+                                       },
+                                       "type": "range"
+                                    },
+                                    {
+                                       "options": {
+                                          "match": "null+nan",
+                                          "result": {
+                                             "color": "transparent",
+                                             "text": "Unknown"
+                                          }
+                                       },
+                                       "type": "special"
+                                    }
+                                 ]
+                              },
+                              {
+                                 "id": "custom.width",
+                                 "value": 86
+                              },
+                              {
+                                 "id": "custom.align",
+                                 "value": "center"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Last run"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              },
+                              {
+                                 "id": "custom.width",
+                                 "value": 74
+                              },
+                              {
+                                 "id": "mappings",
+                                 "value": [
+                                    {
+                                       "options": {
+                                          "from": "-Infinity",
+                                          "result": {
+                                             "text": "Never"
+                                          },
+                                          "to": 0
+                                       },
+                                       "type": "range"
+                                    }
+                                 ]
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "fill": 1,
+                  "id": 4,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 3,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "max by(pod)\n(\n  (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))\n  - \n  cortex_compactor_last_successful_run_timestamp_seconds\n)\n",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "15s",
+                        "intervalFactor": 2,
+                        "legendFormat": "Last run",
+                        "legendLink": null,
+                        "refId": "Last run",
+                        "step": 10
+                     },
+                     {
+                        "expr": "max by (pod) \n(\n  cortex_compactor_compaction_interval_seconds\n)\n",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "15s",
+                        "intervalFactor": 2,
+                        "legendFormat": "Interval",
+                        "legendLink": null,
+                        "refId": "Interval",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Last successful run per-compactor replica",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "transformations": [
+                     {
+                        "id": "seriesToColumns",
+                        "options": {
+                           "byField": "instance"
+                        }
+                     },
+                     {
+                        "id": "organize",
+                        "options": {
+                           "renameByName": {
+                              "Value #Interval": "Interval",
+                              "Value #Last run": "Last run",
+                              "pod": "Compactor"
+                           }
+                        }
+                     },
+                     {
+                        "id": "calculateField",
+                        "options": {
+                           "alias": "Status",
+                           "binary": {
+                              "left": "Last run",
+                              "operator": "/",
+                              "right": "Interval"
+                           },
+                           "mode": "binary",
+                           "replaceFields": false
+                        }
+                     },
+                     {
+                        "id": "sortBy",
+                        "options": {
+                           "sort": [
+                              {
+                                 "desc": true,
+                                 "field": "Status"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "id": "filterFieldsByName",
+                        "options": {
+                           "include": {
+                              "names": [
+                                 "Compactor",
+                                 "Last run",
+                                 "Status"
+                              ]
+                           }
+                        }
+                     },
+                     {
+                        "id": "filterByValue",
+                        "options": {
+                           "filters": [
+                              {
+                                 "config": {
+                                    "id": "isNull"
+                                 },
+                                 "fieldName": "Last run"
+                              }
+                           ],
+                           "match": "any",
+                           "type": "exclude"
+                        }
+                     }
+                  ],
+                  "type": "table",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -224,7 +713,7 @@
                   "datasource": "$datasource",
                   "description": "### TSDB compactions / sec\nRate of TSDB compactions. Single TSDB compaction takes one or more input blocks and produces one or more (during \"split\" phase) output blocks.\n\n",
                   "fill": 1,
-                  "id": 3,
+                  "id": 5,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -302,7 +791,7 @@
                   "datasource": "$datasource",
                   "description": "### TSDB compaction duration\nDisplay the amount of time that it has taken to run a single TSDB compaction.\n\n",
                   "fill": 1,
-                  "id": 4,
+                  "id": 6,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -409,7 +898,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 5,
+                  "id": 7,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -487,7 +976,7 @@
                   "datasource": "$datasource",
                   "description": "### Tenants with largest number of blocks\nThe 10 tenants with the largest number of blocks.\n\n",
                   "fill": 1,
-                  "id": 6,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -576,7 +1065,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 7,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -656,7 +1145,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 8,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -757,7 +1246,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 9,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -843,7 +1332,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 10,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -950,7 +1439,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 11,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1027,7 +1516,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 12,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1104,7 +1593,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 13,
+                  "id": 15,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1199,7 +1688,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 14,
+                  "id": 16,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1306,7 +1795,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 15,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1401,7 +1890,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 16,
+                  "id": 18,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1496,7 +1985,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 17,
+                  "id": 19,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1591,7 +2080,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 18,
+                  "id": 20,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1706,7 +2195,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 19,
+                  "id": 21,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1783,7 +2272,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 20,
+                  "id": 22,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -63,12 +63,12 @@ local fixTargetsForTransformations(panel, refIds) = panel {
 
   local lastRunThresholds = {
 
-    local hours = 60 * 60,
+    local secondsPerHour = 60 * 60,
 
     // In terms of hours
-    local delayed = 2 * hours,
-    local late = 6 * hours,
-    local veryLate = 12 * hours,
+    local delayed = 2 * secondsPerHour,
+    local late = 6 * secondsPerHour,
+    local veryLate = 12 * secondsPerHour,
 
     // steps for thresholds
     steps: [
@@ -87,6 +87,19 @@ local fixTargetsForTransformations(panel, refIds) = panel {
       mappingRange(veryLate, 'Infinity', { color: 'red', text: 'Very late' }),
       mappingSpecial('null+nan', { color: 'transparent', text: 'Unknown' }),
     ],
+
+    descriptions: |||
+      The value in the status column is based on how long it has been since the last successful compaction.
+
+      - Okay: less than %(delayed)s hours
+      - Delayed: more than %(delayed)s hours
+      - Late: more than %(late)s hours
+      - Very late: more than %(veryLate)s hours
+    ||| % {
+      delayed: delayed / secondsPerHour,
+      late: late / secondsPerHour,
+      veryLate: veryLate / secondsPerHour,
+    },
   },
 
   local lastRunQuery =
@@ -215,15 +228,9 @@ local fixTargetsForTransformations(panel, refIds) = panel {
             Displays the compactor replicas, and for each, shows how long it has been since
             its last successful compaction run.
 
-            The value in the status column is based on how long it has been since the last successful compaction.
-
-            - Okay: less than 2 hours
-            - Delayed: more than 2 hours
-            - Late: more than 6 hours
-            - Very late: more than 12 hours
-
+            %(thresholdDescriptions)s
             If the status of any compactor replicas are *Late* or *Very late*, check their health.
-          |||
+          ||| % { thresholdDescriptions: lastRunThresholds.descriptions },
         ) +
         $.queryPanel(lastRunQuery, 'Last run') {
           type: 'table',

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -66,11 +66,9 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     local hours = 60 * 60,
 
     // In terms of hours
-    delayed: 2 * hours,
-    late: 6 * hours,
-    veryLate: 12 * hours,
-
-    local _ = self,
+    local delayed = 2 * hours,
+    local late = 6 * hours,
+    local veryLate = 12 * hours,
 
     // steps for thresholds
     steps: [
@@ -95,11 +93,11 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     |||
       max by(%(instance)s)
       (
-        (time() * (max_over_time(cortex_compactor_last_successful_run_timestamp_seconds[1h]) !=bool 0))
+        (time() * (max_over_time(cortex_compactor_last_successful_run_timestamp_seconds{%(job)s}[1h]) !=bool 0))
         -
-        max_over_time(cortex_compactor_last_successful_run_timestamp_seconds[1h])
+        max_over_time(cortex_compactor_last_successful_run_timestamp_seconds{%(job)s}[1h])
       )
-    ||| % { instance: $._config.per_instance_label },
+    ||| % { instance: $._config.per_instance_label, job: $.jobMatcher($._config.job_names.compactor) },
 
   local lastRunCommonTransformations = [
     transformation('organize', {

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -123,9 +123,9 @@ local fixTargetsForTransformations(panel, refIds) = panel {
         transformations:
           [transformation('merge')] +
           lastRunCommonTransformations +
-          [  
+          [
             // Not a visible field, but used as a max to determine what the "Red" value is in GrYlRd
-            // This corresponds to the "Very late" mapping range in `lastRunTablePanel` 
+            // This corresponds to the "Very late" mapping range in `lastRunTablePanel`
             transformationCalculateField('Maximum of threshold', 'Interval', '*', '9'),
           ],
         fieldConfig: super.fieldConfig + {
@@ -138,7 +138,7 @@ local fixTargetsForTransformations(panel, refIds) = panel {
               overrideProperty('mappings', [
                 mappingRange('-Infinity', 0, { color: 'text', text: 'No successful runs' }),
               ]),
-              overrideProperty('color', { mode: 'continuous-GrYlRd' }), // Green is zero, red is `Maximum of threshold`
+              overrideProperty('color', { mode: 'continuous-GrYlRd' }),  // Green is zero, red is `Maximum of threshold`
             ]),
           ],
         },
@@ -247,10 +247,10 @@ local fixTargetsForTransformations(panel, refIds) = panel {
             If there is no time value, one of the following messages may appear:
 
             - If you see "No compactor data" in this panel, that means that no compactors are active yet.
-            
+
             - If you see "No successful runs" in this panel, that means that compactors are active, but none 
               of them were successfully executed yet.
-            
+
             These may be expected - for example, if you just recently restarted your compactors, they may not 
             yet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. 
             However, if these messages persist, you should check the health of your compactors.

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -198,7 +198,7 @@ local fixTargetsForTransformations(panel, refIds) = panel {
               overrideFieldByName('Last run', [
                 overrideProperty('custom.width', 74),
                 overrideProperty('mappings', [
-                  mappingRange('-Infinity', 0, { color: 'text', text: 'No successful runs' }),
+                  mappingRange('-Infinity', 0, { color: 'text', text: 'No successful runs since startup yet' }),
                 ]),
                 overrideProperty('color', { mode: 'thresholds' }),
                 overrideProperty('thresholds', { mode: 'absolute', steps: lastRunThresholds.steps }),

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -1,6 +1,199 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
+// Panel query override functions
+local overrideFieldByName(fieldName, overrideProperties) = {
+  matcher: {
+    id: 'byName',
+    options: fieldName,
+  },
+  properties: overrideProperties,
+};
+
+local overrideProperty(id, value) = { id: id, value: value };
+
+// Panel query value mapping functions
+local mappingRange(from, to, result) = {
+  type: 'range',
+  options: {
+    from: from,
+    to: to,
+    result: result,
+  },
+};
+
+local mappingSpecial(match, result) = {
+  type: 'special',
+  options: {
+    match: match,
+    result: result,
+  },
+};
+
+// Panel query transformation functions
+
+local transformation(id, options={}) = { id: id, options: options };
+
+local transformationCalculateField(alias, left, operator, right, replaceFields=false) =
+  transformation('calculateField', {
+    alias: alias,
+    binary: {
+      left: left,
+      operator: operator,
+      right: right,
+    },
+    mode: 'binary',
+    replaceFields: replaceFields,
+  });
+
+
+// This applies to the "longest time since successful run queries"
+local fixTargetsForTransformations(panel, refIds) = panel {
+  // Make some adjustments to the targets to make them compatible with the transformations required
+  targets: [
+    panel.targets[i] {
+      refId: refIds[i],
+      format: 'table',
+      instant: true,
+    }
+    for i in std.range(0, std.length(refIds) - 1)
+  ],
+};
+
 (import 'dashboard-utils.libsonnet') {
+
+  local vars = {
+    instance: $._config.per_instance_label,
+  },
+
+  local lastRunQueries = {
+    queries: [
+      // Last run - (will be exactly zero if no successful run)
+      |||
+        max by(%(instance)s)
+        (
+          (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))
+          - 
+          cortex_compactor_last_successful_run_timestamp_seconds
+        )
+      ||| % (vars),
+      // Interval
+      |||
+        max by (%(instance)s) 
+        (
+          cortex_compactor_compaction_interval_seconds
+        )
+      ||| % (vars),
+    ],
+    refIds: [
+      'Last run',
+      'Interval',
+    ],
+  },
+
+  local lastRunCommonTransformations = [
+    transformation('organize', {
+      renameByName: {
+        'Value #Interval': 'Interval',
+        'Value #Last run': 'Last run',
+        ['%s' % vars.instance]: 'Compactor',
+      },
+    }),
+    transformationCalculateField('Status', 'Last run', '/', 'Interval'),
+    transformation('sortBy', {
+      sort: [
+        {
+          desc: true,
+          field: 'Status',
+        },
+      ],
+    }),
+  ],
+
+  lastRunStatPanel():: (
+    local panel =
+      $.newStatPanel(lastRunQueries.queries, lastRunQueries.refIds, unit='s') + {
+        options: {
+          reduceOptions: {
+            values: false,
+            calcs: ['first'],
+            fields: '/^Last run$/',
+          },
+          textMode: 'value',
+        },
+        transformations:
+          [transformation('merge')] +
+          lastRunCommonTransformations +
+          [  
+            // Not a visible field, but used as a max to determine what the "Red" value is in GrYlRd
+            // This corresponds to the "Very late" mapping range in `lastRunTablePanel` 
+            transformationCalculateField('Maximum of threshold', 'Interval', '*', '9'),
+          ],
+        fieldConfig: super.fieldConfig + {
+          defaults: super.defaults {
+            noValue: 'No compactor data',
+          },
+          overrides: [
+            overrideFieldByName('Last run', [
+              overrideProperty('custom.width', 74),
+              overrideProperty('mappings', [
+                mappingRange('-Infinity', 0, { color: 'text', text: 'No successful runs' }),
+              ]),
+              overrideProperty('color', { mode: 'continuous-GrYlRd' }), // Green is zero, red is `Maximum of threshold`
+            ]),
+          ],
+        },
+      };
+    fixTargetsForTransformations(panel, lastRunQueries.refIds)
+  ),
+
+  lastRunTablePanel():: (
+    local panel =
+      $.queryPanel(lastRunQueries.queries, lastRunQueries.refIds) + {
+        type: 'table',
+        transformations:
+          [{ id: 'seriesToColumns', options: { byField: 'instance' } }] +
+          lastRunCommonTransformations +
+          [
+            transformation('filterFieldsByName', {
+              include: {  // Only include these fields in the display
+                names: ['Compactor', 'Last run', 'Status'],
+              },
+            }),
+            transformation('filterByValue', {
+              filters: [{ fieldName: 'Last run', config: { id: 'isNull' } }],
+              type: 'exclude',
+              match: 'any',
+            }),
+          ],
+        fieldConfig: {
+          overrides: [
+            overrideFieldByName('Status', [
+              overrideProperty('custom.displayMode', 'color-background'),
+              overrideProperty('mappings', [
+                mappingRange('-Infinity', 0, { color: 'transparent', text: 'N/A' }),
+                // These numbers are multiples of the compaction interval
+                // Default interval 1hr, so 0hrs to 3hrs is okay, 3hrs to 6hrs is Delayed, etc.
+                mappingRange(0, 3, { color: 'green', text: 'Ok' }),
+                mappingRange(3, 6, { color: 'yellow', text: 'Delayed' }),
+                mappingRange(6, 9, { color: 'orange', text: 'Late' }),
+                mappingRange(9, 'Infinity', { color: 'red', text: 'Very late' }),
+                mappingSpecial('null+nan', { color: 'transparent', text: 'Unknown' }),
+              ]),
+              overrideProperty('custom.width', 86),
+              overrideProperty('custom.align', 'center'),
+            ]),
+            overrideFieldByName('Last run', [
+              overrideProperty('unit', 's'),
+              overrideProperty('custom.width', 74),
+              overrideProperty('mappings', [
+                mappingRange('-Infinity', 0, { text: 'Never' }),
+              ]),
+            ]),
+          ],
+        },
+      };
+    fixTargetsForTransformations(panel, lastRunQueries.refIds)
+  ),
   'mimir-compactor.json':
     ($.dashboard('Compactor') + { uid: '9c408e1d55681ecb8a22c9fab46875cc' })
     .addClusterSelectorTemplates()
@@ -39,6 +232,29 @@ local utils = import 'mixin-utils/utils.libsonnet';
             Reset to <tt>0</tt> after the compaction run is completed for all tenants in the shard.
           |||
         ),
+      )
+      .addPanel(
+        $.panel('Longest time since last successful run') +
+        $.panelDescription(
+          'Longest time since last successful run',
+          |||
+            Displays the amount of time since the most recent successful execution
+            of the compactor replica with the longest delay (per compaction interval).
+          |||
+        ) +
+        $.lastRunStatPanel()
+      )
+      .addPanel(
+        $.panel('Last successful run per-compactor replica') +
+        $.panelDescription(
+          'Last successful run per-compactor replica',
+          |||
+            Displays the compactor replicas, and for each, indicate the status of their
+            most recent compaction in terms of how long it has been since that compactor
+            was successfully executed, along with its compaction interval.
+          |||
+        ) +
+        $.lastRunTablePanel()
       )
     )
     .addRow(

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -239,7 +239,21 @@ local fixTargetsForTransformations(panel, refIds) = panel {
           'Longest time since last successful run',
           |||
             Displays the amount of time since the most recent successful execution
-            of the compactor replica with the longest delay (per compaction interval).
+            of the compactor.
+            The value shown will be for the compactor replica which has the longest time since its
+            last successful run, relative to its compaction interval.
+            The table to the right shows a summary for all compactor replicas.
+
+            If there is no time value, one of the following messages may appear:
+
+            - If you see "No compactor data" in this panel, that means that no compactors are active yet.
+            
+            - If you see "No successful runs" in this panel, that means that compactors are active, but none 
+              of them were successfully executed yet.
+            
+            These may be expected - for example, if you just recently restarted your compactors, they may not 
+            yet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. 
+            However, if these messages persist, you should check the health of your compactors.
           |||
         ) +
         $.lastRunStatPanel()
@@ -249,9 +263,17 @@ local fixTargetsForTransformations(panel, refIds) = panel {
         $.panelDescription(
           'Last successful run per-compactor replica',
           |||
-            Displays the compactor replicas, and for each, indicate the status of their
-            most recent compaction in terms of how long it has been since that compactor
-            was successfully executed, along with its compaction interval.
+            Displays the compactor replicas, and for each, shows how long it has been since
+            its last successful compaction run.
+
+            The value in status column is based on how long it has been since the last compaction, 
+            relative to the compaction interval (which is by default, one hour long).
+
+            - Delayed: more than 3 times the interval
+            - Late: more than 6 times the interval
+            - Very late: more than 9 times the interval
+
+            If the status of any compactor replicas are late, you should check their health.
           |||
         ) +
         $.lastRunTablePanel()

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -169,19 +169,19 @@ local fixTargetsForTransformations(panel, refIds) = panel {
           |||
             Displays the amount of time since the most recent successful execution
             of the compactor.
-            The value shown will be for the compactor replica which has the longest time since its
+            The value shown will be for the compactor replica that has the longest time since its
             last successful run.
             The table to the right shows a summary for all compactor replicas.
 
-            If there is no time value, one of the following messages may appear:
+            If there is no time value, one of the following messages might appear:
 
             - If you see "No compactor data" in this panel, that means that no compactors are active yet.
 
             - If you see "No successful runs" in this panel, that means that compactors are active, but none 
               of them were successfully executed yet.
 
-            These may be expected - for example, if you just recently restarted your compactors, they may not 
-            yet be broadcasting metrics, or they may not have had a chance to complete their first compaction run. 
+            These might be expected - for example, if you just recently restarted your compactors, they might not 
+            yet be broadcasting metrics, or they might not have had a chance to complete their first compaction run. 
             However, if these messages persist, you should check the health of your compactors.
           |||
         ) +
@@ -223,13 +223,14 @@ local fixTargetsForTransformations(panel, refIds) = panel {
             Displays the compactor replicas, and for each, shows how long it has been since
             its last successful compaction run.
 
-            The value in status column is based on how long it has been since the last successful compaction.
+            The value in the status column is based on how long it has been since the last successful compaction.
 
+            - Okay: less than 2 hours
             - Delayed: more than 2 hours
             - Late: more than 6 hours
             - Very late: more than 12 hours
 
-            If the status of any compactor replicas are late, you should check their health.
+            If the status of any compactor replicas are *Late* or *Very late*, check their health.
           |||
         ) +
         $.queryPanel(lastRunQuery, 'Last run') {

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -189,9 +189,7 @@ local fixTargetsForTransformations(panel, refIds) = panel {
             textMode: 'value',
           },
           targets: [target { format: 'table', instant: true } for target in super.targets],
-          transformations:
-            //[transformation('merge')] +
-            lastRunCommonTransformations,
+          transformations: lastRunCommonTransformations,
           fieldConfig: super.fieldConfig + {
             defaults: super.defaults {
               noValue: 'No compactor data',

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -99,9 +99,9 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     |||
       max by(%(instance)s)
       (
-        (time() * (cortex_compactor_last_successful_run_timestamp_seconds !=bool 0))
+        (time() * (max_over_time(cortex_compactor_last_successful_run_timestamp_seconds[1h]) !=bool 0))
         - 
-        cortex_compactor_last_successful_run_timestamp_seconds
+        max_over_time(cortex_compactor_last_successful_run_timestamp_seconds[1h])
       )
     ||| % (vars),
 

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -61,10 +61,6 @@ local fixTargetsForTransformations(panel, refIds) = panel {
 
 (import 'dashboard-utils.libsonnet') {
 
-  local vars = {
-    instance: $._config.per_instance_label,
-  },
-
   local lastRunThresholds = {
 
     local hours = 60 * 60,
@@ -100,16 +96,16 @@ local fixTargetsForTransformations(panel, refIds) = panel {
       max by(%(instance)s)
       (
         (time() * (max_over_time(cortex_compactor_last_successful_run_timestamp_seconds[1h]) !=bool 0))
-        - 
+        -
         max_over_time(cortex_compactor_last_successful_run_timestamp_seconds[1h])
       )
-    ||| % (vars),
+    ||| % { instance: $._config.per_instance_label },
 
   local lastRunCommonTransformations = [
     transformation('organize', {
       renameByName: {
         Value: 'Last run',
-        ['%s' % vars.instance]: 'Compactor',
+        ['%s' % $._config.per_instance_label]: 'Compactor',
       },
     }),
     transformationCalculateField('Status', 'Last run', '*', 1),  // Duplicate field to be transformed
@@ -177,11 +173,11 @@ local fixTargetsForTransformations(panel, refIds) = panel {
 
             - If you see "No compactor data" in this panel, that means that no compactors are active yet.
 
-            - If you see "No successful runs" in this panel, that means that compactors are active, but none 
+            - If you see "No successful runs" in this panel, that means that compactors are active, but none
               of them were successfully executed yet.
 
             These might be expected - for example, if you just recently restarted your compactors,
-            they might not have had a chance to complete their first compaction run. 
+            they might not have had a chance to complete their first compaction run.
             However, if these messages persist, you should check the health of your compactors.
           |||
         ) +

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -1,51 +1,5 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
-// Panel query override functions
-local overrideFieldByName(fieldName, overrideProperties) = {
-  matcher: {
-    id: 'byName',
-    options: fieldName,
-  },
-  properties: overrideProperties,
-};
-
-local overrideProperty(id, value) = { id: id, value: value };
-
-// Panel query value mapping functions
-local mappingRange(from, to, result) = {
-  type: 'range',
-  options: {
-    from: from,
-    to: to,
-    result: result,
-  },
-};
-
-local mappingSpecial(match, result) = {
-  type: 'special',
-  options: {
-    match: match,
-    result: result,
-  },
-};
-
-// Panel query transformation functions
-
-local transformation(id, options={}) = { id: id, options: options };
-
-local transformationCalculateField(alias, left, operator, right, replaceFields=false) =
-  transformation('calculateField', {
-    alias: alias,
-    binary: {
-      left: left,
-      operator: operator,
-      right: right,
-    },
-    mode: 'binary',
-    replaceFields: replaceFields,
-  });
-
-
 // This applies to the "longest time since successful run queries"
 local fixTargetsForTransformations(panel, refIds) = panel {
   // Make some adjustments to the targets to make them compatible with the transformations required
@@ -80,12 +34,12 @@ local fixTargetsForTransformations(panel, refIds) = panel {
 
     // status mappings: messages and colors
     mappings: [
-      mappingRange('-Infinity', 0, { color: 'transparent', text: 'N/A' }),
-      mappingRange(0, delayed, { color: 'green', text: 'Ok' }),
-      mappingRange(delayed, late, { color: 'yellow', text: 'Delayed' }),
-      mappingRange(late, veryLate, { color: 'orange', text: 'Late' }),
-      mappingRange(veryLate, 'Infinity', { color: 'red', text: 'Very late' }),
-      mappingSpecial('null+nan', { color: 'transparent', text: 'Unknown' }),
+      $.mappingRange('-Infinity', 0, { color: 'transparent', text: 'N/A' }),
+      $.mappingRange(0, delayed, { color: 'green', text: 'Ok' }),
+      $.mappingRange(delayed, late, { color: 'yellow', text: 'Delayed' }),
+      $.mappingRange(late, veryLate, { color: 'orange', text: 'Late' }),
+      $.mappingRange(veryLate, 'Infinity', { color: 'red', text: 'Very late' }),
+      $.mappingSpecial('null+nan', { color: 'transparent', text: 'Unknown' }),
     ],
 
     descriptions: |||
@@ -113,14 +67,14 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     ||| % { instance: $._config.per_instance_label, job: $.jobMatcher($._config.job_names.compactor) },
 
   local lastRunCommonTransformations = [
-    transformation('organize', {
+    $.transformation('organize', {
       renameByName: {
         Value: 'Last run',
         ['%s' % $._config.per_instance_label]: 'Compactor',
       },
     }),
-    transformationCalculateField('Status', 'Last run', '*', 1),  // Duplicate field to be transformed
-    transformation('sortBy', {
+    $.transformationCalculateField('Status', 'Last run', '*', 1),  // Duplicate field to be transformed
+    $.transformation('sortBy', {
       sort: [
         {
           desc: true,
@@ -208,13 +162,13 @@ local fixTargetsForTransformations(panel, refIds) = panel {
               noValue: 'No compactor data',
             },
             overrides: [
-              overrideFieldByName('Last run', [
-                overrideProperty('custom.width', 74),
-                overrideProperty('mappings', [
-                  mappingRange('-Infinity', 0, { color: 'text', text: 'No successful runs since startup yet' }),
+              $.overrideFieldByName('Last run', [
+                $.overrideProperty('custom.width', 74),
+                $.overrideProperty('mappings', [
+                  $.mappingRange('-Infinity', 0, { color: 'text', text: 'No successful runs since startup yet' }),
                 ]),
-                overrideProperty('color', { mode: 'thresholds' }),
-                overrideProperty('thresholds', { mode: 'absolute', steps: lastRunThresholds.steps }),
+                $.overrideProperty('color', { mode: 'thresholds' }),
+                $.overrideProperty('thresholds', { mode: 'absolute', steps: lastRunThresholds.steps }),
               ]),
             ],
           },
@@ -237,24 +191,24 @@ local fixTargetsForTransformations(panel, refIds) = panel {
           targets: [target { format: 'table', instant: true } for target in super.targets],
           transformations:
             lastRunCommonTransformations +
-            [transformation('filterFieldsByName', {
+            [$.transformation('filterFieldsByName', {
               include: {  // Only include these fields in the display
                 names: ['Compactor', 'Last run', 'Status'],
               },
             })],
           fieldConfig: {
             overrides: [
-              overrideFieldByName('Status', [
-                overrideProperty('custom.displayMode', 'color-background'),
-                overrideProperty('mappings', lastRunThresholds.mappings),
-                overrideProperty('custom.width', 86),
-                overrideProperty('custom.align', 'center'),
+              $.overrideFieldByName('Status', [
+                $.overrideProperty('custom.displayMode', 'color-background'),
+                $.overrideProperty('mappings', lastRunThresholds.mappings),
+                $.overrideProperty('custom.width', 86),
+                $.overrideProperty('custom.align', 'center'),
               ]),
-              overrideFieldByName('Last run', [
-                overrideProperty('unit', 's'),
-                overrideProperty('custom.width', 74),
-                overrideProperty('mappings', [
-                  mappingRange('-Infinity', 0, { text: 'Never' }),
+              $.overrideFieldByName('Last run', [
+                $.overrideProperty('unit', 's'),
+                $.overrideProperty('custom.width', 74),
+                $.overrideProperty('mappings', [
+                  $.mappingRange('-Infinity', 0, { text: 'Never' }),
                 ]),
               ]),
             ],

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -75,18 +75,18 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     // steps for thresholds
     steps: [
       { value: 0, color: 'green' },
-      { value: _.delayed, color: 'yellow' },
-      { value: _.late, color: 'orange' },
-      { value: _.veryLate, color: 'red' },
+      { value: delayed, color: 'yellow' },
+      { value: late, color: 'orange' },
+      { value: veryLate, color: 'red' },
     ],
 
     // status mappings: messages and colors
     mappings: [
       mappingRange('-Infinity', 0, { color: 'transparent', text: 'N/A' }),
-      mappingRange(0, _.delayed, { color: 'green', text: 'Ok' }),
-      mappingRange(_.delayed, _.late, { color: 'yellow', text: 'Delayed' }),
-      mappingRange(_.late, _.veryLate, { color: 'orange', text: 'Late' }),
-      mappingRange(_.veryLate, 'Infinity', { color: 'red', text: 'Very late' }),
+      mappingRange(0, delayed, { color: 'green', text: 'Ok' }),
+      mappingRange(delayed, late, { color: 'yellow', text: 'Delayed' }),
+      mappingRange(late, veryLate, { color: 'orange', text: 'Late' }),
+      mappingRange(veryLate, 'Infinity', { color: 'red', text: 'Very late' }),
       mappingSpecial('null+nan', { color: 'transparent', text: 'Unknown' }),
     ],
   },

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -180,8 +180,8 @@ local fixTargetsForTransformations(panel, refIds) = panel {
             - If you see "No successful runs" in this panel, that means that compactors are active, but none 
               of them were successfully executed yet.
 
-            These might be expected - for example, if you just recently restarted your compactors, they might not 
-            yet be broadcasting metrics, or they might not have had a chance to complete their first compaction run. 
+            These might be expected - for example, if you just recently restarted your compactors,
+            they might not have had a chance to complete their first compaction run. 
             However, if these messages persist, you should check the health of your compactors.
           |||
         ) +

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -597,4 +597,50 @@ local utils = import 'mixin-utils/utils.libsonnet';
       %s
     ||| % [title, description],
   },
+
+  // Panel query override functions
+  overrideFieldByName(fieldName, overrideProperties):: {
+    matcher: {
+      id: 'byName',
+      options: fieldName,
+    },
+    properties: overrideProperties,
+  },
+
+  overrideProperty(id, value):: { id: id, value: value },
+
+  // Panel query value mapping functions
+  mappingRange(from, to, result):: {
+    type: 'range',
+    options: {
+      from: from,
+      to: to,
+      result: result,
+    },
+  },
+
+  mappingSpecial(match, result):: {
+    type: 'special',
+    options: {
+      match: match,
+      result: result,
+    },
+  },
+
+  // Panel query transformation functions
+
+  transformation(id, options={}):: { id: id, options: options },
+
+  transformationCalculateField(alias, left, operator, right, replaceFields=false)::
+    $.transformation('calculateField', {
+      alias: alias,
+      binary: {
+        left: left,
+        operator: operator,
+        right: right,
+      },
+      mode: 'binary',
+      replaceFields: replaceFields,
+    }),
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds two panels to the compactor dashboard:
- Longest time since last successful run
  - a stat panel which displays the amount of time since the most recent successful execution of the compactor replica with the longest delay (per compaction interval). 
- Last successful run per-compactor replica
  -  a table panel which displays the compactor replicas, and for each, indicates the status of their most recent compaction.
  
#### Checklist

- [ ] Tests updated
  - N/A
- [x] Documentation added inline
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
  - N/A
