### PR TITLE
Relax mimir-continuous-test pressure when deployed with Jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@
 
 ### Jsonnet
 
-* [FEATURE] Added support for `mimir-continuous-test`. To deploy `mimir-continuous-test` you can use the following configuration: #1675
+* [FEATURE] Added support for `mimir-continuous-test`. To deploy `mimir-continuous-test` you can use the following configuration: #1675 #1850
   ```jsonnet
   _config+: {
     continuous_test_enabled: true,

--- a/operations/mimir/continuous-test.libsonnet
+++ b/operations/mimir/continuous-test.libsonnet
@@ -16,6 +16,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     'tests.write-endpoint': $._config.continuous_test_write_endpoint,
     'tests.read-endpoint': $._config.continuous_test_read_endpoint,
     'tests.tenant-id': $._config.continuous_test_tenant_id,
+    'tests.write-read-series-test.num-series': 1000,
+    'tests.write-read-series-test.max-query-age': '48h',
   },
 
   continuous_test_container::


### PR DESCRIPTION
#### What this PR does
I would like to relax the `mimir-continuous-test` pressure when deployed with Jsonnet, based on the experience running it at Grafana Labs.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
