### PR TITLE
Update out-of-order branch with mimir-prom/main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -227,10 +227,11 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110
 replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220622100834-e4aa706fc7ab
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220622114521-df59320886e0
 
-// OOO Support forces us to fork thanos because we've changed the ChunkReader interface
-replace github.com/thanos-io/thanos => github.com/jesusvazquez/thanos v0.19.1-0.20220610094531-ab07eb568317
+// Out of order Support forces us to fork thanos because we've changed the ChunkReader interface.
+// Once the out of order support is upstreamed and Thanos has vendored it, we can remove this override.
+replace github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -744,10 +744,12 @@ github.com/grafana/e2e v0.1.1-0.20220519104354-1db01e4751fe h1:mxrRWDjKtob43xF9n
 github.com/grafana/e2e v0.1.1-0.20220519104354-1db01e4751fe/go.mod h1:+26VJWpczg2OU3D0537acnHSHzhJORpxOs6F+M27tZo=
 github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167 h1:PgEQkGHR4YimSCEGT5IoswN9gJKZDVskf+he6UClCLw=
 github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20220622100834-e4aa706fc7ab h1:yT8wpVAqODpotSw6OIWlnIOAeXJbtRvO8VoMnhe97LM=
-github.com/grafana/mimir-prometheus v0.0.0-20220622100834-e4aa706fc7ab/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
+github.com/grafana/mimir-prometheus v0.0.0-20220622114521-df59320886e0 h1:TXqXoFZweHWWTEX26PZY0RfqivxObBz5nOPU2WcnLvc=
+github.com/grafana/mimir-prometheus v0.0.0-20220622114521-df59320886e0/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317 h1:DG++oZD7E6YUm8YNZOu7RwZ8J/Slhcx3iOlKQBY6Oh0=
+github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317/go.mod h1:9e/ytDfVepSKxihUWXyy1irj+ipM/DAlOBqsyXs+Y10=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
@@ -841,8 +843,6 @@ github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGk
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jesusvazquez/thanos v0.19.1-0.20220610094531-ab07eb568317 h1:hvM2NqbuhELZHcEti7+yCdY1DPXgneBf8mcmHyPoxyA=
-github.com/jesusvazquez/thanos v0.19.1-0.20220610094531-ab07eb568317/go.mod h1:9e/ytDfVepSKxihUWXyy1irj+ipM/DAlOBqsyXs+Y10=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -1972,12 +1972,15 @@ func (noopSeriesLifecycleCallback) PostCreation(labels.Labels)      {}
 func (noopSeriesLifecycleCallback) PostDeletion(...labels.Labels)   {}
 
 func (h *Head) Size() int64 {
-	var walSize int64
+	var walSize, wblSize int64
 	if h.wal != nil {
 		walSize, _ = h.wal.Size()
 	}
+	if h.wbl != nil {
+		wblSize, _ = h.wbl.Size()
+	}
 	cdmSize, _ := h.chunkDiskMapper.Size()
-	return walSize + cdmSize
+	return walSize + wblSize + cdmSize
 }
 
 func (h *RangeHead) Size() int64 {

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
@@ -541,7 +541,6 @@ func (o mergedOOOChunks) NumSamples() int {
 	return samples
 }
 
-// Compact TODO(jesus.vazquez) Clarify why this method wont be called
 func (o mergedOOOChunks) Compact() {}
 
 var _ chunkenc.Chunk = &boundedChunk{}

--- a/vendor/github.com/prometheus/prometheus/tsdb/index/postings.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/index/postings.go
@@ -49,12 +49,8 @@ var ensureOrderBatchPool = sync.Pool{
 // EnsureOrder() must be called once before any reads are done. This allows for quick
 // unordered batch fills on startup.
 type MemPostings struct {
-	mtx sync.RWMutex
-	m   map[string]map[string][]storage.SeriesRef
-	// TODO We should have a mapping of which series have out of order metrics
-	// and we figured one way to do it is by keeping a map where the keys are
-	// the series ref, that way we can do efficient lookups.
-	// oooMap map[storage.SeriesRef]struct{}
+	mtx     sync.RWMutex
+	m       map[string]map[string][]storage.SeriesRef
 	ordered bool
 }
 
@@ -219,8 +215,6 @@ func (p *MemPostings) Get(name, value string) Postings {
 	}
 	return newListPostings(lp...)
 }
-
-// TODO GetOOOPostings( returns newOOOListPostings )
 
 // All returns a postings list over all documents ever added.
 func (p *MemPostings) All() Postings {

--- a/vendor/github.com/prometheus/prometheus/tsdb/ooo_head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/ooo_head.go
@@ -53,11 +53,9 @@ func (oh *OOORangeHead) Meta() BlockMeta {
 	}
 }
 
-// Size returns 0 because the space taken by the out of order samples is taken
-// into account by the RangeHead size.
+// Size returns the size taken by the Head block.
 func (oh *OOORangeHead) Size() int64 {
-	// TODO(jesus.vazquez) Find what's the appropriate value here
-	return 0
+	return oh.head.Size()
 }
 
 // String returns an human readable representation of the out of order range

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -717,7 +717,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519 => github.com/grafana/mimir-prometheus v0.0.0-20220622100834-e4aa706fc7ab
+# github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519 => github.com/grafana/mimir-prometheus v0.0.0-20220622114521-df59320886e0
 ## explicit; go 1.17
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -807,7 +807,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.26.1-0.20220602051129-a6f6ce060ed4 => github.com/jesusvazquez/thanos v0.19.1-0.20220610094531-ab07eb568317
+# github.com/thanos-io/thanos v0.26.1-0.20220602051129-a6f6ce060ed4 => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
 ## explicit; go 1.17
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/metadata
@@ -1227,8 +1227,8 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220622100834-e4aa706fc7ab
-# github.com/thanos-io/thanos => github.com/jesusvazquez/thanos v0.19.1-0.20220610094531-ab07eb568317
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220622114521-df59320886e0
+# github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167


### PR DESCRIPTION
#### What this PR does

This is going into out-of-order branch.

This PR now updates out-of-order branch to use the main branch of mimir-prometheus. It also updates the thanos dependency to use grafana/thanos. I will merge this on green.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
