### PR TITLE
Add write rate limit to mimir-continuous-test

### DIFF
--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -86,7 +86,7 @@ func (t *WriteReadSeriesTest) Init(ctx context.Context, now time.Time) error {
 // Run implements Test.
 func (t *WriteReadSeriesTest) Run(ctx context.Context, now time.Time) {
 	// Configure the rate limiter to send a sample for each series per second. At startup, this test may catch up
-	// with previous missing writes: this rate limit reduce the chances to hit the ingestion limit on Mimir side.
+	// with previous missing writes: this rate limit reduces the chances to hit the ingestion limit on Mimir side.
 	writeLimiter := rate.NewLimiter(rate.Limit(t.cfg.NumSeries), t.cfg.NumSeries)
 
 	// Write series for each expected timestamp until now.

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -84,8 +85,17 @@ func (t *WriteReadSeriesTest) Init(ctx context.Context, now time.Time) error {
 
 // Run implements Test.
 func (t *WriteReadSeriesTest) Run(ctx context.Context, now time.Time) {
+	// Configure the rate limiter to send a sample for each series per second. At startup, this test may catch up
+	// with previous missing writes: this rate limit reduce the chances to hit the ingestion limit on Mimir side.
+	writeLimiter := rate.NewLimiter(rate.Limit(t.cfg.NumSeries), t.cfg.NumSeries)
+
 	// Write series for each expected timestamp until now.
 	for timestamp := t.nextWriteTimestamp(now); !timestamp.After(now); timestamp = t.nextWriteTimestamp(now) {
+		if err := writeLimiter.WaitN(ctx, t.cfg.NumSeries); err != nil {
+			// Context has been canceled, so we should interrupt.
+			return
+		}
+
 		statusCode, err := t.client.WriteSeries(ctx, generateSineWaveSeries(metricName, timestamp, t.cfg.NumSeries))
 
 		t.metrics.writesTotal.Inc()


### PR DESCRIPTION
#### What this PR does
At start, `mimir-continuous-test` tool catch up writes from last written samples (if it's not older than 50m ago). When doing this catch up, we may hit the ingestion rate limit on Mimir side (depends on the actual limits set). The testing tool already handles the case the write fails with a 4xx error, but it would be better to avoid it if possible. In this PR I'm introducing a simple write rate limit to reduce the likelihood we hit the rate limit on Mimir side.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
