### PR TITLE
Imported mimir-rules-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 
 * [FEATURE] Added a `markblocks` tool that creates `no-compact` and `delete` marks for the blocks. #1551
 * [FEATURE] Added `mimir-continuous-test` tool to continuously run smoke tests on live Mimir clusters. #1535 #1540 #1653 #1603 #1630 #1691 #1675 #1676 #1692 #1706 #1709
+* [FEATURE] Added `mimir-rules-action` GitHub action, located at `operations/mimir-rules-action/`, used to lint, prepare, verify, diff, and sync rules to a Mimir cluster. #1723
 
 ## 2.0.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,6 +86,7 @@ To publish a stable release:
    1. Ensure the `VERSION` file has **no** `-rc.X` suffix
    1. Update the Mimir version in the following locations:
       - `operations/mimir/images.libsonnet` (`_images.mimir` and `_images.query_tee` fields)
+      - `operations/mimir-rules-action/Dockerfile` (`grafana/mimirtool` image tag)
 1. Update dashboard screenshots
    1. Run `make mixin-screenshots`
    1. Review all updated screenshots and ensure no sensitive data is disclosed

--- a/operations/mimir-rules-action/Dockerfile
+++ b/operations/mimir-rules-action/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
 FROM grafana/mimirtool:2.0.0
 
 COPY entrypoint.sh /entrypoint.sh

--- a/operations/mimir-rules-action/Dockerfile
+++ b/operations/mimir-rules-action/Dockerfile
@@ -1,0 +1,5 @@
+FROM grafana/mimirtool:2.0.0
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/operations/mimir-rules-action/README.md
+++ b/operations/mimir-rules-action/README.md
@@ -1,0 +1,119 @@
+# Mimirtool Github Action
+
+This action is used to lint, prepare, verify, diff, and sync rules to a [Grafana Mimir](https://github.com/grafana/mimir) cluster.
+
+## Environment Variables
+
+This action is configured using environment variables defined in the workflow. The following variables can be configured.
+
+| Name                         | Description                                                                                                                                                                                                                                | Required | Default |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- |
+| `MIMIR_ADDRESS`             | URL address for the target Mimir cluster                                                                                                                                                                                                  | `false`  | N/A     |
+| `MIMIR_TENANT_ID`           | ID for the desired tenant in the target Mimir cluster. Used as the username under HTTP Basic authentication.                                                                                                                                                                                     | `false`  | N/A     |
+| `MIMIR_API_KEY`             | Optional password that is required for password-protected Mimir clusters. An encrypted [github secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets ) is recommended. Used as the password under HTTP Basic authentication. | `false`  | N/A     |
+| `ACTION`                     | Which action to take. One of `lint`, `prepare`, `check`, `diff` or `sync`                                                                                                                                                                  | `true`   | N/A     |
+| `RULES_DIR`                  | Comma-separated list of directories to walk in order to source rules files                                                                                                                                                                 | `false`  | `./`    |
+| `LABEL_EXCLUDED_RULE_GROUPS` | Comma separated list of rule group names to exclude when including the configured label to aggregations. This option is supported only by the `prepare` action.                                                                            | `false`  | N/A     |
+| `NAMESPACES`                 | Comma-separated list of namespaces to use                                                                                                                                                                                                  | `false`  | N/A     |
+
+## Authentication
+
+This GitHub Action uses [`mimirtool`](https://github.com/grafana/mimir) under the hood.
+`mimirtool` uses HTTP Basic authentication against a Mimir cluster. The variable `MIMIR_TENANT_ID` is used as the username and `MIMIR_API_KEY` as the password.
+
+## Actions
+
+All actions will crawl the specified `RULES_DIR` for Prometheus rules and alerts files with a `yaml`/`yml` extension.
+
+### `diff`
+
+Outputs the differences in the configured files and the currently configured ruleset in a Mimir cluster. It will output the required operations in order to make the running Mimir cluster match the rules configured in the directory. It will **not create/update/delete any rules** currently running in the Mimir cluster.
+
+### `sync`
+
+Reconcile the differences with the sourced rules and the rules currently running in a configured Mimir cluster. It **will create/update/delete rules** currently running in Mimir to match what is configured in the files in the provided directory.
+
+### `lint`
+
+Lints a rules file(s). The linter's aim is not to verify correctness but to fix YAML and PromQL expression formatting within the rule file(s). The linting happens in-place within the specified file(s). Does not interact with your Mimir cluster.
+
+### `prepare`
+Prepares a rules file(s) for upload to Mimir. It lints all your PromQL expressions and adds a `cluster` label to your PromQL query aggregations in the file. Prepare modifies the file(s) in-place. Does not interact with your Mimir cluster.
+
+### `check`
+
+Checks rules file(s) against the recommended [best practices](https://prometheus.io/docs/practices/rules/) for rules. Does not interact with your Mimir cluster.
+
+### `print`
+
+fetch & print rules from the Mimir cluster.
+
+## Outputs
+
+### `summary`
+
+The `summary` output variable is a string denoting the output summary of the action, if there is one.
+
+### `detailed`
+
+The `detailed` output variable returned by this action is the full output of the command executed.
+
+## Example Workflows
+
+### Pull Request Diff
+
+The following workflow will run a diff on every pull request against the repo and print the summary as a comment in the associated pull request:
+
+```yaml
+name: diff_rules_pull_request
+on: [pull_request]
+jobs:
+  diff-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Diff Rules
+        id: diff_rules
+        uses: grafana/mimir/operations/mimir-rules-action@main
+        env:
+          MIMIR_ADDRESS: https://example-cluster.com/
+          MIMIR_TENANT_ID: 1
+          MIMIR_API_KEY: ${{ secrets.MIMIR_API_KEY }} # Encrypted Github Secret https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
+          ACTION: diff
+          RULES_DIR: "./rules/" # In this example rules are stored in a rules directory in the repo
+      - name: comment PR
+        uses: unsplash/comment-on-pr@v1.2.0 # https://github.com/unsplash/comment-on-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: "${{ steps.diff_rules.outputs.summary }}" # summary could be replaced with detailed for a more granular view
+```
+
+### Master Sync
+
+The following workflow will sync the rule files in the `master` branch with the configured Mimir cluster.
+
+```yaml
+name: sync_rules_master
+on:
+ push:
+   branches:
+     - master
+jobs:
+  sync-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: sync-rules
+        uses: grafana/mimir/operations/mimir-rules-action@main
+        env:
+          MIMIR_ADDRESS: https://example-cluster.com/
+          MIMIR_TENANT_ID: 1
+          MIMIR_API_KEY: ${{ secrets.MIMIR_API_KEY }} # Encrypted Github Secret https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
+          ACTION: sync
+          RULES_DIR: "./rules/" # In this example rules are stored in a rules directory in the repo
+```

--- a/operations/mimir-rules-action/README.md
+++ b/operations/mimir-rules-action/README.md
@@ -6,15 +6,15 @@ This action is used to lint, prepare, verify, diff, and sync rules to a [Grafana
 
 This action is configured using environment variables defined in the workflow. The following variables can be configured.
 
-| Name                         | Description                                                                                                                                                                                                                                | Required | Default |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- |
-| `MIMIR_ADDRESS`             | URL address for the target Mimir cluster                                                                                                                                                                                                  | `false`  | N/A     |
-| `MIMIR_TENANT_ID`           | ID for the desired tenant in the target Mimir cluster. Used as the username under HTTP Basic authentication.                                                                                                                                                                                     | `false`  | N/A     |
-| `MIMIR_API_KEY`             | Optional password that is required for password-protected Mimir clusters. An encrypted [github secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets ) is recommended. Used as the password under HTTP Basic authentication. | `false`  | N/A     |
-| `ACTION`                     | Which action to take. One of `lint`, `prepare`, `check`, `diff` or `sync`                                                                                                                                                                  | `true`   | N/A     |
-| `RULES_DIR`                  | Comma-separated list of directories to walk in order to source rules files                                                                                                                                                                 | `false`  | `./`    |
-| `LABEL_EXCLUDED_RULE_GROUPS` | Comma separated list of rule group names to exclude when including the configured label to aggregations. This option is supported only by the `prepare` action.                                                                            | `false`  | N/A     |
-| `NAMESPACES`                 | Comma-separated list of namespaces to use                                                                                                                                                                                                  | `false`  | N/A     |
+| Name                         | Description                                                                                                                                                                                                                                                                                        | Required | Default |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `MIMIR_ADDRESS`              | URL address for the target Mimir cluster                                                                                                                                                                                                                                                           | `false`  | N/A     |
+| `MIMIR_TENANT_ID`            | ID for the desired tenant in the target Mimir cluster. Used as the username under HTTP Basic authentication.                                                                                                                                                                                       | `false`  | N/A     |
+| `MIMIR_API_KEY`              | Optional password that is required for password-protected Mimir clusters. An encrypted [github secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) is recommended. Used as the password under HTTP Basic authentication. | `false`  | N/A     |
+| `ACTION`                     | Which action to take. One of `lint`, `prepare`, `check`, `diff` or `sync`                                                                                                                                                                                                                          | `true`   | N/A     |
+| `RULES_DIR`                  | Comma-separated list of directories to walk in order to source rules files                                                                                                                                                                                                                         | `false`  | `./`    |
+| `LABEL_EXCLUDED_RULE_GROUPS` | Comma separated list of rule group names to exclude when including the configured label to aggregations. This option is supported only by the `prepare` action.                                                                                                                                    | `false`  | N/A     |
+| `NAMESPACES`                 | Comma-separated list of namespaces to use                                                                                                                                                                                                                                                          | `false`  | N/A     |
 
 ## Authentication
 
@@ -38,6 +38,7 @@ Reconcile the differences with the sourced rules and the rules currently running
 Lints a rules file(s). The linter's aim is not to verify correctness but to fix YAML and PromQL expression formatting within the rule file(s). The linting happens in-place within the specified file(s). Does not interact with your Mimir cluster.
 
 ### `prepare`
+
 Prepares a rules file(s) for upload to Mimir. It lints all your PromQL expressions and adds a `cluster` label to your PromQL query aggregations in the file. Prepare modifies the file(s) in-place. Does not interact with your Mimir cluster.
 
 ### `check`
@@ -97,9 +98,9 @@ The following workflow will sync the rule files in the `master` branch with the 
 ```yaml
 name: sync_rules_master
 on:
- push:
-   branches:
-     - master
+  push:
+    branches:
+      - master
 jobs:
   sync-master:
     runs-on: ubuntu-latest

--- a/operations/mimir-rules-action/action.yaml
+++ b/operations/mimir-rules-action/action.yaml
@@ -1,0 +1,14 @@
+name: mimirtool-sync
+author: jtlisi
+description: "A set of actions to interact with Prometheus Rules files and a Grafana Mimir cluster."
+runs:
+  using: "docker"
+  image: "Dockerfile"
+outputs:
+  summary:
+    description: A summary of changes that will be made.
+  detailed:
+    description: A detailed description of changes that will be made.
+branding:
+  icon: "upload"  
+  color: "blue"

--- a/operations/mimir-rules-action/action.yaml
+++ b/operations/mimir-rules-action/action.yaml
@@ -1,5 +1,5 @@
 name: mimirtool-sync
-author: jtlisi
+author: Grafana Labs
 description: "A set of actions to interact with Prometheus Rules files and a Grafana Mimir cluster."
 runs:
   using: "docker"

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-only
 # shellcheck shell=dash
 #
 # Interact with the Mimir Ruler API using mimirtool.

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# shellcheck shell=dash
+#
+# Interact with the Mimir Ruler API using mimirtool.
+
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: " + "$@" >&2
+}
+
+# For commands that interact with the server, we need to verify that the
+# MIMIR_TENANT_ID and MIMIR_ADDRESS are set.
+verifyTenantAndAddress() {
+  if [ -z "${MIMIR_TENANT_ID}" ]; then
+    err "MIMIR_TENANT_ID has not been set."
+    exit 1
+  fi
+
+  if [ -z "${MIMIR_ADDRESS}" ]; then
+    err "MIMIR_ADDRESS has not been set."
+    exit 1
+  fi
+}
+
+LINT_CMD=lint
+CHECK_CMD=check
+PREPARE_CMD=prepare
+SYNC_CMD=sync
+DIFF_CMD="diff"
+PRINT_CMD=print
+
+if [ -z "${RULES_DIR}" ]; then
+  echo "RULES_DIR not set, using './' as a default."
+  RULES_DIR="./"
+fi
+
+if [ -z "${ACTION}" ]; then
+  err "ACTION has not been set."
+  exit 1
+fi
+
+case "${ACTION}" in
+  "$SYNC_CMD")
+    verifyTenantAndAddress
+    OUTPUT=$(/bin/mimirtool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} "$@")
+    STATUS=$?
+    ;;
+  "$DIFF_CMD")
+    verifyTenantAndAddress
+    OUTPUT=$(/bin/mimirtool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} --disable-color "$@")
+    STATUS=$?
+    ;;
+  "$LINT_CMD")
+    OUTPUT=$(/bin/mimirtool rules lint --rule-dirs="${RULES_DIR}" "$@")
+    STATUS=$?
+    ;;
+  "$PREPARE_CMD")
+    OUTPUT=$(/bin/mimirtool rules prepare -i --rule-dirs="${RULES_DIR}" --label-excluded-rule-groups="${LABEL_EXCLUDED_RULE_GROUPS}" "$@")
+    STATUS=$?
+    ;;
+  "$CHECK_CMD")
+    OUTPUT=$(/bin/mimirtool rules check --rule-dirs="${RULES_DIR}" "$@")
+    STATUS=$?
+    ;;
+  "$PRINT_CMD")
+      OUTPUT=$(/bin/mimirtool rules print --disable-color "$@")
+      STATUS=$?
+      ;;
+  *)
+    err "Unexpected action '${ACTION}'"
+    exit 1
+    ;;
+esac
+
+SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
+echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
+SUMMARY=$(echo "${OUTPUT}" | grep Summary)
+echo ::set-output name=summary::"${SUMMARY}"
+
+exit $STATUS


### PR DESCRIPTION
#### What this PR does
As discussed in https://github.com/grafana/cortex-rules-action/pull/21, in this PR I'm importing `mimir-rules-action` to the Mimir repo. The imported code and README is exactly the content of https://github.com/grafana/cortex-rules-action/pull/21, so I would suggest to review it there to see the actual diff compared to `cortex-rules-action`.

Plan is:
- Get this PR merged
- Switch Grafana Labs internal usage from `cortex-rules-action` to `mimir-rules-action`, to test it
- Deprecate `grafana/cortex-rules-action`

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
