### PR TITLE
mixin: adapt alerts/playbooks to consider ruler query path components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [CHANGE] Split `mimir_queries` rules group into `mimir_queries` and `mimir_ingester_queries` to keep number of rules per group within the default per-tenant limit. #1885
 * [CHANGE] Dashboards: Expose full image tag in "Mimir / Rollout progress" dashboard's "Pod per version panel." #1932
 * [CHANGE] Dashboards: Disabled gateway panels by default, because most users don't have a gateway exposing the metrics expected by Mimir dashboards. You can re-enable it setting `gateway_enabled: true` in the mixin config and recompiling the mixin running `make build-mixin`. #1954
+* [CHANGE] Alerts: adapt `MimirFrontendQueriesStuck` and `MimirSchedulerQueriesStuck` to consider ruler query path components. #1949
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
 * [ENHANCEMENT] Dashboards: Added "Mimir / Remote ruler reads" and "Mimir / Remote ruler reads resources" dashboards. #1911 #1937
 * [ENHANCEMENT] Dashboards: Make networking panels work for pods created by the mimir-distributed helm chart. #1927

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -667,7 +667,7 @@ How to **investigate**:
   - An increased latency reduces the number of queries we can run / sec: once all workers are busy, new queries will pile up in the queue
   - Temporarily scale up queriers to try to stop the bleed
   - Check if a specific tenant is running heavy queries
-    - Run `sum by (user) (cortex_query_scheduler_queue_length{namespace="<namespace>",container="query-scheduler"}) > 0` to find tenants with enqueued queries
+    - Run `sum by (user) (cortex_query_scheduler_queue_length{namespace="<namespace>"}) > 0` to find tenants with enqueued queries
     - Check the `Mimir / Slow Queries` dashboard to find slow queries
   - On multi-tenant Mimir cluster with **shuffle-sharing for queriers disabled**, you may consider to enable it for that specific tenant to reduce its blast radius. To enable queriers shuffle-sharding for a single tenant you need to set the `max_queriers_per_tenant` limit override for the specific tenant (the value should be set to the number of queriers assigned to the tenant).
   - On multi-tenant Mimir cluster with **shuffle-sharding for queriers enabled**, you may consider to temporarily increase the shard size for affected tenants: be aware that this could affect other tenants too, reducing resources available to run other tenant queries. Alternatively, you may choose to do nothing and let Mimir return errors for that given user once the per-tenant queue is full.

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -334,18 +334,6 @@ How to **fix** it:
 - Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes.
 - Try splitting up the rule group into multiple rule groups. Rule groups are evaluated in parallel, so the same rules may still fit in the same resolution.
 
-### MimirRulerFrontendQueriesStuck
-
-This alert fires if Mimir is running without ruler-query-scheduler and queries are piling up in the ruler-query-frontend queue.
-
-The procedure to investigate it is the same as the one for [`MimirSchedulerQueriesStuck`](#MimirSchedulerQueriesStuck): please see the other playbook for more details.
-
-### MimirRulerSchedulerQueriesStuck
-
-This alert fires if queries are piling up in the ruler-query-scheduler.
-
-The procedure to investigate it is the same as the one for [`MimirSchedulerQueriesStuck`](#MimirSchedulerQueriesStuck): please see the other playbook for more details.
-
 ### MimirIngesterHasNotShippedBlocks
 
 This alert fires when a Mimir ingester is not uploading any block to the long-term storage. An ingester is expected to upload a block to the storage every block range period (defaults to 2h) and if a longer time elapse since the last successful upload it means something is not working correctly.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -322,6 +322,19 @@ groups:
     for: 5m
     labels:
       severity: warning
+  - alert: MimirRulerMissedEvaluations
+    annotations:
+      message: |
+        Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+    expr: |
+      100 * (
+      sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+        /
+      sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+      ) > 1
+    for: 5m
+    labels:
+      severity: warning
   - alert: MimirRulerFailedRingCheck
     annotations:
       message: |

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -66,18 +66,18 @@ groups:
   - alert: MimirFrontendQueriesStuck
     annotations:
       message: |
-        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} query-frontend.
+        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
     expr: |
-      sum by (cluster, namespace) (cortex_query_frontend_queue_length{container="query-frontend"}) > 1
+      sum by (cluster, namespace, job) (cortex_query_frontend_queue_length) > 1
     for: 5m
     labels:
       severity: critical
   - alert: MimirSchedulerQueriesStuck
     annotations:
       message: |
-        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} query-scheduler.
+        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
     expr: |
-      sum by (cluster, namespace) (cortex_query_scheduler_queue_length{container="query-scheduler"}) > 1
+      sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 1
     for: 5m
     labels:
       severity: critical
@@ -318,37 +318,6 @@ groups:
       sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
         /
       sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
-      ) > 1
-    for: 5m
-    labels:
-      severity: warning
-  - alert: MimirRulerFrontendQueriesStuck
-    annotations:
-      message: |
-        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} ruler-query-frontend.
-    expr: |
-      sum by (cluster, namespace) (cortex_query_frontend_queue_length{container="ruler-query-frontend"}) > 1
-    for: 5m
-    labels:
-      severity: warning
-  - alert: MimirRulerSchedulerQueriesStuck
-    annotations:
-      message: |
-        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} ruler-query-scheduler.
-    expr: |
-      sum by (cluster, namespace) (cortex_query_scheduler_queue_length{container="ruler-query-scheduler"}) > 1
-    for: 5m
-    labels:
-      severity: warning
-  - alert: MimirRulerMissedEvaluations
-    annotations:
-      message: |
-        Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
-    expr: |
-      100 * (
-      sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
-        /
-      sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
       ) > 1
     for: 5m
     labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -68,7 +68,7 @@ groups:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} query-frontend.
     expr: |
-      sum by (cluster, namespace) (cortex_query_frontend_queue_length) > 1
+      sum by (cluster, namespace) (cortex_query_frontend_queue_length{container="query-frontend"}) > 1
     for: 5m
     labels:
       severity: critical
@@ -77,7 +77,7 @@ groups:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} query-scheduler.
     expr: |
-      sum by (cluster, namespace) (cortex_query_scheduler_queue_length) > 1
+      sum by (cluster, namespace) (cortex_query_scheduler_queue_length{container="query-scheduler"}) > 1
     for: 5m
     labels:
       severity: critical
@@ -319,6 +319,24 @@ groups:
         /
       sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
       ) > 1
+    for: 5m
+    labels:
+      severity: warning
+  - alert: MimirRulerFrontendQueriesStuck
+    annotations:
+      message: |
+        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} ruler-query-frontend.
+    expr: |
+      sum by (cluster, namespace) (cortex_query_frontend_queue_length{container="ruler-query-frontend"}) > 1
+    for: 5m
+    labels:
+      severity: warning
+  - alert: MimirRulerSchedulerQueriesStuck
+    annotations:
+      message: |
+        There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} ruler-query-scheduler.
+    expr: |
+      sum by (cluster, namespace) (cortex_query_scheduler_queue_length{container="ruler-query-scheduler"}) > 1
     for: 5m
     labels:
       severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -127,7 +127,7 @@
         {
           alert: $.alertName('FrontendQueriesStuck'),
           expr: |||
-            sum by (%s) (cortex_query_frontend_queue_length{container="query-frontend"}) > 1
+            sum by (%s, job) (cortex_query_frontend_queue_length) > 1
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {
@@ -135,14 +135,14 @@
           },
           annotations: {
             message: |||
-              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s query-frontend.
+              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s {{ $labels.job }}.
             ||| % $._config,
           },
         },
         {
           alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
-            sum by (%s) (cortex_query_scheduler_queue_length{container="query-scheduler"}) > 1
+            sum by (%s, job) (cortex_query_scheduler_queue_length) > 1
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {
@@ -150,7 +150,7 @@
           },
           annotations: {
             message: |||
-              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s query-scheduler.
+              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s {{ $labels.job }}.
             ||| % $._config,
           },
         },
@@ -525,55 +525,6 @@
           annotations: {
             message: |||
               %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% errors while evaluating rules.
-            ||| % $._config,
-          },
-        },
-        {
-          alert: $.alertName('RulerFrontendQueriesStuck'),
-          expr: |||
-            sum by (%s) (cortex_query_frontend_queue_length{container="ruler-query-frontend"}) > 1
-          ||| % $._config.alert_aggregation_labels,
-          'for': '5m',  // We don't want to block for longer.
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: |||
-              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s ruler-query-frontend.
-            ||| % $._config,
-          },
-        },
-        {
-          alert: $.alertName('RulerSchedulerQueriesStuck'),
-          expr: |||
-            sum by (%s) (cortex_query_scheduler_queue_length{container="ruler-query-scheduler"}) > 1
-          ||| % $._config.alert_aggregation_labels,
-          'for': '5m',  // We don't want to block for longer.
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: |||
-              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s ruler-query-scheduler.
-            ||| % $._config,
-          },
-        },
-        {
-          alert: $.alertName('RulerMissedEvaluations'),
-          expr: |||
-            100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
-              /
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
-            ) > 1
-          ||| % $._config,
-          'for': '5m',
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: |||
-              %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% missed iterations for the rule group {{ $labels.rule_group }}.
             ||| % $._config,
           },
         },

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -529,6 +529,25 @@
           },
         },
         {
+          alert: $.alertName('RulerMissedEvaluations'),
+          expr: |||
+            100 * (
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+              /
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            ) > 1
+          ||| % $._config,
+          'for': '5m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% missed iterations for the rule group {{ $labels.rule_group }}.
+            ||| % $._config,
+          },
+        },
+        {
           alert: $.alertName('RulerFailedRingCheck'),
           expr: |||
             sum by (%s, job) (rate(cortex_ruler_ring_check_errors_total[1m]))

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -127,7 +127,7 @@
         {
           alert: $.alertName('FrontendQueriesStuck'),
           expr: |||
-            sum by (%s) (cortex_query_frontend_queue_length) > 1
+            sum by (%s) (cortex_query_frontend_queue_length{container="query-frontend"}) > 1
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {
@@ -142,7 +142,7 @@
         {
           alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
-            sum by (%s) (cortex_query_scheduler_queue_length) > 1
+            sum by (%s) (cortex_query_scheduler_queue_length{container="query-scheduler"}) > 1
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {
@@ -525,6 +525,36 @@
           annotations: {
             message: |||
               %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% errors while evaluating rules.
+            ||| % $._config,
+          },
+        },
+        {
+          alert: $.alertName('RulerFrontendQueriesStuck'),
+          expr: |||
+            sum by (%s) (cortex_query_frontend_queue_length{container="ruler-query-frontend"}) > 1
+          ||| % $._config.alert_aggregation_labels,
+          'for': '5m',  // We don't want to block for longer.
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s ruler-query-frontend.
+            ||| % $._config,
+          },
+        },
+        {
+          alert: $.alertName('RulerSchedulerQueriesStuck'),
+          expr: |||
+            sum by (%s) (cortex_query_scheduler_queue_length{container="ruler-query-scheduler"}) > 1
+          ||| % $._config.alert_aggregation_labels,
+          'for': '5m',  // We don't want to block for longer.
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s ruler-query-scheduler.
             ||| % $._config,
           },
         },


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add extra alerts for ruler query path components and adapt current ones to avoid conflicting with regular query path. 

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
