### PR TITLE
Add support for store_gateway_zone args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 * [ENHANCEMENT] Added `node_selector` configuration option to select Kubernetes nodes where Mimir should run. #1596
 * [ENHANCEMENT] Alertmanager: Added a `PodDisruptionBudget` of `withMaxUnavailable = 1`, to ensure we maintain quorum during rollouts. #1683
 * [ENHANCEMENT] Store-gateway anti-affinity can now be enabled/disabled using `store_gateway_allow_multiple_replicas_on_same_node` configuration key. #1730
+* [ENHANCEMENT] Added `store_gateway_zone_a_args`, `store_gateway_zone_b_args` and `store_gateway_zone_c_args` configuration options. #1807
 * [BUGFIX] Pass primary and secondary multikv stores via CLI flags. Introduced new `multikv_switch_primary_secondary` config option to flip primary and secondary in runtime config.
 
 ### Mimirtool

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -182,18 +182,24 @@
   // Multi-zone store-gateways.
   //
 
-  newStoreGatewayZoneContainer(zone)::
+  store_gateway_zone_a_args:: {},
+  store_gateway_zone_b_args:: {},
+  store_gateway_zone_c_args:: {},
+
+  newStoreGatewayZoneContainer(zone, zone_args)::
     $.store_gateway_container +
-    container.withArgs($.util.mapToFlags($.store_gateway_args {
-      'store-gateway.sharding-ring.instance-availability-zone': 'zone-%s' % zone,
-      'store-gateway.sharding-ring.zone-awareness-enabled': true,
+    container.withArgs($.util.mapToFlags(
+      $.store_gateway_args + zone_args + {
+        'store-gateway.sharding-ring.instance-availability-zone': 'zone-%s' % zone,
+        'store-gateway.sharding-ring.zone-awareness-enabled': true,
 
-      // Use a different prefix so that both single-zone and multi-zone store-gateway rings can co-exists.
-      'store-gateway.sharding-ring.prefix': 'multi-zone/',
+        // Use a different prefix so that both single-zone and multi-zone store-gateway rings can co-exists.
+        'store-gateway.sharding-ring.prefix': 'multi-zone/',
 
-      // Do not unregister from ring at shutdown, so that no blocks re-shuffling occurs during rollouts.
-      'store-gateway.sharding-ring.unregister-on-shutdown': false,
-    })),
+        // Do not unregister from ring at shutdown, so that no blocks re-shuffling occurs during rollouts.
+        'store-gateway.sharding-ring.unregister-on-shutdown': false,
+      }
+    )),
 
   newStoreGatewayZoneStatefulSet(zone, container)::
     local name = 'store-gateway-zone-%s' % zone;
@@ -237,7 +243,7 @@
   },
 
   store_gateway_zone_a_container:: if !$._config.multi_zone_store_gateway_enabled then null else
-    self.newStoreGatewayZoneContainer('a'),
+    self.newStoreGatewayZoneContainer('a', $.store_gateway_zone_a_args),
 
   store_gateway_zone_a_statefulset: if !$._config.multi_zone_store_gateway_enabled then null else
     (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('a', $.store_gateway_zone_a_container),
@@ -246,7 +252,7 @@
     self.newStoreGatewayZoneService($.store_gateway_zone_a_statefulset),
 
   store_gateway_zone_b_container:: if !$._config.multi_zone_store_gateway_enabled then null else
-    self.newStoreGatewayZoneContainer('b'),
+    self.newStoreGatewayZoneContainer('b', $.store_gateway_zone_b_args),
 
   store_gateway_zone_b_statefulset: if !$._config.multi_zone_store_gateway_enabled then null else
     (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('b', $.store_gateway_zone_b_container),
@@ -255,7 +261,7 @@
     self.newStoreGatewayZoneService($.store_gateway_zone_b_statefulset),
 
   store_gateway_zone_c_container:: if !$._config.multi_zone_store_gateway_enabled then null else
-    self.newStoreGatewayZoneContainer('c'),
+    self.newStoreGatewayZoneContainer('c', $.store_gateway_zone_c_args),
 
   store_gateway_zone_c_statefulset: if !$._config.multi_zone_store_gateway_enabled then null else
     (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('c', $.store_gateway_zone_c_container),


### PR DESCRIPTION
#### What this PR does

Allow customizing mimir cli flags per zone for the store gateway.
Copied the same solution as we have for ingesters.

#### Which issue(s) this PR fixes or relates to

Fixes N/A. Internal request to be able to turn off some flag for testing an individual store gateway zone.

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
   -  krajo: this level of detail is not documented for ingesters either
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
