### PR TITLE
Deprecate -ingester.ring.join-after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Grafana Mimir - main / unreleased
+
 ### Grafana Mimir
 
 * [CHANGE] Increased default configuration for `-server.grpc-max-recv-msg-size-bytes` and `-server.grpc-max-send-msg-size-bytes` from 4MB to 100MB. #1883
@@ -12,6 +13,7 @@
     - `-querier.query-ingesters-within`
     - `-querier.query-store-after`
 * [CHANGE] Config flag category overrides can be set dynamically at runtime. #1934
+* [CHANGE] Ingester: deprecated `-ingester.ring.join-after`. Mimir now behaves as this setting is always set to 0s. This configuration option will be removed in Mimir 2.4.0. #1965
 * [ENHANCEMENT] Distributor: Added limit to prevent tenants from sending excessive number of requests: #1843
   * The following CLI flags (and their respective YAML config options) have been added:
     * `-distributor.request-rate-limit`

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2193,17 +2193,6 @@
             },
             {
               "kind": "field",
-              "name": "join_after",
-              "required": false,
-              "desc": "Period to wait for a claim from another member; will join automatically after this.",
-              "fieldValue": null,
-              "fieldDefaultValue": 0,
-              "fieldFlag": "ingester.ring.join-after",
-              "fieldType": "duration",
-              "fieldCategory": "advanced"
-            },
-            {
-              "kind": "field",
               "name": "min_ready_duration",
               "required": false,
               "desc": "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -639,8 +639,6 @@ Usage of ./cmd/mimir/mimir:
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -distributor.drop-label value
     	This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.
-  -distributor.extend-writes value
-    	Deprecated: this setting was used to try writing to an additional ingester in the presence of an ingester not in the ACTIVE state. Mimir now behaves as this setting is always disabled.
   -distributor.forwarding.enabled
     	[experimental] Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.
   -distributor.forwarding.request-timeout duration
@@ -913,8 +911,6 @@ Usage of ./cmd/mimir/mimir:
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -ingester.ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
-  -ingester.ring.join-after duration
-    	Period to wait for a claim from another member; will join automatically after this.
   -ingester.ring.min-ready-duration duration
     	Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates. (default 15s)
   -ingester.ring.multi.mirror-enabled

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -225,8 +225,6 @@ Usage of ./cmd/mimir/mimir:
     	Expands ${var} or $var in config according to the values of the environment variables.
   -config.file value
     	Configuration file to load.
-  -distributor.extend-writes value
-    	Deprecated: this setting was used to try writing to an additional ingester in the presence of an ingester not in the ACTIVE state. Mimir now behaves as this setting is always disabled.
   -distributor.ha-tracker.cluster string
     	Prometheus label to look for in samples to identify a Prometheus HA cluster. (default "cluster")
   -distributor.ha-tracker.consul.hostname string

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -679,11 +679,6 @@ ring:
   # CLI flag: -ingester.ring.observe-period
   [observe_period: <duration> | default = 0s]
 
-  # (advanced) Period to wait for a claim from another member; will join
-  # automatically after this.
-  # CLI flag: -ingester.ring.join-after
-  [join_after: <duration> | default = 0s]
-
   # (advanced) Minimum duration to wait after the internal readiness checks have
   # passed but before succeeding the readiness endpoint. This is used to
   # slowdown deployment controllers (eg. Kubernetes) after an instance is ready

--- a/pkg/ingester/ingester_ring.go
+++ b/pkg/ingester/ingester_ring.go
@@ -44,13 +44,16 @@ type RingConfig struct {
 
 	// Config for the ingester lifecycle control
 	ObservePeriod            time.Duration `yaml:"observe_period" category:"advanced"`
-	JoinAfter                time.Duration `yaml:"join_after" category:"advanced"`
+	JoinAfter                time.Duration `yaml:"join_after" category:"advanced" doc:"hidden"` // TODO Deprecated: remove in Mimir 2.4.0.
 	MinReadyDuration         time.Duration `yaml:"min_ready_duration" category:"advanced"`
 	FinalSleep               time.Duration `yaml:"final_sleep" category:"advanced"`
 	ReadinessCheckRingHealth bool          `yaml:"readiness_check_ring_health" category:"advanced"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
+
+	// Used only for testing.
+	JoinAfterMock time.Duration `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -88,7 +91,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	/// Lifecycler.
 	f.DurationVar(&cfg.ObservePeriod, prefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
-	f.DurationVar(&cfg.JoinAfter, prefix+"join-after", 0*time.Second, "Period to wait for a claim from another member; will join automatically after this.")
+	flagext.DeprecatedFlag(f, prefix+"join-after", "Deprecated: this setting was used to set a period of time to wait before joining the hash ring. Mimir now behaves as this setting is always set to 0s.", logger)
 	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 15*time.Second, "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates.")
 	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 0, "Duration to sleep for before exiting, to ensure metrics are scraped.")
 	f.BoolVar(&cfg.ReadinessCheckRingHealth, prefix+"readiness-check-ring-health", true, "When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down.")
@@ -123,7 +126,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	lc.HeartbeatPeriod = cfg.HeartbeatPeriod
 	lc.HeartbeatTimeout = cfg.HeartbeatTimeout
 	lc.ObservePeriod = cfg.ObservePeriod
-	lc.JoinAfter = cfg.JoinAfter
+	lc.JoinAfter = cfg.JoinAfterMock
 	lc.MinReadyDuration = cfg.MinReadyDuration
 	lc.InfNames = cfg.InstanceInterfaceNames
 	lc.FinalSleep = cfg.FinalSleep

--- a/pkg/ingester/ingester_ring_test.go
+++ b/pkg/ingester/ingester_ring_test.go
@@ -49,7 +49,6 @@ func TestRingConfig_CustomConfigToLifecyclerConfig(t *testing.T) {
 	cfg.InstanceZone = "zone-X"
 	cfg.UnregisterOnShutdown = true
 	cfg.ObservePeriod = 10 * time.Minute
-	cfg.JoinAfter = 5 * time.Minute
 	cfg.MinReadyDuration = 3 * time.Minute
 	cfg.FinalSleep = 2 * time.Minute
 	cfg.ReadinessCheckRingHealth = false
@@ -67,7 +66,7 @@ func TestRingConfig_CustomConfigToLifecyclerConfig(t *testing.T) {
 	expected.HeartbeatPeriod = cfg.HeartbeatPeriod
 	expected.HeartbeatTimeout = cfg.HeartbeatTimeout
 	expected.ObservePeriod = cfg.ObservePeriod
-	expected.JoinAfter = cfg.JoinAfter
+	expected.JoinAfter = 0
 	expected.MinReadyDuration = cfg.MinReadyDuration
 	expected.InfNames = cfg.InstanceInterfaceNames
 	expected.FinalSleep = cfg.FinalSleep

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -619,7 +619,6 @@ func TestIngester_Push(t *testing.T) {
 
 			// Create a mocked ingester
 			cfg := defaultIngesterTestConfig(t)
-			cfg.IngesterRing.JoinAfter = 0
 			cfg.ActiveSeriesMetricsEnabled = !testData.disableActiveSeries
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = testData.maxExemplars
@@ -720,7 +719,6 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 
 	// Create a mocked ingester
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, registry)
 	require.NoError(t, err)
@@ -808,7 +806,6 @@ func TestIngester_Push_DecreaseInactiveSeries(t *testing.T) {
 	// Create a mocked ingester
 	cfg := defaultIngesterTestConfig(t)
 	cfg.ActiveSeriesMetricsIdleTimeout = 100 * time.Millisecond
-	cfg.IngesterRing.JoinAfter = 0
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, registry)
 	currentTime := time.Now()
@@ -878,7 +875,6 @@ func benchmarkIngesterPush(b *testing.B, limits validation.Limits, errorsExpecte
 
 	// Create a mocked ingester
 	cfg := defaultIngesterTestConfig(b)
-	cfg.IngesterRing.JoinAfter = 0
 
 	ingester, err := prepareIngesterWithBlocksStorage(b, cfg, registry)
 	require.NoError(b, err)
@@ -1176,7 +1172,6 @@ func Benchmark_Ingester_PushOnError(b *testing.B) {
 
 					// Create a mocked ingester
 					cfg := defaultIngesterTestConfig(b)
-					cfg.IngesterRing.JoinAfter = 0
 
 					limits := defaultLimitsTestConfig()
 					if !testData.prepareConfig(&limits, instanceLimits) {
@@ -1838,7 +1833,7 @@ func TestIngester_Push_ShouldNotCreateTSDBIfNotInActiveState(t *testing.T) {
 	// Configure the lifecycler to not immediately join the ring, to make sure
 	// the ingester will NOT be in the ACTIVE state when we'll push samples.
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 10 * time.Second
+	cfg.IngesterRing.JoinAfterMock = 10 * time.Second
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
 	require.NoError(t, err)
@@ -1886,7 +1881,7 @@ func TestIngester_getOrCreateTSDB_ShouldNotAllowToCreateTSDBIfIngesterStateIsNot
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cfg := defaultIngesterTestConfig(t)
-			cfg.IngesterRing.JoinAfter = 60 * time.Second
+			cfg.IngesterRing.JoinAfterMock = 60 * time.Second
 
 			i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
 			require.NoError(t, err)
@@ -3028,7 +3023,6 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 
 func TestIngester_shipBlocks(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
 	// Create ingester
@@ -3066,7 +3060,6 @@ func TestIngester_shipBlocks(t *testing.T) {
 
 func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
 	// Create ingester
@@ -3115,7 +3108,6 @@ func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) 
 
 func TestIngester_seriesCountIsCorrectAfterClosingTSDBForDeletedTenant(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
 	// Create ingester
@@ -3159,7 +3151,6 @@ func TestIngester_seriesCountIsCorrectAfterClosingTSDBForDeletedTenant(t *testin
 func TestIngester_closeAndDeleteUserTSDBIfIdle_shouldNotCloseTSDBIfShippingIsInProgress(t *testing.T) {
 	ctx := context.Background()
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 2
 
 	// We want it to be idle immediately (setting to 1ns because 0 means disabled).
@@ -3305,7 +3296,6 @@ func (m *shipperMock) Sync(ctx context.Context) (uploaded int, err error) {
 
 func TestIngester_invalidSamplesDontChangeLastUpdateTime(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 
 	// Create ingester
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
@@ -3533,7 +3523,6 @@ func TestIngester_flushing(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := defaultIngesterTestConfig(t)
-			cfg.IngesterRing.JoinAfter = 0
 			cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 			cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Minute // Long enough to not be reached during the test.
 
@@ -3564,7 +3553,6 @@ func TestIngester_flushing(t *testing.T) {
 
 func TestIngester_ForFlush(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 	cfg.BlocksStorageConfig.TSDB.ShipInterval = 10 * time.Minute // Long enough to not be reached during the test.
 
@@ -3740,7 +3728,6 @@ func Test_Ingester_AllUserStats(t *testing.T) {
 
 func TestIngesterCompactIdleBlock(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = 1 * time.Hour      // Long enough to not be reached during the test.
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionIdleTimeout = 1 * time.Second // Testing this.
@@ -3819,7 +3806,6 @@ func TestIngesterCompactIdleBlock(t *testing.T) {
 
 func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Second // Required to enable shipping.
 	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionIdleTimeout = 1 * time.Second
@@ -4033,7 +4019,6 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 
 func TestIngester_CloseTSDBsOnShutdown(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.IngesterRing.JoinAfter = 0
 
 	// Create ingester
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
@@ -4066,7 +4051,6 @@ func TestIngesterNotDeleteUnshippedBlocks(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{chunkRange}
 	cfg.BlocksStorageConfig.TSDB.Retention = time.Millisecond // Which means delete all but first block.
-	cfg.IngesterRing.JoinAfter = 0
 
 	// Create ingester
 	reg := prometheus.NewPedanticRegistry()
@@ -4370,7 +4354,6 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			// Create a mocked ingester
 			cfg := defaultIngesterTestConfig(t)
-			cfg.IngesterRing.JoinAfter = 0
 			cfg.InstanceLimitsFn = func() *InstanceLimits {
 				return &testData.limits
 			}
@@ -4439,7 +4422,6 @@ func TestIngester_instanceLimitsMetrics(t *testing.T) {
 	cfg.InstanceLimitsFn = func() *InstanceLimits {
 		return &l
 	}
-	cfg.IngesterRing.JoinAfter = 0
 
 	_, err := prepareIngesterWithBlocksStorage(t, cfg, reg)
 	require.NoError(t, err)
@@ -4472,7 +4454,6 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 	// Create a mocked ingester
 	cfg := defaultIngesterTestConfig(t)
 	cfg.InstanceLimitsFn = func() *InstanceLimits { return &limits }
-	cfg.IngesterRing.JoinAfter = 0
 
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
 	require.NoError(t, err)
@@ -5292,7 +5273,6 @@ func TestIngesterActiveSeries(t *testing.T) {
 
 			// Create a mocked ingester
 			cfg := defaultIngesterTestConfig(t)
-			cfg.IngesterRing.JoinAfter = 0
 			cfg.ActiveSeriesMetricsEnabled = !testData.disableActiveSeries
 
 			limits := defaultLimitsTestConfig()
@@ -5624,7 +5604,6 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 
 			// Create a mocked ingester
 			cfg := defaultIngesterTestConfig(t)
-			cfg.IngesterRing.JoinAfter = 0
 			cfg.ActiveSeriesMetricsEnabled = true
 
 			limits := defaultLimitsTestConfig()

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -33,6 +33,11 @@ func Usage(printAll bool, configs ...interface{}) error {
 		fieldCat := fieldcategory.Basic
 		var field reflect.StructField
 
+		// Do not print usage for deprecated flags.
+		if fl.Value.String() == "deprecated" {
+			return
+		}
+
 		if override, ok := fieldcategory.GetOverride(fl.Name); ok {
 			fieldCat = override
 		} else if v.Kind() == reflect.Ptr {


### PR DESCRIPTION
#### What this PR does
In this PR I've deprecated `-ingester.ring.join-after` and removed deprecated flags from usage help. The `JoinAfter` feature is used in a couple of unit tests (to delay the ring joining) where I haven't find an easy way to get rid of it: since the feature is not going to be removed from dskit, I just kept using it for testing.

#### Which issue(s) this PR fixes or relates to

Fixes #1962

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
