### PR TITLE
Test alertmanager firewall with HTTP proxy too

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -475,6 +475,24 @@ receivers:
 `, backendURL)
 			},
 		},
+		// We expect requests against the HTTP proxy to be blocked too.
+		"HTTP proxy": {
+			getAlertmanagerConfig: func(backendURL string) string {
+				return fmt.Sprintf(`
+route:
+  receiver: webhook
+  group_wait: 0s
+  group_interval: 1s
+
+receivers:
+  - name: webhook
+    webhook_configs:
+      - url: https://www.google.com
+        http_config:
+          proxy_url: %s
+`, backendURL)
+			},
+		},
 	}
 
 	for receiverName, testData := range tests {


### PR DESCRIPTION
#### What this PR does
I'm sharing my feedback on https://github.com/grafana/mimir/issues/2044 and the [last comment](https://github.com/grafana/mimir/issues/2044#issuecomment-1152134837) made me change my mind. The current firewall we have protects HTTP proxy requests too, but we don't have a test to enforce it. This PR add such test case.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
