### PR TITLE
Make MimirGossipMembersMismatch less sensitive, and make it fire fewer alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 * [BUGFIX] Fix `MimirRulerMissedEvaluations` to show % of missed alerts as a value between 0 and 100 instead of 0 and 1. #1895
 * [BUGFIX] Fix `MimirCompactorHasNotUploadedBlocks` alert false positive when Mimir is deployed in monolithic mode. #1901
+* [BUGFIX] Fix `MimirGossipMembersMismatch` to make it less sensitive during rollouts and fire one alert per installation, not per pod.
 * [BUGFIX] Do not trigger `MimirAllocatingTooMuchMemory` alerts if no container limits are supplied. #1905
 
 ### Jsonnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [BUGFIX] Fix `MimirGossipMembersMismatch` alerts if Mimir alertmanager is activated #1870
 * [BUGFIX] Fix `MimirRulerMissedEvaluations` to show % of missed alerts as a value between 0 and 100 instead of 0 and 1. #1895
 * [BUGFIX] Fix `MimirCompactorHasNotUploadedBlocks` alert false positive when Mimir is deployed in monolithic mode. #1901
-* [BUGFIX] Fix `MimirGossipMembersMismatch` to make it less sensitive during rollouts and fire one alert per installation, not per pod.
+* [BUGFIX] Fix `MimirGossipMembersMismatch` to make it less sensitive during rollouts and fire one alert per installation, not per job. #1926
 * [BUGFIX] Do not trigger `MimirAllocatingTooMuchMemory` alerts if no container limits are supplied. #1905
 
 ### Jsonnet

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -352,10 +352,8 @@ groups:
       message: Mimir instance {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} sees incorrect number of gossip members.
     expr: |
-      memberlist_client_cluster_members_count
-        != on (cluster, namespace) group_left
-      sum by (cluster, namespace) (up{job=~".+/(alertmanager|compactor|distributor|ingester.*|querier.*|ruler|store-gateway.*|cortex|mimir)"})
-    for: 5m
+      avg by (cluster, namespace) (memberlist_client_cluster_members_count) != sum by (cluster, namespace) (up{job=~".+/(alertmanager|compactor|distributor|ingester.*|querier.*|ruler|store-gateway.*|cortex|mimir)"})
+    for: 15m
     labels:
       severity: warning
 - name: etcd_alerts

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -572,11 +572,9 @@
           alert: $.alertName('GossipMembersMismatch'),
           expr:
             |||
-              memberlist_client_cluster_members_count
-                != on (%s) group_left
-              sum by (%s) (up{job=~".+/%s"})
+              avg by (%s) (memberlist_client_cluster_members_count) != sum by (%s) (up{job=~".+/%s"})
             ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels, simpleRegexpOpt($._config.job_names.ring_members)],
-          'for': '5m',
+          'for': '15m',
           labels: {
             severity: 'warning',
           },


### PR DESCRIPTION
#### What this PR does

This PR adjusts `MimirGossipMembersMismatch`.

Alert is defined to compare number of memberlist members against number of alertmanager, compactor, distributor, ingester, querier, ruler and store-gateway jobs. Under normal operations, these numbers should match. During rollouts they often mismatch because of two reasons:
- memberlist_client_cluster_members_count relies on "leave cluster" message propagation, and may not be up to date
- jobs may be "up" before they had a chance to join the memberlist cluster

This is what it looks like on one of our clusters (diff between average memberlist_client_cluster_members_count and number of `up` metrics), with multizone setup for ingesters and store-gateways:

<img width="1725" alt="Screenshot 2022-05-25 at 13 51 41" src="https://user-images.githubusercontent.com/895919/170255714-939eec62-3676-499a-90a1-075c34643962.png">

This PR extends "for" time before alert fires, and also modifies the expression to generate single value per installation, instead of single value per job (ie. one alert instead of hundreds).

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
