### PR TITLE
Include full image tag on rollout dashboard

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -1177,7 +1177,7 @@
             "id": 11,
             "targets": [
                {
-                  "expr": "count by(container, version) (\n  label_replace(\n    kube_pod_container_info{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\".*(cortex-gw|distributor|ingester|query-frontend|query-scheduler|querier|compactor|store-gateway|ruler|alertmanager|overrides-exporter|cortex|mimir).*\"},\n    \"version\", \"$1\", \"image\", \".*:(.+)-.*\"\n  )\n)\n",
+                  "expr": "count by(container, version) (\n  label_replace(\n    kube_pod_container_info{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\".*(cortex-gw|distributor|ingester|query-frontend|query-scheduler|querier|compactor|store-gateway|ruler|alertmanager|overrides-exporter|cortex|mimir).*\"},\n    \"version\", \"$1\", \"image\", \".*:(.*)\"\n  )\n)\n",
                   "instant": true,
                   "legendFormat": "",
                   "refId": "A"

--- a/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
@@ -237,7 +237,7 @@ local filename = 'mimir-rollout-progress.json';
                 count by(container, version) (
                   label_replace(
                     kube_pod_container_info{%(namespace_matcher)s,container=~"%(all_services_regex)s"},
-                    "version", "$1", "image", ".*:(.+)-.*"
+                    "version", "$1", "image", ".*:(.*)"
                   )
                 )
               ||| % config,


### PR DESCRIPTION

#### What this PR does

Include the whole image tag in the rollout dashbaord. This breaks any user who is using a non-weekly release (e.g. 2.0.0)

how it used to be 
![Screenshot 2022-05-25 at 19 39 28](https://user-images.githubusercontent.com/21020035/170329407-d53b3b83-768c-4f5b-8bfd-4225bdacb7f8.png)

how it is 
![Screenshot 2022-05-25 at 19 45 16](https://user-images.githubusercontent.com/21020035/170329327-cd16620d-4ef9-4995-a459-26ca56d7a3c7.png)


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
