### PR TITLE
Removed migration of alertmanager local state files from old hierarchy (Cortex 1.8 and earlier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [CHANGE] Default values have changed for the following settings. This improves query performance for recent data (within 12h) by only reading from ingesters: #1909 #1921
     - `-blocks-storage.bucket-store.ignore-blocks-within` now defaults to `10h` (previously `0`)
     - `-querier.query-store-after` now defaults to `12h` (previously `0`)
-
+* [CHANGE] Alertmanager: removed support for migrating local files from Cortex 1.8 or earlier. Related to original Cortex PR #3910.
 * [CHANGE] The following settings are now classified as advanced because the defaults should work for most users and tuning them requires in-depth knowledge of how the read path works: #1929
     - `-querier.query-ingesters-within`
     - `-querier.query-store-after`

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -30,7 +30,6 @@ import (
 	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/user"
@@ -386,11 +385,6 @@ func (h *handlerForGRPCServer) ServeHTTP(w http.ResponseWriter, req *http.Reques
 }
 
 func (am *MultitenantAlertmanager) starting(ctx context.Context) (err error) {
-	err = am.migrateStateFilesToPerTenantDirectories()
-	if err != nil {
-		return err
-	}
-
 	defer func() {
 		if err == nil || am.subservices == nil {
 			return
@@ -451,119 +445,6 @@ func (am *MultitenantAlertmanager) starting(ctx context.Context) (err error) {
 	level.Info(am.logger).Log("msg", "alertmanager is ACTIVE in the ring")
 
 	return nil
-}
-
-// migrateStateFilesToPerTenantDirectories migrates any existing configuration from old place to new hierarchy.
-// TODO: Remove in Cortex 1.11.
-func (am *MultitenantAlertmanager) migrateStateFilesToPerTenantDirectories() error {
-	migrate := func(from, to string) error {
-		level.Info(am.logger).Log("msg", "migrating alertmanager state", "from", from, "to", to)
-		err := os.Rename(from, to)
-		return errors.Wrapf(err, "failed to migrate alertmanager state from %v to %v", from, to)
-	}
-
-	st, err := am.getObsoleteFilesPerUser()
-	if err != nil {
-		return errors.Wrap(err, "failed to migrate alertmanager state files")
-	}
-
-	for userID, files := range st {
-		tenantDir := am.getTenantDirectory(userID)
-		err := os.MkdirAll(tenantDir, 0777)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create per-tenant directory %v", tenantDir)
-		}
-
-		errs := tsdb_errors.NewMulti()
-
-		if files.notificationLogSnapshot != "" {
-			errs.Add(migrate(files.notificationLogSnapshot, filepath.Join(tenantDir, notificationLogSnapshot)))
-		}
-
-		if files.silencesSnapshot != "" {
-			errs.Add(migrate(files.silencesSnapshot, filepath.Join(tenantDir, silencesSnapshot)))
-		}
-
-		if files.templatesDir != "" {
-			errs.Add(migrate(files.templatesDir, filepath.Join(tenantDir, templatesDir)))
-		}
-
-		if err := errs.Err(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type obsoleteStateFiles struct {
-	notificationLogSnapshot string
-	silencesSnapshot        string
-	templatesDir            string
-}
-
-// getObsoleteFilesPerUser returns per-user set of files that should be migrated from old structure to new structure.
-func (am *MultitenantAlertmanager) getObsoleteFilesPerUser() (map[string]obsoleteStateFiles, error) {
-	files, err := ioutil.ReadDir(am.cfg.DataDir)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list dir %v", am.cfg.DataDir)
-	}
-
-	// old names
-	const (
-		notificationLogPrefix = "nflog:"
-		silencesPrefix        = "silences:"
-		templates             = "templates"
-	)
-
-	result := map[string]obsoleteStateFiles{}
-
-	for _, f := range files {
-		fullPath := filepath.Join(am.cfg.DataDir, f.Name())
-
-		if f.IsDir() {
-			// Process templates dir.
-			if f.Name() != templates {
-				// Ignore other files -- those are likely per tenant directories.
-				continue
-			}
-
-			templateDirs, err := ioutil.ReadDir(fullPath)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to list dir %v", fullPath)
-			}
-
-			// Previously templates directory contained per-tenant subdirectory.
-			for _, d := range templateDirs {
-				if d.IsDir() {
-					v := result[d.Name()]
-					v.templatesDir = filepath.Join(fullPath, d.Name())
-					result[d.Name()] = v
-				} else {
-					level.Warn(am.logger).Log("msg", "ignoring unknown local file while migrating local alertmanager state files", "file", filepath.Join(fullPath, d.Name()))
-				}
-			}
-			continue
-		}
-
-		switch {
-		case strings.HasPrefix(f.Name(), notificationLogPrefix):
-			userID := strings.TrimPrefix(f.Name(), notificationLogPrefix)
-			v := result[userID]
-			v.notificationLogSnapshot = fullPath
-			result[userID] = v
-
-		case strings.HasPrefix(f.Name(), silencesPrefix):
-			userID := strings.TrimPrefix(f.Name(), silencesPrefix)
-			v := result[userID]
-			v.silencesSnapshot = fullPath
-			result[userID] = v
-
-		default:
-			level.Warn(am.logger).Log("msg", "ignoring unknown local data file while migrating local alertmanager state files", "file", fullPath)
-		}
-	}
-
-	return result, nil
 }
 
 func (am *MultitenantAlertmanager) run(ctx context.Context) error {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -596,39 +596,6 @@ receivers:
 	}
 }
 
-func TestMultitenantAlertmanager_migrateStateFilesToPerTenantDirectories(t *testing.T) {
-	ctx := context.Background()
-
-	const (
-		user1 = "user1"
-		user2 = "user2"
-	)
-
-	store := prepareInMemoryAlertStore()
-	require.NoError(t, store.SetAlertConfig(ctx, alertspb.AlertConfigDesc{
-		User:      user2,
-		RawConfig: simpleConfigOne,
-		Templates: []*alertspb.TemplateDesc{},
-	}))
-
-	reg := prometheus.NewPedanticRegistry()
-	cfg := mockAlertmanagerConfig(t)
-	am, err := createMultitenantAlertmanager(cfg, nil, store, nil, nil, log.NewNopLogger(), reg)
-	require.NoError(t, err)
-
-	createFile(t, filepath.Join(cfg.DataDir, "nflog:"+user1))
-	createFile(t, filepath.Join(cfg.DataDir, "silences:"+user1))
-	createFile(t, filepath.Join(cfg.DataDir, "nflog:"+user2))
-	createFile(t, filepath.Join(cfg.DataDir, "templates", user2, "template.tpl"))
-
-	require.NoError(t, am.migrateStateFilesToPerTenantDirectories())
-	require.True(t, fileExists(t, filepath.Join(cfg.DataDir, user1, notificationLogSnapshot)))
-	require.True(t, fileExists(t, filepath.Join(cfg.DataDir, user1, silencesSnapshot)))
-	require.True(t, fileExists(t, filepath.Join(cfg.DataDir, user2, notificationLogSnapshot)))
-	require.True(t, dirExists(t, filepath.Join(cfg.DataDir, user2, templatesDir)))
-	require.True(t, fileExists(t, filepath.Join(cfg.DataDir, user2, templatesDir, "template.tpl")))
-}
-
 func fileExists(t *testing.T, path string) bool {
 	return checkExists(t, path, false)
 }


### PR DESCRIPTION
#### What this PR does

This PR removes support for migrating old state files on local disk from hierarchy used by Cortex 1.8 and earlier (before https://github.com/cortexproject/cortex/pull/3910)

#### Which issue(s) this PR fixes or relates to

Found while doing release 2.2 preparation.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
