### PR TITLE
Set CODEOWNERS to primary technical writer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/ @grafana/docs-squad @jdbaldry
+/docs/ @osg-grafana


### PR DESCRIPTION
Not all members of the @grafana/docs-squad team are responsible for technical writer review on Mimir docs.