### PR TITLE
Remove hardlinking in Shipper code.

### DIFF
--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -24,6 +24,8 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/shipper"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb"
 )
 
 type metrics struct {
@@ -185,42 +187,22 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 	return uploaded, nil
 }
 
-// sync uploads the block if not exists in remote storage.
-// TODO(khyatisoneji): Double check if block does not have deletion-mark.json for some reason, otherwise log it or return error.
+// update local meta.json file with Thanos-specific details, and upload the block
+// to blocks storage.
 func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 	level.Info(s.logger).Log("msg", "upload new block", "id", meta.ULID)
 
-	// We hard-link the files into a temporary upload directory so we are not affected
-	// by other operations happening against the TSDB directory.
-	updir := filepath.Join(s.dir, "thanos", "upload", meta.ULID.String())
+	blockDir := filepath.Join(s.dir, meta.ULID.String())
 
-	// Remove updir just in case.
-	if err := os.RemoveAll(updir); err != nil {
-		return errors.Wrap(err, "clean upload directory")
-	}
-	if err := os.MkdirAll(updir, 0750); err != nil {
-		return errors.Wrap(err, "create upload dir")
-	}
-	defer func() {
-		if err := os.RemoveAll(updir); err != nil {
-			level.Error(s.logger).Log("msg", "failed to clean upload directory", "err", err)
-		}
-	}()
-
-	dir := filepath.Join(s.dir, meta.ULID.String())
-	if err := hardlinkBlock(dir, updir); err != nil {
-		return errors.Wrap(err, "hard link block")
-	}
-	// Attach current labels and write a new meta file with Thanos extensions.
+	// Attach current labels and write. Don't write the file to disk, but upload it to the bucket.
 	if lset := s.labels(); lset != nil {
 		meta.Thanos.Labels = lset.Map()
 	}
 	meta.Thanos.Source = s.source
-	meta.Thanos.SegmentFiles = block.GetSegmentFiles(updir)
-	if err := meta.WriteToDir(s.logger, updir); err != nil {
-		return errors.Wrap(err, "write meta file")
-	}
-	return block.Upload(ctx, s.logger, s.bucket, updir, s.hashFunc)
+	meta.Thanos.SegmentFiles = block.GetSegmentFiles(blockDir)
+
+	// Upload block with custom metadata.
+	return tsdb.UploadBlock(ctx, s.logger, s.bucket, blockDir, meta)
 }
 
 // blockMetasFromOldest returns the block meta of each block found in dir
@@ -257,34 +239,6 @@ func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, _ error) {
 		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
 	})
 	return metas, nil
-}
-
-func hardlinkBlock(src, dst string) error {
-	chunkDir := filepath.Join(dst, block.ChunksDirname)
-
-	if err := os.MkdirAll(chunkDir, 0750); err != nil {
-		return errors.Wrap(err, "create chunks dir")
-	}
-
-	fis, err := ioutil.ReadDir(filepath.Join(src, block.ChunksDirname))
-	if err != nil {
-		return errors.Wrap(err, "read chunk dir")
-	}
-	files := make([]string, 0, len(fis))
-	for _, fi := range fis {
-		files = append(files, fi.Name())
-	}
-	for i, fn := range files {
-		files[i] = filepath.Join(block.ChunksDirname, fn)
-	}
-	files = append(files, block.MetaFilename, block.IndexFilename)
-
-	for _, fn := range files {
-		if err := os.Link(filepath.Join(src, fn), filepath.Join(dst, fn)); err != nil {
-			return errors.Wrapf(err, "hard link file %s", fn)
-		}
-	}
-	return nil
 }
 
 func readShippedBlocks(dir string) (map[ulid.ULID]struct{}, error) {

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func createBlock(t *testing.T, blocksDir string, id ulid.ULID, m metadata.Meta) {
-	// We need "chunks" dir and "index" file for hardlinking code to work.
+	// We need "chunks" dir and "index" files for upload to work correctly (it expects these to exist).
 	require.NoError(t, os.MkdirAll(path.Join(blocksDir, id.String(), "chunks"), 0777))
 	require.NoError(t, m.WriteToDir(log.NewNopLogger(), path.Join(blocksDir, id.String())))
 
@@ -88,7 +88,7 @@ func TestShipper(t *testing.T) {
 
 	id2 := ulid.MustNew(2, nil)
 
-	t.Run("sync another block", func(t *testing.T) {
+	t.Run("sync block without external labels", func(t *testing.T) {
 		createBlock(t, blocksDir, id2, metadata.Meta{
 			BlockMeta: tsdb.BlockMeta{
 				ULID:    id2,
@@ -99,7 +99,7 @@ func TestShipper(t *testing.T) {
 					NumSamples: 100,
 				},
 			},
-			Thanos: metadata.Thanos{Labels: map[string]string{"c": "d"}},
+			// No Thanos stuff, this will still work.
 		})
 
 		// Sync new block

--- a/pkg/storage/tsdb/upload.go
+++ b/pkg/storage/tsdb/upload.go
@@ -1,0 +1,125 @@
+package tsdb
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+// UploadBlock is copy of block.Upload with following modifications:
+//
+// - If meta parameter is supplied (not nil), then local meta.json file is ignored, and uploaded meta.json file reflects meta parameter.
+//
+// - Meta struct is updated with gatherFileStats
+//
+// - external labels are not checked for
+func UploadBlock(ctx context.Context, logger log.Logger, bkt objstore.Bucket, blockDir string, meta *metadata.Meta) error {
+	df, err := os.Stat(blockDir)
+	if err != nil {
+		return err
+	}
+	if !df.IsDir() {
+		return errors.Errorf("%s is not a directory", blockDir)
+	}
+
+	// Verify dir.
+	id, err := ulid.Parse(df.Name())
+	if err != nil {
+		return errors.Wrap(err, "not a block dir")
+	}
+
+	if meta == nil {
+		meta, err = metadata.ReadFromDir(blockDir)
+		if err != nil {
+			// No meta or broken meta file.
+			return errors.Wrap(err, "read meta")
+		}
+	}
+
+	// Note that entry for meta.json file will be incorrect and will reflect local file,
+	// not updated Meta struct.
+	meta.Thanos.Files, err = gatherFileStats(blockDir)
+	if err != nil {
+		return errors.Wrap(err, "gather meta file stats")
+	}
+
+	metaEncoded := strings.Builder{}
+	if err := meta.Write(&metaEncoded); err != nil {
+		return errors.Wrap(err, "encode meta file")
+	}
+
+	if err := objstore.UploadDir(ctx, logger, bkt, filepath.Join(blockDir, block.ChunksDirname), path.Join(id.String(), block.ChunksDirname)); err != nil {
+		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload chunks"))
+	}
+
+	if err := objstore.UploadFile(ctx, logger, bkt, filepath.Join(blockDir, block.IndexFilename), path.Join(id.String(), block.IndexFilename)); err != nil {
+		return cleanUp(logger, bkt, id, errors.Wrap(err, "upload index"))
+	}
+
+	// Meta.json always need to be uploaded as a last item. This will allow to assume block directories without meta file to be pending uploads.
+	if err := bkt.Upload(ctx, path.Join(id.String(), block.MetaFilename), strings.NewReader(metaEncoded.String())); err != nil {
+		// Don't call cleanUp here. Despite getting error, meta.json may have been uploaded in certain cases,
+		// and even though cleanUp will not see it yet, meta.json may appear in the bucket later.
+		// (Eg. S3 is known to behave this way when it returns 503 "SlowDown" error).
+		// If meta.json is not uploaded, this will produce partial blocks, but such blocks will be cleaned later.
+		return errors.Wrap(err, "upload meta file")
+	}
+
+	return nil
+}
+
+// Hopefully can be replaced with Thanos public function: https://github.com/thanos-io/thanos/pull/5400
+func gatherFileStats(blockDir string) (res []metadata.File, _ error) {
+	files, err := ioutil.ReadDir(filepath.Join(blockDir, block.ChunksDirname))
+	if err != nil {
+		return nil, errors.Wrapf(err, "read dir %v", filepath.Join(blockDir, block.ChunksDirname))
+	}
+	for _, f := range files {
+		mf := metadata.File{
+			RelPath:   filepath.Join(block.ChunksDirname, f.Name()),
+			SizeBytes: f.Size(),
+		}
+		res = append(res, mf)
+	}
+
+	indexFile, err := os.Stat(filepath.Join(blockDir, block.IndexFilename))
+	if err != nil {
+		return nil, errors.Wrapf(err, "stat %v", filepath.Join(blockDir, block.IndexFilename))
+	}
+	mf := metadata.File{
+		RelPath:   indexFile.Name(),
+		SizeBytes: indexFile.Size(),
+	}
+	res = append(res, mf)
+
+	metaFile, err := os.Stat(filepath.Join(blockDir, block.MetaFilename))
+	if err != nil {
+		return nil, errors.Wrapf(err, "stat %v", filepath.Join(blockDir, block.MetaFilename))
+	}
+	res = append(res, metadata.File{RelPath: metaFile.Name()})
+
+	sort.Slice(res, func(i, j int) bool {
+		return strings.Compare(res[i].RelPath, res[j].RelPath) < 0
+	})
+	return res, err
+}
+
+func cleanUp(logger log.Logger, bkt objstore.Bucket, id ulid.ULID, err error) error {
+	// Cleanup the dir with an uncancelable context.
+	cleanErr := block.Delete(context.Background(), logger, bkt, id)
+	if cleanErr != nil {
+		return errors.Wrapf(err, "failed to clean block after upload issue. Partial block in system. Err: %s", err.Error())
+	}
+	return err
+}

--- a/pkg/storage/tsdb/upload.go
+++ b/pkg/storage/tsdb/upload.go
@@ -85,7 +85,7 @@ func UploadBlock(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bl
 	return nil
 }
 
-// Hopefully we can replace this function with version from Thanos: https://github.com/thanos-io/thanos/pull/5400
+// gatherFileStats can hopefully be replaced with Thanos public function: https://github.com/thanos-io/thanos/pull/5400
 func gatherFileStats(blockDir string) (res []metadata.File, _ error) {
 	files, err := ioutil.ReadDir(filepath.Join(blockDir, block.ChunksDirname))
 	if err != nil {

--- a/pkg/storage/tsdb/upload.go
+++ b/pkg/storage/tsdb/upload.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package tsdb
 
 import (

--- a/pkg/storage/tsdb/upload.go
+++ b/pkg/storage/tsdb/upload.go
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/block/block.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
 
 package tsdb
 

--- a/pkg/storage/tsdb/upload.go
+++ b/pkg/storage/tsdb/upload.go
@@ -21,7 +21,8 @@ import (
 
 // UploadBlock is copy of block.Upload with following modifications:
 //
-// - If meta parameter is supplied (not nil), then local meta.json file is ignored, and uploaded meta.json file reflects meta parameter.
+// - If meta parameter is supplied (not nil), then uploaded meta.json file reflects meta parameter. However local
+// meta.json file must still exist.
 //
 // - Meta struct is updated with gatherFileStats
 //

--- a/pkg/storage/tsdb/upload_test.go
+++ b/pkg/storage/tsdb/upload_test.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/block/block_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
 package tsdb
 
 import (

--- a/pkg/storage/tsdb/upload_test.go
+++ b/pkg/storage/tsdb/upload_test.go
@@ -1,0 +1,197 @@
+package tsdb
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/grafana/mimir/pkg/storegateway/testhelper"
+	"github.com/grafana/mimir/pkg/util/test"
+)
+
+func TestUploadBlock(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+
+	bkt := objstore.NewInMemBucket()
+	b1, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+		{{Name: "a", Value: "3"}},
+		{{Name: "a", Value: "4"}},
+		{{Name: "b", Value: "1"}},
+	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path.Join(tmpDir, "test", b1.String()), os.ModePerm))
+
+	t.Run("wrong dir", func(t *testing.T) {
+		// Wrong dir.
+		err := UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "not-existing"), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/not-existing: no such file or directory")
+	})
+
+	t.Run("wrong existing dir (not a block)", func(t *testing.T) {
+		err := UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test"), nil)
+		require.EqualError(t, err, "not a block dir: ulid: bad data size when unmarshaling")
+	})
+
+	t.Run("empty block dir", func(t *testing.T) {
+		err := UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/meta.json: no such file or directory")
+	})
+
+	t.Run("missing chunks", func(t *testing.T) {
+		test.Copy(t, path.Join(tmpDir, b1.String(), block.MetaFilename), path.Join(tmpDir, "test", b1.String(), block.MetaFilename))
+
+		err := UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/chunks: no such file or directory")
+	})
+
+	t.Run("missing index file", func(t *testing.T) {
+		require.NoError(t, os.MkdirAll(path.Join(tmpDir, "test", b1.String(), block.ChunksDirname), 0777))
+		test.Copy(t, path.Join(tmpDir, b1.String(), block.ChunksDirname, "000001"), path.Join(tmpDir, "test", b1.String(), block.ChunksDirname, "000001"))
+
+		err := UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/index: no such file or directory")
+	})
+
+	t.Run("missing meta.json file", func(t *testing.T) {
+		test.Copy(t, path.Join(tmpDir, b1.String(), block.IndexFilename), path.Join(tmpDir, "test", b1.String(), block.IndexFilename))
+		require.NoError(t, os.Remove(path.Join(tmpDir, "test", b1.String(), block.MetaFilename)))
+
+		// Missing meta.json file.
+		err := UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/meta.json: no such file or directory")
+	})
+
+	t.Run("missing meta.json file, but valid metadata supplied as argument", func(t *testing.T) {
+		// Read meta.json from original block
+		meta, err := metadata.ReadFromDir(path.Join(tmpDir, b1.String()))
+		require.NoError(t, err)
+
+		// Make sure meta.json doesn't exist in "test" block.
+		require.NoError(t, os.RemoveAll(path.Join(tmpDir, "test", b1.String(), block.MetaFilename)))
+
+		// Missing meta.json file.
+		err = UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), meta)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/meta.json: no such file or directory")
+	})
+
+	test.Copy(t, path.Join(tmpDir, b1.String(), block.MetaFilename), path.Join(tmpDir, "test", b1.String(), block.MetaFilename))
+
+	t.Run("full block", func(t *testing.T) {
+		// Full block.
+		require.NoError(t, UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil))
+		require.Equal(t, 3, len(bkt.Objects()))
+		require.Equal(t, 3751, len(bkt.Objects()[path.Join(b1.String(), block.ChunksDirname, "000001")]))
+		require.Equal(t, 401, len(bkt.Objects()[path.Join(b1.String(), block.IndexFilename)]))
+		require.Equal(t, 546, len(bkt.Objects()[path.Join(b1.String(), block.MetaFilename)]))
+
+		origMeta, err := metadata.ReadFromDir(path.Join(tmpDir, "test", b1.String()))
+		require.NoError(t, err)
+
+		uploadedMeta, err := block.DownloadMeta(context.Background(), log.NewNopLogger(), bkt, b1)
+		require.NoError(t, err)
+
+		files := uploadedMeta.Thanos.Files
+		require.Len(t, files, 3)
+		require.Equal(t, metadata.File{RelPath: "chunks/000001", SizeBytes: 3751}, files[0])
+		require.Equal(t, metadata.File{RelPath: "index", SizeBytes: 401}, files[1])
+		require.Equal(t, metadata.File{RelPath: "meta.json", SizeBytes: 0}, files[2]) // meta.json is added to the files without its size.
+
+		// clear files before comparing against original meta.json
+		uploadedMeta.Thanos.Files = nil
+
+		require.Equal(t, origMeta, &uploadedMeta)
+	})
+
+	t.Run("upload is idempotent", func(t *testing.T) {
+		// Test Upload is idempotent.
+		require.NoError(t, UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil))
+		require.Equal(t, 3, len(bkt.Objects()))
+		require.Equal(t, 3751, len(bkt.Objects()[path.Join(b1.String(), block.ChunksDirname, "000001")]))
+		require.Equal(t, 401, len(bkt.Objects()[path.Join(b1.String(), block.IndexFilename)]))
+		require.Equal(t, 546, len(bkt.Objects()[path.Join(b1.String(), block.MetaFilename)]))
+	})
+
+	t.Run("upload with no external labels works just fine", func(t *testing.T) {
+		// Upload with no external labels should be blocked.
+		b2, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
+			{{Name: "a", Value: "1"}},
+			{{Name: "a", Value: "2"}},
+			{{Name: "a", Value: "3"}},
+			{{Name: "a", Value: "4"}},
+			{{Name: "b", Value: "1"}},
+		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+		require.NoError(t, err)
+
+		err = UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), nil)
+		require.NoError(t, err)
+
+		require.Equal(t, 6, len(bkt.Objects())) // 3 from b1, 3 from b2
+		require.Equal(t, 3736, len(bkt.Objects()[path.Join(b2.String(), block.ChunksDirname, "000001")]))
+		require.Equal(t, 401, len(bkt.Objects()[path.Join(b2.String(), block.IndexFilename)]))
+		require.Equal(t, 525, len(bkt.Objects()[path.Join(b2.String(), block.MetaFilename)]))
+
+		origMeta, err := metadata.ReadFromDir(path.Join(tmpDir, b2.String()))
+		require.NoError(t, err)
+
+		uploadedMeta, err := block.DownloadMeta(context.Background(), log.NewNopLogger(), bkt, b2)
+		require.NoError(t, err)
+
+		// Files are not in the original meta.
+		uploadedMeta.Thanos.Files = nil
+		require.Equal(t, origMeta, &uploadedMeta)
+	})
+
+	t.Run("upload with supplied meta.json", func(t *testing.T) {
+		// Upload with no external labels should be blocked.
+		b3, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
+			{{Name: "a", Value: "1"}},
+			{{Name: "a", Value: "2"}},
+			{{Name: "a", Value: "3"}},
+			{{Name: "a", Value: "4"}},
+			{{Name: "b", Value: "1"}},
+		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+		require.NoError(t, err)
+
+		// Prepare metadata that will be uploaded to the bucket.
+		updatedMeta, err := metadata.ReadFromDir(path.Join(tmpDir, b3.String()))
+		require.NoError(t, err)
+		require.Empty(t, updatedMeta.Thanos.Labels)
+		require.Equal(t, metadata.TestSource, updatedMeta.Thanos.Source)
+		updatedMeta.Thanos.Labels = map[string]string{"a": "b", "c": "d"}
+		updatedMeta.Thanos.Source = "hello world"
+
+		// Upload block with new metadata.
+		err = UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b3.String()), updatedMeta)
+		require.NoError(t, err)
+
+		// Verify that original (on-disk) meta.json is not changed
+		origMeta, err := metadata.ReadFromDir(path.Join(tmpDir, b3.String()))
+		require.NoError(t, err)
+		require.Empty(t, origMeta.Thanos.Labels)
+		require.Equal(t, metadata.TestSource, origMeta.Thanos.Source)
+
+		// Verify that meta.json uploaded in the bucket has updated values.
+		bucketMeta, err := block.DownloadMeta(context.Background(), log.NewNopLogger(), bkt, b3)
+		require.NoError(t, err)
+		require.Equal(t, updatedMeta.Thanos.Labels, bucketMeta.Thanos.Labels)
+		require.Equal(t, updatedMeta.Thanos.Source, bucketMeta.Thanos.Source)
+	})
+}


### PR DESCRIPTION
#### What this PR does

This PR modifies Shipper to avoid doing local copy of a block (using hardlinks) before uploading the block. Shipper was also updating its own copy of meta.json file. This has been replaced with new `tsdb.UploadBlock` method which uploads `meta.json` file from in-memory structure instead of using meta.json file from disk.

Why cannot we update local `meta.json` file for block loaded by ingester? TSDB library tries to reload the blocks at some points. When updating local `meta.json` file, shipper deletes old version first and then uses Replace call from temp file to `meta.json`. If TSDB library tried to reload the blocks while `meta.json` is missing, it would unload the block from memory instead (and possibly load it again later when finding the block again).

This PR copies `block.Upload` function from Thanos into `tsdb.UploadBlock`. This version of the function takes metadata to upload as a parameter.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/1957#discussion_r884932268

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
