### PR TITLE
cleanup of partial blocks

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -56,17 +56,18 @@ type BlocksCleaner struct {
 	lastOwnedUsers []string
 
 	// Metrics.
-	runsStarted                 prometheus.Counter
-	runsCompleted               prometheus.Counter
-	runsFailed                  prometheus.Counter
-	runsLastSuccess             prometheus.Gauge
-	blocksCleanedTotal          prometheus.Counter
-	blocksFailedTotal           prometheus.Counter
-	blocksMarkedForDeletion     prometheus.Counter
-	tenantBlocks                *prometheus.GaugeVec
-	tenantMarkedBlocks          *prometheus.GaugeVec
-	tenantPartialBlocks         *prometheus.GaugeVec
-	tenantBucketIndexLastUpdate *prometheus.GaugeVec
+	runsStarted                    prometheus.Counter
+	runsCompleted                  prometheus.Counter
+	runsFailed                     prometheus.Counter
+	runsLastSuccess                prometheus.Gauge
+	blocksCleanedTotal             prometheus.Counter
+	blocksFailedTotal              prometheus.Counter
+	blocksMarkedForDeletion        prometheus.Counter
+	partialBlocksMarkedForDeletion prometheus.Counter
+	tenantBlocks                   *prometheus.GaugeVec
+	tenantMarkedBlocks             *prometheus.GaugeVec
+	tenantPartialBlocks            *prometheus.GaugeVec
+	tenantBucketIndexLastUpdate    *prometheus.GaugeVec
 }
 
 func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, ownUser func(userID string) (bool, error), cfgProvider ConfigProvider, logger log.Logger, reg prometheus.Registerer) *BlocksCleaner {
@@ -105,6 +106,10 @@ func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, own
 			Name:        blocksMarkedForDeletionName,
 			Help:        blocksMarkedForDeletionHelp,
 			ConstLabels: prometheus.Labels{"reason": "retention"},
+		}),
+		partialBlocksMarkedForDeletion: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_compactor_partial_blocks_marked_for_deletion_total",
+			Help: "Total number of partial blocks marked for deletion in compactor.",
 		}),
 
 		// The following metrics don't have the "cortex_compactor" prefix because not strictly related to
@@ -349,7 +354,12 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) (returnErr
 	// Partial blocks with a deletion mark can be cleaned up. This is a best effort, so we don't return
 	// error if the cleanup of partial blocks fail.
 	if len(partials) > 0 {
-		c.cleanUserPartialBlocks(ctx, partials, idx, userBucket, userLogger)
+		delay := c.cfgProvider.CompactorPartialBlockDeletionDelay(userID)
+		var partialDeletionCutoffTime time.Time
+		if delay > 0 {
+			partialDeletionCutoffTime = time.Now().Add(-delay)
+		}
+		c.cleanUserPartialBlocks(ctx, partials, idx, partialDeletionCutoffTime, userBucket, userLogger)
 	}
 
 	// Upload the updated index to the storage.
@@ -400,9 +410,8 @@ func (c *BlocksCleaner) deleteBlocksMarkedForDeletion(ctx context.Context, idx *
 	})
 }
 
-// cleanUserPartialBlocks delete partial blocks which are safe to be deleted. The provided partials map
-// and index are updated accordingly.
-func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map[ulid.ULID]error, idx *bucketindex.Index, userBucket objstore.InstrumentedBucket, userLogger log.Logger) {
+// cleanUserPartialBlocks deletes partial blocks which are safe to be deleted. The provided index is updated accordingly.
+func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map[ulid.ULID]error, idx *bucketindex.Index, partialDeletionCutoffTime time.Time, userBucket objstore.InstrumentedBucket, userLogger log.Logger) {
 	// Collect all blocks with missing meta.json into buffered channel.
 	blocks := make([]ulid.ULID, 0, len(partials))
 
@@ -411,11 +420,11 @@ func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map
 		if !errors.Is(blockErr, bucketindex.ErrBlockMetaNotFound) {
 			continue
 		}
-
 		blocks = append(blocks, blockID)
 	}
 
 	var mu sync.Mutex
+	var partialsToMark []ulid.ULID
 
 	// We don't want to return errors from our function, as that would stop ForEach loop early.
 	_ = concurrency.ForEachJob(ctx, len(blocks), c.cfg.DeleteBlocksConcurrency, func(ctx context.Context, jobIdx int) error {
@@ -424,6 +433,9 @@ func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map
 		// We can safely delete only partial blocks with a deletion mark.
 		err := metadata.ReadMarker(ctx, userLogger, userBucket, blockID.String(), &metadata.DeletionMark{})
 		if errors.Is(err, metadata.ErrorMarkerNotFound) {
+			mu.Lock()
+			partialsToMark = append(partialsToMark, blockID)
+			mu.Unlock()
 			return nil
 		}
 		if err != nil {
@@ -449,6 +461,24 @@ func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map
 		level.Info(userLogger).Log("msg", "deleted partial block marked for deletion", "block", blockID)
 		return nil
 	})
+
+	// Check if partial block is older than delay period, and mark for deletion
+	for _, blockID := range partialsToMark {
+		if !partialDeletionCutoffTime.IsZero() {
+			lastModified, err := findLastModifiedTimeForBlock(ctx, blockID, userBucket, userLogger)
+			if err != nil {
+				level.Warn(userLogger).Log("msg", "failed to find last modified time for partial block", "block", blockID)
+			}
+			if !lastModified.IsZero() && lastModified.Before(partialDeletionCutoffTime) {
+				level.Info(userLogger).Log("msg", "stale partial block found: marking block for deletion", "block", blockID, "last modified", lastModified)
+				if err := block.MarkForDeletion(ctx, userLogger, userBucket, blockID, "stale partial block", c.blocksMarkedForDeletion); err != nil {
+					level.Warn(userLogger).Log("msg", "failed to mark partial block for deletion", "block", blockID, "err", err)
+				} else {
+					c.partialBlocksMarkedForDeletion.Inc()
+				}
+			}
+		}
+	}
 }
 
 // applyUserRetentionPeriod marks blocks for deletion which have aged past the retention period.
@@ -492,4 +522,22 @@ func listBlocksOutsideRetentionPeriod(idx *bucketindex.Index, threshold time.Tim
 	}
 
 	return
+}
+
+// findLastModifiedTimeForBlock finds the most recent modification time for all files in a block
+func findLastModifiedTimeForBlock(ctx context.Context, blockID ulid.ULID, userBucket objstore.InstrumentedBucket, userLogger log.Logger) (time.Time, error) {
+	var modifiedTime time.Time
+	blockName := blockID.String()
+	err := userBucket.Iter(ctx, blockName, func(name string) error {
+		attrib, err := userBucket.Attributes(ctx, name)
+		if err != nil {
+			level.Warn(userLogger).Log("msg", "couldn't get attribute for file in block", "block", blockName, "file", name)
+		} else {
+			if attrib.LastModified.After(modifiedTime) {
+				modifiedTime = attrib.LastModified
+			}
+		}
+		return nil
+	})
+	return modifiedTime, err
 }

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -192,6 +192,9 @@ type ConfigProvider interface {
 
 	// CompactorTenantShardSize returns number of compactors that this user can use. 0 = all compactors.
 	CompactorTenantShardSize(userID string) int
+
+	// CompactorPartialBlockDeletionDelay returns the delay time period for a given user.
+	CompactorPartialBlockDeletionDelay(userID string) time.Duration
 }
 
 // MultitenantCompactor is a multi-tenant TSDB blocks compactor based on Thanos.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -123,10 +123,11 @@ type Limits struct {
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
 
 	// Compactor.
-	CompactorBlocksRetentionPeriod model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
-	CompactorSplitAndMergeShards   int            `yaml:"compactor_split_and_merge_shards" json:"compactor_split_and_merge_shards"`
-	CompactorSplitGroups           int            `yaml:"compactor_split_groups" json:"compactor_split_groups"`
-	CompactorTenantShardSize       int            `yaml:"compactor_tenant_shard_size" json:"compactor_tenant_shard_size"`
+	CompactorBlocksRetentionPeriod     model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
+	CompactorSplitAndMergeShards       int            `yaml:"compactor_split_and_merge_shards" json:"compactor_split_and_merge_shards"`
+	CompactorSplitGroups               int            `yaml:"compactor_split_groups" json:"compactor_split_groups"`
+	CompactorTenantShardSize           int            `yaml:"compactor_tenant_shard_size" json:"compactor_tenant_shard_size"`
+	CompactorPartialBlockDeletionDelay model.Duration `yaml:"compactor_partial_block_deletion_delay" json:"compactor_partial_block_deletion_delay"`
 
 	// This config doesn't have a CLI flag registered here because they're registered in
 	// their own original config struct.
@@ -204,6 +205,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.CompactorSplitAndMergeShards, "compactor.split-and-merge-shards", 0, "The number of shards to use when splitting blocks. 0 to disable splitting.")
 	f.IntVar(&l.CompactorSplitGroups, "compactor.split-groups", 1, "Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards.")
 	f.IntVar(&l.CompactorTenantShardSize, "compactor.compactor-tenant-shard-size", 0, "Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.")
+	f.Var(&l.CompactorPartialBlockDeletionDelay, "compactor.partial-block-deletion-delay", "Mark partial blocks for deletion after delay. 0 to disable.")
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.")
@@ -527,6 +529,11 @@ func (o *Overrides) CompactorSplitAndMergeShards(userID string) int {
 // CompactorSplitGroupsCount returns the number of groups that blocks for splitting should be grouped into.
 func (o *Overrides) CompactorSplitGroups(userID string) int {
 	return o.getOverridesForUser(userID).CompactorSplitGroups
+}
+
+// CompactorPartialBlockDeletionDelay returns the delay time period for a given user.
+func (o *Overrides) CompactorPartialBlockDeletionDelay(userID string) time.Duration {
+	return time.Duration(o.getOverridesForUser(userID).CompactorPartialBlockDeletionDelay)
 }
 
 // MetricRelabelConfigs returns the metric relabel configs for a given user.


### PR DESCRIPTION
#### What this PR does
This PR adds functionality to automatically delete partial blocks on a per tenant basis based on a configurable delay period. It also adds a metric to track the number of partial blocks that have been marked for deletion.

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
