### PR TITLE
Rename config option introduced in PR 1730

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * [ENHANCEMENT] Ingester anti-affinity can now be disabled by using `ingester_allow_multiple_replicas_on_same_node` configuration key. #1581
 * [ENHANCEMENT] Added `node_selector` configuration option to select Kubernetes nodes where Mimir should run. #1596
 * [ENHANCEMENT] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #1683
-* [ENHANCEMENT] Store Gateway anti-affinity can now be enabled/disabled using `storegateway_allow_multiple_replicas_on_same_node` configuration key. #1730
+* [ENHANCEMENT] Store-gateway anti-affinity can now be enabled/disabled using `store_gateway_allow_multiple_replicas_on_same_node` configuration key. #1730
 * [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.
 
 ### Mimirtool

--- a/operations/mimir/README.md
+++ b/operations/mimir/README.md
@@ -77,7 +77,7 @@ mimir {
     ruler_allow_multiple_replicas_on_same_node: true,
     querier_allow_multiple_replicas_on_same_node: true,
     query_frontend_allow_multiple_replicas_on_same_node: true,
-    storegateway_allow_multiple_replicas_on_same_node: true,
+    store_gateway_allow_multiple_replicas_on_same_node: true,
   },
 }
 ```

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -24,7 +24,7 @@
     ruler_allow_multiple_replicas_on_same_node: false,
     querier_allow_multiple_replicas_on_same_node: false,
     query_frontend_allow_multiple_replicas_on_same_node: false,
-    storegateway_allow_multiple_replicas_on_same_node: false,
+    store_gateway_allow_multiple_replicas_on_same_node: false,
 
     test_exporter_enabled: false,
     test_exporter_start_time: error 'must specify test exporter start time',

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -205,7 +205,7 @@
     statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': 'store-gateway' }) +
     statefulSet.mixin.spec.updateStrategy.withType('OnDelete') +
     statefulSet.mixin.spec.withReplicas(std.ceil($._config.multi_zone_store_gateway_replicas / 3)) +
-    if $._config.storegateway_allow_multiple_replicas_on_same_node then {} else {
+    if $._config.store_gateway_allow_multiple_replicas_on_same_node then {} else {
       spec+:
         // Allow to schedule 2+ store-gateways in the same zone on the same node, but do not schedule 2+ store-gateways in
         // different zones on the same node. In case of 1 node failure in the Kubernetes cluster, only store-gateways

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -90,7 +90,7 @@
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     (if with_anti_affinity then $.util.antiAffinity else {}),
 
-  store_gateway_statefulset: self.newStoreGatewayStatefulSet('store-gateway', $.store_gateway_container, !$._config.storegateway_allow_multiple_replicas_on_same_node),
+  store_gateway_statefulset: self.newStoreGatewayStatefulSet('store-gateway', $.store_gateway_container, !$._config.store_gateway_allow_multiple_replicas_on_same_node),
 
   store_gateway_service:
     $.util.serviceFor($.store_gateway_statefulset, $._config.service_ignored_labels),


### PR DESCRIPTION
#### What this PR does
A tiny follow up on top of #1730. We're used to name the store-gateway with the dash in between and so the conversion to config options is `store_gateway`.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
