### PR TITLE
Update minio docker compose in the playgraound to clear the existing docker command

### DIFF
--- a/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
+++ b/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.4'
 services:
   minio:
     image: minio/minio
+    entrypoint: [""]
     command: ["sh", "-c", "mkdir -p /data/mimir-blocks /data/mimir-ruler /data/mimir-alertmanager && minio server --quiet /data"]
-    entrypoint: ""
     environment:
       - MINIO_ACCESS_KEY=mimir
       - MINIO_SECRET_KEY=supersecret


### PR DESCRIPTION


Signed-off-by: Chee Hau Lim <ch33hau@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fix `minio` in playground won't be started successfully

#### Which issue(s) this PR fixes or relates to

Fixes #1740

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
