### PR TITLE
Improve instance limits, ingester limits, query limiter, some querier errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     - `-querier.query-store-after` now defaults to `12h` (previously `0`)
     - `-querier.shuffle-sharding-ingesters-lookback-period` now defaults to `13h` (previously `0`)
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run requests in a dedicated OS thread pool. This feature can be configured using `-store-gateway.thread-pool-size` and is disabled by default. Replaces the ability to run index header operations in a dedicated thread pool. #1660 #1812
-* [ENHANCEMENT] Improved error messages to make them easier to understand and referencing a unique global identifier that can be looked up in the runbooks. #1907 #1919
+* [ENHANCEMENT] Improved error messages to make them easier to understand and referencing a unique global identifier that can be looked up in the runbooks. #1907 #1919 #1888
 * [ENHANCEMENT] Memberlist KV: incoming messages are now processed on per-key goroutine. This may reduce loss of "maintanance" packets in busy memberlist installations, but use more CPU. New `memberlist_client_received_broadcasts_dropped_total` counter tracks number of dropped per-key messages. #1912
 * [BUGFIX] Fix regexp parsing panic for regexp label matchers with start/end quantifiers. #1883
 * [BUGFIX] Ingester: fixed deceiving error log "failed to update cached shipped blocks after shipper initialisation", occurring for each new tenant in the ingester. #1893

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -879,7 +879,7 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 
 	_, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max number of series limit")
+	assert.ErrorContains(t, err, "the query reached the maximum number of series")
 }
 
 func TestHashCollisionHandling(t *testing.T) {

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -879,7 +879,7 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 
 	_, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "the query reached the maximum number of series")
+	assert.ErrorContains(t, err, "the query exceeded the maximum number of series")
 }
 
 func TestHashCollisionHandling(t *testing.T) {

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1134,7 +1134,7 @@ The limit protects the system’s stability from potential abuse or mistakes, an
 
 This critical error occurs when the rate of received samples per second is exceeded in an ingester.
 
-The ingester implements a rate limit on the samples per second that can be ingested, and it's used to protect an ingester from overloading in case of an high traffic.
+The ingester implements a rate limit on the samples per second that can be ingested, and it's used to protect an ingester from overloading in case of high traffic.
 The limit is a per-instance limit and it's applied on all samples received, across all tenants, in each ingester.
 
 How to **fix**:
@@ -1149,14 +1149,14 @@ How to **fix**:
 - In case of emergency, increase the limit by using the `-ingester.instance-limits.max-tenants` option (or `max_tenants` in the runtime config).
 - Consider configuring ingesters shuffle sharding to reduce the number of tenants per ingester.
 
-### err-mimir-ingester-ingester-max-series
+### err-mimir-ingester-max-series
 
 This critical error occurs when an ingester rejects a write request because it reached the maximum number of in-memory series.
 
 How it **works**:
 
 - The ingester keeps most recent series data in-memory.
-- The ingester has a per-instance limit on the number of in-memory series, used to protect the ingester from overloading in case of an high traffic.
+- The ingester has a per-instance limit on the number of in-memory series, used to protect the ingester from overloading in case of high traffic.
 - When the number of in-memory series, new series are rejected, while samples can still be appended to existing ones.
 - You can configure the limit by setting the `-ingester.instance-limits.max-series` option (or `max_series` in the runtime config).
 
@@ -1169,12 +1169,12 @@ This error occurs when an ingester rejects a write request because the max infli
 
 How it **works**:
 - The ingester has per-instance limit on the number of inflight write (push) requests.
-- The limit applies on all inflight write requests, across all tenants, and is used to protect the ingester from overloading in case of an high traffic.
+- The limit applies on all inflight write requests, across all tenants, and is used to protect the ingester from overloading in case of high traffic.
 - You can configure the limit by setting the `-ingester.instance-limits.max-inflight-push-requests` option (or `max_inflight_push_requests` in the runtime config).
 
 How to **fix**:
 - In case of emergency, increase the limit by setting the `-ingester.instance-limits.max-inflight-push-requests` option (or `max_inflight_push_requests` in the runtime config).
-- Check the write requests latency through the `Mimir / Writes` dashboard and eventually investigate the root cause of an high latency (the higher the latency, the higher the number of inflight write requests).
+- Check the write requests latency through the `Mimir / Writes` dashboard and eventually investigate the root cause of high latency (the higher the latency, the higher the number of inflight write requests).
 - Consider scaling out the ingesters.
 
 ### err-mimir-max-series-per-user

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1157,7 +1157,7 @@ How it **works**:
 
 - The ingester keeps most recent series data in-memory.
 - The ingester has a per-instance limit on the number of in-memory series, used to protect the ingester from overloading in case of high traffic.
-- When the number of in-memory series, new series are rejected, while samples can still be appended to existing ones.
+- When the limit on the number of in-memory series is reached, new series are rejected, while samples can still be appended to existing ones.
 - You can configure the limit by setting the `-ingester.instance-limits.max-series` option (or `max_series` in the runtime config).
 
 How to **fix**:
@@ -1181,7 +1181,7 @@ How to **fix**:
 
 This error occurs when the number of in-memory series for a given tenant exceeds the configured limit.
 
-The limit is used to protect ingesters from overloading in case a tenant writes an high number of series, as well as to protect the whole system’s stability from potential abuse or mistakes.
+The limit is used to protect ingesters from overloading in case a tenant writes a high number of series, as well as to protect the whole system’s stability from potential abuse or mistakes.
 You can configure the limit on a per-tenant basis by using the `-ingester.max-global-series-per-user` option (or `max_global_series_per_user` in the runtime configuration).
 
 How to **fix**:
@@ -1201,7 +1201,7 @@ You can configure the limit on a per-tenant basis by using the `-ingester.max-gl
 How to **fix**:
 
 - Check the details in the error message to find out which is the affected metric name.
-- Investigate if the high number of series exposed for the affected metric name are legit.
+- Investigate if the high number of series exposed for the affected metric name is legit.
 - Consider reducing the cardinality of the affected metric, by tuning or removing some of its labels.
 - Consider increasing the per-tenant limit by using the `-ingester.max-global-series-per-metric` option.
 - Consider excluding specific metric names from this limit's check by using the `-ingester.ignore-series-limit-for-metric-names` option (or `max_global_series_per_metric` in the runtime configuration).
@@ -1228,7 +1228,8 @@ This non-critical error occurs when the number of different metadata for a given
 
 Metric metadata is a set of information attached to a metric name, like its unit (e.g. counter) and description.
 Typically, for a given metric name there's only one set of metadata (e.g. the same metric name exposed by different application has the same counter and description).
-However, there could be some edge cases where the same metric name has a different meaning between applications or the same meaning but a slightly different description, and these cases they would expose different metadata.
+However, there could be some edge cases where the same metric name has a different meaning between applications or the same meaning but a slightly different description.
+In these edge cases, different applications would expose different metadata for the same metric name.
 
 This limit is used to protect the whole system’s stability from potential abuse or mistakes, in case the number of metadata variants for a given metric name grows indefinitely.
 You can configure the limit on a per-tenant basis by using the `-ingester.max-global-series-per-metric` option (or `max_global_metadata_per_metric` in the runtime configuration).
@@ -1243,7 +1244,7 @@ How to **fix**:
 
 This error occurs when a query execution exceeds the limit on the number of series chunks fetched.
 
-This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching an huge amount of data.
+This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
 
 How to **fix**:
@@ -1254,7 +1255,7 @@ How to **fix**:
 
 This error occurs when a query execution exceeds the limit on the maximum number of series.
 
-This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching an huge amount of data.
+This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
 
 How to **fix**:
@@ -1265,7 +1266,7 @@ How to **fix**:
 
 This error occurs when a query execution exceeds the limit on aggregated size (in bytes) of fetched chunks.
 
-This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching an huge amount of data.
+This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).
 
 How to **fix**:

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1241,21 +1241,36 @@ How to **fix**:
 
 ### err-mimir-max-chunks-per-query
 
-This non-critical error occurs when a query reads from too many chunks. Try changing the query to span across less data. One way to do that is to include more label selectors. Another is to reduce the range of the query.
+This error occurs when a query execution exceeds the limit on the number of series chunks fetched.
 
-The `-querier.max-fetched-chunks-per-query` option control the default value and the `max_fetched_chunks_per_query` limit controls the per-tenant value.
+This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching an huge amount of data.
+You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
+
+How to **fix**:
+- Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
+- Consider increasing the per-tenant limit by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
 
 ### err-mimir-max-series-per-query
 
-This non-critical error occurs when a query reads from too many series. Try changing the query to span across less data. One way to do that is to include more label selectors. Another is to reduce the range of the query.
+This error occurs when a query execution exceeds the limit on the maximum number of series.
 
-The `-querier.max-fetched-series-per-query` option control the default value and the `max_fetched_series_per_query` limit controls the per-tenant value.
+This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching an huge amount of data.
+You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
+
+How to **fix**:
+- Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
+- Consider increasing the per-tenant limit by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
 
 ### err-mimir-max-chunks-bytes-per-query
 
-This non-critical error occurs when a query reads too much data. Try changing the query to span across less data. One way to do that is to include more label selectors. Another is to reduce the range of the query.
+This error occurs when a query execution exceeds the limit on aggregated size (in bytes) of fetched chunks.
 
-The `-querier.max-fetched-chunk-bytes-per-query` option control the default value and the `max_fetched_chunk_bytes_per_query` limit controls the per-tenant value.
+This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching an huge amount of data.
+You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).
+
+How to **fix**:
+- Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
+- Consider increasing the per-tenant limit by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).
 
 ## Mimir routes by path
 

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1212,6 +1212,7 @@ This non-critical error occurs when the number of in-memory metrics with metadat
 
 Metric metadata is a set of information attached to a metric name, like its unit (e.g. counter) and description.
 Metric metadata can be included by the sender in the write request, and it's returned when querying the `/api/v1/metadata` API endpoint.
+Metric metadata is stored in the ingesters memory, so the higher the number of metrics metadata stored, the higher the memory utilization.
 
 Mimir has a per-tenant limit of the number of metric names that have metadata attached.
 This limit is used to protect the whole system’s stability from potential abuse or mistakes.

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1219,7 +1219,7 @@ You can configure the limit on a per-tenant basis by using the `-ingester.max-gl
 
 How to **fix**:
 
-- Check the current number of metric names for the affected tenant, running the instant query `count(count by(__name__) ({__name__=~".+"}))`
+- Check the current number of metric names for the affected tenant, running the instant query `count(count by(__name__) ({__name__=~".+"}))`. Alternatively, you can get the cardinality of `__name__` label calling the API endpoint `/api/v1/cardinality/label_names`.
 - Consider increasing the per-tenant limit setting to a value greater than the number of unique metric names returned by the previous query.
 
 ### err-mimir-max-metadata-per-metric

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1238,7 +1238,7 @@ How to **fix**:
 
 - Check the metadata for the affected metric name, querying the `/api/v1/metadata?metric=<name>` API endpoint (replace `<name>` with the metric name).
 - If the different metadata is unexpected, consider fixing the discrepancy in the instrumented applications.
-- If the different metadata is expected, Consider increasing the per-tenant limit by using the `-ingester.max-global-series-per-metric` option (or `max_global_metadata_per_metric` in the runtime configuration).
+- If the different metadata is expected, consider increasing the per-tenant limit by using the `-ingester.max-global-series-per-metric` option (or `max_global_metadata_per_metric` in the runtime configuration).
 
 ### err-mimir-max-chunks-per-query
 

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1138,6 +1138,7 @@ The ingester implements a rate limit on the samples per second that can be inges
 The limit is a per-instance limit and it's applied on all samples received, across all tenants, in each ingester.
 
 How to **fix**:
+
 - Scale up ingesters.
 - Increase the limit by using the `-ingester.instance-limits.max-ingestion-rate` option (or `max_ingestion_rate` in the runtime config).
 
@@ -1146,6 +1147,7 @@ How to **fix**:
 This critical error occurs when the ingester receives a write request for a new tenant (a tenant for which no series have been stored yet) but the ingester cannot accept it because the maximum number of allowed tenants per ingester has been reached.
 
 How to **fix**:
+
 - In case of emergency, increase the limit by using the `-ingester.instance-limits.max-tenants` option (or `max_tenants` in the runtime config).
 - Consider configuring ingesters shuffle sharding to reduce the number of tenants per ingester.
 
@@ -1161,6 +1163,7 @@ How it **works**:
 - You can configure the limit by setting the `-ingester.instance-limits.max-series` option (or `max_series` in the runtime config).
 
 How to **fix**:
+
 - See [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit) runbook.
 
 ### err-mimir-ingester-max-inflight-push-requests
@@ -1168,11 +1171,13 @@ How to **fix**:
 This error occurs when an ingester rejects a write request because the max inflight requests limit has been reached.
 
 How it **works**:
+
 - The ingester has per-instance limit on the number of inflight write (push) requests.
 - The limit applies on all inflight write requests, across all tenants, and is used to protect the ingester from overloading in case of high traffic.
 - You can configure the limit by setting the `-ingester.instance-limits.max-inflight-push-requests` option (or `max_inflight_push_requests` in the runtime config).
 
 How to **fix**:
+
 - In case of emergency, increase the limit by setting the `-ingester.instance-limits.max-inflight-push-requests` option (or `max_inflight_push_requests` in the runtime config).
 - Check the write requests latency through the `Mimir / Writes` dashboard and eventually investigate the root cause of high latency (the higher the latency, the higher the number of inflight write requests).
 - Consider scaling out the ingesters.
@@ -1249,6 +1254,7 @@ This limit is used to protect the system’s stability from potential abuse or m
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
 
 How to **fix**:
+
 - Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
 - Consider increasing the per-tenant limit by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
 
@@ -1260,6 +1266,7 @@ This limit is used to protect the system’s stability from potential abuse or m
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
 
 How to **fix**:
+
 - Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
 - Consider increasing the per-tenant limit by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
 
@@ -1271,6 +1278,7 @@ This limit is used to protect the system’s stability from potential abuse or m
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).
 
 How to **fix**:
+
 - Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
 - Consider increasing the per-tenant limit by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).
 

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -54,7 +54,7 @@ How the limit is **configured**:
 - When configured in the runtime config, changes are applied live without requiring an ingester restart
 - The configured limit can be queried via `cortex_ingester_instance_limits{limit="max_series"}`
 
-How to **fix**:
+How to **fix** it:
 
 1. **Temporarily increase the limit**<br />
    If the actual number of series is very close to or already hit the limit, or if you foresee the ingester will hit the limit before dropping the stale series as an effect of the scale up, you should also temporarily increase the limit.
@@ -125,7 +125,7 @@ How the limit is **configured**:
 - When configured in the runtime config, changes are applied live without requiring an ingester restart
 - The configured limit can be queried via `cortex_ingester_instance_limits{limit="max_tenants"}`
 
-How to **fix**:
+How to **fix** it:
 
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
@@ -150,7 +150,7 @@ How the limit is **configured**:
 - These changes are applied with a distributor restart.
 - The configured limit can be queried via `cortex_distributor_instance_limits{limit="max_inflight_push_requests"})`
 
-How to **fix**:
+How to **fix** it:
 
 1. **Temporarily increase the limit**<br />
    If the actual number of inflight push requests is very close to or already hit the limit.
@@ -264,7 +264,7 @@ This alert goes off when an ingester is marked as unhealthy. Check the ring web 
 
 This alert fires when a Mimir process has a number of memory map areas close to the limit. The limit is a per-process limit imposed by the kernel and this issue is typically caused by a large number of mmap-ed failes.
 
-How to **fix**:
+How to **fix** it:
 
 - Increase the limit on your system: `sysctl -w vm.max_map_count=<NEW LIMIT>`
 - If it's caused by a store-gateway, consider enabling `-blocks-storage.bucket-store.index-header-lazy-loading-enabled=true` to lazy mmap index-headers at query time
@@ -285,7 +285,7 @@ This alert fires when rulers cannot push new samples (result of rule evaluation)
 In general, pushing samples can fail due to problems with Mimir operations (eg. too many ingesters have crashed, and ruler cannot write samples to them), or due to problems with resulting data (eg. user hitting limit for number of series, out of order samples, etc.).
 This alert fires only for first kind of problems, and not for problems caused by limits or invalid rules.
 
-How to **fix**:
+How to **fix** it:
 
 - Investigate the ruler logs to find out the reason why ruler cannot write samples. Note that ruler logs all push errors, including "user errors", but those are not causing the alert to fire. Focus on problems with ingesters.
 
@@ -297,7 +297,7 @@ Each rule evaluation may fail due to many reasons, eg. due to invalid PromQL exp
 
 There is a category of errors that is more important: errors due to failure to read data from store-gateways or ingesters. These errors would result in 500 when run from querier. This alert fires if there is too many of such failures.
 
-How to **fix**:
+How to **fix** it:
 
 - Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that ruler logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways.
 
@@ -310,7 +310,7 @@ How it **works**:
 - The Mimir ruler will evaluate a rule group according to the evaluation interval on the rule group.
 - If an evaluation is not finished by the time the next evaluation should happen, the next evaluation is missed.
 
-How to **fix**:
+How to **fix** it:
 
 - Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes.
 - Try splitting up the rule group into multiple rule groups. Rule groups are evaluated in parallel, so the same rules may still fit in the same resolution.
@@ -467,7 +467,7 @@ How it **works**:
 - When the tenant shard size is less than the replicas of store-gateways, some store-gateways may not get any tenants' blocks sharded to them.
 - This is more likely to happen in Mimir clusters with fewer number of tenants.
 
-How to **fix**:
+How to **fix** it:
 
 There are three options:
 
@@ -690,7 +690,7 @@ How to **investigate**:
 
 This alert fires if the average number of in-memory series per ingester is above our target (1.5M).
 
-How to **fix**:
+How to **fix** it:
 
 - Scale up ingesters
   - To find out the Mimir clusters where ingesters should be scaled up and how many minimum replicas are expected:
@@ -704,7 +704,7 @@ How to **fix**:
 
 This alert fires if the average number of samples ingested / sec in ingesters is above our target.
 
-How to **fix**:
+How to **fix** it:
 
 - Scale up ingesters
   - To compute the desired number of ingesters to satisfy the average samples rate you can run the following query, replacing `<namespace>` with the namespace to analyse and `<target>` with the target number of samples/sec per ingester (check out the alert threshold to see the current target):
@@ -724,7 +724,7 @@ How it **works**:
 - Ingester memory short spikes are primarily influenced by queries and TSDB head compaction into new blocks (occurring every 2h)
 - A pod gets `OOMKilled` once its working set memory reaches the configured limit, so it's important to prevent ingesters' memory utilization (working set memory) from getting close to the limit (we need to keep at least 30% room for spikes due to queries)
 
-How to **fix**:
+How to **fix** it:
 
 - Check if the issue occurs only for few ingesters. If so:
   - Restart affected ingesters 1 by 1 (proceed with the next one once the previous pod has restarted and it's Ready)
@@ -883,7 +883,7 @@ How it **works**:
 - Alertmanager memory baseline usage is primarily influenced by memory allocated by the process (mostly Go heap) for alerts and silences.
 - A pod gets `OOMKilled` once its working set memory reaches the configured limit, so it's important to prevent alertmanager's memory utilization (working set memory) from going over to the limit. The memory usage is typically sustained and does not suffer from spikes, hence thresholds are set very close to the limit.
 
-How to **fix**:
+How to **fix** it:
 
 - Scale up alertmanager replicas; you can use e.g. the `Mimir / Scaling` dashboard for reference, in order to determine the needed amount of alertmanagers.
 
@@ -1137,7 +1137,7 @@ This critical error occurs when the rate of received samples per second is excee
 The ingester implements a rate limit on the samples per second that can be ingested, and it's used to protect an ingester from overloading in case of high traffic.
 The limit is a per-instance limit and it's applied on all samples received, across all tenants, in each ingester.
 
-How to **fix**:
+How to **fix** it:
 
 - Scale up ingesters.
 - Increase the limit by using the `-ingester.instance-limits.max-ingestion-rate` option (or `max_ingestion_rate` in the runtime config).
@@ -1146,7 +1146,7 @@ How to **fix**:
 
 This critical error occurs when the ingester receives a write request for a new tenant (a tenant for which no series have been stored yet) but the ingester cannot accept it because the maximum number of allowed tenants per ingester has been reached.
 
-How to **fix**:
+How to **fix** it:
 
 - In case of emergency, increase the limit by using the `-ingester.instance-limits.max-tenants` option (or `max_tenants` in the runtime config).
 - Consider configuring ingesters shuffle sharding to reduce the number of tenants per ingester.
@@ -1162,7 +1162,7 @@ How it **works**:
 - When the limit on the number of in-memory series is reached, new series are rejected, while samples can still be appended to existing ones.
 - You can configure the limit by setting the `-ingester.instance-limits.max-series` option (or `max_series` in the runtime config).
 
-How to **fix**:
+How to **fix** it:
 
 - See [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit) runbook.
 
@@ -1176,7 +1176,7 @@ How it **works**:
 - The limit applies on all inflight write requests, across all tenants, and is used to protect the ingester from overloading in case of high traffic.
 - You can configure the limit by setting the `-ingester.instance-limits.max-inflight-push-requests` option (or `max_inflight_push_requests` in the runtime config).
 
-How to **fix**:
+How to **fix** it:
 
 - In case of emergency, increase the limit by setting the `-ingester.instance-limits.max-inflight-push-requests` option (or `max_inflight_push_requests` in the runtime config).
 - Check the write requests latency through the `Mimir / Writes` dashboard and eventually investigate the root cause of high latency (the higher the latency, the higher the number of inflight write requests).
@@ -1189,7 +1189,7 @@ This error occurs when the number of in-memory series for a given tenant exceeds
 The limit is used to protect ingesters from overloading in case a tenant writes a high number of series, as well as to protect the whole system’s stability from potential abuse or mistakes.
 You can configure the limit on a per-tenant basis by using the `-ingester.max-global-series-per-user` option (or `max_global_series_per_user` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Ensure the actual number of series written by the affected tenant is legit.
 - Consider increasing the per-tenant limit by using the `-ingester.max-global-series-per-user` option (or `max_global_series_per_user` in the runtime configuration).
@@ -1203,7 +1203,7 @@ For example, if an instrumented application exposes a metric with a label value 
 This limit introduces a cap on the maximum number of series each metric name can have, rejecting exceeding series only for that metric name, before the per-tenant series limit is reached.
 You can configure the limit on a per-tenant basis by using the `-ingester.max-global-series-per-metric` option (or `max_global_series_per_metric` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Check the details in the error message to find out which is the affected metric name.
 - Investigate if the high number of series exposed for the affected metric name is legit.
@@ -1223,7 +1223,7 @@ Mimir has a per-tenant limit of the number of metric names that have metadata at
 This limit is used to protect the whole system’s stability from potential abuse or mistakes.
 You can configure the limit on a per-tenant basis by using the `-ingester.max-global-series-per-user` option (or `max_global_metadata_per_user` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Check the current number of metric names for the affected tenant, running the instant query `count(count by(__name__) ({__name__=~".+"}))`. Alternatively, you can get the cardinality of `__name__` label calling the API endpoint `/api/v1/cardinality/label_names`.
 - Consider increasing the per-tenant limit setting to a value greater than the number of unique metric names returned by the previous query.
@@ -1240,7 +1240,7 @@ In these edge cases, different applications would expose different metadata for 
 This limit is used to protect the whole system’s stability from potential abuse or mistakes, in case the number of metadata variants for a given metric name grows indefinitely.
 You can configure the limit on a per-tenant basis by using the `-ingester.max-global-series-per-metric` option (or `max_global_metadata_per_metric` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Check the metadata for the affected metric name, querying the `/api/v1/metadata?metric=<name>` API endpoint (replace `<name>` with the metric name).
 - If the different metadata is unexpected, consider fixing the discrepancy in the instrumented applications.
@@ -1253,7 +1253,7 @@ This error occurs when a query execution exceeds the limit on the number of seri
 This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
 - Consider increasing the per-tenant limit by using the `-querier.max-fetched-chunks-per-query` option (or `max_fetched_chunks_per_query` in the runtime configuration).
@@ -1265,7 +1265,7 @@ This error occurs when a query execution exceeds the limit on the maximum number
 This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
 - Consider increasing the per-tenant limit by using the `-querier.max-fetched-series-per-query` option (or `max_fetched_series_per_query` in the runtime configuration).
@@ -1277,7 +1277,7 @@ This error occurs when a query execution exceeds the limit on aggregated size (i
 This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
 You can configure the limit on a per-tenant basis by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).
 
-How to **fix**:
+How to **fix** it:
 
 - Consider reducing the time range and/or cardinality of the query. To reduce the cardinality of the query, you can add more label matchers to the query, restricting the set of matching series.
 - Consider increasing the per-tenant limit by using the `-querier.max-fetched-chunk-bytes-per-query` option (or `max_fetched_chunk_bytes_per_query` in the runtime configuration).

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -973,7 +973,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "the query reached the maximum number of series")
+	assert.ErrorContains(t, err, "the query exceeded the maximum number of series")
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIsReached(t *testing.T) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -923,7 +923,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "the query hit the max number of chunks limit")
+	assert.Contains(t, err.Error(), "the query reached the max number of chunks limit")
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReached(t *testing.T) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -923,7 +923,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "the query reached the maximum number of chunks")
+	assert.ErrorContains(t, err, "the query exceeded the maximum number of chunks")
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReached(t *testing.T) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -923,7 +923,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "the query reached the max number of chunks limit")
+	assert.ErrorContains(t, err, "the query reached the maximum number of chunks")
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReached(t *testing.T) {
@@ -973,7 +973,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max number of series limit")
+	assert.ErrorContains(t, err, "the query reached the maximum number of series")
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIsReached(t *testing.T) {
@@ -1041,7 +1041,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.Equal(t, err, validation.LimitError(fmt.Sprintf(limiter.MaxChunkBytesHitMsgFormat, maxBytesLimit)))
+	assert.ErrorContains(t, err, fmt.Sprintf(limiter.MaxChunkBytesHitMsgFormat, maxBytesLimit))
 }
 
 func TestDistributor_Push_LabelRemoval(t *testing.T) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1041,7 +1041,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 	// a query running on all series to fail.
 	_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
 	require.Error(t, err)
-	assert.Equal(t, err, validation.LimitError(fmt.Sprintf(limiter.ErrMaxChunkBytesHit, maxBytesLimit)))
+	assert.Equal(t, err, validation.LimitError(fmt.Sprintf(limiter.MaxChunkBytesHitMsgFormat, maxBytesLimit)))
 }
 
 func TestDistributor_Push_LabelRemoval(t *testing.T) {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -89,6 +89,11 @@ const (
 	sampleOutOfOrder     = "sample-out-of-order"
 	newValueForTimestamp = "new-value-for-timestamp"
 	sampleOutOfBounds    = "sample-out-of-bounds"
+
+	maxIngestionRateFlag        = "ingester.instance-limits.max-ingestion-rate"
+	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
+	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
+	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
 )
 
 var (
@@ -158,10 +163,10 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.StreamChunksWhenUsingBlocks, "ingester.stream-chunks-when-using-blocks", true, "Stream chunks from ingesters to queriers.")
 	f.DurationVar(&cfg.ExemplarsUpdatePeriod, "ingester.exemplars-update-period", 15*time.Second, "Period with which to update per-tenant max exemplar limit.")
 
-	f.Float64Var(&cfg.DefaultLimits.MaxIngestionRate, "ingester.instance-limits.max-ingestion-rate", 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
-	f.Int64Var(&cfg.DefaultLimits.MaxInMemoryTenants, "ingester.instance-limits.max-tenants", 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.DefaultLimits.MaxInMemorySeries, "ingester.instance-limits.max-series", 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.DefaultLimits.MaxInflightPushRequests, "ingester.instance-limits.max-inflight-push-requests", 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+	f.Float64Var(&cfg.DefaultLimits.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
+	f.Int64Var(&cfg.DefaultLimits.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
+	f.Int64Var(&cfg.DefaultLimits.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
+	f.Int64Var(&cfg.DefaultLimits.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.")
 }
@@ -556,7 +561,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 	il := i.getInstanceLimits()
 	if il != nil && il.MaxInflightPushRequests > 0 {
 		if inflight > il.MaxInflightPushRequests {
-			return nil, errTooManyInflightPushRequests
+			return nil, errMaxInflightRequestsReached
 		}
 	}
 
@@ -567,7 +572,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 
 	if il != nil && il.MaxIngestionRate > 0 {
 		if rate := i.ingestionRate.Rate(); rate >= il.MaxIngestionRate {
-			return nil, errMaxSamplesPushRateLimitReached
+			return nil, errMaxIngestionRateReached
 		}
 	}
 
@@ -1423,7 +1428,7 @@ func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*userTSDB, error)
 	gl := i.getInstanceLimits()
 	if gl != nil && gl.MaxInMemoryTenants > 0 {
 		if users := int64(len(i.tsdbs)); users >= gl.MaxInMemoryTenants {
-			return nil, errMaxUsersLimitReached
+			return nil, errMaxTenantsReached
 		}
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -89,11 +89,6 @@ const (
 	sampleOutOfOrder     = "sample-out-of-order"
 	newValueForTimestamp = "new-value-for-timestamp"
 	sampleOutOfBounds    = "sample-out-of-bounds"
-
-	maxIngestionRateFlag        = "ingester.instance-limits.max-ingestion-rate"
-	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
-	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
-	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
 )
 
 var (
@@ -163,10 +158,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.StreamChunksWhenUsingBlocks, "ingester.stream-chunks-when-using-blocks", true, "Stream chunks from ingesters to queriers.")
 	f.DurationVar(&cfg.ExemplarsUpdatePeriod, "ingester.exemplars-update-period", 15*time.Second, "Period with which to update per-tenant max exemplar limit.")
 
-	f.Float64Var(&cfg.DefaultLimits.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
-	f.Int64Var(&cfg.DefaultLimits.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.DefaultLimits.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.DefaultLimits.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+	cfg.DefaultLimits.RegisterFlags(f)
 
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.")
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4308,7 +4308,7 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 				},
 			},
 
-			expectedErr: wrapWithUser(errMaxSeriesLimitReached, "test"),
+			expectedErr: wrapWithUser(errMaxInMemorySeriesReached, "test"),
 		},
 
 		"should fail creating two users": {
@@ -4335,7 +4335,7 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 					),
 				},
 			},
-			expectedErr: wrapWithUser(errMaxUsersLimitReached, "user2"),
+			expectedErr: wrapWithUser(errMaxTenantsReached, "user2"),
 		},
 
 		"should fail pushing samples in two requests due to rate limit": {
@@ -4360,7 +4360,7 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 					),
 				},
 			},
-			expectedErr: errMaxSamplesPushRateLimitReached,
+			expectedErr: errMaxIngestionRateReached,
 		},
 	}
 
@@ -4540,7 +4540,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 		req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, "testcase"), 1, 1024)
 
 		_, err := i.Push(ctx, req)
-		require.Equal(t, errTooManyInflightPushRequests, err)
+		require.Equal(t, errMaxInflightRequestsReached, err)
 		return nil
 	})
 

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
-	errMaxIngestionRateReached    = errors.New(globalerror.MaxIngestionRate.MessageWithLimitConfig(maxIngestionRateFlag, "cannot push more samples: exceeded the allowed rate of push requests"))
+	errMaxIngestionRateReached    = errors.New(globalerror.MaxIngesterIngestionRate.MessageWithLimitConfig(maxIngestionRateFlag, "cannot push more samples: exceeded the allowed rate of push requests"))
 	errMaxTenantsReached          = errors.New(globalerror.MaxTenants.MessageWithLimitConfig(maxInMemoryTenantsFlag, "cannot create TSDB: exceeded the allowed number of in-memory tenants in an ingester"))
 	errMaxInMemorySeriesReached   = errors.New(globalerror.MaxInMemorySeries.MessageWithLimitConfig(maxInMemorySeriesFlag, "cannot add series: exceeded the allowed number of in-memory series in an ingester"))
 	errMaxInflightRequestsReached = errors.New(globalerror.MaxInflightPushRequests.MessageWithLimitConfig(maxInflightPushRequestsFlag, "cannot push: exceeded the allowed number of inflight push requests to the ingester"))

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -23,7 +23,7 @@ const (
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
 	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithLimitConfig(maxIngestionRateFlag, "the write request has been rejected because the ingester exceeded the samples ingestion rate limit"))
-	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithLimitConfig(maxInMemoryTenantsFlag, "thr write request has been rejected because the ingester exceeded the allowed number of tenants"))
+	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithLimitConfig(maxInMemoryTenantsFlag, "the write request has been rejected because the ingester exceeded the allowed number of tenants"))
 	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithLimitConfig(maxInMemorySeriesFlag, "the write request has been rejected because the ingester exceeded the allowed number of in-memory series"))
 	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithLimitConfig(maxInflightPushRequestsFlag, "the write request has been rejected because the ingester exceeded the allowed number of inflight push requests"))
 )

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -6,17 +6,26 @@
 package ingester
 
 import (
+	"flag"
+
 	"github.com/pkg/errors"
 
 	"github.com/grafana/mimir/pkg/util/globalerror"
 )
 
+const (
+	maxIngestionRateFlag        = "ingester.instance-limits.max-ingestion-rate"
+	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
+	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
+	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
+)
+
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
-	errMaxIngestionRateReached    = errors.New(globalerror.MaxIngesterIngestionRate.MessageWithLimitConfig(maxIngestionRateFlag, "cannot push more samples: exceeded the allowed rate of push requests"))
-	errMaxTenantsReached          = errors.New(globalerror.MaxTenants.MessageWithLimitConfig(maxInMemoryTenantsFlag, "cannot create TSDB: exceeded the allowed number of in-memory tenants in an ingester"))
-	errMaxInMemorySeriesReached   = errors.New(globalerror.MaxInMemorySeries.MessageWithLimitConfig(maxInMemorySeriesFlag, "cannot add series: exceeded the allowed number of in-memory series in an ingester"))
-	errMaxInflightRequestsReached = errors.New(globalerror.MaxInflightPushRequests.MessageWithLimitConfig(maxInflightPushRequestsFlag, "cannot push: exceeded the allowed number of inflight push requests to the ingester"))
+	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithLimitConfig(maxIngestionRateFlag, "the write request has been rejected because the ingester exceeded the samples ingestion rate limit"))
+	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithLimitConfig(maxInMemoryTenantsFlag, "thr write request has been rejected because the ingester exceeded the allowed number of tenants"))
+	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithLimitConfig(maxInMemorySeriesFlag, "the write request has been rejected because the ingester exceeded the allowed number of in-memory series"))
+	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithLimitConfig(maxInflightPushRequestsFlag, "the write request has been rejected because the ingester exceeded the allowed number of inflight push requests"))
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return
@@ -26,6 +35,13 @@ type InstanceLimits struct {
 	MaxInMemoryTenants      int64   `yaml:"max_tenants" category:"advanced"`
 	MaxInMemorySeries       int64   `yaml:"max_series" category:"advanced"`
 	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+}
+
+func (cfg *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
+	f.Float64Var(&cfg.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
+	f.Int64Var(&cfg.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
+	f.Int64Var(&cfg.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
+	f.Int64Var(&cfg.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -5,14 +5,18 @@
 
 package ingester
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+
+	"github.com/grafana/mimir/pkg/util/globalerror"
+)
 
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
-	errMaxSamplesPushRateLimitReached = errors.New("cannot push more samples: ingester's samples push rate limit reached")
-	errMaxUsersLimitReached           = errors.New("cannot create TSDB: ingesters's max tenants limit reached")
-	errMaxSeriesLimitReached          = errors.New("cannot add series: ingesters's max series limit reached")
-	errTooManyInflightPushRequests    = errors.New("cannot push: too many inflight push requests in ingester")
+	errMaxIngestionRateReached    = errors.New(globalerror.MaxIngestionRate.MessageWithLimitConfig(maxIngestionRateFlag, "cannot push more samples: exceeded the allowed rate of push requests"))
+	errMaxTenantsReached          = errors.New(globalerror.MaxTenants.MessageWithLimitConfig(maxInMemoryTenantsFlag, "cannot create TSDB: exceeded the allowed number of in-memory tenants in an ingester"))
+	errMaxInMemorySeriesReached   = errors.New(globalerror.MaxInMemorySeries.MessageWithLimitConfig(maxInMemorySeriesFlag, "cannot add series: exceeded the allowed number of in-memory series in an ingester"))
+	errMaxInflightRequestsReached = errors.New(globalerror.MaxInflightPushRequests.MessageWithLimitConfig(maxInflightPushRequestsFlag, "cannot push: exceeded the allowed number of inflight push requests to the ingester"))
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -37,11 +37,11 @@ type InstanceLimits struct {
 	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests" category:"advanced"`
 }
 
-func (cfg *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
-	f.Float64Var(&cfg.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
-	f.Int64Var(&cfg.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
+	f.Float64Var(&l.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
+	f.Int64Var(&l.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -115,7 +115,7 @@ func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	actualLimit := l.maxSeriesPerUser(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
 
-	return fmt.Errorf("per-user series limit of %d exceeded, please contact administrator to raise it (per-ingester local limit: %d)",
+	return fmt.Errorf("per-user series limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
 		globalLimit, actualLimit)
 }
 
@@ -123,7 +123,7 @@ func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 	actualLimit := l.maxSeriesPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
 
-	return fmt.Errorf("per-metric series limit of %d exceeded, please contact administrator to raise it (per-ingester local limit: %d)",
+	return fmt.Errorf("per-metric series limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
 		globalLimit, actualLimit)
 }
 
@@ -131,7 +131,7 @@ func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
 	actualLimit := l.maxMetadataPerUser(userID)
 	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
 
-	return fmt.Errorf("per-user metric metadata limit of %d exceeded, please contact administrator to raise it (per-ingester local limit: %d)",
+	return fmt.Errorf("per-user metric metadata limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
 		globalLimit, actualLimit)
 }
 
@@ -139,7 +139,7 @@ func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
 	actualLimit := l.maxMetadataPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
 
-	return fmt.Errorf("per-metric metadata limit of %d exceeded, please contact administrator to raise it (per-ingester local limit: %d)",
+	return fmt.Errorf("per-metric metadata limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
 		globalLimit, actualLimit)
 }
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -114,42 +114,38 @@ func (l *Limiter) FormatError(userID string, err error) error {
 }
 
 func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
-	actualLimit := l.maxSeriesPerUser(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
 
 	return errors.New(globalerror.MaxSeriesPerUser.MessageWithLimitConfig(
 		validation.MaxSeriesPerUserFlag,
-		fmt.Sprintf("per-user series limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+		fmt.Sprintf("per-user series limit of %d exceeded", globalLimit),
 	))
 }
 
 func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
-	actualLimit := l.maxSeriesPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
 
 	return errors.New(globalerror.MaxSeriesPerMetric.MessageWithLimitConfig(
 		validation.MaxSeriesPerMetricFlag,
-		fmt.Sprintf("per-metric series limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+		fmt.Sprintf("per-metric series limit of %d exceeded", globalLimit),
 	))
 }
 
 func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
-	actualLimit := l.maxMetadataPerUser(userID)
 	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
 
 	return errors.New(globalerror.MaxMetadataPerUser.MessageWithLimitConfig(
 		validation.MaxMetadataPerUserFlag,
-		fmt.Sprintf("per-user metric metadata limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+		fmt.Sprintf("per-user metric metadata limit of %d exceeded", globalLimit),
 	))
 }
 
 func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
-	actualLimit := l.maxMetadataPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
 
 	return errors.New(globalerror.MaxMetadataPerMetric.MessageWithLimitConfig(
 		validation.MaxMetadataPerMetricFlag,
-		fmt.Sprintf("per-metric metadata limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+		fmt.Sprintf("per-metric metadata limit of %d exceeded", globalLimit),
 	))
 }
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -12,11 +12,13 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/globalerror"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 var (
+	// These errors are only internal, to change the API error messages, see Limiter's methods below.
 	errMaxSeriesPerMetricLimitExceeded   = errors.New("per-metric series limit exceeded")
 	errMaxMetadataPerMetricLimitExceeded = errors.New("per-metric metadata limit exceeded")
 	errMaxSeriesPerUserLimitExceeded     = errors.New("per-user series limit exceeded")
@@ -115,32 +117,40 @@ func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	actualLimit := l.maxSeriesPerUser(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
 
-	return fmt.Errorf("per-user series limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
-		globalLimit, actualLimit)
+	return errors.New(globalerror.MaxSeriesPerUser.MessageWithLimitConfig(
+		validation.MaxSeriesPerUserFlag,
+		fmt.Sprintf("per-user series limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+	))
 }
 
 func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 	actualLimit := l.maxSeriesPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
 
-	return fmt.Errorf("per-metric series limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
-		globalLimit, actualLimit)
+	return errors.New(globalerror.MaxSeriesPerMetric.MessageWithLimitConfig(
+		validation.MaxSeriesPerMetricFlag,
+		fmt.Sprintf("per-metric series limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+	))
 }
 
 func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
 	actualLimit := l.maxMetadataPerUser(userID)
 	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
 
-	return fmt.Errorf("per-user metric metadata limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
-		globalLimit, actualLimit)
+	return errors.New(globalerror.MaxMetadataPerUser.MessageWithLimitConfig(
+		validation.MaxMetadataPerUserFlag,
+		fmt.Sprintf("per-user metric metadata limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+	))
 }
 
 func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
 	actualLimit := l.maxMetadataPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
 
-	return fmt.Errorf("per-metric metadata limit of %d exceeded, contact an administrator to raise it (per-ingester local limit: %d)",
-		globalLimit, actualLimit)
+	return errors.New(globalerror.MaxMetadataPerMetric.MessageWithLimitConfig(
+		validation.MaxMetadataPerMetricFlag,
+		fmt.Sprintf("per-metric metadata limit of %d exceeded, per-ingester local limit: %d", globalLimit, actualLimit),
+	))
 }
 
 func (l *Limiter) maxSeriesPerMetric(userID string) int {

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -412,16 +412,16 @@ func TestLimiter_FormatError(t *testing.T) {
 	limiter := NewLimiter(limits, ring, 3, false)
 
 	actual := limiter.FormatError("user-1", errMaxSeriesPerUserLimitExceeded)
-	assert.EqualError(t, actual, "per-user series limit of 100 exceeded, please contact administrator to raise it (per-ingester local limit: 100)")
+	assert.EqualError(t, actual, "per-user series limit of 100 exceeded, contact an administrator to raise it (per-ingester local limit: 100)")
 
 	actual = limiter.FormatError("user-1", errMaxSeriesPerMetricLimitExceeded)
-	assert.EqualError(t, actual, "per-metric series limit of 20 exceeded, please contact administrator to raise it (per-ingester local limit: 20)")
+	assert.EqualError(t, actual, "per-metric series limit of 20 exceeded, contact an administrator to raise it (per-ingester local limit: 20)")
 
 	actual = limiter.FormatError("user-1", errMaxMetadataPerUserLimitExceeded)
-	assert.EqualError(t, actual, "per-user metric metadata limit of 10 exceeded, please contact administrator to raise it (per-ingester local limit: 10)")
+	assert.EqualError(t, actual, "per-user metric metadata limit of 10 exceeded, contact an administrator to raise it (per-ingester local limit: 10)")
 
 	actual = limiter.FormatError("user-1", errMaxMetadataPerMetricLimitExceeded)
-	assert.EqualError(t, actual, "per-metric metadata limit of 3 exceeded, please contact administrator to raise it (per-ingester local limit: 3)")
+	assert.EqualError(t, actual, "per-metric metadata limit of 3 exceeded, contact an administrator to raise it (per-ingester local limit: 3)")
 
 	input := errors.New("unknown error")
 	actual = limiter.FormatError("user-1", input)

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -412,16 +412,16 @@ func TestLimiter_FormatError(t *testing.T) {
 	limiter := NewLimiter(limits, ring, 3, false)
 
 	actual := limiter.FormatError("user-1", errMaxSeriesPerUserLimitExceeded)
-	assert.EqualError(t, actual, "per-user series limit of 100 exceeded, contact an administrator to raise it (per-ingester local limit: 100)")
+	assert.ErrorContains(t, actual, "per-user series limit of 100 exceeded, per-ingester local limit: 100")
 
 	actual = limiter.FormatError("user-1", errMaxSeriesPerMetricLimitExceeded)
-	assert.EqualError(t, actual, "per-metric series limit of 20 exceeded, contact an administrator to raise it (per-ingester local limit: 20)")
+	assert.ErrorContains(t, actual, "per-metric series limit of 20 exceeded, per-ingester local limit: 20")
 
 	actual = limiter.FormatError("user-1", errMaxMetadataPerUserLimitExceeded)
-	assert.EqualError(t, actual, "per-user metric metadata limit of 10 exceeded, contact an administrator to raise it (per-ingester local limit: 10)")
+	assert.ErrorContains(t, actual, "per-user metric metadata limit of 10 exceeded, per-ingester local limit: 10")
 
 	actual = limiter.FormatError("user-1", errMaxMetadataPerMetricLimitExceeded)
-	assert.EqualError(t, actual, "per-metric metadata limit of 3 exceeded, contact an administrator to raise it (per-ingester local limit: 3)")
+	assert.ErrorContains(t, actual, "per-metric metadata limit of 3 exceeded, per-ingester local limit: 3")
 
 	input := errors.New("unknown error")
 	actual = limiter.FormatError("user-1", input)

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -412,16 +412,16 @@ func TestLimiter_FormatError(t *testing.T) {
 	limiter := NewLimiter(limits, ring, 3, false)
 
 	actual := limiter.FormatError("user-1", errMaxSeriesPerUserLimitExceeded)
-	assert.ErrorContains(t, actual, "per-user series limit of 100 exceeded, per-ingester local limit: 100")
+	assert.ErrorContains(t, actual, "per-user series limit of 100 exceeded")
 
 	actual = limiter.FormatError("user-1", errMaxSeriesPerMetricLimitExceeded)
-	assert.ErrorContains(t, actual, "per-metric series limit of 20 exceeded, per-ingester local limit: 20")
+	assert.ErrorContains(t, actual, "per-metric series limit of 20 exceeded")
 
 	actual = limiter.FormatError("user-1", errMaxMetadataPerUserLimitExceeded)
-	assert.ErrorContains(t, actual, "per-user metric metadata limit of 10 exceeded, per-ingester local limit: 10")
+	assert.ErrorContains(t, actual, "per-user metric metadata limit of 10 exceeded")
 
 	actual = limiter.FormatError("user-1", errMaxMetadataPerMetricLimitExceeded)
-	assert.ErrorContains(t, actual, "per-metric metadata limit of 3 exceeded, per-ingester local limit: 3")
+	assert.ErrorContains(t, actual, "per-metric metadata limit of 3 exceeded")
 
 	input := errors.New("unknown error")
 	actual = limiter.FormatError("user-1", input)

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -182,7 +182,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 	gl := u.instanceLimitsFn()
 	if gl != nil && gl.MaxInMemorySeries > 0 {
 		if series := u.instanceSeriesCount.Load(); series >= gl.MaxInMemorySeries {
-			return errMaxSeriesLimitReached
+			return errMaxInMemorySeriesReached
 		}
 	}
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -63,7 +63,7 @@ const (
 )
 
 var (
-	errMaxChunksPerQueryLimit = "the query hit the max number of chunks limit while fetching chunks from store-gateways for %s (limit: %d)"
+	errMaxChunksPerQueryLimit = "the query reached the max number of chunks limit while fetching chunks from store-gateways for %s (limit: %d)"
 )
 
 // BlocksStoreSet is the interface used to get the clients to query series on a set of blocks.

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -66,7 +66,7 @@ const (
 var (
 	maxChunksPerQueryLimitMsgFormat = globalerror.MaxChunksPerQuery.MessageWithLimitConfig(
 		validation.MaxChunksPerQueryFlag,
-		fmt.Sprintf("the query exceeded the maximum number of chunks fetched from store-gateways when querying '%%s' (limit: %%d)"),
+		"the query exceeded the maximum number of chunks fetched from store-gateways when querying '%s' (limit: %d)",
 	)
 )
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -480,7 +480,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{maxChunksPerQuery: 1},
 			queryLimiter: noOpQueryLimiter,
-			expectedErr:  validation.LimitError(fmt.Sprintf(errMaxChunksPerQueryLimit, fmt.Sprintf("{__name__=%q}", metricName), 1)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(maxChunksPerQueryLimitMsgFormat, fmt.Sprintf("{__name__=%q}", metricName), 1)),
 		},
 		"max chunks per query limit hit while fetching chunks at first attempt - global limit": {
 			finderResult: bucketindex.Blocks{
@@ -498,7 +498,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{},
 			queryLimiter: limiter.NewQueryLimiter(0, 0, 1),
-			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.ErrMaxChunksPerQueryLimit, 1)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.MaxChunksPerQueryLimitMsgFormat, 1)),
 		},
 		"max chunks per query limit hit while fetching chunks during subsequent attempts": {
 			finderResult: bucketindex.Blocks{
@@ -536,7 +536,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{maxChunksPerQuery: 3},
 			queryLimiter: noOpQueryLimiter,
-			expectedErr:  validation.LimitError(fmt.Sprintf(errMaxChunksPerQueryLimit, fmt.Sprintf("{__name__=%q}", metricName), 3)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(maxChunksPerQueryLimitMsgFormat, fmt.Sprintf("{__name__=%q}", metricName), 3)),
 		},
 		"max chunks per query limit hit while fetching chunks during subsequent attempts - global": {
 			finderResult: bucketindex.Blocks{
@@ -574,7 +574,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{},
 			queryLimiter: limiter.NewQueryLimiter(0, 0, 3),
-			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.ErrMaxChunksPerQueryLimit, 3)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.MaxChunksPerQueryLimitMsgFormat, 3)),
 		},
 		"max series per query limit hit while fetching chunks": {
 			finderResult: bucketindex.Blocks{
@@ -592,7 +592,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{},
 			queryLimiter: limiter.NewQueryLimiter(1, 0, 0),
-			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.ErrMaxSeriesHit, 1)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.MaxSeriesHitMsgFormat, 1)),
 		},
 		"max chunk bytes per query limit hit while fetching chunks": {
 			finderResult: bucketindex.Blocks{
@@ -610,7 +610,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{maxChunksPerQuery: 1},
 			queryLimiter: limiter.NewQueryLimiter(0, 8, 0),
-			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.ErrMaxChunkBytesHit, 8)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.MaxChunkBytesHitMsgFormat, 8)),
 		},
 		"blocks with non-matching shard are filtered out": {
 			finderResult: bucketindex.Blocks{
@@ -846,7 +846,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			sp := &storage.SelectHints{Start: minT, End: maxT}
 			set := q.Select(true, sp, matchers...)
 			if testData.expectedErr != nil {
-				assert.EqualError(t, set.Err(), testData.expectedErr.Error())
+				assert.ErrorContains(t, set.Err(), testData.expectedErr.Error())
 				assert.IsType(t, set.Err(), testData.expectedErr)
 				assert.False(t, set.Next())
 				assert.Nil(t, set.Warnings())

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -22,7 +22,7 @@ const (
 	SeriesWithDuplicateLabelNames ID = "duplicate-label-names"
 	SeriesLabelsNotSorted         ID = "labels-not-sorted"
 	SampleTooFarInFuture          ID = "too-far-in-future"
-	MaxIngestionRate              ID = "max-ingestion-rate"
+	MaxIngesterIngestionRate      ID = "max-ingester-ingestion-rate"
 	MaxTenants                    ID = "max-tenants-reached"
 	MaxInMemorySeries             ID = "max-in-memory-series"
 	MaxInflightPushRequests       ID = "max-inflight-push-requests"

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -26,6 +26,10 @@ const (
 	MaxTenants                    ID = "max-tenants-reached"
 	MaxInMemorySeries             ID = "max-in-memory-series"
 	MaxInflightPushRequests       ID = "max-inflight-push-requests"
+	MaxSeriesPerMetric            ID = "max-series-per-metric"
+	MaxMetadataPerMetric          ID = "max-metadata-per-metric"
+	MaxSeriesPerUser              ID = "max-series-per-user"
+	MaxMetadataPerUser            ID = "max-metadata-per-user"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -30,6 +30,9 @@ const (
 	MaxMetadataPerMetric          ID = "max-metadata-per-metric"
 	MaxSeriesPerUser              ID = "max-series-per-user"
 	MaxMetadataPerUser            ID = "max-metadata-per-user"
+	MaxChunksPerQuery             ID = "max-chunks-per-query"
+	MaxSeriesPerQuery             ID = "max-series-per-query"
+	MaxChunkBytesPerQuery         ID = "max-chunks-bytes-per-query"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -22,10 +22,6 @@ const (
 	SeriesWithDuplicateLabelNames ID = "duplicate-label-names"
 	SeriesLabelsNotSorted         ID = "labels-not-sorted"
 	SampleTooFarInFuture          ID = "too-far-in-future"
-	MaxIngesterIngestionRate      ID = "max-ingester-ingestion-rate"
-	MaxTenants                    ID = "max-tenants-reached"
-	MaxInMemorySeries             ID = "max-in-memory-series"
-	MaxInflightPushRequests       ID = "max-inflight-push-requests"
 	MaxSeriesPerMetric            ID = "max-series-per-metric"
 	MaxMetadataPerMetric          ID = "max-metadata-per-metric"
 	MaxSeriesPerUser              ID = "max-series-per-user"
@@ -33,6 +29,11 @@ const (
 	MaxChunksPerQuery             ID = "max-chunks-per-query"
 	MaxSeriesPerQuery             ID = "max-series-per-query"
 	MaxChunkBytesPerQuery         ID = "max-chunks-bytes-per-query"
+
+	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
+	IngesterMaxTenants              ID = "ingester-max-tenants"
+	IngesterMaxInMemorySeries       ID = "ingester-max-series"
+	IngesterMaxInflightPushRequests ID = "ingester-max-inflight-push-requests"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -22,6 +22,10 @@ const (
 	SeriesWithDuplicateLabelNames ID = "duplicate-label-names"
 	SeriesLabelsNotSorted         ID = "labels-not-sorted"
 	SampleTooFarInFuture          ID = "too-far-in-future"
+	MaxIngestionRate              ID = "max-ingestion-rate"
+	MaxTenants                    ID = "max-tenants-reached"
+	MaxInMemorySeries             ID = "max-in-memory-series"
+	MaxInflightPushRequests       ID = "max-inflight-push-requests"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"

--- a/pkg/util/limiter/query_limiter.go
+++ b/pkg/util/limiter/query_limiter.go
@@ -21,9 +21,9 @@ type queryLimiterCtxKey struct{}
 
 var (
 	ctxKey                    = &queryLimiterCtxKey{}
-	ErrMaxSeriesHit           = "the query hit the max number of series limit (limit: %d series)"
-	ErrMaxChunkBytesHit       = "the query hit the aggregated chunks size limit (limit: %d bytes)"
-	ErrMaxChunksPerQueryLimit = "the query hit the max number of chunks limit (limit: %d chunks)"
+	ErrMaxSeriesHit           = "the query reached the max number of series limit (limit: %d series)"
+	ErrMaxChunkBytesHit       = "the query reached the aggregated chunks size limit (limit: %d bytes)"
+	ErrMaxChunksPerQueryLimit = "the query reached the max number of chunks limit (limit: %d chunks)"
 )
 
 type QueryLimiter struct {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -23,9 +23,9 @@ import (
 
 const (
 	MaxSeriesPerMetricFlag    = "ingester.max-global-series-per-metric"
-	MaxMetadataPerMetricFlag  = "ingester.max-global-metadata-per-user"
+	MaxMetadataPerMetricFlag  = "ingester.max-global-metadata-per-metric"
 	MaxSeriesPerUserFlag      = "ingester.max-global-series-per-user"
-	MaxMetadataPerUserFlag    = "ingester.max-global-metadata-per-metric"
+	MaxMetadataPerUserFlag    = "ingester.max-global-metadata-per-user"
 	MaxChunksPerQueryFlag     = "querier.max-fetched-chunks-per-query"
 	MaxChunkBytesPerQueryFlag = "querier.max-fetched-chunk-bytes-per-query"
 	MaxSeriesPerQueryFlag     = "querier.max-fetched-series-per-query"

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -22,6 +22,11 @@ import (
 )
 
 const (
+	MaxSeriesPerMetricFlag   = "ingester.max-global-series-per-metric"
+	MaxMetadataPerMetricFlag = "ingester.max-global-metadata-per-user"
+	MaxSeriesPerUserFlag     = "ingester.max-global-series-per-user"
+	MaxMetadataPerUserFlag   = "ingester.max-global-metadata-per-metric"
+
 	maxLabelNamesPerSeriesFlag = "validation.max-label-names-per-series"
 	maxLabelNameLengthFlag     = "validation.max-length-label-name"
 	maxLabelValueLengthFlag    = "validation.max-length-label-value"
@@ -152,11 +157,11 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`.")
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")
 
-	f.IntVar(&l.MaxGlobalSeriesPerUser, "ingester.max-global-series-per-user", 150000, "The maximum number of active series per tenant, across the cluster before replication. 0 to disable.")
-	f.IntVar(&l.MaxGlobalSeriesPerMetric, "ingester.max-global-series-per-metric", 20000, "The maximum number of active series per metric name, across the cluster before replication. 0 to disable.")
+	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of active series per tenant, across the cluster before replication. 0 to disable.")
+	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 20000, "The maximum number of active series per metric name, across the cluster before replication. 0 to disable.")
 
-	f.IntVar(&l.MaxGlobalMetricsWithMetadataPerUser, "ingester.max-global-metadata-per-user", 0, "The maximum number of active metrics with metadata per tenant, across the cluster. 0 to disable.")
-	f.IntVar(&l.MaxGlobalMetadataPerMetric, "ingester.max-global-metadata-per-metric", 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")
+	f.IntVar(&l.MaxGlobalMetricsWithMetadataPerUser, MaxMetadataPerUserFlag, 0, "The maximum number of active metrics with metadata per tenant, across the cluster. 0 to disable.")
+	f.IntVar(&l.MaxGlobalMetadataPerMetric, MaxMetadataPerMetricFlag, 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")
 	f.IntVar(&l.MaxGlobalExemplarsPerUser, "ingester.max-global-exemplars-per-user", 0, "The maximum number of exemplars in memory, across the cluster. 0 to disable exemplars ingestion.")
 	f.Var(&l.ActiveSeriesCustomTrackersConfig, "ingester.active-series-custom-trackers", "Additional active series metrics, matching the provided matchers. Matchers should be in form <name>:<matcher>, like 'foobar:{foo=\"bar\"}'. Multiple matchers can be provided either providing the flag multiple times or providing multiple semicolon-separated values to a single flag.")
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -22,10 +22,13 @@ import (
 )
 
 const (
-	MaxSeriesPerMetricFlag   = "ingester.max-global-series-per-metric"
-	MaxMetadataPerMetricFlag = "ingester.max-global-metadata-per-user"
-	MaxSeriesPerUserFlag     = "ingester.max-global-series-per-user"
-	MaxMetadataPerUserFlag   = "ingester.max-global-metadata-per-metric"
+	MaxSeriesPerMetricFlag    = "ingester.max-global-series-per-metric"
+	MaxMetadataPerMetricFlag  = "ingester.max-global-metadata-per-user"
+	MaxSeriesPerUserFlag      = "ingester.max-global-series-per-user"
+	MaxMetadataPerUserFlag    = "ingester.max-global-metadata-per-metric"
+	MaxChunksPerQueryFlag     = "querier.max-fetched-chunks-per-query"
+	MaxChunkBytesPerQueryFlag = "querier.max-fetched-chunk-bytes-per-query"
+	MaxSeriesPerQueryFlag     = "querier.max-fetched-series-per-query"
 
 	maxLabelNamesPerSeriesFlag = "validation.max-label-names-per-series"
 	maxLabelNameLengthFlag     = "validation.max-length-label-name"
@@ -165,9 +168,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxGlobalExemplarsPerUser, "ingester.max-global-exemplars-per-user", 0, "The maximum number of exemplars in memory, across the cluster. 0 to disable exemplars ingestion.")
 	f.Var(&l.ActiveSeriesCustomTrackersConfig, "ingester.active-series-custom-trackers", "Additional active series metrics, matching the provided matchers. Matchers should be in form <name>:<matcher>, like 'foobar:{foo=\"bar\"}'. Multiple matchers can be provided either providing the flag multiple times or providing multiple semicolon-separated values to a single flag.")
 
-	f.IntVar(&l.MaxChunksPerQuery, "querier.max-fetched-chunks-per-query", 2e6, "Maximum number of chunks that can be fetched in a single query from ingesters and long-term storage. This limit is enforced in the querier, ruler and store-gateway. 0 to disable.")
-	f.IntVar(&l.MaxFetchedSeriesPerQuery, "querier.max-fetched-series-per-query", 0, "The maximum number of unique series for which a query can fetch samples from each ingesters and storage. This limit is enforced in the querier and ruler. 0 to disable")
-	f.IntVar(&l.MaxFetchedChunkBytesPerQuery, "querier.max-fetched-chunk-bytes-per-query", 0, "The maximum size of all chunks in bytes that a query can fetch from each ingester and storage. This limit is enforced in the querier and ruler. 0 to disable.")
+	f.IntVar(&l.MaxChunksPerQuery, MaxChunksPerQueryFlag, 2e6, "Maximum number of chunks that can be fetched in a single query from ingesters and long-term storage. This limit is enforced in the querier, ruler and store-gateway. 0 to disable.")
+	f.IntVar(&l.MaxFetchedSeriesPerQuery, MaxSeriesPerQueryFlag, 0, "The maximum number of unique series for which a query can fetch samples from each ingesters and storage. This limit is enforced in the querier and ruler. 0 to disable")
+	f.IntVar(&l.MaxFetchedChunkBytesPerQuery, MaxChunkBytesPerQueryFlag, 0, "The maximum size of all chunks in bytes that a query can fetch from each ingester and storage. This limit is enforced in the querier and ruler. 0 to disable.")
 	f.Var(&l.MaxQueryLength, "store.max-query-length", "Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.")
 	f.Var(&l.MaxQueryLookback, "querier.max-query-lookback", "Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. This limit is enforced in the query-frontend, querier and ruler. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers.")


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

#### What this PR does

Rephrases some limits errors, introduces the usage of error IDs, and adds playbooks similar to #1907

Error covered in this PR are ones in:
* `pkg/ingester/instance_limits.go `
* `pkg/ingester/limiter.go`
* `pkg/querier/blocks_store_queryable.go`
* `pkg/util/limiter/query_limiter.go`

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
