### PR TITLE
Fix binary_reader.go header text.

### DIFF
--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -2,8 +2,6 @@
 // Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/block/indexheader/binary_reader.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Thanos Authors.
-// Copyright (c) The Thanos Authors.
-// Licensed under the Apache License 2.0.
 
 package indexheader
 


### PR DESCRIPTION
Mistakenly left two lines when updating the provenance for the file.
