### PR TITLE
Fix flaky tests on querier graceful shutdown

### DIFF
--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -25,7 +25,6 @@ import (
 // - The execution context is canceled when the worker context gets cancelled (ie. querier is shutting down)
 // and there's no inflight query execution. In case there's an inflight query, the execution context is canceled
 // once the inflight query terminates and the response has been sent.
-
 func newExecutionContext(workerCtx context.Context, logger log.Logger) (execCtx context.Context, execCancel context.CancelFunc, inflightQuery *atomic.Bool) {
 	execCtx, execCancel = context.WithCancel(context.Background())
 	inflightQuery = atomic.NewBool(false)


### PR DESCRIPTION
#### What this PR does
I've seen a flaky test:
```
--- FAIL: TestFrontendProcessor_processQueriesOnSingleStream (0.00s)
    --- FAIL: TestFrontendProcessor_processQueriesOnSingleStream/should_immediately_return_if_worker_context_is_canceled_and_there's_no_inflight_query (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xfd44af]

goroutine 28 [running]:
testing.tRunner.func1.2({0x1082800, 0x18fe1f0})
	/usr/local/go/src/testing/testing.go:1209 +0x36c
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x3b6
panic({0x1082800, 0x18fe1f0})
	/usr/local/go/src/runtime/panic.go:1047 +0x266
github.com/grafana/mimir/pkg/querier/worker.TestFrontendProcessor_processQueriesOnSingleStream.func1(0x0)
	/__w/mimir/mimir/pkg/querier/worker/frontend_processor_test.go:45 +0x34f
testing.tRunner(0xc000319ba0, 0x11b8e10)
	/usr/local/go/src/testing/testing.go:1259 +0x230
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x727
FAIL	github.com/grafana/mimir/pkg/querier/worker	0.047s
```

It's caused by a timing issue due to the fact these tests cancel the worker context before calling `processQueriesOnSingleStream()` but the execution context is actually canceled by `newExecutionContext()` in a separate goroutine, so `client.Process()` may or may not be called at all, depending how quickly is the `newExecutionContext()` goroutine executed.

This PR fixes that and actually improve the test, cancelling the worker while it's waiting on `Recv()`.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
