### PR TITLE
Prepare mimir beta chart release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -3,7 +3,7 @@ name: helm-release
 on:
   push:
     branches:
-      - helm-release-test
+      - main
 
 jobs:
   call-update-helm-repo:

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.1.0-beta.1
+
+* [ENHANCEMENT] Version bump only for release tests.
+
 ## 2.0.14
 
 * [BUGFIX] exclude headless services from ServiceMonitors to prevent duplication of prometheus scrape targets #1308

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://grafana.com/docs/mimir/v2.0.x/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg
 kubeVersion: ^1.10.0-0
-name: mimir-distributed-beta
+name: mimir-distributed
 dependencies:
   - name: memcached
     alias: memcached

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.14
+version: 2.1.0-beta.1
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.0.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
 
-# mimir-distributed-beta
+# mimir-distributed
 
 ![Version: 2.1.0-beta.1](https://img.shields.io/badge/Version-2.1.0--beta.1-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed-beta
 
-![Version: 2.0.14](https://img.shields.io/badge/Version-2.0.14-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.1.0-beta.1](https://img.shields.io/badge/Version-2.1.0--beta.1-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 


### PR DESCRIPTION
#### What this PR does

Rename the chart back to mimir-distributed for simplicity.
Bump the version to 2.1.0-beta.1 , but no other changes to test that helm tools provide the protection against accidental use.
Enable releasing chart from main as test on branch was successful.

#### Which issue(s) this PR fixes or relates to

Internal squad 668

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
