### PR TITLE
Fix `MimirRulerMissedEvaluations` text and add playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedTenants` alert that fires when there is a store-gateway owning no tenants. #1882
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
+* [BUGFIX] Fix `MimirRulerMissedEvaluations` showing % of missed alerts as a value between 0 and 1 instead of 0 and 100. #1895
 
 ## 2.1.0-rc.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [ENHANCEMENT] Alerts: Add `MimirStoreGatewayNoSyncedTenants` alert that fires when there is a store-gateway owning no tenants. #1882
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
-* [BUGFIX] Fix `MimirRulerMissedEvaluations` showing % of missed alerts as a value between 0 and 1 instead of 0 and 100. #1895
+* [BUGFIX] Fix `MimirRulerMissedEvaluations` to show % of missed alerts as a value between 0 and 100 instead of 0 and 1. #1895
 
 ## 2.1.0-rc.0
 

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -327,10 +327,11 @@ groups:
       message: |
         Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
     expr: |
+      100 * (
       sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
         /
       sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
-        > 0.01
+      ) > 1
     for: 5m
     labels:
       severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -531,10 +531,11 @@
         {
           alert: $.alertName('RulerMissedEvaluations'),
           expr: |||
+            100 * (
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
-              > 0.01
+            ) > 1
           ||| % $._config,
           'for': '5m',
           labels: {

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -312,7 +312,7 @@ How it **works**:
 
 How to **fix**:
 
-- Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes. 
+- Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes.
 - Try splitting up the rule group into multiple rule groups. Rule groups are evaluated in parallel, so the same rules may still fit in the same resolution.
 
 ### MimirIngesterHasNotShippedBlocks

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -303,7 +303,17 @@ How to **fix**:
 
 ### MimirRulerMissedEvaluations
 
-_TODO: this playbook has not been written yet._
+This alert fires when there is a rule group that is taking longer to evaluate than its evaluation interval.
+
+How it **works**:
+
+- The Mimir ruler will evaluate a rule group according to the evaluation interval on the rule group.
+- If an evaluation is not finished by the time the next evaluation should happen, the next evaluation is missed.
+
+How to **fix**:
+
+- Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes. 
+- Try splitting up the rule group into multiple rule groups. Rule groups are evaluated in parallel, so the same rules may still fit in the same resolution.
 
 ### MimirIngesterHasNotShippedBlocks
 


### PR DESCRIPTION
#### What this PR does

The alert `MimirRulerMissedEvaluations` reports an incorrect value. It reports the rate of missed evaluations (which is a number from 0 to 1) as the percentage of missed evaluations (which should be a number from 0 to 100).

Also add a playbook for it, since that was missing.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
