### PR TITLE
Allow custom data source regex in mixin dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Grafana Mimir - main / unreleased
 
+### Mixin
+* [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
+
 ## 2.1.0-rc.0
 
 ### Grafana Mimir

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -873,8 +873,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -950,8 +950,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1039,8 +1039,8 @@
                   "timeShift": null,
                   "title": "Writes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1116,8 +1116,8 @@
                   "timeShift": null,
                   "title": "Reads",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1205,8 +1205,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -873,8 +873,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -950,8 +950,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1039,8 +1039,8 @@
                   "timeShift": null,
                   "title": "Writes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1116,8 +1116,8 @@
                   "timeShift": null,
                   "title": "Reads",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1205,8 +1205,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1258,7 +1258,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -71,8 +71,8 @@
                   "timeShift": null,
                   "title": "Total alerts",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -147,8 +147,8 @@
                   "timeShift": null,
                   "title": "Total silences",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -223,8 +223,8 @@
                   "timeShift": null,
                   "title": "Tenants",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -320,8 +320,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -412,8 +412,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -510,8 +510,8 @@
                   "timeShift": null,
                   "title": "APS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -608,8 +608,8 @@
                   "timeShift": null,
                   "title": "NPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -694,8 +694,8 @@
                   "timeShift": null,
                   "title": "NPS by integration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -789,8 +789,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -886,8 +886,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -978,8 +978,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1067,8 +1067,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1144,8 +1144,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1239,8 +1239,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1334,8 +1334,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1441,8 +1441,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1536,8 +1536,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1631,8 +1631,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1726,8 +1726,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1815,8 +1815,8 @@
                   "timeShift": null,
                   "title": "Per pod tenants",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1892,8 +1892,8 @@
                   "timeShift": null,
                   "title": "Per pod alerts",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1969,8 +1969,8 @@
                   "timeShift": null,
                   "title": "Per pod silences",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2067,8 +2067,8 @@
                   "timeShift": null,
                   "title": "Syncs/sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2144,8 +2144,8 @@
                   "timeShift": null,
                   "title": "Syncs/sec (by reason)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2221,8 +2221,8 @@
                   "timeShift": null,
                   "title": "Ring check errors/sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2310,8 +2310,8 @@
                   "timeShift": null,
                   "title": "Initial syncs /sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2405,8 +2405,8 @@
                   "timeShift": null,
                   "title": "Initial sync duration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2491,8 +2491,8 @@
                   "timeShift": null,
                   "title": "Fetch state from other alertmanagers /sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2589,8 +2589,8 @@
                   "timeShift": null,
                   "title": "Replicate state to other alertmanagers /sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2675,8 +2675,8 @@
                   "timeShift": null,
                   "title": "Merge state from other alertmanagers /sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2761,8 +2761,8 @@
                   "timeShift": null,
                   "title": "Persist state to remote storage /sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -71,8 +71,8 @@
                   "timeShift": null,
                   "title": "Total alerts",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -147,8 +147,8 @@
                   "timeShift": null,
                   "title": "Total silences",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -223,8 +223,8 @@
                   "timeShift": null,
                   "title": "Tenants",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -320,8 +320,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -412,8 +412,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -510,8 +510,8 @@
                   "timeShift": null,
                   "title": "APS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -608,8 +608,8 @@
                   "timeShift": null,
                   "title": "NPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -694,8 +694,8 @@
                   "timeShift": null,
                   "title": "NPS by integration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -789,8 +789,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -886,8 +886,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -978,8 +978,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1067,8 +1067,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1144,8 +1144,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1239,8 +1239,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1334,8 +1334,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1441,8 +1441,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1536,8 +1536,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1631,8 +1631,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1726,8 +1726,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1815,8 +1815,8 @@
                   "timeShift": null,
                   "title": "Per pod tenants",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1892,8 +1892,8 @@
                   "timeShift": null,
                   "title": "Per pod alerts",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1969,8 +1969,8 @@
                   "timeShift": null,
                   "title": "Per pod silences",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2067,8 +2067,8 @@
                   "timeShift": null,
                   "title": "Syncs/sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2144,8 +2144,8 @@
                   "timeShift": null,
                   "title": "Syncs/sec (by reason)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2221,8 +2221,8 @@
                   "timeShift": null,
                   "title": "Ring check errors/sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2310,8 +2310,8 @@
                   "timeShift": null,
                   "title": "Initial syncs /sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2405,8 +2405,8 @@
                   "timeShift": null,
                   "title": "Initial sync duration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2491,8 +2491,8 @@
                   "timeShift": null,
                   "title": "Fetch state from other alertmanagers /sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2589,8 +2589,8 @@
                   "timeShift": null,
                   "title": "Replicate state to other alertmanagers /sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2675,8 +2675,8 @@
                   "timeShift": null,
                   "title": "Merge state from other alertmanagers /sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2761,8 +2761,8 @@
                   "timeShift": null,
                   "title": "Persist state to remote storage /sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2814,7 +2814,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -339,8 +339,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -416,8 +416,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -505,8 +505,8 @@
                   "timeShift": null,
                   "title": "Disk writes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -582,8 +582,8 @@
                   "timeShift": null,
                   "title": "Disk reads",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -659,8 +659,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -712,7 +712,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -339,8 +339,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -416,8 +416,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -505,8 +505,8 @@
                   "timeShift": null,
                   "title": "Disk writes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -582,8 +582,8 @@
                   "timeShift": null,
                   "title": "Disk reads",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -659,8 +659,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -95,8 +95,8 @@
                   "timeShift": null,
                   "title": "Per-instance runs / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -173,8 +173,8 @@
                   "timeShift": null,
                   "title": "Tenants compaction progress",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -336,8 +336,8 @@
                   "timeShift": null,
                   "title": "Longest time since last successful run",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transformations": [
@@ -575,8 +575,8 @@
                   "timeShift": null,
                   "title": "Last successful run per-compactor replica",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transformations": [
@@ -712,8 +712,8 @@
                   "timeShift": null,
                   "title": "TSDB compactions / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -808,8 +808,8 @@
                   "timeShift": null,
                   "title": "TSDB compaction duration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -897,8 +897,8 @@
                   "timeShift": null,
                   "title": "Average blocks / tenant",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -975,8 +975,8 @@
                   "timeShift": null,
                   "title": "Tenants with largest number of blocks",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1064,8 +1064,8 @@
                   "timeShift": null,
                   "title": "Blocks marked for deletion / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1153,8 +1153,8 @@
                   "timeShift": null,
                   "title": "Blocks deletions / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1254,8 +1254,8 @@
                   "timeShift": null,
                   "title": "Metadata syncs / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1349,8 +1349,8 @@
                   "timeShift": null,
                   "title": "Metadata sync duration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1438,8 +1438,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1515,8 +1515,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1610,8 +1610,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1705,8 +1705,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1812,8 +1812,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1907,8 +1907,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2002,8 +2002,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2097,8 +2097,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2194,8 +2194,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2289,8 +2289,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2342,7 +2342,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -95,8 +95,8 @@
                   "timeShift": null,
                   "title": "Per-instance runs / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -173,8 +173,8 @@
                   "timeShift": null,
                   "title": "Tenants compaction progress",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -336,8 +336,8 @@
                   "timeShift": null,
                   "title": "Longest time since last successful run",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transformations": [
@@ -575,8 +575,8 @@
                   "timeShift": null,
                   "title": "Last successful run per-compactor replica",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transformations": [
@@ -712,8 +712,8 @@
                   "timeShift": null,
                   "title": "TSDB compactions / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -808,8 +808,8 @@
                   "timeShift": null,
                   "title": "TSDB compaction duration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -897,8 +897,8 @@
                   "timeShift": null,
                   "title": "Average blocks / tenant",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -975,8 +975,8 @@
                   "timeShift": null,
                   "title": "Tenants with largest number of blocks",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1064,8 +1064,8 @@
                   "timeShift": null,
                   "title": "Blocks marked for deletion / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1153,8 +1153,8 @@
                   "timeShift": null,
                   "title": "Blocks deletions / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1254,8 +1254,8 @@
                   "timeShift": null,
                   "title": "Metadata syncs / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1349,8 +1349,8 @@
                   "timeShift": null,
                   "title": "Metadata sync duration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1438,8 +1438,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1515,8 +1515,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1610,8 +1610,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1705,8 +1705,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1812,8 +1812,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1907,8 +1907,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2002,8 +2002,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2097,8 +2097,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2194,8 +2194,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2289,8 +2289,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "Startup config file hashes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -161,8 +161,8 @@
                   "timeShift": null,
                   "title": "Runtime config file hashes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -214,7 +214,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "Startup config file hashes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -161,8 +161,8 @@
                   "timeShift": null,
                   "title": "Runtime config file hashes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "RPS / component",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -149,8 +149,8 @@
                   "timeShift": null,
                   "title": "Error rate / component",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -238,8 +238,8 @@
                   "timeShift": null,
                   "title": "RPS / operation",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -315,8 +315,8 @@
                   "timeShift": null,
                   "title": "Error rate / operation",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -422,8 +422,8 @@
                   "timeShift": null,
                   "title": "Op: Get",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -517,8 +517,8 @@
                   "timeShift": null,
                   "title": "Op: GetRange",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -612,8 +612,8 @@
                   "timeShift": null,
                   "title": "Op: Exists",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -719,8 +719,8 @@
                   "timeShift": null,
                   "title": "Op: Attributes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -814,8 +814,8 @@
                   "timeShift": null,
                   "title": "Op: Upload",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -909,8 +909,8 @@
                   "timeShift": null,
                   "title": "Op: Delete",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -962,7 +962,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "RPS / component",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -149,8 +149,8 @@
                   "timeShift": null,
                   "title": "Error rate / component",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -238,8 +238,8 @@
                   "timeShift": null,
                   "title": "RPS / operation",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -315,8 +315,8 @@
                   "timeShift": null,
                   "title": "Error rate / operation",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -422,8 +422,8 @@
                   "timeShift": null,
                   "title": "Op: Get",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -517,8 +517,8 @@
                   "timeShift": null,
                   "title": "Op: GetRange",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -612,8 +612,8 @@
                   "timeShift": null,
                   "title": "Op: Exists",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -719,8 +719,8 @@
                   "timeShift": null,
                   "title": "Op: Attributes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -814,8 +814,8 @@
                   "timeShift": null,
                   "title": "Op: Upload",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -909,8 +909,8 @@
                   "timeShift": null,
                   "title": "Op: Delete",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
@@ -147,7 +147,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -90,8 +90,8 @@
                   "timeShift": null,
                   "title": "Queue duration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -185,8 +185,8 @@
                   "timeShift": null,
                   "title": "Retries",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -262,8 +262,8 @@
                   "timeShift": null,
                   "title": "Queue length (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -339,8 +339,8 @@
                   "timeShift": null,
                   "title": "Queue length (per user)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -446,8 +446,8 @@
                   "timeShift": null,
                   "title": "Queue duration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -523,8 +523,8 @@
                   "timeShift": null,
                   "title": "Queue length (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -600,8 +600,8 @@
                   "timeShift": null,
                   "title": "Queue length (per user)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -690,8 +690,8 @@
                   "timeShift": null,
                   "title": "Intervals per Query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -767,8 +767,8 @@
                   "timeShift": null,
                   "title": "Results cache hit %",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -844,8 +844,8 @@
                   "timeShift": null,
                   "title": "Results cache misses",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -934,8 +934,8 @@
                   "timeShift": null,
                   "title": "Sharded queries ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1030,8 +1030,8 @@
                   "timeShift": null,
                   "title": "Number of sharded queries per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1119,8 +1119,8 @@
                   "timeShift": null,
                   "title": "Stages",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1223,8 +1223,8 @@
                   "timeShift": null,
                   "title": "Series per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1315,8 +1315,8 @@
                   "timeShift": null,
                   "title": "Chunks per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1407,8 +1407,8 @@
                   "timeShift": null,
                   "title": "Samples per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1499,8 +1499,8 @@
                   "timeShift": null,
                   "title": "Exemplars per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1606,8 +1606,8 @@
                   "timeShift": null,
                   "title": "Number of store-gateways hit per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1701,8 +1701,8 @@
                   "timeShift": null,
                   "title": "Refetches of missing blocks per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1778,8 +1778,8 @@
                   "timeShift": null,
                   "title": "Consistency checks failed",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1885,8 +1885,8 @@
                   "timeShift": null,
                   "title": "Bucket indexes loaded (per querier)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1974,8 +1974,8 @@
                   "timeShift": null,
                   "title": "Bucket indexes load / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2069,8 +2069,8 @@
                   "timeShift": null,
                   "title": "Bucket indexes load latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2158,8 +2158,8 @@
                   "timeShift": null,
                   "title": "Blocks queried / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2235,8 +2235,8 @@
                   "timeShift": null,
                   "title": "Data fetched / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2312,8 +2312,8 @@
                   "timeShift": null,
                   "title": "Data touched / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2419,8 +2419,8 @@
                   "timeShift": null,
                   "title": "Series fetch duration (per request)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2514,8 +2514,8 @@
                   "timeShift": null,
                   "title": "Series merge duration (per request)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2591,8 +2591,8 @@
                   "timeShift": null,
                   "title": "Series returned (per request)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2680,8 +2680,8 @@
                   "timeShift": null,
                   "title": "Blocks currently loaded",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2769,8 +2769,8 @@
                   "timeShift": null,
                   "title": "Blocks loaded / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2858,8 +2858,8 @@
                   "timeShift": null,
                   "title": "Blocks dropped / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2947,8 +2947,8 @@
                   "timeShift": null,
                   "title": "Lazy loaded index-headers",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3042,8 +3042,8 @@
                   "timeShift": null,
                   "title": "Index-header lazy load duration",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3131,8 +3131,8 @@
                   "timeShift": null,
                   "title": "Series hash cache hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3208,8 +3208,8 @@
                   "timeShift": null,
                   "title": "ExpandedPostings cache hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3285,8 +3285,8 @@
                   "timeShift": null,
                   "title": "Chunks attributes in-memory cache hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -90,8 +90,8 @@
                   "timeShift": null,
                   "title": "Queue duration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -185,8 +185,8 @@
                   "timeShift": null,
                   "title": "Retries",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -262,8 +262,8 @@
                   "timeShift": null,
                   "title": "Queue length (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -339,8 +339,8 @@
                   "timeShift": null,
                   "title": "Queue length (per user)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -446,8 +446,8 @@
                   "timeShift": null,
                   "title": "Queue duration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -523,8 +523,8 @@
                   "timeShift": null,
                   "title": "Queue length (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -600,8 +600,8 @@
                   "timeShift": null,
                   "title": "Queue length (per user)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -690,8 +690,8 @@
                   "timeShift": null,
                   "title": "Intervals per Query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -767,8 +767,8 @@
                   "timeShift": null,
                   "title": "Results cache hit %",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -844,8 +844,8 @@
                   "timeShift": null,
                   "title": "Results cache misses",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -934,8 +934,8 @@
                   "timeShift": null,
                   "title": "Sharded queries ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1030,8 +1030,8 @@
                   "timeShift": null,
                   "title": "Number of sharded queries per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1119,8 +1119,8 @@
                   "timeShift": null,
                   "title": "Stages",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1223,8 +1223,8 @@
                   "timeShift": null,
                   "title": "Series per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1315,8 +1315,8 @@
                   "timeShift": null,
                   "title": "Chunks per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1407,8 +1407,8 @@
                   "timeShift": null,
                   "title": "Samples per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1499,8 +1499,8 @@
                   "timeShift": null,
                   "title": "Exemplars per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1606,8 +1606,8 @@
                   "timeShift": null,
                   "title": "Number of store-gateways hit per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1701,8 +1701,8 @@
                   "timeShift": null,
                   "title": "Refetches of missing blocks per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1778,8 +1778,8 @@
                   "timeShift": null,
                   "title": "Consistency checks failed",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1885,8 +1885,8 @@
                   "timeShift": null,
                   "title": "Bucket indexes loaded (per querier)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1974,8 +1974,8 @@
                   "timeShift": null,
                   "title": "Bucket indexes load / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2069,8 +2069,8 @@
                   "timeShift": null,
                   "title": "Bucket indexes load latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2158,8 +2158,8 @@
                   "timeShift": null,
                   "title": "Blocks queried / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2235,8 +2235,8 @@
                   "timeShift": null,
                   "title": "Data fetched / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2312,8 +2312,8 @@
                   "timeShift": null,
                   "title": "Data touched / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2419,8 +2419,8 @@
                   "timeShift": null,
                   "title": "Series fetch duration (per request)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2514,8 +2514,8 @@
                   "timeShift": null,
                   "title": "Series merge duration (per request)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2591,8 +2591,8 @@
                   "timeShift": null,
                   "title": "Series returned (per request)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2680,8 +2680,8 @@
                   "timeShift": null,
                   "title": "Blocks currently loaded",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2769,8 +2769,8 @@
                   "timeShift": null,
                   "title": "Blocks loaded / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2858,8 +2858,8 @@
                   "timeShift": null,
                   "title": "Blocks dropped / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2947,8 +2947,8 @@
                   "timeShift": null,
                   "title": "Lazy loaded index-headers",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3042,8 +3042,8 @@
                   "timeShift": null,
                   "title": "Index-header lazy load duration",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3131,8 +3131,8 @@
                   "timeShift": null,
                   "title": "Series hash cache hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3208,8 +3208,8 @@
                   "timeShift": null,
                   "title": "ExpandedPostings cache hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3285,8 +3285,8 @@
                   "timeShift": null,
                   "title": "Chunks attributes in-memory cache hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3338,7 +3338,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -149,8 +149,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -235,8 +235,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -330,8 +330,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -419,8 +419,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -496,8 +496,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -582,8 +582,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -677,8 +677,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -766,8 +766,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -843,8 +843,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -929,8 +929,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1024,8 +1024,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1113,8 +1113,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1190,8 +1190,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1276,8 +1276,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1371,8 +1371,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1460,8 +1460,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1537,8 +1537,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1623,8 +1623,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1718,8 +1718,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1807,8 +1807,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1884,8 +1884,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1970,8 +1970,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2065,8 +2065,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2118,7 +2118,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -149,8 +149,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -235,8 +235,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -330,8 +330,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -419,8 +419,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -496,8 +496,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -582,8 +582,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -677,8 +677,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -766,8 +766,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -843,8 +843,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -929,8 +929,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1024,8 +1024,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1113,8 +1113,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1190,8 +1190,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1276,8 +1276,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1371,8 +1371,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1460,8 +1460,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1537,8 +1537,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1623,8 +1623,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1718,8 +1718,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1807,8 +1807,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1884,8 +1884,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1970,8 +1970,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2065,8 +2065,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -1407,8 +1407,8 @@
                   "timeShift": null,
                   "title": "Rules",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2030,8 +2030,8 @@
                   "timeShift": null,
                   "title": "Disk writes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2107,8 +2107,8 @@
                   "timeShift": null,
                   "title": "Disk reads",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2184,8 +2184,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -1407,8 +1407,8 @@
                   "timeShift": null,
                   "title": "Rules",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2030,8 +2030,8 @@
                   "timeShift": null,
                   "title": "Disk writes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2107,8 +2107,8 @@
                   "timeShift": null,
                   "title": "Disk reads",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2184,8 +2184,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2237,7 +2237,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -95,8 +95,8 @@
                   "timeShift": null,
                   "title": "Instant queries / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -172,8 +172,8 @@
                   "timeShift": null,
                   "title": "Range queries / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -269,8 +269,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -361,8 +361,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -527,8 +527,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -619,8 +619,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -796,8 +796,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -891,8 +891,8 @@
                   "timeShift": null,
                   "title": "Latency (Time in Queue)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -980,8 +980,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1072,8 +1072,8 @@
                   "timeShift": null,
                   "title": "Latency (old)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1167,8 +1167,8 @@
                   "timeShift": null,
                   "title": "Latency (new)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1264,8 +1264,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1356,8 +1356,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1533,8 +1533,8 @@
                   "timeShift": null,
                   "title": "Replicas",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1625,8 +1625,8 @@
                   "timeShift": null,
                   "title": "Scaling metric",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1703,8 +1703,8 @@
                   "timeShift": null,
                   "title": "Autoscaler failures rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1800,8 +1800,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1892,8 +1892,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2058,8 +2058,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2150,8 +2150,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2316,8 +2316,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2411,8 +2411,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2500,8 +2500,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2595,8 +2595,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2673,8 +2673,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2762,8 +2762,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2857,8 +2857,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2934,8 +2934,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3023,8 +3023,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3118,8 +3118,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3195,8 +3195,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3284,8 +3284,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3379,8 +3379,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3456,8 +3456,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3545,8 +3545,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3622,8 +3622,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3717,8 +3717,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3812,8 +3812,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3919,8 +3919,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4014,8 +4014,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4109,8 +4109,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4204,8 +4204,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4293,8 +4293,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4370,8 +4370,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4465,8 +4465,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4560,8 +4560,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4667,8 +4667,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4762,8 +4762,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4857,8 +4857,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4952,8 +4952,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -95,8 +95,8 @@
                   "timeShift": null,
                   "title": "Instant queries / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -172,8 +172,8 @@
                   "timeShift": null,
                   "title": "Range queries / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -269,8 +269,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -361,8 +361,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -527,8 +527,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -619,8 +619,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -796,8 +796,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -891,8 +891,8 @@
                   "timeShift": null,
                   "title": "Latency (Time in Queue)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -980,8 +980,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1072,8 +1072,8 @@
                   "timeShift": null,
                   "title": "Latency (old)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1167,8 +1167,8 @@
                   "timeShift": null,
                   "title": "Latency (new)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1264,8 +1264,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1356,8 +1356,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1533,8 +1533,8 @@
                   "timeShift": null,
                   "title": "Replicas",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1625,8 +1625,8 @@
                   "timeShift": null,
                   "title": "Scaling metric",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1703,8 +1703,8 @@
                   "timeShift": null,
                   "title": "Autoscaler failures rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1800,8 +1800,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1892,8 +1892,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2058,8 +2058,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2150,8 +2150,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2316,8 +2316,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2411,8 +2411,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2500,8 +2500,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2595,8 +2595,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2673,8 +2673,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2762,8 +2762,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2857,8 +2857,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2934,8 +2934,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3023,8 +3023,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3118,8 +3118,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3195,8 +3195,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3284,8 +3284,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3379,8 +3379,8 @@
                   "timeShift": null,
                   "title": "Latency (getmulti)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3456,8 +3456,8 @@
                   "timeShift": null,
                   "title": "Hit ratio",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3545,8 +3545,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3622,8 +3622,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3717,8 +3717,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3812,8 +3812,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -3919,8 +3919,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4014,8 +4014,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4109,8 +4109,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4204,8 +4204,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4293,8 +4293,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4370,8 +4370,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4465,8 +4465,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4560,8 +4560,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4667,8 +4667,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4762,8 +4762,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4857,8 +4857,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -4952,8 +4952,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -5005,7 +5005,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -119,8 +119,8 @@
             "timeShift": null,
             "title": "Rollout progress",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "bargauge",
@@ -223,8 +223,8 @@
             "timeShift": null,
             "title": "Writes - 2xx",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -335,8 +335,8 @@
             "timeShift": null,
             "title": "Writes - 4xx",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -443,8 +443,8 @@
             "timeShift": null,
             "title": "Writes - 5xx",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -555,8 +555,8 @@
             "timeShift": null,
             "title": "Writes 99th latency",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -659,8 +659,8 @@
             "timeShift": null,
             "title": "Reads - 2xx",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -771,8 +771,8 @@
             "timeShift": null,
             "title": "Reads - 4xx",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -879,8 +879,8 @@
             "timeShift": null,
             "title": "Reads - 5xx",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -991,8 +991,8 @@
             "timeShift": null,
             "title": "Reads 99th latency",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -1119,8 +1119,8 @@
             "timeShift": null,
             "title": "Unhealthy pods",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "stat",
@@ -1274,8 +1274,8 @@
             "timeShift": null,
             "title": "Latency vs 24h ago",
             "tooltip": {
-               "shared": true,
-               "sort": 2,
+               "shared": false,
+               "sort": 0,
                "value_type": "individual"
             },
             "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -119,8 +119,8 @@
             "timeShift": null,
             "title": "Rollout progress",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "bargauge",
@@ -223,8 +223,8 @@
             "timeShift": null,
             "title": "Writes - 2xx",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -335,8 +335,8 @@
             "timeShift": null,
             "title": "Writes - 4xx",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -443,8 +443,8 @@
             "timeShift": null,
             "title": "Writes - 5xx",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -555,8 +555,8 @@
             "timeShift": null,
             "title": "Writes 99th latency",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -659,8 +659,8 @@
             "timeShift": null,
             "title": "Reads - 2xx",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -771,8 +771,8 @@
             "timeShift": null,
             "title": "Reads - 4xx",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -879,8 +879,8 @@
             "timeShift": null,
             "title": "Reads - 5xx",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -991,8 +991,8 @@
             "timeShift": null,
             "title": "Reads 99th latency",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -1119,8 +1119,8 @@
             "timeShift": null,
             "title": "Unhealthy pods",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "stat",
@@ -1274,8 +1274,8 @@
             "timeShift": null,
             "title": "Latency vs 24h ago",
             "tooltip": {
-               "shared": false,
-               "sort": 0,
+               "shared": true,
+               "sort": 2,
                "value_type": "individual"
             },
             "type": "graph",
@@ -1321,7 +1321,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -71,8 +71,8 @@
                   "timeShift": null,
                   "title": "Active configurations",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -147,8 +147,8 @@
                   "timeShift": null,
                   "title": "Total rules",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -223,8 +223,8 @@
                   "timeShift": null,
                   "title": "Read from ingesters - QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -299,8 +299,8 @@
                   "timeShift": null,
                   "title": "Write to ingesters - QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -397,8 +397,8 @@
                   "timeShift": null,
                   "title": "EPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -474,8 +474,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -571,8 +571,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -663,8 +663,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -740,8 +740,8 @@
                   "timeShift": null,
                   "title": "Per route p99 latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -837,8 +837,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -932,8 +932,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1029,8 +1029,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1124,8 +1124,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1221,8 +1221,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1316,8 +1316,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1423,8 +1423,8 @@
                   "timeShift": null,
                   "title": "Number of store-gateways hit per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1518,8 +1518,8 @@
                   "timeShift": null,
                   "title": "Refetches of missing blocks per query",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1595,8 +1595,8 @@
                   "timeShift": null,
                   "title": "Consistency checks failed",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1684,8 +1684,8 @@
                   "timeShift": null,
                   "title": "Delivery errors",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1761,8 +1761,8 @@
                   "timeShift": null,
                   "title": "Queue length",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1838,8 +1838,8 @@
                   "timeShift": null,
                   "title": "Dropped",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1927,8 +1927,8 @@
                   "timeShift": null,
                   "title": "Missed iterations",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2004,8 +2004,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2081,8 +2081,8 @@
                   "timeShift": null,
                   "title": "Failures",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2170,8 +2170,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2259,8 +2259,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2336,8 +2336,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2431,8 +2431,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2526,8 +2526,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2633,8 +2633,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2728,8 +2728,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2823,8 +2823,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2918,8 +2918,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -71,8 +71,8 @@
                   "timeShift": null,
                   "title": "Active configurations",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -147,8 +147,8 @@
                   "timeShift": null,
                   "title": "Total rules",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -223,8 +223,8 @@
                   "timeShift": null,
                   "title": "Read from ingesters - QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -299,8 +299,8 @@
                   "timeShift": null,
                   "title": "Write to ingesters - QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -397,8 +397,8 @@
                   "timeShift": null,
                   "title": "EPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -474,8 +474,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -571,8 +571,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -663,8 +663,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -740,8 +740,8 @@
                   "timeShift": null,
                   "title": "Per route p99 latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -837,8 +837,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -932,8 +932,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1029,8 +1029,8 @@
                   "timeShift": null,
                   "title": "QPS",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1124,8 +1124,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1221,8 +1221,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1316,8 +1316,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1423,8 +1423,8 @@
                   "timeShift": null,
                   "title": "Number of store-gateways hit per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1518,8 +1518,8 @@
                   "timeShift": null,
                   "title": "Refetches of missing blocks per query",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1595,8 +1595,8 @@
                   "timeShift": null,
                   "title": "Consistency checks failed",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1684,8 +1684,8 @@
                   "timeShift": null,
                   "title": "Delivery errors",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1761,8 +1761,8 @@
                   "timeShift": null,
                   "title": "Queue length",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1838,8 +1838,8 @@
                   "timeShift": null,
                   "title": "Dropped",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1927,8 +1927,8 @@
                   "timeShift": null,
                   "title": "Missed iterations",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2004,8 +2004,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2081,8 +2081,8 @@
                   "timeShift": null,
                   "title": "Failures",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2170,8 +2170,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2259,8 +2259,8 @@
                   "timeShift": null,
                   "title": "Operations / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2336,8 +2336,8 @@
                   "timeShift": null,
                   "title": "Error rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2431,8 +2431,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Attributes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2526,8 +2526,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Exists",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2633,8 +2633,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Get",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2728,8 +2728,8 @@
                   "timeShift": null,
                   "title": "Latency of op: GetRange",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2823,8 +2823,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Upload",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2918,8 +2918,8 @@
                   "timeShift": null,
                   "title": "Latency of op: Delete",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2971,7 +2971,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
@@ -207,8 +207,8 @@
                   "timeShift": null,
                   "title": "Workload-based scaling",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
@@ -207,8 +207,8 @@
                   "timeShift": null,
                   "title": "Workload-based scaling",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -261,7 +261,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -171,7 +171,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -129,8 +129,8 @@
                   "timeShift": null,
                   "title": "Series",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -201,8 +201,8 @@
                   "timeShift": null,
                   "title": "Series with exemplars",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -273,8 +273,8 @@
                   "timeShift": null,
                   "title": "Newest seen sample age",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -345,8 +345,8 @@
                   "timeShift": null,
                   "title": "Oldest exemplar age",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -429,8 +429,8 @@
                   "timeShift": null,
                   "title": "Distributor samples incoming rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -522,8 +522,8 @@
                   "timeShift": null,
                   "title": "Distributor samples received (accepted) rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -609,8 +609,8 @@
                   "timeShift": null,
                   "title": "Distributor deduplicated/non-HA",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -696,8 +696,8 @@
                   "timeShift": null,
                   "title": "Distributor and ingester discarded samples rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -780,8 +780,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars incoming rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -852,8 +852,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars received (accepted) rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -930,8 +930,8 @@
                   "timeShift": null,
                   "title": "Distributor discarded exemplars rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1002,8 +1002,8 @@
                   "timeShift": null,
                   "title": "Ingester appended exemplars rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1092,8 +1092,8 @@
                   "timeShift": null,
                   "title": "Symbol table size for loaded blocks",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1170,8 +1170,8 @@
                   "timeShift": null,
                   "title": "Space used by local blocks",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1275,8 +1275,8 @@
                   "timeShift": null,
                   "title": "Number of groups",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1347,8 +1347,8 @@
                   "timeShift": null,
                   "title": "Number of rules",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1418,8 +1418,8 @@
                   "timeShift": null,
                   "title": "Total evaluations rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1495,8 +1495,8 @@
                   "timeShift": null,
                   "title": "Failed evaluations rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1622,8 +1622,8 @@
                   "timeShift": null,
                   "title": "Top $limit biggest groups",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1738,8 +1738,8 @@
                   "timeShift": null,
                   "title": "Top $limit slowest groups (last evaluation)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1822,8 +1822,8 @@
                   "timeShift": null,
                   "title": "Sent notifications rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1893,8 +1893,8 @@
                   "timeShift": null,
                   "title": "Failed notifications rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -129,8 +129,8 @@
                   "timeShift": null,
                   "title": "Series",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -201,8 +201,8 @@
                   "timeShift": null,
                   "title": "Series with exemplars",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -273,8 +273,8 @@
                   "timeShift": null,
                   "title": "Newest seen sample age",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -345,8 +345,8 @@
                   "timeShift": null,
                   "title": "Oldest exemplar age",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -429,8 +429,8 @@
                   "timeShift": null,
                   "title": "Distributor samples incoming rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -522,8 +522,8 @@
                   "timeShift": null,
                   "title": "Distributor samples received (accepted) rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -609,8 +609,8 @@
                   "timeShift": null,
                   "title": "Distributor deduplicated/non-HA",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -696,8 +696,8 @@
                   "timeShift": null,
                   "title": "Distributor and ingester discarded samples rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -780,8 +780,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars incoming rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -852,8 +852,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars received (accepted) rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -930,8 +930,8 @@
                   "timeShift": null,
                   "title": "Distributor discarded exemplars rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1002,8 +1002,8 @@
                   "timeShift": null,
                   "title": "Ingester appended exemplars rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1092,8 +1092,8 @@
                   "timeShift": null,
                   "title": "Symbol table size for loaded blocks",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1170,8 +1170,8 @@
                   "timeShift": null,
                   "title": "Space used by local blocks",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1275,8 +1275,8 @@
                   "timeShift": null,
                   "title": "Number of groups",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1347,8 +1347,8 @@
                   "timeShift": null,
                   "title": "Number of rules",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1418,8 +1418,8 @@
                   "timeShift": null,
                   "title": "Total evaluations rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1495,8 +1495,8 @@
                   "timeShift": null,
                   "title": "Failed evaluations rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1622,8 +1622,8 @@
                   "timeShift": null,
                   "title": "Top $limit biggest groups",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1738,8 +1738,8 @@
                   "timeShift": null,
                   "title": "Top $limit slowest groups (last evaluation)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1822,8 +1822,8 @@
                   "timeShift": null,
                   "title": "Sent notifications rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1893,8 +1893,8 @@
                   "timeShift": null,
                   "title": "Failed notifications rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1946,7 +1946,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -133,8 +133,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by active series",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -261,8 +261,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by in-memory series (series created - series removed)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -351,8 +351,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by in-memory series (series created - series removed) that grew the most between query range start and query range end",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -478,8 +478,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by received samples rate in last 5m",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -912,8 +912,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by series with exemplars",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1040,8 +1040,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by received exemplars rate in last 5m",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1168,8 +1168,8 @@
                   "timeShift": null,
                   "title": "Top $limit biggest groups",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1296,8 +1296,8 @@
                   "timeShift": null,
                   "title": "Top $limit slowest groups (last evaluation)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1350,7 +1350,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -133,8 +133,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by active series",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -261,8 +261,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by in-memory series (series created - series removed)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -351,8 +351,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by in-memory series (series created - series removed) that grew the most between query range start and query range end",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -478,8 +478,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by received samples rate in last 5m",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -912,8 +912,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by series with exemplars",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1040,8 +1040,8 @@
                   "timeShift": null,
                   "title": "Top $limit users by received exemplars rate in last 5m",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1168,8 +1168,8 @@
                   "timeShift": null,
                   "title": "Top $limit biggest groups",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",
@@ -1296,8 +1296,8 @@
                   "timeShift": null,
                   "title": "Top $limit slowest groups (last evaluation)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "transform": "table",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -149,8 +149,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -235,8 +235,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -330,8 +330,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -419,8 +419,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -496,8 +496,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -582,8 +582,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -677,8 +677,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -766,8 +766,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -843,8 +843,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -929,8 +929,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1024,8 +1024,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -72,8 +72,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -149,8 +149,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -235,8 +235,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -330,8 +330,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -419,8 +419,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -496,8 +496,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -582,8 +582,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -677,8 +677,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -766,8 +766,8 @@
                   "timeShift": null,
                   "title": "Receive bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -843,8 +843,8 @@
                   "timeShift": null,
                   "title": "Transmit bandwidth",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -929,8 +929,8 @@
                   "timeShift": null,
                   "title": "Inflight requests (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1024,8 +1024,8 @@
                   "timeShift": null,
                   "title": "TCP connections (per pod)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1077,7 +1077,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -960,8 +960,8 @@
                   "timeShift": null,
                   "title": "Disk writes",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1037,8 +1037,8 @@
                   "timeShift": null,
                   "title": "Disk reads",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1114,8 +1114,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -960,8 +960,8 @@
                   "timeShift": null,
                   "title": "Disk writes",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1037,8 +1037,8 @@
                   "timeShift": null,
                   "title": "Disk reads",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1114,8 +1114,8 @@
                   "timeShift": null,
                   "title": "Disk space utilization",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1167,7 +1167,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -94,8 +94,8 @@
                   "timeShift": null,
                   "title": "Samples / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -171,8 +171,8 @@
                   "timeShift": null,
                   "title": "Exemplars / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -248,8 +248,8 @@
                   "timeShift": null,
                   "title": "In-memory series",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -325,8 +325,8 @@
                   "timeShift": null,
                   "title": "Exemplars in ingesters",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -401,8 +401,8 @@
                   "timeShift": null,
                   "title": "Tenants",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -477,8 +477,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -574,8 +574,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -666,8 +666,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -832,8 +832,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -924,8 +924,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1090,8 +1090,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1182,8 +1182,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1348,8 +1348,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1443,8 +1443,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1540,8 +1540,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1635,8 +1635,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1732,8 +1732,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1827,8 +1827,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1929,8 +1929,8 @@
                   "timeShift": null,
                   "title": "Uploaded blocks / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2025,8 +2025,8 @@
                   "timeShift": null,
                   "title": "Upload latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2127,8 +2127,8 @@
                   "timeShift": null,
                   "title": "Compactions / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2223,8 +2223,8 @@
                   "timeShift": null,
                   "title": "Compactions latency",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2325,8 +2325,8 @@
                   "timeShift": null,
                   "title": "WAL truncations / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2415,8 +2415,8 @@
                   "timeShift": null,
                   "title": "Checkpoints created / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2493,8 +2493,8 @@
                   "timeShift": null,
                   "title": "WAL truncations latency (includes checkpointing)",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2582,8 +2582,8 @@
                   "timeShift": null,
                   "title": "Corruptions / sec",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2672,8 +2672,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars incoming rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2750,8 +2750,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars received rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2828,8 +2828,8 @@
                   "timeShift": null,
                   "title": "Ingester ingested exemplars rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2906,8 +2906,8 @@
                   "timeShift": null,
                   "title": "Ingester appended exemplars rate",
                   "tooltip": {
-                     "shared": true,
-                     "sort": 2,
+                     "shared": false,
+                     "sort": 0,
                      "value_type": "individual"
                   },
                   "type": "graph",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -94,8 +94,8 @@
                   "timeShift": null,
                   "title": "Samples / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -171,8 +171,8 @@
                   "timeShift": null,
                   "title": "Exemplars / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -248,8 +248,8 @@
                   "timeShift": null,
                   "title": "In-memory series",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -325,8 +325,8 @@
                   "timeShift": null,
                   "title": "Exemplars in ingesters",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -401,8 +401,8 @@
                   "timeShift": null,
                   "title": "Tenants",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -477,8 +477,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "singlestat",
@@ -574,8 +574,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -666,8 +666,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -832,8 +832,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -924,8 +924,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1090,8 +1090,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1182,8 +1182,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1348,8 +1348,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1443,8 +1443,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1540,8 +1540,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1635,8 +1635,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1732,8 +1732,8 @@
                   "timeShift": null,
                   "title": "Requests / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1827,8 +1827,8 @@
                   "timeShift": null,
                   "title": "Latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -1929,8 +1929,8 @@
                   "timeShift": null,
                   "title": "Uploaded blocks / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2025,8 +2025,8 @@
                   "timeShift": null,
                   "title": "Upload latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2127,8 +2127,8 @@
                   "timeShift": null,
                   "title": "Compactions / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2223,8 +2223,8 @@
                   "timeShift": null,
                   "title": "Compactions latency",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2325,8 +2325,8 @@
                   "timeShift": null,
                   "title": "WAL truncations / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2415,8 +2415,8 @@
                   "timeShift": null,
                   "title": "Checkpoints created / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2493,8 +2493,8 @@
                   "timeShift": null,
                   "title": "WAL truncations latency (includes checkpointing)",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2582,8 +2582,8 @@
                   "timeShift": null,
                   "title": "Corruptions / sec",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2672,8 +2672,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars incoming rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2750,8 +2750,8 @@
                   "timeShift": null,
                   "title": "Distributor exemplars received rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2828,8 +2828,8 @@
                   "timeShift": null,
                   "title": "Ingester ingested exemplars rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2906,8 +2906,8 @@
                   "timeShift": null,
                   "title": "Ingester appended exemplars rate",
                   "tooltip": {
-                     "shared": false,
-                     "sort": 0,
+                     "shared": true,
+                     "sort": 2,
                      "value_type": "individual"
                   },
                   "type": "graph",
@@ -2959,7 +2959,7 @@
                   "value": "default"
                },
                "hide": 0,
-               "label": null,
+               "label": "Data Source",
                "name": "datasource",
                "options": [ ],
                "query": "prometheus",

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -89,5 +89,6 @@
 
     // The default datasource used for dashboards.
     dashboard_datasource: 'default',
+    datasource_regex: '',
   },
 }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -19,7 +19,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // Prefix the dashboard title with "<product> /" unless configured otherwise.
     super.dashboard(
       title='%(prefix)s%(title)s' % { prefix: $._config.dashboard_prefix, title: title },
-      datasource=$._config.dashboard_datasource, datasource_regex=$._config.datasource_regex
+      datasource=$._config.dashboard_datasource,
+      datasource_regex=$._config.datasource_regex
     ) + {
       addRowIf(condition, row)::
         if condition

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -19,7 +19,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // Prefix the dashboard title with "<product> /" unless configured otherwise.
     super.dashboard(
       title='%(prefix)s%(title)s' % { prefix: $._config.dashboard_prefix, title: title },
-      datasource=$._config.dashboard_datasource
+      datasource=$._config.dashboard_datasource, datasource_regex=$._config.datasource_regex
     ) + {
       addRowIf(condition, row)::
         if condition

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -123,6 +123,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
     then [utils.selector.noop('%s' % $._config.per_cluster_label), utils.selector.re('job', '$job')]
     else [utils.selector.re('%s' % $._config.per_cluster_label, '$cluster'), utils.selector.re('job', '($namespace)/(%s)' % job)],
 
+  panel(title)::
+    super.panel(title) + {
+      tooltip+: {
+        shared: false,
+        sort: 0,
+      },
+    },
+
   queryPanel(queries, legends, legendLink=null)::
     super.queryPanel(queries, legends, legendLink) + {
       targets: [

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "0d13e5ba1b3a4c29015738c203d92ea39f71ebe2",
-      "sum": "GRf2GvwEU4jhXV+JOonXSZ4wdDv8mnHBPCQ6TUVd+g8="
+      "version": "2e980525502eda008cfb88a5672bd70d7d411fda",
+      "sum": "TieGrr7GyKjURk1+wXHFpdoCiwNaIVfZvyc5mbI9OM0="
     },
     {
       "source": {


### PR DESCRIPTION
#### What this PR does
The current dashboards offer the possibility to select a data source
among all prometheus data sources in the organization. Depending on the
number of data sources the list could be rather big (>10). Not all data
sources host Mimir metrics as such listing them is not helpful for the
users.

#### Which issue(s) this PR fixes or relates to

To be able to use this enhancement it is needed to merge the following PR https://github.com/grafana/jsonnet-libs/pull/774 as well as update jsonnetfile.lock.json

The error `RUNTIME ERROR: function has no parameter datasource_regex` is expected until then.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
