### PR TITLE
Add alert for store-gateways without blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
-* [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedTenants` alert that fires when there is a store-gateway without any blocks sharded to it. #1882
+* [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedTenants` alert that fires when there is a store-gateway owning no tenants. #1882
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
+* [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedBlocks` alert that fires when there is a store-gateway without any blocks sharded to it. #1882
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
-* [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedBlocks` alert that fires when there is a store-gateway without any blocks sharded to it. #1882
+* [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedTenants` alert that fires when there is a store-gateway without any blocks sharded to it. #1882
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -608,6 +608,15 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirStoreGatewayNoSyncedBlocks
+    annotations:
+      message: Mimir Store Gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} is not syncing any blocks for any tenant.
+    expr: |
+      min by(cluster, namespace, pod) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0
+    for: 1h
+    labels:
+      severity: warning
   - alert: MimirBucketIndexNotUpdated
     annotations:
       message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -608,7 +608,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: MimirStoreGatewayNoSyncedBlocks
+  - alert: MimirStoreGatewayNoSyncedTenants
     annotations:
       message: Mimir Store Gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} is not syncing any blocks for any tenant.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -598,7 +598,7 @@ groups:
       severity: warning
   - alert: MimirStoreGatewayHasNotSyncTheBucket
     annotations:
-      message: Mimir Store Gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+      message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} has not successfully synched the bucket since {{ $value | humanizeDuration
         }}.
     expr: |
@@ -610,7 +610,7 @@ groups:
       severity: critical
   - alert: MimirStoreGatewayNoSyncedTenants
     annotations:
-      message: Mimir Store Gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+      message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} is not syncing any blocks for any tenant.
     expr: |
       min by(cluster, namespace, pod) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -211,7 +211,7 @@
         },
         {
           // Alert if the store-gateway is not owning any tenant.
-          alert: $.alertName('StoreGatewayNoSyncedBlocks'),
+          alert: $.alertName('StoreGatewayNoSyncedTenants'),
           'for': '1h',
           expr: |||
             min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -210,6 +210,20 @@
           },
         },
         {
+          // Alert if the store-gateway is not owning any blocks
+          alert: $.alertName('StoreGatewayNoSyncedBlocks'),
+          'for': '1h',
+          expr: |||
+            min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s Store Gateway %(alert_instance_variable)s in %(alert_aggregation_variables)s is not syncing any blocks for any tenant.' % $._config,
+          },
+        },
+        {
           // Alert if the bucket index has not been updated for a given user.
           alert: $.alertName('BucketIndexNotUpdated'),
           expr: |||

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -206,7 +206,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: '%(product)s Store Gateway %(alert_instance_variable)s in %(alert_aggregation_variables)s has not successfully synched the bucket since {{ $value | humanizeDuration }}.' % $._config,
+            message: '%(product)s store-gateway %(alert_instance_variable)s in %(alert_aggregation_variables)s has not successfully synched the bucket since {{ $value | humanizeDuration }}.' % $._config,
           },
         },
         {
@@ -220,7 +220,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s Store Gateway %(alert_instance_variable)s in %(alert_aggregation_variables)s is not syncing any blocks for any tenant.' % $._config,
+            message: '%(product)s store-gateway %(alert_instance_variable)s in %(alert_aggregation_variables)s is not syncing any blocks for any tenant.' % $._config,
           },
         },
         {

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -210,7 +210,7 @@
           },
         },
         {
-          // Alert if the store-gateway is not owning any blocks
+          // Alert if the store-gateway is not owning any tenant.
           alert: $.alertName('StoreGatewayNoSyncedBlocks'),
           'for': '1h',
           expr: |||

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -446,7 +446,7 @@ How to **investigate**:
 
 - Look for any scan error in the store-gateway logs (ie. networking or rate limiting issues)
 
-### MimirStoreGatewayNoSyncedBlocks
+### MimirStoreGatewayNoSyncedTenants
 
 This alert fires when a store-gateway doesn't own any tenant. Effectively it is sitting idle because no blocks are sharded to it.
 

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -448,11 +448,11 @@ How to **investigate**:
 
 ### MimirStoreGatewayNoSyncedBlocks
 
-This alert fires a store-gateway is not syncing any blocks. Effectively it is sitting idle because no blocks are sharded to it.
+This alert fires when a store-gateway doesn't own any tenant. Effectively it is sitting idle because no blocks are sharded to it.
 
 How it **works**:
 
-- Store-gateways join a hash ring to shard block IDs across all store-gateway replicas.
+- Store-gateways join a hash ring to shard tenants and blocks across all store-gateway replicas.
 - A tenant can be sharded across multiple store-gateways. How many exactly is determined by `-store-gateway.tenant-shard-size` or the `store_gateway_tenant_shard_size` limit.
 - When the tenant shard size is less than the replicas of store-gateways, some store-gateways may not get any tenants' blocks sharded to them.
 - This is more likely to happen in Mimir clusters with fewer number of tenants.

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -446,6 +446,25 @@ How to **investigate**:
 
 - Look for any scan error in the store-gateway logs (ie. networking or rate limiting issues)
 
+### MimirStoreGatewayNoSyncedBlocks
+
+This alert fires a store-gateway is not syncing any blocks. Effectively it is sitting idle because no blocks are sharded to it.
+
+How it **works**:
+
+- Store-gateways join a hash ring to shard block IDs across all store-gateway replicas.
+- A tenant can be sharded across multiple store-gateways. How many exactly is determined by `-store-gateway.tenant-shard-size` or the `store_gateway_tenant_shard_size` limit.
+- When the tenant shard size is less than the replicas of store-gateways, some store-gateways may not get any tenants' blocks sharded to them.
+- This is more likely to happen in Mimir clusters with fewer number of tenants.
+
+How to **fix**:
+
+There are three options:
+
+- Reduce the replicas of store-gateways so that they match the highest number of shards per tenant or
+- Increase the shard size of one or more tenants to match the number of replicas or
+- Set the shard size of one or more tenant to `0`; this will shard this tenant's blocks across all store-gateways.
+
 ### MimirCompactorHasNotSuccessfullyCleanedUpBlocks
 
 This alert fires when a Mimir compactor is not successfully deleting blocks marked for deletion for a long time.
@@ -522,7 +541,7 @@ gsutil mv gs://BUCKET/TENANT/BLOCK gs://BUCKET/TENANT/corrupted-BLOCK
 
 Where:
 
-- `BUCKET` is the gcs bucket name the compactor is using. The cell's bucket name is specified as the `blocks_storage_bucket_name` in the cell configuration
+- `BUCKET` is the gcs bucket name the compactor is using. The cluster's bucket name is specified as the `blocks_storage_bucket_name` in the cluster configuration
 - `TENANT` is the tenant id reported in the example error message above as `REDACTED-TENANT`
 - `BLOCK` is the last part of the file path reported as `REDACTED-BLOCK` in the example error message above
 
@@ -546,7 +565,7 @@ How to **investigate**:
 
 1. Look for partial blocks in the logs. Example Loki query: `{cluster="<cluster>",namespace="<namespace>",container="compactor"} |= "skipped partial block"`
 1. Pick a block and note its ID (`block` field in log entry) and tenant ID (`org_id` in log entry)
-1. Find the bucket used by the Mimir cell, such as checking the configured `blocks_storage_bucket_name` if you are using Jsonnet.
+1. Find the bucket used by the Mimir cluster, such as checking the configured `blocks_storage_bucket_name` if you are using Jsonnet.
 1. Find out which Mimir component operated on the block last (e.g. uploaded by ingester/compactor, or deleted by compactor)
    1. Determine when the partial block was uploaded: `gsutil ls -l gs://${BUCKET}/${TENANT_ID}/${BLOCK_ID}`. Alternatively you can use `ulidtime` command from Mimir tools directory `ulidtime ${BLOCK_ID}` to find block creation time.
    1. Search in the logs around that time to find the log entry from when the compactor created the block ("compacted blocks" for log message)


### PR DESCRIPTION
#### What this PR does

When store-gateways are overscaled some replicas might end up without any blocks sharded to them. This PR adds a warning alert to the monitoring mixin that detects this case.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
