### PR TITLE
ruler: preallocate slices when converting remote querier response

### DIFF
--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -291,20 +291,24 @@ func decodeQueryResponse(valTyp model.ValueType, result json.RawMessage) (promql
 }
 
 func vectorToPromQLVector(vec prommodel.Vector) promql.Vector {
-	var retVal promql.Vector
+	retVal := make(promql.Vector, 0, len(vec))
 	for _, p := range vec {
-		var sm promql.Sample
 
-		sm.V = float64(p.Value)
-		sm.T = int64(p.Timestamp)
-
-		var lbl labels.Labels
+		lbl := make(labels.Labels, 0, len(p.Metric))
 		for ln, lv := range p.Metric {
-			lbl = append(lbl, labels.Label{Name: string(ln), Value: string(lv)})
+			lbl = append(lbl, labels.Label{
+				Name:  string(ln),
+				Value: string(lv),
+			})
 		}
-		sm.Metric = lbl
 
-		retVal = append(retVal, sm)
+		retVal = append(retVal, promql.Sample{
+			Metric: lbl,
+			Point: promql.Point{
+				V: float64(p.Value),
+				T: int64(p.Timestamp),
+			},
+		})
 	}
 	return retVal
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->
#### What this PR does

Preallocate slice capacity when converting `query-frontend` vector response in remote evaluation mode. 

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
