### PR TITLE
Changed -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items default from 0 to 50000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Ingester: Add `user` label to metrics `cortex_ingester_ingested_samples_total` and `cortex_ingester_ingested_samples_failures_total`. #1533
 * [CHANGE] Ingester: Changed `-blocks-storage.tsdb.isolation-enabled` default from `true` to `false`. The config option has also been deprecated and will be removed in 2 minor version.
 * [CHANGE] Query-frontend: results cache keys are now versioned, this will cause cache to be re-filled when rolling out this version. #1631
+* [CHANGE] Store-gateway: enabled attributes in-memory cache by default. New default configuration is `-blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000`. #1727
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Ruler: Added support for expression remote evaluation. #1536
   * The following CLI flags (and their respective YAML config options) have been added:

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4688,7 +4688,7 @@
                   "required": false,
                   "desc": "Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.",
                   "fieldValue": null,
-                  "fieldDefaultValue": 0,
+                  "fieldDefaultValue": 50000,
                   "fieldFlag": "blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items",
                   "fieldType": "int",
                   "fieldCategory": "advanced"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -275,7 +275,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes int
     	Size - in bytes - of the smallest chunks pool bucket. (default 16000)
   -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items int
-    	Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.
+    	Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache. (default 50000)
   -blocks-storage.bucket-store.chunks-cache.attributes-ttl duration
     	TTL for caching object attributes for chunks. If the metadata cache is configured, attributes will be stored under this cache backend, otherwise attributes are stored in the chunks cache backend. (default 168h0m0s)
   -blocks-storage.bucket-store.chunks-cache.backend string

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3188,7 +3188,7 @@ bucket_store:
     # level in-memory LRU cache. Metadata will be stored and fetched in-memory
     # before hitting the cache backend. 0 to disable the in-memory cache.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items
-    [attributes_in_memory_max_items: <int> | default = 0]
+    [attributes_in_memory_max_items: <int> | default = 50000]
 
     # (advanced) TTL for caching individual chunks subranges.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-ttl

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -1307,7 +1307,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -1640,7 +1640,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-gossip-generated.yaml
+++ b/operations/mimir-tests/test-gossip-generated.yaml
@@ -1686,7 +1686,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-gossip-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multi-zone-generated.yaml
@@ -2155,7 +2155,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2273,7 +2272,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2391,7 +2389,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-gossip-multikv-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-generated.yaml
@@ -1716,7 +1716,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
@@ -1716,7 +1716,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-gossip-multikv-teardown-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-teardown-generated.yaml
@@ -1689,7 +1689,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-gossip-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-gossip-ruler-disabled-generated.yaml
@@ -1570,7 +1570,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -2086,7 +2086,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2199,7 +2198,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2312,7 +2310,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -2246,7 +2246,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2356,7 +2355,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2469,7 +2467,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
@@ -2582,7 +2579,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1643,7 +1643,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1650,7 +1650,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1654,7 +1654,6 @@ spec:
         - -blocks-storage.azure.account-name=blocks-account-name
         - -blocks-storage.azure.container-name=blocks-bucket
         - -blocks-storage.backend=azure
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1639,7 +1639,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=gcs
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1646,7 +1646,6 @@ spec:
       containers:
       - args:
         - -blocks-storage.backend=s3
-        - -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -50,9 +50,6 @@
       'blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections': $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency'],
       'blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections': $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency'],
 
-      // Enable segment objects attributes in-memory cache.
-      'blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items': 50000,
-
       // Queriers will not query store for data younger than 12h (see -querier.query-store-after).
       // Store-gateways don't need to load blocks with very most recent data. We use 2h buffer to
       // make sure that blocks are ready for querying when needed.

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -44,7 +44,7 @@ func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 	f.Int64Var(&cfg.SubrangeSize, prefix+"subrange-size", 16000, "Size of each subrange that bucket object is split into for better caching.")
 	f.IntVar(&cfg.MaxGetRangeRequests, prefix+"max-get-range-requests", 3, "Maximum number of sub-GetRange requests that a single GetRange request can be split into when fetching chunks. Zero or negative value = unlimited number of sub-requests.")
 	f.DurationVar(&cfg.AttributesTTL, prefix+"attributes-ttl", 168*time.Hour, "TTL for caching object attributes for chunks. If the metadata cache is configured, attributes will be stored under this cache backend, otherwise attributes are stored in the chunks cache backend.")
-	f.IntVar(&cfg.AttributesInMemoryMaxItems, prefix+"attributes-in-memory-max-items", 0, "Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.")
+	f.IntVar(&cfg.AttributesInMemoryMaxItems, prefix+"attributes-in-memory-max-items", 50000, "Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.")
 	f.DurationVar(&cfg.SubrangeTTL, prefix+"subrange-ttl", 24*time.Hour, "TTL for caching individual chunks subranges.")
 }
 


### PR DESCRIPTION
#### What this PR does
See #1726

#### Which issue(s) this PR fixes or relates to

Fixes #1726

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
