### PR TITLE
Make propagation of forwarding errors configurable

### DIFF
--- a/pkg/distributor/forwarding/config.go
+++ b/pkg/distributor/forwarding/config.go
@@ -16,5 +16,5 @@ type Config struct {
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Enabled, "distributor.forwarding.enabled", false, "Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.")
 	f.DurationVar(&c.RequestTimeout, "distributor.forwarding.request-timeout", 10*time.Second, "Timeout for requests to ingestion endpoints to which we forward metrics.")
-	f.BoolVar(&c.PropagateErrors, "distributor.forwarding.propagate_errors", false, "If enabled then errors which resulted from forwarding requests get propagated back to the client, otherwise the forwarding is a fire-and-forget operation.")
+	f.BoolVar(&c.PropagateErrors, "distributor.forwarding.propagate-errors", true, "If disabled then forwarding requests are a fire-and-forget operation, errors get dropped.")
 }

--- a/pkg/distributor/forwarding/config.go
+++ b/pkg/distributor/forwarding/config.go
@@ -8,11 +8,13 @@ import (
 )
 
 type Config struct {
-	Enabled        bool          `yaml:"enabled" category:"experimental"`
-	RequestTimeout time.Duration `yaml:"request_timeout" category:"experimental"`
+	Enabled         bool          `yaml:"enabled" category:"experimental"`
+	RequestTimeout  time.Duration `yaml:"request_timeout" category:"experimental"`
+	PropagateErrors bool          `yaml:"propagate_errors" category:"experimental"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Enabled, "distributor.forwarding.enabled", false, "Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.")
 	f.DurationVar(&c.RequestTimeout, "distributor.forwarding.request-timeout", 10*time.Second, "Timeout for requests to ingestion endpoints to which we forward metrics.")
+	f.BoolVar(&c.PropagateErrors, "distributor.forwarding.propagate_errors", false, "If enabled then errors which resulted from forwarding requests get propagated back to the client, otherwise the forwarding is a fire-and-forget operation.")
 }


### PR DESCRIPTION
We want to be able to swallow forwarding errors, as opposed to returning them to the remote_write client, to ensure that any instability in the forwarding destination can't lead to metrics ingestion getting blocked because the remote_write client keeps retrying the same request and the forwarding destination keeps returning recoverable errors (5xx).