### PR TITLE
Use a dedicated thread pool for creating indexheader.Readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] ring: optimize shuffle-shard computation when lookback is used, and all instances have registered timestamp within the lookback window. In that case we can immediately return origial ring, because we would select all instances anyway. #2309
 * [ENHANCEMENT] Memberlist: added experimental memberlist cluster label support via `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` CLI flags (and their respective YAML config options). #2354
 * [ENHANCEMENT] Object storage can now be configured for all components using the `common` YAML config option key (or `-common.storage.*` CLI flags). #2330
+* [ENHANCEMENT] Store-gateway: Add the experimental ability to load TSDB index headers in a dedicated thread pool. This feature can be configured using `-blocks-storage.bucket-store.index-header-thread-pool-size` and is disabled by default. #2048 #1660 #1812
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while synching rules. #2289

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5213,6 +5213,17 @@
                   "fieldFlag": "blocks-storage.bucket-store.index-header.map-populate-enabled",
                   "fieldType": "boolean",
                   "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "thread_pool_size",
+                  "required": false,
+                  "desc": "Number of dedicated OS threads to use for loading index header files from disk using mmap. Set to 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "blocks-storage.bucket-store.index-header.thread-pool-size",
+                  "fieldType": "int",
+                  "fieldCategory": "experimental"
                 }
               ],
               "fieldValue": null,
@@ -6564,17 +6575,6 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
-        },
-        {
-          "kind": "field",
-          "name": "thread_pool_size",
-          "required": false,
-          "desc": "Number of OS threads that are dedicated for handling requests. Set to 0 to disable use of dedicated OS threads for handling requests.",
-          "fieldValue": null,
-          "fieldDefaultValue": 0,
-          "fieldFlag": "store-gateway.thread-pool-size",
-          "fieldType": "int",
-          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -338,6 +338,8 @@ Usage of ./cmd/mimir/mimir:
     	If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
   -blocks-storage.bucket-store.index-header.map-populate-enabled
     	[experimental] If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.
+  -blocks-storage.bucket-store.index-header.thread-pool-size uint
+    	[experimental] Number of dedicated OS threads to use for loading index header files from disk using mmap. Set to 0 to disable.
   -blocks-storage.bucket-store.max-chunk-pool-bytes uint
     	Max size - in bytes - of a chunks pool, used to reduce memory allocations. The pool is shared across all tenants. 0 to disable the limit. (default 2147483648)
   -blocks-storage.bucket-store.max-concurrent int
@@ -1785,8 +1787,6 @@ Usage of ./cmd/mimir/mimir:
     	True to enable zone-awareness and replicate blocks across different availability zones. This option needs be set both on the store-gateway, querier and ruler when running in microservices mode.
   -store-gateway.tenant-shard-size int
     	The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.
-  -store-gateway.thread-pool-size uint
-    	[experimental] Number of OS threads that are dedicated for handling requests. Set to 0 to disable use of dedicated OS threads for handling requests.
   -store.max-labels-query-length value
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -store.max-query-length value

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2912,6 +2912,11 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.map-populate-enabled
     [map_populate_enabled: <boolean> | default = false]
 
+    # (experimental) Number of dedicated OS threads to use for loading index
+    # header files from disk using mmap. Set to 0 to disable.
+    # CLI flag: -blocks-storage.bucket-store.index-header.thread-pool-size
+    [thread_pool_size: <int> | default = 0]
+
 tsdb:
   # Directory to store TSDBs (including WAL) in the ingesters. This directory is
   # required to be persisted between restarts.
@@ -3337,11 +3342,6 @@ sharding_ring:
   # Unregister from the ring upon clean shutdown.
   # CLI flag: -store-gateway.sharding-ring.unregister-on-shutdown
   [unregister_on_shutdown: <boolean> | default = true]
-
-# (experimental) Number of OS threads that are dedicated for handling requests.
-# Set to 0 to disable use of dedicated OS threads for handling requests.
-# CLI flag: -store-gateway.thread-pool-size
-[thread_pool_size: <int> | default = 0]
 ```
 
 ### memcached

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1496,7 +1496,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		bkt:             objstore.WithNoopInstr(bkt),
 		logger:          logger,
 		indexCache:      indexCache,
-		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil)),
+		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), false, 0, indexheader.NewReaderPoolMetrics(nil), indexheader.DefaultReaderFactory),
 		metrics:         NewBucketStoreMetrics(nil),
 		blockSet:        &bucketBlockSet{blocks: [][]*bucketBlock{{b1, b2}}},
 		blocks: map[ulid.ULID]*bucketBlock{

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
-	"github.com/grafana/mimir/pkg/storegateway/threadpool"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -52,15 +51,11 @@ var (
 // Config holds the store gateway config.
 type Config struct {
 	ShardingRing RingConfig `yaml:"sharding_ring" doc:"description=The hash ring configuration."`
-	// ThreadPoolSize controls the number of OS threads that are dedicated for handling requests
-	ThreadPoolSize uint `yaml:"thread_pool_size" category:"experimental"`
 }
 
 // RegisterFlags registers the Config flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.ShardingRing.RegisterFlags(f, logger)
-
-	f.UintVar(&cfg.ThreadPoolSize, "store-gateway.thread-pool-size", uint(0), "Number of OS threads that are dedicated for handling requests. Set to 0 to disable use of dedicated OS threads for handling requests.")
 }
 
 // Validate the Config.
@@ -83,7 +78,6 @@ type StoreGateway struct {
 	logger     log.Logger
 	stores     *BucketStores
 	tracker    *activitytracker.ActivityTracker
-	threadpool *threadpool.Threadpool
 
 	// Ring used for sharding blocks.
 	ringLifecycler *ring.BasicLifecycler
@@ -125,7 +119,6 @@ func newStoreGateway(gatewayCfg Config, storageCfg mimir_tsdb.BlocksStorageConfi
 		storageCfg: storageCfg,
 		logger:     logger,
 		tracker:    tracker,
-		threadpool: threadpool.NewThreadpool(gatewayCfg.ThreadPoolSize, reg),
 		bucketSync: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_storegateway_bucket_sync_total",
 			Help: "Total number of times the bucket sync operation triggered.",
@@ -191,7 +184,7 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 
 	// First of all we register the instance in the ring and wait
 	// until the lifecycler successfully started.
-	if g.subservices, err = services.NewManager(g.ringLifecycler, g.ring, g.threadpool); err != nil {
+	if g.subservices, err = services.NewManager(g.ringLifecycler, g.ring, g.stores); err != nil {
 		return errors.Wrap(err, "unable to start store-gateway dependencies")
 	}
 
@@ -308,11 +301,7 @@ func (g *StoreGateway) Series(req *storepb.SeriesRequest, srv storegatewaypb.Sto
 	})
 	defer g.tracker.Delete(ix)
 
-	_, err := g.threadpool.Execute(func() (interface{}, error) {
-		return nil, g.stores.Series(req, srv)
-	})
-
-	return err
+	return g.stores.Series(req, srv)
 }
 
 // LabelNames implements the Storegateway proto service.
@@ -322,15 +311,7 @@ func (g *StoreGateway) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 	})
 	defer g.tracker.Delete(ix)
 
-	res, err := g.threadpool.Execute(func() (interface{}, error) {
-		return g.stores.LabelNames(ctx, req)
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return res.(*storepb.LabelNamesResponse), err
+	return g.stores.LabelNames(ctx, req)
 }
 
 // LabelValues implements the Storegateway proto service.
@@ -340,15 +321,7 @@ func (g *StoreGateway) LabelValues(ctx context.Context, req *storepb.LabelValues
 	})
 	defer g.tracker.Delete(ix)
 
-	res, err := g.threadpool.Execute(func() (interface{}, error) {
-		return g.stores.LabelValues(ctx, req)
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return res.(*storepb.LabelValuesResponse), err
+	return g.stores.LabelValues(ctx, req)
 }
 
 func requestActivity(ctx context.Context, name string, req interface{}) string {

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -464,10 +464,12 @@ type BinaryReader struct {
 
 type BinaryReaderConfig struct {
 	MapPopulateEnabled bool `yaml:"map_populate_enabled" category:"experimental"`
+	ThreadPoolSize     uint `yaml:"thread_pool_size" category:"experimental"`
 }
 
 func (cfg *BinaryReaderConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.MapPopulateEnabled, prefix+"map-populate-enabled", false, "If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.")
+	f.UintVar(&cfg.ThreadPoolSize, prefix+"thread-pool-size", 0, "Number of dedicated OS threads to use for loading index header files from disk using mmap. Set to 0 to disable.")
 }
 
 // NewBinaryReader loads or builds new index-header if not present on disk.

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -38,7 +38,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 	require.NoError(t, err)
 	defer func() { require.NoError(t, bkt.Close()) }()
 
-	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, BinaryReaderConfig{}, NewLazyBinaryReaderMetrics(nil), nil)
+	_, err = NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, ulid.MustNew(0, nil), 3, BinaryReaderConfig{}, NewLazyBinaryReaderMetrics(nil), nil, DefaultReaderFactory)
 	require.Error(t, err)
 }
 
@@ -62,7 +62,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil, DefaultReaderFactory)
 	require.NoError(t, err)
 	require.True(t, r.reader == nil)
 	require.Equal(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -107,7 +107,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil, DefaultReaderFactory)
 	require.NoError(t, err)
 	require.True(t, r.reader == nil)
 	require.Equal(t, float64(0), promtestutil.ToFloat64(m.loadCount))
@@ -143,7 +143,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil, DefaultReaderFactory)
 	require.NoError(t, err)
 	require.True(t, r.reader == nil)
 
@@ -195,7 +195,7 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil, DefaultReaderFactory)
 	require.NoError(t, err)
 	require.True(t, r.reader == nil)
 
@@ -246,7 +246,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	m := NewLazyBinaryReaderMetrics(nil)
-	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil)
+	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil, DefaultReaderFactory)
 	require.NoError(t, err)
 	require.True(t, r.reader == nil)
 	t.Cleanup(func() {

--- a/pkg/storegateway/indexheader/reader_factory.go
+++ b/pkg/storegateway/indexheader/reader_factory.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package indexheader
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/grafana/mimir/pkg/storegateway/threadpool"
+)
+
+// DefaultReaderFactory creates new BinaryReader instances directly in the calling goroutine.
+var DefaultReaderFactory = ReaderFactoryFunc(NewBinaryReader)
+
+// ReaderFactory creates new BinaryReader instances.
+type ReaderFactory interface {
+	NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg BinaryReaderConfig) (*BinaryReader, error)
+}
+
+// ReaderFactoryFunc is a ReaderFactory implementation for a function.
+type ReaderFactoryFunc func(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg BinaryReaderConfig) (*BinaryReader, error)
+
+func (f ReaderFactoryFunc) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg BinaryReaderConfig) (*BinaryReader, error) {
+	return f(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, cfg)
+}
+
+// threadedReaderFactory creates new BinaryReader instances using a pool of dedicated OS threads.
+//
+// This exists so that we can optionally create new instances in an isolated way, avoiding page faults when
+// accessing memory mapped files. This is beneficial since the go runtime is not aware when accesses to memory
+// mapped files block an entire OS thread and all other goroutines running on it.
+type threadedReaderFactory struct {
+	pool *threadpool.ThreadPool
+}
+
+// NewThreadedReaderFactory creates a new ReaderFactory that uses a threadpool to ensure creation
+// of BinaryReader instances does not block the calling OS thread.
+func NewThreadedReaderFactory(pool *threadpool.ThreadPool) ReaderFactory {
+	return &threadedReaderFactory{pool: pool}
+}
+
+func (f *threadedReaderFactory) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg BinaryReaderConfig) (*BinaryReader, error) {
+	res, err := f.pool.Execute(func() (interface{}, error) {
+		return NewBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, cfg)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res.(*BinaryReader), nil
+}

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -63,7 +63,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout, NewReaderPoolMetrics(nil))
+			pool := NewReaderPool(log.NewNopLogger(), testData.lazyReaderEnabled, testData.lazyReaderIdleTimeout, NewReaderPoolMetrics(nil), DefaultReaderFactory)
 			defer pool.Close()
 
 			r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{})
@@ -100,7 +100,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
 	metrics := NewReaderPoolMetrics(nil)
-	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout, metrics)
+	pool := NewReaderPool(log.NewNopLogger(), true, idleTimeout, metrics, DefaultReaderFactory)
 	defer pool.Close()
 
 	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{})

--- a/pkg/storegateway/threadpool/threadpool_test.go
+++ b/pkg/storegateway/threadpool/threadpool_test.go
@@ -20,7 +20,7 @@ func TestThreadpool_Call(t *testing.T) {
 		test.VerifyNoLeak(t)
 
 		ctx := context.Background()
-		pool := NewThreadpool(1, prometheus.NewPedanticRegistry())
+		pool := NewThreadPool(1, prometheus.NewPedanticRegistry())
 		require.NoError(t, services.StartAndAwaitRunning(ctx, pool))
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, pool))
 
@@ -35,7 +35,7 @@ func TestThreadpool_Call(t *testing.T) {
 		test.VerifyNoLeak(t)
 
 		ctx := context.Background()
-		pool := NewThreadpool(0, prometheus.NewPedanticRegistry())
+		pool := NewThreadPool(0, prometheus.NewPedanticRegistry())
 		require.NoError(t, services.StartAndAwaitRunning(ctx, pool))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, pool))
@@ -53,7 +53,7 @@ func TestThreadpool_Call(t *testing.T) {
 		test.VerifyNoLeak(t)
 
 		ctx := context.Background()
-		pool := NewThreadpool(1, prometheus.NewPedanticRegistry())
+		pool := NewThreadPool(1, prometheus.NewPedanticRegistry())
 		require.NoError(t, services.StartAndAwaitRunning(ctx, pool))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, pool))
@@ -71,7 +71,7 @@ func TestThreadpool_Call(t *testing.T) {
 		test.VerifyNoLeak(t)
 
 		ctx := context.Background()
-		pool := NewThreadpool(1, prometheus.NewPedanticRegistry())
+		pool := NewThreadPool(1, prometheus.NewPedanticRegistry())
 		require.NoError(t, services.StartAndAwaitRunning(ctx, pool))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, pool))


### PR DESCRIPTION
#### What this PR does

Remove use of a dedicated thread pool for store-gateway requests. Instead,
only use the thread pool for creation of new indexheader.Reader instances
since this is when most I/O on memory mapped files happens.

Using dedicated threads for entire requests introduced a new way for store-
gateways to fail when becoming overloaded. Since the threads in the pool are
a constrained resource, when slow requests monopolize them all other requests
are blocked waiting for a thread. By moving use of the thread pool to
creation of indexheader.Reader instances, we minimize the amount of time
that a thread must be used for while also making sure that we don't use
the thread pool at all when not needed.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
