### PR TITLE
Move initialization of multi KV runtime watcher into initRuntimeConfig function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 * [BUGFIX] Mimir: services' status content-type is now correctly set to `text/html`. #1575
 * [BUGFIX] Multikv: Fix panic when using using runtime config to set primary KV store used by `multi` KV. #1587
+* [BUGFIX] Multikv: Fix watching for runtime config changes in `multi` KV store in ruler and querier. #1665
 
 ### Mixin
 

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -169,12 +169,14 @@ func TestMultiKVSetup(t *testing.T) {
 	for target, checkFn := range map[string]func(t *testing.T, c Config){
 		All: func(t *testing.T, c Config) {
 			require.NotNil(t, c.Distributor.DistributorRing.KVStore.Multi.ConfigProvider)
-			require.NotNil(t, c.Ingester.IngesterRing.KVStore.Multi)
+			require.NotNil(t, c.Ingester.IngesterRing.KVStore.Multi.ConfigProvider)
 			require.NotNil(t, c.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider)
 			require.NotNil(t, c.Compactor.ShardingRing.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.Ruler.Ring.KVStore.Multi.ConfigProvider)
 		},
 
 		Ruler: func(t *testing.T, c Config) {
+			require.NotNil(t, c.Ingester.IngesterRing.KVStore.Multi.ConfigProvider)
 			require.NotNil(t, c.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider)
 			require.NotNil(t, c.Ruler.Ring.KVStore.Multi.ConfigProvider)
 		},
@@ -184,6 +186,7 @@ func TestMultiKVSetup(t *testing.T) {
 		},
 
 		Distributor: func(t *testing.T, c Config) {
+			require.NotNil(t, c.Distributor.DistributorRing.KVStore.Multi.ConfigProvider)
 			require.NotNil(t, c.Ingester.IngesterRing.KVStore.Multi.ConfigProvider)
 		},
 
@@ -197,6 +200,11 @@ func TestMultiKVSetup(t *testing.T) {
 
 		Querier: func(t *testing.T, c Config) {
 			require.NotNil(t, c.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.Ingester.IngesterRing.KVStore.Multi.ConfigProvider)
+		},
+
+		Compactor: func(t *testing.T, c Config) {
+			require.NotNil(t, c.Compactor.ShardingRing.KVStore.Multi.ConfigProvider)
 		},
 	} {
 		t.Run(target, func(t *testing.T) {

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -175,6 +175,7 @@ func TestMultiKVSetup(t *testing.T) {
 		},
 
 		Ruler: func(t *testing.T, c Config) {
+			require.NotNil(t, c.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider)
 			require.NotNil(t, c.Ruler.Ring.KVStore.Multi.ConfigProvider)
 		},
 
@@ -188,6 +189,14 @@ func TestMultiKVSetup(t *testing.T) {
 
 		Ingester: func(t *testing.T, c Config) {
 			require.NotNil(t, c.Ingester.IngesterRing.KVStore.Multi.ConfigProvider)
+		},
+
+		StoreGateway: func(t *testing.T, c Config) {
+			require.NotNil(t, c.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider)
+		},
+
+		Querier: func(t *testing.T, c Config) {
+			require.NotNil(t, c.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider)
 		},
 	} {
 		t.Run(target, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does
This PR moves initialization of multi KV runtime watcher into `initRuntimeConfig` function.

This fixes problem where Mimir-derived subproject overriding "ruler" init method wouldn't wire the runtime config watcher properly. This PR also fixes problem where ruler and querier wouldn't have runtime config watcher for multi KV installed for  `querier-store-gateway` KV.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
