### PR TITLE
Dev Docker compose: Add `fallback_config_file` to the Alertmanager config

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/alertmanager.yaml
+++ b/development/tsdb-blocks-storage-s3/config/alertmanager.yaml
@@ -1,4 +1,4 @@
-# Example alertmanager config file to load to Mimir via the alertmanager API.
+# Example alertmanager config file to load to Mimir. It is used as the fallback configuration for the Alertmanager.
 global:
   # The smarthost and SMTP sender used for mail notifications.
   smtp_smarthost: 'localhost:25'

--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -96,6 +96,7 @@ ruler_storage:
     insecure:          true
 
 alertmanager:
+  fallback_config_file: './config/alertmanager.yaml'
   sharding_ring:
     replication_factor: 3
     heartbeat_period: 5s


### PR DESCRIPTION
#### What this PR does

This enables an alert sent from the Ruler to the Alertmanager not to fail when there is no configuration on the Alertmanager side. Instead, an alertmanager instance with the fallback configuration would be applied.

*Do I need a changelog entry?*

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- N/A Tests updated
- N/A Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
