### PR TITLE
Graceful shutdown querier without query-scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482 #1549
 * [ENHANCEMENT] Alertmanager: added `insight=true` field to alertmanager dispatch logs. #1379
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run index header operations in a dedicated thread pool. This feature can be configured using `-blocks-storage.bucket-store.index-header-thread-pool-size` and is disabled by default. #1660
-* [ENHANCEMENT] Querier: wait until inflight queries are completed when shutting down queriers and running Mimir with query-scheduler. #1756
+* [ENHANCEMENT] Querier: wait until inflight queries are completed when shutting down queriers. #1756 #1767
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 * [BUGFIX] Query-frontend: added `component=query-frontend` label to results cache memcached metrics to fix a panic when Mimir is running in single binary mode and results cache is enabled. #1704
 * [BUGFIX] Mimir: services' status content-type is now correctly set to `text/html`. #1575

--- a/pkg/querier/worker/frontend_processor.go
+++ b/pkg/querier/worker/frontend_processor.go
@@ -64,11 +64,12 @@ func (fp *frontendProcessor) notifyShutdown(ctx context.Context, conn *grpc.Clie
 	}
 }
 
-// runOne loops, trying to establish a stream to the frontend to begin request processing.
+// processQueriesOnSingleStream tries to establish a stream to the query-frontend and then process queries received
+// on the stream. This function loops until workerCtx is canceled.
 func (fp *frontendProcessor) processQueriesOnSingleStream(workerCtx context.Context, conn *grpc.ClientConn, address string) {
 	client := fp.frontendClientFactory(conn)
 
-	// Run the querier loop (and so all the queries) in a dedicated context that we call the "execution context".
+	// Run the gRPC client and process all the queries in a dedicated context that we call the "execution context".
 	// The execution context is cancelled once the workerCtx is cancelled AND there's no inflight query executing.
 	exec := newExecutionContext(workerCtx, fp.log)
 	defer exec.cancel()

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -13,11 +13,84 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/mimir/pkg/frontend/v1/frontendv1pb"
 )
+
+func TestFrontendProcessor_processQueriesOnSingleStream(t *testing.T) {
+	t.Run("should immediately return if worker context is canceled and there's no inflight query", func(t *testing.T) {
+		fp, processClient, requestHandler := prepareFrontendProcessor()
+
+		processClient.On("Recv").Return(func() (*frontendv1pb.FrontendToClient, error) {
+			// No query to execute, so wait until terminated.
+			<-processClient.Context().Done()
+			return nil, processClient.Context().Err()
+		})
+
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Return(&httpgrpc.HTTPResponse{}, nil)
+
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		workerCancel()
+
+		fp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
+
+		// We expect at this point, the execution context has been canceled too.
+		require.Error(t, processClient.Context().Err())
+
+		// We expect Send() has not been called, because no query has been executed.
+		processClient.AssertNumberOfCalls(t, "Send", 0)
+	})
+
+	t.Run("should wait until inflight query execution is completed before returning when worker context is canceled", func(t *testing.T) {
+		fp, processClient, requestHandler := prepareFrontendProcessor()
+
+		recvCount := atomic.NewInt64(0)
+
+		processClient.On("Recv").Return(func() (*frontendv1pb.FrontendToClient, error) {
+			switch recvCount.Inc() {
+			case 1:
+				return &frontendv1pb.FrontendToClient{
+					Type:        frontendv1pb.HTTP_REQUEST,
+					HttpRequest: nil,
+				}, nil
+			default:
+				// No more messages to process, so waiting until terminated.
+				<-processClient.Context().Done()
+				return nil, processClient.Context().Err()
+			}
+		})
+
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			// Cancel the worker context while the query execution is in progress.
+			workerCancel()
+
+			// Ensure the execution context hasn't been canceled yet.
+			require.Nil(t, processClient.Context().Err())
+
+			// Intentionally slow down the query execution, to double check the worker waits until done.
+			time.Sleep(time.Second)
+		}).Return(&httpgrpc.HTTPResponse{}, nil)
+
+		startTime := time.Now()
+		fp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
+		assert.GreaterOrEqual(t, time.Since(startTime), time.Second)
+
+		// We expect at this point, the execution context has been canceled too.
+		require.Error(t, processClient.Context().Err())
+
+		// We expect Send() to be called once, to send the query result.
+		processClient.AssertNumberOfCalls(t, "Send", 1)
+	})
+}
 
 func TestRecvFailDoesntCancelProcess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -77,4 +150,98 @@ func TestContextCancelStopsProcess(t *testing.T) {
 	test.Poll(t, time.Second, 0, func() interface{} {
 		return int(pm.currentProcessors.Load())
 	})
+}
+
+func prepareFrontendProcessor() (*frontendProcessor, *frontendProcessClientMock, *requestHandlerMock) {
+	var processCtx context.Context
+
+	processClient := &frontendProcessClientMock{}
+	processClient.On("Send", mock.Anything).Return(nil)
+	processClient.On("Context").Return(func() context.Context {
+		return processCtx
+	})
+
+	frontendClient := &frontendClientMock{}
+	frontendClient.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		processCtx = args.Get(0).(context.Context)
+	}).Return(processClient, nil)
+
+	requestHandler := &requestHandlerMock{}
+
+	fp := newFrontendProcessor(Config{QuerierID: "test-querier-id"}, requestHandler, log.NewNopLogger())
+	fp.frontendClientFactory = func(_ *grpc.ClientConn) frontendv1pb.FrontendClient {
+		return frontendClient
+	}
+
+	return fp, processClient, requestHandler
+}
+
+type frontendClientMock struct {
+	mock.Mock
+}
+
+func (m *frontendClientMock) Process(ctx context.Context, opts ...grpc.CallOption) (frontendv1pb.Frontend_ProcessClient, error) {
+	args := m.Called(ctx, opts)
+	return args.Get(0).(frontendv1pb.Frontend_ProcessClient), args.Error(1)
+}
+
+func (m *frontendClientMock) NotifyClientShutdown(ctx context.Context, in *frontendv1pb.NotifyClientShutdownRequest, opts ...grpc.CallOption) (*frontendv1pb.NotifyClientShutdownResponse, error) {
+	args := m.Called(ctx, in, opts)
+	return args.Get(0).(*frontendv1pb.NotifyClientShutdownResponse), args.Error(1)
+}
+
+type frontendProcessClientMock struct {
+	mock.Mock
+}
+
+func (m *frontendProcessClientMock) Send(msg *frontendv1pb.ClientToFrontend) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *frontendProcessClientMock) Recv() (*frontendv1pb.FrontendToClient, error) {
+	args := m.Called()
+
+	// Allow to mock the Recv() with a function which is called each time.
+	if fn, ok := args.Get(0).(func() (*frontendv1pb.FrontendToClient, error)); ok {
+		return fn()
+	}
+
+	return args.Get(0).(*frontendv1pb.FrontendToClient), args.Error(1)
+}
+
+func (m *frontendProcessClientMock) Header() (metadata.MD, error) {
+	args := m.Called()
+	return args.Get(0).(metadata.MD), args.Error(1)
+}
+
+func (m *frontendProcessClientMock) Trailer() metadata.MD {
+	args := m.Called()
+	return args.Get(0).(metadata.MD)
+}
+
+func (m *frontendProcessClientMock) CloseSend() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *frontendProcessClientMock) Context() context.Context {
+	args := m.Called()
+
+	// Allow to mock the Context() with a function which is called each time.
+	if fn, ok := args.Get(0).(func() context.Context); ok {
+		return fn()
+	}
+
+	return args.Get(0).(context.Context)
+}
+
+func (m *frontendProcessClientMock) SendMsg(msg interface{}) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *frontendProcessClientMock) RecvMsg(msg interface{}) error {
+	args := m.Called(msg)
+	return args.Error(0)
 }

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -11,9 +11,12 @@ import (
 	"go.uber.org/atomic"
 )
 
-// executionContext wraps the context.Context used to run the querier's worker loop and execute
-// queries. The purpose of the execution context is to gracefully shutdown queriers, waiting
+// newExecutionContext returns a new execution context (execCtx) that wraps the input workerCtx and
+// it used to run the querier's worker loop and execute queries.
+// The purpose of the execution context is to gracefully shutdown queriers, waiting
 // until inflight queries are terminated before the querier process exits.
+//
+// The caller must call execCancel() once done.
 //
 // How it's used:
 //
@@ -22,21 +25,10 @@ import (
 // - The execution context is canceled when the worker context gets cancelled (ie. querier is shutting down)
 // and there's no inflight query execution. In case there's an inflight query, the execution context is canceled
 // once the inflight query terminates and the response has been sent.
-type executionContext struct {
-	execCtx       context.Context
-	execCancel    context.CancelFunc
-	inflightQuery *atomic.Bool
-}
 
-// newExecutionContext returns a new executionContext. The caller must call cancel() on it once done.
-func newExecutionContext(workerCtx context.Context, logger log.Logger) *executionContext {
-	execCtx, execCancel := context.WithCancel(context.Background())
-
-	c := &executionContext{
-		execCtx:       execCtx,
-		execCancel:    execCancel,
-		inflightQuery: atomic.NewBool(false),
-	}
+func newExecutionContext(workerCtx context.Context, logger log.Logger) (execCtx context.Context, execCancel context.CancelFunc, inflightQuery *atomic.Bool) {
+	execCtx, execCancel = context.WithCancel(context.Background())
+	inflightQuery = atomic.NewBool(false)
 
 	go func() {
 		// Wait until it's safe to cancel the execution context, which is when one of the following conditions happen:
@@ -46,7 +38,7 @@ func newExecutionContext(workerCtx context.Context, logger log.Logger) *executio
 		case <-workerCtx.Done():
 			level.Debug(logger).Log("msg", "querier worker context has been canceled, waiting until there's no inflight query")
 
-			for c.inflightQuery.Load() {
+			for inflightQuery.Load() {
 				select {
 				case <-execCtx.Done():
 					// In the meanwhile, the execution context has been explicitly canceled, so we should just terminate.
@@ -63,21 +55,5 @@ func newExecutionContext(workerCtx context.Context, logger log.Logger) *executio
 		}
 	}()
 
-	return c
-}
-
-func (c *executionContext) queryStarted() {
-	c.inflightQuery.Store(true)
-}
-
-func (c *executionContext) queryEnded() {
-	c.inflightQuery.Store(false)
-}
-
-func (c *executionContext) context() context.Context {
-	return c.execCtx
-}
-
-func (c *executionContext) cancel() {
-	c.execCancel()
+	return
 }


### PR DESCRIPTION
#### What this PR does
Like #1756 but for the case Mimir is running without query-scheduler.

Manual tests I've done:

- Shutdown a querier when there's no query running or enqueued --> terminates immediately
- Shutdown a querier when there's an inflight query only --> waits until the query completes and then terminate
- Shutdown a querier when there's an inflight query running and enqueued requests in the frontend --> waits until the query completes and then terminate. The enqueued requests stay in the frontend. If you restart the querier, it will process the enqueued requests

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
