### PR TITLE
DO NOT MERGE: Don't create buffer for Azure blob downloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,9 @@ replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus 
 
 // Out of order Support forces us to fork thanos because we've changed the ChunkReader interface.
 // Once the out of order support is upstreamed and Thanos has vendored it, we can remove this override.
-replace github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
+//replace github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
+// Testing Azure blob reader changes
+replace github.com/thanos-io/thanos => github.com/56quarters/thanos v0.24.1-0.20220627201918-c9b0424e047f
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/trace v0.1.0/go.mod h1:wxEwsoeRVPbeSkt7ZC9nWCgmoKQRAoySN7XHW2AmI7g=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/56quarters/thanos v0.24.1-0.20220627201918-c9b0424e047f h1:okyie/PJa6mUR19sWv+bq7yuXYzKm9BuBP0i9QvLiCY=
+github.com/56quarters/thanos v0.24.1-0.20220627201918-c9b0424e047f/go.mod h1:9e/ytDfVepSKxihUWXyy1irj+ipM/DAlOBqsyXs+Y10=
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go v65.0.0+incompatible h1:HzKLt3kIwMm4KeJYTdx9EbjRYTySD/t8i1Ee/W5EGXw=
@@ -748,8 +750,6 @@ github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5 h1:xlK4WG
 github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
-github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317 h1:DG++oZD7E6YUm8YNZOu7RwZ8J/Slhcx3iOlKQBY6Oh0=
-github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317/go.mod h1:9e/ytDfVepSKxihUWXyy1irj+ipM/DAlOBqsyXs+Y10=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/azure/azure.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/azure/azure.go
@@ -4,10 +4,8 @@
 package azure
 
 import (
-	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -316,39 +314,15 @@ func (b *Bucket) getBlobReader(ctx context.Context, name string, offset, length 
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot get Azure blob URL, address: %s", name)
 	}
-	var props *blob.BlobGetPropertiesResponse
-	props, err = blobURL.GetProperties(ctx, blob.BlobAccessConditions{}, blob.ClientProvidedKeyOptions{})
+
+	dl, err := blobURL.Download(ctx, offset, length, blob.BlobAccessConditions{}, false, blob.ClientProvidedKeyOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get properties for container: %s", name)
+		return nil, errors.Wrapf(err, "cannot get download Azure blob URL, address: %s", name)
 	}
 
-	var size int64
-	// If a length is specified and it won't go past the end of the file,
-	// then set it as the size.
-	if length > 0 && length <= props.ContentLength()-offset {
-		size = length
-		level.Debug(b.logger).Log("msg", "set size to length", "size", size, "length", length, "offset", offset, "name", name)
-	} else {
-		size = props.ContentLength() - offset
-		level.Debug(b.logger).Log("msg", "set size to go to EOF", "contentlength", props.ContentLength(), "size", size, "length", length, "offset", offset, "name", name)
-	}
-
-	destBuffer := make([]byte, size)
-
-	if err := blob.DownloadBlobToBuffer(context.Background(), blobURL.BlobURL, offset, size,
-		destBuffer, blob.DownloadFromBlobOptions{
-			BlockSize:   blob.BlobDefaultDownloadBlockSize,
-			Parallelism: uint16(3),
-			Progress:    nil,
-			RetryReaderOptionsPerBlock: blob.RetryReaderOptions{
-				MaxRetryRequests: b.config.ReaderConfig.MaxRetryRequests,
-			},
-		},
-	); err != nil {
-		return nil, errors.Wrapf(err, "cannot download blob, address: %s", blobURL.BlobURL)
-	}
-
-	return ioutil.NopCloser(bytes.NewReader(destBuffer)), nil
+	return dl.Body(blob.RetryReaderOptions{
+		MaxRetryRequests: b.config.ReaderConfig.MaxRetryRequests,
+	}), nil
 }
 
 // Get returns a reader for the given object name.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -807,7 +807,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.26.1-0.20220602051129-a6f6ce060ed4 => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
+# github.com/thanos-io/thanos v0.26.1-0.20220602051129-a6f6ce060ed4 => github.com/56quarters/thanos v0.24.1-0.20220627201918-c9b0424e047f
 ## explicit; go 1.17
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/metadata
@@ -1228,7 +1228,7 @@ gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 # github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
-# github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
+# github.com/thanos-io/thanos => github.com/56quarters/thanos v0.24.1-0.20220627201918-c9b0424e047f
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167


### PR DESCRIPTION
Don't preallocate a buffer for the entire size of objects downloaded
from Azure blob storage.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
