### PR TITLE
Helm: Add global POD annotations

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Change default value for `blocks_storage.bucket_store.chunks_cache.memcached.timeout` to `450ms` to increase use of cached data. #2035
+* [ENHANCEMENT] Add `global.podAnnotations` which can add POD annotations to PODs directly controlled by this chart (mimir services, nginx). #2099
 * [ENHANCEMENT] Introduce the value `configStorageType` which can be either `ConfigMap` or `Secret`. This value sets where to store the Mimir/GEM application configuration. When using the value `ConfigMap`, make sure that any secrets, passwords, keys are injected from the environment from a separate `Secret`. See also: #2031, #2017. #2089
 * [ENHANCEMENT] Add `global.extraEnv` and `global.extraEnvFrom` to values. This enables setting common environment variables and common injection of secrets to the POD environment of Mimir/GEM services and Nginx. Memcached and minio are out of scope for now. #2031
 * [ENHANCEMENT] Add `extraEnvFrom` capability to all Mimir services to enable injecting secrets via environment variables. #2017

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -213,13 +213,13 @@ app.kubernetes.io/part-of: memberlist
 POD annotations
 */}}
 {{- define "mimir.podAnnotations" -}}
-{{- if .ctx.Values.useExternalConfig -}}
+{{- if .ctx.Values.useExternalConfig }}
 checksum/config: {{ .ctx.Values.externalConfigVersion }}
 {{- else -}}
 checksum/config: {{ include (print .ctx.Template.BasePath "/mimir-config.yaml") .ctx | sha256sum }}
 {{- end }}
 {{- with .ctx.Values.global.podAnnotations }}
-{{- toYaml . }}
+{{ toYaml . }}
 {{- end }}
 {{- if .component }}
 {{- $componentSection := .component | replace "-" "_" }}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -218,6 +218,9 @@ checksum/config: {{ .ctx.Values.externalConfigVersion }}
 {{- else -}}
 checksum/config: {{ include (print .ctx.Template.BasePath "/mimir-config.yaml") .ctx | sha256sum }}
 {{- end }}
+{{- with .Values.global.podAnnotations }}
+{{- toYaml . }}
+{{- end }}
 {{- if .component }}
 {{- $componentSection := .component | replace "-" "_" }}
 {{- if not (hasKey .ctx.Values $componentSection) }}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -218,7 +218,7 @@ checksum/config: {{ .ctx.Values.externalConfigVersion }}
 {{- else -}}
 checksum/config: {{ include (print .ctx.Template.BasePath "/mimir-config.yaml") .ctx | sha256sum }}
 {{- end }}
-{{- with .Values.global.podAnnotations }}
+{{- with .ctx.Values.global.podAnnotations }}
 {{- toYaml . }}
 {{- end }}
 {{- if .component }}

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -23,6 +23,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/nginx/nginx-configmap.yaml") . | sha256sum }}
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.nginx.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -30,17 +30,20 @@ global:
   dnsNamespace: kube-system
   clusterDomain: cluster.local
 
-  # -- Common environment variables to add to all PODs directly managed by this chart (mimir services, nginx).
+  # -- Common environment variables to add to all pods directly managed by this chart.
+  # scope: admin-api, alertmanager, compactor, distributor, gateway, ingester, nginx, overrides-exporter, querier, query-frontend, ruler, store-gateway, tokengen
   extraEnv: []
 
-  # -- Common source of environment injections to add to all PODs directly managed by this chart (mimir services, nginx).
+  # -- Common source of environment injections to add to all pods directly managed by this chart.
+  # scope: admin-api, alertmanager, compactor, distributor, gateway, ingester, nginx, overrides-exporter, querier, query-frontend, ruler, store-gateway, tokengen
   # For example to inject values from a Secret, use:
   # extraEnvFrom:
   #   - secretRef:
   #      name: mysecret
   extraEnvFrom: []
 
-  # -- POD annotations for all PODs directly managed by this chart (mimir services, nginx). Useable for example to associate a version to 'global.extraEnv' and 'global.extraEnvFrom' and trigger a restart of the affected services.
+  # -- Pod annotations for all pods directly managed by this chart. Usable for example to associate a version to 'global.extraEnv' and 'global.extraEnvFrom' and trigger a restart of the affected services.
+  # scope: admin-api, alertmanager, compactor, distributor, gateway, ingester, nginx, overrides-exporter, querier, query-frontend, ruler, store-gateway, tokengen
   podAnnotations: {}
 
 serviceAccount:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -25,20 +25,23 @@ image:
   #   - myRegistryKeySecretName
 
 global:
-  # definitions to set up nginx resolver
+  # -- Definitions to set up nginx resolver
   dnsService: kube-dns
   dnsNamespace: kube-system
   clusterDomain: cluster.local
 
-  # Common environment variables to add to all PODs directly managed by this chart (mimir services, nginx). Doesn't include memcached or minio.
+  # -- Common environment variables to add to all PODs directly managed by this chart (mimir services, nginx).
   extraEnv: []
 
-  # Common source of environment injections to add to all PODs directly managed by this chart (mimir services, nginx). Doesn't include memcached or minio.
+  # -- Common source of environment injections to add to all PODs directly managed by this chart (mimir services, nginx).
   # For example to inject values from a Secret, use:
   # extraEnvFrom:
   #   - secretRef:
   #      name: mysecret
   extraEnvFrom: []
+
+  # -- POD annotations for all PODs directly managed by this chart (mimir services, nginx). Useable for example to associate a version to 'global.extraEnv' and 'global.extraEnvFrom' and trigger a restart of the affected services.
+  podAnnotations: {}
 
 serviceAccount:
   create: true


### PR DESCRIPTION
#### What this PR does

Introduce global.podAnnotations , let's the user version their extra envFrom to trigger a service
restart on changes.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/helm-charts/issues/1150 and https://github.com/grafana/helm-charts/pull/1181

#### Checklist

- [N/A] Tests updated - next PR
- [N/A] Documentation added - part of https://github.com/grafana/mimir/issues/1945
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
