### PR TITLE
Publish helm charts from release branches

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-[0-9]+.[0-9]+"
 
 jobs:
   call-update-helm-repo:


### PR DESCRIPTION
#### What this PR does

Enable helm chart publication from release-X.Y branches. The plan is to publish 2.1 by cherry picking the latest 2.1-beta.X to the `release-2.1` branch. This way all source for 2.1 will continue to live on the release-2.1 branch. 

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
