### PR TITLE
Fix panic at startup when Mimir is running in monolithic mode and query sharding is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [BUGFIX] Ingester: fixed deceiving error log "failed to update cached shipped blocks after shipper initialisation", occurring for each new tenant in the ingester. #1893
 * [BUGFIX] Ring: fix bug where instances may appear unhealthy in the hash ring web UI even though they are not. #1933
 * [BUGFIX] API: gzip is now enforced when identity encoding is explicitly rejected. #1864
+* [BUGFIX] Fix panic at startup when Mimir is running in monolithic mode and query sharding is enabled. #2036
 
 ### Mixin
 

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -310,8 +310,9 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 
 func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 	tests := map[string]struct {
-		indexCacheBackend  string
-		bucketIndexEnabled bool
+		indexCacheBackend    string
+		bucketIndexEnabled   bool
+		queryShardingEnabled bool
 	}{
 		"inmemory index cache": {
 			indexCacheBackend: tsdb.IndexCacheBackendInMemory,
@@ -322,6 +323,10 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 		"memcached index cache, bucket index enabled": {
 			indexCacheBackend:  tsdb.IndexCacheBackendMemcached,
 			bucketIndexEnabled: true,
+		},
+		"inmemory index cache, query sharding enabled": {
+			indexCacheBackend:    tsdb.IndexCacheBackendInMemory,
+			queryShardingEnabled: true,
 		},
 	}
 
@@ -372,6 +377,8 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 				"-compactor.cleanup-interval":                     "2s", // Update bucket index often.
 				// Querier.
 				"-querier.query-store-after": "0",
+				// Query-frontend.
+				"-query-frontend.parallelize-shardable-queries": strconv.FormatBool(testCfg.queryShardingEnabled),
 			})
 
 			// Start Mimir replicas.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -504,13 +504,15 @@ func (t *Mimir) initFlusher() (serv services.Service, err error) {
 // initQueryFrontendTripperware instantiates the tripperware used by the query frontend
 // to optimize Prometheus query requests.
 func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error) {
+	promqlEngineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "query-frontend"}, prometheus.DefaultRegisterer)
+
 	tripperware, err := querymiddleware.NewTripperware(
 		t.Cfg.Frontend.QueryMiddleware,
 		util_log.Logger,
 		t.Overrides,
 		querymiddleware.PrometheusCodec,
 		querymiddleware.PrometheusResponseExtractor{},
-		engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, prometheus.DefaultRegisterer),
+		engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer),
 		prometheus.DefaultRegisterer,
 	)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does
I'm doing some tests and I've just realized that Mimir panics at startup when running in monolithic mode and query sharding is enabled, because of conflicting metrics registered by PromQL engine:

```
panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "prometheus_engine_queries", help: "The current number of queries being executed or waiting.", constLabels: {engine="querier"}, variableLabels: []} has different label names or a different help string

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*wrappingRegisterer).MustRegister(0xc010ee4f90, {0xc01102c000, 0x5, 0x6})
	/go/src/github.com/grafana/mimir/vendor/github.com/prometheus/client_golang/prometheus/wrap.go:104 +0x151
github.com/prometheus/prometheus/promql.NewEngine({{0x235b9a0, 0xc00036aaa0}, {0x237bed0, 0xc010ee4f90}, 0x2faf080, 0x45d964b800, {0x237b510, 0xc010ec0f00}, 0x45d964b800, 0xc0005d37d0, ...})
	/go/src/github.com/grafana/mimir/vendor/github.com/prometheus/prometheus/promql/engine.go:350 +0x8f0
github.com/grafana/mimir/pkg/querier.New({0x0, 0x1, 0x2a9079602000, 0x274a48a78000, 0x8bb2c97000, {0x0, {{0x0, 0x0}, {0x0, 0x0}, ...}}, ...}, ...)
	/go/src/github.com/grafana/mimir/pkg/querier/querier.go:134 +0x3a5
github.com/grafana/mimir/pkg/mimir.(*Mimir).initQueryable(0xc00062e000)
	/go/src/github.com/grafana/mimir/pkg/mimir/modules.go:311 +0x1c5
github.com/grafana/dskit/modules.(*Manager).initModule(0xc00000ce88, {0x7ffef8c6a608, 0x1e16cab}, 0x1e, 0x0)
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/modules/modules.go:120 +0x224
github.com/grafana/dskit/modules.(*Manager).InitModuleServices(0x1aee9c0, {0xc00093e960, 0x1, 0x4})
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/modules/modules.go:92 +0x10c
github.com/grafana/mimir/pkg/mimir.(*Mimir).Run(0xc00062e000)
	/go/src/github.com/grafana/mimir/pkg/mimir/mimir.go:438 +0x21c
main.main()
	/go/src/github.com/grafana/mimir/cmd/mimir/main.go:204 +0xa90
```

This PR fixes it, adding `engine` label to PromQL engine registerer used by query-frontend. The `engine` label is already injected by querier and ruler, so in this PR I'm just following what we already did there.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
