### PR TITLE
Remove tutorials/ symlink

### DIFF
--- a/tutorials
+++ b/tutorials
@@ -1,1 +1,1 @@
-docs/sources/tutorials
+Content moved to docs/sources/tutorials/


### PR DESCRIPTION
#### What this PR does
See #1979. The `tutorials/` symlink cause `docker-compose` to not work correctly in some environments and it already caused troubles to few people. I suggest to remove that link. The [play with Grafana Mimir tutorial](https://grafana.com/tutorials/play-with-grafana-mimir/) already says to `cd docs/sources/tutorials/play-with-grafana-mimir/`.

#### Which issue(s) this PR fixes or relates to

Fixes #1979

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
