### PR TITLE
Refactoring: simplify FilterUsers() logic in store-gateway

### DIFF
--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -63,7 +62,7 @@ func TestBucketIndexMetadataFetcher_Fetch(t *testing.T) {
 		newMinTimeMetaFilter(1 * time.Hour),
 	}
 
-	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, newNoShardingStrategy(), nil, logger, reg, filters)
+	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, nil, logger, reg, filters)
 	metas, partials, err := fetcher.Fetch(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, map[ulid.ULID]*metadata.Meta{
@@ -118,7 +117,7 @@ func TestBucketIndexMetadataFetcher_Fetch_NoBucketIndex(t *testing.T) {
 	logs := &concurrency.SyncBuffer{}
 	logger := log.NewLogfmtLogger(logs)
 
-	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, newNoShardingStrategy(), nil, logger, reg, nil)
+	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, nil, logger, reg, nil)
 	metas, partials, err := fetcher.Fetch(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, metas)
@@ -173,7 +172,7 @@ func TestBucketIndexMetadataFetcher_Fetch_CorruptedBucketIndex(t *testing.T) {
 	// Upload a corrupted bucket index.
 	require.NoError(t, bkt.Upload(ctx, path.Join(userID, bucketindex.IndexCompressedFilename), strings.NewReader("invalid}!")))
 
-	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, newNoShardingStrategy(), nil, logger, reg, nil)
+	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, nil, logger, reg, nil)
 	metas, partials, err := fetcher.Fetch(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, metas)
@@ -214,129 +213,6 @@ func TestBucketIndexMetadataFetcher_Fetch_CorruptedBucketIndex(t *testing.T) {
 		"blocks_meta_synced",
 		"blocks_meta_syncs_total",
 	))
-}
-
-func TestBucketIndexMetadataFetcher_Fetch_ShouldResetGaugeMetrics(t *testing.T) {
-	const userID = "user-1"
-
-	bkt, _ := mimir_testutil.PrepareFilesystemBucket(t)
-	reg := prometheus.NewPedanticRegistry()
-	ctx := context.Background()
-	now := time.Now()
-	logger := log.NewNopLogger()
-	strategy := &mockShardingStrategy{}
-	strategy.On("FilterUsers", mock.Anything, mock.Anything).Return([]string{userID})
-
-	// Corrupted bucket index.
-	require.NoError(t, bkt.Upload(ctx, path.Join(userID, bucketindex.IndexCompressedFilename), strings.NewReader("invalid}!")))
-
-	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, strategy, nil, logger, reg, nil)
-	metas, _, err := fetcher.Fetch(ctx)
-	require.NoError(t, err)
-	assert.Len(t, metas, 0)
-
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP blocks_meta_synced Number of block metadata synced
-		# TYPE blocks_meta_synced gauge
-		blocks_meta_synced{state="corrupted-bucket-index"} 1
-		blocks_meta_synced{state="corrupted-meta-json"} 0
-		blocks_meta_synced{state="duplicate"} 0
-		blocks_meta_synced{state="failed"} 0
-		blocks_meta_synced{state="label-excluded"} 0
-		blocks_meta_synced{state="loaded"} 0
-		blocks_meta_synced{state="marked-for-deletion"} 0
-		blocks_meta_synced{state="marked-for-no-compact"} 0
-		blocks_meta_synced{state="no-bucket-index"} 0
-		blocks_meta_synced{state="no-meta-json"} 0
-		blocks_meta_synced{state="time-excluded"} 0
-		blocks_meta_synced{state="min-time-excluded"} 0
-		blocks_meta_synced{state="too-fresh"} 0
-	`), "blocks_meta_synced"))
-
-	// No bucket index.
-	require.NoError(t, bucketindex.DeleteIndex(ctx, bkt, userID, nil))
-
-	metas, _, err = fetcher.Fetch(ctx)
-	require.NoError(t, err)
-	assert.Len(t, metas, 0)
-
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP blocks_meta_synced Number of block metadata synced
-		# TYPE blocks_meta_synced gauge
-		blocks_meta_synced{state="corrupted-bucket-index"} 0
-		blocks_meta_synced{state="corrupted-meta-json"} 0
-		blocks_meta_synced{state="duplicate"} 0
-		blocks_meta_synced{state="failed"} 0
-		blocks_meta_synced{state="label-excluded"} 0
-		blocks_meta_synced{state="loaded"} 0
-		blocks_meta_synced{state="marked-for-deletion"} 0
-		blocks_meta_synced{state="marked-for-no-compact"} 0
-		blocks_meta_synced{state="no-bucket-index"} 1
-		blocks_meta_synced{state="no-meta-json"} 0
-		blocks_meta_synced{state="time-excluded"} 0
-		blocks_meta_synced{state="min-time-excluded"} 0
-		blocks_meta_synced{state="too-fresh"} 0
-	`), "blocks_meta_synced"))
-
-	// Create a bucket index.
-	block1 := &bucketindex.Block{ID: ulid.MustNew(1, nil)}
-	block2 := &bucketindex.Block{ID: ulid.MustNew(2, nil)}
-	block3 := &bucketindex.Block{ID: ulid.MustNew(3, nil)}
-
-	require.NoError(t, bucketindex.WriteIndex(ctx, bkt, userID, nil, &bucketindex.Index{
-		Version:   bucketindex.IndexVersion1,
-		Blocks:    bucketindex.Blocks{block1, block2, block3},
-		UpdatedAt: now.Unix(),
-	}))
-
-	metas, _, err = fetcher.Fetch(ctx)
-	require.NoError(t, err)
-	assert.Len(t, metas, 3)
-
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP blocks_meta_synced Number of block metadata synced
-		# TYPE blocks_meta_synced gauge
-		blocks_meta_synced{state="corrupted-bucket-index"} 0
-		blocks_meta_synced{state="corrupted-meta-json"} 0
-		blocks_meta_synced{state="duplicate"} 0
-		blocks_meta_synced{state="failed"} 0
-		blocks_meta_synced{state="label-excluded"} 0
-		blocks_meta_synced{state="loaded"} 3
-		blocks_meta_synced{state="marked-for-deletion"} 0
-		blocks_meta_synced{state="marked-for-no-compact"} 0
-		blocks_meta_synced{state="no-bucket-index"} 0
-		blocks_meta_synced{state="no-meta-json"} 0
-		blocks_meta_synced{state="time-excluded"} 0
-		blocks_meta_synced{state="min-time-excluded"} 0
-		blocks_meta_synced{state="too-fresh"} 0
-	`), "blocks_meta_synced"))
-
-	// Remove the tenant from the shard.
-	strategy = &mockShardingStrategy{}
-	strategy.On("FilterUsers", mock.Anything, mock.Anything).Return([]string{})
-	fetcher.strategy = strategy
-
-	metas, _, err = fetcher.Fetch(ctx)
-	require.NoError(t, err)
-	assert.Len(t, metas, 0)
-
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP blocks_meta_synced Number of block metadata synced
-		# TYPE blocks_meta_synced gauge
-		blocks_meta_synced{state="corrupted-bucket-index"} 0
-		blocks_meta_synced{state="corrupted-meta-json"} 0
-		blocks_meta_synced{state="duplicate"} 0
-		blocks_meta_synced{state="failed"} 0
-		blocks_meta_synced{state="label-excluded"} 0
-		blocks_meta_synced{state="loaded"} 0
-		blocks_meta_synced{state="marked-for-deletion"} 0
-		blocks_meta_synced{state="marked-for-no-compact"} 0
-		blocks_meta_synced{state="no-bucket-index"} 0
-		blocks_meta_synced{state="no-meta-json"} 0
-		blocks_meta_synced{state="time-excluded"} 0
-		blocks_meta_synced{state="min-time-excluded"} 0
-		blocks_meta_synced{state="too-fresh"} 0
-	`), "blocks_meta_synced"))
 }
 
 // noShardingStrategy is a no-op strategy. When this strategy is used, no tenant/block is filtered out.

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -276,15 +275,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 
 	// Lazily create a bucket store for each new user found
 	// and submit a sync job for each user.
-	for _, userID := range userIDs {
-		// If we don't have a store for the tenant yet, then we should skip it if it's not
-		// included in the store-gateway shard. If we already have it, we need to sync it
-		// anyway to make sure all its blocks are unloaded and metrics updated correctly
-		// (but bucket API calls are skipped thanks to the objstore client adapter).
-		if _, included := includeUserIDs[userID]; !included && u.getStore(userID) == nil {
-			continue
-		}
-
+	for userID := range includeUserIDs {
 		bs, err := u.getOrCreateStore(userID)
 		if err != nil {
 			errsMx.Lock()
@@ -312,7 +303,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 	close(jobs)
 	wg.Wait()
 
-	u.deleteLocalFilesForExcludedTenants(includeUserIDs)
+	u.closeBucketStoreAndDeleteLocalFilesForExcludedTenants(includeUserIDs)
 
 	return errs.Err()
 }
@@ -397,16 +388,14 @@ func (u *BucketStores) getStore(userID string) *BucketStore {
 }
 
 var (
-	errBucketStoreNotEmpty = errors.New("bucket store not empty")
 	errBucketStoreNotFound = errors.New("bucket store not found")
 )
 
-// closeEmptyBucketStore closes bucket store for given user, if it is empty,
+// closeBucketStore closes bucket store for given user
 // and removes it from bucket stores map and metrics.
 // If bucket store doesn't exist, returns errBucketStoreNotFound.
-// If bucket store is not empty, returns errBucketStoreNotEmpty.
 // Otherwise returns error from closing the bucket store.
-func (u *BucketStores) closeEmptyBucketStore(userID string) error {
+func (u *BucketStores) closeBucketStore(userID string) error {
 	u.storesMu.Lock()
 	unlockInDefer := true
 	defer func() {
@@ -420,21 +409,12 @@ func (u *BucketStores) closeEmptyBucketStore(userID string) error {
 		return errBucketStoreNotFound
 	}
 
-	if !isEmptyBucketStore(bs) {
-		return errBucketStoreNotEmpty
-	}
-
 	delete(u.stores, userID)
 	unlockInDefer = false
 	u.storesMu.Unlock()
 
 	u.metaFetcherMetrics.RemoveUserRegistry(userID)
 	return bs.RemoveBlocksAndClose()
-}
-
-func isEmptyBucketStore(bs *BucketStore) bool {
-	min, max := bs.TimeRange()
-	return min == math.MaxInt64 && max == math.MinInt64
 }
 
 func (u *BucketStores) syncDirForUser(userID string) string {
@@ -483,25 +463,17 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 		fetcher = NewBucketIndexMetadataFetcher(
 			userID,
 			u.bucket,
-			u.shardingStrategy,
 			u.limits,
 			u.logger,
 			fetcherReg,
 			filters,
 		)
 	} else {
-		// Wrap the bucket reader to skip iterating the bucket at all if the user doesn't
-		// belong to the store-gateway shard. We need to run the BucketStore synching anyway
-		// in order to unload previous tenants in case of a resharding leading to tenants
-		// moving out from the store-gateway shard and also make sure both MetaFetcher and
-		// BucketStore metrics are correctly updated.
-		fetcherBkt := NewShardingBucketReaderAdapter(userID, u.shardingStrategy, userBkt)
-
 		var err error
 		fetcher, err = block.NewMetaFetcher(
 			userLogger,
 			u.cfg.BucketStore.MetaSyncConcurrency,
-			fetcherBkt,
+			userBkt,
 			u.syncDirForUser(userID), // The fetcher stores cached metas in the "meta-syncer/" sub directory
 			fetcherReg,
 			filters,
@@ -549,9 +521,9 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 	return bs, nil
 }
 
-// deleteLocalFilesForExcludedTenants removes local "sync" directories for tenants that are not included in the current
-// shard.
-func (u *BucketStores) deleteLocalFilesForExcludedTenants(includeUserIDs map[string]struct{}) {
+// closeBucketStoreAndDeleteLocalFilesForExcludedTenants closes bucket store and removes local "sync" directories
+// for tenants that are not included in the current shard.
+func (u *BucketStores) closeBucketStoreAndDeleteLocalFilesForExcludedTenants(includeUserIDs map[string]struct{}) {
 	files, err := ioutil.ReadDir(u.cfg.BucketStore.SyncDir)
 	if err != nil {
 		return
@@ -568,10 +540,8 @@ func (u *BucketStores) deleteLocalFilesForExcludedTenants(includeUserIDs map[str
 			continue
 		}
 
-		err := u.closeEmptyBucketStore(userID)
+		err := u.closeBucketStore(userID)
 		switch {
-		case errors.Is(err, errBucketStoreNotEmpty):
-			continue
 		case errors.Is(err, errBucketStoreNotFound):
 			// This is OK, nothing was closed.
 		case err == nil:


### PR DESCRIPTION
#### What this PR does
To ease the resolution of #1805, I need to get to the point `ShardingStrategy.FilterUsers()` is only called in a single place inside the store-gateway. This PR does a refactoring to achieve it.

**A bit of history:**
`BucketStore` was originally vendored from Thanos and we didn't have control over it. Since blocks were not removed on `BucketStore.Close()`, before closing the `BucketStore` we had to call `BucketStore.SyncBlocks()` and make sure `SyncBlocks()` was removing all blocks.

Since we need to close a `BucketStore` for a tenant only when that tenant doesn't belong to the store-gateway shard anymore, to do achieve it we did some hacks to have the `MetadataFetcher` returning "no blocks" when the tenant wasn't belonging to the shard.

To do it we did introduce the following logic, depending bucket index was used or not:
- Bucket index **enabled**: add strategy to `BucketIndexMetadataFetcher` and call `FilterUsers()` in `BucketIndexMetadataFetcher.Fetch()`.
- Bucket index **disabled**: wrap `MetaFetcher` with `shardingBucketReaderAdapter` and filter out tenants not belonging to the shard. Basically, it was simulating an "empty bucket" for any tenant not belonging to the shard.

**Fast-forwarding to nowadays:**
Today we are in control of `BucketStore`, so in https://github.com/grafana/mimir/pull/1817 I changed the code to remove all blocks before closing it. This tiny change brings an huge benefit: we don't have to call `SyncBlocks()` anymore to unload all blocks before closing `BucketStore`.

This allowed me this remove the hacks described above to make `MetadataFetcher` returning "no blocks" when the tenant doesn't belong to the shard anymore.

So, in this PR I keep calling `SyncBlocks()` **only** for tenants belonging to the shard. Then, at the end of `BucketStores.syncUsersBlocks()` we "forcely" close `BucketStore` for tenants not belonging to the shard anymore. The result is that `ShardingStrategy.FilterUsers()` is called only in 1 place, inside `BucketStores.syncUsersBlocks()`.

**Manual tests I've done:**
The following manual tests have been done both with bucket index enabled and disabled:
- Store-gateway synching works fine
  - Check: queries work fine
  - Check: metrics are consistent
- User is reshuffled to another store-gateway
  - Check: queries works fine
  - Check: metrics are consistent
  - Check: store-gateway local disk is cleaned up for tenants moved to another store-gateway
- The following metrics have been checked to make sure the were consistent after reshuffling
  - COUNTER    cortex_bucket_store_block_loads_total
  - COUNTER    cortex_bucket_store_block_load_failures_total
  - COUNTER    cortex_bucket_store_block_drops_total
  - COUNTER    cortex_bucket_store_block_drop_failures_total
  - COUNTER    cortex_blocks_meta_syncs_total
  - COUNTER    cortex_blocks_meta_sync_failures_total
  - HISTOGRAM  cortex_blocks_meta_sync_duration_seconds
  - GAUGE (TX) cortex_blocks_meta_synced

#### Which issue(s) this PR fixes or relates to

Part of #1805

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
