### PR TITLE
Alertmanager: Do not validate alertmanager configuration if it's not running.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * [BUGFIX] Multikv: Fix watching for runtime config changes in `multi` KV store in ruler and querier. #1665
 * [BUGFIX] Memcached: allow to use CNAME DNS records for the memcached backend addresses. #1654
 * [BUGFIX] Querier: fixed temporary partial query results when shuffle sharding is enabled and hash ring backend storage is flushed / reset. #1829
+* [BUGFIX] Alertmanager: Do not validate alertmanager configuration if it's not running. #1835
 
 ### Mixin
 

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -202,8 +202,10 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.AlertmanagerStorage.Validate(); err != nil {
 		return errors.Wrap(err, "invalid alertmanager storage config")
 	}
-	if err := c.Alertmanager.Validate(c.AlertmanagerStorage); err != nil {
-		return errors.Wrap(err, "invalid alertmanager config")
+	if c.isModuleEnabled(AlertManager) {
+		if err := c.Alertmanager.Validate(c.AlertmanagerStorage); err != nil {
+			return errors.Wrap(err, "invalid alertmanager config")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Allows other targets to start up even if an invalid alertmanager configuration
is passed in.

Fixes #1784
