### PR TITLE
Fix typos in cortex migration guide.

### DIFF
--- a/docs/sources/migration-guide/migrating-from-cortex.md
+++ b/docs/sources/migration-guide/migrating-from-cortex.md
@@ -221,13 +221,13 @@ You can update to the Grafana Mimir Helm chart from the Cortex Helm chart.
    a. Extract the Cortex configuration and write the output to the `cortex.yaml` file.
 
    ```bash
-   yq -Y '.config' <VALUES YAML FILE> > cortex.yaml
+   yq '.config' <VALUES YAML FILE> > cortex.yaml
    ```
 
    b. Use `mimirtool` to update the configuration.
 
    ```bash
-   mimirtool config convert cortex.yaml
+   mimirtool config convert --yaml-file cortex.yaml
    ```
 
    c. Place the updated configuration under the `mimir.config` key at the top level of your Helm values file.


### PR DESCRIPTION
- `-Y` isn't a valid flag for `yq`
- `--yaml-file` is a positional argument to `mimirtool config convert`

Signed-off-by: Josh Carp <jm.carp@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
