### PR TITLE
Cleanup unused part of relabelLabels from store-gateway

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1158,7 +1158,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		if !b.overlapsClosedInterval(req.Start, req.End) {
 			continue
 		}
-		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
+		if len(reqBlockMatchers) > 0 && !b.matchLabels(reqBlockMatchers) {
 			continue
 		}
 
@@ -1319,7 +1319,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		if !b.overlapsClosedInterval(req.Start, req.End) {
 			continue
 		}
-		if len(reqBlockMatchers) > 0 && !b.matchRelabelLabels(reqBlockMatchers) {
+		if len(reqBlockMatchers) > 0 && !b.matchLabels(reqBlockMatchers) {
 			continue
 		}
 
@@ -1561,7 +1561,7 @@ func (s *bucketBlockSet) getFor(mint, maxt, maxResolutionMillis int64, blockMatc
 
 		// Include the block in the list of matching ones only if there are no block-level matchers
 		// or they actually match.
-		if len(blockMatchers) == 0 || b.matchRelabelLabels(blockMatchers) {
+		if len(blockMatchers) == 0 || b.matchLabels(blockMatchers) {
 			bs = append(bs, b)
 		}
 
@@ -1596,7 +1596,7 @@ type bucketBlock struct {
 
 	// Block's labels used by block-level matchers to filter blocks to query. These are used to select blocks using
 	// request hints' BlockMatchers.
-	relabelLabels labels.Labels
+	blockLabels labels.Labels
 
 	expandedPostingsPromises sync.Map
 }
@@ -1625,9 +1625,8 @@ func newBucketBlock(
 		partitioner:       p,
 		meta:              meta,
 		indexHeaderReader: indexHeadReader,
-		// Translate the block's labels and inject the block ID as a label
-		// to allow to match blocks also by ID.
-		relabelLabels: labels.Labels{labels.Label{
+		// Inject the block ID as a label to allow to match blocks by ID.
+		blockLabels: labels.Labels{labels.Label{
 			Name:  block.BlockIDLabel,
 			Value: meta.ULID.String(),
 		}},
@@ -1719,10 +1718,10 @@ func (b *bucketBlock) chunkReader(ctx context.Context) *bucketChunkReader {
 	return newBucketChunkReader(ctx, b)
 }
 
-// matchRelabelLabels verifies whether the block matches the given matchers.
-func (b *bucketBlock) matchRelabelLabels(matchers []*labels.Matcher) bool {
+// matchLabels verifies whether the block matches the given matchers.
+func (b *bucketBlock) matchLabels(matchers []*labels.Matcher) bool {
 	for _, m := range matchers {
-		if !m.Matches(b.relabelLabels.Get(m.Name)) {
+		if !m.Matches(b.blockLabels.Get(m.Name)) {
 			return false
 		}
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1627,12 +1627,11 @@ func newBucketBlock(
 		indexHeaderReader: indexHeadReader,
 		// Translate the block's labels and inject the block ID as a label
 		// to allow to match blocks also by ID.
-		relabelLabels: append(labels.FromMap(meta.Thanos.Labels), labels.Label{
+		relabelLabels: labels.Labels{labels.Label{
 			Name:  block.BlockIDLabel,
 			Value: meta.ULID.String(),
-		}),
+		}},
 	}
-	sort.Sort(b.relabelLabels)
 
 	// Get object handles for all chunk files (segment files) from meta.json, if available.
 	if len(meta.Thanos.SegmentFiles) > 0 {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -280,7 +280,7 @@ func TestBucketBlock_matchLabels(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		ok := b.matchRelabelLabels(c.in)
+		ok := b.matchLabels(c.in)
 		assert.Equal(t, c.match, ok)
 	}
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -211,10 +211,7 @@ func TestBucketBlock_matchLabels(t *testing.T) {
 	meta := &metadata.Meta{
 		BlockMeta: tsdb.BlockMeta{ULID: blockID},
 		Thanos: metadata.Thanos{
-			Labels: map[string]string{
-				"a": "b",
-				"c": "d",
-			},
+			Labels: map[string]string{}, // this is empty in Mimir
 		},
 	}
 
@@ -234,7 +231,7 @@ func TestBucketBlock_matchLabels(t *testing.T) {
 				{Type: labels.MatchEqual, Name: "a", Value: "b"},
 				{Type: labels.MatchEqual, Name: "c", Value: "d"},
 			},
-			match: true,
+			match: false,
 		},
 		{
 			in: []*labels.Matcher{
@@ -288,10 +285,7 @@ func TestBucketBlock_matchLabels(t *testing.T) {
 	}
 
 	// Ensure block's labels in the meta have not been manipulated.
-	assert.Equal(t, map[string]string{
-		"a": "b",
-		"c": "d",
-	}, meta.Thanos.Labels)
+	assert.Equal(t, map[string]string{}, meta.Thanos.Labels)
 }
 
 func TestBucketBlockSet_addGet(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Remove the always-empty `meta.Thanos.Labels` from `relabelLabels `.

#### Which issue(s) this PR fixes or relates to

Follow-up on https://github.com/grafana/mimir/pull/2240 and cleanup more unneeded code.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
