### PR TITLE
Added mimir-continuous-test alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,10 @@
 
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
-* [FEATURE] Alerts: added `mimir-continuous-test` alerts. #1676
+* [FEATURE] Alerts: added the following alerts on `mimir-continuous-test` tool: #1676
+  - `MimirContinuousTestNotRunningOnWrites`
+  - `MimirContinuousTestNotRunningOnReads`
+  - `MimirContinuousTestFailed`
 * [BUGFIX] Dashboards: Fix "Failed evaluation rate" panel on Tenants dashboard. #1629
 
 ### Jsonnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
+* [FEATURE] Alerts: added `mimir-continuous-test` alerts. #1676
 * [BUGFIX] Dashboards: Fix "Failed evaluation rate" panel on Tenants dashboard. #1629
 
 ### Jsonnet

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -708,3 +708,31 @@ groups:
     for: 15m
     labels:
       severity: warning
+- name: mimir_continuous_test
+  rules:
+  - alert: MimirContinuousTestNotRunning
+    annotations:
+      message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{
+        $labels.namespace }} is not effectively running because writes are failing.
+    expr: |
+      sum by(cluster, namespace, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: MimirContinuousTestNotRunning
+    annotations:
+      message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{
+        $labels.namespace }} is not effectively running because queries are failing.
+    expr: |
+      sum by(cluster, namespace, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: MimirContinuousTestFailed
+    annotations:
+      message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{
+        $labels.namespace }} failed when asserting query results.
+    expr: |
+      sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[5m])) > 0
+    labels:
+      severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -710,7 +710,7 @@ groups:
       severity: warning
 - name: mimir_continuous_test
   rules:
-  - alert: MimirContinuousTestNotRunning
+  - alert: MimirContinuousTestNotRunningOnWrites
     annotations:
       message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{
         $labels.namespace }} is not effectively running because writes are failing.
@@ -719,7 +719,7 @@ groups:
     for: 1h
     labels:
       severity: warning
-  - alert: MimirContinuousTestNotRunning
+  - alert: MimirContinuousTestNotRunningOnReads
     annotations:
       message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{
         $labels.namespace }} is not effectively running because queries are failing.

--- a/operations/mimir-mixin/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts.libsonnet
@@ -5,5 +5,6 @@
     (import 'alerts/blocks.libsonnet') +
     (import 'alerts/compactor.libsonnet') +
     (import 'alerts/autoscaling.libsonnet') +
+    (import 'alerts/continuous-test.libsonnet') +
     { _config:: $._config + $._group_config },
 }

--- a/operations/mimir-mixin/alerts/continuous-test.libsonnet
+++ b/operations/mimir-mixin/alerts/continuous-test.libsonnet
@@ -6,7 +6,7 @@
         {
           // Alert if Mimir continuous test is not effectively running because writes are failing.
           // This alert tolerates short failures, due to temporarily outages in the Mimir cluster.
-          alert: $.alertName('ContinuousTestNotRunning'),
+          alert: $.alertName('ContinuousTestNotRunningOnWrites'),
           'for': '1h',
           expr: |||
             sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
@@ -21,7 +21,7 @@
         {
           // Alert if Mimir continuous test is not effectively running because queries are failing.
           // This alert tolerates short failures, due to temporarily outages in the Mimir cluster.
-          alert: $.alertName('ContinuousTestNotRunning'),
+          alert: $.alertName('ContinuousTestNotRunningOnReads'),
           'for': '1h',
           expr: |||
             sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0

--- a/operations/mimir-mixin/alerts/continuous-test.libsonnet
+++ b/operations/mimir-mixin/alerts/continuous-test.libsonnet
@@ -1,0 +1,53 @@
+(import 'alerts-utils.libsonnet') {
+  groups+: [
+    {
+      name: 'mimir_continuous_test',
+      rules: [
+        {
+          // Alert if Mimir continuous test is not effectively running because writes are failing.
+          // This alert tolerates short failures, due to temporarily outages in the Mimir cluster.
+          alert: $.alertName('ContinuousTestNotRunning'),
+          'for': '1h',
+          expr: |||
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s continuous test {{ $labels.test }} in %(alert_aggregation_variables)s is not effectively running because writes are failing.' % $._config,
+          },
+        },
+        {
+          // Alert if Mimir continuous test is not effectively running because queries are failing.
+          // This alert tolerates short failures, due to temporarily outages in the Mimir cluster.
+          alert: $.alertName('ContinuousTestNotRunning'),
+          'for': '1h',
+          expr: |||
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s continuous test {{ $labels.test }} in %(alert_aggregation_variables)s is not effectively running because queries are failing.' % $._config,
+          },
+        },
+        {
+          // Alert if Mimir continuous test failed when asserting results. This alert has no "for" duration because it
+          // should have no "grace period" and alert as soon as the test fails.
+          alert: $.alertName('ContinuousTestFailed'),
+          expr: |||
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_query_result_checks_failed_total[5m])) > 0
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s continuous test {{ $labels.test }} in %(alert_aggregation_variables)s failed when asserting query results.' % $._config,
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -919,9 +919,9 @@ How to **investigate**:
   kubectl logs -n keda deployment/keda-operator-metrics-apiserver
   ```
 
-### MimirContinuousTestNotRunning
+### MimirContinuousTestNotRunningOnWrites
 
-This alert fires when `mimir-continuous-test` is deployed in the Mimir cluster, and continuous testing is not effectively running because either writes or queries are failing.
+This alert fires when `mimir-continuous-test` is deployed in the Mimir cluster, and continuous testing is not effectively running because writes are failing.
 
 How it **works**:
 
@@ -935,6 +935,10 @@ How to **investigate**:
   ```
   kubectl logs -n <namespace> deployment/continuous-test
   ```
+
+### MimirContinuousTestNotRunningOnReads
+
+This alert is like [`MimirContinuousTestNotRunningOnWrites`](#MimirContinuousTestNotRunningOnWrites) but it fires when queries are failing.
 
 ### MimirContinuousTestFailed
 

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -919,6 +919,44 @@ How to **investigate**:
   kubectl logs -n keda deployment/keda-operator-metrics-apiserver
   ```
 
+### MimirContinuousTestNotRunning
+
+This alert fires when `mimir-continuous-test` is deployed in the Mimir cluster, and continuous testing is not effectively running because either writes or queries are failing.
+
+How it **works**:
+
+- `mimir-continuous-test` is an optional testing tool that can be deployed in the Mimir cluster
+- The tool runs some tests against the Mimir cluster itself at regular intervals
+- This alert fires if the tool is unable to properly run the tests, and not if the tool assertions don't match the expected results
+
+How to **investigate**:
+
+- Check continuous test logs to find out more details about the failure:
+  ```
+  kubectl logs -n <namespace> deployment/continuous-test
+  ```
+
+### MimirContinuousTestFailed
+
+This alert fires when `mimir-continuous-test` is deployed in the Mimir cluster, and continuous testing tool's assertions don't match the expected results.
+When this alert fires there could be a bug in Mimir that should be investigated as soon as possible.
+
+How it **works**:
+
+- `mimir-continuous-test` is an optional testing tool that can be deployed in the Mimir cluster
+- The tool runs some tests against the Mimir cluster itself at regular intervals
+- This alert fires if the tool assertions don't match the expected results
+
+How to **investigate**:
+
+- Check continuous test logs to find out more details about the failed assertions:
+  ```
+  kubectl logs -n <namespace> deployment/continuous-test
+  ```
+- This alert should always be actionable. There are two possible outcomes:
+  1. The alert fired because of a bug in Mimir: fix it.
+  1. The alert fired because of a bug or edge case in the continuous test tool, causing a false positive: fix it.
+
 ## Mimir routes by path
 
 **Write path**:


### PR DESCRIPTION
#### What this PR does
In this PR I'm adding 2 class of alerts on `mimir-continuous-test`:

1. `MimirContinuousTestNotRunning` firing when the test is not running properly
2. `MimirContinuousTestFailed` firing when the testing tool is running, but assertions are failing

Severity is `warning` for now, but plan is to raise it after gaining some confidence on the tool.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
