### PR TITLE
Adding support for new config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [BUGFIX] Ingester: fix slow rollout when using `-ingester.ring.unregister-on-shutdown=false` with long `-ingester.ring.heartbeat-period`. #2085
 * [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinitely. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
 * [BUGFIX] Ingester: reduce sleep time when reading WAL. #2098
-* [BUGFIX] Limits: Active series custom tracker configuration has been named back from `active_series_custom_trackers_config` to `active_series_custom_trackers`. For backwards compatibility both version is going to be supported for until Mimir v2.3. When both are specified, the old config takes precedence.
+* [BUGFIX] Limits: Active series custom tracker configuration has been named back from `active_series_custom_trackers_config` to `active_series_custom_trackers`. For backwards compatibility both version is going to be supported for until Mimir v2.4. When both are specified, the old config takes precedence.
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [BUGFIX] Ingester: fix slow rollout when using `-ingester.ring.unregister-on-shutdown=false` with long `-ingester.ring.heartbeat-period`. #2085
 * [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinitely. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
 * [BUGFIX] Ingester: reduce sleep time when reading WAL. #2098
+* [BUGFIX] Limits: Active series custom tracker configuration has been named back from `active_series_custom_trackers_config` to `active_series_custom_trackers`. For backwards compatibility both version is going to be supported for until Mimir v2.3. When both are specified, the old config takes precedence.
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [BUGFIX] Ingester: fix slow rollout when using `-ingester.ring.unregister-on-shutdown=false` with long `-ingester.ring.heartbeat-period`. #2085
 * [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinitely. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
 * [BUGFIX] Ingester: reduce sleep time when reading WAL. #2098
-* [BUGFIX] Limits: Active series custom tracker configuration has been named back from `active_series_custom_trackers_config` to `active_series_custom_trackers`. For backwards compatibility both version is going to be supported for until Mimir v2.4. When both are specified, the old config takes precedence.
+* [BUGFIX] Limits: Active series custom tracker configuration has been named back from `active_series_custom_trackers_config` to `active_series_custom_trackers`. For backwards compatibility both version is going to be supported for until Mimir v2.4. When both fields are specified, `active_series_custom_trackers_config` takes precedence over `active_series_custom_trackers`. #2101
 
 ### Mixin
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2639,7 +2639,7 @@
         },
         {
           "kind": "field",
-          "name": "active_series_custom_trackers_config",
+          "name": "active_series_custom_trackers",
           "required": false,
           "desc": "Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero).",
           "fieldValue": null,

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -2715,11 +2715,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 #   The following configuration will count the active series coming from dev and
 #   prod namespaces for each tenant and label them as {name="dev"} and
 #   {name="prod"} in the cortex_ingester_active_series_custom_tracker metric.
-#   active_series_custom_trackers_config:
+#   active_series_custom_trackers:
 #       dev: '{namespace=~"dev-.*"}'
 #       prod: '{namespace=~"prod-.*"}'
 # CLI flag: -ingester.active-series-custom-trackers
-[active_series_custom_trackers_config: <map of tracker name (string) to matcher (string)> | default = ]
+[active_series_custom_trackers: <map of tracker name (string) to matcher (string)> | default = ]
 
 # Maximum number of chunks that can be fetched in a single query from ingesters
 # and long-term storage. This limit is enforced in the querier, ruler and

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -248,6 +248,7 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if !l.ActiveSeriesCustomTrackersConfigOld.Empty() {
 		l.ActiveSeriesCustomTrackersConfig = l.ActiveSeriesCustomTrackersConfigOld
+		l.ActiveSeriesCustomTrackersConfigOld = activeseries.CustomTrackersConfig{}
 	}
 	return nil
 }
@@ -276,6 +277,7 @@ func (l *Limits) UnmarshalJSON(data []byte) error {
 
 	if !l.ActiveSeriesCustomTrackersConfigOld.Empty() {
 		l.ActiveSeriesCustomTrackersConfig = l.ActiveSeriesCustomTrackersConfigOld
+		l.ActiveSeriesCustomTrackersConfigOld = activeseries.CustomTrackersConfig{}
 	}
 	return nil
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -93,7 +93,7 @@ type Limits struct {
 	MaxGlobalExemplarsPerUser int `yaml:"max_global_exemplars_per_user" json:"max_global_exemplars_per_user" category:"experimental"`
 	// Active series custom trackers
 	// TODO remove this with Mimir version 2.3
-	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config" json:"active_series_custom_trackers_config" doc:"description=[Deprecated] Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
+	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config" json:"active_series_custom_trackers_config" doc:"hidden"`
 	ActiveSeriesCustomTrackersConfig    activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
 
 	// Querier enforced limits.
@@ -239,7 +239,17 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		l.copyNotificationIntegrationLimits(defaultLimits.NotificationRateLimitPerIntegration)
 	}
 	type plain Limits
-	return unmarshal((*plain)(l))
+	// TODO Revert back from Mimir version 2.3
+	// return unmarshal((*plain)(l))
+	err := unmarshal((*plain)(l))
+	if err != nil {
+		return err
+	}
+
+	if !l.ActiveSeriesCustomTrackersConfigOld.Empty() {
+		l.ActiveSeriesCustomTrackersConfig = l.ActiveSeriesCustomTrackersConfigOld
+	}
+	return nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -257,7 +267,17 @@ func (l *Limits) UnmarshalJSON(data []byte) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 
-	return dec.Decode((*plain)(l))
+	// TODO Revert back from Mimir version 2.3
+	// return dec.Decode((*plain)(l))
+	err := dec.Decode((*plain)(l))
+	if err != nil {
+		return err
+	}
+
+	if !l.ActiveSeriesCustomTrackersConfigOld.Empty() {
+		l.ActiveSeriesCustomTrackersConfig = l.ActiveSeriesCustomTrackersConfigOld
+	}
+	return nil
 }
 
 func (l *Limits) copyNotificationIntegrationLimits(defaults NotificationRateLimitMap) {
@@ -477,10 +497,6 @@ func (o *Overrides) MaxGlobalExemplarsPerUser(userID string) int {
 }
 
 func (o *Overrides) ActiveSeriesCustomTrackersConfig(userID string) activeseries.CustomTrackersConfig {
-	if !o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfigOld.Empty() {
-		// TODO remove this with Mimir version 2.3
-		return o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfigOld
-	}
 	return o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfig
 }
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -93,7 +93,7 @@ type Limits struct {
 	MaxGlobalExemplarsPerUser int `yaml:"max_global_exemplars_per_user" json:"max_global_exemplars_per_user" category:"experimental"`
 	// Active series custom trackers
 	// TODO remove this with Mimir version 2.4
-	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config,omitempty" json:"active_series_custom_trackers_config,omitempty" doc:"hidden"`
+	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config" json:"active_series_custom_trackers_config" doc:"hidden"`
 	ActiveSeriesCustomTrackersConfig    activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
 
 	// Querier enforced limits.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -92,8 +92,8 @@ type Limits struct {
 	// Exemplars
 	MaxGlobalExemplarsPerUser int `yaml:"max_global_exemplars_per_user" json:"max_global_exemplars_per_user" category:"experimental"`
 	// Active series custom trackers
-	// TODO remove this with Mimir version 2.3
-	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config" json:"active_series_custom_trackers_config" doc:"hidden"`
+	// TODO remove this with Mimir version 2.4
+	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config,omitempty" json:"active_series_custom_trackers_config,omitempty" doc:"hidden"`
 	ActiveSeriesCustomTrackersConfig    activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
 
 	// Querier enforced limits.
@@ -239,8 +239,7 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		l.copyNotificationIntegrationLimits(defaultLimits.NotificationRateLimitPerIntegration)
 	}
 	type plain Limits
-	// TODO Revert back from Mimir version 2.3
-	// return unmarshal((*plain)(l))
+
 	err := unmarshal((*plain)(l))
 	if err != nil {
 		return err
@@ -268,8 +267,6 @@ func (l *Limits) UnmarshalJSON(data []byte) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 
-	// TODO Revert back from Mimir version 2.3
-	// return dec.Decode((*plain)(l))
 	err := dec.Decode((*plain)(l))
 	if err != nil {
 		return err

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -92,7 +92,9 @@ type Limits struct {
 	// Exemplars
 	MaxGlobalExemplarsPerUser int `yaml:"max_global_exemplars_per_user" json:"max_global_exemplars_per_user" category:"experimental"`
 	// Active series custom trackers
-	ActiveSeriesCustomTrackersConfig activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config" json:"active_series_custom_trackers_config" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
+	// TODO remove this with Mimir version 2.3
+	ActiveSeriesCustomTrackersConfigOld activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers_config" json:"active_series_custom_trackers_config" doc:"description=[Deprecated] Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
+	ActiveSeriesCustomTrackersConfig    activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
 
 	// Querier enforced limits.
 	MaxChunksPerQuery              int            `yaml:"max_fetched_chunks_per_query" json:"max_fetched_chunks_per_query"`
@@ -475,6 +477,10 @@ func (o *Overrides) MaxGlobalExemplarsPerUser(userID string) int {
 }
 
 func (o *Overrides) ActiveSeriesCustomTrackersConfig(userID string) activeseries.CustomTrackersConfig {
+	if !o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfigOld.Empty() {
+		// TODO remove this with Mimir version 2.3
+		return o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfigOld
+	}
 	return o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfig
 }
 

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -489,3 +489,49 @@ testuser:
 		})
 	}
 }
+
+// TODO remove this with Mimir version 2.3
+func TestCustomTrackersConfigRename(t *testing.T) {
+	oldYaml := `
+    user:
+        active_series_custom_trackers_config:
+            baz: '{foo="bar"}'
+    `
+	newYaml := `
+    user:
+        active_series_custom_trackers:
+            baz: '{foo="bar"}'
+    `
+
+	t.Run("testOldVersion", func(t *testing.T) {
+		limits := Limits{}
+		overrides := map[string]*Limits{}
+		err := yaml.Unmarshal([]byte(oldYaml), &overrides)
+		require.NoError(t, err, "parsing overrides")
+
+		tl := newMockTenantLimits(overrides)
+
+		ov, err := NewOverrides(limits, tl)
+		require.NoError(t, err)
+
+		SetDefaultLimitsForYAMLUnmarshalling(Limits{})
+
+		assert.False(t, ov.ActiveSeriesCustomTrackersConfig("user").Empty())
+	})
+
+	t.Run("testNewVersion", func(t *testing.T) {
+		limits := Limits{}
+		overrides := map[string]*Limits{}
+		err := yaml.Unmarshal([]byte(newYaml), &overrides)
+		require.NoError(t, err, "parsing overrides")
+
+		tl := newMockTenantLimits(overrides)
+
+		ov, err := NewOverrides(limits, tl)
+		require.NoError(t, err)
+
+		SetDefaultLimitsForYAMLUnmarshalling(Limits{})
+
+		assert.False(t, ov.ActiveSeriesCustomTrackersConfig("user").Empty())
+	})
+}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -535,3 +535,21 @@ func TestCustomTrackersConfigRename(t *testing.T) {
 		assert.False(t, ov.ActiveSeriesCustomTrackersConfig("user").Empty())
 	})
 }
+
+// TODO remove this with Mimir version 2.3
+func TestCustomTrackerOldVersionShouldSerializeToNewOne(t *testing.T) {
+	oldYaml := `
+    user:
+        active_series_custom_trackers_config:
+            baz: '{foo="bar"}'
+    `
+	t.Run("testOldVersion", func(t *testing.T) {
+		overrides := map[string]*Limits{}
+		err := yaml.Unmarshal([]byte(oldYaml), &overrides)
+		require.NoError(t, err, "parsing overrides")
+
+		assert.True(t, overrides["user"].ActiveSeriesCustomTrackersConfigOld.Empty())
+		assert.False(t, overrides["user"].ActiveSeriesCustomTrackersConfig.Empty())
+	})
+
+}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -536,10 +536,3 @@ func TestCustomTrackerConfigDeserialize(t *testing.T) {
 		})
 	}
 }
-
-func TestCustomTrackerConfigSerialize(t *testing.T) {
-	limits := Limits{}
-	out, err := yaml.Marshal(limits)
-	require.NoError(t, err, "failed to serialize limits")
-	assert.False(t, strings.Contains(string(out), "active_series_custom_trackers_config"), "serialized string should not contain old name of the config")
-}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -515,13 +515,13 @@ func TestCustomTrackerConfigDeserialize(t *testing.T) {
 	for name, tc := range map[string]struct {
 		yaml string
 	}{
-		"testOldVersion": {
+		"testOldVersionCopiedToNewField": {
 			yaml: oldYaml,
 		},
 		"testNewVersion": {
 			yaml: newYaml,
 		},
-		"testBothVersionsOldTakesPrecedence": {
+		"testBothVersionsOldTakesPrecedenceInNewField": {
 			yaml: bothYaml,
 		},
 	} {
@@ -538,11 +538,8 @@ func TestCustomTrackerConfigDeserialize(t *testing.T) {
 }
 
 func TestCustomTrackerConfigSerialize(t *testing.T) {
-	config, err := activeseries.NewCustomTrackersConfig(map[string]string{"baz": `{foo="bar"}`})
-	require.NoError(t, err, "creating expected config")
 	limits := Limits{}
-	limits.ActiveSeriesCustomTrackersConfigOld = config
 	out, err := yaml.Marshal(limits)
 	require.NoError(t, err, "failed to serialize limits")
-	assert.False(t, strings.Contains(string(out), "active_series_custom_trackers_config"))
+	assert.False(t, strings.Contains(string(out), "active_series_custom_trackers_config"), "serialized string should not contain old name of the config")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
In #1188 the config name of `active_series_custom_trackers` has been changed to `active_series_custom_trackers_config` by accident. The aim of this PR is to change it back to `ąctive_series_custom_trackers` while supporting the suffixed version for 2 releases.

When both are specified, the old config takes precedence.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
