### PR TITLE
Ruler: Add timeout for remote rule evaluation queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Fix panic at startup when Mimir is running in monolithic mode and query sharding is enabled. #2036
 * [BUGFIX] Ruler: report failed evaluation metric for any 5xx status code returned by the query-frontend when remote operational mode is enabled. #2053
 * [BUGFIX] Ingester: fix slow rollout when using `-ingester.ring.unregister-on-shutdown=false` with long `-ingester.ring.heartbeat-period`. #2085
+* [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinately. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * [BUGFIX] Fix panic at startup when Mimir is running in monolithic mode and query sharding is enabled. #2036
 * [BUGFIX] Ruler: report failed evaluation metric for any 5xx status code returned by the query-frontend when remote operational mode is enabled. #2053
 * [BUGFIX] Ingester: fix slow rollout when using `-ingester.ring.unregister-on-shutdown=false` with long `-ingester.ring.heartbeat-period`. #2085
-* [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinately. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
+* [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinitely. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
 
 ### Mixin
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7372,6 +7372,16 @@
               "fieldType": "string"
             },
             {
+              "kind": "field",
+              "name": "timeout",
+              "required": false,
+              "desc": "The timeout for a rule query being evaluated by the query-frontend.",
+              "fieldValue": null,
+              "fieldDefaultValue": 120000000000,
+              "fieldFlag": "ruler.query-frontend.timeout",
+              "fieldType": "duration"
+            },
+            {
               "kind": "block",
               "name": "grpc_client_config",
               "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1444,6 +1444,8 @@ Usage of ./cmd/mimir/mimir:
     	Path to the key file for the client certificate. Also requires the client certificate to be configured.
   -ruler.query-frontend.grpc-client-config.tls-server-name string
     	Override the expected name on the server certificate.
+  -ruler.query-frontend.timeout duration
+    	The timeout for a rule query being evaluated by the query-frontend. (default 2m0s)
   -ruler.query-stats-enabled
     	Report the wall time for ruler queries to complete as a per-tenant metric and as an info level log message.
   -ruler.resend-delay duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -450,6 +450,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
   -ruler.query-frontend.address string
     	GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) to enable client side load balancing.
+  -ruler.query-frontend.timeout duration
+    	The timeout for a rule query being evaluated by the query-frontend. (default 2m0s)
   -ruler.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -ruler.ring.etcd.endpoints value

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -1400,6 +1400,10 @@ query_frontend:
   # CLI flag: -ruler.query-frontend.address
   [address: <string> | default = ""]
 
+  # The timeout for a rule query being evaluated by the query-frontend.
+  # CLI flag: -ruler.query-frontend.timeout
+  [timeout: <duration> | default = 2m]
+
   grpc_client_config:
     # (advanced) gRPC client max receive message size (bytes).
     # CLI flag: -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -576,7 +576,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		if err != nil {
 			return nil, err
 		}
-		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
+		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Ruler.QueryFrontend.Timeout, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
 
 		embeddedQueryable = prom_remote.NewSampleAndChunkQueryableClient(
 			remoteQuerier,

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
@@ -44,7 +45,7 @@ func TestRemoteQuerier_ReadReq(t *testing.T) {
 			Body: snappy.Encode(nil, b),
 		}, nil
 	}
-	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), "/prometheus", log.NewNopLogger())
+	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, "/prometheus", log.NewNopLogger())
 
 	_, err := q.Read(context.Background(), &prompb.Query{})
 	require.NoError(t, err)
@@ -55,6 +56,17 @@ func TestRemoteQuerier_ReadReq(t *testing.T) {
 	require.Equal(t, "/prometheus/api/v1/read", inReq.Url)
 }
 
+func TestRemoteQuerier_ReadReqTimeout(t *testing.T) {
+	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Second, "/prometheus", log.NewNopLogger())
+
+	_, err := q.Read(context.Background(), &prompb.Query{})
+	require.Error(t, err)
+}
+
 func TestRemoteQuerier_QueryReq(t *testing.T) {
 	var inReq *httpgrpc.HTTPRequest
 	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
@@ -63,7 +75,7 @@ func TestRemoteQuerier_QueryReq(t *testing.T) {
 							"status": "success","data": {"resultType":"vector","result":[]}
 						}`)}, nil
 	}
-	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), "/prometheus", log.NewNopLogger())
+	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, "/prometheus", log.NewNopLogger())
 
 	tm := time.Unix(1649092025, 515834)
 	_, err := q.Query(context.Background(), "qs", tm)
@@ -73,4 +85,16 @@ func TestRemoteQuerier_QueryReq(t *testing.T) {
 	require.Equal(t, http.MethodPost, inReq.Method)
 	require.Equal(t, "query=qs&time="+url.QueryEscape(tm.Format(time.RFC3339Nano)), string(inReq.Body))
 	require.Equal(t, "/prometheus/api/v1/query", inReq.Url)
+}
+
+func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
+	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		<-ctx.Done()
+		return nil, errors.New("Err")
+	}
+	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Second, "/prometheus", log.NewNopLogger())
+
+	tm := time.Unix(1649092025, 515834)
+	_, err := q.Query(context.Background(), "qs", tm)
+	require.Error(t, err)
 }

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
@@ -90,7 +89,7 @@ func TestRemoteQuerier_QueryReq(t *testing.T) {
 func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
 	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 		<-ctx.Done()
-		return nil, errors.New("Err")
+		return nil, ctx.Err()
 	}
 	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Second, "/prometheus", log.NewNopLogger())
 


### PR DESCRIPTION
During a rule group evaluation, if the remote query never completes for any
reason, then the rule group will become stuck and never evaluate again.
