### PR TITLE
Chore: introduced newDiscoveryService() util in jsonnet

### DIFF
--- a/operations/mimir/common.libsonnet
+++ b/operations/mimir/common.libsonnet
@@ -18,4 +18,12 @@
       container.mixin.readinessProbe.withInitialDelaySeconds(15) +
       container.mixin.readinessProbe.withTimeoutSeconds(1),
   },
+
+  newDiscoveryService(name, deployment)::
+    local service = $.core.v1.service;
+
+    $.util.serviceFor(deployment, $._config.service_ignored_labels) +
+    service.mixin.spec.withPublishNotReadyAddresses(true) +
+    service.mixin.spec.withClusterIp('None') +
+    service.mixin.metadata.withName(name),
 }

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -51,18 +51,13 @@
 
   query_frontend_deployment: self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container),
 
-  local service = $.core.v1.service,
-
   query_frontend_service:
     $.util.serviceFor($.query_frontend_deployment, $._config.service_ignored_labels),
 
   query_frontend_discovery_service:
-    $.util.serviceFor($.query_frontend_deployment, $._config.service_ignored_labels) +
     // Make sure that query frontend worker, running in the querier, do resolve
     // each query-frontend pod IP and NOT the service IP. To make it, we do NOT
     // use the service cluster IP so that when the service DNS is resolved it
     // returns the set of query-frontend IPs.
-    service.mixin.spec.withPublishNotReadyAddresses(true) +
-    service.mixin.spec.withClusterIp('None') +
-    service.mixin.metadata.withName('query-frontend-discovery'),
+    $.newDiscoveryService('query-frontend-discovery', $.query_frontend_deployment),
 }

--- a/operations/mimir/query-scheduler.libsonnet
+++ b/operations/mimir/query-scheduler.libsonnet
@@ -3,7 +3,6 @@
 {
   local container = $.core.v1.container,
   local deployment = $.apps.v1.deployment,
-  local service = $.core.v1.service,
 
   query_scheduler_args+::
     $._config.grpcConfig
@@ -44,10 +43,7 @@
 
   // Headless to make sure resolution gets IP address of target pods, and not service IP.
   newQuerySchedulerDiscoveryService(name, deployment)::
-    $.util.serviceFor(deployment, $._config.service_ignored_labels) +
-    service.mixin.spec.withPublishNotReadyAddresses(true) +
-    service.mixin.spec.withClusterIp('None') +
-    service.mixin.metadata.withName(discoveryServiceName(name)),
+    $.newDiscoveryService(discoveryServiceName(name), deployment),
 
   query_scheduler_discovery_service: if !$._config.query_scheduler_enabled then {} else
     self.newQuerySchedulerDiscoveryService('query-scheduler', $.query_scheduler_deployment),


### PR DESCRIPTION
#### What this PR does
I need to create a "discovery" service in a downstream project. I would like to introduce a new `newDiscoveryService()` utility to do it, so that I can just reuse it like we do for other `newXXX()` functions.

_This PR is expected to be a no-op._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
