### PR TITLE
Fix ruler config in getting started guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [ENHANCEMENT] Recommend fast disks for ingesters and store-gateways in production tips. #1903
 * [ENHANCEMENT] Explain the runtime override of active series matchers. #1868
 * [ENHANCEMENT] Clarify "Set rule group" API specification. #1869
+* [BUGFIX] Fixed ruler configuration used in the getting started guide. #2052
 
 ## 2.1.0
 ### Grafana Mimir

--- a/docs/configurations/demo.yaml
+++ b/docs/configurations/demo.yaml
@@ -31,9 +31,9 @@ ingester:
     replication_factor: 1
 
 ruler_storage:
-  backend: local
-  local:
-    directory: /tmp/mimir/rules
+  backend: filesystem
+  filesystem:
+    dir: /tmp/mimir/rules
 
 server:
   http_listen_port: 9009

--- a/docs/sources/operators-guide/getting-started/_index.md
+++ b/docs/sources/operators-guide/getting-started/_index.md
@@ -82,9 +82,9 @@ ingester:
     replication_factor: 1
 
 ruler_storage:
-  backend: local
-  local:
-    directory: /tmp/mimir/rules
+  backend: filesystem
+  filesystem:
+    dir: /tmp/mimir/rules
 
 server:
   http_listen_port: 9009
@@ -103,7 +103,7 @@ In a terminal, run one of the following commands:
 - Using Docker:
 
   ```bash
-  docker run --rm --name mimir --publish 9009:9009 --volume "$(pwd)"/demo.yaml:/etc/mimir/demo.yaml grafana/mimir:${MIMIR_LATEST} --config.file=/etc/mimir/demo.yaml
+  docker run --rm --name mimir --publish 9009:9009 --volume "$(pwd)"/demo.yaml:/etc/mimir/demo.yaml grafana/mimir:latest --config.file=/etc/mimir/demo.yaml
   ```
 
 - Using a local binary:


### PR DESCRIPTION
#### What this PR does
#862 made me realized that the getting started guide uses `local` storage for the ruler, which requires the directory to exists and doesn't support `mimirtool` to upload rules config. I recommend to switch to `filesystem` which fixes #862 and also work with `mimirtool`. I manually tested it.

#### Which issue(s) this PR fixes or relates to

Fixes #862

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
