### PR TITLE
Update config value for -querier.query-ingesters-within to work with …

### DIFF
--- a/development/tsdb-blocks-storage-s3-single-binary/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/mimir.yaml
@@ -24,7 +24,7 @@ ingester:
     replication_factor: 1
 
 querier:
-  query_ingesters_within: 3h
+  query_ingesters_within: 13h
 
 store_gateway:
   sharding_ring:

--- a/development/tsdb-blocks-storage-s3-single-binary/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/mimir.yaml
@@ -23,9 +23,6 @@ ingester:
         host: consul:8500
     replication_factor: 1
 
-querier:
-  query_ingesters_within: 13h
-
 store_gateway:
   sharding_ring:
     replication_factor: 1

--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -36,9 +36,6 @@ memberlist:
   abort_if_cluster_join_fails: false
   rejoin_interval: 10s
 
-querier:
-  query_ingesters_within: 13h
-
 blocks_storage:
   backend: s3
 

--- a/development/tsdb-blocks-storage-s3/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-s3/config/mimir.yaml
@@ -37,7 +37,7 @@ memberlist:
   rejoin_interval: 10s
 
 querier:
-  query_ingesters_within: 3h
+  query_ingesters_within: 13h
 
 blocks_storage:
   backend: s3

--- a/development/tsdb-blocks-storage-swift-single-binary/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-swift-single-binary/config/mimir.yaml
@@ -24,7 +24,7 @@ ingester:
     replication_factor: 1
 
 querier:
-  query_ingesters_within: 3h
+  query_ingesters_within: 13h
 
 store_gateway:
   sharding_ring:

--- a/development/tsdb-blocks-storage-swift-single-binary/config/mimir.yaml
+++ b/development/tsdb-blocks-storage-swift-single-binary/config/mimir.yaml
@@ -23,9 +23,6 @@ ingester:
         host: consul:8500
     replication_factor: 1
 
-querier:
-  query_ingesters_within: 13h
-
 store_gateway:
   sharding_ring:
     replication_factor: 1


### PR DESCRIPTION
…new default value for -querier.query-store-after

#### What this PR does

It updates the config value for `-querier.query-ingesters-within` for the docker-compose scripts in the `development` folder to match the default of 13h. Currently, running those scripts from `main` branch results in the error `querier_1          | error validating config: invalid querier config: the -querier.query-ingesters-within setting must be greater than -querier.query-store-after otherwise queries might return partial results` so querier cannot start.

#### Which issue(s) this PR fixes or relates to

No issue, but the default value of `-querier.query-store-after` was recently updated in https://github.com/grafana/mimir/pull/1909 

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

None of the above, but not sure if they are relevant for this change.

Also, since it's just setting it to the default value, would it be better if we removed those configs from the affected files instead?
