### PR TITLE
Allow custom data source in mixin dashboards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [ENHANCEMENT] Added `per_cluster_label` support to allow to change the label name used to differentiate between Kubernetes clusters. #1651
 * [ENHANCEMENT] Dashboards: Show QPS and latency of the Alertmanager Distributor. #1696
 * [ENHANCEMENT] Playbooks: Add Alertmanager suggestions for `MimirRequestErrors` and `MimirRequestLatency` #1702
+* [ENHANCEMENT] Dashboards: Allow custom datasources. #1749
 * [BUGFIX] Dashboards: Fix "Failed evaluation rate" panel on Tenants dashboard. #1629
 * [BUGFIX] Honor the configured `per_instance_label` in all dashboards and alerts. #1697
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -83,5 +83,8 @@
 
     // The routes to exclude from alerts.
     alert_excluded_routes: [],
+
+    // The default datasource used for dashboards.
+    dashboard_datasource: 'default',
   },
 }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -9,7 +9,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
   // - some links that propagate the selectred cluster.
   dashboard(title)::
     // Prefix the dashboard title with "<product> /" unless configured otherwise.
-    super.dashboard('%(prefix)s%(title)s' % { prefix: $._config.dashboard_prefix, title: title }) + {
+    super.dashboard(
+      title='%(prefix)s%(title)s' % { prefix: $._config.dashboard_prefix, title: title },
+      datasource=$._config.dashboard_datasource
+    ) + {
       addRowIf(condition, row)::
         if condition
         then self.addRow(row)


### PR DESCRIPTION
#### What this PR does

This restores a tiny change from cortex-jsonnet to allow custom datasources for compiled dashboards: https://github.com/grafana/cortex-jsonnet/pull/407.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
