### PR TITLE
Add protection to store-gateway to not drop all blocks if unhealthy in the ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482 #1549
 * [ENHANCEMENT] Alertmanager: added `insight=true` field to alertmanager dispatch logs. #1379
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run index header operations in a dedicated thread pool. This feature can be configured using `-blocks-storage.bucket-store.index-header-thread-pool-size` and is disabled by default. #1660
-* [ENHANCEMENT] Store-gateway: Add protection to store-gateway to not drop all blocks if unhealthy in the ring. #1806
+* [ENHANCEMENT] Store-gateway: don't drop all blocks if instance finds itself as unhealthy in the ring. #1806
 * [ENHANCEMENT] Querier: wait until inflight queries are completed when shutting down queriers. #1756 #1767
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 * [BUGFIX] Query-frontend: added `component=query-frontend` label to results cache memcached metrics to fix a panic when Mimir is running in single binary mode and results cache is enabled. #1704

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [ENHANCEMENT] Admin: Admin API now has some styling. #1482 #1549
 * [ENHANCEMENT] Alertmanager: added `insight=true` field to alertmanager dispatch logs. #1379
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run index header operations in a dedicated thread pool. This feature can be configured using `-blocks-storage.bucket-store.index-header-thread-pool-size` and is disabled by default. #1660
+* [ENHANCEMENT] Store-gateway: Add protection to store-gateway to not drop all blocks if unhealthy in the ring. #1806
 * [ENHANCEMENT] Querier: wait until inflight queries are completed when shutting down queriers. #1756 #1767
 * [BUGFIX] Query-frontend: do not shard queries with a subquery unless the subquery is inside a shardable aggregation function call. #1542
 * [BUGFIX] Query-frontend: added `component=query-frontend` label to results cache memcached metrics to fix a panic when Mimir is running in single binary mode and results cache is enabled. #1704

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -58,6 +58,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 		replicationFactor int
 		limits            ShardingLimits
 		setupRing         func(*ring.Desc)
+		prevLoadedBlocks  map[string]map[ulid.ULID]struct{}
 		expectedUsers     []usersExpectation
 		expectedBlocks    []blocksExpectation
 	}{
@@ -189,7 +190,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 				{instanceID: "instance-3", instanceAddr: "127.0.0.3", blocks: []ulid.ULID{block4 /* replicated: */, block3}},
 			},
 		},
-		"one unhealthy instance in the ring with RF = 1 and SS = 3": {
+		"one unhealthy instance in the ring with RF = 1, SS = 3 and NO previously loaded blocks": {
 			replicationFactor: 1,
 			limits:            &shardingLimitsMock{storeGatewayTenantShardSize: 3},
 			setupRing: func(r *ring.Desc) {
@@ -215,7 +216,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 				{instanceID: "instance-3", instanceAddr: "127.0.0.3", blocks: []ulid.ULID{}},
 			},
 		},
-		"one unhealthy instance in the ring with RF = 2 and SS = 3": {
+		"one unhealthy instance in the ring with RF = 2, SS = 3 and NO previously loaded blocks": {
 			replicationFactor: 2,
 			limits:            &shardingLimitsMock{storeGatewayTenantShardSize: 3},
 			setupRing: func(r *ring.Desc) {
@@ -240,7 +241,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 				{instanceID: "instance-3", instanceAddr: "127.0.0.3", blocks: []ulid.ULID{}},
 			},
 		},
-		"one unhealthy instance in the ring with RF = 2 and SS = 2": {
+		"one unhealthy instance in the ring with RF = 2, SS = 2 and NO previously loaded blocks": {
 			replicationFactor: 2,
 			limits:            &shardingLimitsMock{storeGatewayTenantShardSize: 2},
 			setupRing: func(r *ring.Desc) {
@@ -263,6 +264,34 @@ func TestShuffleShardingStrategy(t *testing.T) {
 				{instanceID: "instance-1", instanceAddr: "127.0.0.1", blocks: []ulid.ULID{block1, block2, block3, block4}},
 				{instanceID: "instance-2", instanceAddr: "127.0.0.2", blocks: []ulid.ULID{ /* no blocks because not belonging to the shard */ }},
 				{instanceID: "instance-3", instanceAddr: "127.0.0.3", blocks: []ulid.ULID{ /* no blocks because unhealthy */ }},
+			},
+		},
+		"one unhealthy instance in the ring with RF = 2, SS = 2 and some previously loaded blocks": {
+			replicationFactor: 2,
+			limits:            &shardingLimitsMock{storeGatewayTenantShardSize: 2},
+			setupRing: func(r *ring.Desc) {
+				r.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1, block4Hash + 1}, ring.ACTIVE, registeredAt)
+				r.AddIngester("instance-2", "127.0.0.2", "", []uint32{block2Hash + 1}, ring.ACTIVE, registeredAt)
+
+				r.Ingesters["instance-3"] = ring.InstanceDesc{
+					Addr:      "127.0.0.3",
+					Timestamp: time.Now().Add(-time.Hour).Unix(),
+					State:     ring.ACTIVE,
+					Tokens:    []uint32{block3Hash + 1},
+				}
+			},
+			prevLoadedBlocks: map[string]map[ulid.ULID]struct{}{
+				"instance-3": {block2: struct{}{}, block4: struct{}{}},
+			},
+			expectedUsers: []usersExpectation{
+				{instanceID: "instance-1", instanceAddr: "127.0.0.1", users: []string{userID}},
+				{instanceID: "instance-2", instanceAddr: "127.0.0.2", users: nil},
+				{instanceID: "instance-3", instanceAddr: "127.0.0.3", users: []string{userID}},
+			},
+			expectedBlocks: []blocksExpectation{
+				{instanceID: "instance-1", instanceAddr: "127.0.0.1", blocks: []ulid.ULID{block1, block2, block3, block4}},
+				{instanceID: "instance-2", instanceAddr: "127.0.0.2", blocks: []ulid.ULID{ /* no blocks because not belonging to the shard */ }},
+				{instanceID: "instance-3", instanceAddr: "127.0.0.3", blocks: []ulid.ULID{block2, block4 /* keeping the previously loaded blocks */}},
 			},
 		},
 		"LEAVING instance in the ring should continue to keep its shard blocks and they should NOT be replicated to another instance": {
@@ -372,7 +401,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 					block4: {},
 				}
 
-				err = filter.FilterBlocks(ctx, userID, metas, map[ulid.ULID]struct{}{}, synced)
+				err = filter.FilterBlocks(ctx, userID, metas, testData.prevLoadedBlocks[expected.instanceID], synced)
 				require.NoError(t, err)
 
 				var actualBlocks []ulid.ULID


### PR DESCRIPTION
#### What this PR does
This PR adds a protection to store-gateway to not drop all blocks if unhealthy in the ring, as proposed in #1805. There's still 1 case not addressed in this PR which is when the store-gateway is removed from the ring by another instance, due to the auto-forget feature (it happens after 10x hearbeat timeout periods, so it's less likely to happen compared to the case covered in this PR).

To fix the auto-forget case I need to do some refactoring first, so I will do the work in separate PRs.

#### Which issue(s) this PR fixes or relates to

Part of #1805

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
