### PR TITLE
Jsonnet: Account for disabled alertmanager when adding memberlist gossip label

### DIFF
--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -71,7 +71,7 @@
   // Don't add label to matcher, only to pod labels.
   local gossipLabel = $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'true' }),
 
-  alertmanager_statefulset+: if !$._config.memberlist_ring_enabled then {} else
+  alertmanager_statefulset+: if !$._config.memberlist_ring_enabled || !$._config.alertmanager_enabled then {} else
     gossipLabel,
 
   compactor_statefulset+: if !$._config.memberlist_ring_enabled then {} else


### PR DESCRIPTION
#### What this PR does

Accounts for the alertmanager being disabled before adding the gossip label. This is (yet another, sorry) follow up PR to https://github.com/grafana/mimir/pull/2102. Opening as a draft because I haven't verified this and don't want to cause further churn.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
