### PR TITLE
Improve docker-compose setup to support multi KV

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -3,6 +3,12 @@ multitenancy_enabled: false
 distributor:
   pool:
     health_check_ingesters: true
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: consul
+      consul:
+        host: consul:8500
 
 ingester_client:
   grpc_client_config:
@@ -28,6 +34,7 @@ memberlist:
   join_members:
     - distributor:10001
   abort_if_cluster_join_fails: false
+  rejoin_interval: 10s
 
 querier:
   query_ingesters_within: 3h

--- a/development/tsdb-blocks-storage-s3/config/runtime.yaml
+++ b/development/tsdb-blocks-storage-s3/config/runtime.yaml
@@ -1,1 +1,7 @@
 # This file can be used to set overrides or other runtime config.
+
+# Runtime configuration for "multi" KV.
+# multi_kv_config:
+#  mirror_enabled: false
+#  primary: consul
+


### PR DESCRIPTION
#### What this PR does
This PR extends docker-compose setup in `development/tsdb-blocks-storage-s3` to support `multi` KV store, and also adds example runtime-config section to show how to change it in runtime. Useful when debugging `multi` KV store support in Mimir.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
