### PR TITLE
Mixin: Make each `MimirCompactorHasNotUploadedBlocks` alert distinct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [BUGFIX] Do not trigger `MimirAllocatingTooMuchMemory` alerts if no container limits are supplied. #1905
 * [BUGFIX] Dashboards: Remove empty "Chunks per query" panel from `Mimir / Queries` dashboard. #1928
 * [BUGFIX] Dashboards: Use Grafana's `$__rate_interval` for rate queries in dashboards to support scrape intervals of >15s. #2011
+* [BUGFIX] Alerts: Make each version of `MimirCompactorHasNotUploadedBlocks` distinct to avoid rule evaluation failures due to duplicate series being generated. #2197
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -665,7 +665,7 @@ groups:
       cortex_compactor_last_successful_run_timestamp_seconds == 0
     for: 24h
     labels:
-      reason: in-since-startup
+      reason: since-startup
       severity: critical
   - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -655,6 +655,7 @@ groups:
       (cortex_compactor_last_successful_run_timestamp_seconds > 0)
     for: 1h
     labels:
+      reason: in-last-24h
       severity: critical
   - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
@@ -664,6 +665,7 @@ groups:
       cortex_compactor_last_successful_run_timestamp_seconds == 0
     for: 24h
     labels:
+      reason: in-since-startup
       severity: critical
   - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
@@ -672,6 +674,7 @@ groups:
     expr: |
       increase(cortex_compactor_runs_failed_total[2h]) >= 2
     labels:
+      reason: consecutive-failures
       severity: critical
   - alert: MimirCompactorHasNotUploadedBlocks
     annotations:

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -28,6 +28,7 @@
           |||,
           labels: {
             severity: 'critical',
+            reason: 'in-last-24h',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
@@ -42,6 +43,7 @@
           |||,
           labels: {
             severity: 'critical',
+            reason: 'in-since-startup',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
@@ -55,6 +57,7 @@
           |||,
           labels: {
             severity: 'critical',
+            reason: 'consecutive-failures',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s failed to run 2 consecutive compactions.' % $._config,

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -43,7 +43,7 @@
           |||,
           labels: {
             severity: 'critical',
-            reason: 'in-since-startup',
+            reason: 'since-startup',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When this alert is evaluated in Mimir itself, it can cause false-positive rule
evaluation failures. This is because multiple alerts with the same name can
fire concurrently, causing duplicate series to be written.

I'm not 100% sure what the best action is here:
1. Make each alert have distinct names
   - This isn't so nice as the _action_ for each alert is the same (i.e. same runbook)
2. Make each alert mutually exclusive so they never fire concurrently
   - This would be a hard thing to test for and likely fragile
3. Give each alert an additional label

I went for (3) - open to opinions.

If we're happy with this option as a generic approach, then I'll work on a linter check to enforce it.

#### Checklist

- n/a Tests updated
- n/a Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
