### PR TITLE
Mixin: Fix "Failed evaluation rate" panel on Tenants dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
+* [BUGFIX] Dashboards: Fix "Failed evaluation rate" panel on Tenants dashboard. #1629
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -1439,7 +1439,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by (rule_group) (rate(cortex_prometheus_rule_group_rules{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir))\", user=\"$user\"}[$__rate_interval]))",
+                        "expr": "sum by (rule_group) (rate(cortex_prometheus_rule_evaluation_failures_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir))\", user=\"$user\"}[$__rate_interval])) > 0",
                         "format": "time_series",
                         "interval": "15s",
                         "intervalFactor": 2,

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -400,7 +400,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         local title = 'Failed evaluations rate';
         $.panel(title) +
         $.queryPanel(
-          'sum by (rule_group) (rate(cortex_prometheus_rule_group_rules{%(job)s, user="$user"}[$__rate_interval]))'
+          'sum by (rule_group) (rate(cortex_prometheus_rule_evaluation_failures_total{%(job)s, user="$user"}[$__rate_interval])) > 0'
           % { job: $.jobMatcher($._config.job_names.ruler) },
           '{{ rule_group }}',
         ) + { stack: true },


### PR DESCRIPTION
Fix to use the correct metric, and only show series which actually have
failures, making the panel easier to read when there are many rule groups.
