### PR TITLE
Docs: Update mixin building instructions

### DIFF
--- a/docs/sources/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts.md
@@ -37,24 +37,13 @@ If you choose this option, you can change the configuration to match your deploy
    git clone https://github.com/grafana/mimir.git
    ```
 2. Review the mixin configuration at `operations/mimir-mixin/config.libsonnet`, and apply your changes if necessary.
-3. Install dependencies:
-   ```bash
-   go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
-   go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
-   ```
-4. Compile the mixin
+3. Compile the mixin
    ```bash
    make build-mixin
    ```
-5. Import the dashboards saved at `operations/mimir-mixin-compiled/dashboards/` in [Grafana](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard)
-6. Install the recording rules saved at `operations/mimir-mixin-compiled/rules.yaml` in your Prometheus
-7. Install the alerts saved at `operations/mimir-mixin-compiled/alerts.yaml` in your Prometheus
-
-Alternatively, you can compile the mixin in a container. To do so, replace steps 3 & 4 with the following command:
-
-```bash
-make BUILD_IN_CONTAINER=true build-mixin
-```
+4. Import the dashboards saved at `operations/mimir-mixin-compiled/dashboards/` in [Grafana](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard)
+5. Install the recording rules saved at `operations/mimir-mixin-compiled/rules.yaml` in your Prometheus
+6. Install the alerts saved at `operations/mimir-mixin-compiled/alerts.yaml` in your Prometheus
 
 ## Install dashboards from Jsonnet mixin
 

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts.md
@@ -50,7 +50,7 @@ If you choose this option, you can change the configuration to match your deploy
 6. Install the recording rules saved at `operations/mimir-mixin-compiled/rules.yaml` in your Prometheus
 7. Install the alerts saved at `operations/mimir-mixin-compiled/alerts.yaml` in your Prometheus
 
-Alternatively, you can compile the mixin in a container. To do so, replace the previous two steps with the following command:
+Alternatively, you can compile the mixin in a container. To do so, replace steps 3 & 4 with the following command:
 
 ```bash
 make BUILD_IN_CONTAINER=true build-mixin


### PR DESCRIPTION
BUILD_IN_CONTAINER is used by default
No need to have separate instructions on how to build mixin's in a
container as it is the default method. Also therefore remove the
unnecessary dependencies.