### PR TITLE
Jsonnet: Preparatory refactoring to simplify deploying parallel query paths.

### DIFF
--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -37,15 +37,18 @@
     JAEGER_REPORTER_MAX_QUEUE_SIZE: '1024',  // Default is 100.
   },
 
-  querier_container::
-    container.new('querier', $._images.querier) +
+  newQuerierContainer(name, args)::
+    container.new(name, $._images.querier) +
     container.withPorts($.querier_ports) +
-    container.withArgsMixin($.util.mapToFlags($.querier_args)) +
+    container.withArgsMixin($.util.mapToFlags(args)) +
     $.jaeger_mixin +
     $.util.readinessProbe +
     container.withEnvMap($.querier_env_map) +
     $.util.resourcesRequests('1', '12Gi') +
     $.util.resourcesLimits(null, '24Gi'),
+
+  querier_container::
+    self.newQuerierContainer('querier', $.querier_args),
 
   local deployment = $.apps.v1.deployment,
 

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -30,14 +30,17 @@
       'runtime-config.file': '%s/overrides.yaml' % $._config.overrides_configmap_mountpoint,
     },
 
-  query_frontend_container::
-    container.new('query-frontend', $._images.query_frontend) +
+  newQueryFrontendContainer(name, args)::
+    container.new(name, $._images.query_frontend) +
     container.withPorts($.util.defaultPorts) +
-    container.withArgsMixin($.util.mapToFlags($.query_frontend_args)) +
+    container.withArgsMixin($.util.mapToFlags(args)) +
     $.jaeger_mixin +
     $.util.readinessProbe +
     $.util.resourcesRequests('2', '600Mi') +
     $.util.resourcesLimits(null, '1200Mi'),
+
+  query_frontend_container::
+    self.newQueryFrontendContainer('query-frontend', $.query_frontend_args),
 
   local deployment = $.apps.v1.deployment,
 

--- a/operations/mimir/query-scheduler.libsonnet
+++ b/operations/mimir/query-scheduler.libsonnet
@@ -13,14 +13,17 @@
       'query-scheduler.max-outstanding-requests-per-tenant': 100,
     },
 
-  query_scheduler_container::
-    container.new('query-scheduler', $._images.query_scheduler) +
+  newQuerySchedulerContainer(name, args)::
+    container.new(name, $._images.query_scheduler) +
     container.withPorts($.util.defaultPorts) +
-    container.withArgsMixin($.util.mapToFlags($.query_scheduler_args)) +
+    container.withArgsMixin($.util.mapToFlags(args)) +
     $.jaeger_mixin +
     $.util.readinessProbe +
     $.util.resourcesRequests('2', '1Gi') +
     $.util.resourcesLimits(null, '2Gi'),
+
+  query_scheduler_container::
+    self.newQuerySchedulerContainer('query-scheduler', $.query_scheduler_args),
 
   newQuerySchedulerDeployment(name, container)::
     deployment.new(name, 2, [container]) +
@@ -37,20 +40,35 @@
   query_scheduler_service: if !$._config.query_scheduler_enabled then {} else
     $.util.serviceFor($.query_scheduler_deployment, $._config.service_ignored_labels),
 
+  local discoveryServiceName(prefix) = '%s-discovery' % prefix,
+
   // Headless to make sure resolution gets IP address of target pods, and not service IP.
-  query_scheduler_discovery_service: if !$._config.query_scheduler_enabled then {} else
-    $.util.serviceFor($.query_scheduler_deployment, $._config.service_ignored_labels) +
+  newQuerySchedulerDiscoveryService(name, deployment)::
+    $.util.serviceFor(deployment, $._config.service_ignored_labels) +
     service.mixin.spec.withPublishNotReadyAddresses(true) +
     service.mixin.spec.withClusterIp('None') +
-    service.mixin.metadata.withName('query-scheduler-discovery'),
+    service.mixin.metadata.withName(discoveryServiceName(name)),
+
+  query_scheduler_discovery_service: if !$._config.query_scheduler_enabled then {} else
+    self.newQuerySchedulerDiscoveryService('query-scheduler', $.query_scheduler_deployment),
 
   // Reconfigure querier and query-frontend to use scheduler.
-  querier_args+:: if !$._config.query_scheduler_enabled then {} else {
+
+  local querySchedulerAddress(name) =
+    '%s.%s.svc.cluster.local:9095' % [discoveryServiceName(name), $._config.namespace],
+
+  querierUseQuerySchedulerArgs(name):: {
     'querier.frontend-address': null,
-    'querier.scheduler-address': 'query-scheduler-discovery.%(namespace)s.svc.cluster.local:9095' % $._config,
+    'querier.scheduler-address': querySchedulerAddress(name),
   },
 
-  query_frontend_args+:: if !$._config.query_scheduler_enabled then {} else {
-    'query-frontend.scheduler-address': 'query-scheduler-discovery.%(namespace)s.svc.cluster.local:9095' % $._config,
+  queryFrontendUseQuerySchedulerArgs(name):: {
+    'query-frontend.scheduler-address': querySchedulerAddress(name),
   },
+
+  querier_args+:: if !$._config.query_scheduler_enabled then {} else
+    self.querierUseQuerySchedulerArgs('query-scheduler'),
+
+  query_frontend_args+:: if !$._config.query_scheduler_enabled then {} else
+    self.queryFrontendUseQuerySchedulerArgs('query-scheduler'),
 }


### PR DESCRIPTION
This change extracts some of the jsonnet used to build query deployments
(querier, query-scheduler, query-frontend) such that it is easier to deploy
secondary query paths. The use case for this is primarily to develop a
query path deployment for ruler remote-evaluation, but there may be other
use cases too.
