### PR TITLE
mimir-continuous-test: Add smoke test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 ### Mimir Continuous Test
 
-* [ENHANCEMENT] Added the `-tests.smoke-test` flag to run the `mimir-continuous-test` suite once and immediately exit.
+* [ENHANCEMENT] Added the `-tests.smoke-test` flag to run the `mimir-continuous-test` suite once and immediately exit. #2047
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
 
 * [BUGFIX] mimirtool analyze: Fix dashboard JSON unmarshalling errors (#1840). #1973
 
+### Mimir Continuous Test
+
+* [ENHANCEMENT] Added the `-tests.smoke-test` flag to run the `mimir-continuous-test` suite once and immediately exit.
+
 ### Documentation
 
 * [ENHANCEMENT] Published Grafana Mimir runbooks as part of documentation. #1970

--- a/docs/sources/operators-guide/tools/mimir-continuous-test.md
+++ b/docs/sources/operators-guide/tools/mimir-continuous-test.md
@@ -10,6 +10,7 @@ weight: 30
 As a developer, you can use the standalone mimir-continuous-test tool to run smoke tests on live Grafana Mimir clusters.
 This tool identifies a class of bugs that could be difficult to spot during development.
 Two operating modes are supported:
+
 - As a continuously running deployment in your environment, mimir-continuous-test can be used to detect issues on a live Grafana Mimir cluster over time.
 - As an ad-hoc smoke test tool, mimir-continuous-test can be used to validate basic functionality after configuration changes are made to a Grafana Mimir cluster.
 

--- a/docs/sources/operators-guide/tools/mimir-continuous-test.md
+++ b/docs/sources/operators-guide/tools/mimir-continuous-test.md
@@ -7,8 +7,11 @@ weight: 30
 
 # Grafana mimir-continuous-test
 
-As a developer, you can use the standalone mimir-continuous-test tool to continuously run smoke tests on live Grafana Mimir clusters.
+As a developer, you can use the standalone mimir-continuous-test tool to run smoke tests on live Grafana Mimir clusters.
 This tool identifies a class of bugs that could be difficult to spot during development.
+Two operating modes are supported:
+- As a continuously running deployment in your environment, mimir-continuous-test can be used to detect issues on a live Grafana Mimir cluster over time.
+- As an ad-hoc smoke test tool, mimir-continuous-test can be used to validate basic functionality after configuration changes are made to a Grafana Mimir cluster.
 
 ## Download mimir-continuous-test
 
@@ -36,6 +39,7 @@ Mimir-continuous-test requires the endpoints of the backend Grafana Mimir cluste
 - Set `-tests.write-endpoint` to the base endpoint on the write path. Remove any trailing slash from the URL. The tool appends the specific API path to the URL, for example `/api/v1/push` for the remote-write API.
 - Set `-tests.read-endpoint` to the base endpoint on the read path. Remove any trailing slash from the URL. The tool appends the specific API path to the URL, for example `/api/v1/query_range` for the range-query API.
 - Set `-tests.tenant-id` to the tenant ID to use to write and read metrics in tests.
+- Set `-tests.smoke-test` to run the test once and immediately exit. In this mode, the process exit code is non-zero when the test fails.
 
 > **Note:** You can run `mimir-continuous-test -help` to list all available configuration options.
 

--- a/pkg/continuoustest/manager_test.go
+++ b/pkg/continuoustest/manager_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package continuoustest
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyTest struct {
+	runs int
+	err  error
+}
+
+// Name implements Test.
+func (d *dummyTest) Name() string {
+	return "dummyTest"
+}
+
+// Init implements Test.
+func (d *dummyTest) Init(ctx context.Context, now time.Time) error {
+	return nil
+}
+
+// Run implements Test.
+func (d *dummyTest) Run(ctx context.Context, now time.Time) error {
+	d.runs++
+	return d.err
+}
+
+func TestManager_PeriodicRun(t *testing.T) {
+	cfg := ManagerConfig{}
+	cfg.RegisterFlags(flag.NewFlagSet("", flag.ContinueOnError))
+	cfg.RunInterval = time.Millisecond * 10
+
+	manager := NewManager(cfg)
+
+	dummyTest := &dummyTest{}
+	manager.AddTest(dummyTest)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+	defer cancel()
+	err := manager.Run(ctx)
+
+	require.NoError(t, err)
+	// Theoretically the test will run 6 times, but small timing differences may
+	// cause it to run only 5 times.
+	require.GreaterOrEqual(t, dummyTest.runs, 5)
+}
+
+func TestManager_SmokeTest(t *testing.T) {
+	t.Run("successful smoke test", func(t *testing.T) {
+		cfg := ManagerConfig{}
+		cfg.RegisterFlags(flag.NewFlagSet("", flag.ContinueOnError))
+		cfg.RunInterval = time.Millisecond * 10
+		cfg.SmokeTest = true
+
+		manager := NewManager(cfg)
+
+		dummyTest := &dummyTest{}
+		manager.AddTest(dummyTest)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+		err := manager.Run(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, dummyTest.runs, 1)
+	})
+
+	t.Run("failed smoke test", func(t *testing.T) {
+		cfg := ManagerConfig{}
+		cfg.RegisterFlags(flag.NewFlagSet("", flag.ContinueOnError))
+		cfg.RunInterval = time.Millisecond * 10
+		cfg.SmokeTest = true
+
+		manager := NewManager(cfg)
+
+		dummyTest := &dummyTest{}
+		dummyTest.err = errors.New("test error")
+		manager.AddTest(dummyTest)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+		err := manager.Run(ctx)
+
+		require.ErrorIs(t, err, dummyTest.err)
+		require.Equal(t, dummyTest.runs, 1)
+	})
+}

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/dskit/multierror"
+
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -35,7 +35,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
 
 		now := time.Unix(1000, 0)
-		test.Run(context.Background(), now)
+		// Ignore this error. It will be non-nil because the query mock does not return any data.
+		_ = test.Run(context.Background(), now)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 1)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, now, 2))
@@ -74,7 +75,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
 
 		now := time.Unix(999, 0)
-		test.Run(context.Background(), now)
+		// Ignore this error. It will be non-nil because the query mock does not return any data.
+		_ = test.Run(context.Background(), now)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 1)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, time.Unix(980, 0), 2))
@@ -114,7 +116,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 
 		test.lastWrittenTimestamp = time.Unix(940, 0)
 		now := time.Unix(1000, 0)
-		test.Run(context.Background(), now)
+		// Ignore this error. It will be non-nil because the query mock does not return any data.
+		_ = test.Run(context.Background(), now)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 3)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, time.Unix(960, 0), 2))
@@ -154,7 +157,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 
 		test.lastWrittenTimestamp = time.Unix(940, 0)
 		now := time.Unix(1000, 0)
-		test.Run(context.Background(), now)
+		err := test.Run(context.Background(), now)
+		assert.Error(t, err)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 1)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, time.Unix(960, 0), 2))
@@ -184,7 +188,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 
 		test.lastWrittenTimestamp = time.Unix(940, 0)
 		now := time.Unix(1000, 0)
-		test.Run(context.Background(), now)
+		err := test.Run(context.Background(), now)
+		assert.Error(t, err)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 1)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, time.Unix(960, 0), 2))
@@ -214,7 +219,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 
 		test.lastWrittenTimestamp = time.Unix(940, 0)
 		now := time.Unix(1000, 0)
-		test.Run(context.Background(), now)
+		err := test.Run(context.Background(), now)
+		assert.NoError(t, err)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 3)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, time.Unix(960, 0), 2))
@@ -252,7 +258,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 		reg := prometheus.NewPedanticRegistry()
 		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
 
-		test.Run(context.Background(), now)
+		err := test.Run(context.Background(), now)
+		assert.NoError(t, err)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 1)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, now, 2))
@@ -306,7 +313,8 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 		reg := prometheus.NewPedanticRegistry()
 		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
 
-		test.Run(context.Background(), now)
+		err := test.Run(context.Background(), now)
+		assert.Error(t, err)
 
 		client.AssertNumberOfCalls(t, "WriteSeries", 1)
 		client.AssertCalled(t, "WriteSeries", mock.Anything, generateSineWaveSeries(metricName, now, 2))


### PR DESCRIPTION
#### What this PR does

Adds a new flag `-tests.smoke-test` to mimir-continuous-test. This flag will run the tests once and immediately exit.

The existing test was updated to support returning errors to the caller. In order to maximize the amount of useful debugging information returned, errors are collected in a slice and returned all at once rather than exiting at the first error.

#### Which issue(s) this PR fixes or relates to

Fixes #2042 

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
