### PR TITLE
Workaround to keep using old memcached bitnami chart for now

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## 2.1.0-beta.4
 
-* [BUGFIX] Set up using older bitnami chart repository for memcached as old charts were deleted from the current one.
+* [BUGFIX] Set up using older bitnami chart repository for memcached as old charts were deleted from the current one. #1998
 
 ## 2.1.0-beta.3
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 2.1.0-beta.4
+
+* [BUGFIX] Set up using older bitnami chart repository for memcached as old charts were deleted from the current one.
+
 ## 2.1.0-beta.3
 
 * [BUGFIX] Use grpc round-robin for distributor clients in GEM gateway and self-monitoring

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: memcached
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   version: 5.5.2
 - name: memcached
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   version: 5.5.2
 - name: memcached
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   version: 5.5.2
 - name: minio
   repository: https://helm.min.io/
   version: 8.0.10
-digest: sha256:8a8861e8a68eae8dacbba0be65dbfcee5574629ebe4fd5bfd7ffee11e58f889d
-generated: "2022-03-30T17:30:35.654777032+01:00"
+digest: sha256:e8e0973e775bc3408e5f3d7a44226230ce5a7af9debcb60b7882b309960851a4
+generated: "2022-06-02T14:41:16.020882885+02:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.1.0-beta.3
+version: 2.1.0-beta.4
 appVersion: 2.0.0
 description: "Grafana Mimir"
 engine: gotpl
@@ -11,17 +11,17 @@ dependencies:
   - name: memcached
     alias: memcached
     version: 5.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: memcached.enabled
   - name: memcached
     alias: memcached-queries
     version: 5.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: memcached-queries.enabled
   - name: memcached
     alias: memcached-metadata
     version: 5.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: memcached-metadata.enabled
   - name: minio
     alias: minio

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.0.x/)
 
 # mimir-distributed
 
-![Version: 2.1.0-beta.3](https://img.shields.io/badge/Version-2.1.0--beta.3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.1.0-beta.4](https://img.shields.io/badge/Version-2.1.0--beta.4-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Grafana Mimir
 
@@ -14,10 +14,10 @@ Kubernetes: `^1.10.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | memcached(memcached) | 5.5.2 |
-| https://charts.bitnami.com/bitnami | memcached-queries(memcached) | 5.5.2 |
-| https://charts.bitnami.com/bitnami | memcached-metadata(memcached) | 5.5.2 |
 | https://helm.min.io/ | minio(minio) | 8.0.10 |
+| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached(memcached) | 5.5.2 |
+| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached-queries(memcached) | 5.5.2 |
+| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached-metadata(memcached) | 5.5.2 |
 
 ## Dependencies
 

--- a/operations/helm/ct.yaml
+++ b/operations/helm/ct.yaml
@@ -4,11 +4,8 @@ target-branch: main
 chart-dirs:
   - operations/helm/charts
 chart-repos:
-  - grafana=https://grafana.github.io/helm-charts
-  - prometheus-community=https://prometheus-community.github.io/helm-charts
-  - elastic=https://helm.elastic.co
   - bitnami=https://charts.bitnami.com/bitnami
-  - hashicorp=https://helm.releases.hashicorp.com
+  - bitnami-pre-2022=https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   - minio=https://helm.min.io
 helm-extra-args: --timeout 600s
 validate-maintainers: false


### PR DESCRIPTION
See also: https://github.com/grafana/helm-charts/pull/1438

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>

- [N/A] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
