### PR TITLE
mixin: Convert "Slow Queries" dashboard to Grafana 9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 
 ### Mixin
 
+* [CHANGE] Dashboards: "Slow Queries" dashboard no longer works with versions older than Grafana 9.0. #2223
 * [ENHANCEMENT] Dashboards: added missed rule evaluations to the "Evaluations per second" panel in the "Mimir / Ruler" dashboard. #2314
 * [BUGFIX] Dashboards: fixed unit of latency panels in the "Mimir / Ruler" dashboard. #2312
 * [BUGFIX] Dashboards: fixed "Intervals per query" panel in the "Mimir / Queries" dashboard. #2308
+* [BUGFIX] Dashboards: Make "Slow Queries" dashboard works with Grafana 9.0. #2223
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -91,8 +91,10 @@
                   "title": "Slow queries",
                   "transformations": [
                      {
-                        "id": "labelsToFields",
-                        "options": { }
+                        "id": "extractFields",
+                        "options": {
+                           "source": "labels"
+                        }
                      },
                      {
                         "id": "calculateField",
@@ -115,12 +117,15 @@
                         "id": "organize",
                         "options": {
                            "excludeByName": {
+                              "Line": true,
+                              "Time": true,
                               "caller": true,
                               "cluster": true,
                               "container": true,
                               "host": true,
                               "id": true,
                               "job": true,
+                              "labels": true,
                               "level": true,
                               "line": true,
                               "method": true,

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -29,8 +29,10 @@ local filename = 'mimir-slow-queries.json';
           transformations: [
             {
               // Convert labels to fields.
-              id: 'labelsToFields',
-              options: {},
+              id: 'extractFields',
+              options: {
+                source: 'labels',
+              },
             },
             {
               // Compute the query time range.
@@ -52,7 +54,7 @@ local filename = 'mimir-slow-queries.json';
               id: 'organize',
               options: {
                 // Hide fields we don't care.
-                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'param_end', 'param_start', 'param_time', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs'],
+                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'param_end', 'param_start', 'param_time', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs', 'labels', 'Line', 'Time'],
 
                 excludeByName: {
                   [field]: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The loki data format changed in grafana 9.0. This broke the Slow Queries dashboard. 

This is what the resulting dashboard looks on Grafana v9.0.0-adfe4ef5pre (adfe4ef56)

![Screenshot 2022-06-24 at 12 52 34](https://user-images.githubusercontent.com/21020035/175521128-e0beed72-ef68-4ee4-9caa-9669e8f14191.png)

The change _is not_ compatible with versions prior to Grafana 9.0

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>



#### Which issue(s) this PR fixes or relates to

Fixes #2119

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
