### PR TITLE
Optional setting to allow querying overlapping blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] Upgrade Docker base images to `alpine:3.16.0`. #2028
 * [ENHANCEMENT] Store-gateway: Add experimental configuration option for the store-gateway to attempt to pre-populate the file system cache when memory-mapping index-header files. Enabled with `-blocks-storage.bucket-store.index-header.map-populate-enabled=true`. Note this flag only has an effect when running on Linux. #2019 #2054
 * [ENHANCEMENT] Chunk Mapper: reduce memory usage of async chunk mapper. #2043
+* [ENHANCEMENT] Ingesters: Added new configuration option that makes it possible for mimir ingesters to perform queries on overlapping blocks in the filesystem. Enabled with `-blocks-storage.tsdb.allow-overlapping-queries`. #2091
 * [BUGFIX] Fix regexp parsing panic for regexp label matchers with start/end quantifiers. #1883
 * [BUGFIX] Ingester: fixed deceiving error log "failed to update cached shipped blocks after shipper initialisation", occurring for each new tenant in the ingester. #1893
 * [BUGFIX] Ring: fix bug where instances may appear unhealthy in the hash ring web UI even though they are not. #1933

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5374,7 +5374,7 @@
               "kind": "field",
               "name": "allow_overlapping_queries",
               "required": false,
-              "desc": "Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.",
+              "desc": "Enable querying overlapping blocks. If there are going to be overlapping blocks in the ingesters this should be enabled.",
               "fieldValue": null,
               "fieldDefaultValue": false,
               "fieldFlag": "blocks-storage.tsdb.allow-overlapping-queries",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5372,6 +5372,17 @@
             },
             {
               "kind": "field",
+              "name": "allow_overlapping_queries",
+              "required": false,
+              "desc": "Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.",
+              "fieldValue": null,
+              "fieldDefaultValue": false,
+              "fieldFlag": "blocks-storage.tsdb.allow-overlapping-queries",
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
               "name": "series_hash_cache_max_size_bytes",
               "required": false,
               "desc": "Max size - in bytes - of the in-memory series hash cache. The cache is shared across all tenants and it's used only when query sharding is enabled.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -478,7 +478,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.swift.username string
     	OpenStack Swift username.
   -blocks-storage.tsdb.allow-overlapping-queries
-    	[experimental] Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.
+    	[experimental] Enable querying overlapping blocks. If there are going to be overlapping blocks in the ingesters this should be enabled.
   -blocks-storage.tsdb.block-ranges-period value
     	TSDB blocks range period. (default 2h0m0s)
   -blocks-storage.tsdb.close-idle-tsdb-timeout duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -477,6 +477,8 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -blocks-storage.swift.username string
     	OpenStack Swift username.
+  -blocks-storage.tsdb.allow-overlapping-queries
+    	[experimental] Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.
   -blocks-storage.tsdb.block-ranges-period value
     	TSDB blocks range period. (default 2h0m0s)
   -blocks-storage.tsdb.close-idle-tsdb-timeout duration

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3516,7 +3516,7 @@ tsdb:
   [isolation_enabled: <boolean> | default = false]
 
   # (experimental) Enable querying overlapping blocks. If there are going to be
-  # overlapping blocks in the filesystem this should be enabled.
+  # overlapping blocks in the ingesters this should be enabled.
   # CLI flag: -blocks-storage.tsdb.allow-overlapping-queries
   [allow_overlapping_queries: <boolean> | default = false]
 

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3518,7 +3518,7 @@ tsdb:
   # (experimental) Enable querying overlapping blocks. If there are going to be
   # overlapping blocks in the filesystem this should be enabled.
   # CLI flag: -blocks-storage.tsdb.allow-overlapping-queries
-  [allow_overlapping_queries: <boolean> | default = true]
+  [allow_overlapping_queries: <boolean> | default = false]
 
   # (advanced) Max size - in bytes - of the in-memory series hash cache. The
   # cache is shared across all tenants and it's used only when query sharding is

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3515,6 +3515,11 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.isolation-enabled
   [isolation_enabled: <boolean> | default = false]
 
+  # (experimental) Enable querying overlapping blocks. If there are going to be
+  # overlapping blocks in the filesystem this should be enabled.
+  # CLI flag: -blocks-storage.tsdb.allow-overlapping-queries
+  [allow_overlapping_queries: <boolean> | default = true]
+
   # (advanced) Max size - in bytes - of the in-memory series hash cache. The
   # cache is shared across all tenants and it's used only when query sharding is
   # enabled.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1478,6 +1478,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
 		NewChunkDiskMapper:             i.cfg.BlocksStorageConfig.TSDB.NewChunkDiskMapper,
 		AllowOverlappingQueries:        i.cfg.BlocksStorageConfig.TSDB.AllowOverlappingQueries,
+		AllowOverlappingCompaction:     false, // always false since Mimir only uploads lvl 1 compacted blocks
 	}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open TSDB: %s", udir)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1477,6 +1477,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		IsolationDisabled:              !i.cfg.BlocksStorageConfig.TSDB.IsolationEnabled,
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
 		NewChunkDiskMapper:             i.cfg.BlocksStorageConfig.TSDB.NewChunkDiskMapper,
+		AllowOverlappingQueries:        i.cfg.BlocksStorageConfig.TSDB.AllowOverlappingQueries,
 	}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open TSDB: %s", udir)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -207,7 +207,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", 0, "The size of the write queue used by the head chunks mapper. Lower values reduce memory utilisation at the cost of potentially higher ingest latency. Value of 0 switches chunks mapper to implementation without a queue. This flag is only used if the new chunk disk mapper is enabled with -blocks-storage.tsdb.new-chunk-disk-mapper.")
 	f.BoolVar(&cfg.NewChunkDiskMapper, "blocks-storage.tsdb.new-chunk-disk-mapper", false, "Temporary flag to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.")
 	f.BoolVar(&cfg.IsolationEnabled, "blocks-storage.tsdb.isolation-enabled", false, "[Deprecated] Enables TSDB isolation feature. Disabling may improve performance.")
-	f.BoolVar(&cfg.AllowOverlappingQueries, "blocks-storage.tsdb.allow-overlapping-queries", false, "Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.")
+	f.BoolVar(&cfg.AllowOverlappingQueries, "blocks-storage.tsdb.allow-overlapping-queries", false, "Enable querying overlapping blocks. If there are going to be overlapping blocks in the ingesters this should be enabled.")
 }
 
 // Validate the config.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -164,6 +164,7 @@ type TSDBConfig struct {
 	HeadChunksWriteQueueSize  int           `yaml:"head_chunks_write_queue_size" category:"experimental"`
 	NewChunkDiskMapper        bool          `yaml:"new_chunk_disk_mapper" category:"experimental"`
 	IsolationEnabled          bool          `yaml:"isolation_enabled" category:"advanced"` // TODO Remove in Mimir 2.3.0
+	AllowOverlappingQueries   bool          `yaml:"allow_overlapping_queries" category:"experimental"`
 
 	// Series hash cache.
 	SeriesHashCacheMaxBytes uint64 `yaml:"series_hash_cache_max_size_bytes" category:"advanced"`
@@ -206,6 +207,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", 0, "The size of the write queue used by the head chunks mapper. Lower values reduce memory utilisation at the cost of potentially higher ingest latency. Value of 0 switches chunks mapper to implementation without a queue. This flag is only used if the new chunk disk mapper is enabled with -blocks-storage.tsdb.new-chunk-disk-mapper.")
 	f.BoolVar(&cfg.NewChunkDiskMapper, "blocks-storage.tsdb.new-chunk-disk-mapper", false, "Temporary flag to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.")
 	f.BoolVar(&cfg.IsolationEnabled, "blocks-storage.tsdb.isolation-enabled", false, "[Deprecated] Enables TSDB isolation feature. Disabling may improve performance.")
+	f.BoolVar(&cfg.AllowOverlappingQueries, "blocks-storage.tsdb.allow-overlapping-queries", true, "Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.")
 }
 
 // Validate the config.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -207,7 +207,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", 0, "The size of the write queue used by the head chunks mapper. Lower values reduce memory utilisation at the cost of potentially higher ingest latency. Value of 0 switches chunks mapper to implementation without a queue. This flag is only used if the new chunk disk mapper is enabled with -blocks-storage.tsdb.new-chunk-disk-mapper.")
 	f.BoolVar(&cfg.NewChunkDiskMapper, "blocks-storage.tsdb.new-chunk-disk-mapper", false, "Temporary flag to select whether to use the new (used in upstream Prometheus) or the old (legacy) chunk disk mapper.")
 	f.BoolVar(&cfg.IsolationEnabled, "blocks-storage.tsdb.isolation-enabled", false, "[Deprecated] Enables TSDB isolation feature. Disabling may improve performance.")
-	f.BoolVar(&cfg.AllowOverlappingQueries, "blocks-storage.tsdb.allow-overlapping-queries", true, "Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.")
+	f.BoolVar(&cfg.AllowOverlappingQueries, "blocks-storage.tsdb.allow-overlapping-queries", false, "Enable querying overlapping blocks. If there are going to be overlapping blocks in the filesystem this should be enabled.")
 }
 
 // Validate the config.


### PR DESCRIPTION
#### What this PR does

Relates to the changes in https://github.com/grafana/mimir-prometheus/pull/251

Adds a new TSDB Config flag to allow querying on overlapping blocks in the ingesters in case there are any in the filesystem.

The new out of order implementation will generate overlapping blocks and this flag makes it possible to revert back to a previous release in case something goes wrong.

Also, if there were any other usecases where overlapping blocks where present in the filesystem, this option will be of help to enable queries.

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
