### PR TITLE
Chore: cleanup unused alertmanager config in Mimir jsonnet

### DIFF
--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -188,8 +188,6 @@
 
     alertmanager: {
       replicas: 3,
-      sharding_enabled: false,
-      gossip_port: 9094,
       fallback_config: {},
       ring_store: 'consul',
       ring_hostname: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,


### PR DESCRIPTION
#### What this PR does
While reviewing https://github.com/grafana/mimir/pull/1870, I reliased there are a couple of unused jsonnet config options for alertmanager. In this PR I'm removing them to cleanup the config.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
