### PR TITLE
mimirtool: Don't use ioutil

### DIFF
--- a/pkg/mimirtool/client/alerts.go
+++ b/pkg/mimirtool/client/alerts.go
@@ -7,7 +7,7 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -62,7 +62,7 @@ func (r *MimirClient) GetAlertmanagerConfig(ctx context.Context) (string, map[st
 	}
 
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/mimirtool/client/rules.go
+++ b/pkg/mimirtool/client/rules.go
@@ -8,7 +8,7 @@ package client
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -67,7 +67,7 @@ func (r *MimirClient) GetRuleGroup(ctx context.Context, namespace, groupName str
 	}
 
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[stri
 	}
 
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return nil, err

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -110,7 +110,7 @@ func (a *AlertmanagerCommand) getConfig(k *kingpin.ParseContext) error {
 }
 
 func (a *AlertmanagerCommand) loadConfig(k *kingpin.ParseContext) error {
-	content, err := ioutil.ReadFile(a.AlertmanagerConfigFile)
+	content, err := os.ReadFile(a.AlertmanagerConfigFile)
 	if err != nil {
 		return errors.Wrap(err, "unable to load config file: "+a.AlertmanagerConfigFile)
 	}
@@ -123,7 +123,7 @@ func (a *AlertmanagerCommand) loadConfig(k *kingpin.ParseContext) error {
 
 	templates := map[string]string{}
 	for _, f := range a.TemplateFiles {
-		tmpl, err := ioutil.ReadFile(f)
+		tmpl, err := os.ReadFile(f)
 		if err != nil {
 			return errors.Wrap(err, "unable to load template file: "+f)
 		}
@@ -258,7 +258,7 @@ func (a *AlertCommand) runVerifyQuery(ctx context.Context, query string) (int, e
 		return 0, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -75,7 +74,7 @@ func writeOut(mig *analyze.MetricsInGrafana, outputFile string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(outputFile, out, os.FileMode(int(0666))); err != nil {
+	if err := os.WriteFile(outputFile, out, os.FileMode(int(0666))); err != nil {
 		return err
 	}
 

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -8,7 +8,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -46,7 +45,7 @@ func (cmd *PrometheusAnalyzeCommand) run(k *kingpin.ParseContext) error {
 
 	if _, err := os.Stat(cmd.grafanaMetricsFile); err == nil {
 		hasGrafanaMetrics = true
-		byt, err := ioutil.ReadFile(cmd.grafanaMetricsFile)
+		byt, err := os.ReadFile(cmd.grafanaMetricsFile)
 		if err != nil {
 			return err
 		}
@@ -58,7 +57,7 @@ func (cmd *PrometheusAnalyzeCommand) run(k *kingpin.ParseContext) error {
 
 	if _, err := os.Stat(cmd.rulerMetricsFile); err == nil {
 		hasRulerMetrics = true
-		byt, err := ioutil.ReadFile(cmd.rulerMetricsFile)
+		byt, err := os.ReadFile(cmd.rulerMetricsFile)
 		if err != nil {
 			return err
 		}
@@ -233,7 +232,7 @@ func (cmd *PrometheusAnalyzeCommand) run(k *kingpin.ParseContext) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(cmd.outputFile, out, os.FileMode(int(0666))); err != nil {
+	if err := os.WriteFile(cmd.outputFile, out, os.FileMode(int(0666))); err != nil {
 		return err
 	}
 

--- a/pkg/mimirtool/commands/analyse_ruler.go
+++ b/pkg/mimirtool/commands/analyse_ruler.go
@@ -8,7 +8,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"sort"
 
@@ -70,7 +69,7 @@ func writeOutRuleMetrics(mir *analyze.MetricsInRuler, outputFile string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(outputFile, out, os.FileMode(int(0666))); err != nil {
+	if err := os.WriteFile(outputFile, out, os.FileMode(int(0666))); err != nil {
 		return err
 	}
 

--- a/pkg/mimirtool/commands/bucket_validation.go
+++ b/pkg/mimirtool/commands/bucket_validation.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -251,7 +250,7 @@ func (b *BucketValidationCommand) validateTestObjects(ctx context.Context) error
 			return errors.Wrapf(err, "failed to get object (%s)", objectPath)
 		}
 
-		content, err := ioutil.ReadAll(reader)
+		content, err := io.ReadAll(reader)
 		if err != nil {
 			return errors.Wrapf(err, "failed to read object (%s)", objectPath)
 		}

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -390,7 +389,7 @@ func (c *RemoteReadCommand) export(k *kingpin.ParseContext) error {
 	}
 
 	if c.tsdbPath == "" {
-		c.tsdbPath, err = ioutil.TempDir("", "mimirtool-tsdb")
+		c.tsdbPath, err = os.MkdirTemp("", "mimirtool-tsdb")
 		if err != nil {
 			return err
 		}

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -8,7 +8,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -774,7 +773,7 @@ func save(nss map[string]rules.RuleNamespace, i bool) error {
 			filepath = filepath + ".result"
 		}
 
-		if err := ioutil.WriteFile(filepath, payload, 0644); err != nil {
+		if err := os.WriteFile(filepath, payload, 0644); err != nil {
 			return err
 		}
 	}

--- a/pkg/mimirtool/config/convert_test.go
+++ b/pkg/mimirtool/config/convert_test.go
@@ -4,7 +4,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -788,7 +788,7 @@ func loadFile(t testing.TB, fileName string) []byte {
 	if fileName == "" {
 		return nil
 	}
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 	return bytes
 }
@@ -799,7 +799,7 @@ func loadFlags(t testing.TB, fileName string) []string {
 	if fileName == "" {
 		return nil
 	}
-	flagBytes, err := ioutil.ReadFile(fileName)
+	flagBytes, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 	return strings.Split(string(flagBytes), "\n")
 }


### PR DESCRIPTION
#### What this PR does
mimirtool: Don't use the deprecated `ioutil` package.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
