### PR TITLE
helm: Add extraEnvFrom to all services and enable injection into mimir config

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -11,6 +11,11 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## main / unreleased
+
+* [ENHANCEMENT] Add `extraEnvFrom` capability to all Mimir services to enable injecting secrets via environment variables. #2017
+* [ENHANCEMENT] Enable `-config.expand-env=true` option in all Mimir services to be able to take secrets/settings from the environment and inject them into the Mimir configuration file. #2017
+
 ## 2.1.0-beta.7
 
 * [ENHANCEMENT] Bump image version to 2.1 #2001

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -53,6 +53,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=admin-api"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.admin_api.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -91,6 +92,10 @@ spec:
           env:
             {{- if .Values.admin_api.env }}
             {{ toYaml .Values.admin_api.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.admin_api.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.admin_api.extraContainers }}
         {{ toYaml . | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -52,6 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=alertmanager"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.alertmanager.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -94,6 +95,10 @@ spec:
           env:
             {{- if .Values.alertmanager.env }}
               {{- toYaml .Values.alertmanager.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.alertmanager.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.alertmanager.extraContainers }}
 {{ toYaml .Values.alertmanager.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -106,6 +106,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=alertmanager"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.alertmanager.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -151,6 +152,10 @@ spec:
           env:
             {{- if .Values.alertmanager.env }}
               {{- toYaml .Values.alertmanager.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.alertmanager.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -102,6 +102,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=compactor"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.compactor.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -144,4 +145,8 @@ spec:
           env:
             {{- if .Values.compactor.env }}
               {{- toYaml .Values.compactor.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.compactor.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -50,6 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=distributor"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.distributor.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -90,6 +91,10 @@ spec:
           env:
             {{- if .Values.distributor.env }}
               {{- toYaml .Values.distributor.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.distributor.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.distributor.extraContainers }}
 {{ toYaml .Values.distributor.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -51,6 +51,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=gateway"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.gateway.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -83,6 +84,10 @@ spec:
           env:
             {{- if .Values.gateway.env }}
             {{ toYaml .Values.gateway.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.gateway.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.gateway.extraContainers }}
         {{ toYaml . | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -104,6 +104,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=ingester"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.ingester.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -147,5 +148,9 @@ spec:
           env:
             {{- if .Values.ingester.env }}
               {{- toYaml .Values.ingester.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.ingester.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -51,6 +51,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=overrides-exporter"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.overrides_exporter.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -88,6 +89,10 @@ spec:
           env:
             {{- if .Values.overrides_exporter.env }}
             {{ toYaml .Values.overrides_exporter.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.overrides_exporter.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.overrides_exporter.extraContainers }}
         {{ toYaml . | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -50,6 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=querier"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.querier.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -90,6 +91,10 @@ spec:
           env:
             {{- if .Values.querier.env }}
               {{- toYaml .Values.querier.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.querier.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.querier.extraContainers }}
 {{ toYaml .Values.querier.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -50,6 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=query-frontend"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.query_frontend.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -89,6 +90,10 @@ spec:
           env:
             {{- if .Values.query_frontend.env }}
               {{- toYaml .Values.query_frontend.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.query_frontend.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.query_frontend.extraContainers }}
 {{ toYaml .Values.query_frontend.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -51,6 +51,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=ruler"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.ruler.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -91,6 +92,10 @@ spec:
           env:
             {{- if .Values.ruler.env }}
               {{- toYaml .Values.ruler.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.ruler.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.ruler.extraContainers }}
 {{ toYaml .Values.ruler.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -102,6 +102,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=store-gateway"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.store_gateway.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -144,4 +145,8 @@ spec:
           env:
             {{- if .Values.store_gateway.env }}
               {{- toYaml .Values.store_gateway.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.store_gateway.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -44,6 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-target=tokengen"
+            - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.tokengenJob.extraArgs }}
             - "-{{ $key }}={{ $value }}"
@@ -59,6 +60,10 @@ spec:
           env:
             {{- if .Values.tokengenJob.env }}
               {{ toYaml .Values.tokengenJob.env | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.tokengenJob.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -384,6 +384,7 @@ alertmanager:
 
   # Extra env variables to pass to the alertmanager container
   env: []
+  extraEnvFrom: []
 
 distributor:
   replicas: 1
@@ -447,6 +448,7 @@ distributor:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 ingester:
   replicas: 3
@@ -539,6 +541,7 @@ ingester:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 overrides_exporter:
   enabled: true
@@ -596,6 +599,7 @@ overrides_exporter:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 ruler:
   enabled: true
@@ -651,6 +655,7 @@ ruler:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 querier:
   replicas: 2
@@ -716,6 +721,7 @@ querier:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 query_frontend:
   replicas: 1
@@ -781,6 +787,7 @@ query_frontend:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 store_gateway:
   replicas: 1
@@ -876,6 +883,7 @@ store_gateway:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 compactor:
   replicas: 1
@@ -972,6 +980,7 @@ compactor:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 memcached:
   enabled: false
@@ -1430,6 +1439,7 @@ tokengenJob:
   enable: true
   extraArgs: {}
   env: []
+  extraEnvFrom: []
   annotations: {}
   initContainers: []
 
@@ -1485,6 +1495,7 @@ admin_api:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
 # Settings for the gateway service providing authentication and authorization via the admin_api.
 # Can only be enabled if enterprise.enabled is true - requires license.
@@ -1541,6 +1552,7 @@ gateway:
   extraVolumes: []
   extraVolumeMounts: []
   env: []
+  extraEnvFrom: []
 
   # Ingress configuration
   ingress:


### PR DESCRIPTION
#### What this PR does

Add `extraEnvFrom` capability to all Mimir services to enable injecting
secrets via environment variables.

Enable `-config.exand-env=true` option in all Mimir services to be able
to take secrets/settings from the environment and inject them into the
 Mimir configuration file.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/helm-charts/issues/1314

#### Checklist

- [N/A] Tests updated  - no baseline yet
- [N/A] Documentation added - no baseline yet
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
