### PR TITLE
Document CHANGELOG scopes and update CHANGELOG for #1934

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] The following settings are now classified as advanced because the defaults should work for most users and tuning them requires in-depth knowledge of how the read path works: #1929
     - `-querier.query-ingesters-within`
     - `-querier.query-store-after`
+* [CHANGE] Config flag category overrides can be set dynamically at runtime. #1934
 * [ENHANCEMENT] Store-gateway: Add the experimental ability to run requests in a dedicated OS thread pool. This feature can be configured using `-store-gateway.thread-pool-size` and is disabled by default. Replaces the ability to run index header operations in a dedicated thread pool. #1660 #1812
 * [ENHANCEMENT] Improved error messages to make them easier to understand and referencing a unique global identifier that can be looked up in the runbooks. #1907 #1919
 * [ENHANCEMENT] Memberlist KV: incoming messages are now processed on per-key goroutine. This may reduce loss of "maintanance" packets in busy memberlist installations, but use more CPU. New `memberlist_client_received_broadcasts_dropped_total` counter tracks number of dropped per-key messages. #1912

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -11,33 +11,8 @@ a piece of work is finished it should:
 - Be organised into one or more commits, each of which has a commit message that describes all changes made in that commit ('why' more than 'what' - we can read the diffs to see the code that changed).
 - Each commit should build towards the whole - don't leave in back-tracks and mistakes that you later corrected.
 - Have unit and/or [integration](./how-integration-tests-work.md) tests for new functionality or tests that would have caught the bug being fixed.
-- Include a CHANGELOG message if users of Grafana Mimir need to hear about what you did.
+- Include a [CHANGELOG](#changelog) message if users of Grafana Mimir need to hear about what you did.
 - If you have made any changes to flags or config, run `make doc` and commit the changed files to update the config file documentation.
-
-## Changelog
-
-When appending to the changelog, the changes must be listed with a corresponding scope. A scope denotes the type of change that has occurred.
-
-The ordering of entries in the changelog should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
-
-### [CHANGE]
-
-The CHANGE scope denotes a change that changes the expected behavior of the project while not adding new functionality or fixing an underling issue. This commonly occurs when renaming things to make them more consistent or to accommodate updated versions of vendored dependencies.
-
-### [FEATURE]
-
-The FEATURE scope denotes a change that adds new functionality to the project/service.
-
-### [ENHANCEMENT]
-
-The ENHANCEMENT scope denotes a change that improves upon the current functionality of the project/service. Generally, an enhancement is something that improves upon something that is already present. Either by making it simpler, more powerful, or more performant. For Example:
-
-- An optimization on a particular process in a service that makes it more performant
-- Simpler syntax for setting a configuration value, like allowing `1m` instead of 60 for a duration setting.
-
-### [BUGFIX]
-
-The BUGFIX scope denotes a change that fixes an issue with the project in question. A BUGFIX should align the behaviour of the service with the current expected behaviour of the service. If a BUGFIX introduces new unexpected behaviour to ameliorate the issue, a corresponding FEATURE or ENHANCEMENT scope should also be added to the changelog.
 
 ## Formatting
 
@@ -102,3 +77,28 @@ Please see the dedicated "[Design patterns and Code conventions](design-patterns
 The Grafana Mimir documentation is compiled into a website published at [grafana.com](https://grafana.com/). Please see "[How to run the website locally](./how-to-run-website-locally.md)" for instructions.
 
 Note: if you attempt to view pages on Github, it's likely that you might find broken links or pages. That is expected and should not be addressed unless it is causing issues with the site that occur as part of the build.
+
+## Changelog
+
+When appending to the changelog, the changes must be listed with a corresponding scope. A scope denotes the type of change that has occurred.
+
+The ordering of entries in the changelog should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
+
+#### [CHANGE]
+
+The CHANGE scope denotes a change that changes the expected behavior of the project while not adding new functionality or fixing an underling issue. This commonly occurs when renaming things to make them more consistent or to accommodate updated versions of vendored dependencies.
+
+#### [FEATURE]
+
+The FEATURE scope denotes a change that adds new functionality to the project/service.
+
+#### [ENHANCEMENT]
+
+The ENHANCEMENT scope denotes a change that improves upon the current functionality of the project/service. Generally, an enhancement is something that improves upon something that is already present. Either by making it simpler, more powerful, or more performant. For Example:
+
+- An optimization on a particular process in a service that makes it more performant
+- Simpler syntax for setting a configuration value, like allowing `1m` instead of 60 for a duration setting.
+
+#### [BUGFIX]
+
+The BUGFIX scope denotes a change that fixes an issue with the project in question. A BUGFIX should align the behaviour of the service with the current expected behaviour of the service. If a BUGFIX introduces new unexpected behaviour to ameliorate the issue, a corresponding FEATURE or ENHANCEMENT scope should also be added to the changelog.

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -14,6 +14,31 @@ a piece of work is finished it should:
 - Include a CHANGELOG message if users of Grafana Mimir need to hear about what you did.
 - If you have made any changes to flags or config, run `make doc` and commit the changed files to update the config file documentation.
 
+## Changelog
+
+When appending to the changelog, the changes must be listed with a corresponding scope. A scope denotes the type of change that has occurred.
+
+The ordering of entries in the changelog should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
+
+### [CHANGE]
+
+The CHANGE scope denotes a change that changes the expected behavior of the project while not adding new functionality or fixing an underling issue. This commonly occurs when renaming things to make them more consistent or to accommodate updated versions of vendored dependencies.
+
+### [FEATURE]
+
+The FEATURE scope denotes a change that adds new functionality to the project/service.
+
+### [ENHANCEMENT]
+
+The ENHANCEMENT scope denotes a change that improves upon the current functionality of the project/service. Generally, an enhancement is something that improves upon something that is already present. Either by making it simpler, more powerful, or more performant. For Example:
+
+- An optimization on a particular process in a service that makes it more performant
+- Simpler syntax for setting a configuration value, like allowing `1m` instead of 60 for a duration setting.
+
+### [BUGFIX]
+
+The BUGFIX scope denotes a change that fixes an issue with the project in question. A BUGFIX should align the behaviour of the service with the current expected behaviour of the service. If a BUGFIX introduces new unexpected behaviour to ameliorate the issue, a corresponding FEATURE or ENHANCEMENT scope should also be added to the changelog.
+
 ## Formatting
 
 Grafana Mimir uses `goimports` tool (`go get golang.org/x/tools/cmd/goimports` to install) to format the Go files, and sort imports. We use goimports with `-local github.com/grafana/mimir` parameter, to put Grafana Mimir internal imports into a separate group. We try to keep imports sorted into three groups: imports from standard library, imports of 3rd party packages and internal Grafana Mimir imports. Goimports will fix the order, but will keep existing newlines between imports in the groups. We try to avoid extra newlines like that.


### PR DESCRIPTION
#### What this PR does

- Documents the meaning of scope labels in CHANGELOG entries
- Updates changelog for #1934 

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
