### PR TITLE
Add `-print-config-stderr` and `-verify-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@
     * `-ruler.query-frontend.tls-insecure-skip-verify`
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [FEATURE] Ingester: Active series custom trackers now supports runtime tenant-specific overrides. The configuration has been moved to limit config, the ingester config has been deprecated.  #1188
-* [FEATURE] Add `-verify-config` CLI flag. This will cause Mimir to exit immediately after running config validation.
-* [FEATURE] Add `-print-config-stderr` CLI flag. This will cause Mimir to pring the complete config object to stderr in YAML format.
+* [FEATURE] Add `-verify-config` CLI flag. This will cause Mimir to exit immediately after running config validation. #1800
+* [FEATURE] Add `-print-config-stderr` CLI flag. This will cause Mimir to pring the complete config object to stderr in YAML format. #1800
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
 * [ENHANCEMENT] Alertmanager: Added the ability to configure additional gRPC client settings for the Alertmanager distributor #1547
   - `-alertmanager.alertmanager-client.backoff-max-period`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
     * `-ruler.query-frontend.tls-insecure-skip-verify`
 * [FEATURE] Distributor: Added the ability to forward specifics metrics to alternative remote_write API endpoints. #1052
 * [FEATURE] Ingester: Active series custom trackers now supports runtime tenant-specific overrides. The configuration has been moved to limit config, the ingester config has been deprecated.  #1188
+* [FEATURE] Add `-verify-config` CLI flag. This will cause Mimir to exit immediately after running config validation.
+* [FEATURE] Add `-print-config-stderr` CLI flag. This will cause Mimir to pring the complete config object to stderr in YAML format.
 * [ENHANCEMENT] Alertmanager API: Concurrency limit for GET requests is now configurable using `-alertmanager.max-concurrent-get-requests-per-tenant`. #1547
 * [ENHANCEMENT] Alertmanager: Added the ability to configure additional gRPC client settings for the Alertmanager distributor #1547
   - `-alertmanager.alertmanager-client.backoff-max-period`

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1011,6 +1011,8 @@ Usage of ./cmd/mimir/mimir:
     	Log debug transport messages. Note: global log.level must be at debug level as well.
   -modules
     	List available values that can be used as target.
+  -print-config-stderr
+    	Dump the entire Mimir config object to stderr in YAML format.
   -print.config
     	Print the config and exit.
   -querier.batch-iterators
@@ -1658,5 +1660,7 @@ Usage of ./cmd/mimir/mimir:
     	Maximum length accepted for label value. This setting also applies to the metric name (default 2048)
   -validation.max-metadata-length int
     	Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. (default 1024)
+  -verify-config
+    	Verify config parameters and exits.
   -version
     	Print application version and exit.

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -311,6 +311,8 @@ Usage of ./cmd/mimir/mimir:
     	Other cluster members to join. Can be specified multiple times. It can be an IP, hostname or an entry specified in the DNS Service Discovery format.
   -modules
     	List available values that can be used as target.
+  -print-config-stderr
+    	Dump the entire Mimir config object to stderr in YAML format.
   -print.config
     	Print the config and exit.
   -querier.cardinality-analysis-enabled
@@ -520,6 +522,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum length accepted for label value. This setting also applies to the metric name (default 2048)
   -validation.max-metadata-length int
     	Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. (default 1024)
+  -verify-config
+    	Verify config parameters and exits.
   -version
     	Print application version and exit.
 

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -7,7 +7,10 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"reflect"
+
+	"gopkg.in/yaml.v3"
 )
 
 // DiffConfig utility function that returns the diff between two config map objects
@@ -70,4 +73,15 @@ func DiffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[in
 	}
 
 	return output, nil
+}
+
+// PrintConfig takes version string and a pointer to a config object, marshals
+// it to YAML and prints the result to the provided writer
+func PrintConfig(w io.Writer, version string, config interface{}) error {
+	lc, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "---\n# Mimir Config\n# %s\n%s\n\n", version, string(lc))
+	return nil
 }


### PR DESCRIPTION
#### What this PR does

* Adds `-print-config-stderr` to print the config object to stderr
* Adds `-verify-config` to run config validation logic and then exit

Together, these flags allow Mimir to run just long enough to resolve configuration from CLI flags and the config file, then print the resulting values. This can be useful to understand how the various parameters interact and also enables an automation use-case I have:

I plan to use this to compare the Mimir configuration generated by our Helm chart with the Mimir configuration generated by the Jsonnet lib in this repo. Since Helm uses exclusively config-file-based parameters and jsonnet uses exclusively CLI flag-based parameters, it's tricky to compare them in an automated fashion.

The particular naming and implementation of these flags is taken from Grafana Loki which has the exact same flags and behavior.

#### Which issue(s) this PR fixes or relates to

- Relates to grafana/mimir-squad/issues/611

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
