### PR TITLE
[helm] disable unregister on shutdown

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,12 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.1.0-beta.6
+
+* [ENHANCEMENT] Disable `ingester.ring.unregister-on-shutdown` and `distributor.extend-writes` #1994
+  - This will prevent resharding every series during a rolling ingester restart
+  - Under some circumstances the previous values (both enabled) could cause write path degredation during rolling restarts
+
 ## 2.1.0-beta.5
 
 * [ENHANCEMENT] Add support for the results cache used by the query frontend #1993

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.1.0-beta.5
+version: 2.1.0-beta.6
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.1.0-beta.5](https://img.shields.io/badge/Version-2.1.0--beta.5-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.1.0-beta.6](https://img.shields.io/badge/Version-2.1.0--beta.6-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -100,10 +100,14 @@ mimir:
     compactor:
       data_dir: "/data"
 
+    distributor:
+      extend_writes: false
+
     ingester:
       ring:
         final_sleep: 0s
         num_tokens: 512
+        unregister_on_shutdown: false
 
     ingester_client:
       grpc_client_config:


### PR DESCRIPTION
#### What this PR does

Disable `distributor.extend-writes` and `ingester.ring.unregister-on-shutdown` by default.

Note we will remove `distributor.extend-writes` in version 2.1, but I've left that out of this PR since we haven't bumped the image to 2.1 yet. 

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/helm-charts/issues/1313

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
