### PR TITLE
fix(mixin): do not trigger TooMuchMemory alerts if no container limits are supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 * [BUGFIX] Fix `MimirRulerMissedEvaluations` to show % of missed alerts as a value between 0 and 100 instead of 0 and 1. #1895
+* [BUGFIX] Do not trigger `MimirAllocatingTooMuchMemory` alerts if no container limits are supplied.
 
 ## 2.1.0-rc.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [BUGFIX] Fix `container_memory_usage_bytes:sum` recording rule #1865
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 * [BUGFIX] Fix `MimirRulerMissedEvaluations` to show % of missed alerts as a value between 0 and 100 instead of 0 and 1. #1895
-* [BUGFIX] Do not trigger `MimirAllocatingTooMuchMemory` alerts if no container limits are supplied.
+* [BUGFIX] Do not trigger `MimirAllocatingTooMuchMemory` alerts if no container limits are supplied. #1905
 
 ## 2.1.0-rc.0
 

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -276,7 +276,7 @@ groups:
       (
         container_memory_working_set_bytes{container="ingester"}
           /
-        container_spec_memory_limit_bytes{container="ingester"}
+        ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
       ) > 0.65
     for: 15m
     labels:
@@ -289,7 +289,7 @@ groups:
       (
         container_memory_working_set_bytes{container="ingester"}
           /
-        container_spec_memory_limit_bytes{container="ingester"}
+        ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
       ) > 0.8
     for: 15m
     labels:
@@ -368,7 +368,7 @@ groups:
       (
         container_memory_working_set_bytes{container="etcd"}
           /
-        container_spec_memory_limit_bytes{container="etcd"}
+        ( container_spec_memory_limit_bytes{container="etcd"} > 0 )
       ) > 0.65
     for: 15m
     labels:
@@ -381,7 +381,7 @@ groups:
       (
         container_memory_working_set_bytes{container="etcd"}
           /
-        container_spec_memory_limit_bytes{container="etcd"}
+        ( container_spec_memory_limit_bytes{container="etcd"} > 0 )
       ) > 0.8
     for: 15m
     labels:

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -453,7 +453,7 @@
             (
               container_memory_working_set_bytes{container="ingester"}
                 /
-              container_spec_memory_limit_bytes{container="ingester"}
+              ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
             ) > 0.65
           |||,
           'for': '15m',
@@ -472,7 +472,7 @@
             (
               container_memory_working_set_bytes{container="ingester"}
                 /
-              container_spec_memory_limit_bytes{container="ingester"}
+              ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
             ) > 0.8
           |||,
           'for': '15m',
@@ -595,7 +595,7 @@
             (
               container_memory_working_set_bytes{container="etcd"}
                 /
-              container_spec_memory_limit_bytes{container="etcd"}
+              ( container_spec_memory_limit_bytes{container="etcd"} > 0 )
             ) > 0.65
           |||,
           'for': '15m',
@@ -614,7 +614,7 @@
             (
               container_memory_working_set_bytes{container="etcd"}
                 /
-              container_spec_memory_limit_bytes{container="etcd"}
+              ( container_spec_memory_limit_bytes{container="etcd"} > 0 )
             ) > 0.8
           |||,
           'for': '15m',


### PR DESCRIPTION
do not trigger `MimirAllocatingTooMuchMemory` or `EtcdAllocatingTooMuchMemory` alerts if no container limits are supplied

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Modifies `MimirAllocatingTooMuchMemory` and `EtcdAllocatingTooMuchMemory` to ignore container which have no limit defined.    

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
