### PR TITLE
Preparation of e2eutils for Thanos indexheader unit tests.

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -26,8 +26,8 @@ import (
 	"google.golang.org/grpc/codes"
 
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
-	"github.com/grafana/mimir/pkg/storegateway/helpers"
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
+	"github.com/grafana/mimir/pkg/storegateway/testhelper"
 
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -91,9 +91,9 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 
 		// Create two blocks per time slot. Only add 10 samples each so only one chunk
 		// gets created each. This way we can easily verify we got 10 chunks per series below.
-		id1, err := helpers.CreateBlock(ctx, dir, series[:4], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
+		id1, err := testhelper.CreateBlock(ctx, dir, series[:4], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
 		assert.NoError(t, err)
-		id2, err := helpers.CreateBlock(ctx, dir, series[4:], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
+		id2, err := testhelper.CreateBlock(ctx, dir, series[4:], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
 		assert.NoError(t, err)
 
 		dir1, dir2 := filepath.Join(dir, id1.String()), filepath.Join(dir, id2.String())

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	"github.com/grafana/mimir/pkg/storegateway/helpers"
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 
 	"github.com/thanos-io/thanos/pkg/block"
@@ -90,9 +91,9 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 
 		// Create two blocks per time slot. Only add 10 samples each so only one chunk
 		// gets created each. This way we can easily verify we got 10 chunks per series below.
-		id1, err := CreateBlock(ctx, dir, series[:4], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
+		id1, err := helpers.CreateBlock(ctx, dir, series[:4], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
 		assert.NoError(t, err)
-		id2, err := CreateBlock(ctx, dir, series[4:], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
+		id2, err := helpers.CreateBlock(ctx, dir, series[4:], 10, mint, maxt, extLset, 0, metadata.NoneFunc)
 		assert.NoError(t, err)
 
 		dir1, dir2 := filepath.Join(dir, id1.String()), filepath.Join(dir, id2.String())

--- a/pkg/storegateway/helpers/helpers.go
+++ b/pkg/storegateway/helpers/helpers.go
@@ -2,7 +2,7 @@
 // Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/testutil/e2eutil/prometheus.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Thanos Authors.
-package storegateway
+package helpers
 
 import (
 	"context"

--- a/pkg/storegateway/testhelper/testhelper.go
+++ b/pkg/storegateway/testhelper/testhelper.go
@@ -2,7 +2,7 @@
 // Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/testutil/e2eutil/prometheus.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Thanos Authors.
-package helpers
+package testhelper
 
 import (
 	"context"

--- a/pkg/util/test/copy.go
+++ b/pkg/util/test/copy.go
@@ -1,0 +1,55 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2eutil
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/runutil"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func Copy(t testing.TB, src, dst string) {
+	testutil.Ok(t, copyRecursive(src, dst))
+}
+
+func copyRecursive(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return os.MkdirAll(filepath.Join(dst, relPath), os.ModePerm)
+		}
+
+		if !info.Mode().IsRegular() {
+			return errors.Errorf("%s is not a regular file", path)
+		}
+
+		source, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			return err
+		}
+		defer runutil.CloseWithErrCapture(&err, source, "close file")
+
+		destination, err := os.Create(filepath.Join(dst, relPath))
+		if err != nil {
+			return err
+		}
+		defer runutil.CloseWithErrCapture(&err, destination, "close file")
+
+		_, err = io.Copy(destination, source)
+		return err
+	})
+}

--- a/pkg/util/test/copy.go
+++ b/pkg/util/test/copy.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Thanos Authors.
 
-package e2eutil
+package test
 
 import (
 	"io"
@@ -11,13 +11,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/grafana/dskit/runutil"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/runutil"
-	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func Copy(t testing.TB, src, dst string) {
-	testutil.Ok(t, copyRecursive(src, dst))
+	require.NoError(t, copyRecursive(src, dst))
 }
 
 func copyRecursive(src, dst string) error {

--- a/pkg/util/test/copy.go
+++ b/pkg/util/test/copy.go
@@ -1,5 +1,7 @@
-// Copyright (c) The Thanos Authors.
-// Licensed under the Apache License 2.0.
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/testutil/e2eutil/copy.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
 
 package e2eutil
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We want to pull in the `indexheader` package from Thanos so that we can add some experimental alternative implementations of `BinaryReader`. In order to also pull in the unit tests for this package, we need the replacements for `e2eutil.Copy` and `e2eutil.CreateBlock`. This change does two things:

1. Copy in `e2eutil/copy.go` and fix it up accordingly.
2. Move `CreateBlock` into a package to avoid circular imports.

The PR is structured into 4 commits to make reviewing the changes to the copied files easier.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- n/a Tests updated
- n/a Documentation added
- n/a `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
