### PR TITLE
Docs: make documentation a first class citizen in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@
 
 * [BUGFIX] mimirtool analyze: Fix dashboard JSON unmarshalling errors (#1840). #1973
 
+### Documentation
+
+* [ENHANCEMENT] Published Grafana Mimir runbooks as part of documentation. #1970
+* [ENHANCEMENT] Improved ruler's "remote operational mode" documentation. #1906
+* [ENHANCEMENT] Recommend fast disks for ingesters and store-gateways in production tips. #1903
+* [ENHANCEMENT] Explain the runtime override of active series matchers. #1868
+* [ENHANCEMENT] Clarify "Set rule group" API specification. #1869
+
 ## 2.1.0
 ### Grafana Mimir
 * [CHANGE] Compactor: No longer upload debug meta files to object storage. #1257


### PR DESCRIPTION
#### What this PR does
We value a lot documentation, but we're not giving credit to its improvements in the CHANGELOG. I propose to make documentation a first class citizen in CHANGELOG.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
