### PR TITLE
Change mixtool and jb installation instructions

### DIFF
--- a/docs/sources/operators-guide/visualizing-metrics/installing-dashboards-and-alerts.md
+++ b/docs/sources/operators-guide/visualizing-metrics/installing-dashboards-and-alerts.md
@@ -37,8 +37,8 @@ If you choose this option, you can change the configuration to match your deploy
 2. Review the mixin configuration at `operations/mimir-mixin/config.libsonnet`, and apply your changes if necessary.
 3. Install dependencies:
    ```bash
-   GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool
-   GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+   go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+   go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
    ```
 4. Compile the mixin
    ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Installing `jb` and `mixtool` per the docs prints a deprecation warning
and updates go.mod and go.sum files, if run from a go project. Update
the docs to use the recommended `go install` with a version.

Signed-off-by: Josh Carp <jm.carp@gmail.com>

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
