### PR TITLE
Refactoring: force removal of all blocks when BucketStore is closed

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -181,7 +181,7 @@ func prepareStoreWithTestBlocksForSeries(t testing.TB, dir string, bkt objstore.
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
-		assert.NoError(t, s.store.Close())
+		assert.NoError(t, s.store.RemoveBlocksAndClose())
 	})
 
 	s.store = store

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -429,7 +429,7 @@ func (u *BucketStores) closeEmptyBucketStore(userID string) error {
 	u.storesMu.Unlock()
 
 	u.metaFetcherMetrics.RemoveUserRegistry(userID)
-	return bs.Close()
+	return bs.RemoveBlocksAndClose()
 }
 
 func isEmptyBucketStore(bs *BucketStore) bool {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1734,7 +1734,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		WithIndexCache(indexCache),
 	)
 	assert.NoError(t, err)
-	defer func() { assert.NoError(t, store.Close()) }()
+	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
 
 	assert.NoError(t, store.SyncBlocks(context.Background()))
 
@@ -2011,7 +2011,7 @@ func setupStoreForHintsTest(t *testing.T) (test.TB, *BucketStore, []*storepb.Ser
 	assert.NoError(tb, err)
 	assert.NoError(tb, store.SyncBlocks(context.Background()))
 
-	closers = append(closers, func() { assert.NoError(t, store.Close()) })
+	closers = append(closers, func() { assert.NoError(t, store.RemoveBlocksAndClose()) })
 
 	return tb, store, seriesSet1, seriesSet2, block1, block2, func() {
 		for _, close := range closers {


### PR DESCRIPTION
#### What this PR does
In this refactoring PR I'm forcing the removal of all blocks from `BucketStore` when it gets closed. To clearly see all places where it gets closed and signal the logic change, I've renamed `BucketStore.Close()` to `BucketStore.RemoveBlocksAndClose()`.

Given the current state of the store-gateway code, this change is expected to be a no-op. The reason is that we currently close the `BucketStore` only if it's empty (so there are no blocks) in `closeEmptyBucketStore()`. However, in a next PR I would like to change such logic and let close the `BucketStore` regardless it's empty or not, letting the `BucketStore` taking care of removing all blocks (releasing their resources) when it gets closed.

#### Which issue(s) this PR fixes or relates to

Part of #1805

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
