### PR TITLE
Added mimir-continuous-test support to Mimir jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@
 
 ### Jsonnet
 
+* [FEATURE] Added support for `mimir-continuous-test`. To deploy `mimir-continuous-test` you can use the following configuration: #1675
+  ```
+  _config+: {
+    continuous_test_enabled: true,
+    continuous_test_tenant_id: 'type-tenant-id',
+    continuous_test_write_endpoint: 'http://type-write-path-hostname',
+    continuous_test_read_endpoint: 'http://type-read-path-hostname/prometheus',
+  },
+  ```
 * [ENHANCEMENT] Ingester anti-affinity can now be disabled by using `ingester_allow_multiple_replicas_on_same_node` configuration key. #1581
 * [ENHANCEMENT] Added `node_selector` configuration option to select Kubernetes nodes where Mimir should run. #1596
 * [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.

--- a/operations/mimir/continuous-test.libsonnet
+++ b/operations/mimir/continuous-test.libsonnet
@@ -1,0 +1,34 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+{
+  _config+: {
+    continuous_test_enabled: false,
+    continuous_test_tenant_id: error 'you must configure the tenant ID to use for continuous testing',
+    continuous_test_write_endpoint: error 'you must configure the write endpoint for continuous testing',
+    continuous_test_read_endpoint: error 'you must configure the read endpoint for continuous testing',
+  },
+
+  local container = k.core.v1.container,
+  local containerPort = k.core.v1.containerPort,
+  local deployment = k.apps.v1.deployment,
+
+  continuous_test_args:: {
+    'tests.write-endpoint': $._config.continuous_test_write_endpoint,
+    'tests.read-endpoint': $._config.continuous_test_read_endpoint,
+    'tests.tenant-id': $._config.continuous_test_tenant_id,
+  },
+
+  continuous_test_container::
+    container.new('continuous-test', $._images.continuous_test) +
+    container.withArgsMixin(k.util.mapToFlags($.continuous_test_args)) +
+    container.withPorts([
+      k.core.v1.containerPort.new('http-metrics', 9900),
+    ]) +
+    k.util.resourcesRequests('1', '512Mi') +
+    k.util.resourcesLimits(null, '1Gi'),
+
+  continuous_test_deployment: if !$._config.continuous_test_enabled then null else
+    deployment.new('continuous-test', 1, [
+      $.continuous_test_container,
+    ]),
+}

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -20,6 +20,7 @@
     overrides_exporter: self.mimir,
 
     query_tee: 'grafana/query-tee:2.0.0',
+    continuous_test: 'grafana/mimir-continuous-test:main-8a8648e81',
 
     // See: https://github.com/grafana/rollout-operator
     rollout_operator: 'grafana/rollout-operator:v0.1.1',

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -24,4 +24,5 @@
 (import 'shuffle-sharding.libsonnet') +
 (import 'query-sharding.libsonnet') +
 (import 'multi-zone.libsonnet') +
-(import 'memberlist.libsonnet')
+(import 'memberlist.libsonnet') +
+(import 'continuous-test.libsonnet')


### PR DESCRIPTION
#### What this PR does
In this PR I'm adding `mimir-continuous-test` support to Mimir jsonnet. This jsonnet is already used internally at Grafana Labs, so I'm basically upstreaming it.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
