### PR TITLE
fix: add namespace for applicable helm chart resources

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
     {{- toYaml .Values.admin_api.annotations | nindent 4 }}
   labels:

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-pdb.yaml
@@ -3,6 +3,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "admin-api") }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "admin-api" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-servmon.yaml
@@ -5,9 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "admin-api") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "admin-api" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "admin-api") }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "admin-api" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
@@ -3,6 +3,7 @@
 apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-servmon.yaml
@@ -5,9 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "alertmanager") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "alertmanager" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
     {{- with .Values.alertmanager.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "compactor") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-servmon.yaml
@@ -4,9 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "compactor") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "compactor" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "compactor") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "compactor") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 4 }}
     {{- with .Values.compactor.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-servmon.yaml
@@ -4,9 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "distributor") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "distributor" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
     {{- with .Values.distributor.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.gateway.replicas }}
   selector:

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: {{ include "mimir.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
   {{- with .Values.gateway.ingress.annotations }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-servmon.yaml
@@ -5,9 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "gateway") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "gateway") | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
     {{- with .Values.gateway.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gossip-ring") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gossip-ring") | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-servmon.yaml
@@ -4,9 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "ingester") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "ingester" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}
     {{- with .Values.ingester.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/license-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/license-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ tpl .Values.license.secretName . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
 data:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/ingress.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/ingress.yaml
@@ -8,6 +8,7 @@ apiVersion: {{ include "mimir.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
   {{- with .Values.nginx.ingress.annotations }}

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
 data:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
 stringData:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
     {{- with .Values.nginx.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "overrides-exporter") | nindent 4 }}
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "overrides-exporter") }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.overrides_exporter.replicas }}
   selector:

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "overrides-exporter") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "overrides-exporter") | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "overrides-exporter") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "overrides-exporter") | nindent 4 }}
     {{- with .Values.overrides_exporter.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" .) }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-servmon.yaml
@@ -4,9 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "querier") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "querier" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}
     {{- with .Values.querier.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-servmon.yaml
@@ -4,9 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "query-frontend") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "query-frontend") | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
     {{- with .Values.query_frontend.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/role.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" .) }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
 rules:

--- a/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" .) }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
 roleRef:

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-servmon.yaml
@@ -5,9 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "ruler") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "ruler" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}
     {{- with .Values.ruler.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/runtime-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "runtime") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
 data:

--- a/operations/helm/charts/mimir-distributed/templates/secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ tpl .Values.externalConfigSecretName . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
 data:

--- a/operations/helm/charts/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "mimir.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-servmon.yaml
@@ -4,9 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "store-gateway") }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "store-gateway" "memberlist" true) | nindent 4 }}
     {{- with .labels }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}
   annotations:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway") }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}
     {{- with .Values.store_gateway.service.labels }}

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -4,6 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "tokengen") }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "tokengen") | nindent 4 }}
   annotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds namespace to all Helm resources. 

Note: I also removed parts with `with .namespace` to normalize namespace declarations.
```
{{- with .namespace }}
  namespace: {{ . }}
  {{- end }}
```
This is probably considered a breaking change, so let me know if I should reintroduce them and fall back to .Release.Namespace instead. It's noteworthy that this convention was also very inconsistent, so I'm finding it hard to believe that it's used 'in the wild'.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2045

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
