### PR TITLE
Helm: add global.extraEnv and global.extraEnvFrom

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [ENHANCEMENT] Add `global.extraEnv` and `global.extraEnvFrom` to values. This enables setting common environment variables and common injection of secrets to environment. #2031
+* [ENHANCEMENT] Add `global.extraEnv` and `global.extraEnvFrom` to values. This enables setting common environment variables and common injection of secrets to the POD environment of Mimir/GEM services and Nginx. Memcached and minio are out of scope for now. #2031
 * [ENHANCEMENT] Add `extraEnvFrom` capability to all Mimir services to enable injecting secrets via environment variables. #2017
 * [ENHANCEMENT] Enable `-config.expand-env=true` option in all Mimir services to be able to take secrets/settings from the environment and inject them into the Mimir configuration file. #2017
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -13,6 +13,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Add `global.extraEnv` and `global.extraEnvFrom` to values. This enables setting common environment variables and common injection of secrets to environment. #2031
 * [ENHANCEMENT] Add `extraEnvFrom` capability to all Mimir services to enable injecting secrets via environment variables. #2017
 * [ENHANCEMENT] Enable `-config.expand-env=true` option in all Mimir services to be able to take secrets/settings from the environment and inject them into the Mimir configuration file. #2017
 

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -90,12 +90,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.admin_api.env }}
-            {{ toYaml .Values.admin_api.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.admin_api.env }}
+              {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.admin_api.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.admin_api.extraContainers }}
         {{ toYaml . | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -93,12 +93,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.alertmanager.env }}
-              {{- toYaml .Values.alertmanager.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.alertmanager.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.alertmanager.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.alertmanager.extraContainers }}
 {{ toYaml .Values.alertmanager.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -150,12 +150,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.alertmanager.env }}
-              {{- toYaml .Values.alertmanager.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.alertmanager.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.alertmanager.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -143,10 +143,16 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.compactor.env }}
-              {{- toYaml .Values.compactor.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.compactor.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.compactor.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -89,12 +89,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.distributor.env }}
-              {{- toYaml .Values.distributor.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.distributor.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.distributor.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.distributor.extraContainers }}
 {{ toYaml .Values.distributor.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -82,12 +82,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.gateway.env }}
-            {{ toYaml .Values.gateway.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.gateway.env }}
+              {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.gateway.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.gateway.extraContainers }}
         {{ toYaml . | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -146,11 +146,17 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.ingester.env }}
-              {{- toYaml .Values.ingester.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.ingester.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.ingester.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -51,12 +51,18 @@ spec:
             - name: http-metric
               containerPort: 8080
               protocol: TCP
-          {{- with .Values.nginx.extraEnv }}
           env:
+          {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nginx.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+          {{- with .Values.global.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.nginx.extraEnvFrom }}
-          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -87,12 +87,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.overrides_exporter.env }}
-            {{ toYaml .Values.overrides_exporter.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.overrides_exporter.env }}
+              {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.overrides_exporter.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.overrides_exporter.extraContainers }}
         {{ toYaml . | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -89,12 +89,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.querier.env }}
-              {{- toYaml .Values.querier.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.querier.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.querier.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.querier.extraContainers }}
 {{ toYaml .Values.querier.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,12 +88,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.query_frontend.env }}
-              {{- toYaml .Values.query_frontend.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.query_frontend.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.query_frontend.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.query_frontend.extraContainers }}
 {{ toYaml .Values.query_frontend.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,12 +90,18 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.ruler.env }}
-              {{- toYaml .Values.ruler.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.ruler.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.ruler.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
 {{- if .Values.ruler.extraContainers }}
 {{ toYaml .Values.ruler.extraContainers | indent 8}}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -143,10 +143,16 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
-            {{- if .Values.store_gateway.env }}
-              {{- toYaml .Values.store_gateway.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.store_gateway.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.store_gateway.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -58,12 +58,18 @@ spec:
             - name: license
               mountPath: /license
           env:
-            {{- if .Values.tokengenJob.env }}
-              {{ toYaml .Values.tokengenJob.env | nindent 12 }}
+            {{- with .Values.global.extraEnv }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.tokengenJob.env }}
+              {{ toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.tokengenJob.extraEnvFrom }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -30,6 +30,12 @@ global:
   dnsNamespace: kube-system
   clusterDomain: cluster.local
 
+  # Common environment variables to add to all PODs directly managed by this chart (mimir services, nginx). Doesn't include memcached or minio.
+  extraEnv: []
+
+  # Common source of environment injections to add to all PODs directly managed by this chart (mimir services, nginx). Doesn't include memcached or minio.
+  extraEnvFrom: []
+
 serviceAccount:
   create: true
   name:


### PR DESCRIPTION
#### What this PR does

Enables setting environment and env injection in one place for
mimir + nginx.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/helm-charts/issues/1284

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added - does not exists see: https://github.com/grafana/mimir/issues/1945
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
