### PR TITLE
Bump grafana/mimir image to 2.1.0 for backward compatibility testing

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,7 +7,7 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.0.0": e2emimir.NoopFlagMapper,
+	"grafana/mimir:2.1.0": e2emimir.NoopFlagMapper,
 }
 
 var (


### PR DESCRIPTION
#### What this PR does
Bumps backward compatibility testing after cutting release 2.1.0