### PR TITLE
Alertmanager: Set a Pod Disruption Budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@
 
 ### Jsonnet
 
-* [CHANGE] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #1683
 * [FEATURE] Added support for `mimir-continuous-test`. To deploy `mimir-continuous-test` you can use the following configuration: #1675
   ```jsonnet
   _config+: {
@@ -65,6 +64,7 @@
   ```
 * [ENHANCEMENT] Ingester anti-affinity can now be disabled by using `ingester_allow_multiple_replicas_on_same_node` configuration key. #1581
 * [ENHANCEMENT] Added `node_selector` configuration option to select Kubernetes nodes where Mimir should run. #1596
+* [ENHANCEMENT] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #1683
 * [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.
 
 ### Mimirtool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 ### Jsonnet
 
+* [CHANGE] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #xxxx
 * [FEATURE] Added support for `mimir-continuous-test`. To deploy `mimir-continuous-test` you can use the following configuration: #1675
   ```jsonnet
   _config+: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 ### Jsonnet
 
-* [CHANGE] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #xxxx
+* [CHANGE] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #1683
 * [FEATURE] Added support for `mimir-continuous-test`. To deploy `mimir-continuous-test` you can use the following configuration: #1675
   ```jsonnet
   _config+: {

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-gossip-generated.yaml
+++ b/operations/mimir-tests/test-gossip-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-gossip-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multi-zone-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-rollout-pdb
   name: ingester-rollout-pdb
   namespace: default

--- a/operations/mimir-tests/test-gossip-multikv-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-gossip-multikv-teardown-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-teardown-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-gossip-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-gossip-ruler-disabled-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-rollout-pdb
   name: ingester-rollout-pdb
   namespace: default

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -7,6 +7,19 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: alertmanager-pdb
+  name: alertmanager-pdb
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: ingester-pdb
   name: ingester-pdb
   namespace: default


### PR DESCRIPTION
#### What this PR does
By default, we enforce a replication factor of 3 which the Alertmanager inherits. To ensure quorum is not lost during disruptions we set a pod disruption budget of `withMaxUnavailable(1)`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- N/A Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
