### PR TITLE
Initialize Tanka with k8s-libsonnet v1.21.

### DIFF
--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.18
+tk init --k8s=1.21
 
 # Install Mimir jsonnet from this branch.
 jb install ../operations/mimir

--- a/operations/mimir/README.md
+++ b/operations/mimir/README.md
@@ -28,7 +28,7 @@ set -e
 
 # Initialise the Tanka.
 mkdir jsonnet-example && cd jsonnet-example
-tk init --k8s=1.18
+tk init --k8s=1.21
 
 # Install Mimir jsonnet.
 jb install github.com/grafana/mimir/operations/mimir@main

--- a/operations/mimir/getting-started.sh
+++ b/operations/mimir/getting-started.sh
@@ -5,7 +5,7 @@ set -e
 
 # Initialise the Tanka.
 mkdir jsonnet-example && cd jsonnet-example
-tk init --k8s=1.18
+tk init --k8s=1.21
 
 # Install Mimir jsonnet.
 jb install github.com/grafana/mimir/operations/mimir@main


### PR DESCRIPTION
#### What this PR does

Update k8s-libsonnet used by Tanka to version 1.21. Previously used version 1.18 is no longer available in https://github.com/jsonnet-libs/k8s-libsonnet/

Trying to use later version (1.22) would run into issue https://github.com/grafana/mimir/issues/1825.

#### Which issue(s) this PR fixes or relates to

Fixes CI errors after recent change in https://github.com/jsonnet-libs/k8s-libsonnet/ when v1.18 was removed. See for example https://github.com/grafana/mimir/runs/6789049505?check_suite_focus=true

#### Checklist

- [na] Tests updated
- [x] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
