### PR TITLE
Check Last-Modified before update tenant index

### DIFF
--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -32,6 +32,14 @@ const (
 	SegmentsFormat1Based6Digits = "1b6d"
 )
 
+// IndexWithLastModified index wrapped with Last-Modified attribute
+type IndexWithLastModified struct {
+	*Index
+
+	// LastModified filled from object attributes in storage on read
+	LastModified time.Time
+}
+
 // Index contains all known blocks and markers of a tenant.
 type Index struct {
 	// Version of the index format.


### PR DESCRIPTION
#### What this PR does

Update (download, unzip and parse) tenant index only if file has changed in storage (changed Last-Modified time). It is useful in case if we need low-latency block detection. With this changes we may use very short update intervals (ex. 1 second).

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
