### PR TITLE
[helm] use grpc round robin for distributor clients

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,11 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.1.0-beta.3
+
+* [BUGFIX] Use grpc round-robin for distributor clients in GEM gateway and self-monitoring
+  - This utilizes an additional headless service for the distributor pods
+
 ## 2.1.0-beta.2
 
 * [ENHANCEMENT] Version bump only for release tests.

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.1.0-beta.2
+version: 2.1.0-beta.3
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.1.0-beta.2](https://img.shields.io/badge/Version-2.1.0--beta.2-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.1.0-beta.3](https://img.shields.io/badge/Version-2.1.0--beta.3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}-headless
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
+    {{- with .Values.distributor.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.distributor.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ include "mimir.serverGrpcListenPort" . }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1303,10 +1303,10 @@ nginx:
 
           # Distributor endpoints
           location /distributor {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location = /api/v1/push {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           # Alertmanager endpoints

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -201,7 +201,7 @@ mimir:
         compactor:
           url: http://{{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}
         distributor:
-          url: http://{{ template "mimir.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}
+          url: dns:///{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverGrpcListenPort" . }}
         ingester:
           url: http://{{ template "mimir.fullname" . }}-ingester.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}
         query_frontend:
@@ -215,7 +215,7 @@ mimir:
     instrumentation:
       enabled: true
       distributor_client:
-        address: 'dns:///{{ template "mimir.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}'
+        address: 'dns:///{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverGrpcListenPort" . }}'
 
     {{- end }}
 


### PR DESCRIPTION
#### What this PR does

Use DNS-lookup based grpc client-side load balancing for distributor requests.

This required adding a new, headless service to support the `dns:///` grpc resolver.

#### Which issue(s) this PR fixes or relates to

Fixes #1987 

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
