### PR TITLE
Ruler: Remove -ruler.query-frontend.timeout and use -querier.timeout instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * [BUGFIX] Fix panic at startup when Mimir is running in monolithic mode and query sharding is enabled. #2036
 * [BUGFIX] Ruler: report `cortex_ruler_queries_failed_total` metric for any remote query error except 4xx when remote operational mode is enabled. #2053 #2143
 * [BUGFIX] Ingester: fix slow rollout when using `-ingester.ring.unregister-on-shutdown=false` with long `-ingester.ring.heartbeat-period`. #2085
-* [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinitely. The duration is configurable with  (`-ruler.query-frontend.timeout` (default `2m`). #2090
+* [BUGFIX] Ruler: add timeout for remote rule evaluation queries to prevent rule group evaluations getting stuck indefinitely. The duration is configurable with `-querier.timeout` (default `2m`). #2090 #2222
 * [BUGFIX] Limits: Active series custom tracker configuration has been named back from `active_series_custom_trackers_config` to `active_series_custom_trackers`. For backwards compatibility both version is going to be supported for until Mimir v2.4. When both fields are specified, `active_series_custom_trackers_config` takes precedence over `active_series_custom_trackers`. #2101
 * [BUGFIX] Ingester: fixed the order of labels applied when incrementing the `cortex_discarded_metadata_total` metric. #2096
 * [BUGFIX] Ingester: fixed bug where retrieving metadata for a metric with multiple metadata entries would return multiple copies of a single metadata entry rather than all available entries. #2096

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1514,7 +1514,7 @@
           "kind": "field",
           "name": "timeout",
           "required": false,
-          "desc": "The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled.",
+          "desc": "The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. This also applies to queries evaluated by the ruler (internally or remotely).",
           "fieldValue": null,
           "fieldDefaultValue": 120000000000,
           "fieldFlag": "querier.timeout",
@@ -7391,16 +7391,6 @@
               "fieldDefaultValue": "",
               "fieldFlag": "ruler.query-frontend.address",
               "fieldType": "string"
-            },
-            {
-              "kind": "field",
-              "name": "timeout",
-              "required": false,
-              "desc": "The timeout for a rule query being evaluated by the query-frontend.",
-              "fieldValue": null,
-              "fieldDefaultValue": 120000000000,
-              "fieldFlag": "ruler.query-frontend.timeout",
-              "fieldType": "duration"
             },
             {
               "kind": "block",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1112,7 +1112,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.store-gateway-client.tls-server-name string
     	Override the expected name on the server certificate.
   -querier.timeout duration
-    	The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. (default 2m0s)
+    	The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. This also applies to queries evaluated by the ruler (internally or remotely). (default 2m0s)
   -query-frontend.align-querier-with-step
     	Mutate incoming queries to align their start and end with their step.
   -query-frontend.cache-results
@@ -1448,8 +1448,6 @@ Usage of ./cmd/mimir/mimir:
     	Path to the key file for the client certificate. Also requires the client certificate to be configured.
   -ruler.query-frontend.grpc-client-config.tls-server-name string
     	Override the expected name on the server certificate.
-  -ruler.query-frontend.timeout duration
-    	The timeout for a rule query being evaluated by the query-frontend. (default 2m0s)
   -ruler.query-stats-enabled
     	Report the wall time for ruler queries to complete as a per-tenant metric and as an info level log message.
   -ruler.resend-delay duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -340,7 +340,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.scheduler-address string
     	Address of the query-scheduler component, in host:port format. Only one of -querier.frontend-address or -querier.scheduler-address can be set. If neither is set, queries are only received via HTTP endpoint.
   -querier.timeout duration
-    	The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. (default 2m0s)
+    	The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. This also applies to queries evaluated by the ruler (internally or remotely). (default 2m0s)
   -query-frontend.align-querier-with-step
     	Mutate incoming queries to align their start and end with their step.
   -query-frontend.cache-results
@@ -452,8 +452,6 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
   -ruler.query-frontend.address string
     	GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) to enable client side load balancing.
-  -ruler.query-frontend.timeout duration
-    	The timeout for a rule query being evaluated by the query-frontend. (default 2m0s)
   -ruler.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -ruler.ring.etcd.endpoints value

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -850,7 +850,8 @@ store_gateway_client:
 [max_concurrent: <int> | default = 20]
 
 # The timeout for a query. This config option should be set on query-frontend
-# too when query sharding is enabled.
+# too when query sharding is enabled. This also applies to queries evaluated by
+# the ruler (internally or remotely).
 # CLI flag: -querier.timeout
 [timeout: <duration> | default = 2m]
 
@@ -1398,10 +1399,6 @@ query_frontend:
   # (prefixed with dns:///) to enable client side load balancing.
   # CLI flag: -ruler.query-frontend.address
   [address: <string> | default = ""]
-
-  # The timeout for a rule query being evaluated by the query-frontend.
-  # CLI flag: -ruler.query-frontend.timeout
-  [timeout: <duration> | default = 2m]
 
   grpc_client_config:
     # (advanced) gRPC client max receive message size (bytes).

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -583,7 +583,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		if err != nil {
 			return nil, err
 		}
-		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Ruler.QueryFrontend.Timeout, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
+		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Querier.EngineConfig.Timeout, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
 
 		embeddedQueryable = prom_remote.NewSampleAndChunkQueryableClient(
 			remoteQuerier,

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -40,7 +40,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	}
 
 	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, sharedWithQueryFrontend("The maximum number of concurrent queries."))
-	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, sharedWithQueryFrontend("The timeout for a query."))
+	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, sharedWithQueryFrontend("The timeout for a query.")+" This also applies to queries evaluated by the ruler (internally or remotely).")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, sharedWithQueryFrontend("Maximum number of samples a single query can load into memory."))
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, sharedWithQueryFrontend("The default evaluation interval or step size for subqueries."))
 	f.DurationVar(&cfg.LookbackDelta, "querier.lookback-delta", 5*time.Minute, sharedWithQueryFrontend("Time since the last sample after which a time series is considered stale and ignored by expression evaluations."))

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -54,9 +54,6 @@ type QueryFrontendConfig struct {
 	// Address is the address of the query-frontend to connect to.
 	Address string `yaml:"address"`
 
-	// Timeout is the length of time we wait on the query-frontend before giving up.
-	Timeout time.Duration `yaml:"timeout"`
-
 	// GRPCClientConfig contains gRPC specific config options.
 	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 }
@@ -67,8 +64,6 @@ func (c *QueryFrontendConfig) RegisterFlags(f *flag.FlagSet) {
 		"",
 		"GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) "+
 			"to enable client side load balancing.")
-
-	f.DurationVar(&c.Timeout, "ruler.query-frontend.timeout", 2*time.Minute, "The timeout for a rule query being evaluated by the query-frontend.")
 
 	c.GRPCClientConfig.RegisterFlagsWithPrefix("ruler.query-frontend.grpc-client-config", f)
 }


### PR DESCRIPTION
Fixes #2129