### PR TITLE
Docs: fix mimir-mixin installation instructions

### DIFF
--- a/docs/sources/operators-guide/visualizing-metrics/installing-dashboards-and-alerts.md
+++ b/docs/sources/operators-guide/visualizing-metrics/installing-dashboards-and-alerts.md
@@ -59,11 +59,15 @@ make BUILD_IN_CONTAINER=true build-mixin
 In case you're already using Jsonnet to define your infrastructure as a code, you can vendor the Grafana Mimir mixin directly into your infrastructure repository and configure it overriding the `_config` fields.
 Given the exact setup really depends on a case-by-case basis, the following instructions are not meant to be prescriptive but just show the main steps required to vendor the mixin.
 
-1. Install Grafana Mimir mixin
+1. Initialise Jsonnet
    ```bash
-   jb install github.com/grafana/mimir/operations/mimir
+   jb init
    ```
-2. Import and configure it
+2. Install Grafana Mimir mixin
+   ```bash
+   jb install github.com/grafana/mimir/operations/mimir-mixin@main
+   ```
+3. Import and configure it
    ```jsonnet
    (import 'github.com/grafana/mimir/operations/mimir-mixin/mixin.libsonnet') + {
      _config+:: {


### PR DESCRIPTION
#### What this PR does
I just went through the mimir-mixin installation instructions (using `jb`) and didn't work. This PR fixes it:
- Mention `jb init`
- Install `@main` because `jb` looks for `master` by default and we don't have `master` branch in Mimir

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
