### PR TITLE
Update contributing guides for the helm chart

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -11,3 +11,4 @@ jobs:
     uses: grafana/helm-charts/.github/workflows/lint-test.yaml@main
     with:
       ct_configfile: operations/helm/ct.yaml
+      ct_check_version_increment: false

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -14,6 +14,10 @@ a piece of work is finished it should:
 - Include a [CHANGELOG](#changelog) message if users of Grafana Mimir need to hear about what you did.
 - If you have made any changes to flags or config, run `make doc` and commit the changed files to update the config file documentation.
 
+## Grafana Mimir Helm chart
+
+Please see the dedicated "[Contributing to Grafana Mimir helm chart](contributing-to-helm-chart.md)" page.
+
 ## Formatting
 
 Grafana Mimir uses `goimports` tool (`go get golang.org/x/tools/cmd/goimports` to install) to format the Go files, and sort imports. We use goimports with `-local github.com/grafana/mimir` parameter, to put Grafana Mimir internal imports into a separate group. We try to keep imports sorted into three groups: imports from standard library, imports of 3rd party packages and internal Grafana Mimir imports. Goimports will fix the order, but will keep existing newlines between imports in the groups. We try to avoid extra newlines like that.

--- a/docs/internal/contributing/contributing-to-helm-chart.md
+++ b/docs/internal/contributing/contributing-to-helm-chart.md
@@ -1,0 +1,20 @@
+# Contributing to the Grafana Mimir Helm Chart
+
+## Differences to general workflow
+
+Please see the [general workflow](README.md#workflow) for reference.
+
+- Changelog is in the chart itself [operations/helm/charts/mimir-distributed/CHANGELOG.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md).
+- If you made any changes to the [operations/helm/charts/mimir-distributed/Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml), run `make doc` and commit the changed files to update the [operations/helm/charts/mimir-distributed/README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md).
+
+## Versioning
+
+Normally contributors need _not_ bump the version. The chart will be released with a beta version weekly by maintainers (unless no changes were made) and also regular stable releases will be released by cherry picking commits from the `main` branch to a release branch (e.g. `release-2.1`).
+
+If version increase is need, the version is set in the chart itself [operations/helm/charts/mimir-distributed/Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml). On the `main` branch, versions should be _pre-release_ only, meaning that the version should be suffixed by `-beta.<n>`, for example `2.1.0-beta.1` for a pre-release of the next stable `2.1.0` chart version. Versioning should follow the [Helm3 standard](https://helm.sh/docs/topics/charts/#charts-and-versioning) which is [SemVer 2](https://semver.org/spec/v2.0.0.html).
+
+## Using beta version
+
+Once a PR that updates the chart version is merged to `main`, it takes a couple of minutes for it to be published in [https://grafana.github.io/helm-charts](https://grafana.github.io/helm-charts) Helm repository.
+
+In order to search, template, install, upgrade, etc beta versions of charts, Helm commands require the user to specify the `--devel` flag. This means that checking for whether the beta version is published should be done with `helm search repo --devel`.

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -185,9 +185,4 @@ helm install test ./ --values ./ci/test-values.yaml
 
 # Contributing/Releasing
 
-All changes require a bump to the chart version, as this enforced by CI. All changes to the chart itself should also have a corresponding CHANGELOG entry.
-
-When making a change and organizing a release, first ensure your changes are encapuslated in a meaningful commit.
-In a separate commit, increase the chart version in the `Chart.yaml` file and add a CHANGELOG entry in the `CHANGELOG.md` file under the new version.
-
-Finally, push your changes and open up a Pull Request with the prefix `[mimir-distributed]`.
+Please see the dedicated "[Contributing to Grafana Mimir helm chart](https://github.com/grafana/mimir/tree/main/docs/internal/contributing/contributing-to-helm-chart.md)" page.

--- a/operations/helm/charts/mimir-distributed/README.md.gotmpl
+++ b/operations/helm/charts/mimir-distributed/README.md.gotmpl
@@ -178,9 +178,4 @@ helm install test ./ --values ./ci/test-values.yaml
 
 # Contributing/Releasing
 
-All changes require a bump to the chart version, as this enforced by CI. All changes to the chart itself should also have a corresponding CHANGELOG entry.
-
-When making a change and organizing a release, first ensure your changes are encapuslated in a meaningful commit.
-In a separate commit, increase the chart version in the `Chart.yaml` file and add a CHANGELOG entry in the `CHANGELOG.md` file under the new version.
-
-Finally, push your changes and open up a Pull Request with the prefix `[mimir-distributed]`.
+Please see the dedicated "[Contributing to Grafana Mimir helm chart](https://github.com/grafana/mimir/tree/main/docs/internal/contributing/contributing-to-helm-chart.md)" page.


### PR DESCRIPTION
#### What this PR does

Documentation follow up for the move of mimir-distributed helm chart from the helm-charts repo.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir-squad/issues/668

#### Checklist

- [N/A] Tests updated
- [x] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
