### PR TITLE
Update r192 with the out-of-order fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/ @grafana/docs-squad @jdbaldry
+/docs/ @osg-grafana

--- a/docs/sources/operators-guide/configuring/about-versioning.md
+++ b/docs/sources/operators-guide/configuring/about-versioning.md
@@ -76,6 +76,7 @@ The following features are currently experimental:
   - Add variance to chunks end time to spread writing across time (`-blocks-storage.tsdb.head-chunks-end-time-variance`)
   - Using queue and asynchronous chunks disk mapper (`-blocks-storage.tsdb.head-chunks-write-queue-size`)
   - Snapshotting of in-memory TSDB data on disk when shutting down (`-blocks-storage.tsdb.memory-snapshot-on-shutdown`)
+  - Out-of-order samples ingestion (`-ingester.out-of-order-allowance`)
 - Query-frontend
   - `-query-frontend.querier-forget-delay`
 - Query-scheduler

--- a/docs/sources/operators-guide/configuring/configuring-out-of-order-samples-ingestion.md
+++ b/docs/sources/operators-guide/configuring/configuring-out-of-order-samples-ingestion.md
@@ -1,0 +1,48 @@
+---
+title: "Configuring out-of-order samples ingestion"
+menuTitle: "Configuring out-of-order samples ingestion"
+description: "Learn how to configure Grafana Mimir to handle out-of-order samples ingestion."
+weight: 120
+---
+
+# Configuring out-of-order samples ingestion
+
+Grafana Mimir and the Prometheus TSDB understand out-of-order as follows.
+
+The moment that a new series sample arrives, Mimir need to determine if the series already exists, and whether or not the sample is too old:
+
+- If the series exists, the incoming sample must have a newer timestamp than the latest sample that is stored for the series.
+  Otherwise, it is considered out-of-order and will be dropped by the ingesters.
+- If the series does not exist, then the sample has to be within bounds, which go back 1 hour from TSDB's head-block max time (when using 2 hour block range). If it fails to be within bounds, then it is also considered out-of-bounds and will be dropped by the ingesters.
+
+> **Note:** If you're writing metrics using Prometheus remote write or the Grafana Agent, then out-of-order samples are unexpected.
+> Prometheus and Grafana Agent guarantee that samples are written in-order for the same series.
+
+If you have out-of-order samples due to the nature of your architecture or the system that is being observed, then you can configure Grafana Mimir to set an out-of-order time-window threshold for how old samples can be ingested.
+As a result, none of the preceding samples will be dropped if they are within the configured time window.
+
+## Configuring out-of-order samples ingestion instance wide
+
+To configure Grafana Mimir to accept out-of-order samples, see the following configuration snippet:
+
+```yaml
+limits:
+  # Allow ingestion of out-of-order samples up to 5 minutes since the latest received sample for the series.
+  out_of_order_time_window: 5m
+```
+
+## Configure out-of-order samples per tenant
+
+If your Grafana Mimir has multitenancy enabled, you can still use the preceding method to set a default out-of-order time window threshold for all tenants.
+If a particular tenant needs a custom threshold, you can use the runtime configuration to set a per-tenant override.
+
+1. Enable [runtime configuration]({{< relref "about-runtime-configuration.md" >}}).
+1. Add an override for the tenant that needs a custom out-of-order time window:
+
+```yaml
+overrides:
+  tenant1:
+    out_of_order_time_window: 2h
+  tenant2:
+    out_of_order_time_window: 30m
+```

--- a/go.mod
+++ b/go.mod
@@ -227,7 +227,7 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110
 replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220624104020-1446b53d874c
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
 
 // Out of order Support forces us to fork thanos because we've changed the ChunkReader interface.
 // Once the out of order support is upstreamed and Thanos has vendored it, we can remove this override.

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/grafana/e2e v0.1.1-0.20220519104354-1db01e4751fe h1:mxrRWDjKtob43xF9n
 github.com/grafana/e2e v0.1.1-0.20220519104354-1db01e4751fe/go.mod h1:+26VJWpczg2OU3D0537acnHSHzhJORpxOs6F+M27tZo=
 github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167 h1:PgEQkGHR4YimSCEGT5IoswN9gJKZDVskf+he6UClCLw=
 github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20220624104020-1446b53d874c h1:oJdK/F/mW2j/dy2nKOtmcMBVnHx70mAf2tE1T2oqLPE=
-github.com/grafana/mimir-prometheus v0.0.0-20220624104020-1446b53d874c/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
+github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5 h1:xlK4WGUnyG7odN0XeMGHzGB7s1/uuEKacl2X9fXcUbA=
+github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317 h1:DG++oZD7E6YUm8YNZOu7RwZ8J/Slhcx3iOlKQBY6Oh0=

--- a/pkg/storage/tsdb/upload_test.go
+++ b/pkg/storage/tsdb/upload_test.go
@@ -105,7 +105,7 @@ func TestUploadBlock(t *testing.T) {
 		require.Equal(t, 3, len(bkt.Objects()))
 		require.Equal(t, 3751, len(bkt.Objects()[path.Join(b1.String(), block.ChunksDirname, "000001")]))
 		require.Equal(t, 401, len(bkt.Objects()[path.Join(b1.String(), block.IndexFilename)]))
-		require.Equal(t, 546, len(bkt.Objects()[path.Join(b1.String(), block.MetaFilename)]))
+		require.Equal(t, 570, len(bkt.Objects()[path.Join(b1.String(), block.MetaFilename)]))
 
 		origMeta, err := metadata.ReadFromDir(path.Join(tmpDir, "test", b1.String()))
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestUploadBlock(t *testing.T) {
 		require.Equal(t, 3, len(bkt.Objects()))
 		require.Equal(t, 3751, len(bkt.Objects()[path.Join(b1.String(), block.ChunksDirname, "000001")]))
 		require.Equal(t, 401, len(bkt.Objects()[path.Join(b1.String(), block.IndexFilename)]))
-		require.Equal(t, 546, len(bkt.Objects()[path.Join(b1.String(), block.MetaFilename)]))
+		require.Equal(t, 570, len(bkt.Objects()[path.Join(b1.String(), block.MetaFilename)]))
 	})
 
 	t.Run("upload with no external labels works just fine", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestUploadBlock(t *testing.T) {
 		require.Equal(t, 6, len(bkt.Objects())) // 3 from b1, 3 from b2
 		require.Equal(t, 3736, len(bkt.Objects()[path.Join(b2.String(), block.ChunksDirname, "000001")]))
 		require.Equal(t, 401, len(bkt.Objects()[path.Join(b2.String(), block.IndexFilename)]))
-		require.Equal(t, 525, len(bkt.Objects()[path.Join(b2.String(), block.MetaFilename)]))
+		require.Equal(t, 549, len(bkt.Objects()[path.Join(b2.String(), block.MetaFilename)]))
 
 		origMeta, err := metadata.ReadFromDir(path.Join(tmpDir, b2.String()))
 		require.NoError(t, err)

--- a/vendor/github.com/prometheus/prometheus/tsdb/block.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/block.go
@@ -169,6 +169,9 @@ type BlockMeta struct {
 
 	// Version of the index format.
 	Version int `json:"version"`
+
+	// OutOfOrder is true if the block was directly created from out-of-order samples.
+	OutOfOrder bool `json:"out_of_order"`
 }
 
 // BlockStats contains stats about contents of a block.

--- a/vendor/github.com/prometheus/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/compact.go
@@ -608,9 +608,10 @@ func (c *LeveledCompactor) compactOOO(dest string, oooHead *OOOCompactionHead, s
 		for jx := range outBlocks[ix] {
 			uid := ulid.MustNew(outBlocksTime, rand.Reader)
 			meta := &BlockMeta{
-				ULID:    uid,
-				MinTime: mint,
-				MaxTime: maxt,
+				ULID:       uid,
+				MinTime:    mint,
+				MaxTime:    maxt,
+				OutOfOrder: true,
 			}
 			meta.Compaction.Level = 1
 			meta.Compaction.Sources = []ulid.ULID{uid}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -717,7 +717,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519 => github.com/grafana/mimir-prometheus v0.0.0-20220624104020-1446b53d874c
+# github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519 => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
 ## explicit; go 1.17
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1227,7 +1227,7 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220624104020-1446b53d874c
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
 # github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2


### PR DESCRIPTION
This PR just syncs main with r192. Vendoring of mimir-prometheus has the fix.
Edit: Since Mimir 2.2 will have these commits, we are adding these commits in the release so that we can test it out.