### PR TITLE
Revert distributor log level to warn in integration tests

### DIFF
--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -71,7 +71,7 @@ func NewDistributor(name string, consulAddress string, flags map[string]string, 
 		name,
 		map[string]string{
 			"-target":                           "distributor",
-			"-log.level":                        "debug",
+			"-log.level":                        "warn",
 			"-auth.multitenancy-enabled":        "true",
 			"-ingester.ring.replication-factor": "1",
 			"-distributor.remote-timeout":       "2s", // Fail fast in integration tests.


### PR DESCRIPTION
#### What this PR does
We can revert the distributor log level back to `warn` (changed to `debug` in https://github.com/grafana/mimir/pull/1793) because the integration tests issue has been spot and fixed in https://github.com/grafana/mimir/pull/1891.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
