### PR TITLE
K6: Take into account HTTP status code 202

### DIFF
--- a/operations/k6/load-testing-with-k6.js
+++ b/operations/k6/load-testing-with-k6.js
@@ -244,7 +244,7 @@ export function write() {
             }
         );
         check(res, {
-            'write worked': (r) => r.status === 200,
+            'write worked': (r) => r.status === 200 || r.status === 202,
         }, { type: "write" }) || fail(`ERR: write failed. Status: ${res.status}. Body: ${res.body}`);
     }
     catch (e) {


### PR DESCRIPTION
#### What this PR does
When using `K6_HA_REPLICAS > 1`, Mimir will accept all HTTP calls but a
part of those call will receive a status code `202`. The following
commit makes this status code as expected otherwise user receive the
following error:
```
reads_inat write (file:///.../mimir-k6/load-testing-with-k6.js:254:8(137))
reads_inat native  executor=ramping-arrival-rate scenario=writing_metrics source=stacktrace
ERRO[0015] GoError: ERR: write failed. Status: 202. Body: replicas did not mach, rejecting sample: replica=replica_1, elected=replica_0
```

At the end of the benchmark summary display errors:
```
     ✗ write worked
      ↳  20% — ✓ 23 / ✗ 92
```

Example of load testing:
```shell
./k6 run load-testing-with-k6.js \
    -e K6_SCHEME="https" \
    -e K6_WRITE_HOSTNAME="${mimir}" \
    -e K6_READ_HOSTNAME="${mimir}" \
    -e K6_USERNAME="${user}" \
    -e K6_WRITE_TOKEN="${password}" \
    -e K6_READ_TOKEN="${password}" \
    -e K6_HA_CLUSTERS="1" \
    -e K6_HA_REPLICAS="3" \
    -e K6_DURATION_MIN="5"
```

Alternatively we could also update the check with `r.status >= 200 && r.status < 300`.
However, my understanding might the be correct because [the documentation](https://k6.io/docs/using-k6/checks/#check-for-http-response-code) explaind that `r.status === 200`  makes sure the HTTP response code is a 2xx
