### PR TITLE
Find previously written samples in mimir-continuous-test and recover from there at startup

### DIFF
--- a/pkg/continuoustest/manager.go
+++ b/pkg/continuoustest/manager.go
@@ -13,7 +13,7 @@ type Test interface {
 	Name() string
 
 	// Init initializes the test. If the initialization fails, the testing tool will terminate.
-	Init() error
+	Init(ctx context.Context, now time.Time) error
 
 	// Run runs a single test cycle. This function is called multiple times, at periodic intervals.
 	Run(ctx context.Context, now time.Time)
@@ -34,7 +34,7 @@ func (m *Manager) AddTest(t Test) {
 func (m *Manager) Run(ctx context.Context) error {
 	// Initialize all tests.
 	for _, t := range m.tests {
-		if err := t.Init(); err != nil {
+		if err := t.Init(ctx, time.Now()); err != nil {
 			return err
 		}
 	}

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -71,36 +71,41 @@ func generateSineWaveValue(t time.Time) float64 {
 
 // verifySineWaveSamplesSum assumes the input matrix is the result of a range query summing the values
 // of expectedSeries sine wave series and checks whether the actual values match the expected ones.
-// Returns error if values don't match.
-func verifySineWaveSamplesSum(matrix model.Matrix, expectedSeries int, expectedStep time.Duration) error {
+// Samples are checked in backward order, from newest to oldest. Returns error if values don't match,
+// and the index of the last sample that matched the expectation or -1 if no sample matches.
+func verifySineWaveSamplesSum(matrix model.Matrix, expectedSeries int, expectedStep time.Duration) (lastMatchingIdx int, err error) {
+	lastMatchingIdx = -1
 	if len(matrix) != 1 {
-		return fmt.Errorf("expected 1 series in the result but got %d", len(matrix))
+		return lastMatchingIdx, fmt.Errorf("expected 1 series in the result but got %d", len(matrix))
 	}
 
 	samples := matrix[0].Values
 
-	for idx, sample := range samples {
+	for idx := len(samples) - 1; idx >= 0; idx-- {
+		sample := samples[idx]
 		ts := time.UnixMilli(int64(sample.Timestamp)).UTC()
 
 		// Assert on value.
 		expectedValue := generateSineWaveValue(ts)
 		if !compareSampleValues(float64(sample.Value), expectedValue*float64(expectedSeries)) {
-			return fmt.Errorf("sample at timestamp %d (%s) has value %f while was expecting %f", sample.Timestamp, ts.String(), sample.Value, expectedValue)
+			return lastMatchingIdx, fmt.Errorf("sample at timestamp %d (%s) has value %f while was expecting %f", sample.Timestamp, ts.String(), sample.Value, expectedValue)
 		}
 
 		// Assert on sample timestamp. We expect no gaps.
-		if idx > 0 {
-			prevTs := time.UnixMilli(int64(samples[idx-1].Timestamp)).UTC()
-			expectedTs := prevTs.Add(expectedStep)
+		if idx < len(samples)-1 {
+			nextTs := time.UnixMilli(int64(samples[idx+1].Timestamp)).UTC()
+			expectedTs := nextTs.Add(-expectedStep)
 
 			if ts.UnixMilli() != expectedTs.UnixMilli() {
-				return fmt.Errorf("sample at timestamp %d (%s) was expected to have timestamp %d (%s) because previous sample had timestamp %d (%s)",
-					sample.Timestamp, ts.String(), expectedTs.UnixMilli(), expectedTs.String(), prevTs.UnixMilli(), prevTs.String())
+				return lastMatchingIdx, fmt.Errorf("sample at timestamp %d (%s) was expected to have timestamp %d (%s) because next sample has timestamp %d (%s)",
+					sample.Timestamp, ts.String(), expectedTs.UnixMilli(), expectedTs.String(), nextTs.UnixMilli(), nextTs.String())
 			}
 		}
+
+		lastMatchingIdx = idx
 	}
 
-	return nil
+	return lastMatchingIdx, nil
 }
 
 func compareSampleValues(actual, expected float64) bool {

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -86,8 +86,8 @@ func verifySineWaveSamplesSum(matrix model.Matrix, expectedSeries int, expectedS
 		ts := time.UnixMilli(int64(sample.Timestamp)).UTC()
 
 		// Assert on value.
-		expectedValue := generateSineWaveValue(ts)
-		if !compareSampleValues(float64(sample.Value), expectedValue*float64(expectedSeries)) {
+		expectedValue := generateSineWaveValue(ts) * float64(expectedSeries)
+		if !compareSampleValues(float64(sample.Value), expectedValue) {
 			return lastMatchingIdx, fmt.Errorf("sample at timestamp %d (%s) has value %f while was expecting %f", sample.Timestamp, ts.String(), sample.Value, expectedValue)
 		}
 

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	writeInterval = 20 * time.Second
+	writeMaxAge   = 50 * time.Minute
 	metricName    = "mimir_continuous_test_sine_wave"
 )
 
@@ -60,8 +61,24 @@ func (t *WriteReadSeriesTest) Name() string {
 }
 
 // Init implements Test.
-func (t *WriteReadSeriesTest) Init() error {
-	// TODO Here we should populate lastWrittenTimestamp, queryMinTime, queryMaxTime after querying Mimir to get data previously written.
+func (t *WriteReadSeriesTest) Init(ctx context.Context, now time.Time) error {
+	level.Info(t.logger).Log("msg", "Finding previously written samples time range to recover writes and reads from previous run")
+
+	from, to := t.findPreviouslyWrittenTimeRange(ctx, now)
+	if from.IsZero() || to.IsZero() {
+		level.Info(t.logger).Log("msg", "No valid previously written samples time range found")
+		return nil
+	}
+	if to.Before(now.Add(-writeMaxAge)) {
+		level.Info(t.logger).Log("msg", "Previously written samples time range found but latest written sample is too old to recover", "last_sample_timestamp", to)
+		return nil
+	}
+
+	t.lastWrittenTimestamp = to
+	t.queryMinTime = from
+	t.queryMaxTime = to
+	level.Info(t.logger).Log("msg", "Successfully found previously written samples time range and recovered writes and reads from there", "last_written_timestamp", t.lastWrittenTimestamp, "query_min_time", t.queryMinTime, "query_max_time", t.queryMaxTime)
+
 	return nil
 }
 
@@ -187,7 +204,7 @@ func (t *WriteReadSeriesTest) runRangeQueryAndVerifyResult(ctx context.Context, 
 	}
 
 	t.metrics.queryResultChecksTotal.Inc()
-	err = verifySineWaveSamplesSum(matrix, t.cfg.NumSeries, step)
+	_, err = verifySineWaveSamplesSum(matrix, t.cfg.NumSeries, step)
 	if err != nil {
 		t.metrics.queryResultChecksFailedTotal.Inc()
 		level.Warn(logger).Log("msg", "Range query result check failed", "err", err)
@@ -229,7 +246,7 @@ func (t *WriteReadSeriesTest) runInstantQueryAndVerifyResult(ctx context.Context
 	}
 
 	t.metrics.queryResultChecksTotal.Inc()
-	err = verifySineWaveSamplesSum(matrix, t.cfg.NumSeries, 0)
+	_, err = verifySineWaveSamplesSum(matrix, t.cfg.NumSeries, 0)
 	if err != nil {
 		t.metrics.queryResultChecksFailedTotal.Inc()
 		level.Warn(logger).Log("msg", "Instant query result check failed", "err", err)
@@ -243,4 +260,59 @@ func (t *WriteReadSeriesTest) nextWriteTimestamp(now time.Time) time.Time {
 	}
 
 	return t.lastWrittenTimestamp.Add(writeInterval)
+}
+
+func (t *WriteReadSeriesTest) findPreviouslyWrittenTimeRange(ctx context.Context, now time.Time) (from, to time.Time) {
+	// We use max_over_time() with a 1s range selector in order to fetch only the samples we previously
+	// wrote and ensure the PromQL lookback period doesn't influence query results.
+	query := fmt.Sprintf("sum(max_over_time(%s[1s]))", metricName)
+	end := alignTimestampToInterval(now, writeInterval)
+	step := writeInterval
+
+	var samples []model.SamplePair
+
+	for {
+		start := alignTimestampToInterval(maxTime(now.Add(-t.cfg.MaxQueryAge), end.Add(-24*time.Hour).Add(step)), writeInterval)
+		if !start.Before(end) {
+			// We've hit the max query age, so we'll keep the last computed valid time range (if any).
+			return
+		}
+
+		logger := log.With(t.logger, "query", query, "start", start, "end", end, "step", step)
+		level.Debug(logger).Log("msg", "Executing query to find previously written samples")
+
+		matrix, err := t.client.QueryRange(ctx, query, start, end, step)
+		if err != nil {
+			level.Warn(logger).Log("msg", "Failed to execute range query used to find previously written samples", "err", err)
+			return
+		}
+
+		if len(matrix) == 0 {
+			// No samples found, so we'll keep the last computed valid time range (if any).
+			return
+		}
+
+		if len(matrix) != 1 {
+			level.Error(logger).Log("msg", "The range query used to find previously written samples returned an unexpected number of series", "expected", 1, "returned", len(matrix))
+			return
+		}
+
+		samples = append(matrix[0].Values, samples...)
+		end = start.Add(-step)
+
+		lastMatchingIdx, _ := verifySineWaveSamplesSum(model.Matrix{{Values: samples}}, t.cfg.NumSeries, step)
+		if lastMatchingIdx == -1 {
+			return
+		}
+
+		// Update the previously written time range.
+		from = samples[lastMatchingIdx].Timestamp.Time()
+		to = samples[len(samples)-1].Timestamp.Time()
+
+		// If the last matching sample is not the one at the beginning of the queried time range
+		// then it means we've found the oldest previously written sample and we can stop searching it.
+		if lastMatchingIdx != 0 || !samples[0].Timestamp.Time().Equal(start) {
+			return
+		}
+	}
 }

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -281,6 +281,7 @@ func (t *WriteReadSeriesTest) findPreviouslyWrittenTimeRange(ctx context.Context
 		logger := log.With(t.logger, "query", query, "start", start, "end", end, "step", step)
 		level.Debug(logger).Log("msg", "Executing query to find previously written samples")
 
+		// TODO Run this query with cache disabled (once will be supported by Mimir).
 		matrix, err := t.client.QueryRange(ctx, query, start, end, step)
 		if err != nil {
 			level.Warn(logger).Log("msg", "Failed to execute range query used to find previously written samples", "err", err)


### PR DESCRIPTION
#### What this PR does
In this PR I'm adding logic to find previously written samples in mimir-continuous-test and recover from there at startup. The idea is that after a restart (eg. rollout new version or K8S re-scheduling) the continuous test tool should try to recover from previous state.

**What's done in this PR:**
- Detect previously written samples at startup (only contiguous samples matching the expected values are considered valid)
- If no data is found, then start remote writing samples from the current timestamp
- If the latest written sample time is older than `1h - 10m delta = 50m` then it acts as if no previous data has been found and starts writing from the current timestamp

**Out of scope of this PR:**
-  Query both with cache enabled and disabled
- Doc & CHANGELOG

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
