### PR TITLE
Reference 'monolithic mode' instead of 'single binary' in logs

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -183,8 +183,7 @@ func (a *API) newRoute(path string, handler http.Handler, isPrefix, auth, gzip b
 	return route
 }
 
-// RegisterAlertmanager registers endpoints associated with the alertmanager. It will only
-// serve endpoints using the legacy http-prefix if it is not run as a single binary.
+// RegisterAlertmanager registers endpoints that are associated with the alertmanager.
 func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, apiEnabled bool, buildInfoHandler http.Handler) {
 	alertmanagerpb.RegisterAlertmanagerServer(a.server.GRPC, am)
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -231,7 +231,7 @@ func NewQuerierHandler(
 	router := mux.NewRouter()
 
 	// Use a separate metric for the querier in order to differentiate requests from the query-frontend when
-	// running Mimir as a single binary.
+	// running Mimir in monolithic mode.
 	instrumentMiddleware := middleware.Instrument{
 		RouteMatcher:     router,
 		Duration:         querierRequestDuration,

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -84,7 +84,7 @@ func errUnsupportedResultsCacheBackend(unsupportedBackend string) error {
 // newResultsCache creates a new results cache based on the input configuration.
 func newResultsCache(cfg ResultsCacheConfig, logger log.Logger, reg prometheus.Registerer) (cache.Cache, error) {
 	// Add the "component" label similarly to other components, so that metrics don't clash and have the same labels set
-	// when running in single binary mode.
+	// when running in monolithic mode.
 	reg = extprom.WrapRegistererWith(prometheus.Labels{"component": "query-frontend"}, reg)
 
 	client, err := cache.CreateClient("frontend-cache", cfg.BackendConfig, logger, reg)


### PR DESCRIPTION
#### What this PR does
In this PR:
- Reference 'monolithic mode' instead of 'single binary' in logs and code.
- Lower "Worker address is empty in single binary mode" log to info, because I've seen several new adopters being confused by that (it's not really an issue, the automatic config typically works). I've also rephrased the log message to make it more clear about what's going on.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
