### PR TITLE
Fixed Mimir Alertmanager datasource in Grafana used by "Play with Grafana Mimir" tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [ENHANCEMENT] Explain the runtime override of active series matchers. #1868
 * [ENHANCEMENT] Clarify "Set rule group" API specification. #1869
 * [BUGFIX] Fixed ruler configuration used in the getting started guide. #2052
+* [BUGFIX] Fixed Mimir Alertmanager datasource in Grafana used by "Play with Grafana Mimir" tutorial. #2115
 
 ## 2.1.0
 ### Grafana Mimir

--- a/docs/sources/tutorials/play-with-grafana-mimir/config/grafana-provisioning-datasources.yaml
+++ b/docs/sources/tutorials/play-with-grafana-mimir/config/grafana-provisioning-datasources.yaml
@@ -10,8 +10,20 @@ datasources:
     editable: true
     jsonData:
       httpHeaderName1: 'X-Scope-OrgID'
+      alertmanagerUid: 'alertmanager'
     secureJsonData:
       httpHeaderValue1: 'demo'
-    # Since there's only 1 datasource configured it will be the default anyway,
-    # but setting this to false hides the datasource named "default".
-    isDefault: false
+    isDefault: true
+  - name: Mimir Alertmanager
+    uid: alertmanager
+    type: alertmanager
+    access: proxy
+    orgId: 1
+    url: http://load-balancer:9009/
+    version: 1
+    editable: true
+    jsonData:
+      httpHeaderName1: 'X-Scope-OrgID'
+      implementation: 'cortex'
+    secureJsonData:
+      httpHeaderValue1: 'demo'

--- a/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
+++ b/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   grafana:
     image: grafana/grafana:latest
+    pull_policy: always
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin


### PR DESCRIPTION
#### What this PR does
While checking https://github.com/grafana/mimir/discussions/1931, I've realised the Grafana Alerting UI doesn't work in the "Play with Grafana Mimir" tutorial, due to some changes done by Grafana in the meanwhile. This PR fixes it (I manually tested it).

Changes:
1. Always pull Grafana latest (so `9.0.0` as of today)
2. Add "Alertmanager" datasource and link it to "Prometheus" one

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
