### PR TITLE
Fix mimirtool build windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.2.0-rc.1
+
+### Mimirtool
+
+* [BUGFIX] Make mimirtool build for Windows work again. #2273
+
 ## 2.2.0-rc.0
 
 ### Grafana Mimir
@@ -60,7 +66,6 @@
 * [BUGFIX] Memberlist: Fix typo in memberlist admin UI. #2202
 * [BUGFIX] Ruler: fixed typo in error message when ruler failed to decode a rule group. #2151
 * [BUGFIX] Active series custom tracker configuration is now displayed properly on `/runtime_config` page. #2065
-* [BUGFIX] Make mimirtool build for Windows work again. #2273
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [BUGFIX] Memberlist: Fix typo in memberlist admin UI. #2202
 * [BUGFIX] Ruler: fixed typo in error message when ruler failed to decode a rule group. #2151
 * [BUGFIX] Active series custom tracker configuration is now displayed properly on `/runtime_config` page. #2065
+* [BUGFIX] Make mimirtool build for Windows work again. #2273
 
 ### Mixin
 

--- a/pkg/storegateway/indexheader/fileutil/mmap_386.go
+++ b/pkg/storegateway/indexheader/fileutil/mmap_386.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/fileutil/mmap_386.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+//go:build windows
+// +build windows
+
+package fileutil
+
+const maxMapSize = 0x7FFFFFFF // 2GB

--- a/pkg/storegateway/indexheader/fileutil/mmap_amd64.go
+++ b/pkg/storegateway/indexheader/fileutil/mmap_amd64.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/fileutil/mmap_amd64.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+//go:build windows
+// +build windows
+
+package fileutil
+
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB

--- a/pkg/storegateway/indexheader/fileutil/mmap_arm64.go
+++ b/pkg/storegateway/indexheader/fileutil/mmap_arm64.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/fileutil/mmap_arm64.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+//go:build windows
+// +build windows
+
+package fileutil
+
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB

--- a/pkg/storegateway/indexheader/fileutil/mmap_windows.go
+++ b/pkg/storegateway/indexheader/fileutil/mmap_windows.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/fileutil/mmap_windows.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package fileutil
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func mmap(f *os.File, size int, populate bool) ([]byte, error) {
+	low, high := uint32(size), uint32(size>>32)
+	h, errno := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READONLY, high, low, nil)
+	if h == 0 {
+		return nil, os.NewSyscallError("CreateFileMapping", errno)
+	}
+
+	addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(size))
+	if addr == 0 {
+		return nil, os.NewSyscallError("MapViewOfFile", errno)
+	}
+
+	if err := syscall.CloseHandle(syscall.Handle(h)); err != nil {
+		return nil, os.NewSyscallError("CloseHandle", err)
+	}
+
+	return (*[maxMapSize]byte)(unsafe.Pointer(addr))[:size], nil
+}
+
+func munmap(b []byte) error {
+	if err := syscall.UnmapViewOfFile((uintptr)(unsafe.Pointer(&b[0]))); err != nil {
+		return os.NewSyscallError("UnmapViewOfFile", err)
+	}
+	return nil
+}


### PR DESCRIPTION
#### What this PR does
This PR imports windows-related mmap code from Prometheus https://github.com/prometheus/prometheus/blob/main/tsdb/fileutil/ package to make `mimirtool` buildable on Windows.

**Note that target for this bugfix was set to `release-2.2`.**

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2258

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
