### PR TITLE
Pass NewChunkDiskMapper option to TSDB in `out-of-order` branch.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1490,6 +1490,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		EnableMemorySnapshotOnShutdown: i.cfg.BlocksStorageConfig.TSDB.MemorySnapshotOnShutdown,
 		IsolationDisabled:              !i.cfg.BlocksStorageConfig.TSDB.IsolationEnabled,
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
+		NewChunkDiskMapper:             i.cfg.BlocksStorageConfig.TSDB.NewChunkDiskMapper,
 		AllowOverlappingQueries:        i.cfg.BlocksStorageConfig.TSDB.OOOAllowance > 0, // always true if out of order support is enabled
 		AllowOverlappingCompaction:     false,                                           // always false since Mimir only uploads lvl 1 compacted blocks
 		OOOAllowance:                   int64(i.cfg.BlocksStorageConfig.TSDB.OOOAllowance / time.Millisecond),


### PR DESCRIPTION
This PR adds back passing of `NewChunkDiskMapper` to TSDB options in `out-of-order` branch, where it was [accidentally removed](https://github.com/grafana/mimir/commit/0d42afbff1a067cbc448385601ef8afab05c86f2#diff-e1032332627c413a3010c66b54b22b6e9835cf152fa339e40cf0b11204f7241f).