### PR TITLE
add option to use new (current in upstream Prometheus) chunk disk mapper

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5316,6 +5316,17 @@
             },
             {
               "kind": "field",
+              "name": "new_chunk_disk_mapper",
+              "required": false,
+              "desc": "Temporary flag which we use to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.",
+              "fieldValue": null,
+              "fieldDefaultValue": false,
+              "fieldFlag": "blocks-storage.tsdb.new-chunk-disk-mapper",
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
               "name": "isolation_enabled",
               "required": false,
               "desc": "[Deprecated] Enables TSDB isolation feature. Disabling may improve performance.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5318,7 +5318,7 @@
               "kind": "field",
               "name": "new_chunk_disk_mapper",
               "required": false,
-              "desc": "Temporary flag which we use to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.",
+              "desc": "Temporary flag to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.",
               "fieldValue": null,
               "fieldDefaultValue": false,
               "fieldFlag": "blocks-storage.tsdb.new-chunk-disk-mapper",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -499,6 +499,8 @@ Usage of ./cmd/mimir/mimir:
     	limit the number of concurrently opening TSDB's on startup (default 10)
   -blocks-storage.tsdb.memory-snapshot-on-shutdown
     	[experimental] True to enable snapshotting of in-memory TSDB data on disk when shutting down.
+  -blocks-storage.tsdb.new-chunk-disk-mapper
+    	[experimental] Temporary flag which we use to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.
   -blocks-storage.tsdb.retention-period duration
     	TSDB blocks retention in the ingester before a block is removed, relative to the newest block written for the tenant. This should be larger than the -blocks-storage.tsdb.block-ranges-period, -querier.query-store-after and large enough to give store-gateways and queriers enough time to discover newly uploaded blocks. (default 24h0m0s)
   -blocks-storage.tsdb.series-hash-cache-max-size-bytes uint

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -500,7 +500,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.tsdb.memory-snapshot-on-shutdown
     	[experimental] True to enable snapshotting of in-memory TSDB data on disk when shutting down.
   -blocks-storage.tsdb.new-chunk-disk-mapper
-    	[experimental] Temporary flag which we use to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.
+    	[experimental] Temporary flag to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.
   -blocks-storage.tsdb.retention-period duration
     	TSDB blocks retention in the ingester before a block is removed, relative to the newest block written for the tenant. This should be larger than the -blocks-storage.tsdb.block-ranges-period, -querier.query-store-after and large enough to give store-gateways and queriers enough time to discover newly uploaded blocks. (default 24h0m0s)
   -blocks-storage.tsdb.series-hash-cache-max-size-bytes uint

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3442,8 +3442,8 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.head-chunks-write-queue-size
   [head_chunks_write_queue_size: <int> | default = 0]
 
-  # (experimental) Temporary flag which we use to select whether to use the new
-  # (used in upstream Prometheus) or the old (legacy) chunk disk mapper.
+  # (experimental) Temporary flag to select whether to use the new (used in
+  # upstream Prometheus) or the old (legacy) chunk disk mapper.
   # CLI flag: -blocks-storage.tsdb.new-chunk-disk-mapper
   [new_chunk_disk_mapper: <boolean> | default = false]
 

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3442,6 +3442,11 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.head-chunks-write-queue-size
   [head_chunks_write_queue_size: <int> | default = 0]
 
+  # (experimental) Temporary flag which we use to select whether to use the new
+  # (used in upstream Prometheus) or the old (legacy) chunk disk mapper.
+  # CLI flag: -blocks-storage.tsdb.new-chunk-disk-mapper
+  [new_chunk_disk_mapper: <boolean> | default = false]
+
   # (advanced) [Deprecated] Enables TSDB isolation feature. Disabling may
   # improve performance.
   # CLI flag: -blocks-storage.tsdb.isolation-enabled

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1482,6 +1482,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		EnableMemorySnapshotOnShutdown: i.cfg.BlocksStorageConfig.TSDB.MemorySnapshotOnShutdown,
 		IsolationDisabled:              !i.cfg.BlocksStorageConfig.TSDB.IsolationEnabled,
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
+		NewChunkDiskMapper:             i.cfg.BlocksStorageConfig.TSDB.NewChunkDiskMapper,
 	}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open TSDB: %s", udir)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -157,6 +157,7 @@ type TSDBConfig struct {
 	CloseIdleTSDBTimeout      time.Duration `yaml:"close_idle_tsdb_timeout" category:"advanced"`
 	MemorySnapshotOnShutdown  bool          `yaml:"memory_snapshot_on_shutdown" category:"experimental"`
 	HeadChunksWriteQueueSize  int           `yaml:"head_chunks_write_queue_size" category:"experimental"`
+	NewChunkDiskMapper        bool          `yaml:"new_chunk_disk_mapper" category:"experimental"`
 	IsolationEnabled          bool          `yaml:"isolation_enabled" category:"advanced"` // TODO Remove in Mimir 2.3.0
 
 	// Series hash cache.
@@ -198,6 +199,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CloseIdleTSDBTimeout, "blocks-storage.tsdb.close-idle-tsdb-timeout", 13*time.Hour, "If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB.")
 	f.BoolVar(&cfg.MemorySnapshotOnShutdown, "blocks-storage.tsdb.memory-snapshot-on-shutdown", false, "True to enable snapshotting of in-memory TSDB data on disk when shutting down.")
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", 0, "The size of the write queue used by the head chunks mapper. Lower values reduce memory utilisation at the cost of potentially higher ingest latency. Value of 0 switches chunks mapper to implementation without a queue.")
+	f.BoolVar(&cfg.NewChunkDiskMapper, "blocks-storage.tsdb.new-chunk-disk-mapper", false, "Temporary flag which we use to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.")
 	f.BoolVar(&cfg.IsolationEnabled, "blocks-storage.tsdb.isolation-enabled", false, "[Deprecated] Enables TSDB isolation feature. Disabling may improve performance.")
 }
 

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -199,7 +199,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CloseIdleTSDBTimeout, "blocks-storage.tsdb.close-idle-tsdb-timeout", 13*time.Hour, "If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB.")
 	f.BoolVar(&cfg.MemorySnapshotOnShutdown, "blocks-storage.tsdb.memory-snapshot-on-shutdown", false, "True to enable snapshotting of in-memory TSDB data on disk when shutting down.")
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", 0, "The size of the write queue used by the head chunks mapper. Lower values reduce memory utilisation at the cost of potentially higher ingest latency. Value of 0 switches chunks mapper to implementation without a queue.")
-	f.BoolVar(&cfg.NewChunkDiskMapper, "blocks-storage.tsdb.new-chunk-disk-mapper", false, "Temporary flag which we use to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.")
+	f.BoolVar(&cfg.NewChunkDiskMapper, "blocks-storage.tsdb.new-chunk-disk-mapper", false, "Temporary flag to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.")
 	f.BoolVar(&cfg.IsolationEnabled, "blocks-storage.tsdb.isolation-enabled", false, "[Deprecated] Enables TSDB isolation feature. Disabling may improve performance.")
 }
 


### PR DESCRIPTION
The default behavior remains unchanged.

We will use this new configuration flag to slowly enable the new chunk disk mapper in our production environments, without enabling the chunk write queue yet. Once it has been enabled everywhere and we are confident that it doesn't cause any issues we can remove the old chunk disk mapper from `mimir-prometheus` and we can also start to slowly enable the chunk write queue.