### PR TITLE
Include helm-docs in build and CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
+      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
+      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
+      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -107,7 +107,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
+      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -191,7 +191,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-build-image-and-github-workflow-89d9d61b4
+      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,8 @@ doc: ## Generates the config file documentation.
 doc: clean-doc $(DOC_TEMPLATES:.template=.md) $(DOC_EMBED:.md=.md.embedmd)
 	# Make up markdown files prettier. When running with check-doc target, it will fail if this produces any change.
 	prettier --write "**/*.md"
+	# Make operations/helm/charts/*/README.md
+	helm-docs
 
 # Add license header to files.
 license:

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= update-build-image-and-github-workflow-89d9d61b4
+LATEST_BUILD_IMAGE_TAG ?= publish-multiarch-images-7a4b40a6d
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/docs/internal/how-to-update-the-build-image.md
+++ b/docs/internal/how-to-update-the-build-image.md
@@ -3,6 +3,6 @@ The build image currently can only be updated by a Grafana Mimir maintainer. If 
 1. Update `mimir-build-image/Dockerfile` on a new branch. Note: the resulting images have the tag name derived from the branch name.
 2. Make sure to have [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/). Docker Desktop and major distributions have it in the docker package.
 3. On Linux you'll need some extra qemu packages as well: `sudo apt-get install qemu qemu-user-static binfmt-support debootstrap`. And set up docker buildx: `docker buildx create --name armBuilder ; docker buildx use armBuilder`.
-4. Build and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for Linux/amd64 and Linux/arm64). Pushing to the `grafana/mimir-build-image` repository can only be done by a maintainer.
+4. Build and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for Linux/amd64 and Linux/arm64).
 5. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
 6. Open a PR and make sure the CI with the new build image passes

--- a/docs/internal/how-to-update-the-build-image.md
+++ b/docs/internal/how-to-update-the-build-image.md
@@ -1,6 +1,8 @@
 The build image currently can only be updated by a Grafana Mimir maintainer. If you're not a maintainer you can still open a PR with the changes, asking a maintainer to assist you in publishing the updated image. The procedure is:
 
-1. Update `mimir-build-image/Dockerfile`.
-2. Build and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for Linux/amd64 and Linux/arm64). Pushing to the `grafana/mimir-build-image` repository can only be done by a maintainer. Running this step successfully requires [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/), but does not require a specific platform.
-3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
-4. Open a PR and make sure the CI with the new build image passes
+1. Update `mimir-build-image/Dockerfile` on a new branch. Note: the resulting images have the tag name derived from the branch name.
+2. Make sure to have [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/). Docker Desktop and major distributions have it in the docker package.
+3. On Linux you'll need some extra qemu packages as well: `sudo apt-get install qemu qemu-user-static binfmt-support debootstrap`. And set up docker buildx: `docker buildx create --name armBuilder ; docker buildx use armBuilder`.
+4. Build and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for Linux/amd64 and Linux/arm64). Pushing to the `grafana/mimir-build-image` repository can only be done by a maintainer.
+5. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
+6. Open a PR and make sure the CI with the new build image passes

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -45,6 +45,7 @@ RUN GO111MODULE=on \
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066 && \
 	go install github.com/mikefarah/yq/v4@v4.13.4 && \
 	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.17.0 && \
+	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1 && \
 	rm -rf /go/pkg /go/src /root/.cache
 
 ENV NODE_PATH=/usr/lib/node_modules


### PR DESCRIPTION
#### What this PR does

Adds helm-docs to the `make doc` target.
The mimir build image is also updated for this to work with it.
The documentation about updating the build image is also updated with more info and Linux specifics.

#### Which issue(s) this PR fixes or relates to

N/A.

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
