### PR TITLE
Improved ValidateMetadata() errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `-blocks-storage.bucket-store.ignore-blocks-within` now defaults to `10h` (previously `0`)
     - `-querier.query-store-after` now defaults to `12h` (previously `0`)
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run requests in a dedicated OS thread pool. This feature can be configured using `-store-gateway.thread-pool-size` and is disabled by default. Replaces the ability to run index header operations in a dedicated thread pool. #1660 #1812
-* [ENHANCEMENT] Improved error messages to make them easier to understand and referencing a unique global identifier that can be looked up in the runbooks. #1907
+* [ENHANCEMENT] Improved error messages to make them easier to understand and referencing a unique global identifier that can be looked up in the runbooks. #1907 #1919
 * [BUGFIX] Fix regexp parsing panic for regexp label matchers with start/end quantifiers. #1883
 * [BUGFIX] Ingester: fixed deceiving error log "failed to update cached shipped blocks after shipper initialisation", occurring for each new tenant in the ingester. #1893
 

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1102,6 +1102,35 @@ An exemplar must have a valid timestamp, otherwise it cannot be correlated to an
 
 > **Note**: Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
 
+### err-mimir-metadata-missing-metric-name
+
+This non-critical error occurs when Mimir receives a write request that contains a metric metadata without a metric name.
+Each metric metadata must have a metric name. Rarely it does not, in which case there might be a bug in the sender client.
+
+> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+
+### err-mimir-metric-name-too-long
+
+This non-critical error occurs when Mimir receives a write request that contains a metric metadata with a metric name whose length exceeds the configured limit.
+The limit protects the system’s stability from potential abuse or mistakes, and you can configure the limit on a per-tenant basis by using the `-validation.max-metadata-length` option.
+
+> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+
+### err-mimir-help-too-long
+
+This non-critical error occurs when Mimir receives a write request that contains a metric metadata with an help description whose length exceeds the configured limit.
+The limit protects the system’s stability from potential abuse or mistakes, and you can configure the limit on a per-tenant basis by using the `-validation.max-metadata-length` option.
+
+> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+
+### err-mimir-unit-too-long
+
+This non-critical error occurs when Mimir receives a write request that contains a metric metadata with unit name whose length exceeds the configured limit.
+The limit protects the system’s stability from potential abuse or mistakes, and you can configure the limit on a per-tenant basis by using the `-validation.max-metadata-length` option.
+
+> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+
+
 ## Mimir routes by path
 
 **Write path**:

--- a/operations/mimir-mixin/docs/playbooks.md
+++ b/operations/mimir-mixin/docs/playbooks.md
@@ -1130,7 +1130,6 @@ The limit protects the system’s stability from potential abuse or mistakes, an
 
 > **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
 
-
 ## Mimir routes by path
 
 **Write path**:

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -738,10 +738,11 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 	}
 
 	for _, m := range req.Metadata {
-		err := validation.ValidateMetadata(d.limits, userID, m)
-		if err != nil {
+		if validationErr := validation.ValidateMetadata(d.limits, userID, m); validationErr != nil {
 			if firstPartialErr == nil {
-				firstPartialErr = err
+				// The metadata info may be retained by validationErr but that's not a problem for this
+				// use case because we format it calling Error() and then we discard it.
+				firstPartialErr = httpgrpc.Errorf(http.StatusBadRequest, validationErr.Error())
 			}
 
 			continue

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3459,7 +3459,7 @@ func TestDistributorValidation(t *testing.T) {
 				Value:       1,
 			}},
 			expectedStatusCode: http.StatusBadRequest,
-			expectedErr:        `metadata missing metric name`,
+			expectedErr:        `received a metric metadata with no metric name`,
 		},
 		// Test empty exemplar labels fails.
 		{

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -26,6 +26,11 @@ const (
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"
 	ExemplarTimestampInvalid ID = "exemplar-timestamp-invalid"
+
+	MetricMetadataMissingMetricName ID = "metadata-missing-metric-name"
+	MetricMetadataMetricNameTooLong ID = "metric-name-too-long"
+	MetricMetadataHelpTooLong       ID = "help-too-long"
+	MetricMetadataUnitTooLong       ID = "unit-too-long"
 )
 
 // Message returns the provided msg, appending the error id.

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -234,7 +234,7 @@ func (e *metadataValidationError) Error() string {
 var metadataMetricNameTooLongMsgFormat = globalerror.MetricMetadataMetricNameTooLong.MessageWithLimitConfig(
 	maxMetadataLengthFlag,
 	// When formatting this error the "cause" will always be an empty string.
-	"received a metric metadata whose metric name length exceeds the limit,%s metric name: '%.200s'")
+	"received a metric metadata whose metric name length exceeds the limit, metric name: '%.200[2]s'")
 
 func newMetadataMetricNameTooLongError(metadata *mimirpb.MetricMetadata) ValidationError {
 	return &metadataValidationError{

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -28,7 +28,7 @@ type genericValidationError struct {
 	series  []mimirpb.LabelAdapter
 }
 
-func (e *genericValidationError) Error() string {
+func (e genericValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.cause, formatLabelSet(e.series))
 }
 
@@ -37,7 +37,7 @@ var labelNameTooLongMsgFormat = globalerror.SeriesLabelNameTooLong.MessageWithLi
 	"received a series whose label name length exceeds the limit, label: '%.200s' series: '%.200s'")
 
 func newLabelNameTooLongError(series []mimirpb.LabelAdapter, labelName string) ValidationError {
-	return &genericValidationError{
+	return genericValidationError{
 		message: labelNameTooLongMsgFormat,
 		cause:   labelName,
 		series:  series,
@@ -51,14 +51,14 @@ type labelValueTooLongError struct {
 	series     []mimirpb.LabelAdapter
 }
 
-func (e *labelValueTooLongError) Error() string {
+func (e labelValueTooLongError) Error() string {
 	return globalerror.SeriesLabelValueTooLong.MessageWithLimitConfig(
 		maxLabelValueLengthFlag,
 		fmt.Sprintf("received a series whose label value length exceeds the limit, value: '%.200s' (truncated) series: '%.200s'", e.labelValue, formatLabelSet(e.series)))
 }
 
 func newLabelValueTooLongError(series []mimirpb.LabelAdapter, labelValue string) ValidationError {
-	return &labelValueTooLongError{
+	return labelValueTooLongError{
 		labelValue: labelValue,
 		series:     series,
 	}
@@ -68,7 +68,7 @@ var invalidLabelMsgFormat = globalerror.SeriesInvalidLabel.Message(
 	"received a series with an invalid label: '%.200s' series: '%.200s'")
 
 func newInvalidLabelError(series []mimirpb.LabelAdapter, labelName string) ValidationError {
-	return &genericValidationError{
+	return genericValidationError{
 		message: invalidLabelMsgFormat,
 		cause:   labelName,
 		series:  series,
@@ -79,7 +79,7 @@ var duplicateLabelMsgFormat = globalerror.SeriesWithDuplicateLabelNames.Message(
 	"received a series with duplicate label name, label: '%.200s' series: '%.200s'")
 
 func newDuplicatedLabelError(series []mimirpb.LabelAdapter, labelName string) ValidationError {
-	return &genericValidationError{
+	return genericValidationError{
 		message: duplicateLabelMsgFormat,
 		cause:   labelName,
 		series:  series,
@@ -90,7 +90,7 @@ var labelsNotSortedMsgFormat = globalerror.SeriesLabelsNotSorted.Message(
 	"received a series where the label names are not alphabetically sorted, label: '%.200s' series: '%.200s'")
 
 func newLabelsNotSortedError(series []mimirpb.LabelAdapter, labelName string) ValidationError {
-	return &genericValidationError{
+	return genericValidationError{
 		message: labelsNotSortedMsgFormat,
 		cause:   labelName,
 		series:  series,
@@ -103,13 +103,13 @@ type tooManyLabelsError struct {
 }
 
 func newTooManyLabelsError(series []mimirpb.LabelAdapter, limit int) ValidationError {
-	return &tooManyLabelsError{
+	return tooManyLabelsError{
 		series: series,
 		limit:  limit,
 	}
 }
 
-func (e *tooManyLabelsError) Error() string {
+func (e tooManyLabelsError) Error() string {
 	return globalerror.MaxLabelNamesPerSeries.MessageWithLimitConfig(
 		maxLabelNamesPerSeriesFlag,
 		fmt.Sprintf("received a series whose number of labels exceeds the limit (actual: %d, limit: %d) series: '%.200s'", len(e.series), e.limit, mimirpb.FromLabelAdaptersToMetric(e.series).String()))
@@ -118,10 +118,10 @@ func (e *tooManyLabelsError) Error() string {
 type noMetricNameError struct{}
 
 func newNoMetricNameError() ValidationError {
-	return &noMetricNameError{}
+	return noMetricNameError{}
 }
 
-func (e *noMetricNameError) Error() string {
+func (e noMetricNameError) Error() string {
 	return globalerror.MissingMetricName.Message("received series has no metric name")
 }
 
@@ -130,12 +130,12 @@ type invalidMetricNameError struct {
 }
 
 func newInvalidMetricNameError(metricName string) ValidationError {
-	return &invalidMetricNameError{
+	return invalidMetricNameError{
 		metricName: metricName,
 	}
 }
 
-func (e *invalidMetricNameError) Error() string {
+func (e invalidMetricNameError) Error() string {
 	return globalerror.InvalidMetricName.Message(fmt.Sprintf("received a series with invalid metric name: '%.200s'", e.metricName))
 }
 
@@ -146,7 +146,7 @@ type sampleValidationError struct {
 	timestamp  int64
 }
 
-func (e *sampleValidationError) Error() string {
+func (e sampleValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.timestamp, e.metricName)
 }
 
@@ -155,7 +155,7 @@ var sampleTimestampTooNewMsgFormat = globalerror.SampleTooFarInFuture.MessageWit
 	"received a sample whose timestamp is too far in the future, timestamp: %d series: '%.200s'")
 
 func newSampleTimestampTooNewError(metricName string, timestamp int64) ValidationError {
-	return &sampleValidationError{
+	return sampleValidationError{
 		message:    sampleTimestampTooNewMsgFormat,
 		metricName: metricName,
 		timestamp:  timestamp,
@@ -170,7 +170,7 @@ type exemplarValidationError struct {
 	timestamp      int64
 }
 
-func (e *exemplarValidationError) Error() string {
+func (e exemplarValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.timestamp, mimirpb.FromLabelAdaptersToLabels(e.seriesLabels).String(), mimirpb.FromLabelAdaptersToLabels(e.exemplarLabels).String())
 }
 
@@ -178,7 +178,7 @@ var exemplarEmptyLabelsMsgFormat = globalerror.ExemplarLabelsMissing.Message(
 	"received an exemplar with no valid labels, timestamp: %d series: %s labels: %s")
 
 func newExemplarEmptyLabelsError(seriesLabels []mimirpb.LabelAdapter, exemplarLabels []mimirpb.LabelAdapter, timestamp int64) ValidationError {
-	return &exemplarValidationError{
+	return exemplarValidationError{
 		message:        exemplarEmptyLabelsMsgFormat,
 		seriesLabels:   seriesLabels,
 		exemplarLabels: exemplarLabels,
@@ -190,7 +190,7 @@ var exemplarMissingTimestampMsgFormat = globalerror.ExemplarTimestampInvalid.Mes
 	"received an exemplar with no timestamp, timestamp: %d series: %s labels: %s")
 
 func newExemplarMissingTimestampError(seriesLabels []mimirpb.LabelAdapter, exemplarLabels []mimirpb.LabelAdapter, timestamp int64) ValidationError {
-	return &exemplarValidationError{
+	return exemplarValidationError{
 		message:        exemplarMissingTimestampMsgFormat,
 		seriesLabels:   seriesLabels,
 		exemplarLabels: exemplarLabels,
@@ -202,7 +202,7 @@ var exemplarMaxLabelLengthMsgFormat = globalerror.ExemplarLabelsTooLong.Message(
 	fmt.Sprintf("received an exemplar where the size of its combined labels exceeds the limit of %d characters, timestamp: %%d series: %%s labels: %%s", ExemplarMaxLabelSetLength))
 
 func newExemplarMaxLabelLengthError(seriesLabels []mimirpb.LabelAdapter, exemplarLabels []mimirpb.LabelAdapter, timestamp int64) ValidationError {
-	return &exemplarValidationError{
+	return exemplarValidationError{
 		message:        exemplarMaxLabelLengthMsgFormat,
 		seriesLabels:   seriesLabels,
 		exemplarLabels: exemplarLabels,
@@ -213,10 +213,10 @@ func newExemplarMaxLabelLengthError(seriesLabels []mimirpb.LabelAdapter, exempla
 type metadataMetricNameMissingError struct{}
 
 func newMetadataMetricNameMissingError() ValidationError {
-	return &metadataMetricNameMissingError{}
+	return metadataMetricNameMissingError{}
 }
 
-func (e *metadataMetricNameMissingError) Error() string {
+func (e metadataMetricNameMissingError) Error() string {
 	return globalerror.MetricMetadataMissingMetricName.Message("received a metric metadata with no metric name")
 }
 
@@ -227,7 +227,7 @@ type metadataValidationError struct {
 	metricName string
 }
 
-func (e *metadataValidationError) Error() string {
+func (e metadataValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.cause, e.metricName)
 }
 
@@ -237,7 +237,7 @@ var metadataMetricNameTooLongMsgFormat = globalerror.MetricMetadataMetricNameToo
 	"received a metric metadata whose metric name length exceeds the limit, metric name: '%.200[2]s'")
 
 func newMetadataMetricNameTooLongError(metadata *mimirpb.MetricMetadata) ValidationError {
-	return &metadataValidationError{
+	return metadataValidationError{
 		message:    metadataMetricNameTooLongMsgFormat,
 		cause:      "",
 		metricName: metadata.GetMetricFamilyName(),
@@ -249,7 +249,7 @@ var metadataHelpTooLongMsgFormat = globalerror.MetricMetadataHelpTooLong.Message
 	"received a metric metadata whose help description length exceeds the limit, help: '%.200s' metric name: '%.200s'")
 
 func newMetadataHelpTooLongError(metadata *mimirpb.MetricMetadata) ValidationError {
-	return &metadataValidationError{
+	return metadataValidationError{
 		message:    metadataHelpTooLongMsgFormat,
 		cause:      metadata.GetHelp(),
 		metricName: metadata.GetMetricFamilyName(),
@@ -261,7 +261,7 @@ var metadataUnitTooLongMsgFormat = globalerror.MetricMetadataUnitTooLong.Message
 	"received a metric metadata whose unit name length exceeds the limit, unit: '%.200s' metric name: '%.200s'")
 
 func newMetadataUnitTooLongError(metadata *mimirpb.MetricMetadata) ValidationError {
-	return &metadataValidationError{
+	return metadataValidationError{
 		message:    metadataUnitTooLongMsgFormat,
 		cause:      metadata.GetUnit(),
 		metricName: metadata.GetMetricFamilyName(),

--- a/pkg/util/validation/errors_test.go
+++ b/pkg/util/validation/errors_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+func TestNewMetadataMetricNameMissingError(t *testing.T) {
+	err := newMetadataMetricNameMissingError()
+	assert.Equal(t, "received a metric metadata with no metric name (err-mimir-metadata-missing-metric-name)", err.Error())
+}
+
+func TestNewMetadataMetricNameTooLongError(t *testing.T) {
+	err := newMetadataMetricNameTooLongError(&mimirpb.MetricMetadata{MetricFamilyName: "test_metric", Unit: "counter", Help: "This is a test metric."})
+	assert.Equal(t, "received a metric metadata whose metric name length exceeds the limit, metric name: 'test_metric' (err-mimir-metric-name-too-long). You can adjust the related per-tenant limit by configuring -validation.max-metadata-length, or by contacting your service administrator.", err.Error())
+}
+
+func TestNewMetadataHelpTooLongError(t *testing.T) {
+	err := newMetadataHelpTooLongError(&mimirpb.MetricMetadata{MetricFamilyName: "test_metric", Unit: "counter", Help: "This is a test metric."})
+	assert.Equal(t, "received a metric metadata whose help description length exceeds the limit, help: 'This is a test metric.' metric name: 'test_metric' (err-mimir-help-too-long). You can adjust the related per-tenant limit by configuring -validation.max-metadata-length, or by contacting your service administrator.", err.Error())
+}
+
+func TestNewMetadataUnitTooLongError(t *testing.T) {
+	err := newMetadataUnitTooLongError(&mimirpb.MetricMetadata{MetricFamilyName: "test_metric", Unit: "counter", Help: "This is a test metric."})
+	assert.Equal(t, "received a metric metadata whose unit name length exceeds the limit, unit: 'counter' metric name: 'test_metric' (err-mimir-unit-too-long). You can adjust the related per-tenant limit by configuring -validation.max-metadata-length, or by contacting your service administrator.", err.Error())
+}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -25,6 +25,7 @@ const (
 	maxLabelNamesPerSeriesFlag = "validation.max-label-names-per-series"
 	maxLabelNameLengthFlag     = "validation.max-length-label-name"
 	maxLabelValueLengthFlag    = "validation.max-length-label-value"
+	maxMetadataLengthFlag      = "validation.max-metadata-length"
 	creationGracePeriodFlag    = "validation.create-grace-period"
 )
 
@@ -146,7 +147,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelNameLength, maxLabelNameLengthFlag, 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, maxLabelValueLengthFlag, 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, maxLabelNamesPerSeriesFlag, 30, "Maximum number of label names per series.")
-	f.IntVar(&l.MaxMetadataLength, "validation.max-metadata-length", 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT.")
+	f.IntVar(&l.MaxMetadataLength, maxMetadataLengthFlag, 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT.")
 	_ = l.CreationGracePeriod.Set("10m")
 	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`.")
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -24,8 +24,6 @@ import (
 const (
 	discardReasonLabel = "reason"
 
-	errMetadataMissingMetricName = "metadata missing metric name"
-
 	// ErrQueryTooLong is used in chunk store, querier and query frontend.
 	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -6,7 +6,6 @@
 package validation
 
 import (
-	"net/http"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -15,7 +14,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
@@ -27,15 +25,6 @@ const (
 	discardReasonLabel = "reason"
 
 	errMetadataMissingMetricName = "metadata missing metric name"
-	errMetadataTooLong           = "metadata '%s' value too long: %.200q metric %.200q"
-
-	typeMetricName = "METRIC_NAME"
-	typeHelp       = "HELP"
-	typeUnit       = "UNIT"
-
-	metricNameTooLong = "metric_name_too_long"
-	helpTooLong       = "help_too_long"
-	unitTooLong       = "unit_too_long"
 
 	// ErrQueryTooLong is used in chunk store, querier and query frontend.
 	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
@@ -70,6 +59,11 @@ var (
 	reasonExemplarTimestampInvalid = metricReasonFromErrorID(globalerror.ExemplarTimestampInvalid)
 	reasonExemplarLabelsBlank      = "exemplar_labels_blank"
 	reasonExemplarTooOld           = "exemplar_too_old"
+
+	// Discarded metadata reasons.
+	reasonMetadataMetricNameTooLong = metricReasonFromErrorID(globalerror.MetricMetadataMetricNameTooLong)
+	reasonMetadataHelpTooLong       = metricReasonFromErrorID(globalerror.MetricMetadataHelpTooLong)
+	reasonMetadataUnitTooLong       = metricReasonFromErrorID(globalerror.MetricMetadataUnitTooLong)
 )
 
 func metricReasonFromErrorID(id globalerror.ID) string {
@@ -252,30 +246,26 @@ type MetadataValidationConfig interface {
 func ValidateMetadata(cfg MetadataValidationConfig, userID string, metadata *mimirpb.MetricMetadata) error {
 	if cfg.EnforceMetadataMetricName(userID) && metadata.GetMetricFamilyName() == "" {
 		DiscardedMetadata.WithLabelValues(reasonMissingMetricName, userID).Inc()
-		return httpgrpc.Errorf(http.StatusBadRequest, errMetadataMissingMetricName)
+		return newMetadataMetricNameMissingError()
 	}
 
 	maxMetadataValueLength := cfg.MaxMetadataLength(userID)
 	var reason string
-	var cause string
-	var metadataType string
+	var err error
 	if len(metadata.GetMetricFamilyName()) > maxMetadataValueLength {
-		metadataType = typeMetricName
-		reason = metricNameTooLong
-		cause = metadata.GetMetricFamilyName()
+		reason = reasonMetadataMetricNameTooLong
+		err = newMetadataMetricNameTooLongError(metadata)
 	} else if len(metadata.Help) > maxMetadataValueLength {
-		metadataType = typeHelp
-		reason = helpTooLong
-		cause = metadata.Help
+		reason = reasonMetadataHelpTooLong
+		err = newMetadataHelpTooLongError(metadata)
 	} else if len(metadata.Unit) > maxMetadataValueLength {
-		metadataType = typeUnit
-		reason = unitTooLong
-		cause = metadata.Unit
+		reason = reasonMetadataUnitTooLong
+		err = newMetadataUnitTooLongError(metadata)
 	}
 
-	if reason != "" {
+	if err != nil {
 		DiscardedMetadata.WithLabelValues(reason, userID).Inc()
-		return httpgrpc.Errorf(http.StatusBadRequest, errMetadataTooLong, metadataType, cause, metadata.GetMetricFamilyName())
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does
As a follow up of #1907, in this PR I'm improving error messages returned by `validation.ValidateMetadata()`. I've also changed the logic to not directly return a `httpgrpc` error, but a `ValidationError`, to keep it consistent with other validation functions.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
