### PR TITLE
Add metric for error codes resulting from forwarding requests

### DIFF
--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -89,7 +89,7 @@ func NewForwarder(reg prometheus.Registerer, cfg Config) Forwarder {
 		errorsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex",
 			Name:      "distributor_forward_errors_total",
-			Help:      "The total number of errors that the distributor received from forwarding targets.",
+			Help:      "The total number of errors that the distributor received from forwarding targets when trying to send samples to them.",
 		}, []string{"status_code", "target"}),
 		samplesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex",

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -89,7 +89,7 @@ func NewForwarder(reg prometheus.Registerer, cfg Config) Forwarder {
 		errorsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex",
 			Name:      "distributor_forward_errors_total",
-			Help:      "The total number of errors which the Distributor received from forwarding targets.",
+			Help:      "The total number of errors that the distributor received from forwarding targets.",
 		}, []string{"user", "status_code"}),
 		samplesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex",

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -218,7 +218,7 @@ func TestForwardingSamplesWithDifferentErrorsWithPropagation(t *testing.T) {
 			if len(expectedErrorsByTarget) > 0 {
 				expectedMetrics.WriteString(`
 				# TYPE cortex_distributor_forward_errors_total counter
-				# HELP cortex_distributor_forward_errors_total The total number of errors that the distributor received from forwarding targets.`)
+				# HELP cortex_distributor_forward_errors_total The total number of errors that the distributor received from forwarding targets when trying to send samples to them.`)
 			}
 			for target, statusCodes := range expectedErrorsByTarget {
 				for statusCode, count := range statusCodes {

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -215,9 +215,9 @@ func TestForwardingSamplesWithDifferentErrorsWithPropagation(t *testing.T) {
 
 			var expectedMetrics strings.Builder
 			if len(expectedErrors) > 0 {
-				expectedMetrics.WriteString(fmt.Sprintf(`
+				expectedMetrics.WriteString(`
 				# TYPE cortex_distributor_forward_errors_total counter
-				# HELP cortex_distributor_forward_errors_total The total number of errors which the Distributor received from forwarding targets.`))
+				# HELP cortex_distributor_forward_errors_total The total number of errors which the Distributor received from forwarding targets.`)
 			}
 			for statusCode, expectedCount := range expectedErrors {
 				expectedMetrics.WriteString(fmt.Sprintf(`


### PR DESCRIPTION
We need to get insight into errors returned by forwarding targets, this adds a metric to track the errors by tenant and status code.