### PR TITLE
operations/mimir: Change multi_zone_ingester_max_unavailable to 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * [CHANGE] Change default value for `-blocks-storage.bucket-store.chunks-cache.memcached.timeout` to `450ms` to increase use of cached data. #2035
 * [CHANGE] The `memberlist_ring_enabled` configuration now applies to Alertmanager. #2102
 * [CHANGE] Default value for `memberlist_ring_enabled` is now true. It means that all hash rings use Memberlist as default KV store instead of Consul (previous default). #2161
+* [CHANGE] Change `_config.multi_zone_ingester_max_unavailable` to 25. #2251
 * [FEATURE] Added querier autoscaling support. It requires [KEDA](https://keda.sh) installed in the Kubernetes cluster and query-scheduler enabled in the Mimir cluster. Querier autoscaler can be enabled and configure through the following options in the jsonnet config: #2013 #2023
   * `autoscaling_querier_enabled`: `true` to enable autoscaling.
   * `autoscaling_querier_min_replicas`: minimum number of querier replicas.

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1517,7 +1517,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-a
@@ -1629,7 +1629,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-b
@@ -1741,7 +1741,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-c

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1170,7 +1170,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-a
@@ -1286,7 +1286,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-b
@@ -1402,7 +1402,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-c

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1341,7 +1341,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-a
@@ -1457,7 +1457,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-b
@@ -1573,7 +1573,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "10"
+    rollout-max-unavailable: "25"
   labels:
     rollout-group: ingester
   name: ingester-zone-c

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -18,7 +18,7 @@
     multi_zone_ingester_replication_write_path_enabled: true,
     multi_zone_ingester_replication_read_path_enabled: true,
     multi_zone_ingester_replicas: 0,
-    multi_zone_ingester_max_unavailable: 10,
+    multi_zone_ingester_max_unavailable: 25,
 
     multi_zone_store_gateway_enabled: false,
     multi_zone_store_gateway_read_path_enabled: $._config.multi_zone_store_gateway_enabled,


### PR DESCRIPTION
#### What this PR does
In operations/mimir, change `multi_zone_ingester_max_unavailable` to 25.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
