### PR TITLE
Helm: fix changelog to be continuous from 2.1 release (#2272)

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -51,42 +51,22 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `NOTES.txt` to show endpoints URLs for the user at install/upgrade. #2189
 * [ENHANCEMENT] Add ServiceMonitor for overrides-exporter. #2068
 
-## 2.1.0-beta.7
+## 2.1.0
 
 * [ENHANCEMENT] Bump image version to 2.1 #2001
   - For Grafana Mimir, see the release notes here: [Grafana Mimir 2.1](https://grafana.com/docs/mimir/latest/release-notes/v2.1/)
   - For Grafana Enterprise Metrics, see the release notes here: [Grafana Enterprise Metrics 2.1](https://grafana.com/docs/enterprise-metrics/v2.1.x/release-notes/v2-1/)
-
-## 2.1.0-beta.6
-
 * [ENHANCEMENT] Disable `ingester.ring.unregister-on-shutdown` and `distributor.extend-writes` #1994
   - This will prevent resharding every series during a rolling ingester restart
   - Under some circumstances the previous values (both enabled) could cause write path degredation during rolling restarts
-
-## 2.1.0-beta.5
-
 * [ENHANCEMENT] Add support for the results cache used by the query frontend #1993
   - This will result in additional resource usage due to the addition of one or
     more memcached replicas. This applies when using small.yaml, large.yaml,
     capped-large.yaml, capped-small.yaml, or when setting
     `memcached-results.enabled=true`
-
-## 2.1.0-beta.4
-
 * [BUGFIX] Set up using older bitnami chart repository for memcached as old charts were deleted from the current one. #1998
-
-## 2.1.0-beta.3
-
 * [BUGFIX] Use grpc round-robin for distributor clients in GEM gateway and self-monitoring
   - This utilizes an additional headless service for the distributor pods
-
-## 2.1.0-beta.2
-
-* [ENHANCEMENT] Version bump only for release tests.
-
-## 2.1.0-beta.1
-
-* [ENHANCEMENT] Version bump only for release tests.
 
 ## 2.0.14
 


### PR DESCRIPTION
#### What this PR does

Cherry pick https://github.com/grafana/mimir/commit/37376ee1287f36542648573ae707c5f74775e7fb

Helm: fix changelog to be continuous from 2.1 release (#2272)
    
    We did release some interim versions, but we switched to weekly releases
    shortly after. Now having those beta versions in the changelog just make
    it messy from release note point of view.
    

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

N/A