### PR TITLE
Split mimir_queries rule group so that it doesn't have more than 20 rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Mixin
 
+* [CHANGE] Split `mimir_queries` rules group into `mimir_queries` and `mimir_ingester_queries` to keep number of rules per group within the default per-tenant limit. #1885
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870

--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,7 @@ dist: ## Generates binaries for a Mimir release.
 build-mixin: check-mixin-jb
 	@rm -rf $(MIXIN_OUT_PATH) && mkdir $(MIXIN_OUT_PATH)
 	@mixtool generate all --output-alerts $(MIXIN_OUT_PATH)/alerts.yaml --output-rules $(MIXIN_OUT_PATH)/rules.yaml --directory $(MIXIN_OUT_PATH)/dashboards ${MIXIN_PATH}/mixin-compiled.libsonnet
+	@./tools/check-rules.sh $(MIXIN_OUT_PATH)/rules.yaml 20 # If any rule group has more than 20 rules, fail. 20 is our default per-tenant limit in the ruler.
 	@cd $(MIXIN_OUT_PATH)/.. && zip -q -r mimir-mixin.zip $$(basename "$(MIXIN_OUT_PATH)")
 	@echo "The mixin has been compiled to $(MIXIN_OUT_PATH) and archived to $$(realpath --relative-to=$$(pwd) $(MIXIN_OUT_PATH)/../mimir-mixin.zip)"
 

--- a/operations/mimir-mixin-compiled/rules.yaml
+++ b/operations/mimir-mixin-compiled/rules.yaml
@@ -225,6 +225,8 @@ groups:
   - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster,
       job)
     record: cluster_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
+- name: mimir_ingester_queries
+  rules:
   - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m]))
       by (le, cluster, job))
     record: cluster_job:cortex_ingester_queried_series:99quantile

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -47,7 +47,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         name: 'mimir_queries',
         rules:
           utils.histogramRules('cortex_query_frontend_retries', [$._config.per_cluster_label, 'job']) +
-          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job']) +
+          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job']),
+      },
+      {
+        name: 'mimir_ingester_queries',
+        rules:
           utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job']) +
           utils.histogramRules('cortex_ingester_queried_samples', [$._config.per_cluster_label, 'job']) +
           utils.histogramRules('cortex_ingester_queried_exemplars', [$._config.per_cluster_label, 'job']),

--- a/tools/check-rules.sh
+++ b/tools/check-rules.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+RULES="$1"
+LIMIT="$2"
+
+BIG_GROUPS=$(yq -o json eval "$RULES" | jq "[.groups[] | select(.rules | length > $LIMIT) | [.name, (.rules | length)]]" )
+CNT=$(echo "$BIG_GROUPS" | jq "length")
+
+if [[ ${CNT} -gt 0 ]]; then
+  echo Found rule groups with more than $LIMIT rules:
+  echo
+  echo "$BIG_GROUPS" | jq -c -r '.[] | .[0] + ": " + (.[1] | tostring)'
+  exit 1
+fi


### PR DESCRIPTION
#### What this PR does

This PR splits mimir_queries rule group into two, so that each group has less than 20 rules. This PR also adds check for number of rules per group, and fails if there are too many.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
