### PR TITLE
Remove unused mutex from LabelNames method

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -356,7 +356,6 @@ func (q *blocksStoreQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, 
 	}
 
 	var (
-		resMtx            sync.Mutex
 		resNameSets       = [][]string{}
 		resWarnings       = storage.Warnings(nil)
 		convertedMatchers = convertMatchersToLabelMatcher(matchers)
@@ -368,10 +367,8 @@ func (q *blocksStoreQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, 
 			return nil, err
 		}
 
-		resMtx.Lock()
 		resNameSets = append(resNameSets, nameSets...)
 		resWarnings = append(resWarnings, warnings...)
-		resMtx.Unlock()
 
 		return queriedBlocks, nil
 	}


### PR DESCRIPTION
Much like #1717, this mutex is unused.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
