### PR TITLE
Make namespace in build-helm-tests explicit

### DIFF
--- a/operations/helm/tests/build.sh
+++ b/operations/helm/tests/build.sh
@@ -19,5 +19,5 @@ for FILEPATH in $TESTS; do
   TEST_NAME=$(basename -s '.yaml' "$FILEPATH")
 
   echo "Templating $TEST_NAME"
-  helm template "${TEST_NAME}" ${CHART_PATH} -f "${FILEPATH}" --output-dir "operations/helm/tests/${TEST_NAME}-generated"
+  helm template "${TEST_NAME}" ${CHART_PATH} -f "${FILEPATH}" --output-dir "operations/helm/tests/${TEST_NAME}-generated" --namespace default
 done


### PR DESCRIPTION

#### What this PR does

Make namespace in build-helm-tests explicit. Otherwise the namespace is taken from the current kubectl context.
