### PR TITLE
Do not export per user and integration Alertmanager metrics when value is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 * [CHANGE] Store-gateway: enabled attributes in-memory cache by default. New default configuration is `-blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items=50000`. #1727
 * [CHANGE] Compactor: Removed the metric `cortex_compactor_garbage_collected_blocks_total` since it duplicates `cortex_compactor_blocks_marked_for_deletion_total`. #1728
 * [CHANGE] All: Logs that used the`org_id` label now use `user` label. #1634 #1758
+* [CHANGE] Alertmanager: the following metrics are not exported for a given `user` and `integration` when the metric value is zero: #1783
+  * `cortex_alertmanager_notifications_total`
+  * `cortex_alertmanager_notifications_failed_total`
+  * `cortex_alertmanager_notification_requests_total`
+  * `cortex_alertmanager_notification_requests_failed_total`
+  * `cortex_alertmanager_notification_rate_limited_total`
 * [FEATURE] Querier: Added support for [streaming remote read](https://prometheus.io/blog/2019/10/10/remote-read-meets-streaming/). Should be noted that benefits of chunking the response are partial here, since in a typical `query-frontend` setup responses will be buffered until they've been completed. #1735
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Ruler: Added support for expression remote evaluation. #1536

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -296,10 +296,10 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerUser(out, m.alertsReceived, "alertmanager_alerts_received_total")
 	data.SendSumOfCountersPerUser(out, m.alertsInvalid, "alertmanager_alerts_invalid_total")
 
-	data.SendSumOfCountersPerUserWithLabels(out, m.numNotifications, "alertmanager_notifications_total", "integration")
-	data.SendSumOfCountersPerUserWithLabels(out, m.numFailedNotifications, "alertmanager_notifications_failed_total", "integration")
-	data.SendSumOfCountersPerUserWithLabels(out, m.numNotificationRequestsTotal, "alertmanager_notification_requests_total", "integration")
-	data.SendSumOfCountersPerUserWithLabels(out, m.numNotificationRequestsFailedTotal, "alertmanager_notification_requests_failed_total", "integration")
+	data.SendSumOfCountersPerUserWithLabelsAndOptions(out, m.numNotifications, "alertmanager_notifications_total", []string{"integration"}, util.SkipZeroValueMetrics)
+	data.SendSumOfCountersPerUserWithLabelsAndOptions(out, m.numFailedNotifications, "alertmanager_notifications_failed_total", []string{"integration"}, util.SkipZeroValueMetrics)
+	data.SendSumOfCountersPerUserWithLabelsAndOptions(out, m.numNotificationRequestsTotal, "alertmanager_notification_requests_total", []string{"integration"}, util.SkipZeroValueMetrics)
+	data.SendSumOfCountersPerUserWithLabelsAndOptions(out, m.numNotificationRequestsFailedTotal, "alertmanager_notification_requests_failed_total", []string{"integration"}, util.SkipZeroValueMetrics)
 	data.SendSumOfHistograms(out, m.notificationLatencySeconds, "alertmanager_notification_latency_seconds")
 	data.SendSumOfGaugesPerUserWithLabels(out, m.markerAlerts, "alertmanager_alerts", "state")
 
@@ -334,7 +334,7 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, m.persistTotal, "alertmanager_state_persist_total")
 	data.SendSumOfCounters(out, m.persistFailed, "alertmanager_state_persist_failed_total")
 
-	data.SendSumOfCountersPerUserWithLabels(out, m.notificationRateLimited, "alertmanager_notification_rate_limited_total", "integration")
+	data.SendSumOfCountersPerUserWithLabelsAndOptions(out, m.notificationRateLimited, "alertmanager_notification_rate_limited_total", []string{"integration"}, util.SkipZeroValueMetrics)
 	data.SendSumOfCountersPerUser(out, m.dispatcherAggregationGroupsLimitReached, "alertmanager_dispatcher_aggregation_group_limit_reached_total")
 	data.SendSumOfCountersPerUser(out, m.insertAlertFailures, "alertmanager_alerts_insert_limited_total")
 	data.SendSumOfGaugesPerUser(out, m.alertsLimiterAlertsCount, "alertmanager_alerts_limiter_current_alerts")

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -110,9 +110,6 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notification_latency_seconds_count 27
 		# HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
 		# TYPE cortex_alertmanager_notifications_failed_total counter
-		cortex_alertmanager_notifications_failed_total{integration="email",user="user1"} 0
-		cortex_alertmanager_notifications_failed_total{integration="email",user="user2"} 0
-		cortex_alertmanager_notifications_failed_total{integration="email",user="user3"} 0
 		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
 		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
 		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user3"} 500
@@ -139,9 +136,6 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notifications_failed_total{integration="sns",user="user3"} 800
 		# HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
 		# TYPE cortex_alertmanager_notification_requests_total counter
-		cortex_alertmanager_notification_requests_total{integration="email",user="user1"} 0
-		cortex_alertmanager_notification_requests_total{integration="email",user="user2"} 0
-		cortex_alertmanager_notification_requests_total{integration="email",user="user3"} 0
 		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user1"} 5
 		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user2"} 50
 		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user3"} 500
@@ -168,9 +162,6 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notification_requests_total{integration="sns",user="user3"} 800
 		# HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
 		# TYPE cortex_alertmanager_notification_requests_failed_total counter
-		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user1"} 0
-		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user2"} 0
-		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user3"} 0
 		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user1"} 5
 		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user2"} 50
 		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user3"} 500
@@ -197,9 +188,6 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user3"} 800
 		# HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
 		# TYPE cortex_alertmanager_notifications_total counter
-		cortex_alertmanager_notifications_total{integration="email",user="user1"} 0
-		cortex_alertmanager_notifications_total{integration="email",user="user2"} 0
-		cortex_alertmanager_notifications_total{integration="email",user="user3"} 0
 		cortex_alertmanager_notifications_total{integration="opsgenie",user="user1"} 5
 		cortex_alertmanager_notifications_total{integration="opsgenie",user="user2"} 50
 		cortex_alertmanager_notifications_total{integration="opsgenie",user="user3"} 500
@@ -411,9 +399,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
         	            # HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
         	            # TYPE cortex_alertmanager_notification_requests_failed_total counter
-        	            cortex_alertmanager_notification_requests_failed_total{integration="email",user="user1"} 0
-        	            cortex_alertmanager_notification_requests_failed_total{integration="email",user="user2"} 0
-        	            cortex_alertmanager_notification_requests_failed_total{integration="email",user="user3"} 0
         	            cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user1"} 5
         	            cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user2"} 50
         	            cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user3"} 500
@@ -441,9 +426,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
         	            # HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
         	            # TYPE cortex_alertmanager_notification_requests_total counter
-        	            cortex_alertmanager_notification_requests_total{integration="email",user="user1"} 0
-        	            cortex_alertmanager_notification_requests_total{integration="email",user="user2"} 0
-        	            cortex_alertmanager_notification_requests_total{integration="email",user="user3"} 0
         	            cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user1"} 5
         	            cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user2"} 50
         	            cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user3"} 500
@@ -471,9 +453,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
         	            # HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
         	            # TYPE cortex_alertmanager_notifications_failed_total counter
-        	            cortex_alertmanager_notifications_failed_total{integration="email",user="user1"} 0
-        	            cortex_alertmanager_notifications_failed_total{integration="email",user="user2"} 0
-        	            cortex_alertmanager_notifications_failed_total{integration="email",user="user3"} 0
         	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
         	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
         	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user3"} 500
@@ -501,9 +480,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
         	            # HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
         	            # TYPE cortex_alertmanager_notifications_total counter
-        	            cortex_alertmanager_notifications_total{integration="email",user="user1"} 0
-        	            cortex_alertmanager_notifications_total{integration="email",user="user2"} 0
-        	            cortex_alertmanager_notifications_total{integration="email",user="user3"} 0
         	            cortex_alertmanager_notifications_total{integration="opsgenie",user="user1"} 5
         	            cortex_alertmanager_notifications_total{integration="opsgenie",user="user2"} 50
         	            cortex_alertmanager_notifications_total{integration="opsgenie",user="user3"} 500
@@ -705,8 +681,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
     		# HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
     		# TYPE cortex_alertmanager_notification_requests_failed_total counter
-    		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user1"} 0
-    		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user2"} 0
     		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user1"} 5
     		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user2"} 50
     		cortex_alertmanager_notification_requests_failed_total{integration="pagerduty",user="user1"} 1
@@ -726,8 +700,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
     		# HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
     		# TYPE cortex_alertmanager_notification_requests_total counter
-    		cortex_alertmanager_notification_requests_total{integration="email",user="user1"} 0
-    		cortex_alertmanager_notification_requests_total{integration="email",user="user2"} 0
     		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user1"} 5
     		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user2"} 50
     		cortex_alertmanager_notification_requests_total{integration="pagerduty",user="user1"} 1
@@ -747,8 +719,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
     		# HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
     		# TYPE cortex_alertmanager_notifications_failed_total counter
-    		cortex_alertmanager_notifications_failed_total{integration="email",user="user1"} 0
-    		cortex_alertmanager_notifications_failed_total{integration="email",user="user2"} 0
     		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
     		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
     		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user1"} 1
@@ -768,8 +738,6 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
     		# HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
     		# TYPE cortex_alertmanager_notifications_total counter
-    		cortex_alertmanager_notifications_total{integration="email",user="user1"} 0
-    		cortex_alertmanager_notifications_total{integration="email",user="user2"} 0
     		cortex_alertmanager_notifications_total{integration="opsgenie",user="user1"} 5
     		cortex_alertmanager_notifications_total{integration="opsgenie",user="user2"} 50
     		cortex_alertmanager_notifications_total{integration="pagerduty",user="user1"} 1

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -124,12 +124,16 @@ func (mfm MetricFamilyMap) SumSummariesTo(name string, output *SummaryData) {
 	}
 }
 
-func (mfm MetricFamilyMap) sumOfSingleValuesWithLabels(metric string, labelNames []string, extractFn func(*dto.Metric) float64, aggregateFn func(labelsKey string, labelValues []string, value float64)) {
+func (mfm MetricFamilyMap) sumOfSingleValuesWithLabels(metric string, labelNames []string, extractFn func(*dto.Metric) float64, aggregateFn func(labelsKey string, labelValues []string, value float64), skipZeroValue bool) {
 	metricsPerLabelValue := getMetricsWithLabelNames(mfm[metric], labelNames)
 
 	for key, mlv := range metricsPerLabelValue {
 		for _, m := range mlv.metrics {
 			val := extractFn(m)
+			if skipZeroValue && val == 0 {
+				continue
+			}
+
 			aggregateFn(key, mlv.labelValues, val)
 		}
 	}
@@ -155,7 +159,7 @@ func (d MetricFamiliesPerUser) SendSumOfCounters(out chan<- prometheus.Metric, d
 }
 
 func (d MetricFamiliesPerUser) SendSumOfCountersWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, counter string, labelNames ...string) {
-	d.sumOfSingleValuesWithLabels(counter, counterValue, labelNames).WriteToMetricChannel(out, desc, prometheus.CounterValue)
+	d.sumOfSingleValuesWithLabels(counter, counterValue, labelNames, false).WriteToMetricChannel(out, desc, prometheus.CounterValue)
 }
 
 func (d MetricFamiliesPerUser) SendSumOfCountersPerUser(out chan<- prometheus.Metric, desc *prometheus.Desc, counter string) {
@@ -165,13 +169,20 @@ func (d MetricFamiliesPerUser) SendSumOfCountersPerUser(out chan<- prometheus.Me
 // SendSumOfCountersPerUserWithLabels provides metrics with the provided label names on a per-user basis. This function assumes that `user` is the
 // first label on the provided metric Desc
 func (d MetricFamiliesPerUser) SendSumOfCountersPerUserWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, labelNames ...string) {
+	d.SendSumOfCountersPerUserWithLabelsAndOptions(out, desc, metric, labelNames)
+}
+
+// SendSumOfCountersPerUserWithLabelsAndOptions provides metrics with the provided label names on a per-user basis. This function assumes that `user` is the
+// first label on the provided metric Desc
+func (d MetricFamiliesPerUser) SendSumOfCountersPerUserWithLabelsAndOptions(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, labelNames []string, options ...MetricOption) {
 	for _, userEntry := range d {
 		if userEntry.user == "" {
 			continue
 		}
 
 		result := singleValueWithLabelsMap{}
-		userEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, counterValue, result.aggregateFn)
+		opts := applyMetricOptions(options...)
+		userEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, counterValue, result.aggregateFn, opts.skipZeroValueMetrics)
 		result.prependUserLabelValue(userEntry.user)
 		result.WriteToMetricChannel(out, desc, prometheus.CounterValue)
 	}
@@ -190,7 +201,7 @@ func (d MetricFamiliesPerUser) SendSumOfGauges(out chan<- prometheus.Metric, des
 }
 
 func (d MetricFamiliesPerUser) SendSumOfGaugesWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string, labelNames ...string) {
-	d.sumOfSingleValuesWithLabels(gauge, gaugeValue, labelNames).WriteToMetricChannel(out, desc, prometheus.GaugeValue)
+	d.sumOfSingleValuesWithLabels(gauge, gaugeValue, labelNames, false).WriteToMetricChannel(out, desc, prometheus.GaugeValue)
 }
 
 func (d MetricFamiliesPerUser) SendSumOfGaugesPerUser(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
@@ -206,16 +217,16 @@ func (d MetricFamiliesPerUser) SendSumOfGaugesPerUserWithLabels(out chan<- prome
 		}
 
 		result := singleValueWithLabelsMap{}
-		userEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, gaugeValue, result.aggregateFn)
+		userEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, gaugeValue, result.aggregateFn, false)
 		result.prependUserLabelValue(userEntry.user)
 		result.WriteToMetricChannel(out, desc, prometheus.GaugeValue)
 	}
 }
 
-func (d MetricFamiliesPerUser) sumOfSingleValuesWithLabels(metric string, fn func(*dto.Metric) float64, labelNames []string) singleValueWithLabelsMap {
+func (d MetricFamiliesPerUser) sumOfSingleValuesWithLabels(metric string, fn func(*dto.Metric) float64, labelNames []string, skipZeroValue bool) singleValueWithLabelsMap {
 	result := singleValueWithLabelsMap{}
 	for _, userEntry := range d {
-		userEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, fn, result.aggregateFn)
+		userEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, fn, result.aggregateFn, skipZeroValue)
 	}
 	return result
 }
@@ -809,4 +820,26 @@ func DeleteMatchingLabels(c CollectorVec, filter map[string]string) error {
 type CollectorVec interface {
 	prometheus.Collector
 	Delete(labels prometheus.Labels) bool
+}
+
+// MetricOption defines a functional-style option for metrics aggregation.
+type MetricOption func(options *metricOptions)
+
+// SkipZeroValueMetrics controls whether metrics aggregation should skip zero value metrics.
+func SkipZeroValueMetrics(options *metricOptions) {
+	options.skipZeroValueMetrics = true
+}
+
+// applyMetricOptions returns a metricOptions with all the input options applied.
+func applyMetricOptions(options ...MetricOption) *metricOptions {
+	actual := &metricOptions{}
+	for _, option := range options {
+		option(actual)
+	}
+
+	return actual
+}
+
+type metricOptions struct {
+	skipZeroValueMetrics bool
 }

--- a/pkg/util/metrics_helper_test.go
+++ b/pkg/util/metrics_helper_test.go
@@ -322,39 +322,58 @@ func TestSendSumOfHistogramsWithLabels(t *testing.T) {
 	}
 }
 
-// TestSumOfCounterPerUserWithLabels tests to ensure multiple metrics for the same user with a matching label are
+// TestSendSumOfCountersPerUserWithLabels tests to ensure multiple metrics for the same user with a matching label are
 // summed correctly
-func TestSumOfCounterPerUserWithLabels(t *testing.T) {
+func TestSendSumOfCountersPerUserWithLabels(t *testing.T) {
 	user1Metric := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_metric"}, []string{"label_one", "label_two"})
 	user2Metric := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_metric"}, []string{"label_one", "label_two"})
+	user3Metric := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_metric"}, []string{"label_one", "label_two"})
 	user1Metric.WithLabelValues("a", "b").Add(100)
 	user1Metric.WithLabelValues("a", "c").Add(80)
 	user2Metric.WithLabelValues("a", "b").Add(60)
-	user2Metric.WithLabelValues("a", "c").Add(40)
+	user2Metric.WithLabelValues("a", "c").Add(0)
+	user3Metric.WithLabelValues("a", "b").Add(0)
+	user3Metric.WithLabelValues("a", "c").Add(0)
 
 	user1Reg := prometheus.NewRegistry()
 	user2Reg := prometheus.NewRegistry()
+	user3Reg := prometheus.NewRegistry()
 	user1Reg.MustRegister(user1Metric)
 	user2Reg.MustRegister(user2Metric)
+	user3Reg.MustRegister(user3Metric)
 
 	regs := NewUserRegistries()
 	regs.AddUserRegistry("user-1", user1Reg)
 	regs.AddUserRegistry("user-2", user2Reg)
+	regs.AddUserRegistry("user-3", user3Reg)
 	mf := regs.BuildMetricFamiliesPerUser()
 
-	{
+	t.Run("group metrics by user and label_one", func(t *testing.T) {
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
 			mf.SendSumOfCountersPerUserWithLabels(out, desc, "test_metric", "label_one")
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_one", "a", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(180)}},
-			{Label: makeLabels("label_one", "a", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(100)}},
+			{Label: makeLabels("label_one", "a", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(60)}},
+			{Label: makeLabels("label_one", "a", "user", "user-3"), Counter: &dto.Counter{Value: proto.Float64(0)}},
 		}
 		require.ElementsMatch(t, expected, actual)
-	}
+	})
 
-	{
+	t.Run("group metrics by user and label_one, and skip zero value metrics", func(t *testing.T) {
+		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one"}, nil)
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendSumOfCountersPerUserWithLabelsAndOptions(out, desc, "test_metric", []string{"label_one"}, SkipZeroValueMetrics)
+		})
+		expected := []*dto.Metric{
+			{Label: makeLabels("label_one", "a", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(180)}},
+			{Label: makeLabels("label_one", "a", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(60)}},
+		}
+		require.ElementsMatch(t, expected, actual)
+	})
+
+	t.Run("group metrics by user and label_two", func(t *testing.T) {
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_two"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
 			mf.SendSumOfCountersPerUserWithLabels(out, desc, "test_metric", "label_two")
@@ -363,12 +382,27 @@ func TestSumOfCounterPerUserWithLabels(t *testing.T) {
 			{Label: makeLabels("label_two", "b", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(100)}},
 			{Label: makeLabels("label_two", "c", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(80)}},
 			{Label: makeLabels("label_two", "b", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(60)}},
-			{Label: makeLabels("label_two", "c", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(40)}},
+			{Label: makeLabels("label_two", "c", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(0)}},
+			{Label: makeLabels("label_two", "b", "user", "user-3"), Counter: &dto.Counter{Value: proto.Float64(0)}},
+			{Label: makeLabels("label_two", "c", "user", "user-3"), Counter: &dto.Counter{Value: proto.Float64(0)}},
 		}
 		require.ElementsMatch(t, expected, actual)
-	}
+	})
 
-	{
+	t.Run("group metrics by user and label_two, and skip zero value metrics", func(t *testing.T) {
+		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_two"}, nil)
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendSumOfCountersPerUserWithLabelsAndOptions(out, desc, "test_metric", []string{"label_two"}, SkipZeroValueMetrics)
+		})
+		expected := []*dto.Metric{
+			{Label: makeLabels("label_two", "b", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(100)}},
+			{Label: makeLabels("label_two", "c", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(80)}},
+			{Label: makeLabels("label_two", "b", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(60)}},
+		}
+		require.ElementsMatch(t, expected, actual)
+	})
+
+	t.Run("group metrics by user, label_one and label_two", func(t *testing.T) {
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one", "label_two"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
 			mf.SendSumOfCountersPerUserWithLabels(out, desc, "test_metric", "label_one", "label_two")
@@ -377,10 +411,25 @@ func TestSumOfCounterPerUserWithLabels(t *testing.T) {
 			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(100)}},
 			{Label: makeLabels("label_one", "a", "label_two", "c", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(80)}},
 			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(60)}},
-			{Label: makeLabels("label_one", "a", "label_two", "c", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(40)}},
+			{Label: makeLabels("label_one", "a", "label_two", "c", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(0)}},
+			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-3"), Counter: &dto.Counter{Value: proto.Float64(0)}},
+			{Label: makeLabels("label_one", "a", "label_two", "c", "user", "user-3"), Counter: &dto.Counter{Value: proto.Float64(0)}},
 		}
 		require.ElementsMatch(t, expected, actual)
-	}
+	})
+
+	t.Run("group metrics by user, label_one and label_two, and skip zero value metrics", func(t *testing.T) {
+		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one", "label_two"}, nil)
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendSumOfCountersPerUserWithLabelsAndOptions(out, desc, "test_metric", []string{"label_one", "label_two"}, SkipZeroValueMetrics)
+		})
+		expected := []*dto.Metric{
+			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(100)}},
+			{Label: makeLabels("label_one", "a", "label_two", "c", "user", "user-1"), Counter: &dto.Counter{Value: proto.Float64(80)}},
+			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-2"), Counter: &dto.Counter{Value: proto.Float64(60)}},
+		}
+		require.ElementsMatch(t, expected, actual)
+	})
 }
 
 func TestSendSumOfSummariesPerUser(t *testing.T) {


### PR DESCRIPTION
#### What this PR does
As discussed in #1750, in this PR I propose to not export Alertmanager counter metrics having both `user` and `integration` labels when their value is 0.

Currently these metrics are exposed for any integration, even if an user doesn't use that integration. Alertmanager supports 10 receiver integrations, and this leads to high cardinality metrics when Alertmanager is handling a large number of tenants. For example, if you run 3 Alertmanager replicas, you have 10k tenants, and each tenant configures 2 integrations, before the change we have in total `3 * 10k * 10 = 300k` metrics, while after the change we have `3 * 10k * 2 = 60k` metrics.

#### Which issue(s) this PR fixes or relates to

Part of #1750

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
