### PR TITLE
Release mimir-distributed-beta to helm-charts repo

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,18 @@
+name: helm-release
+
+on:
+  push:
+    branches:
+      - helm-release-test
+
+jobs:
+  call-update-helm-repo:
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
+    with:
+      charts_dir: operations/helm/charts
+      cr_configfile: operations/helm/cr.yaml
+      ct_configfile: operations/helm/ct.yaml
+    secrets:
+      helm_repo_token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+      # See https://github.com/grafana/helm-charts/blob/main/INTERNAL.md about this key
+      gpg_key_base64: ${{ secrets.HELM_SIGN_KEY_BASE64 }}

--- a/operations/helm/cr.yaml
+++ b/operations/helm/cr.yaml
@@ -1,2 +1,5 @@
-sign: true
+git-repo: helm-charts
 key: Grafana Loki
+owner: grafana
+sign: true
+skip-existing: true


### PR DESCRIPTION
#### What this PR does

Implements releasing the mimir-distributed(-beta) chart from operations/helm/charts to:
- helm-charts repo (releases)
- helm-charts github pages (index.yaml)

#### Which issue(s) this PR fixes or relates to

Internal mimir-squad number 668

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
