### PR TITLE
Adjust the name of the tag expected by documentation publishing

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -42,7 +42,7 @@ jobs:
       uses: "./actions/has-matching-release-tag"
       with:
         ref_name: "${{ github.ref_name }}"
-        release_tag_regexp: "^mimir-v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+        release_tag_regexp: "^mimir-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
         release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
 
     - name: "Determine technical documentation version"


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Tags in the mimir repo follow the format `mimir-2.0.0`. The Github action to publish documentation expected them to be `mimir-v2.0.0`. This resulted in the docs for 2.1 not being published (2.0 were likely synced manually as part of the release).

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
