### PR TITLE
Increased default -tests.run-interval from 1m to 5m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 ### Tools
 
 * [FEATURE] Added a `markblocks` tool that creates `no-compact` and `delete` marks for the blocks. #1551
-* [FEATURE] Added `mimir-continuous-test` tool to continuously run smoke tests on live Mimir clusters. #1535 #1540 #1653 #1603 #1630 #1691 #1675 #1676 #1692 #1706 #1709 #1777
+* [FEATURE] Added `mimir-continuous-test` tool to continuously run smoke tests on live Mimir clusters. #1535 #1540 #1653 #1603 #1630 #1691 #1675 #1676 #1692 #1706 #1709 #1777 #1778
 * [FEATURE] Added `mimir-rules-action` GitHub action, located at `operations/mimir-rules-action/`, used to lint, prepare, verify, diff, and sync rules to a Mimir cluster. #1723
 
 ## 2.0.0

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -732,6 +732,6 @@ groups:
       message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{
         $labels.namespace }} failed when asserting query results.
     expr: |
-      sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[5m])) > 0
+      sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0
     labels:
       severity: warning

--- a/operations/mimir-mixin/alerts/continuous-test.libsonnet
+++ b/operations/mimir-mixin/alerts/continuous-test.libsonnet
@@ -38,7 +38,7 @@
           // should have no "grace period" and alert as soon as the test fails.
           alert: $.alertName('ContinuousTestFailed'),
           expr: |||
-            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_query_result_checks_failed_total[5m])) > 0
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0
           ||| % $._config,
           labels: {
             severity: 'warning',

--- a/pkg/continuoustest/manager.go
+++ b/pkg/continuoustest/manager.go
@@ -25,7 +25,7 @@ type ManagerConfig struct {
 }
 
 func (cfg *ManagerConfig) RegisterFlags(f *flag.FlagSet) {
-	f.DurationVar(&cfg.RunInterval, "tests.run-interval", time.Minute, "How frequently tests should run.")
+	f.DurationVar(&cfg.RunInterval, "tests.run-interval", 5*time.Minute, "How frequently tests should run.")
 }
 
 type Manager struct {


### PR DESCRIPTION
#### What this PR does
I think I've been too much aggressive when I've set 1m default test interval for `mimir-continuous-test`. I think running the test every 5m is perfectly fine.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
