### PR TITLE
Addendum to alertmanager respecting memberlist_ring_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 * [CHANGE] Remove use of `-querier.query-store-after`, `-querier.shuffle-sharding-ingesters-lookback-period`, `-blocks-storage.bucket-store.ignore-blocks-within`, and `-blocks-storage.tsdb.close-idle-tsdb-timeout` CLI flags since the values now match defaults. #1915 #1921
 * [CHANGE] Change default value for `-blocks-storage.bucket-store.chunks-cache.memcached.timeout` to `450ms` to increase use of cached data. #2035
+* [CHANGE] The `memberlist_ring_enabled` configuration now applies to Alertmanager. #2102
 * [FEATURE] Added querier autoscaling support. It requires [KEDA](https://keda.sh) installed in the Kubernetes cluster and query-scheduler enabled in the Mimir cluster. Querier autoscaler can be enabled and configure through the following options in the jsonnet config: #2013 #2023
   * `autoscaling_querier_enabled`: `true` to enable autoscaling.
   * `autoscaling_querier_min_replicas`: minimum number of querier replicas.
@@ -69,7 +70,6 @@
   * `autoscaling_prometheus_url`: Prometheus base URL from which to scrape Mimir metrics (e.g. `http://prometheus.default:9090/prometheus`).
 * [ENHANCEMENT] Added `compactor` service, that can be used to route requests directly to compactor (e.g. admin UI). #2063
 * [ENHANCEMENT] Added a `consul_enabled` configuration option that defaults to true (matching previous behavior) to provide the ability to disable consul. #2093
-* [CHANGE] The `memberlist_ring_enabled` configuration now applies to Alertmanager. #2102
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-gossip-disable-consul-generated.yaml
+++ b/operations/mimir-tests/test-gossip-disable-consul-generated.yaml
@@ -67,6 +67,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -787,6 +790,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -818,6 +822,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir-tests/test-gossip-generated.yaml
+++ b/operations/mimir-tests/test-gossip-generated.yaml
@@ -318,6 +318,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -1193,6 +1196,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -1224,6 +1228,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir-tests/test-gossip-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multi-zone-generated.yaml
@@ -368,6 +368,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -1405,6 +1408,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -1436,6 +1440,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir-tests/test-gossip-multikv-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-generated.yaml
@@ -321,6 +321,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -1217,6 +1220,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -1251,6 +1255,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-switch-primary-secondary-generated.yaml
@@ -321,6 +321,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -1217,6 +1220,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -1251,6 +1255,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir-tests/test-gossip-multikv-teardown-generated.yaml
+++ b/operations/mimir-tests/test-gossip-multikv-teardown-generated.yaml
@@ -321,6 +321,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -1196,6 +1199,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -1227,6 +1231,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir-tests/test-gossip-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-gossip-ruler-disabled-generated.yaml
@@ -318,6 +318,9 @@ spec:
   - name: alertmanager-grpc
     port: 9095
     targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
     name: alertmanager
 ---
@@ -1082,6 +1085,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: alertmanager
     spec:
       containers:
@@ -1113,6 +1117,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -43,10 +43,12 @@
       pvc.mixin.spec.resources.withRequests({ storage: '100Gi' })
     else {},
 
+  alertmanager_ports:: $.util.defaultPorts,
+
   alertmanager_container::
     if $._config.alertmanager_enabled then
       container.new('alertmanager', $._images.alertmanager) +
-      container.withPorts($.util.defaultPorts) +
+      container.withPorts($.alertmanager_ports) +
       container.withEnvMixin([container.envType.fromFieldPath('POD_IP', 'status.podIP')]) +
       container.withArgsMixin(
         $.util.mapToFlags($.alertmanager_args)

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -60,6 +60,7 @@
   local containerPort = $.core.v1.containerPort,
   local gossipPort = containerPort.newNamed(name='gossip-ring', containerPort=gossipRingPort),
 
+  alertmanager_ports+:: if !$._config.memberlist_ring_enabled then [] else [gossipPort],
   compactor_ports+:: if !$._config.memberlist_ring_enabled then [] else [gossipPort],
   distributor_ports+:: if !$._config.memberlist_ring_enabled then [] else [gossipPort],
   ingester_ports+:: if !$._config.memberlist_ring_enabled then [] else [gossipPort],
@@ -69,6 +70,9 @@
 
   // Don't add label to matcher, only to pod labels.
   local gossipLabel = $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'true' }),
+
+  alertmanager_statefulset+: if !$._config.memberlist_ring_enabled then {} else
+    gossipLabel,
 
   compactor_statefulset+: if !$._config.memberlist_ring_enabled then {} else
     gossipLabel,


### PR DESCRIPTION
#### What this PR does

This is a follow-up PR to https://github.com/grafana/mimir/pull/2102. It sets the gossip port and gossip label, which was previously missed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
