### PR TITLE
#2044 reenable proxy_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [BUGFIX] Ring: fix bug where instances may appear unhealthy in the hash ring web UI even though they are not. #1933
 * [BUGFIX] API: gzip is now enforced when identity encoding is explicitly rejected. #1864
 * [BUGFIX] Fix panic at startup when Mimir is running in monolithic mode and query sharding is enabled. #2036
-
+* [CHANGE] Re-enable the `proxy_url` option for receiver configuration. #2044
 ### Mixin
 
 * [CHANGE] Split `mimir_queries` rules group into `mimir_queries` and `mimir_ingester_queries` to keep number of rules per group within the default per-tenant limit. #1885

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -422,14 +422,8 @@ func validateReceiverHTTPConfig(cfg commoncfg.HTTPClientConfig) error {
 	if cfg.BearerTokenFile != "" {
 		return errPasswordFileNotAllowed
 	}
-	if cfg.ProxyURL.URL != nil {
-		return errProxyURLNotAllowed
-	}
 	if cfg.OAuth2 != nil && cfg.OAuth2.ClientSecretFile != "" {
 		return errOAuth2SecretFileNotAllowed
-	}
-	if cfg.OAuth2 != nil && cfg.OAuth2.ProxyURL.URL != nil {
-		return errProxyURLNotAllowed
 	}
 	return validateReceiverTLSConfig(cfg.TLSConfig)
 }

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -307,25 +307,6 @@ alertmanager_config: |
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
 		},
 		{
-			name: "Should return error if global OAuth2 proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  global:
-    http_config:
-      oauth2:
-        client_id: test
-        client_secret: xxx
-        token_url: http://example.com
-        proxy_url: http://example.com
-
-  route:
-    receiver: 'default-receiver'
-  receivers:
-    - name: default-receiver
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
-		},
-		{
 			name: "Should return error if global OAuth2 TLS key_file is set",
 			cfg: `
 alertmanager_config: |
@@ -413,42 +394,6 @@ alertmanager_config: |
     receiver: 'default-receiver'
 `,
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
-		},
-		{
-			name: "Should return error if receiver's OAuth2 proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  receivers:
-    - name: default-receiver
-      webhook_configs:
-        - url: http://localhost
-          http_config:
-            oauth2:
-              client_id: test
-              token_url: http://example.com
-              client_secret: xxx
-              proxy_url: http://localhost
-
-  route:
-    receiver: 'default-receiver'
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
-		},
-		{
-			name: "Should return error if receiver's HTTP proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  receivers:
-    - name: default-receiver
-      webhook_configs:
-        - url: http://localhost
-          http_config:
-            proxy_url: http://localhost
-
-  route:
-    receiver: 'default-receiver'
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
 		},
 		{
 			name: "Should return error if global slack_api_url_file is set",


### PR DESCRIPTION
#### What this PR does
It re-enables the proxy_url option for alertmanager receivers.

See #2044 and the related cortex PR: https://github.com/cortexproject/cortex/pull/4741 


#### Which issue(s) this PR fixes or relates to

Fixes #2044

#### Checklist

- [X] Tests updated
- [x]  Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
