### PR TITLE
Redirect `/docs/mimir` -> `/docs/mimir/$(DOCS_VERSION)` in local webserver

### DIFF
--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -24,9 +24,7 @@ define docs_docker_run
 	@if [[ -z $${NON_INTERACTIVE} ]]; then \
 		read -p "Press a key to continue"; \
 	fi
-	# The loki _index.md file is intentionally used until the equivalent file in the grafana/website repository is
-	# created for Mimir.
-	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'mv content/docs/loki/_index.md content/docs/$(DOCS_PROJECT)/ && find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \;  && exec $(1)'
+	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \;  && exec $(1)'
 endef
 
 .PHONY: docs-docker-rm

--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -24,7 +24,7 @@ define docs_docker_run
 	@if [[ -z $${NON_INTERACTIVE} ]]; then \
 		read -p "Press a key to continue"; \
 	fi
-	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c 'find content/docs/ -mindepth 1 -maxdepth 1 -type d -a ! -name "$(DOCS_PROJECT)" -exec rm -rf {} \;  && exec $(1)'
+	@docker run --name $(DOCS_DOCKER_CONTAINER) $(DOCS_DOCKER_RUN_FLAGS) /bin/bash -c "sed -i'' -e s/latest/$(DOCS_VERSION)/ content/docs/mimir/_index.md && exec $(1)"
 endef
 
 .PHONY: docs-docker-rm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

**[Remove Loki index file](https://github.com/grafana/mimir/commit/f90c1f307550148e3e87f0faa7336983ca7df5a3)**

This is no longer needed as the updated `grafana/docs-base` image has
the Mimir index file built in.

**[Ensure /docs/mimir redirects to $(DOCS_VERSION)](https://github.com/grafana/mimir/commit/050a62b0213f60c0220e904facb225676bd6442f)**

By default it redirects to "latest" which is desirable on the
published website.

Typically in development we would like it to redirect to "next".
