### PR TITLE
Add distinct labels on compactor alerts

### DIFF
--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -655,6 +655,7 @@ groups:
       (cortex_compactor_last_successful_run_timestamp_seconds > 0)
     for: 1h
     labels:
+      reason: no compactions for 24h
       severity: critical
   - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
@@ -664,6 +665,7 @@ groups:
       cortex_compactor_last_successful_run_timestamp_seconds == 0
     for: 24h
     labels:
+      reason: no compactions since startup 24h ago
       severity: critical
   - alert: MimirCompactorHasNotSuccessfullyRunCompaction
     annotations:
@@ -672,6 +674,7 @@ groups:
     expr: |
       increase(cortex_compactor_runs_failed_total[2h]) >= 2
     labels:
+      reason: 2 consecutive failed compactions
       severity: critical
   - alert: MimirCompactorHasNotUploadedBlocks
     annotations:

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -28,6 +28,7 @@
           |||,
           labels: {
             severity: 'critical',
+            reason: 'no compactions for 24h',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
@@ -42,6 +43,7 @@
           |||,
           labels: {
             severity: 'critical',
+            reason: 'no compactions since startup 24h ago',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has not run compaction in the last 24 hours.' % $._config,
@@ -55,6 +57,7 @@
           |||,
           labels: {
             severity: 'critical',
+            reason: '2 consecutive failed compactions',
           },
           annotations: {
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s failed to run 2 consecutive compactions.' % $._config,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
If multiple alerts fire, the ruler starts failing because they have the
same labelset so the ruler gets "duplicate sample for timestamp"

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>



#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
