### PR TITLE
Remove duplicate cortex_compactor_garbage_collected_blocks_total metric

### DIFF
--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -116,7 +116,7 @@ func TestFilterOwnJobs(t *testing.T) {
 		},
 	}
 
-	m := NewBucketCompactorMetrics(prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}), nil)
+	m := NewBucketCompactorMetrics(prometheus.NewCounter(prometheus.CounterOpts{}), nil)
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			bc, err := NewBucketCompactor(log.NewNopLogger(), nil, nil, nil, nil, "", nil, 2, false, testCase.ownJob, nil, 4, m)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -191,10 +191,6 @@ func TestMultitenantCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		# HELP cortex_compactor_runs_failed_total Total number of compaction runs failed.
 		cortex_compactor_runs_failed_total 0
 
-		# HELP cortex_compactor_garbage_collected_blocks_total Total number of blocks marked for deletion by compactor.
-		# TYPE cortex_compactor_garbage_collected_blocks_total counter
-		cortex_compactor_garbage_collected_blocks_total 0
-
 		# HELP cortex_compactor_garbage_collection_duration_seconds Time it took to perform garbage collection iteration.
 		# TYPE cortex_compactor_garbage_collection_duration_seconds histogram
 		cortex_compactor_garbage_collection_duration_seconds_bucket{le="+Inf"} 0
@@ -271,7 +267,6 @@ func TestMultitenantCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		"cortex_compactor_runs_started_total",
 		"cortex_compactor_runs_completed_total",
 		"cortex_compactor_runs_failed_total",
-		"cortex_compactor_garbage_collected_blocks_total",
 		"cortex_compactor_garbage_collection_duration_seconds",
 		"cortex_compactor_garbage_collection_failures_total",
 		"cortex_compactor_garbage_collection_total",
@@ -334,10 +329,6 @@ func TestMultitenantCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUser
 		# TYPE cortex_compactor_runs_failed_total counter
 		# HELP cortex_compactor_runs_failed_total Total number of compaction runs failed.
 		cortex_compactor_runs_failed_total 1
-
-		# HELP cortex_compactor_garbage_collected_blocks_total Total number of blocks marked for deletion by compactor.
-		# TYPE cortex_compactor_garbage_collected_blocks_total counter
-		cortex_compactor_garbage_collected_blocks_total 0
 
 		# HELP cortex_compactor_garbage_collection_duration_seconds Time it took to perform garbage collection iteration.
 		# TYPE cortex_compactor_garbage_collection_duration_seconds histogram
@@ -415,7 +406,6 @@ func TestMultitenantCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUser
 		"cortex_compactor_runs_started_total",
 		"cortex_compactor_runs_completed_total",
 		"cortex_compactor_runs_failed_total",
-		"cortex_compactor_garbage_collected_blocks_total",
 		"cortex_compactor_garbage_collection_duration_seconds",
 		"cortex_compactor_garbage_collection_failures_total",
 		"cortex_compactor_garbage_collection_total",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Remove duplicate cortex_compactor_garbage_collected_blocks_total metric. It looks like the places that have updated it are updating cortex_compactor_blocks_marked_for_deletion_total. We should be able to remove it safely 

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/105

#### Checklist

- [x] Tests updated