### PR TITLE
Print version+arch of Mimir loaded to Docker.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -169,6 +169,8 @@ jobs:
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
           skopeo copy oci-archive:/tmp/images/mimir.oci "docker-daemon:grafana/mimir:$IMAGE_TAG"
+          # Print Mimir version and architecture loaded to Docker.
+          docker run "grafana/mimir:$IMAGE_TAG" --version
       - name: Preload Images
         # We download docker images used by integration tests so that all images are available
         # locally and the download time doesn't account in the test execution time, which is subject

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -71,7 +71,7 @@ func NewDistributor(name string, consulAddress string, flags map[string]string, 
 		name,
 		map[string]string{
 			"-target":                           "distributor",
-			"-log.level":                        "warn",
+			"-log.level":                        "debug",
 			"-auth.multitenancy-enabled":        "true",
 			"-ingester.ring.replication-factor": "1",
 			"-distributor.remote-timeout":       "2s", // Fail fast in integration tests.


### PR DESCRIPTION
#### What this PR does
We're trying to find out why integration tests are flaky. This PR logs version of Mimir loaded into Docker and enables debug log for distributor.

Flaky runs:
- https://github.com/grafana/mimir/runs/6228928597?check_suite_focus=true
- https://github.com/grafana/mimir/runs/6229008323?check_suite_focus=true

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
