### PR TITLE
Making active series custom tracker configs marshalable for runtime c…

### DIFF
--- a/pkg/ingester/activeseries/custom_trackers_config.go
+++ b/pkg/ingester/activeseries/custom_trackers_config.go
@@ -133,6 +133,11 @@ func (c *CustomTrackersConfig) UnmarshalYAML(unmarshal func(interface{}) error) 
 	return err
 }
 
+// MarshalYAML implements yaml.Marshaler.
+func (c CustomTrackersConfig) MarshalYAML() (interface{}, error) {
+	return c.source, nil
+}
+
 func NewCustomTrackersConfig(m map[string]string) (c CustomTrackersConfig, err error) {
 	c.source = m
 	c.config = map[string]labelsMatchers{}

--- a/pkg/ingester/activeseries/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/custom_trackers_config_test.go
@@ -205,3 +205,21 @@ func TestTrackersConfigs_Deserialization(t *testing.T) {
 		assert.Error(t, err, "should not deserialize malformed input")
 	})
 }
+
+func TestTrackersConfigs_SerializeDeserialize(t *testing.T) {
+	sourceYAML := `
+    baz: "{baz='bar'}"
+    foo: "{foo='bar'}"
+    `
+
+	obj := mustNewCustomTrackersConfigDeserializedFromYaml(t, sourceYAML)
+
+	t.Run("ShouldSerializeDeserializeResultsTheSame", func(t *testing.T) {
+		out, err := yaml.Marshal(obj)
+		require.NoError(t, err, "failed do serialize Custom trackers config")
+		reSerialized := CustomTrackersConfig{}
+		err = yaml.Unmarshal(out, &reSerialized)
+		require.NoError(t, err, "Failed to deserialize serialized object")
+		assert.Equal(t, obj, reSerialized)
+	})
+}


### PR DESCRIPTION
…onfig

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adding a MarshalYAML method to the `CustomTrackersConfig` as without it it is not Marshalled to the /runtime_config endpoint. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
