### PR TITLE
Update thanos vendored dependency for ooo support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -230,7 +230,7 @@ replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-
 replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220426153921-b003d620b2f4
 
 // OOO Support forces us to fork thanos because we've changed the ChunkReader interface
-replace github.com/thanos-io/thanos => github.com/jesusvazquez/thanos v0.19.1-0.20220425161949-a7f23aaea4e4
+replace github.com/thanos-io/thanos => github.com/jesusvazquez/thanos v0.19.1-0.20220427121402-46735047853b
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1068,8 +1068,8 @@ github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGk
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jesusvazquez/thanos v0.19.1-0.20220425161949-a7f23aaea4e4 h1:QOCywma53LX3K5XHTpEqWkIzo+5/uxCVzmCXVQwy3K4=
-github.com/jesusvazquez/thanos v0.19.1-0.20220425161949-a7f23aaea4e4/go.mod h1:/WiTX1fRzebFlnvMkPNojcB3QfKsaz/o89JnDMomcsQ=
+github.com/jesusvazquez/thanos v0.19.1-0.20220427121402-46735047853b h1:5DyOpfQlkHOv9FE9ZsnfCFUJyH4JGcKdc5cPbSn7wEE=
+github.com/jesusvazquez/thanos v0.19.1-0.20220427121402-46735047853b/go.mod h1:/WiTX1fRzebFlnvMkPNojcB3QfKsaz/o89JnDMomcsQ=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -807,7 +807,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.24.1-0.20220416232747-81218afa5b01 => github.com/jesusvazquez/thanos v0.19.1-0.20220425161949-a7f23aaea4e4
+# github.com/thanos-io/thanos v0.24.1-0.20220416232747-81218afa5b01 => github.com/jesusvazquez/thanos v0.19.1-0.20220427121402-46735047853b
 ## explicit; go 1.17
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/indexheader
@@ -1228,7 +1228,7 @@ gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 # github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220426153921-b003d620b2f4
-# github.com/thanos-io/thanos => github.com/jesusvazquez/thanos v0.19.1-0.20220425161949-a7f23aaea4e4
+# github.com/thanos-io/thanos => github.com/jesusvazquez/thanos v0.19.1-0.20220427121402-46735047853b
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b


### PR DESCRIPTION
We merged https://github.com/jesusvazquez/thanos/pull/1 so now we can
update Thanos dependency to the latest commit of the out of order branch
in thanos fork.
