### PR TITLE
Helm: test simplified configuration e2e

### DIFF
--- a/operations/helm/charts/mimir-distributed/ci/test-enterprise-configmap-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-enterprise-configmap-values.yaml
@@ -4,6 +4,33 @@ kubeVersionOverride: "1.20"
 # TODO remove when it is the default
 configStorageType: ConfigMap
 
+global:
+  extraEnvFrom:
+    - secretRef:
+        name: mimir-minio-secret
+  podAnnotations:
+    minio-secret-version: '42'
+
+mimir:
+  structuredConfig:
+    admin_client:
+      storage:
+        s3:
+          access_key_id: "${MINIO_ACCESS_KEY_ID}"
+          secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+    alertmanager_storage:
+      s3:
+        access_key_id: "${MINIO_ACCESS_KEY_ID}"
+        secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+    blocks_storage:
+      s3:
+        access_key_id: "${MINIO_ACCESS_KEY_ID}"
+        secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+    ruler_storage:
+      s3:
+        access_key_id: "${MINIO_ACCESS_KEY_ID}"
+        secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+
 enterprise:
   enabled: true
 
@@ -25,3 +52,8 @@ ingester:
 store_gateway:
   persistentVolume:
     enabled: false
+
+# For testing only
+testing:
+  minio:
+    use_secret: true

--- a/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
@@ -4,6 +4,28 @@ kubeVersionOverride: "1.20"
 # TODO remove when it is the default
 configStorageType: ConfigMap
 
+global:
+  extraEnvFrom:
+    - secretRef:
+        name: mimir-minio-secret
+  podAnnotations:
+    minio-secret-version: '42'
+
+mimir:
+  structuredConfig:
+    alertmanager_storage:
+      s3:
+        access_key_id: "${MINIO_ACCESS_KEY_ID}"
+        secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+    blocks_storage:
+      s3:
+        access_key_id: "${MINIO_ACCESS_KEY_ID}"
+        secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+    ruler_storage:
+      s3:
+        access_key_id: "${MINIO_ACCESS_KEY_ID}"
+        secret_access_key: "${MINIO_SECRET_ACCESS_KEY}"
+
 alertmanager:
   persistentVolume:
     enabled: false
@@ -22,3 +44,8 @@ ingester:
 store_gateway:
   persistentVolume:
     enabled: false
+
+# For testing only
+testing:
+  minio:
+    use_secret: true

--- a/operations/helm/charts/mimir-distributed/templates/minio-secrets.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/minio-secrets.yaml
@@ -1,0 +1,12 @@
+{{- if ((.Values.testing).minio).use_secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mimir-minio-secret
+  labels:
+    {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
+type: Opaque
+data:
+  MINIO_ACCESS_KEY_ID: {{ .Values.minio.accessKey | b64enc }}
+  MINIO_SECRET_ACCESS_KEY: {{ .Values.minio.secretKey | b64enc }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -39,7 +39,7 @@ global:
   # For example to inject values from a Secret, use:
   # extraEnvFrom:
   #   - secretRef:
-  #      name: mysecret
+  #       name: mysecret
   extraEnvFrom: []
 
   # -- Pod annotations for all pods directly managed by this chart. Usable for example to associate a version to 'global.extraEnv' and 'global.extraEnvFrom' and trigger a restart of the affected services.

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: admin-api
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -83,6 +84,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -107,3 +108,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -113,3 +114,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -84,6 +85,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: gateway
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -76,6 +77,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -104,3 +105,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -23,11 +23,11 @@ data:
     admin_client:
       storage:
         s3:
-          access_key_id: grafana-mimir
+          access_key_id: ${MINIO_ACCESS_KEY_ID}
           bucket_name: enterprise-metrics-admin
           endpoint: test-enterprise-configmap-values-minio.citestns.svc:9000
           insecure: true
-          secret_access_key: supersecret
+          secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
         type: s3
     alertmanager:
       data_dir: /data
@@ -36,11 +36,11 @@ data:
     alertmanager_storage:
       backend: s3
       s3:
-        access_key_id: grafana-mimir
+        access_key_id: ${MINIO_ACCESS_KEY_ID}
         bucket_name: mimir-ruler
         endpoint: test-enterprise-configmap-values-minio.citestns.svc:9000
         insecure: true
-        secret_access_key: supersecret
+        secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
     auth:
       type: enterprise
     blocks_storage:
@@ -48,11 +48,11 @@ data:
       bucket_store:
         sync_dir: /data/tsdb-sync
       s3:
-        access_key_id: grafana-mimir
+        access_key_id: ${MINIO_ACCESS_KEY_ID}
         bucket_name: mimir-tsdb
         endpoint: test-enterprise-configmap-values-minio.citestns.svc:9000
         insecure: true
-        secret_access_key: supersecret
+        secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
       tsdb:
         dir: /data/tsdb
     cluster_name: test-enterprise-configmap-values
@@ -112,11 +112,11 @@ data:
     ruler_storage:
       backend: s3
       s3:
-        access_key_id: grafana-mimir
+        access_key_id: ${MINIO_ACCESS_KEY_ID}
         bucket_name: mimir-ruler
         endpoint: test-enterprise-configmap-values-minio.citestns.svc:9000
         insecure: true
-        secret_access_key: supersecret
+        secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
     runtime_config:
       file: /var/mimir/runtime.yaml
     server:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/minio-secrets.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/minio-secrets.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/minio-secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mimir-minio-secret
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-configmap-values
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  MINIO_ACCESS_KEY_ID: Z3JhZmFuYS1taW1pcg==
+  MINIO_SECRET_ACCESS_KEY: c3VwZXJzZWNyZXQ=

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: overrides-exporter
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -82,6 +83,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -84,6 +85,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -78,6 +79,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -84,6 +85,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir
       securityContext:
@@ -111,3 +112,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -46,6 +46,8 @@ spec:
               mountPath: /license
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       restartPolicy: OnFailure
       volumes:
         - name: config

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -102,3 +103,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -108,3 +109,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -82,6 +83,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -99,3 +100,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -21,21 +21,21 @@ data:
     alertmanager_storage:
       backend: s3
       s3:
-        access_key_id: grafana-mimir
+        access_key_id: ${MINIO_ACCESS_KEY_ID}
         bucket_name: mimir-ruler
         endpoint: test-oss-values-minio.citestns.svc:9000
         insecure: true
-        secret_access_key: supersecret
+        secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
     blocks_storage:
       backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       s3:
-        access_key_id: grafana-mimir
+        access_key_id: ${MINIO_ACCESS_KEY_ID}
         bucket_name: mimir-tsdb
         endpoint: test-oss-values-minio.citestns.svc:9000
         insecure: true
-        secret_access_key: supersecret
+        secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
       tsdb:
         dir: /data/tsdb
     compactor:
@@ -68,11 +68,11 @@ data:
     ruler_storage:
       backend: s3
       s3:
-        access_key_id: grafana-mimir
+        access_key_id: ${MINIO_ACCESS_KEY_ID}
         bucket_name: mimir-ruler
         endpoint: test-oss-values-minio.citestns.svc:9000
         insecure: true
-        secret_access_key: supersecret
+        secret_access_key: ${MINIO_SECRET_ACCESS_KEY}
     runtime_config:
       file: /var/mimir/runtime.yaml
     server:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/minio-secrets.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/minio-secrets.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/minio-secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mimir-minio-secret
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-values
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  MINIO_ACCESS_KEY_ID: Z3JhZmFuYS1taW1pcg==
+  MINIO_SECRET_ACCESS_KEY: c3VwZXJzZWNyZXQ=

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        minio-secret-version: "42"
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
@@ -48,6 +49,8 @@ spec:
               protocol: TCP
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
           readinessProbe:
             httpGet:
               path: /

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: overrides-exporter
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -80,6 +81,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -82,6 +83,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -76,6 +77,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -35,6 +35,7 @@ spec:
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -82,6 +83,8 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret
       nodeSelector:
         {}
       affinity:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
+        minio-secret-version: "42"
     spec:
       serviceAccountName: test-oss-values-mimir
       securityContext:
@@ -106,3 +107,5 @@ spec:
             readOnlyRootFilesystem: true
           env:
           envFrom:
+            - secretRef:
+                name: mimir-minio-secret


### PR DESCRIPTION
#### What this PR does

Test that mimir.structuredConfig can be used to alter parts of the
application configuration.
Test that environment injection works from a secret.
Test that environment expansion works in Mimir/GEM.
Test that global POD annotations work.

#### Which issue(s) this PR fixes or relates to

Relates to:
#2017 
#2031 
#2099 
#2100 

#### Checklist

- [x] Tests updated
- [N/A] Documentation added - it is input for https://github.com/grafana/mimir/issues/1945
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
