### PR TITLE
K6 script: default HA clusters to 1

### DIFF
--- a/operations/k6/README.md
+++ b/operations/k6/README.md
@@ -36,7 +36,7 @@ The [load-testing-with-k6.js] script can be configured using the following envir
 | `K6_RAMP_DOWN_MIN`            |          | 0             | Duration of the ramp down period in minutes.                                          |
 | `K6_SCRAPE_INTERVAL_SECONDS`  |          | 20            | Simulated Prometheus scrape interval in seconds.                                      |
 | `K6_HA_REPLICAS`              |          | 1             | Number of HA replicas to simulate (use 1 for no HA).                                  |
-| `K6_HA_CLUSTERS`              |          | 100           | Number of HA clusters to simulate.                                                    |
+| `K6_HA_CLUSTERS`              |          | 1             | Number of HA clusters to simulate.                                                    |
 
 For example, if Mimir is running on `localhost:80` you can run a small scale test with this command:
 

--- a/operations/k6/load-testing-with-k6.js
+++ b/operations/k6/load-testing-with-k6.js
@@ -88,7 +88,7 @@ const HA_REPLICAS = parseInt(__ENV.K6_HA_REPLICAS || 1);
  * Number of HA clusters to simulate.
  * @constant {number}
  */
-const HA_CLUSTERS = parseInt(__ENV.K6_HA_CLUSTERS || 100);
+const HA_CLUSTERS = parseInt(__ENV.K6_HA_CLUSTERS || 1);
 
 const remote_write_url = get_remote_write_url();
 console.debug("Remote write URL:", remote_write_url)


### PR DESCRIPTION
#### What this PR does
I'm using the K6 script to load test a Mimir cluster and I've noticed the default `HA_CLUSTER=100` caused 100x series to be generated than I would have expected. I suggest to change the default to 1.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
