### PR TITLE
Update build image and GitHub workflow

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -18,9 +18,9 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
+      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -48,9 +48,9 @@ jobs:
         run: make BUILD_IN_CONTAINER=false check-tsdb-blocks-storage-s3-docker-compose-yaml
 
   lint-jsonnet:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
+      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
         run: make BUILD_IN_CONTAINER=false check-jsonnet-tests
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
@@ -81,7 +81,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
+      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -105,9 +105,9 @@ jobs:
           docker run -v ${PWD}/docs/sources:/hugo/content/docs/mimir/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   build-mimir:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
+      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -134,9 +134,9 @@ jobs:
           path: ./mimir-images.tar
 
   build-tools:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
+      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -165,7 +165,7 @@ jobs:
 
   integration:
     needs: build-mimir
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
@@ -214,9 +214,9 @@ jobs:
     needs: [build-mimir, build-tools, test, lint, integration]
     # Only deploy images on pushes to the grafana/mimir repo, which either are tag pushes or weekly release branch pushes.
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.17.8-8a996bb57
+      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ fetch-build-image:
 push-multiarch-build-image:
 	@echo
 	# Build image for each platform separately... it tends to generate fewer errors.
-	$(SUDO) docker buildx build --platform linux/amd64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) mimir-build-image/
-	$(SUDO) docker buildx build --platform linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) mimir-build-image/
+	$(SUDO) docker buildx build --platform linux/amd64 --progress=plain --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) mimir-build-image/
+	$(SUDO) docker buildx build --platform linux/arm64 --progress=plain --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) mimir-build-image/
 	# This command will run the same build as above, but it will reuse existing platform-specific images,
 	# put them together and push to registry.
 	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
@@ -189,7 +189,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= update-go-1.17.8-8a996bb57
+LATEST_BUILD_IMAGE_TAG ?= update-build-image-and-github-workflow-89d9d61b4
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -3,10 +3,10 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM golang:1.17.8-buster
+FROM golang:1.17.8-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev && \
+RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev skopeo && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -


### PR DESCRIPTION
#### What this PR does

This PR updates build-image base to `golang:1.17.8-bullseye` (Bullseye is latest [stable Debian release](https://www.debian.org/releases/)), and adds `skopeo` package to build-image (only available in bullseye and unstable).

This PR also updates Github Action jobs to use `ubuntu-latest` as a machine type.

> Note: The -latest virtual environments are the latest stable images that GitHub provides, and might not be the most recent version of the operating system available from the operating system vendor.

(from https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on)

This PR is a preparation for next PR, which will build and push multiarch docker images to the repository. Update to `ubuntu-latest` is needed to make Docker's Buildx and QEMU github actions work. (This will be part of next PR)

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
