### PR TITLE
Move usage generation to separate package

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimir"
 	util_log "github.com/grafana/mimir/pkg/util/log"
+	"github.com/grafana/mimir/pkg/util/usage"
 	"github.com/grafana/mimir/pkg/util/version"
 )
 
@@ -113,7 +114,7 @@ func main() {
 	if mainFlags.printHelp || mainFlags.printHelpAll {
 		// Print available parameters to stdout, so that users can grep/less them easily.
 		flag.CommandLine.SetOutput(os.Stdout)
-		if err := usage(&mainFlags, &cfg); err != nil {
+		if err := usage.Usage(mainFlags.printHelpAll, &mainFlags, &cfg); err != nil {
 			fmt.Fprintf(os.Stderr, "error printing usage: %s\n", err)
 			os.Exit(1)
 		}

--- a/pkg/util/fieldcategory/overrides.go
+++ b/pkg/util/fieldcategory/overrides.go
@@ -65,6 +65,12 @@ var overrides = map[string]Category{
 	"server.register-instrumentation":                   Advanced,
 }
 
+func AddOverrides(o map[string]Category) {
+	for n, c := range o {
+		overrides[n] = c
+	}
+}
+
 func GetOverride(fieldName string) (category Category, ok bool) {
 	category, ok = overrides[fieldName]
 	return

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package main
+package usage
 
 import (
 	"flag"
@@ -12,18 +12,18 @@ import (
 	"github.com/grafana/dskit/flagext"
 
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
-	"github.com/grafana/mimir/pkg/mimir"
 	"github.com/grafana/mimir/pkg/util/fieldcategory"
 )
 
-// usage prints command-line usage. If mf.printHelpAll is false then only basic flags are included, otherwise all flags are included.
-func usage(mf *mainFlags, cfg *mimir.Config) error {
+// Usage prints command-line usage.
+// printAll controls whether only basic flags or all flags are included.
+// configs are expected to be pointers to structs.
+func Usage(printAll bool, configs ...interface{}) error {
 	fields := map[uintptr]reflect.StructField{}
-	if err := parseStructure(mf, fields); err != nil {
-		return err
-	}
-	if err := parseStructure(cfg, fields); err != nil {
-		return err
+	for _, c := range configs {
+		if err := parseStructure(c, fields); err != nil {
+			return err
+		}
 	}
 
 	fs := flag.CommandLine
@@ -49,7 +49,7 @@ func usage(mf *mainFlags, cfg *mimir.Config) error {
 			}
 		}
 
-		if fieldCat != fieldcategory.Basic && !mf.printHelpAll {
+		if fieldCat != fieldcategory.Basic && !printAll {
 			// Don't print help for this flag since we're supposed to print only basic flags
 			return
 		}
@@ -85,7 +85,7 @@ func usage(mf *mainFlags, cfg *mimir.Config) error {
 		fmt.Fprint(fs.Output(), b.String(), "\n")
 	})
 
-	if !mf.printHelpAll {
+	if !printAll {
 		fmt.Fprintf(fs.Output(), "\nTo see all flags, use -help-all\n")
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR moves the command line usage generation function into a separate package, and adds a function to set flag category overrides at runtime.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
