### PR TITLE
Checkout the repository as part of the documentation sync

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: "test"
     steps:
+    - name: "Check out code"
+      uses: "actions/checkout@v3"
+
     - name: "Clone website-sync Action"
       run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -6,6 +6,7 @@ on:
     - "main"
     paths:
     - "docs/sources/**"
+    workflow_dispatch:
 jobs:
   test:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
I assumed this was already done but the GitHub docs confirm that it is
required.
https://docs.github.com/en/github-ae@latest/actions/using-workflows/about-workflows#about-workflows.

This also configures `workflow_dispatch` so we can manually trigger the sync in the future.