### PR TITLE
Chore: remove unused clientConfig from ingester

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -192,8 +192,7 @@ func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {
 type Ingester struct {
 	*services.BasicService
 
-	cfg          Config
-	clientConfig client.Config
+	cfg Config
 
 	metrics *ingesterMetrics
 	logger  log.Logger
@@ -263,7 +262,7 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 }
 
 // New returns an Ingester that uses Mimir block storage.
-func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, registerer prometheus.Registerer, logger log.Logger) (*Ingester, error) {
+func New(cfg Config, limits *validation.Overrides, registerer prometheus.Registerer, logger log.Logger) (*Ingester, error) {
 	defaultInstanceLimits = &cfg.DefaultLimits
 
 	if cfg.ingesterClientFactory == nil {
@@ -274,7 +273,6 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, r
 	if err != nil {
 		return nil, err
 	}
-	i.clientConfig = clientConfig
 	i.ingestionRate = util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval)
 	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetricsEnabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests)
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2863,13 +2863,12 @@ func prepareIngesterWithBlockStorageAndOverrides(t testing.TB, ingesterCfg Confi
 	}
 
 	bucketDir := t.TempDir()
-	clientCfg := defaultClientTestConfig()
 
 	ingesterCfg.BlocksStorageConfig.TSDB.Dir = dataDir
 	ingesterCfg.BlocksStorageConfig.Bucket.Backend = "filesystem"
 	ingesterCfg.BlocksStorageConfig.Bucket.Filesystem.Directory = bucketDir
 
-	ingester, err := New(ingesterCfg, clientCfg, overrides, registerer, log.NewNopLogger())
+	ingester, err := New(ingesterCfg, overrides, registerer, log.NewNopLogger())
 	if err != nil {
 		return nil, err
 	}
@@ -2993,7 +2992,6 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 		testName := name
 		testData := test
 		t.Run(testName, func(t *testing.T) {
-			clientCfg := defaultClientTestConfig()
 			limits := defaultLimitsTestConfig()
 
 			overrides, err := validation.NewOverrides(limits, nil)
@@ -3011,7 +3009,7 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 			// setup the tsdbs dir
 			testData.setup(t, tempDir)
 
-			ingester, err := New(ingesterCfg, clientCfg, overrides, nil, log.NewNopLogger())
+			ingester, err := New(ingesterCfg, overrides, nil, log.NewNopLogger())
 			require.NoError(t, err)
 
 			startErr := services.StartAndAwaitRunning(context.Background(), ingester)
@@ -4006,7 +4004,6 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 		require.NoError(t, db.Close())
 	}
 
-	clientCfg := defaultClientTestConfig()
 	limits := defaultLimitsTestConfig()
 
 	overrides, err := validation.NewOverrides(limits, nil)
@@ -4018,7 +4015,7 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 	ingesterCfg.BlocksStorageConfig.Bucket.S3.Endpoint = "localhost"
 	ingesterCfg.BlocksStorageConfig.TSDB.Retention = 2 * 24 * time.Hour // Make sure that no newly created blocks are deleted.
 
-	ingester, err := New(ingesterCfg, clientCfg, overrides, nil, log.NewNopLogger())
+	ingester, err := New(ingesterCfg, overrides, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ingester))
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -465,7 +465,7 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.InstanceLimitsFn = ingesterInstanceLimits(t.RuntimeConfig)
 	t.tsdbIngesterConfig()
 
-	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Cfg.IngesterClient, t.Overrides, prometheus.DefaultRegisterer, util_log.Logger)
+	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Overrides, prometheus.DefaultRegisterer, util_log.Logger)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
#### What this PR does
I recently noticed we have `clientConfig` in `Ingester` but that's unused. I think it's a left over from chunks storage. We can safely remove it.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
