### PR TITLE
Update Thanos vendor for memcache improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.7.1
-	github.com/thanos-io/thanos v0.26.1-0.20220519101240-9812db5d88a0
+	github.com/thanos-io/thanos v0.26.1-0.20220524120302-5d49fbc057c4
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/weaveworks/common v0.0.0-20211109170639-0684aab3d884
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1784,8 +1784,8 @@ github.com/thanos-io/thanos v0.13.1-0.20210226164558-03dace0a1aa1/go.mod h1:gMCy
 github.com/thanos-io/thanos v0.13.1-0.20210401085038-d7dff0c84d17/go.mod h1:zU8KqE+6A+HksK4wiep8e/3UvCZLm+Wrw9AqZGaAm9k=
 github.com/thanos-io/thanos v0.22.0/go.mod h1:SZDWz3phcUcBr4MYFoPFRvl+Z9Nbi45HlwQlwSZSt+Q=
 github.com/thanos-io/thanos v0.24.0/go.mod h1:sfnKJG7cDA41ixNL4gsTJEa3w9Qt8lwAjw+dqRMSDG0=
-github.com/thanos-io/thanos v0.26.1-0.20220519101240-9812db5d88a0 h1:pv6q/Kk7/jqEqwSee+EkxXcugRPDeD8enfGhXWFW7pc=
-github.com/thanos-io/thanos v0.26.1-0.20220519101240-9812db5d88a0/go.mod h1:9e/ytDfVepSKxihUWXyy1irj+ipM/DAlOBqsyXs+Y10=
+github.com/thanos-io/thanos v0.26.1-0.20220524120302-5d49fbc057c4 h1:QKs0sZZjhFN517LFtNUTpzKdHBMEIwgicJarGqQ6puI=
+github.com/thanos-io/thanos v0.26.1-0.20220524120302-5d49fbc057c4/go.mod h1:9e/ytDfVepSKxihUWXyy1irj+ipM/DAlOBqsyXs+Y10=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/testutil.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/testutil.go
@@ -87,6 +87,52 @@ func Equals(tb testing.TB, exp, act interface{}, v ...interface{}) {
 	tb.Fatal(sprintfWithLimit("\033[31m%s:%d:"+msg+"\n\n\texp: %#v\n\n\tgot: %#v%s\033[39m\n\n", filepath.Base(file), line, exp, act, diff(exp, act)))
 }
 
+// Contains fails the test if needle is not contained within haystack, if haystack or needle is
+// an empty slice, or if needle is longer than haystack.
+func Contains(tb testing.TB, haystack, needle []string) {
+	_, file, line, _ := runtime.Caller(1)
+
+	if !contains(haystack, needle) {
+		tb.Fatalf(sprintfWithLimit("\033[31m%s:%d: %#v does not contain %#v\033[39m\n\n", filepath.Base(file), line, haystack, needle))
+	}
+}
+
+func contains(haystack, needle []string) bool {
+	if len(haystack) == 0 || len(needle) == 0 {
+		return false
+	}
+
+	if len(haystack) < len(needle) {
+		return false
+	}
+
+	for i := 0; i < len(haystack); i++ {
+		outer := i
+
+		for j := 0; j < len(needle); j++ {
+			// End of the haystack but not the end of the needle, end
+			if outer == len(haystack) {
+				return false
+			}
+
+			// No match, try the next index of the haystack
+			if haystack[outer] != needle[j] {
+				break
+			}
+
+			// End of the needle and it still matches, end
+			if j == len(needle)-1 {
+				return true
+			}
+
+			// This element matches between the two slices, try the next one
+			outer++
+		}
+	}
+
+	return false
+}
+
 func sprintfWithLimit(act string, v ...interface{}) string {
 	s := fmt.Sprintf(act, v...)
 	if len(s) > 10000 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -807,7 +807,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.26.1-0.20220519101240-9812db5d88a0
+# github.com/thanos-io/thanos v0.26.1-0.20220524120302-5d49fbc057c4
 ## explicit; go 1.17
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/indexheader


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Update our vendor of Thanos so that memcache keys are grouped by the
server they are owned by before being split into batches.

#### Which issue(s) this PR fixes or relates to

Fixes #423

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
