### PR TITLE
Fix TestRulerEvaluationDelay flakyness

### DIFF
--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -287,7 +287,7 @@ func TestRulerEvaluationDelay(t *testing.T) {
 	// Wait until all the pushed samples have been evaluated by the rule. This
 	// ensures that rule results are successfully written even after a
 	// staleness period.
-	require.NoError(t, mimir.WaitSumMetrics(e2e.GreaterOrEqual(ruleEvaluationsAfterPush[0]+float64(samplesToSend)), "cortex_prometheus_rule_evaluations_total"))
+	require.NoError(t, mimir.WaitSumMetrics(e2e.Greater(ruleEvaluationsAfterPush[0]+float64(samplesToSend)), "cortex_prometheus_rule_evaluations_total"))
 
 	// query all results to verify rules have been evaluated correctly
 	result, err = c.QueryRange("stale_nan_eval", now.Add(-evaluationDelay), now, time.Second)


### PR DESCRIPTION
#### What this PR does
When running `TestRulerEvaluationDelay` I got it failing with this error:
```
    ruler_test.go:314:
        	Error Trace:	ruler_test.go:314
        	Error:      	Not equal:
        	            	expected: 20
        	            	actual  : 18
        	Test:       	TestRulerEvaluationDelay
```

Reason is that there's a timing issue in the way we check the number of rule evaluations run (metric: `cortex_prometheus_rule_evaluations_total`). The tiny change in this PR ensures we always wait for 1 more evaluation, which should fix the flakyness occurring when the failing assertion is on the last sample (expected value `20`).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
