### PR TITLE
Fixed deceiving error log "failed to update cached shipped blocks after shipper initialisation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] Increased default configuration for `-server.grpc-max-recv-msg-size-bytes` and `-server.grpc-max-send-msg-size-bytes` from 4MB to 100MB. #1883
 * [BUGFIX] Fix regexp parsing panic for regexp label matchers with start/end quantifiers. #1883
+* [BUGFIX] Ingester: fixed deceiving error log "failed to update cached shipped blocks after shipper initialisation", occurring for each new tenant in the ingester. #1893
 
 ### Mixin
 

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -253,7 +253,7 @@ func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
 // updateCachedShipperBlocks reads the shipper meta file and updates the cached shipped blocks.
 func (u *userTSDB) updateCachedShippedBlocks() error {
 	shipperMeta, err := shipper.ReadMetaFile(u.db.Dir())
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		// If the meta file doesn't exist it means the shipper hasn't run yet.
 		shipperMeta = &shipper.Meta{}
 	} else if err != nil {


### PR DESCRIPTION
#### What this PR does
While investigating #1891, I've noticed this log in each integration test:
```
2022-05-19T10:36:54.4321365Z 10:36:13 mimir: level=error ts=2022-05-19T10:36:13.797571821Z caller=ingester.go:1542 user=anonymous msg="failed to update cached shipped blocks after shipper initialisation" err="failed to read /tmp/mimir/tsdb/anonymous/thanos.shipper.json: open /tmp/mimir/tsdb/anonymous/thanos.shipper.json: no such file or directory"
```

When a new tenant TSDB and its blocks shipper are created in a ingester, there's no shipping meta file yet. We handled this case in the code, but error returned by `shipper.ReadMetaFile()` is wrapped since #1257: we need to unwrap it to correctly detect if it's a `os.ErrNotExist` error.

_I manually tested the change to ensure it works as expected now._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
