### PR TITLE
Docs: recommend fast disks for ingesters and store-gateways

### DIFF
--- a/docs/sources/operators-guide/running-production-environment/production-tips/index.md
+++ b/docs/sources/operators-guide/running-production-environment/production-tips/index.md
@@ -94,7 +94,7 @@ We recommend configuring the system's `file-max` ulimit at least to `65536` to a
 ### Store-gateway disk IOPS
 
 The IOPS and latency performances of the store-gateway disk can affect queries.
-The store-gateway downloads block's [index-headers]({{< relref "../../architecture/binary-index-header.md" >}}) on local disk and reads them on each query hitting the long-term storage.
+The store-gateway downloads the block’s [index-headers]({{< relref "../../architecture/binary-index-header.md" >}}) onto local disk, and reads them for each query that needs to fetch data from the long-term storage.
 
 For these reasons, run the store-gateways on disks such as SSDs that have fast disk speed.
 

--- a/docs/sources/operators-guide/running-production-environment/production-tips/index.md
+++ b/docs/sources/operators-guide/running-production-environment/production-tips/index.md
@@ -30,6 +30,13 @@ The required disk space depends on the number of time series stored in the inges
 
 For more information about estimating the required ingester disk space, refer to [Planning capacity]({{< relref "../planning-capacity.md#ingester" >}}).
 
+### Ingester disk IOPS
+
+The ingester disk performances (IOPS and latency) can impact both write and read requests.
+On this write path, ingester disk is touched to write the write-ahead log (WAL), while on the read path the ingester disk is touched to query series whose chunks have already been written to disk.
+
+We recommend to run ingesters with a fast disk (e.g. SSD disk).
+
 ## Querier
 
 ### Ensure caching is enabled
@@ -83,6 +90,13 @@ The store-gateway keeps a file descriptor open for each index-header loaded at a
 The total number of file descriptors used to load index-headers linearly increases with the number of blocks owned by the store-gateway instance.
 
 We recommend configuring the system's `file-max` ulimit at least to `65536` to avoid reaching the maximum number of open file descriptors.
+
+### Store-gateway disk IOPS
+
+The store-gateway disk performances (IOPS and latency) can impact queries.
+The store-gateway downloads block's [index-headers]({{< relref "../../architecture/binary-index-header.md" >}}) on local disk and reads them on each query hitting the long-term storage.
+
+We recommend to run store-gateways with a fast disk (e.g. SSD disk).
 
 ## Compactor
 

--- a/docs/sources/operators-guide/running-production-environment/production-tips/index.md
+++ b/docs/sources/operators-guide/running-production-environment/production-tips/index.md
@@ -32,7 +32,7 @@ For more information about estimating the required ingester disk space, refer to
 
 ### Ingester disk IOPS
 
-The ingester disk performances (IOPS and latency) can impact both write and read requests.
+The IOPS (input/output operations per second) and latency performances of the ingester disks can affect both write and read requests.
 On this write path, ingester disk is touched to write the write-ahead log (WAL), while on the read path the ingester disk is touched to query series whose chunks have already been written to disk.
 
 We recommend to run ingesters with a fast disk (e.g. SSD disk).
@@ -93,10 +93,10 @@ We recommend configuring the system's `file-max` ulimit at least to `65536` to a
 
 ### Store-gateway disk IOPS
 
-The store-gateway disk performances (IOPS and latency) can impact queries.
+The IOPS and latency performances of the store-gateway disk can affect queries.
 The store-gateway downloads block's [index-headers]({{< relref "../../architecture/binary-index-header.md" >}}) on local disk and reads them on each query hitting the long-term storage.
 
-We recommend to run store-gateways with a fast disk (e.g. SSD disk).
+For these reasons, run the store-gateways on disks such as SSDs that have fast disk speed.
 
 ## Compactor
 

--- a/docs/sources/operators-guide/running-production-environment/production-tips/index.md
+++ b/docs/sources/operators-guide/running-production-environment/production-tips/index.md
@@ -33,9 +33,10 @@ For more information about estimating the required ingester disk space, refer to
 ### Ingester disk IOPS
 
 The IOPS (input/output operations per second) and latency performances of the ingester disks can affect both write and read requests.
-On this write path, ingester disk is touched to write the write-ahead log (WAL), while on the read path the ingester disk is touched to query series whose chunks have already been written to disk.
+On the write path, the ingester writes to the write-ahead log (WAL) on disk.
+On the read path, the ingester reads from the series whose chunks have already been written to disk.
 
-We recommend to run ingesters with a fast disk (e.g. SSD disk).
+For these reasons, run the ingesters on disks such as SSDs that have fast disk speed.
 
 ## Querier
 


### PR DESCRIPTION
#### What this PR does
While giving support to a community user, we found out we're not recommending fast disks for ingesters and store-gateways, but we should.

#### Which issue(s) this PR fixes or relates to

Fixes #1792

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
