### PR TITLE
Helm: add NOTES.txt

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/NOTES.txt
+++ b/operations/helm/charts/mimir-distributed/templates/NOTES.txt
@@ -1,0 +1,33 @@
+{{- $gateway := .Values.nginx }}
+{{- if .Values.enterprise.enabled }}
+{{- $gateway = .Values.gateway }}
+Welcome to Grafana Enterprise Metrics!
+{{- else }}
+Welcome to Grafana Mimir!
+{{- end }}
+
+Remote write endpoints for Prometheus or Grafana Agent:
+{{ with $gateway.ingress -}}
+{{- if .enabled -}}
+From outside the cluster via ingress:
+{{ range .hosts }}  http{{ if .tls }}s{{ end }}://{{ .host }}/api/v1/push
+{{ end }}
+{{- else -}}
+Ingress is not enabled, see {{ if $.Values.enterprise.enabled }}gateway.ingress{{ else }}nginx.ingress{{ end }} values.
+{{- end -}}
+{{- end }}
+From inside the cluster:
+  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port | default "80" }}/api/v1/push
+
+Read address, Grafana data source (Prometheus) URL:
+{{ with $gateway.ingress -}}
+{{- if .enabled -}}
+From outside the cluster via ingress:
+{{ range .hosts }}  http{{ if .tls }}s{{ end }}://{{ .host }}/prometheus
+{{ end }}
+{{- else -}}
+Ingress is not enabled, see {{ if $.Values.enterprise.enabled }}gateway.ingress{{ else }}nginx.ingress{{ end }} values.
+{{- end -}}
+{{- end }}
+From inside the cluster:
+  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port | default "80" }}/prometheus


### PR DESCRIPTION
#### What this PR does

Add a NOTES.txt that prints the endpoints that will be usable by the user
for interacting with mimir/gem.

Currently helm does not support rendering the NOTES for testing.
Rage/vote here: https://github.com/helm/helm/issues/6901

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [N/A] Tests updated - not possible at the moment
- [N/A] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
