### PR TITLE
Change all Grafana dashboards UIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,27 @@
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
 * [CHANGE] Dashboards: Slow-queries dashboard now uses `user` label from logs instead of `org_id`. #1634
+* [CHANGE] Dashboards: changed all Grafana dashboards UIDs to not conflict with Cortex ones, to let people install both while migrating from Cortex to Mimir: #1801
+  * Alertmanager from `a76bee5913c97c918d9e56a3cc88cc28` to `GupFKpgkt`
+  * Alertmanager Resources from `68b66aed90ccab448009089544a8d6c6` to `r5DZRDusm`
+  * Compactor from `9c408e1d55681ecb8a22c9fab46875cc` to `oMZ8ngTZF`
+  * Compactor Resources from `df9added6f1f4332f95848cca48ebd99` to `ma9ZA9a7C`
+  * Config from `61bb048ced9817b2d3e07677fb1c6290` to `u6dLadEbi`
+  * Object Store from `d5a3a4489d57c733b5677fb55370a723` to `VKXaoOZXb`
+  * Overrides from `b5c95fee2e5e7c4b5930826ff6e89a12` to `BWZ9xZOUo`
+  * Queries from `d9931b1054053c8b972d320774bb8f1d` to `bHf8Zf5fk`
+  * Reads from `8d6ba60eccc4b6eedfa329b24b1bd339` to `2dvAcvdvV`
+  * Reads Networking from `c0464f0d8bd026f776c9006b05910000` to `3xAjZAhJ5`
+  * Reads Resources from `2fd2cda9eea8d8af9fbc0a5960425120` to `mBNJaEkET`
+  * Rollout Progress from `7544a3a62b1be6ffd919fc990ab8ba8f` to `4wbNeyoyO`
+  * Ruler from `44d12bcb1f95661c6ab6bc946dfc3473` to `4ATLNTbTa`
+  * Scaling from `88c041017b96856c9176e07cf557bdcf` to `mNp3epNpo`
+  * Slow queries from `e6f3091e29d2636e3b8393447e925668` to `30rav7n7X`
+  * Tenants from `35fa247ce651ba189debf33d7ae41611` to `4BQmVQBvF`
+  * Top Tenants from `bc6e12d4fe540e4a1785b9d3ca0ffdd9` to `6gZlLegev`
+  * Writes from `0156f6d15aa234d452a33a4f13c838e3` to `CVmvemOmR`
+  * Writes Networking from `681cd62b680b7154811fe73af55dcfd4` to `iqgpV8q8Y`
+  * Writes Resources from `c0464f0d8bd026f776c9006b0591bb0b` to `6tIBbVtV2`
 * [FEATURE] Alerts: added the following alerts on `mimir-continuous-test` tool: #1676
   - `MimirContinuousTestNotRunningOnWrites`
   - `MimirContinuousTestNotRunningOnReads`

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -1345,6 +1345,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Alertmanager resources",
-      "uid": "68b66aed90ccab448009089544a8d6c6",
+      "uid": "r5DZRDusm",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -2903,6 +2903,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Alertmanager",
-      "uid": "a76bee5913c97c918d9e56a3cc88cc28",
+      "uid": "GupFKpgkt",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -801,6 +801,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Compactor resources",
-      "uid": "df9added6f1f4332f95848cca48ebd99",
+      "uid": "ma9ZA9a7C",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -2431,6 +2431,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Compactor",
-      "uid": "9c408e1d55681ecb8a22c9fab46875cc",
+      "uid": "oMZ8ngTZF",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -303,6 +303,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Config",
-      "uid": "61bb048ced9817b2d3e07677fb1c6290",
+      "uid": "u6dLadEbi",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -1051,6 +1051,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Object Store",
-      "uid": "d5a3a4489d57c733b5677fb55370a723",
+      "uid": "VKXaoOZXb",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
@@ -253,6 +253,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Overrides",
-      "uid": "b5c95fee2e5e7c4b5930826ff6e89a12",
+      "uid": "BWZ9xZOUo",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -3427,6 +3427,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Queries",
-      "uid": "d9931b1054053c8b972d320774bb8f1d",
+      "uid": "bHf8Zf5fk",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -2205,6 +2205,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Reads networking",
-      "uid": "c0464f0d8bd026f776c9006b05910000",
+      "uid": "3xAjZAhJ5",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -2324,6 +2324,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Reads resources",
-      "uid": "2fd2cda9eea8d8af9fbc0a5960425120",
+      "uid": "mBNJaEkET",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -5094,6 +5094,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Reads",
-      "uid": "8d6ba60eccc4b6eedfa329b24b1bd339",
+      "uid": "2dvAcvdvV",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -1408,6 +1408,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Rollout progress",
-      "uid": "7544a3a62b1be6ffd919fc990ab8ba8f",
+      "uid": "4wbNeyoyO",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -3060,6 +3060,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Ruler",
-      "uid": "44d12bcb1f95661c6ab6bc946dfc3473",
+      "uid": "4ATLNTbTa",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
@@ -350,6 +350,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Scaling",
-      "uid": "88c041017b96856c9176e07cf557bdcf",
+      "uid": "mNp3epNpo",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -305,6 +305,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Slow queries",
-      "uid": "e6f3091e29d2636e3b8393447e925668",
+      "uid": "30rav7n7X",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -2055,6 +2055,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Tenants",
-      "uid": "35fa247ce651ba189debf33d7ae41611",
+      "uid": "4BQmVQBvF",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -1162,6 +1162,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Top tenants",
-      "uid": "bc6e12d4fe540e4a1785b9d3ca0ffdd9",
+      "uid": "6gZlLegev",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -1164,6 +1164,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Writes networking",
-      "uid": "681cd62b680b7154811fe73af55dcfd4",
+      "uid": "iqgpV8q8Y",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -1254,6 +1254,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Writes resources",
-      "uid": "c0464f0d8bd026f776c9006b0591bb0b",
+      "uid": "6tIBbVtV2",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -3048,6 +3048,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Writes",
-      "uid": "0156f6d15aa234d452a33a4f13c838e3",
+      "uid": "CVmvemOmR",
       "version": 0
    }

--- a/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-alertmanager-resources.json':
-    ($.dashboard('Alertmanager resources') + { uid: '68b66aed90ccab448009089544a8d6c6' })
+    ($.dashboard('Alertmanager resources') + { uid: 'r5DZRDusm' })
     .addClusterSelectorTemplates(false)
     .addRowIf(
       $._config.gateway_enabled,

--- a/operations/mimir-mixin/dashboards/alertmanager.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-alertmanager.json':
-    ($.dashboard('Alertmanager') + { uid: 'a76bee5913c97c918d9e56a3cc88cc28' })
+    ($.dashboard('Alertmanager') + { uid: 'GupFKpgkt' })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Headlines') + {

--- a/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-compactor-resources.json':
-    ($.dashboard('Compactor resources') + { uid: 'df9added6f1f4332f95848cca48ebd99' })
+    ($.dashboard('Compactor resources') + { uid: 'ma9ZA9a7C' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('CPU and memory')

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -88,7 +88,7 @@ local fixTargetsForTransformations(panel, refIds) = panel {
   ],
 
   'mimir-compactor.json':
-    ($.dashboard('Compactor') + { uid: '9c408e1d55681ecb8a22c9fab46875cc' })
+    ($.dashboard('Compactor') + { uid: 'oMZ8ngTZF' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Summary')

--- a/operations/mimir-mixin/dashboards/config.libsonnet
+++ b/operations/mimir-mixin/dashboards/config.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-config.json':
-    ($.dashboard('Config') + { uid: '61bb048ced9817b2d3e07677fb1c6290' })
+    ($.dashboard('Config') + { uid: 'u6dLadEbi' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Startup config file')

--- a/operations/mimir-mixin/dashboards/object-store.libsonnet
+++ b/operations/mimir-mixin/dashboards/object-store.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-object-store.json':
-    ($.dashboard('Object Store') + { uid: 'd5a3a4489d57c733b5677fb55370a723' })
+    ($.dashboard('Object Store') + { uid: 'VKXaoOZXb' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Components')

--- a/operations/mimir-mixin/dashboards/overrides.libsonnet
+++ b/operations/mimir-mixin/dashboards/overrides.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-overrides.json':
-    ($.dashboard('Overrides') + { uid: 'b5c95fee2e5e7c4b5930826ff6e89a12' })
+    ($.dashboard('Overrides') + { uid: 'BWZ9xZOUo' })
     .addClusterSelectorTemplates(false)
     .addRow(
       $.row('')

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-queries.json':
-    ($.dashboard('Queries') + { uid: 'd9931b1054053c8b972d320774bb8f1d' })
+    ($.dashboard('Queries') + { uid: 'bHf8Zf5fk' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Query-frontend')

--- a/operations/mimir-mixin/dashboards/reads-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-networking.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-reads-networking.json':
-    ($.dashboard('Reads networking') + { uid: 'c0464f0d8bd026f776c9006b05910000' })
+    ($.dashboard('Reads networking') + { uid: '3xAjZAhJ5' })
     .addClusterSelectorTemplates(false)
     .addRowIf($._config.gateway_enabled, $.jobNetworkingRow('Gateway', 'gateway'))
     .addRow($.jobNetworkingRow('Query-frontend', 'query_frontend'))

--- a/operations/mimir-mixin/dashboards/reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-resources.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-reads-resources.json':
-    ($.dashboard('Reads resources') + { uid: '2fd2cda9eea8d8af9fbc0a5960425120' })
+    ($.dashboard('Reads resources') + { uid: 'mBNJaEkET' })
     .addClusterSelectorTemplates(false)
     .addRowIf(
       $._config.gateway_enabled,

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-reads.json':
-    ($.dashboard('Reads') + { uid: '8d6ba60eccc4b6eedfa329b24b1bd339' })
+    ($.dashboard('Reads') + { uid: '2dvAcvdvV' })
     .addClusterSelectorTemplates()
     .addRowIf(
       $._config.show_dashboard_descriptions.reads,

--- a/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
@@ -11,7 +11,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   'mimir-rollout-progress.json':
-    ($.dashboard('Rollout progress') + { uid: '7544a3a62b1be6ffd919fc990ab8ba8f' })
+    ($.dashboard('Rollout progress') + { uid: '4wbNeyoyO' })
     .addClusterSelectorTemplates(false) + {
       // This dashboard uses the new grid system in order to place panels (using gridPos).
       // Because of this we can't use the mixin's addRow() and addPanel().

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -59,7 +59,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   'mimir-ruler.json':
-    ($.dashboard('Ruler') + { uid: '44d12bcb1f95661c6ab6bc946dfc3473' })
+    ($.dashboard('Ruler') + { uid: '4ATLNTbTa' })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Headlines') + {

--- a/operations/mimir-mixin/dashboards/scaling.libsonnet
+++ b/operations/mimir-mixin/dashboards/scaling.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-scaling.json':
-    ($.dashboard('Scaling') + { uid: '88c041017b96856c9176e07cf557bdcf' })
+    ($.dashboard('Scaling') + { uid: 'mNp3epNpo' })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Service scaling') + { height: '200px' })

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-slow-queries.json':
-    ($.dashboard('Slow queries') + { uid: 'e6f3091e29d2636e3b8393447e925668' })
+    ($.dashboard('Slow queries') + { uid: '30rav7n7X' })
     .addClusterSelectorTemplates(false)
     .addRow(
       $.row('')

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-tenants.json':
-    ($.dashboard('Tenants') + { uid: '35fa247ce651ba189debf33d7ae41611' })
+    ($.dashboard('Tenants') + { uid: '4BQmVQBvF' })
     .addClusterSelectorTemplates()
     .addActiveUserSelectorTemplates()
     .addCustomTemplate('limit', ['10', '50', '100', '500', '1000'])

--- a/operations/mimir-mixin/dashboards/top-tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/top-tenants.libsonnet
@@ -19,7 +19,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   'mimir-top-tenants.json':
-    ($.dashboard('Top tenants') + { uid: 'bc6e12d4fe540e4a1785b9d3ca0ffdd9' })
+    ($.dashboard('Top tenants') + { uid: '6gZlLegev' })
     .addClusterSelectorTemplates()
     .addCustomTemplate('limit', ['10', '50', '100'])
     .addRowIf(

--- a/operations/mimir-mixin/dashboards/writes-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-networking.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-writes-networking.json':
-    ($.dashboard('Writes networking') + { uid: '681cd62b680b7154811fe73af55dcfd4' })
+    ($.dashboard('Writes networking') + { uid: 'iqgpV8q8Y' })
     .addClusterSelectorTemplates(false)
     .addRowIf($._config.gateway_enabled, $.jobNetworkingRow('Gateway', 'gateway'))
     .addRow($.jobNetworkingRow('Distributor', 'distributor'))

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-writes-resources.json':
-    ($.dashboard('Writes resources') + { uid: 'c0464f0d8bd026f776c9006b0591bb0b' })
+    ($.dashboard('Writes resources') + { uid: '6tIBbVtV2' })
     .addClusterSelectorTemplates(false)
     .addRowIf(
       $._config.gateway_enabled,

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'mimir-writes.json':
-    ($.dashboard('Writes') + { uid: '0156f6d15aa234d452a33a4f13c838e3' })
+    ($.dashboard('Writes') + { uid: 'CVmvemOmR' })
     .addClusterSelectorTemplates()
     .addRowIf(
       $._config.show_dashboard_descriptions.writes,


### PR DESCRIPTION
#### What this PR does
To fix #1789 and let people install Cortex and Mimir dashboards side-by-side (useful while migrating from Cortex to Mimir), I propose to change all Grafana dashboards UIDs to not conflict with Cortex ones.

New UIDs has been generated with the [same function](https://github.com/grafana/grafana/blob/main/pkg/util/shortid_generator.go) used by Grafana to auto-generate dashboard UIDs.

#### Which issue(s) this PR fixes or relates to

Fixes #1789

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
