### PR TITLE
Helm: Add extraContainers to nginx deployments and override to resolve for nginxConfig

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,6 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Check for the containerSecurityContext in values file. #2112
 * [ENHANCEMENT] Add `NOTES.txt` to show endpoints URLs for the user at install/upgrade. #2189
 * [ENHANCEMENT] Add ServiceMonitor for overrides-exporter. #2068
+* [ENHANCEMENT] Add `nginx.resolver` for allow custom resolver in nginx configuration and `nginx.extraContainers` which allow add side containers to the nginx deployment #2196
 
 ## 2.1.0-beta.7
 

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -90,6 +90,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.nginx.resources | nindent 12 }}
+        {{- if .Values.nginx.extraContainers }}
+        {{- toYaml .Values.nginx.extraContainers | nindent 8}}
+        {{- end }}
       {{- with .Values.nginx.affinity }}
       affinity:
         {{- tpl . $ | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1533,7 +1533,12 @@ nginx:
 
         sendfile     on;
         tcp_nopush   on;
+
+        {{- if .Values.nginx.nginxConfig.resolver }}
+        resolver {{ .Values.nginx.nginxConfig.resolver }};
+        {{- else }}
         resolver {{ .Values.global.dnsService }}.{{ .Values.global.dnsNamespace }}.svc.{{ .Values.global.clusterDomain }};
+        {{- end }}
 
         {{- with .Values.nginx.nginxConfig.httpSnippet }}
         {{ . | nindent 2 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1488,6 +1488,19 @@ nginx:
       port: http-metric
     initialDelaySeconds: 15
     timeoutSeconds: 1
+
+  # -- Additional containers to be added to the nginx pod.
+  extraContainers: []
+  # - name: dnsmasq
+  #   image: "janeczku/go-dnsmasq:release-1.0.7"
+  #   imagePullPolicy: IfNotPresent
+  #   args:
+  #     - --listen
+  #     - "127.0.0.1:8053"
+  #     - --hostsfile=/etc/hosts
+  #     - --enable-search
+  #     - --verbose
+
   nginxConfig:
     # -- NGINX log format
     logFormat: |-
@@ -1498,6 +1511,8 @@ nginx:
     serverSnippet: ""
     # -- Allows appending custom configuration to the http block
     httpSnippet: ""
+    # -- Allows to set a custom resolver
+    resolver: null
     # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
     # @default -- See values.yaml
     file: |


### PR DESCRIPTION
The goal is provides a path for working around issues with nginx's DNS resolution that occur when the kube-dns pods are restarted in certain clusters (any cluster using conntrack for keeping state on UDP flows, typically).
Adding a local resolver as side container to the nginx can be used to workaround it.

* Add `extraContainers` feature for nginx so you can add sidecar containers to the deployment
* Add a new variable `nginx.nginxConfig.resolver` to the nginx component of the chart

This allows overriding the DNS resolver used by nginx. This is necessary to work around issues with UDP services that occur when kube-dns pods are restarted. This was happening also in other charts like loki. More details: https://github.com/grafana/helm-charts/issues/1058

With these features a workaround can be deployed with the following nignx config:
```yaml
mimir-distributed:
  nginx:
    extraContainers:
      - name: dnsmasq
        image: "janeczku/go-dnsmasq:release-1.0.7"
        imagePullPolicy: IfNotPresent
        args:
          - --listen
          - "127.0.0.1:8053"
          - --hostsfile=/etc/hosts
          - --enable-search
          - --verbose

    nginxConfig:
      resolver: "127.0.0.1:8053"
```