### PR TITLE
Mixin: Change `MimirRulerTooManyFailedQueries` alert to `critical`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [CHANGE] Dashboards: Expose full image tag in "Mimir / Rollout progress" dashboard's "Pod per version panel." #1932
 * [CHANGE] Dashboards: Disabled gateway panels by default, because most users don't have a gateway exposing the metrics expected by Mimir dashboards. You can re-enable it setting `gateway_enabled: true` in the mixin config and recompiling the mixin running `make build-mixin`. #1954
 * [CHANGE] Alerts: adapt `MimirFrontendQueriesStuck` and `MimirSchedulerQueriesStuck` to consider ruler query path components. #1949
+* [CHANGE] Alerts: Change `MimirRulerTooManyFailedQueries` severity to `critical`. #2165
 * [ENHANCEMENT] Dashboards: Add config option `datasource_regex` to customise the regular expression used to select valid datasources for Mimir dashboards. #1802
 * [ENHANCEMENT] Dashboards: Added "Mimir / Remote ruler reads" and "Mimir / Remote ruler reads resources" dashboards. #1911 #1937
 * [ENHANCEMENT] Dashboards: Make networking panels work for pods created by the mimir-distributed helm chart. #1927

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -321,7 +321,7 @@ groups:
       ) > 1
     for: 5m
     labels:
-      severity: warning
+      severity: critical
   - alert: MimirRulerMissedEvaluations
     annotations:
       message: |

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -520,7 +520,7 @@
           ||| % $._config,
           'for': '5m',
           labels: {
-            severity: 'warning',
+            severity: 'critical',
           },
           annotations: {
             message: |||


### PR DESCRIPTION
#### What this PR does

Changes the `MimirRulerTooManyFailedQueries` alert severity to `critical`.

Currently there is no critical alert coverage for issues which occur on the ruler read path (regardless of operational mode). When using "Remote" operational mode, there are more services which could cause rule queries to fail. However, there are valid reasons they may fail when running in "Internal" mode too which should be investigated (e.g. cannot contact ingesters, store-gateways, ...).

Note that in both operational modes, the `cortex_ruler_queries_failed_total` does not get incremented for queries which fail for reasons due to user actions (hitting query limits, many-to-many joins, etc.), so the expectation is that this only fires for critical issues which need investigation.

#### Checklist

- n/a Tests updated
- n/a Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
