### PR TITLE
[ruler] Remove unused fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
+* [CHANGE] Ruler: Remove unused fields `-ruler.search-pending-for` and `-ruler.flush-period`. #2288
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
-* [CHANGE] Ruler: Remove unused fields `-ruler.search-pending-for` and `-ruler.flush-period`. #2288
+* [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 
 ### Mixin

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6960,17 +6960,6 @@
           "fieldCategory": "advanced"
         },
         {
-          "kind": "field",
-          "name": "search_pending_for",
-          "required": false,
-          "desc": "Time to spend searching for a pending ruler when shutting down.",
-          "fieldValue": null,
-          "fieldDefaultValue": 300000000000,
-          "fieldFlag": "ruler.search-pending-for",
-          "fieldType": "duration",
-          "fieldCategory": "advanced"
-        },
-        {
           "kind": "block",
           "name": "ring",
           "required": false,
@@ -7343,17 +7332,6 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
-        },
-        {
-          "kind": "field",
-          "name": "flush_period",
-          "required": false,
-          "desc": "Period with which to attempt to flush rule groups.",
-          "fieldValue": null,
-          "fieldDefaultValue": 60000000000,
-          "fieldFlag": "ruler.flush-period",
-          "fieldType": "duration",
-          "fieldCategory": "advanced"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1404,8 +1404,6 @@ Usage of ./cmd/mimir/mimir:
     	How frequently to evaluate rules (default 1m0s)
   -ruler.external.url value
     	URL of alerts return path.
-  -ruler.flush-period duration
-    	Period with which to attempt to flush rule groups. (default 1m0s)
   -ruler.for-grace-period duration
     	Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. (default 10m0s)
   -ruler.for-outage-tolerance duration
@@ -1518,8 +1516,6 @@ Usage of ./cmd/mimir/mimir:
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -ruler.rule-path string
     	Directory to store temporary rule files loaded by the Prometheus rule managers. This directory is not required to be persisted between restarts. (default "./data-ruler/")
-  -ruler.search-pending-for duration
-    	Time to spend searching for a pending ruler when shutting down. (default 5m0s)
   -ruler.tenant-federation.enabled
     	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's 'source_tenants' field. If this flag is set to 'false' when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
   -ruler.tenant-shard-size int

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -1298,10 +1298,6 @@ alertmanager_client:
 # CLI flag: -ruler.resend-delay
 [resend_delay: <duration> | default = 1m]
 
-# (advanced) Time to spend searching for a pending ruler when shutting down.
-# CLI flag: -ruler.search-pending-for
-[search_pending_for: <duration> | default = 5m]
-
 ring:
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
@@ -1368,10 +1364,6 @@ ring:
   # (advanced) Number of tokens for each ruler.
   # CLI flag: -ruler.ring.num-tokens
   [num_tokens: <int> | default = 128]
-
-# (advanced) Period with which to attempt to flush rule groups.
-# CLI flag: -ruler.flush-period
-[flush_period: <duration> | default = 1m]
 
 # Enable the ruler config API.
 # CLI flag: -ruler.enable-api

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -102,9 +102,7 @@ type Config struct {
 	ResendDelay time.Duration `yaml:"resend_delay" category:"advanced"`
 
 	// Enable sharding rule groups.
-	SearchPendingFor time.Duration `yaml:"search_pending_for" category:"advanced"`
-	Ring             RingConfig    `yaml:"ring"`
-	FlushCheckPeriod time.Duration `yaml:"flush_period" category:"advanced"`
+	Ring RingConfig `yaml:"ring"`
 
 	EnableAPI bool `yaml:"enable_api"`
 
@@ -150,8 +148,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.IntVar(&cfg.NotificationQueueCapacity, "ruler.notification-queue-capacity", 10000, "Capacity of the queue for notifications to be sent to the Alertmanager.")
 	f.DurationVar(&cfg.NotificationTimeout, "ruler.notification-timeout", 10*time.Second, "HTTP timeout duration when sending notifications to the Alertmanager.")
 
-	f.DurationVar(&cfg.SearchPendingFor, "ruler.search-pending-for", 5*time.Minute, "Time to spend searching for a pending ruler when shutting down.")
-	f.DurationVar(&cfg.FlushCheckPeriod, "ruler.flush-period", 1*time.Minute, "Period with which to attempt to flush rule groups.")
 	f.StringVar(&cfg.RulePath, "ruler.rule-path", "./data-ruler/", "Directory to store temporary rule files loaded by the Prometheus rule managers. This directory is not required to be persisted between restarts.")
 	f.BoolVar(&cfg.EnableAPI, "ruler.enable-api", true, "Enable the ruler config API.")
 	f.DurationVar(&cfg.OutageTolerance, "ruler.for-outage-tolerance", time.Hour, `Max time to tolerate outage for restoring "for" state of alert.`)

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -805,9 +805,8 @@ func TestSharding(t *testing.T) {
 						},
 						HeartbeatTimeout: 1 * time.Minute,
 					},
-					FlushCheckPeriod: 0,
-					EnabledTenants:   tc.enabledUsers,
-					DisabledTenants:  tc.disabledUsers,
+					EnabledTenants:  tc.enabledUsers,
+					DisabledTenants: tc.disabledUsers,
 				}
 
 				r := buildRuler(t, cfg, newMockRuleStore(allRules), nil)


### PR DESCRIPTION
I was helping someone debug notifications being sent every min and we found that
these two fields are not used anywhere at all.

I am not sure of the deprecation and breaking change policy. Should I mark them
deprecated somehow and then remove them or just remove them right away since they
are not being used.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
