### PR TITLE
Removed cortex_distributor_ingester_appends_total and cortex_distributor_ingester_append_failures_total unused metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 * [CHANGE] Querier / Ruler: removed the following metrics tracking number of query requests send to each ingester. You can use `cortex_request_duration_seconds_count{route=~"/cortex.Ingester/(QueryStream|QueryExemplars)"}` instead. #1797
   * `cortex_distributor_ingester_queries_total`
   * `cortex_distributor_ingester_query_failures_total`
+* [CHANGE] Distributor: removed the following metrics tracking the number of requests from a distributor to ingesters: #1799
+  * `cortex_distributor_ingester_appends_total`
+  * `cortex_distributor_ingester_append_failures_total`
 * [FEATURE] Querier: Added support for [streaming remote read](https://prometheus.io/blog/2019/10/10/remote-read-meets-streaming/). Should be noted that benefits of chunking the response are partial here, since in a typical `query-frontend` setup responses will be buffered until they've been completed. #1735
 * [FEATURE] Ruler: Allow setting `evaluation_delay` for each rule group via rules group configuration file. #1474
 * [FEATURE] Ruler: Added support for expression remote evaluation. #1536

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -63,9 +63,6 @@ const (
 )
 
 const (
-	typeSamples  = "samples"
-	typeMetadata = "metadata"
-
 	instanceIngestionRateTickInterval = time.Second
 )
 
@@ -113,8 +110,6 @@ type Distributor struct {
 	dedupedSamples                   *prometheus.CounterVec
 	labelsHistogram                  prometheus.Histogram
 	sampleDelayHistogram             prometheus.Histogram
-	ingesterAppends                  *prometheus.CounterVec
-	ingesterAppendFailures           *prometheus.CounterVec
 	replicationFactor                prometheus.Gauge
 	latestSeenSampleTimestampPerUser *prometheus.GaugeVec
 }
@@ -310,16 +305,6 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 				60 * 60 * 24, // 24h
 			},
 		}),
-		ingesterAppends: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "cortex",
-			Name:      "distributor_ingester_appends_total",
-			Help:      "The total number of batch appends sent to ingesters.",
-		}, []string{"ingester", "type"}),
-		ingesterAppendFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "cortex",
-			Name:      "distributor_ingester_append_failures_total",
-			Help:      "The total number of failed batch appends sent to ingesters.",
-		}, []string{"ingester", "type"}),
 		replicationFactor: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "cortex",
 			Name:      "distributor_replication_factor",
@@ -885,19 +870,6 @@ func (d *Distributor) send(ctx context.Context, ingester ring.InstanceDesc, time
 		Source:     source,
 	}
 	_, err = c.Push(ctx, &req)
-
-	if len(metadata) > 0 {
-		d.ingesterAppends.WithLabelValues(ingester.Addr, typeMetadata).Inc()
-		if err != nil {
-			d.ingesterAppendFailures.WithLabelValues(ingester.Addr, typeMetadata).Inc()
-		}
-	}
-	if len(timeseries) > 0 {
-		d.ingesterAppends.WithLabelValues(ingester.Addr, typeSamples).Inc()
-		if err != nil {
-			d.ingesterAppendFailures.WithLabelValues(ingester.Addr, typeSamples).Inc()
-		}
-	}
 
 	return err
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -100,8 +100,6 @@ func TestConfig_Validate(t *testing.T) {
 func TestDistributor_Push(t *testing.T) {
 	// Metrics to assert on.
 	lastSeenTimestamp := "cortex_distributor_latest_seen_sample_timestamp_seconds"
-	distributorAppend := "cortex_distributor_ingester_appends_total"
-	distributorAppendFailure := "cortex_distributor_ingester_append_failures_total"
 	distributorSampleDelay := "cortex_distributor_sample_delay_seconds"
 	ctx := user.InjectOrgID(context.Background(), "user")
 
@@ -198,17 +196,9 @@ func TestDistributor_Push(t *testing.T) {
 			happyIngesters:   2,
 			samples:          samplesIn{num: 1, startTimestampMs: now.UnixMilli() - 80000*1000}, // 80k seconds old
 			metadata:         0,
-			metricNames:      []string{distributorAppend, distributorAppendFailure, distributorSampleDelay},
+			metricNames:      []string{distributorSampleDelay},
 			expectedResponse: emptyResponse,
 			expectedMetrics: `
-				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_append_failures_total counter
-				cortex_distributor_ingester_append_failures_total{ingester="2",type="samples"} 1
-				# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_appends_total counter
-				cortex_distributor_ingester_appends_total{ingester="0",type="samples"} 1
-				cortex_distributor_ingester_appends_total{ingester="1",type="samples"} 1
-				cortex_distributor_ingester_appends_total{ingester="2",type="samples"} 1
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
 				cortex_distributor_sample_delay_seconds_bucket{le="30"} 0
@@ -233,17 +223,9 @@ func TestDistributor_Push(t *testing.T) {
 			happyIngesters:   2,
 			samples:          samplesIn{num: 1, startTimestampMs: now.UnixMilli() - 1000}, // 1 second old
 			metadata:         0,
-			metricNames:      []string{distributorAppend, distributorAppendFailure, distributorSampleDelay},
+			metricNames:      []string{distributorSampleDelay},
 			expectedResponse: emptyResponse,
 			expectedMetrics: `
-				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_append_failures_total counter
-				cortex_distributor_ingester_append_failures_total{ingester="2",type="samples"} 1
-				# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_appends_total counter
-				cortex_distributor_ingester_appends_total{ingester="0",type="samples"} 1
-				cortex_distributor_ingester_appends_total{ingester="1",type="samples"} 1
-				cortex_distributor_ingester_appends_total{ingester="2",type="samples"} 1
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
 				cortex_distributor_sample_delay_seconds_bucket{le="30"} 1
@@ -268,17 +250,9 @@ func TestDistributor_Push(t *testing.T) {
 			happyIngesters:   2,
 			samples:          samplesIn{num: 0, startTimestampMs: 123456789000},
 			metadata:         1,
-			metricNames:      []string{distributorAppend, distributorAppendFailure, distributorSampleDelay},
+			metricNames:      []string{distributorSampleDelay},
 			expectedResponse: emptyResponse,
 			expectedMetrics: `
-				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_append_failures_total counter
-				cortex_distributor_ingester_append_failures_total{ingester="2",type="metadata"} 1
-				# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_appends_total counter
-				cortex_distributor_ingester_appends_total{ingester="0",type="metadata"} 1
-				cortex_distributor_ingester_appends_total{ingester="1",type="metadata"} 1
-				cortex_distributor_ingester_appends_total{ingester="2",type="metadata"} 1
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
 				cortex_distributor_sample_delay_seconds_bucket{le="30"} 0


### PR DESCRIPTION
#### What this PR does
The metrics `cortex_distributor_ingester_appends_total` and `cortex_distributor_ingester_append_failures_total` are quite high cardinality, but we're **not** using them (neither in dashboards, alerts or manual queries over last 30d at Grafana Labs). I'm wondering if we can safely just drop them.

My main argument is that in case of distributor failures you won't look at these metrics, but logs to get more insights about what's going on. Otherwise, is there any other use case where these metrics could be useful?

**Draft** because I want to ear opinions first.

#### Which issue(s) this PR fixes or relates to
Part of #1750

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
