### PR TITLE
helm: meta-monitoring

### DIFF
--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: minio
   repository: https://helm.min.io/
   version: 8.0.10
-digest: sha256:0b58716cf86880510e4ce9dacb312db80918d14704e68127b833b81b5fd7d7f3
-generated: "2022-06-02T09:31:09.709064-05:00"
+- name: grafana-agent-operator
+  repository: https://grafana.github.io/helm-charts
+  version: 0.1.12
+digest: sha256:b6bf751065e0c6295bee867a8318b4857f3628dbba951e55b121d8be3e1ee2d0
+generated: "2022-06-03T16:14:21.551239+02:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -33,3 +33,8 @@ dependencies:
     version: 8.0.10
     repository: https://helm.min.io/
     condition: minio.enabled
+  - name: grafana-agent-operator
+    alias: grafana-agent-operator
+    version: 0.1.12
+    repository: https://grafana.github.io/helm-charts
+    condition: metamonitoring.grafanaAgent.installOperator

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -37,4 +37,4 @@ dependencies:
     alias: grafana-agent-operator
     version: 0.1.12
     repository: https://grafana.github.io/helm-charts
-    condition: metamonitoring.grafanaAgent.installOperator
+    condition: metaMonitoring.grafanaAgent.installOperator

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 version: 2.2.0-weekly.189
 appVersion: 2.1.0
 description: "Grafana Mimir"
-engine: gotpl
 home: https://grafana.com/docs/mimir/v2.1.x/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg
 kubeVersion: ^1.10.0-0

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -165,9 +165,6 @@ app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 {{/*
 POD labels
 */}}
-{{/*
-POD labels
-*/}}
 {{- define "mimir.podLabels" -}}
 {{- if .ctx.Values.enterprise.legacyLabels }}
 {{- if .component -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "mimir.metaMonitoring.metrics.remoteWrite" -}}
+{{- if .url -}}
+url: {{ .url }}
+{{- if or .username .passwordSecretName }}
+basicAuth:
+{{- if .username }}
+  username:
+    name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" "metrics-instance-usernames") }}
+    key: {{ .usernameKey }}
+{{- end }}
+{{- if .passwordSecretName }}
+  password:
+    name: {{ .passwordSecretName }}
+    key: password
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -16,3 +16,27 @@ basicAuth:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{- define "mimir.metaMonitoring.logs.client" -}}
+{{- if .url -}}
+url: {{ .url }}
+{{- if .tenantId }}
+tenantId: {{ .tenantId }}
+{{- end }}
+{{- if or .username .passwordSecretName }}
+basicAuth:
+{{- if .username }}
+  username:
+    name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" "logs-instance-usernames") }}
+    key: {{ .usernameKey }}
+{{- end }}
+{{- if .passwordSecretName }}
+  password:
+    name: {{ .passwordSecretName }}
+    key: password
+{{- end }}
+{{- end }}
+externalLabels:
+  cluster: "{{ include "mimir.clusterName" $.ctx }}"
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -8,12 +8,17 @@ metadata:
     app: grafana-agent
 spec:
   serviceAccountName: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  logs:
+    instanceSelector:
+      matchLabels:
+        {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "meta-monitoring") | nindent 8 }}
+    # cluster label for logs is added in the LogsInstance
   metrics:
     instanceSelector:
       matchLabels:
         {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "meta-monitoring") | nindent 8 }}
     externalLabels:
-      cluster: k8s-cluster
+      cluster: {{ include "mimir.clusterName" $ }}
 
 ---
 

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -1,11 +1,19 @@
-{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
+{{- with .Values.metaMonitoring.grafanaAgent }}
+{{- if .enabled }}
 apiVersion: monitoring.grafana.com/v1alpha1
 kind: GrafanaAgent
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "meta-monitoring") }}
-  namespace: {{ .Values.metaMonitoring.grafanaAgent.namespace | default .Release.Namespace }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
-    app: grafana-agent
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceAccountName: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
   logs:
@@ -26,7 +34,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
-  namespace: {{ .Values.metaMonitoring.grafanaAgent.namespace | default .Release.Namespace }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
 
 ---
 
@@ -34,6 +44,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -69,6 +82,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -76,5 +92,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
-    namespace: {{ .Values.metaMonitoring.grafanaAgent.namespace | default .Release.Namespace }}
+    namespace: {{ .namespace | default $.Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: GrafanaAgent
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "meta-monitoring") }}
+  namespace: {{ .Values.metaMonitoring.grafanaAgent.namespace | default .Release.Namespace }}
+  labels:
+    app: grafana-agent
+spec:
+  serviceAccountName: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  metrics:
+    instanceSelector:
+      matchLabels:
+        {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "meta-monitoring") | nindent 8 }}
+    externalLabels:
+      cluster: k8s-cluster
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  namespace: {{ .Values.metaMonitoring.grafanaAgent.namespace | default .Release.Namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+    namespace: {{ .Values.metaMonitoring.grafanaAgent.namespace | default .Release.Namespace }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.metaMonitoring.grafanaAgent.enabled .Values.metaMonitoring.grafanaAgent.metrics.scrapeK8s.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "k8s-ksm") }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "k8s-ksm") | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: http-metrics
+      metricRelabelings:
+        - action: keep
+          regex: {{ include "mimir.resourceName" (dict "ctx"  $) }}.*
+          sourceLabels:
+            - deployment
+            - statefulset
+            - pod
+          separator: ''
+      path: /metrics
+      honorLabels: true # retain namespace label from kube-state-metrics
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  {{- with $.Values.metaMonitoring.grafanaAgent.metrics.scrapeK8s.kubeStateMetrics }}
+  namespaceSelector:
+    matchNames:
+      - {{ .namespace }}
+  selector:
+    matchLabels:
+      {{- toYaml .labelSelectors | nindent 6 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "k8s-ksm") }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
-    {{- include "mimir.labels" (dict "ctx" $ "component" "k8s-ksm") | nindent 4 }}
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/kubelet-cadvisor-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/kubelet-cadvisor-servmon.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.metaMonitoring.grafanaAgent.enabled .Values.metaMonitoring.grafanaAgent.metrics.scrapeK8s.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "k8s-kubelet-cadvisor") }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "k8s-kubelet-cadvisor") | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      port: https-metrics
+      honorLabels: true # retain namespace label from kubelet
+      relabelings:
+        - replacement: kubelet # add so that e.g. up{} metric doesn't get clashes with the other endpoint
+          targetLabel: source
+        {{- with .relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      metricRelabelings:
+        - action: keep
+          regex: storage-{{ include "mimir.resourceName" (dict "ctx"  $) }}.*
+          sourceLabels:
+            - persistentvolumeclaim # present on kubelet_volume_stats* metrics
+        - targetLabel: instance # replace so that the metrics work with the default metrics mixin
+          sourceLabels:
+            - node
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics/cadvisor
+      port: https-metrics
+      honorLabels: true # retain namespace label from cadvisor
+      relabelings:
+        - replacement: cadvisor # add so that e.g. up{} metric doesn't get clashes with the other endpoint
+          targetLabel: source
+        - targetLabel: instance # replace so that the metrics work with the default metrics mixin
+          sourceLabels:
+            - node
+        {{- with .relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      metricRelabelings:
+        - action: keep
+          regex: {{ include "mimir.resourceName" (dict "ctx"  $) }}.*
+          sourceLabels:
+            - pod
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  namespaceSelector:
+    matchNames:
+        # "default" is the default namespace in which the operator creates the kubelet service.
+      - default
+  selector:
+    matchLabels:
+      # This is a service added by the agent operator, so this labels is hardcoded to what the operator creates.
+      app.kubernetes.io/name: kubelet
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/kubelet-cadvisor-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/kubelet-cadvisor-servmon.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "k8s-kubelet-cadvisor") }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
-    {{- include "mimir.labels" (dict "ctx" $ "component" "k8s-kubelet-cadvisor") | nindent 4 }}
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "logs-instance-usernames") }}
   labels:
-    {{- include "mimir.labels" (dict "ctx" $ "component" "logs-instance-usernames") | nindent 4 }}
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
 data:
   default: {{ .remote.basicAuth.username | b64enc }}
   {{- range $i, $cfg := .additionalClientConfigs }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
+{{- with .Values.metaMonitoring.grafanaAgent.logs }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "logs-instance-usernames") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "logs-instance-usernames") | nindent 4 }}
+data:
+  default: {{ .remote.basicAuth.username | b64enc }}
+  {{- range $i, $cfg := .additionalClientConfigs }}
+  additional-{{ $i }}: {{ $cfg.basicAuth.username | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
-{{- with .Values.metaMonitoring.grafanaAgent.logs }}
+{{- with .Values.metaMonitoring.grafanaAgent }}
+{{- if .enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,9 +7,9 @@ metadata:
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
 data:
-  default: {{ .remote.basicAuth.username | b64enc }}
-  {{- range $i, $cfg := .additionalClientConfigs }}
-  additional-{{ $i }}: {{ $cfg.basicAuth.username | b64enc }}
+  default: {{ .logs.remote.auth.username | b64enc | quote }} # quoted to work with empty values
+  {{- range $i, $cfg := .logs.additionalClientConfigs }}
+  additional-{{ $i }}: {{ $cfg.auth.username | b64enc }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance.yaml
@@ -1,0 +1,37 @@
+{{- with .Values.metaMonitoring.grafanaAgent }}
+{{- if .enabled }}
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: LogsInstance
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "meta-monitoring") }}
+  namespace: {{ $.Values.metaMonitoring.grafanaAgent.namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clients:
+    {{- with .logs.remote }}
+    - {{- include "mimir.metaMonitoring.logs.client" (dict "ctx" $ "url" .url "username" .auth.username "tenantId" .tenantId "passwordSecretName" .auth.passwordSecretName "usernameKey" "default") | nindent 6 -}}
+    {{- end }}
+    {{- range $i, $cfg := .logs.additionalClientConfigs }}
+    {{- with $cfg }}
+    - {{- include "mimir.metaMonitoring.logs.client" (dict "ctx" $ "url" .url "username" .auth.username "tenantId" .tenantId "passwordSecretName" .auth.passwordSecretName "usernameKey" (printf "%s-%d" "additional" $i)) | nindent 6 -}}
+    {{- end }}
+    {{- end }}
+
+  # Supply an empty namespace selector to look in all namespaces. Remove
+  # this to only look in the same namespace as the LogsInstance CR
+  podLogsNamespaceSelector: { }
+
+  podLogsSelector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $) | nindent 6 }}
+
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
+{{- with .Values.metaMonitoring.grafanaAgent.metrics }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "metrics-instance-usernames") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $) | nindent 4 }}
+data:
+  default: {{ .remote.basicAuth.username | b64enc }}
+  {{- range $i, $cfg := .additionalRemoteWriteConfigs }}
+  additional-{{ $i }}: {{ $cfg.basicAuth.username | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
 data:
-  default: {{ .remote.basicAuth.username | b64enc }}
+  default: {{ .remote.auth.username | b64enc | quote }} # quoted to work with empty values
   {{- range $i, $cfg := .additionalRemoteWriteConfigs }}
-  additional-{{ $i }}: {{ $cfg.basicAuth.username | b64enc }}
+  additional-{{ $i }}: {{ $cfg.auth.username | b64enc }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "metrics-instance-usernames") }}
   labels:
-    {{- include "mimir.labels" (dict "ctx" $) | nindent 4 }}
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
 data:
   default: {{ .remote.basicAuth.username | b64enc }}
   {{- range $i, $cfg := .additionalRemoteWriteConfigs }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -1,0 +1,37 @@
+{{- with .Values.metaMonitoring.grafanaAgent }}
+{{- if .enabled }}
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: MetricsInstance
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "meta-monitoring") }}
+  namespace: {{ $.Values.metaMonitoring.grafanaAgent.namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring" ) | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  remoteWrite:
+    {{- with .metrics.remote }}
+    - {{- include "mimir.metaMonitoring.metrics.remoteWrite" (dict "ctx" $ "url" .url "username" .auth.username "passwordSecretName" .auth.passwordSecretName "usernameKey" "default") | nindent 6 }}
+    {{- end }}
+    {{- range $i, $cfg := .metrics.additionalRemoteWriteConfigs }}
+    {{- with $cfg }}
+    - {{- include "mimir.metaMonitoring.logs.client" (dict "ctx" $ "url" .url "username" .auth.username "tenantId" .tenantId "passwordSecretName" .auth.passwordSecretName "usernameKey" (printf "%s-%d" "additional" $i)) | nindent 6 -}}
+    {{- end }}
+    {{- end }}
+
+  # Supply an empty namespace selector to look in all namespaces. Remove
+  # this to only look in the same namespace as the MetricsInstance CR
+  serviceMonitorNamespaceSelector: {}
+
+  serviceMonitorSelector:
+    # Scrape ServiceMonitors from all components
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $) | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/pods-logs.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/pods-logs.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
+{{- with .Values.metaMonitoring.grafanaAgent }}
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: PodLogs
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "meta-monitoring") }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  pipelineStages:
+    - cri: { }
+  relabelings:
+    - action: replace
+      replacement: $1
+      separator: /
+      sourceLabels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_container_name
+      targetLabel: job
+    - action: replace # Necessary for slow queries dashboard
+      sourceLabels:
+        - __meta_kubernetes_pod_container_name
+      targetLabel: name
+    - targetLabel: cluster
+      replacement: {{ include "mimir.clusterName" $ }}
+
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" $) | nindent 6 }}
+
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/pods-logs.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/pods-logs.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.metaMonitoring.grafanaAgent.enabled }}
 {{- with .Values.metaMonitoring.grafanaAgent }}
+{{- if .enabled }}
 apiVersion: monitoring.grafana.com/v1alpha1
 kind: PodLogs
 metadata:
@@ -18,7 +18,7 @@ spec:
   pipelineStages:
     - cri: { }
   relabelings:
-    - action: replace
+    - action: replace # For consistency with metrics
       replacement: $1
       separator: /
       sourceLabels:

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/pods-logs.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/pods-logs.yaml
@@ -38,6 +38,7 @@ spec:
 
   selector:
     matchLabels:
+      # Scrape logs from all components
       {{- include "mimir.selectorLabels" (dict "ctx" $) | nindent 6 }}
 
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1584,13 +1584,14 @@ gateway:
 
 metaMonitoring:
   grafanaAgent:
-    # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
-    namespace: ''
-    # -- Controls whether to create MetricsInstance, LogsInstance, and GrafanaAgent CRs to scrape the
-    # ServiceMonitors of the chart and ship metrics to the remote_write endpoints below
+    # -- Controls whether to create PodLogs, MetricsInstance, LogsInstance, and GrafanaAgent CRs to scrape the
+    # ServiceMonitors of the chart and ship metrics and logs to the remote endpoints below.
+    # Note that you need to configure serviceMonitor in order to have some metrics available.
     enabled: false
 
-    # -- Controls whether to install the Grafana Agent Operator
+    # -- Controls whether to install the Grafana Agent Operator and its CRDs.
+    # Note that helm will not install CRDs if this flag is enabled during an upgrade.
+    # In that case install the CRDs manually from https://github.com/grafana/agent/tree/main/production/operator/crds
     installOperator: false
 
     # -- Controls whether to scrape cadvisor, kubelet, and kube-state-metrics for metrics related to Mimir.
@@ -1602,9 +1603,14 @@ metaMonitoring:
       # configuration to write logs to this Loki-compatible remote. Optional.
       remote:
         url: ''
-        basicAuth:
+
+        # -- Used to set X-Scope-OrgID header on requests. Usually not used in combination with basic authentication.
+        tenantId: ''
+        auth:
+          # -- Basic authentication username. Optional.
           username: ''
-          # -- The value under key 'password' in this secret will be used as the basic authentication password.
+
+          # -- The value under key 'password' in this secret will be used as the basic authentication password. Optional.
           passwordSecretName: ''
 
       # -- Client configurations for the LogsInstance that will scrape Mimir pods. Follows the format of .remote.
@@ -1613,19 +1619,23 @@ metaMonitoring:
     metrics:
       # -- Default destination for metrics. The config here is translated to remote_write
       # configuration to push metrics to this Prometheus-compatible remote. Optional.
+      # Note that you need to configure serviceMonitor in order to have some metrics available.
       remote:
         url: ''
-        basicAuth:
+        auth:
+          # -- Basic authentication username. Optional.
           username: ''
-          # The value under key 'password' in this secret will be used as the basic authentication password.
+
+          # -- The value under key 'password' in this secret will be used as the basic authentication password. Optional.
           passwordSecretName: ''
 
       # -- Additional remote-write for the MetricsInstance that will scrape Mimir pods. Follows the format of .remote.
       additionalRemoteWriteConfigs: [ ]
 
       scrapeK8s:
-        # -- When grafanaAgent.enabled, controls whether to create ServiceMonitors for cadvisor, kubelet, and kube-state-metrics.
-        # The scraped metrics and logs are reduced to those pertaining to the Mimir release only.
+        # -- When grafanaAgent.enabled and serviceMonitor.enabled, controls whether to create ServiceMonitors CRs
+        # for cadvisor, kubelet, and kube-state-metrics. The scraped metrics are reduced to those pertaining to
+        # Mimir pods only.
         enabled: true
 
         # -- Controls service discovery of kube-state-metrics.
@@ -1639,8 +1649,8 @@ metaMonitoring:
 
     # -- Labels to add to all monitoring.grafana.com custom resources.
     # Does not affect the ServiceMonitors for kubernetes metrics; use serviceMonitor.labels for that.
-    labels: {}
+    labels: { }
 
     # -- Annotations to add to all monitoring.grafana.com custom resources.
     # Does not affect the ServiceMonitors for kubernetes metrics; use serviceMonitor.annotations for that.
-    annotations: {}
+    annotations: { }

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1636,3 +1636,11 @@ metaMonitoring:
 
     # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
     namespace: ''
+
+    # -- Labels to add to all monitoring.grafana.com custom resources.
+    # Does not affect the ServiceMonitors for kubernetes metrics; use serviceMonitor.labels for that.
+    labels: {}
+
+    # -- Annotations to add to all monitoring.grafana.com custom resources.
+    # Does not affect the ServiceMonitors for kubernetes metrics; use serviceMonitor.annotations for that.
+    annotations: {}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1582,14 +1582,20 @@ gateway:
         hosts:
           - gateway.gem.example.com
 
-metamonitoring:
+metaMonitoring:
   grafanaAgent:
+    # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
+    namespace: ''
     # -- Controls whether to create MetricsInstance, LogsInstance, and GrafanaAgent CRs to scrape the
     # ServiceMonitors of the chart and ship metrics to the remote_write endpoints below
     enabled: false
 
     # -- Controls whether to install the Grafana Agent Operator
     installOperator: false
+
+    # -- Controls whether to scrape cadvisor, kubelet, and kube-state-metrics for metrics related to Mimir.
+    # The scraped metrics will be limited to ones concerning Mimir only: where pod
+    scrapeK8s: true
 
     logs:
       # -- Default destination for logs. The config here is translated to Promtail client
@@ -1598,10 +1604,10 @@ metamonitoring:
         url: ''
         basicAuth:
           username: ''
-          password: ''
+          # -- The value under key 'password' in this secret will be used as the basic authentication password.
+          passwordSecretName: ''
 
-      # -- Client configurations for the LogsInstance that will scrape Mimir pods. Follows the format of
-      # [`promtail.client`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients).
+      # -- Client configurations for the LogsInstance that will scrape Mimir pods. Follows the format of .remote.
       additionalClientConfigs: [ ]
 
     metrics:
@@ -1611,15 +1617,22 @@ metamonitoring:
         url: ''
         basicAuth:
           username: ''
-          password: ''
+          # The value under key 'password' in this secret will be used as the basic authentication password.
+          passwordSecretName: ''
 
-      # -- Additional remote-write for the MetricsInstance that will scrape Mimir pods. Follows the format of
-      # [Prometheus `remote_write`](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#remote_write)
+      # -- Additional remote-write for the MetricsInstance that will scrape Mimir pods. Follows the format of .remote.
       additionalRemoteWriteConfigs: [ ]
 
-    # -- When grafanaAgent.enabled, controls whether to create ServiceMonitors for cadvisor, kubelet, and kube-state-metrics.
-    # The scraped metrics and logs are reduced to those pertaining to the Mimir release only.
-    scrapeK8s: false
+      scrapeK8s:
+        # -- When grafanaAgent.enabled, controls whether to create ServiceMonitors for cadvisor, kubelet, and kube-state-metrics.
+        # The scraped metrics and logs are reduced to those pertaining to the Mimir release only.
+        enabled: true
+
+        # -- Controls service discovery of kube-state-metrics.
+        kubeStateMetrics:
+          namespace: kube-system
+          labelSelectors:
+            app.kubernetes.io/name: kube-state-metrics
 
     # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
     namespace: ''

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1581,3 +1581,45 @@ gateway:
       - secretName: gem-gateway-tls
         hosts:
           - gateway.gem.example.com
+
+metamonitoring:
+  grafanaAgent:
+    # -- Controls whether to create MetricsInstance, LogsInstance, and GrafanaAgent CRs to scrape the
+    # ServiceMonitors of the chart and ship metrics to the remote_write endpoints below
+    enabled: false
+
+    # -- Controls whether to install the Grafana Agent Operator
+    installOperator: false
+
+    logs:
+      # -- Default destination for logs. The config here is translated to Promtail client
+      # configuration to write logs to this Loki-compatible remote. Optional.
+      remote:
+        url: ''
+        basicAuth:
+          username: ''
+          password: ''
+
+      # -- Client configurations for the LogsInstance that will scrape Mimir pods. Follows the format of
+      # [`promtail.client`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients).
+      additionalClientConfigs: [ ]
+
+    metrics:
+      # -- Default destination for metrics. The config here is translated to remote_write
+      # configuration to push metrics to this Prometheus-compatible remote. Optional.
+      remote:
+        url: ''
+        basicAuth:
+          username: ''
+          password: ''
+
+      # -- Additional remote-write for the MetricsInstance that will scrape Mimir pods. Follows the format of
+      # [Prometheus `remote_write`](https://prometheus.io/docs/prometheus/2.27/configuration/configuration/#remote_write)
+      additionalRemoteWriteConfigs: [ ]
+
+    # -- When grafanaAgent.enabled, controls whether to create ServiceMonitors for cadvisor, kubelet, and kube-state-metrics.
+    # The scraped metrics and logs are reduced to those pertaining to the Mimir release only.
+    scrapeK8s: false
+
+    # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
+    namespace: ''


### PR DESCRIPTION

#### What this PR does

Aims to make monitoring of Mimir/GEM when deployed via the helm chart easier. The idea is to make the process as streamlined as possible so that an operator has to spend minimal time on configuring scraping and relabelling configs.

This PR tries to achieve this by vendoring the Grafana Agent Operator helm chart. The mimir-distributed chart creates custom resources that create two grafana agents: one that scrapes metrics and one that collects logs. Optionally the mimir chart can also create resources that scrape relevant metrics from cadvisor, kubelet, and kube-state-metrics because these are used in alerts and dashboards.

#### Which issue(s) this PR fixes or relates to

Fixes #2014 

#### Checklist

- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
