### PR TITLE
Gracefully shutdown querier when using query-scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482 #1549
 * [ENHANCEMENT] Alertmanager: added `insight=true` field to alertmanager dispatch logs. #1379
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run index header operations in a dedicated thread pool. This feature can be configured using `-blocks-storage.bucket-store.index-header-thread-pool-size` and is disabled by default. #1660
+* [ENHANCEMENT] Querier: wait until inflight queries are completed when shutting down queriers and running Mimir with query-scheduler. #1756
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 * [BUGFIX] Query-frontend: added `component=query-frontend` label to results cache memcached metrics to fix a panic when Mimir is running in single binary mode and results cache is enabled. #1704
 * [BUGFIX] Mimir: services' status content-type is now correctly set to `text/html`. #1575

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -92,7 +92,7 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 	schedulerClient := schedulerpb.NewSchedulerForQuerierClient(conn)
 
 	// Run the querier loop (and so all the queries) in a dedicated context that we call the "execution context".
-	// The execution context is cancelled once the processCtx is cancelled AND there's no inflight query executing.
+	// The execution context is cancelled once the workerCtx is cancelled AND there's no inflight query executing.
 	exec := newExecutionContext(workerCtx, sp.log)
 	defer exec.cancel()
 

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -34,9 +34,7 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 		workerCtx, workerCancel := context.WithCancel(context.Background())
 		workerCancel()
 
-		startTime := time.Now()
 		sp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
-		assert.Less(t, time.Since(startTime), time.Second)
 
 		// We expect at this point, the execution context has been canceled too.
 		require.Error(t, loopClient.Context().Err())

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
+)
+
+func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
+	t.Run("should immediately return if worker context is canceled and there's no inflight query", func(t *testing.T) {
+		sp, loopClient, requestHandler := prepareSchedulerProcessor()
+
+		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
+			// No query to execute, so wait until terminated.
+			<-loopClient.Context().Done()
+			return nil, loopClient.Context().Err()
+		})
+
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Return(&httpgrpc.HTTPResponse{}, nil)
+
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		workerCancel()
+
+		startTime := time.Now()
+		sp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
+		assert.Less(t, time.Since(startTime), time.Second)
+
+		// We expect at this point, the execution context has been canceled too.
+		require.Error(t, loopClient.Context().Err())
+
+		// We expect Send() has been called only once, to send the querier ID to scheduler.
+		loopClient.AssertNumberOfCalls(t, "Send", 1)
+		loopClient.AssertCalled(t, "Send", &schedulerpb.QuerierToScheduler{QuerierID: "test-querier-id"})
+
+	})
+
+	t.Run("should wait until inflight query execution is completed before returning when worker context is canceled", func(t *testing.T) {
+		sp, loopClient, requestHandler := prepareSchedulerProcessor()
+
+		recvCount := atomic.NewInt64(0)
+
+		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
+			switch recvCount.Inc() {
+			case 1:
+				return &schedulerpb.SchedulerToQuerier{
+					QueryID:         1,
+					HttpRequest:     nil,
+					FrontendAddress: "127.0.0.2",
+					UserID:          "user-1",
+				}, nil
+			default:
+				// No more messages to process, so waiting until terminated.
+				<-loopClient.Context().Done()
+				return nil, loopClient.Context().Err()
+			}
+		})
+
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			// Cancel the worker context while the query execution is in progress.
+			workerCancel()
+
+			// Ensure the execution context hasn't been canceled yet.
+			require.Nil(t, loopClient.Context().Err())
+
+			// Intentionally slow down the query execution, to double check the worker waits until done.
+			time.Sleep(time.Second)
+		}).Return(&httpgrpc.HTTPResponse{}, nil)
+
+		startTime := time.Now()
+		sp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
+		assert.GreaterOrEqual(t, time.Since(startTime), time.Second)
+
+		// We expect at this point, the execution context has been canceled too.
+		require.Error(t, loopClient.Context().Err())
+
+		// We expect Send() to be called twice: first to send the querier ID to scheduler
+		// and then to send the query result.
+		loopClient.AssertNumberOfCalls(t, "Send", 2)
+		loopClient.AssertCalled(t, "Send", &schedulerpb.QuerierToScheduler{QuerierID: "test-querier-id"})
+	})
+}
+
+func prepareSchedulerProcessor() (*schedulerProcessor, *querierLoopClientMock, *requestHandlerMock) {
+	var querierLoopCtx context.Context
+
+	loopClient := &querierLoopClientMock{}
+	loopClient.On("Send", mock.Anything).Return(nil)
+	loopClient.On("Context").Return(func() context.Context {
+		return querierLoopCtx
+	})
+
+	schedulerClient := &schedulerForQuerierClientMock{}
+	schedulerClient.On("QuerierLoop", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		querierLoopCtx = args.Get(0).(context.Context)
+	}).Return(loopClient, nil)
+
+	requestHandler := &requestHandlerMock{}
+
+	sp, _ := newSchedulerProcessor(Config{QuerierID: "test-querier-id"}, requestHandler, log.NewNopLogger(), nil)
+	sp.schedulerClientFactory = func(_ *grpc.ClientConn) schedulerpb.SchedulerForQuerierClient {
+		return schedulerClient
+	}
+
+	return sp, loopClient, requestHandler
+}
+
+type schedulerForQuerierClientMock struct {
+	mock.Mock
+}
+
+func (m *schedulerForQuerierClientMock) QuerierLoop(ctx context.Context, opts ...grpc.CallOption) (schedulerpb.SchedulerForQuerier_QuerierLoopClient, error) {
+	args := m.Called(ctx, opts)
+	return args.Get(0).(schedulerpb.SchedulerForQuerier_QuerierLoopClient), args.Error(1)
+}
+
+func (m *schedulerForQuerierClientMock) NotifyQuerierShutdown(ctx context.Context, in *schedulerpb.NotifyQuerierShutdownRequest, opts ...grpc.CallOption) (*schedulerpb.NotifyQuerierShutdownResponse, error) {
+	args := m.Called(ctx, in, opts)
+	return args.Get(0).(*schedulerpb.NotifyQuerierShutdownResponse), args.Error(1)
+}
+
+type querierLoopClientMock struct {
+	mock.Mock
+}
+
+func (m *querierLoopClientMock) Send(msg *schedulerpb.QuerierToScheduler) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *querierLoopClientMock) Recv() (*schedulerpb.SchedulerToQuerier, error) {
+	args := m.Called()
+
+	// Allow to mock the Recv() with a function which is called each time.
+	if fn, ok := args.Get(0).(func() (*schedulerpb.SchedulerToQuerier, error)); ok {
+		return fn()
+	}
+
+	return args.Get(0).(*schedulerpb.SchedulerToQuerier), args.Error(1)
+}
+
+func (m *querierLoopClientMock) Header() (metadata.MD, error) {
+	args := m.Called()
+	return args.Get(0).(metadata.MD), args.Error(1)
+}
+
+func (m *querierLoopClientMock) Trailer() metadata.MD {
+	args := m.Called()
+	return args.Get(0).(metadata.MD)
+}
+
+func (m *querierLoopClientMock) CloseSend() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *querierLoopClientMock) Context() context.Context {
+	args := m.Called()
+
+	// Allow to mock the Context() with a function which is called each time.
+	if fn, ok := args.Get(0).(func() context.Context); ok {
+		return fn()
+	}
+
+	return args.Get(0).(context.Context)
+}
+
+func (m *querierLoopClientMock) SendMsg(msg interface{}) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *querierLoopClientMock) RecvMsg(msg interface{}) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+type requestHandlerMock struct {
+	mock.Mock
+}
+
+func (m *requestHandlerMock) Handle(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(*httpgrpc.HTTPResponse), args.Error(1)
+}

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -16,11 +16,12 @@ import (
 // until inflight queries are terminated before the querier process exits.
 //
 // How it's used:
+//
 // - The querier worker's loop run in a dedicated context, called the "execution context".
+//
 // - The execution context is canceled when the worker context gets cancelled (ie. querier is shutting down)
-//   and there's no inflight query execution. In case there's an inflight query, the execution context is canceled
-//   once the inflight query terminates and the response has been sent.
-type executionContext struct {
+// and there's no inflight query execution. In case there's an inflight query, the execution context is canceled
+// once the inflight query terminates and the response has been sent.
 	execCtx       context.Context
 	execCancel    context.CancelFunc
 	inflightQuery *atomic.Bool

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -22,6 +22,7 @@ import (
 // - The execution context is canceled when the worker context gets cancelled (ie. querier is shutting down)
 // and there's no inflight query execution. In case there's an inflight query, the execution context is canceled
 // once the inflight query terminates and the response has been sent.
+type executionContext struct {
 	execCtx       context.Context
 	execCancel    context.CancelFunc
 	inflightQuery *atomic.Bool

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"go.uber.org/atomic"
+)
+
+type executionContext struct {
+	execCtx       context.Context
+	execCancel    context.CancelFunc
+	inflightQuery *atomic.Bool
+}
+
+func newExecutionContext(workerCtx context.Context, logger log.Logger) *executionContext {
+	execCtx, execCancel := context.WithCancel(context.Background())
+
+	c := &executionContext{
+		execCtx:       execCtx,
+		execCancel:    execCancel,
+		inflightQuery: atomic.NewBool(false),
+	}
+
+	go func() {
+		// Wait until it's safe to cancel the execution context, which is when one of the following conditions happen:
+		// - The worker context has been canceled and there's no inflight query
+		// - The execution context itself has been explicitly canceled
+		select {
+		case <-workerCtx.Done():
+			level.Debug(logger).Log("msg", "querier worker context has been canceled, waiting until there's no inflight query")
+
+			for c.inflightQuery.Load() {
+				select {
+				case <-execCtx.Done():
+					// In the meanwhile, the execution context has been explicitly canceled, so we should just terminate.
+					return
+				case <-time.After(100 * time.Millisecond):
+					// Going to check it again.
+				}
+			}
+
+			level.Debug(logger).Log("msg", "querier worker context has been canceled and there's no inflight query, canceling the execution context too")
+			execCancel()
+		case <-execCtx.Done():
+			// Nothing to do. The execution context has been explicitly canceled.
+		}
+	}()
+
+	return c
+}
+
+func (c *executionContext) queryStarted() {
+	c.inflightQuery.Store(true)
+}
+
+func (c *executionContext) queryEnded() {
+	c.inflightQuery.Store(false)
+}
+
+func (c *executionContext) context() context.Context {
+	return c.execCtx
+}
+
+func (c *executionContext) cancel() {
+	c.execCancel()
+}

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -28,6 +28,7 @@ type executionContext struct {
 	inflightQuery *atomic.Bool
 }
 
+// newExecutionContext returns a new executionContext. The caller must call cancel() on it once done.
 func newExecutionContext(workerCtx context.Context, logger log.Logger) *executionContext {
 	execCtx, execCancel := context.WithCancel(context.Background())
 

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -11,6 +11,15 @@ import (
 	"go.uber.org/atomic"
 )
 
+// executionContext wraps the context.Context used to run the querier's worker loop and execute
+// queries. The purpose of the execution context is to gracefully shutdown queriers, waiting
+// until inflight queries are terminated before the querier process exits.
+//
+// How it's used:
+// - The querier worker's loop run in a dedicated context, called the "execution context".
+// - The execution context is canceled when the worker context gets cancelled (ie. querier is shutting down)
+//   and there's no inflight query execution. In case there's an inflight query, the execution context is canceled
+//   once the inflight query terminates and the response has been sent.
 type executionContext struct {
 	execCtx       context.Context
 	execCancel    context.CancelFunc

--- a/pkg/scheduler/queue/user_queues.go
+++ b/pkg/scheduler/queue/user_queues.go
@@ -148,6 +148,12 @@ func (q *queues) getOrAddQueue(userID string, maxQueriers int) chan Request {
 func (q *queues) getNextQueueForQuerier(lastUserIndex int, querierID string) (chan Request, string, int) {
 	uid := lastUserIndex
 
+	// Ensure the querier is not shutting down. If the querier is shutting down, we shouldn't forward
+	// any more queries to it.
+	if info := q.queriers[querierID]; info == nil || info.shuttingDown {
+		return nil, "", uid
+	}
+
 	for iters := 0; iters < len(q.users); iters++ {
 		uid = uid + 1
 

--- a/pkg/scheduler/queue/user_queues_test.go
+++ b/pkg/scheduler/queue/user_queues_test.go
@@ -22,6 +22,9 @@ func TestQueues(t *testing.T) {
 	assert.NotNil(t, uq)
 	assert.NoError(t, isConsistent(uq))
 
+	uq.addQuerierConnection("querier-1")
+	uq.addQuerierConnection("querier-2")
+
 	q, u, lastUserIndex := uq.getNextQueueForQuerier(-1, "querier-1")
 	assert.Nil(t, q)
 	assert.Equal(t, "", u)
@@ -70,6 +73,36 @@ func TestQueues(t *testing.T) {
 
 	q, _, _ = uq.getNextQueueForQuerier(lastUserIndex, "querier-1")
 	assert.Nil(t, q)
+}
+
+func TestQueuesOnTerminatingQuerier(t *testing.T) {
+	uq := newUserQueues(0, 0)
+	assert.NotNil(t, uq)
+	assert.NoError(t, isConsistent(uq))
+
+	uq.addQuerierConnection("querier-1")
+	uq.addQuerierConnection("querier-2")
+
+	// Add queues: [one, two]
+	qOne := getOrAdd(t, uq, "one", 0)
+	qTwo := getOrAdd(t, uq, "two", 0)
+	confirmOrderForQuerier(t, uq, "querier-1", -1, qOne, qTwo, qOne, qTwo)
+	confirmOrderForQuerier(t, uq, "querier-2", -1, qOne, qTwo, qOne, qTwo)
+
+	// After notify shutdown for querier-2, it's expected to own no queue.
+	uq.notifyQuerierShutdown("querier-2")
+	q, u, _ := uq.getNextQueueForQuerier(-1, "querier-2")
+	assert.Nil(t, q)
+	assert.Equal(t, "", u)
+
+	// However, querier-1 still get queues because it's still running.
+	confirmOrderForQuerier(t, uq, "querier-1", -1, qOne, qTwo, qOne, qTwo)
+
+	// After disconnecting querier-2, it's expected to own no queue.
+	uq.removeQuerier("querier-2")
+	q, u, _ = uq.getNextQueueForQuerier(-1, "querier-2")
+	assert.Nil(t, q)
+	assert.Equal(t, "", u)
 }
 
 func TestQueuesWithQueriers(t *testing.T) {


### PR DESCRIPTION
#### What this PR does
This is an approach alternative to #1742, to gracefully shutdown querier when using query-scheduler, which also supports query cancellation and querier shutdown when there's no enqueued query for the given querier.

The idea in this PR is pretty simple:
- Run the querier worker's loop in a dedicated context, called the "execution context"
- Cancel the execution context when the worker context gets cancelled (ie. querier is shutting down) **and** there's no inflight query execution (otherwise wait the inflight query to terminate)

When the querier shutdowns (at the beginning of the shutdown process) it sends a notification to the scheduler (see `schedulerProcessor.notifyShutdown()`). I did a small change in the scheduler's queue, to make sure it never forwards a new query to a shutting down querier (with the code in `main` it could happen). This basically prevents the case that new queries are sent to a querier which is shutting down, and just waiting for the inflight queries to complete.

Manual tests I've done:
- Shutdown a querier when there's no query running or enqueued --> terminates immediately
- Shutdown a querier when there's an inflight query only --> waits until the query completes and then terminate
- Shutdown a querier when there's an inflight query running and enqueued requests in the scheduler --> waits until the query completes and then terminate. The enqueued requests stay in the scheduler. If you restart the querier, it will process the enqueued requests

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
