### PR TITLE
Resync store gateway on limits change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Grafana Mimir - main / unreleased
 
+### Grafana Mimir
+
+* [ENHANCEMENT] Store-gateway: resync blocks as soon as the overrides runtime configuration changes. #1879
+
 ### Mixin
 
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802

--- a/development/tsdb-blocks-storage-s3/config/runtime.yaml
+++ b/development/tsdb-blocks-storage-s3/config/runtime.yaml
@@ -4,4 +4,3 @@
 # multi_kv_config:
 #  mirror_enabled: false
 #  primary: consul
-

--- a/pkg/util/validation/exporter_test.go
+++ b/pkg/util/validation/exporter_test.go
@@ -26,7 +26,7 @@ func TestOverridesExporter_noConfig(t *testing.T) {
 }
 
 func TestOverridesExporter_emptyConfig(t *testing.T) {
-	exporter := NewOverridesExporter(&Limits{}, newMockTenantLimits(nil))
+	exporter := NewOverridesExporter(&Limits{}, NewMockTenantLimits(nil))
 
 	// With no updated override configurations, there should be no override metrics
 	count := testutil.CollectAndCount(exporter, "cortex_limits_overrides")
@@ -64,7 +64,7 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 		MaxFetchedChunkBytesPerQuery: 29,
 		RulerMaxRulesPerRuleGroup:    31,
 		RulerMaxRuleGroupsPerTenant:  32,
-	}, newMockTenantLimits(tenantLimits))
+	}, NewMockTenantLimits(tenantLimits))
 	limitsMetrics := `
 # HELP cortex_limits_overrides Resource limit overrides applied to tenants
 # TYPE cortex_limits_overrides gauge

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/util/validation/limits_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package validation
+
+import "sync"
+
+// MockTenantLimits exposes per-tenant limits based on a provided map
+type MockTenantLimits struct {
+	limits map[string]*Limits
+
+	listenersMx     sync.Mutex
+	listeners       map[int]ChangeListener
+	listenersNextID int
+}
+
+// NewMockTenantLimits creates a new MockTenantLimits that returns per-tenant limits based on
+// the given map
+func NewMockTenantLimits(limits map[string]*Limits) *MockTenantLimits {
+	return &MockTenantLimits{
+		limits:    limits,
+		listeners: make(map[int]ChangeListener),
+	}
+}
+
+func (l *MockTenantLimits) AddChangeListener(listener ChangeListener) ChangeListenerRef {
+	l.listenersMx.Lock()
+	id := l.listenersNextID
+	l.listeners[id] = listener
+	l.listenersNextID++
+	l.listenersMx.Unlock()
+
+	return id
+}
+
+func (l *MockTenantLimits) RemoveChangeListener(ref ChangeListenerRef) {
+	id, ok := ref.(int)
+	if !ok {
+		return
+	}
+
+	l.listenersMx.Lock()
+	delete(l.listeners, id)
+	l.listenersMx.Unlock()
+}
+
+func (l *MockTenantLimits) NotifyChangeListeners() {
+	// Get a copy of all listeners.
+	l.listenersMx.Lock()
+	listeners := make([]ChangeListener, 0, len(l.listeners))
+	for _, entry := range l.listeners {
+		listeners = append(listeners, entry)
+	}
+	l.listenersMx.Unlock()
+
+	// Notify all listeners.
+	for _, listener := range listeners {
+		listener()
+	}
+}
+
+func (l *MockTenantLimits) ByUserID(userID string) *Limits {
+	return l.limits[userID]
+}
+
+func (l *MockTenantLimits) AllByUserID() map[string]*Limits {
+	return l.limits
+}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -20,34 +20,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// mockTenantLimits exposes per-tenant limits based on a provided map
-type mockTenantLimits struct {
-	limits map[string]*Limits
-}
-
-// newMockTenantLimits creates a new mockTenantLimits that returns per-tenant limits based on
-// the given map
-func newMockTenantLimits(limits map[string]*Limits) *mockTenantLimits {
-	return &mockTenantLimits{
-		limits: limits,
-	}
-}
-
-func (l *mockTenantLimits) ByUserID(userID string) *Limits {
-	return l.limits[userID]
-}
-
-func (l *mockTenantLimits) AllByUserID() map[string]*Limits {
-	return l.limits
-}
-
 func TestOverridesManager_GetOverrides(t *testing.T) {
 	tenantLimits := map[string]*Limits{}
 
 	defaults := Limits{
 		MaxLabelNamesPerSeries: 100,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user1"))
@@ -200,7 +179,7 @@ func TestSmallestPositiveIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryParallelism: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -232,7 +211,7 @@ func TestSmallestPositiveNonZeroIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueriersPerTenant: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -264,7 +243,7 @@ func TestSmallestPositiveNonZeroDurationPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryLength: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -479,7 +458,7 @@ testuser:
 			err = yaml.Unmarshal([]byte(tc.overrides), &overrides)
 			require.NoError(t, err, "parsing overrides")
 
-			tl := newMockTenantLimits(overrides)
+			tl := NewMockTenantLimits(overrides)
 
 			ov, err := NewOverrides(limitsYAML, tl)
 			require.NoError(t, err)


### PR DESCRIPTION
#### What this PR does
In this PR I proposes a solution to fix #1832. The idea is to add a change listener `TenantLimits` and register it in the store-gateway. When the store-gateway detects any change on the limits config, we just trigger a resync.

For simplicity, I'm triggering a resync each time the limits config changes (not just the store-gateway shuffle shard size of any tenant) but if you have concerns about it I could work on a more elaborated solution to monitor only a specific config option.

#### Which issue(s) this PR fixes or relates to

Fixes #1832

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
