### PR TITLE
helm: use custom memcached templates

### DIFF
--- a/docs/sources/migration-guide/migrating-from-cortex.md
+++ b/docs/sources/migration-guide/migrating-from-cortex.md
@@ -260,26 +260,26 @@ You can update to the Grafana Mimir Helm chart from the Cortex Helm chart.
    mimir:
      config: |
        blocks_storage:
-         {{- if .Values.memcached.enabled }}
+         {{- if index .Values "memcached-chunks" "enabled" }}
          chunks_cache:
            backend: "memcached"
            memcached:
-             addresses: "dns+{{ .Release.Name }}-memcached.{{ .Release.Namespace }}.svc:11211"
-             max_item_size: {{ .Values.memcached.maxItemMemory }}
+             addresses: dns+{{ .Release.Name }}-memcached-chunks-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
+             max_item_size: {{ mul (index .Values "memcached-chunks").maxItemMemory 1024 1024 }}
          {{- end }}
          {{- if index .Values "memcached-metadata" "enabled" }}
          metadata_cache:
            backend: "memcached"
            memcached:
-             addresses: "dns+{{ .Release.Name }}-memcached-metadata.{{ .Release.Namespace }}.svc:11211"
-             max_item_size: {{ (index .Values "memcached-metadata").maxItemMemory }}
+             addresses: dns+{{ .Release.Name }}-memcached-metadata-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-metadata").port }}
+             max_item_size: {{ mul (index .Values "memcached-metadata").maxItemMemory 1024 1024 }}
          {{- end }}
          {{- if index .Values "memcached-queries" "enabled" }}
          index_cache:
            backend: "memcached"
            memcached:
-             addresses: "dns+{{ .Release.Name }}-memcached-queries.{{ .Release.Namespace }}.svc:11211"
-             max_item_size: {{ (index .Values "memcached-queries").maxItemMemory }}
+             addresses: dns+{{ .Release.Name }}-memcached-index-queries-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
+             max_item_size: {{ mul (index .Values "memcached-index-queries").maxItemMemory 1024 1024 }}
          {{- end }}
        frontend_worker:
          frontend_address: "{{ template "mimir.fullname" . }}-query-frontend-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}"

--- a/docs/sources/migration-guide/migrating-from-cortex.md
+++ b/docs/sources/migration-guide/migrating-from-cortex.md
@@ -264,25 +264,25 @@ You can update to the Grafana Mimir Helm chart from the Cortex Helm chart.
          chunks_cache:
            backend: "memcached"
            memcached:
-             addresses: dns+{{ .Release.Name }}-memcached-chunks-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
+             addresses: dns+{{ template "mimir.fullname" . }}-memcached-chunks.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
              max_item_size: {{ mul (index .Values "memcached-chunks").maxItemMemory 1024 1024 }}
          {{- end }}
          {{- if index .Values "memcached-metadata" "enabled" }}
          metadata_cache:
            backend: "memcached"
            memcached:
-             addresses: dns+{{ .Release.Name }}-memcached-metadata-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-metadata").port }}
+             addresses: dns+{{ template "mimir.fullname" . }}-memcached-metadata.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-metadata").port }}
              max_item_size: {{ mul (index .Values "memcached-metadata").maxItemMemory 1024 1024 }}
          {{- end }}
          {{- if index .Values "memcached-queries" "enabled" }}
          index_cache:
            backend: "memcached"
            memcached:
-             addresses: dns+{{ .Release.Name }}-memcached-index-queries-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
+             addresses: dns+{{ template "mimir.fullname" . }}-memcached-index-queries.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
              max_item_size: {{ mul (index .Values "memcached-index-queries").maxItemMemory 1024 1024 }}
          {{- end }}
        frontend_worker:
-         frontend_address: "{{ template "mimir.fullname" . }}-query-frontend-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}"
+         frontend_address: "{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}"
        ingester:
          ring:
            num_tokens: 512

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -14,6 +14,20 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Enable multi-tenancy by default. This means `multitenancy_enabled` is now `true` for both Mimir and Enterprise Metrics. Nginx will inject `X-Scope-OrgID=anonymous` header if the header is not present, ensuring backwards compatibility. #2117
+* [CHANGE] Use custom memcached templates to remove bitnami dependency. There are changes to the Helm values, listed bellow. #2064
+  - The `memcached` section now contains common values shared across all memcached instances.
+  - New `memcachedExporter` section was added to configure memcached metrics exporter.
+  - New `memcached-chunks` section was added that refers to previous `memcached` configuration.
+  - The section `memcached-queries` is renamed to `memcached-index-queries`.
+  - The value `memcached-*.replicaCount` is replaced with `memcached-*.replicas` to align with the rest of the services.
+    - Renamed `memcached.replicaCount` to `memcached-chunks.replicas`.
+    - Renamed `memcached-queries.replicaCount` to `memcached-index-queries.replicas`.
+    - Renamed `memcached-metadata.replicaCount` to `memcached-metadata.replicas`.
+    - Renamed `memcached-results.replicaCount` to `memcached-results.replicas`.
+  - All memcached instances now share the same `ServiceAccount` that the chart uses for its services.
+  - The value `memcached-*.architecture` was removed.
+  - The value `memcached-*.arguments` was removed, the default arguments are now encoded in the template. Use `memcached-*.extraArgs` to provide additional arguments as well as the values `memcached-*.allocatedMemory`, `memcached-*.maxItemMemory` and `memcached-*.port` to set the memcached command line flags `-m`, `-I` and `-u`.
+  - The remaining arguments are aligned with the rest of the chart's services, please consult the values file to check whether a parameter exists or was renamed.
 * [CHANGE] Change default value for `blocks_storage.bucket_store.chunks_cache.memcached.timeout` to `450ms` to increase use of cached data. #2035
 * [FEATURE] Add `mimir-continuous-test` in smoke-test mode. Use `helm test` to run a smoke test of the read + write path.
 * [ENHANCEMENT] ServiceMonitor object will now have default values based on release namesapce in the `namespace` and `namespaceSelector` fields. #2123

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -14,7 +14,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Enable multi-tenancy by default. This means `multitenancy_enabled` is now `true` for both Mimir and Enterprise Metrics. Nginx will inject `X-Scope-OrgID=anonymous` header if the header is not present, ensuring backwards compatibility. #2117
-* [CHANGE] Use custom memcached templates to remove bitnami dependency. There are changes to the Helm values, listed bellow. #2064
+* [CHANGE] **breaking change** Chart now uses custom memcached templates to remove bitnami dependency. There are changes to the Helm values, listed bellow. #2064
   - The `memcached` section now contains common values shared across all memcached instances.
   - New `memcachedExporter` section was added to configure memcached metrics exporter.
   - New `memcached-chunks` section was added that refers to previous `memcached` configuration.

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -1,18 +1,6 @@
 dependencies:
-- name: memcached
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 5.5.2
-- name: memcached
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 5.5.2
-- name: memcached
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 5.5.2
-- name: memcached
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 5.5.2
 - name: minio
   repository: https://helm.min.io/
   version: 8.0.10
-digest: sha256:0b58716cf86880510e4ce9dacb312db80918d14704e68127b833b81b5fd7d7f3
-generated: "2022-06-02T09:31:09.709064-05:00"
+digest: sha256:826b6cc453742c71c2159500596d78666fbdf0ff3ed105caa7ca162ecbd36a45
+generated: "2022-06-09T08:29:05.191797+02:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -8,26 +8,6 @@ icon: https://grafana.com/static/img/logos/logo-mimir.svg
 kubeVersion: ^1.10.0-0
 name: mimir-distributed
 dependencies:
-  - name: memcached
-    alias: memcached
-    version: 5.5.2
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: memcached.enabled
-  - name: memcached
-    alias: memcached-queries
-    version: 5.5.2
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: memcached-queries.enabled
-  - name: memcached
-    alias: memcached-metadata
-    version: 5.5.2
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: memcached-metadata.enabled
-  - name: memcached
-    alias: memcached-results
-    version: 5.5.2
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: memcached-results.enabled
   - name: minio
     alias: minio
     version: 8.0.10

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -15,10 +15,6 @@ Kubernetes: `^1.10.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.min.io/ | minio(minio) | 8.0.10 |
-| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached(memcached) | 5.5.2 |
-| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached-queries(memcached) | 5.5.2 |
-| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached-metadata(memcached) | 5.5.2 |
-| https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami | memcached-results(memcached) | 5.5.2 |
 
 ## Dependencies
 

--- a/operations/helm/charts/mimir-distributed/capped-large.yaml
+++ b/operations/helm/charts/mimir-distributed/capped-large.yaml
@@ -71,13 +71,13 @@ ingester:
                   - ingester
           topologyKey: 'kubernetes.io/hostname'
 
-memcached:
+memcached-chunks:
   enabled: true
-  replicaCount: 32
+  replicas: 32
 
-memcached-queries:
+memcached-index-queries:
   enabled: true
-  replicaCount: 10
+  replicas: 10
 
 memcached-metadata:
   enabled: true

--- a/operations/helm/charts/mimir-distributed/capped-small.yaml
+++ b/operations/helm/charts/mimir-distributed/capped-small.yaml
@@ -71,13 +71,13 @@ ingester:
                   - ingester
           topologyKey: 'kubernetes.io/hostname'
 
-memcached:
+memcached-chunks:
   enabled: true
-  replicaCount: 2
+  replicas: 2
 
-memcached-queries:
+memcached-index-queries:
   enabled: true
-  replicaCount: 3
+  replicas: 3
 
 memcached-metadata:
   enabled: true

--- a/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
@@ -49,3 +49,15 @@ store_gateway:
 testing:
   minio:
     use_secret: true
+
+memcached-chunks:
+  enabled: true
+
+memcached-index-queries:
+  enabled: true
+
+memcached-metadata:
+  enabled: true
+
+memcached-results:
+  enabled: true

--- a/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
@@ -52,12 +52,28 @@ testing:
 
 memcached-chunks:
   enabled: true
+  allocatedMemory: 10
+  resources:
+    requests:
+      cpu: 10m
 
 memcached-index-queries:
   enabled: true
+  allocatedMemory: 30
+  resources:
+    requests:
+      cpu: 10m
 
 memcached-metadata:
   enabled: true
+  allocatedMemory: 10
+  resources:
+    requests:
+      cpu: 10m
 
 memcached-results:
   enabled: true
+  allocatedMemory: 10
+  resources:
+    requests:
+      cpu: 10m

--- a/operations/helm/charts/mimir-distributed/large.yaml
+++ b/operations/helm/charts/mimir-distributed/large.yaml
@@ -69,20 +69,20 @@ ingester:
           topologyKey: 'kubernetes.io/hostname'
 
 
-memcached:
+memcached-chunks:
   enabled: true
-  replicaCount: 32
+  replicas: 32
 
-memcached-queries:
+memcached-index-queries:
   enabled: true
-  replicaCount: 10
+  replicas: 10
 
 memcached-metadata:
   enabled: true
 
 memcached-results:
   enabled: true
-  replicaCount: 4
+  replicas: 4
 
 minio:
   enabled: false

--- a/operations/helm/charts/mimir-distributed/small.yaml
+++ b/operations/helm/charts/mimir-distributed/small.yaml
@@ -69,13 +69,13 @@ ingester:
           topologyKey: 'kubernetes.io/hostname'
 
 
-memcached:
+memcached-chunks:
   enabled: true
-  replicaCount: 2
+  replicas: 2
 
-memcached-queries:
+memcached-index-queries:
   enabled: true
-  replicaCount: 3
+  replicas: 3
 
 memcached-metadata:
   enabled: true

--- a/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.podDisruptionBudget" (dict "ctx" $ "component" "memcached-chunks" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-servmon.yaml
@@ -1,0 +1,3 @@
+{{- if index .Values "memcached-chunks" "enabled" }}
+{{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-chunks") }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "memcached-chunks" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.service" (dict "ctx" $ "component" "memcached-chunks" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.podDisruptionBudget" (dict "ctx" $ "component" "memcached-index-queries" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-servmon.yaml
@@ -1,0 +1,3 @@
+{{- if index .Values "memcached-index-queries" "enabled" }}
+{{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-index-queries") }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "memcached-index-queries" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.service" (dict "ctx" $ "component" "memcached-index-queries" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.podDisruptionBudget" (dict "ctx" $ "component" "memcached-metadata" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-servmon.yaml
@@ -1,0 +1,3 @@
+{{- if index .Values "memcached-metadata" "enabled" }}
+{{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-metadata") }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "memcached-metadata" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.service" (dict "ctx" $ "component" "memcached-metadata" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.podDisruptionBudget" (dict "ctx" $ "component" "memcached-results" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-servmon.yaml
@@ -1,0 +1,3 @@
+{{- if index .Values "memcached-results" "enabled" }}
+{{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "memcached-results") }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "memcached-results" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
@@ -1,0 +1,1 @@
+{{- include "mimir.memcached.service" (dict "ctx" $ "component" "memcached-results" ) }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-pdb.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-pdb.tpl
@@ -1,0 +1,23 @@
+{{/*
+memcached PodDisruptionBudget
+*/}}
+{{- define "mimir.memcached.podDisruptionBudget" -}}
+{{ with (index $.ctx.Values $.component) }}
+{{- if .enabled -}}
+{{- if .podDisruptionBudget -}}
+apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" $ }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" $.component) }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $.ctx "component" $.component) | nindent 4 }}
+  namespace: {{ $.ctx.Release.Namespace | quote }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $.ctx "component" $.component) | nindent 6 }}
+{{ toYaml .podDisruptionBudget | indent 2 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -1,0 +1,116 @@
+{{/*
+memcached StatefulSet
+*/}}
+{{- define "mimir.memcached.statefulSet" -}}
+{{ with (index $.ctx.Values $.component) }}
+{{- if .enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" $.component) }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $.ctx "component" "memcached") | nindent 4 }}
+  annotations:
+    {{- toYaml .annotations | nindent 4 }}
+  namespace: {{ $.ctx.Release.Namespace | quote }}
+spec:
+  podManagementPolicy: {{ .podManagementPolicy }}
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $.ctx "component" $.component) | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .statefulStrategy | nindent 4 }}
+  serviceName: {{ template "mimir.fullname" $.ctx }}-{{ $.component }}
+
+  template:
+    metadata:
+      labels:
+        {{- include "mimir.podLabels" (dict "ctx" $.ctx "component" $.component) | nindent 8 }}
+        {{- with .podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with $.ctx.Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+    spec:
+      serviceAccountName: {{ template "mimir.serviceAccountName" $.ctx }}
+      {{- if .priorityClassName }}
+      priorityClassName: {{ .priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $.ctx.Values.memcached.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .initContainers | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+      containers:
+        {{- if .extraContainers }}
+        {{ toYaml .extraContainers | nindent 8 }}
+        {{- end }}
+        - name: memcached
+          {{- with $.ctx.Values.memcached.image }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          resources:
+          {{- if .resources }}
+            {{- toYaml .resources | nindent 12 }}
+          {{- else }}
+            limits:
+              memory: {{ round (mulf .allocatedMemory 1.2) 0 }}Mi
+            requests:
+              cpu: 500m
+              memory: {{ round (mulf .allocatedMemory 1.2) 0 }}Mi
+          {{- end }}
+          ports:
+            - containerPort: {{ .port }}
+              name: client
+          args:
+            - -m {{ .allocatedMemory }}
+            - -o
+            - modern
+            - -I {{ .maxItemMemory }}m
+            - -c 16384
+            - -v
+            - -u {{ .port }}
+            {{- range $key, $value := .extraArgs }}
+            - "-{{ $key }} {{ $value }}"
+            {{- end }}
+          env:
+            {{- with $.ctx.Values.global.extraEnv }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with $.ctx.Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          securityContext:
+            {{- toYaml $.ctx.Values.memcached.containerSecurityContext | nindent 12 }}
+
+      {{- if $.ctx.Values.memcachedExporter.enabled }}
+        - name: exporter
+          {{- with $.ctx.Values.memcachedExporter.image }}
+          image: {{ .repository}}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:{{ .port }}"
+            - "--web.listen-address=0.0.0.0:9150"
+      {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
@@ -10,7 +10,6 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" $.component) }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $.ctx "component" $.component) | nindent 4 }}
-    prometheus.io/service-monitor: "false"
     {{- with .service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -25,7 +24,7 @@ spec:
       port: {{ .port }}
       targetPort: {{ .port }}
     {{ if $.ctx.Values.memcachedExporter.enabled }}
-    - name: exporter-http-metrics
+    - name: http-metrics
       port: 9150
       targetPort: 9150
     {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
@@ -1,0 +1,36 @@
+{{/*
+memcached Service
+*/}}
+{{- define "mimir.memcached.service" -}}
+{{ with (index $.ctx.Values $.component) }}
+{{- if .enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" $.component) }}-headless
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $.ctx "component" $.component) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
+    {{- with .service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .service.annotations | nindent 4 }}
+  namespace: {{ $.ctx.Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: {{ .port }}
+      targetPort: {{ .port }}
+    {{ if $.ctx.Values.memcachedExporter.enabled }}
+    - name: exporter-http-metrics
+      port: 9150
+      targetPort: 9150
+    {{ end }}
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" $.ctx "component" $.component) | nindent 4 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
@@ -7,7 +7,7 @@ memcached Service
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" $.component) }}-headless
+  name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" $.component) }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $.ctx "component" $.component) | nindent 4 }}
     prometheus.io/service-monitor: "false"

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -118,27 +118,27 @@ mimir:
     blocks_storage:
       backend: s3
       bucket_store:
-        {{- if .Values.memcached.enabled }}
+        {{- if index .Values "memcached-chunks" "enabled" }}
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+{{ .Release.Name }}-memcached.{{ .Release.Namespace }}.svc:11211
-            max_item_size: {{ .Values.memcached.maxItemMemory }}
+            addresses: dns+{{ .Release.Name }}-memcached-chunks-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
+            max_item_size: {{ mul (index .Values "memcached-chunks").maxItemMemory 1024 1024 }}
             timeout: 450ms
         {{- end }}
-        {{- if index .Values "memcached-queries" "enabled" }}
+        {{- if index .Values "memcached-index-queries" "enabled" }}
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+{{ .Release.Name }}-memcached-queries.{{ .Release.Namespace }}.svc:11211
-            max_item_size: {{ (index .Values "memcached-queries").maxItemMemory }}
+            addresses: dns+{{ .Release.Name }}-memcached-index-queries-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
+            max_item_size: {{ mul (index .Values "memcached-index-queries").maxItemMemory 1024 1024 }}
         {{- end }}
         {{- if index .Values "memcached-metadata" "enabled" }}
         metadata_cache:
           backend: memcached
           memcached:
             addresses: dns+{{ .Release.Name }}-memcached-metadata.{{ .Release.Namespace }}.svc:11211
-            max_item_size: {{ (index .Values "memcached-metadata").maxItemMemory }}
+            max_item_size: {{ mul (index .Values "memcached-metadata").maxItemMemory 1024 1024 }}
         {{- end }}
         sync_dir: /data/tsdb-sync
       {{- if .Values.minio.enabled }}
@@ -167,7 +167,7 @@ mimir:
         backend: memcached
         memcached:
           addresses: dns+{{ .Release.Name }}-memcached-results.{{ .Release.Namespace }}.svc:11211
-          max_item_size: {{ (index .Values "memcached-results").maxItemMemory }}
+          max_item_size: {{ mul (index .Values "memcached-results").maxItemMemory 1024 1024 }}
       cache_results: true
       {{- end }}
 
@@ -1013,132 +1013,273 @@ compactor:
   extraEnvFrom: []
 
 memcached:
-  enabled: false
-  architecture: high-availability
-  arguments:
-    - -m 8192
-    - -o
-    - modern
-    - -v
-    - -I 1m
-    - -c 4096
   image:
+    # -- Memcached Docker image repository
     repository: memcached
-    tag: 1.6.9
-  # maxItemMemory is in bytes. Should match memcached -I flag (which is in MB)
-  # It is a string to avoid https://github.com/helm/helm/issues/1707.
-  maxItemMemory: '1048576'  # (* 1 (* 1024 1024))
-  metrics:
-    enabled: true
-    image:
-      registry: quay.io
-      repository: prometheus/memcached-exporter
-      tag: v0.9.0
-  replicaCount: 1
-  resources:
-    limits:
-      # memory limits should match requests
-      memory: 9830Mi
-    requests:
-      cpu: 500m
-      # memory requests should be exceed memcached -m flag
-      memory: 9830Mi  # (floor (* 1.2 8192))
+    # -- Memcached Docker image tag
+    tag: 1.6.9-alpine
+    # -- Memcached Docker image pull policy
+    pullPolicy: IfNotPresent
 
-memcached-queries:
-  enabled: false
-  architecture: high-availability
-  arguments:
-    - -m 2048
-    - -o
-    - modern
-    - -v
-    - -I 15m
-    - -c 1024
+  # -- The SecurityContext for memcached pods
+  podSecurityContext:
+    fsGroup: 11211
+    runAsGroup: 11211
+    runAsNonRoot: true
+    runAsUser: 11211
+
+  # -- The SecurityContext for memcached containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+
+memcachedExporter:
+  # -- Whether memcached metrics should be exported
+  enabled: true
+
   image:
-    repository: memcached
-    tag: 1.6.9
-  # maxItemMemory is in bytes. Should match memcached -I flag (which is in MB)
-  # It is a string to avoid https://github.com/helm/helm/issues/1707.
-  maxItemMemory: '15728640'  # (* 15 (* 1024 1024))
-  metrics:
-    enabled: true
-    image:
-      registry: quay.io
-      repository: prometheus/memcached-exporter
-      tag: v0.9.0
-  replicaCount: 1
-  resources:
-    limits:
-      # memory limits should match requests
-      memory: 2457Mi
-    requests:
-      cpu: 500m
-      # memory requests should be exceed memcached -m flag
-      memory: 2457Mi  # (floor (* 1.2 2048))
+    repository: prom/memcached-exporter
+    tag: v0.6.0
+    pullPolicy: IfNotPresent
+
+memcached-chunks:
+  # -- Specifies whether memcached-chunks should be enabled
+  enabled: false
+
+  # -- Total number of memcached-chunks replicas
+  replicas: 1
+
+  # -- Port of the memcached-chunks service
+  port: 11211
+
+  # -- Amount of memory allocated to memcached-chunks for object storage (in MB).
+  allocatedMemory: 8192
+
+  # -- Maximum item memory for memcached-chunks (in MB).
+  maxItemMemory: 1
+
+  # -- Extra init containers for memcached-chunks pods
+  initContainers: []
+
+  # -- Annotations for the memcached-chunks pods
+  annotations: {}
+  # -- Node selector for memcached-chunks pods
+  nodeSelector: {}
+  # -- Affinity for memcached-chunks pods
+  affinity: {}
+  # -- Tolerations for memcached-chunks pods
+  tolerations: []
+  # -- Pod Disruption Budget
+  podDisruptionBudget: {}
+  # -- The name of the PriorityClass for memcached-chunks pods
+  priorityClassName: null
+  # -- Labels for memcached-chunks pods
+  podLabels: {}
+  # -- Annotations for memcached-chunks pods
+  podAnnotations: {}
+  # -- Management policy for memcached-chunks pods
+  podManagementPolicy: Parallel
+  # -- Grace period to allow the memcached-chunks to shutdown before it is killed
+  terminationGracePeriodSeconds: 60
+
+  # -- Stateful memcached-chunks strategy
+  statefulStrategy:
+    type: RollingUpdate
+
+  # -- Additional CLI args for memcached-chunks
+  extraArgs: []
+
+  # -- Additional containers to be added to the memcached-chunks pod.
+  extraContainers: []
+
+  # -- Resource requests and limits for the memcached-results
+  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  resources: null
+
+  # -- Service annotations and labels
+  service:
+    annotations: {}
+    labels: {}
+
+memcached-index-queries:
+  # -- Specifies whether memcached-index-queries should be enabled
+  enabled: false
+
+  # -- Total number of memcached-index-queries replicas
+  replicas: 1
+
+  # -- Port of the memcached-index-queries service
+  port: 11211
+
+  # -- Amount of memory allocated to memcached-index-queries for object storage (in MB).
+  allocatedMemory: 2048
+
+  # -- Maximum item memcached-index-queries for memcached (in MB).
+  maxItemMemory: 15
+
+  # -- Extra init containers for memcached-index-queries pods
+  initContainers: []
+
+  # -- Annotations for the memcached-index-queries pods
+  annotations: {}
+  # -- Node selector for memcached-index-queries pods
+  nodeSelector: {}
+  # -- Affinity for memcached-index-queries pods
+  affinity: {}
+  # -- Tolerations for memcached-index-queries pods
+  tolerations: []
+  # -- Pod Disruption Budget
+  podDisruptionBudget: {}
+  # -- The name of the PriorityClass for memcached-index-queries pods
+  priorityClassName: null
+  # -- Labels for memcached-index-queries pods
+  podLabels: {}
+  # -- Annotations for memcached-index-queries pods
+  podAnnotations: {}
+  # -- Management policy for memcached-index-queries pods
+  podManagementPolicy: Parallel
+  # -- Grace period to allow the memcached-index-queries to shutdown before it is killed
+  terminationGracePeriodSeconds: 60
+
+  # -- Stateful memcached-index-queries strategy
+  statefulStrategy:
+    type: RollingUpdate
+
+  # -- Additional CLI args for memcached-index-queries
+  extraArgs: []
+
+  # -- Additional containers to be added to the memcached-index-queries pod.
+  extraContainers: []
+
+  # -- Resource requests and limits for the memcached-results
+  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  resources: null
+
+  # -- Service annotations and labels
+  service:
+    annotations: {}
+    labels: {}
 
 memcached-metadata:
+  # -- Specifies whether memcached-metadata should be enabled
   enabled: false
-  architecture: high-availability
-  arguments:
-    - -m 512
-    - -o
-    - modern
-    - -v
-    - -I 1m
-    - -c 1024
-  image:
-    repository: memcached
-    tag: 1.6.9
-  # maxItemMemory is in bytes. Should match memcached -I flag (which is in MB)
-  # It is a string to avoid https://github.com/helm/helm/issues/1707.
-  maxItemMemory: '1048576'  # (* 1 (* 1024 1024))
-  metrics:
-    enabled: true
-    image:
-      registry: quay.io
-      repository: prometheus/memcached-exporter
-      tag: v0.9.0
-  replicaCount: 1
-  resources:
-    limits:
-      # memory limits should match requests
-      memory: 614Mi
-    requests:
-      cpu: 500m
-      # memory requests should be exceed memcached -m flag
-      memory: 614Mi  # (floor (* 1.2 512))
+
+  # -- Total number of memcached-metadata replicas
+  replicas: 1
+
+  # -- Port of the memcached-metadata service
+  port: 11211
+
+  # -- Amount of memory allocated to memcached-metadata for object storage (in MB).
+  allocatedMemory: 512
+
+  # -- Maximum item memcached-metadata for memcached (in MB).
+  maxItemMemory: 1
+
+  # -- Extra init containers for memcached-metadata pods
+  initContainers: []
+
+  # -- Annotations for the memcached-metadata pods
+  annotations: {}
+  # -- Node selector for memcached-metadata pods
+  nodeSelector: {}
+  # -- Affinity for memcached-metadata pods
+  affinity: {}
+  # -- Tolerations for memcached-metadata pods
+  tolerations: []
+  # -- Pod Disruption Budget
+  podDisruptionBudget: {}
+  # -- The name of the PriorityClass for memcached-metadata pods
+  priorityClassName: null
+  # -- Labels for memcached-metadata pods
+  podLabels: {}
+  # -- Annotations for memcached-metadata pods
+  podAnnotations: {}
+  # -- Management policy for memcached-metadata pods
+  podManagementPolicy: Parallel
+  # -- Grace period to allow the memcached-metadata to shutdown before it is killed
+  terminationGracePeriodSeconds: 60
+
+  # -- Stateful memcached-metadata strategy
+  statefulStrategy:
+    type: RollingUpdate
+
+  # -- Additional CLI args for memcached-metadata
+  extraArgs: []
+
+  # -- Additional containers to be added to the memcached-metadata pod.
+  extraContainers: []
+
+  # -- Resource requests and limits for the memcached-results
+  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  resources: null
+
+  # -- Service annotations and labels
+  service:
+    annotations: {}
+    labels: {}
 
 memcached-results:
+  # -- Specifies whether memcached-results should be enabled
   enabled: false
-  architecture: high-availability
-  arguments:
-    - -m 512
-    - -o
-    - modern
-    - -v
-    - -I 1m
-    - -c 1024
-  image:
-    repository: memcached
-    tag: 1.6.9
-  # maxItemMemory is in bytes. Should match memcached -I flag (which is in MB)
-  # It is a string to avoid https://github.com/helm/helm/issues/1707.
-  maxItemMemory: '1048576'  # (* 1 (* 1024 1024))
-  metrics:
-    enabled: true
-    image:
-      registry: quay.io
-      repository: prometheus/memcached-exporter
-      tag: v0.9.0
-  replicaCount: 1
-  resources:
-    limits:
-      # memory limits should match requests
-      memory: 614Mi
-    requests:
-      cpu: 500m
-      # memory requests should be exceed memcached -m flag
-      memory: 614Mi  # (floor (* 1.2 512))
+
+  # -- Total number of memcached-results replicas
+  replicas: 1
+
+  # -- Port of the memcached-results service
+  port: 11211
+
+  # -- Amount of memory allocated to memcached-results for object storage (in MB).
+  allocatedMemory: 512
+
+  # -- Maximum item memcached-results for memcached (in MB).
+  maxItemMemory: 1
+
+  # -- Extra init containers for memcached-results pods
+  initContainers: []
+
+  # -- Annotations for the memcached-results pods
+  annotations: {}
+  # -- Node selector for memcached-results pods
+  nodeSelector: {}
+  # -- Affinity for memcached-results pods
+  affinity: {}
+  # -- Tolerations for memcached-results pods
+  tolerations: []
+  # -- Pod Disruption Budget
+  podDisruptionBudget: {}
+  # -- The name of the PriorityClass for memcached-results pods
+  priorityClassName: null
+  # -- Labels for memcached-results pods
+  podLabels: {}
+  # -- Annotations for memcached-results pods
+  podAnnotations: {}
+  # -- Management policy for memcached-results pods
+  podManagementPolicy: Parallel
+  # -- Grace period to allow the memcached-results to shutdown before it is killed
+  terminationGracePeriodSeconds: 60
+
+  # -- Stateful memcached-results strategy
+  statefulStrategy:
+    type: RollingUpdate
+
+  # -- Additional CLI args for memcached-results
+  extraArgs: []
+
+  # -- Additional containers to be added to the memcached-results pod.
+  extraContainers: []
+
+  # -- Resource requests and limits for the memcached-results
+  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  resources: null
+
+  # -- Service annotations and labels
+  service:
+    annotations: {}
+    labels: {}
 
 minio:
   enabled: true

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -122,7 +122,7 @@ mimir:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+{{ .Release.Name }}-memcached-chunks-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
+            addresses: dns+{{ template "mimir.fullname" . }}-memcached-chunks.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
             max_item_size: {{ mul (index .Values "memcached-chunks").maxItemMemory 1024 1024 }}
             timeout: 450ms
         {{- end }}
@@ -130,14 +130,14 @@ mimir:
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+{{ .Release.Name }}-memcached-index-queries-headless.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
+            addresses: dns+{{ template "mimir.fullname" . }}-memcached-index-queries.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
             max_item_size: {{ mul (index .Values "memcached-index-queries").maxItemMemory 1024 1024 }}
         {{- end }}
         {{- if index .Values "memcached-metadata" "enabled" }}
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+{{ .Release.Name }}-memcached-metadata.{{ .Release.Namespace }}.svc:11211
+            addresses: dns+{{ template "mimir.fullname" . }}-memcached-metadata.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-metadata").port }}
             max_item_size: {{ mul (index .Values "memcached-metadata").maxItemMemory 1024 1024 }}
         {{- end }}
         sync_dir: /data/tsdb-sync
@@ -166,7 +166,7 @@ mimir:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+{{ .Release.Name }}-memcached-results.{{ .Release.Namespace }}.svc:11211
+          addresses: dns+{{ template "mimir.fullname" . }}-memcached-results.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-results").port }}
           max_item_size: {{ mul (index .Values "memcached-results").maxItemMemory 1024 1024 }}
       cache_results: true
       {{- end }}

--- a/operations/helm/ct.yaml
+++ b/operations/helm/ct.yaml
@@ -4,8 +4,6 @@ target-branch: main
 chart-dirs:
   - operations/helm/charts
 chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
-  - bitnami-pre-2022=https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   - minio=https://helm.min.io
 helm-extra-args: --timeout 600s
 validate-maintainers: false

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
@@ -1,0 +1,94 @@
+---
+# Source: mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-values-mimir-memcached-chunks
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-values
+      app.kubernetes.io/component: memcached-chunks
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-oss-values-mimir-memcached-chunks
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-values
+        app.kubernetes.io/version: "2.1.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: memcached-chunks
+      annotations:
+        minio-secret-version: "42"
+
+    spec:
+      serviceAccountName: test-oss-values-mimir
+      securityContext:
+        fsGroup: 11211
+        runAsGroup: 11211
+        runAsNonRoot: true
+        runAsUser: 11211
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: memcached
+          image: memcached:1.6.9-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 9830Mi
+            requests:
+              cpu: 500m
+              memory: 9830Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 8192
+            - -o
+            - modern
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+            - secretRef:
+                name: mimir-minio-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.6.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-statefulset.yaml
@@ -57,16 +57,13 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              memory: 9830Mi
             requests:
-              cpu: 500m
-              memory: 9830Mi
+              cpu: 10m
           ports:
             - containerPort: 11211
               name: client
           args:
-            - -m 8192
+            - -m 10
             - -o
             - modern
             - -I 1m

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-values-mimir-memcached-chunks-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-chunks
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: exporter-http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-chunks

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: memcached-chunks
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    prometheus.io/service-monitor: "false"
   annotations:
     {}
   namespace: "citestns"
@@ -22,7 +21,7 @@ spec:
       port: 11211
       targetPort: 11211
     
-    - name: exporter-http-metrics
+    - name: http-metrics
       port: 9150
       targetPort: 9150
     

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-chunks/memcached-chunks-svc-headless.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-oss-values-mimir-memcached-chunks-headless
+  name: test-oss-values-mimir-memcached-chunks
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
@@ -1,0 +1,94 @@
+---
+# Source: mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-values-mimir-memcached-index-queries
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-values
+      app.kubernetes.io/component: memcached-index-queries
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-oss-values-mimir-memcached-index-queries
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-values
+        app.kubernetes.io/version: "2.1.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: memcached-index-queries
+      annotations:
+        minio-secret-version: "42"
+
+    spec:
+      serviceAccountName: test-oss-values-mimir
+      securityContext:
+        fsGroup: 11211
+        runAsGroup: 11211
+        runAsNonRoot: true
+        runAsUser: 11211
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: memcached
+          image: memcached:1.6.9-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 2458Mi
+            requests:
+              cpu: 500m
+              memory: 2458Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 2048
+            - -o
+            - modern
+            - -I 15m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+            - secretRef:
+                name: mimir-minio-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.6.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-statefulset.yaml
@@ -57,16 +57,13 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              memory: 2458Mi
             requests:
-              cpu: 500m
-              memory: 2458Mi
+              cpu: 10m
           ports:
             - containerPort: 11211
               name: client
           args:
-            - -m 2048
+            - -m 30
             - -o
             - modern
             - -I 15m

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-values-mimir-memcached-index-queries-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-index-queries
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: exporter-http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-index-queries

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: memcached-index-queries
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    prometheus.io/service-monitor: "false"
   annotations:
     {}
   namespace: "citestns"
@@ -22,7 +21,7 @@ spec:
       port: 11211
       targetPort: 11211
     
-    - name: exporter-http-metrics
+    - name: http-metrics
       port: 9150
       targetPort: 9150
     

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-index-queries/memcached-index-queries-svc-headless.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-oss-values-mimir-memcached-index-queries-headless
+  name: test-oss-values-mimir-memcached-index-queries
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
@@ -1,0 +1,94 @@
+---
+# Source: mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-values-mimir-memcached-metadata
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-values
+      app.kubernetes.io/component: memcached-metadata
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-oss-values-mimir-memcached-metadata
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-values
+        app.kubernetes.io/version: "2.1.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: memcached-metadata
+      annotations:
+        minio-secret-version: "42"
+
+    spec:
+      serviceAccountName: test-oss-values-mimir
+      securityContext:
+        fsGroup: 11211
+        runAsGroup: 11211
+        runAsNonRoot: true
+        runAsUser: 11211
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: memcached
+          image: memcached:1.6.9-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 614Mi
+            requests:
+              cpu: 500m
+              memory: 614Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 512
+            - -o
+            - modern
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+            - secretRef:
+                name: mimir-minio-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.6.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-statefulset.yaml
@@ -57,16 +57,13 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              memory: 614Mi
             requests:
-              cpu: 500m
-              memory: 614Mi
+              cpu: 10m
           ports:
             - containerPort: 11211
               name: client
           args:
-            - -m 512
+            - -m 10
             - -o
             - modern
             - -I 1m

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: memcached-metadata
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    prometheus.io/service-monitor: "false"
   annotations:
     {}
   namespace: "citestns"
@@ -22,7 +21,7 @@ spec:
       port: 11211
       targetPort: 11211
     
-    - name: exporter-http-metrics
+    - name: http-metrics
       port: 9150
       targetPort: 9150
     

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-values-mimir-memcached-metadata-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-metadata
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: exporter-http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-metadata

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-metadata/memcached-metadata-svc-headless.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-oss-values-mimir-memcached-metadata-headless
+  name: test-oss-values-mimir-memcached-metadata
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
@@ -1,0 +1,94 @@
+---
+# Source: mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-values-mimir-memcached-results
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-values
+      app.kubernetes.io/component: memcached-results
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-oss-values-mimir-memcached-results
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-values
+        app.kubernetes.io/version: "2.1.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: memcached-results
+      annotations:
+        minio-secret-version: "42"
+
+    spec:
+      serviceAccountName: test-oss-values-mimir
+      securityContext:
+        fsGroup: 11211
+        runAsGroup: 11211
+        runAsNonRoot: true
+        runAsUser: 11211
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: memcached
+          image: memcached:1.6.9-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 614Mi
+            requests:
+              cpu: 500m
+              memory: 614Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 512
+            - -o
+            - modern
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+            - secretRef:
+                name: mimir-minio-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.6.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-statefulset.yaml
@@ -57,16 +57,13 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              memory: 614Mi
             requests:
-              cpu: 500m
-              memory: 614Mi
+              cpu: 10m
           ports:
             - containerPort: 11211
               name: client
           args:
-            - -m 512
+            - -m 10
             - -o
             - modern
             - -I 1m

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-values-mimir-memcached-results-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-results
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: exporter-http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/component: memcached-results

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: memcached-results
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    prometheus.io/service-monitor: "false"
   annotations:
     {}
   namespace: "citestns"
@@ -22,7 +21,7 @@ spec:
       port: 11211
       targetPort: 11211
     
-    - name: exporter-http-metrics
+    - name: http-metrics
       port: 9150
       targetPort: 9150
     

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/memcached-results/memcached-results-svc-headless.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-oss-values-mimir-memcached-results-headless
+  name: test-oss-values-mimir-memcached-results
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -33,18 +33,18 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-values-memcached-chunks-headless.citestns.svc:11211
+            addresses: dns+test-oss-values-mimir-memcached-chunks.citestns.svc:11211
             max_item_size: 1048576
             timeout: 450ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-values-memcached-index-queries-headless.citestns.svc:11211
+            addresses: dns+test-oss-values-mimir-memcached-index-queries.citestns.svc:11211
             max_item_size: 15728640
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-values-memcached-metadata.citestns.svc:11211
+            addresses: dns+test-oss-values-mimir-memcached-metadata.citestns.svc:11211
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
       s3:
@@ -64,7 +64,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+test-oss-values-memcached-results.citestns.svc:11211
+          addresses: dns+test-oss-values-mimir-memcached-results.citestns.svc:11211
           max_item_size: 1048576
     frontend_worker:
       frontend_address: test-oss-values-mimir-query-frontend-headless.citestns.svc:9095

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -30,6 +30,22 @@ data:
     blocks_storage:
       backend: s3
       bucket_store:
+        chunks_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+test-oss-values-memcached-chunks-headless.citestns.svc:11211
+            max_item_size: 1048576
+            timeout: 450ms
+        index_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+test-oss-values-memcached-index-queries-headless.citestns.svc:11211
+            max_item_size: 15728640
+        metadata_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+test-oss-values-memcached-metadata.citestns.svc:11211
+            max_item_size: 1048576
         sync_dir: /data/tsdb-sync
       s3:
         access_key_id: ${MINIO_ACCESS_KEY_ID}
@@ -43,7 +59,13 @@ data:
       data_dir: /data
     frontend:
       align_queries_with_step: true
+      cache_results: true
       log_queries_longer_than: 10s
+      results_cache:
+        backend: memcached
+        memcached:
+          addresses: dns+test-oss-values-memcached-results.citestns.svc:11211
+          max_item_size: 1048576
     frontend_worker:
       frontend_address: test-oss-values-mimir-query-frontend-headless.citestns.svc:9095
     ingester:


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds mimir custom templates for memcached components, allowing us to break bitnami chart dependency. 

While additional testing may be required to verify and validate read/write path correct functioning, contents of this PR have been tried against a local cluster, verifying that all expected services were up and running and config changes were properly applied. 

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/helm-charts/issues/1315

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
