### PR TITLE
Adopt mixin convention to set dashboard UIDs based on md5(filename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,27 +68,27 @@
 * [CHANGE] Dashboards: Remove per-user series legends from Tenants dashboard. #1605
 * [CHANGE] Dashboards: Show in-memory series and the per-user series limit on Tenants dashboard. #1613
 * [CHANGE] Dashboards: Slow-queries dashboard now uses `user` label from logs instead of `org_id`. #1634
-* [CHANGE] Dashboards: changed all Grafana dashboards UIDs to not conflict with Cortex ones, to let people install both while migrating from Cortex to Mimir: #1801
-  * Alertmanager from `a76bee5913c97c918d9e56a3cc88cc28` to `GupFKpgkt`
-  * Alertmanager Resources from `68b66aed90ccab448009089544a8d6c6` to `r5DZRDusm`
-  * Compactor from `9c408e1d55681ecb8a22c9fab46875cc` to `oMZ8ngTZF`
-  * Compactor Resources from `df9added6f1f4332f95848cca48ebd99` to `ma9ZA9a7C`
-  * Config from `61bb048ced9817b2d3e07677fb1c6290` to `u6dLadEbi`
-  * Object Store from `d5a3a4489d57c733b5677fb55370a723` to `VKXaoOZXb`
-  * Overrides from `b5c95fee2e5e7c4b5930826ff6e89a12` to `BWZ9xZOUo`
-  * Queries from `d9931b1054053c8b972d320774bb8f1d` to `bHf8Zf5fk`
-  * Reads from `8d6ba60eccc4b6eedfa329b24b1bd339` to `2dvAcvdvV`
-  * Reads Networking from `c0464f0d8bd026f776c9006b05910000` to `3xAjZAhJ5`
-  * Reads Resources from `2fd2cda9eea8d8af9fbc0a5960425120` to `mBNJaEkET`
-  * Rollout Progress from `7544a3a62b1be6ffd919fc990ab8ba8f` to `4wbNeyoyO`
-  * Ruler from `44d12bcb1f95661c6ab6bc946dfc3473` to `4ATLNTbTa`
-  * Scaling from `88c041017b96856c9176e07cf557bdcf` to `mNp3epNpo`
-  * Slow queries from `e6f3091e29d2636e3b8393447e925668` to `30rav7n7X`
-  * Tenants from `35fa247ce651ba189debf33d7ae41611` to `4BQmVQBvF`
-  * Top Tenants from `bc6e12d4fe540e4a1785b9d3ca0ffdd9` to `6gZlLegev`
-  * Writes from `0156f6d15aa234d452a33a4f13c838e3` to `CVmvemOmR`
-  * Writes Networking from `681cd62b680b7154811fe73af55dcfd4` to `iqgpV8q8Y`
-  * Writes Resources from `c0464f0d8bd026f776c9006b0591bb0b` to `6tIBbVtV2`
+* [CHANGE] Dashboards: changed all Grafana dashboards UIDs to not conflict with Cortex ones, to let people install both while migrating from Cortex to Mimir: #1801 #1808
+  * Alertmanager from `a76bee5913c97c918d9e56a3cc88cc28` to `b0d38d318bbddd80476246d4930f9e55`
+  * Alertmanager Resources from `68b66aed90ccab448009089544a8d6c6` to `a6883fb22799ac74479c7db872451092`
+  * Compactor from `9c408e1d55681ecb8a22c9fab46875cc` to `1b3443aea86db629e6efdb7d05c53823`
+  * Compactor Resources from `df9added6f1f4332f95848cca48ebd99` to `09a5c49e9cdb2f2b24c6d184574a07fd`
+  * Config from `61bb048ced9817b2d3e07677fb1c6290` to `5d9d0b4724c0f80d68467088ec61e003`
+  * Object Store from `d5a3a4489d57c733b5677fb55370a723` to `e1324ee2a434f4158c00a9ee279d3292`
+  * Overrides from `b5c95fee2e5e7c4b5930826ff6e89a12` to `1e2c358600ac53f09faea133f811b5bb`
+  * Queries from `d9931b1054053c8b972d320774bb8f1d` to `b3abe8d5c040395cc36615cb4334c92d`
+  * Reads from `8d6ba60eccc4b6eedfa329b24b1bd339` to `e327503188913dc38ad571c647eef643`
+  * Reads Networking from `c0464f0d8bd026f776c9006b05910000` to `54b2a0a4748b3bd1aefa92ce5559a1c2`
+  * Reads Resources from `2fd2cda9eea8d8af9fbc0a5960425120` to `cc86fd5aa9301c6528986572ad974db9`
+  * Rollout Progress from `7544a3a62b1be6ffd919fc990ab8ba8f` to `7f0b5567d543a1698e695b530eb7f5de`
+  * Ruler from `44d12bcb1f95661c6ab6bc946dfc3473` to `631e15d5d85afb2ca8e35d62984eeaa0`
+  * Scaling from `88c041017b96856c9176e07cf557bdcf` to `64bbad83507b7289b514725658e10352`
+  * Slow queries from `e6f3091e29d2636e3b8393447e925668` to `6089e1ce1e678788f46312a0a1e647e6`
+  * Tenants from `35fa247ce651ba189debf33d7ae41611` to `35fa247ce651ba189debf33d7ae41611`
+  * Top Tenants from `bc6e12d4fe540e4a1785b9d3ca0ffdd9` to `bc6e12d4fe540e4a1785b9d3ca0ffdd9`
+  * Writes from `0156f6d15aa234d452a33a4f13c838e3` to `8280707b8f16e7b87b840fc1cc92d4c5`
+  * Writes Networking from `681cd62b680b7154811fe73af55dcfd4` to `978c1cb452585c96697a238eaac7fe2d`
+  * Writes Resources from `c0464f0d8bd026f776c9006b0591bb0b` to `bc9160e50b52e89e0e49c840fea3d379`
 * [FEATURE] Alerts: added the following alerts on `mimir-continuous-test` tool: #1676
   - `MimirContinuousTestNotRunningOnWrites`
   - `MimirContinuousTestNotRunningOnReads`

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -1345,6 +1345,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Alertmanager resources",
-      "uid": "r5DZRDusm",
+      "uid": "a6883fb22799ac74479c7db872451092",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -2903,6 +2903,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Alertmanager",
-      "uid": "GupFKpgkt",
+      "uid": "b0d38d318bbddd80476246d4930f9e55",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -801,6 +801,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Compactor resources",
-      "uid": "ma9ZA9a7C",
+      "uid": "09a5c49e9cdb2f2b24c6d184574a07fd",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -2431,6 +2431,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Compactor",
-      "uid": "oMZ8ngTZF",
+      "uid": "1b3443aea86db629e6efdb7d05c53823",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -303,6 +303,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Config",
-      "uid": "u6dLadEbi",
+      "uid": "5d9d0b4724c0f80d68467088ec61e003",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -1051,6 +1051,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Object Store",
-      "uid": "VKXaoOZXb",
+      "uid": "e1324ee2a434f4158c00a9ee279d3292",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
@@ -253,6 +253,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Overrides",
-      "uid": "BWZ9xZOUo",
+      "uid": "1e2c358600ac53f09faea133f811b5bb",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -3427,6 +3427,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Queries",
-      "uid": "bHf8Zf5fk",
+      "uid": "b3abe8d5c040395cc36615cb4334c92d",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -2205,6 +2205,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Reads networking",
-      "uid": "3xAjZAhJ5",
+      "uid": "54b2a0a4748b3bd1aefa92ce5559a1c2",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -2324,6 +2324,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Reads resources",
-      "uid": "mBNJaEkET",
+      "uid": "cc86fd5aa9301c6528986572ad974db9",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -5094,6 +5094,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Reads",
-      "uid": "2dvAcvdvV",
+      "uid": "e327503188913dc38ad571c647eef643",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -1408,6 +1408,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Rollout progress",
-      "uid": "4wbNeyoyO",
+      "uid": "7f0b5567d543a1698e695b530eb7f5de",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -3060,6 +3060,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Ruler",
-      "uid": "4ATLNTbTa",
+      "uid": "631e15d5d85afb2ca8e35d62984eeaa0",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
@@ -350,6 +350,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Scaling",
-      "uid": "mNp3epNpo",
+      "uid": "64bbad83507b7289b514725658e10352",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -305,6 +305,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Slow queries",
-      "uid": "30rav7n7X",
+      "uid": "6089e1ce1e678788f46312a0a1e647e6",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -2055,6 +2055,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Tenants",
-      "uid": "4BQmVQBvF",
+      "uid": "35fa247ce651ba189debf33d7ae41611",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -1162,6 +1162,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Top tenants",
-      "uid": "6gZlLegev",
+      "uid": "bc6e12d4fe540e4a1785b9d3ca0ffdd9",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -1164,6 +1164,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Writes networking",
-      "uid": "iqgpV8q8Y",
+      "uid": "978c1cb452585c96697a238eaac7fe2d",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -1254,6 +1254,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Writes resources",
-      "uid": "6tIBbVtV2",
+      "uid": "bc9160e50b52e89e0e49c840fea3d379",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -3048,6 +3048,6 @@
       },
       "timezone": "utc",
       "title": "Mimir / Writes",
-      "uid": "CVmvemOmR",
+      "uid": "8280707b8f16e7b87b840fc1cc92d4c5",
       "version": 0
    }

--- a/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-alertmanager-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-alertmanager-resources.json':
-    ($.dashboard('Alertmanager resources') + { uid: 'r5DZRDusm' })
+  [filename]:
+    ($.dashboard('Alertmanager resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf(
       $._config.gateway_enabled,

--- a/operations/mimir-mixin/dashboards/alertmanager.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-alertmanager.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-alertmanager.json':
-    ($.dashboard('Alertmanager') + { uid: 'GupFKpgkt' })
+  [filename]:
+    ($.dashboard('Alertmanager') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Headlines') + {

--- a/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-compactor-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-compactor-resources.json':
-    ($.dashboard('Compactor resources') + { uid: 'ma9ZA9a7C' })
+  [filename]:
+    ($.dashboard('Compactor resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('CPU and memory')

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -1,4 +1,5 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-compactor.json';
 
 // This applies to the "longest time since successful run queries"
 local fixTargetsForTransformations(panel, refIds) = panel {
@@ -87,8 +88,8 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     }),
   ],
 
-  'mimir-compactor.json':
-    ($.dashboard('Compactor') + { uid: 'oMZ8ngTZF' })
+  [filename]:
+    ($.dashboard('Compactor') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Summary')

--- a/operations/mimir-mixin/dashboards/config.libsonnet
+++ b/operations/mimir-mixin/dashboards/config.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-config.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-config.json':
-    ($.dashboard('Config') + { uid: 'u6dLadEbi' })
+  [filename]:
+    ($.dashboard('Config') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Startup config file')

--- a/operations/mimir-mixin/dashboards/object-store.libsonnet
+++ b/operations/mimir-mixin/dashboards/object-store.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-object-store.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-object-store.json':
-    ($.dashboard('Object Store') + { uid: 'VKXaoOZXb' })
+  [filename]:
+    ($.dashboard('Object Store') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Components')

--- a/operations/mimir-mixin/dashboards/overrides.libsonnet
+++ b/operations/mimir-mixin/dashboards/overrides.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-overrides.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-overrides.json':
-    ($.dashboard('Overrides') + { uid: 'BWZ9xZOUo' })
+  [filename]:
+    ($.dashboard('Overrides') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(
       $.row('')

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-queries.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-queries.json':
-    ($.dashboard('Queries') + { uid: 'bHf8Zf5fk' })
+  [filename]:
+    ($.dashboard('Queries') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Query-frontend')

--- a/operations/mimir-mixin/dashboards/reads-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-networking.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-reads-networking.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-reads-networking.json':
-    ($.dashboard('Reads networking') + { uid: '3xAjZAhJ5' })
+  [filename]:
+    ($.dashboard('Reads networking') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf($._config.gateway_enabled, $.jobNetworkingRow('Gateway', 'gateway'))
     .addRow($.jobNetworkingRow('Query-frontend', 'query_frontend'))

--- a/operations/mimir-mixin/dashboards/reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-resources.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-reads-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-reads-resources.json':
-    ($.dashboard('Reads resources') + { uid: 'mBNJaEkET' })
+  [filename]:
+    ($.dashboard('Reads resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf(
       $._config.gateway_enabled,

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-reads.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-reads.json':
-    ($.dashboard('Reads') + { uid: '2dvAcvdvV' })
+  [filename]:
+    ($.dashboard('Reads') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRowIf(
       $._config.show_dashboard_descriptions.reads,

--- a/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
@@ -1,4 +1,5 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-rollout-progress.json';
 
 (import 'dashboard-utils.libsonnet') {
   local config = {
@@ -10,8 +11,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     all_services_regex: std.join('|', ['cortex-gw', 'distributor', 'ingester.*', 'query-frontend.*', 'query-scheduler.*', 'querier.*', 'compactor', 'store-gateway.*', 'ruler', 'alertmanager.*', 'overrides-exporter', 'cortex', 'mimir']),
   },
 
-  'mimir-rollout-progress.json':
-    ($.dashboard('Rollout progress') + { uid: '4wbNeyoyO' })
+  [filename]:
+    ($.dashboard('Rollout progress') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false) + {
       // This dashboard uses the new grid system in order to place panels (using gridPos).
       // Because of this we can't use the mixin's addRow() and addPanel().

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -1,4 +1,5 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-ruler.json';
 
 (import 'dashboard-utils.libsonnet') {
   local ruler_config_api_routes_re = '(prometheus|api_prom)_(rules.*|api_v1_(rules|alerts))',
@@ -58,8 +59,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
   },
 
-  'mimir-ruler.json':
-    ($.dashboard('Ruler') + { uid: '4ATLNTbTa' })
+  [filename]:
+    ($.dashboard('Ruler') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Headlines') + {

--- a/operations/mimir-mixin/dashboards/scaling.libsonnet
+++ b/operations/mimir-mixin/dashboards/scaling.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-scaling.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-scaling.json':
-    ($.dashboard('Scaling') + { uid: 'mNp3epNpo' })
+  [filename]:
+    ($.dashboard('Scaling') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Service scaling') + { height: '200px' })

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-slow-queries.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-slow-queries.json':
-    ($.dashboard('Slow queries') + { uid: '30rav7n7X' })
+  [filename]:
+    ($.dashboard('Slow queries') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(
       $.row('')

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-tenants.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-tenants.json':
-    ($.dashboard('Tenants') + { uid: '4BQmVQBvF' })
+  [filename]:
+    ($.dashboard('Tenants') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addActiveUserSelectorTemplates()
     .addCustomTemplate('limit', ['10', '50', '100', '500', '1000'])

--- a/operations/mimir-mixin/dashboards/top-tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/top-tenants.libsonnet
@@ -1,4 +1,5 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-top-tenants.json';
 
 (import 'dashboard-utils.libsonnet') {
   local in_memory_series_per_user_query(at='') = |||
@@ -18,8 +19,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     group_by_cluster: $._config.group_by_cluster,
   },
 
-  'mimir-top-tenants.json':
-    ($.dashboard('Top tenants') + { uid: '6gZlLegev' })
+  [filename]:
+    ($.dashboard('Top tenants') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addCustomTemplate('limit', ['10', '50', '100'])
     .addRowIf(

--- a/operations/mimir-mixin/dashboards/writes-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-networking.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-writes-networking.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-writes-networking.json':
-    ($.dashboard('Writes networking') + { uid: 'iqgpV8q8Y' })
+  [filename]:
+    ($.dashboard('Writes networking') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf($._config.gateway_enabled, $.jobNetworkingRow('Gateway', 'gateway'))
     .addRow($.jobNetworkingRow('Distributor', 'distributor'))

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-writes-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-writes-resources.json':
-    ($.dashboard('Writes resources') + { uid: '6tIBbVtV2' })
+  [filename]:
+    ($.dashboard('Writes resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf(
       $._config.gateway_enabled,

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -1,8 +1,9 @@
 local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-writes.json';
 
 (import 'dashboard-utils.libsonnet') {
-  'mimir-writes.json':
-    ($.dashboard('Writes') + { uid: 'CVmvemOmR' })
+  [filename]:
+    ($.dashboard('Writes') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRowIf(
       $._config.show_dashboard_descriptions.writes,


### PR DESCRIPTION
#### What this PR does
After merging #1801 and rolling out the change at Grafana Labs, I learned (the hard way) that among our mixins we  have a convention to use `md5(filename)` as UID. I'm just going to adhere to the existing convention.

#### Which issue(s) this PR fixes or relates to

Fixes #1789

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
