### PR TITLE
Return and log detailed services information on /ready

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -530,12 +530,13 @@ func (t *Mimir) readyHandler(sm *services.Manager) http.HandlerFunc {
 			msg := bytes.Buffer{}
 			msg.WriteString("Some services are not Running:\n")
 
-			byState := sm.ServicesByState()
-			for st, ls := range byState {
-				msg.WriteString(fmt.Sprintf("%v: %d\n", st, len(ls)))
+			for name, s := range t.ServiceMap {
+				msg.WriteString(fmt.Sprintf("%s: %s\n", name, s.State()))
 			}
 
-			http.Error(w, msg.String(), http.StatusServiceUnavailable)
+			strMsg := msg.String()
+			level.Debug(util_log.Logger).Log(strMsg)
+			http.Error(w, strMsg, http.StatusServiceUnavailable)
 			return
 		}
 

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -531,7 +531,9 @@ func (t *Mimir) readyHandler(sm *services.Manager) http.HandlerFunc {
 			msg.WriteString("Some services are not Running:\n")
 
 			for name, s := range t.ServiceMap {
-				msg.WriteString(fmt.Sprintf("%s: %s\n", name, s.State()))
+				if s.State() != services.Running {
+					msg.WriteString(fmt.Sprintf("%s: %s\n", name, s.State()))
+				}
 			}
 
 			strMsg := msg.String()


### PR DESCRIPTION

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The `/ready` will now include each service's state when there is at least one non-`Running` service (e.g. `Failed` or `Starting`). The same will be logged at debug level.

Previously output:

```
Some services are not Running:
Running: 11
Starting: 1
```

Current output:

```
Some services are not Running:
distributor-service: Starting
```

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/1780

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
