### PR TITLE
Use menuTitle for more user-friendly lists of topics 

### DIFF
--- a/docs/sources/migration-guide/_index.md
+++ b/docs/sources/migration-guide/_index.md
@@ -9,4 +9,4 @@ weight: 30
 
 Refer to the following migration guides when you migrate to Grafana Mimir.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/migration-guide/migrating-from-cortex.md
+++ b/docs/sources/migration-guide/migrating-from-cortex.md
@@ -1,5 +1,6 @@
 ---
 title: "Migrating from Cortex to Grafana Mimir"
+menuTitle: "Migrating from Cortex"
 description: "Learn how to migrate your deployment of Cortex to Grafana Mimir to simplify the deployment and continued operation of a horizontally scalable, multi-tenant time series database with long-term storage."
 weight: 10
 ---

--- a/docs/sources/migration-guide/migrating-from-thanos-or-prometheus.md
+++ b/docs/sources/migration-guide/migrating-from-thanos-or-prometheus.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating from Thanos or Prometheus to Grafana Mimir"
-menuTitle: "Migrating from Thanos or Prometheus to Grafana Mimir"
+menuTitle: "Migrating from Thanos or Prometheus"
 description: "Learn how to migrate from Thanos or Prometheus to Grafana Mimir."
 weight: 10
 ---

--- a/docs/sources/operators-guide/_index.md
+++ b/docs/sources/operators-guide/_index.md
@@ -23,4 +23,4 @@ The intended audience for this guide includes:
 
 This guide contains the following sections:
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/architecture/_index.md
+++ b/docs/sources/operators-guide/architecture/_index.md
@@ -9,4 +9,4 @@ weight: 20
 
 The following topics include overviews of the Grafana Mimir architecture.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
+++ b/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
@@ -17,9 +17,7 @@ For more information, refer to [Deployment modes]({{< relref "../deployment-mode
 
 ## Grafana Mimir components
 
-Most components are stateless and do not require any data persisted between process restarts. Some components are stateful and rely on non-volatile storage to prevent data loss between process restarts. For details about each component, see its page.
-
-{{< section >}}
+Most components are stateless and do not require any data persisted between process restarts. Some components are stateful and rely on non-volatile storage to prevent data loss between process restarts. For details about each component, see its page in [Components]({{< relref "components/" >}}).
 
 ### The write path
 

--- a/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
+++ b/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
@@ -17,7 +17,7 @@ For more information, refer to [Deployment modes]({{< relref "../deployment-mode
 
 ## Grafana Mimir components
 
-Most components are stateless and do not require any data persisted between process restarts. Some components are stateful and rely on non-volatile storage to prevent data loss between process restarts. For details about each component, see its page in [Components]({{< relref "components/_index.md" >}}).
+Most components are stateless and do not require any data persisted between process restarts. Some components are stateful and rely on non-volatile storage to prevent data loss between process restarts. For details about each component, see its page in [Components]({{< relref "../components/_index.md" >}}).
 
 ### The write path
 

--- a/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
+++ b/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
@@ -17,7 +17,7 @@ For more information, refer to [Deployment modes]({{< relref "../deployment-mode
 
 ## Grafana Mimir components
 
-Most components are stateless and do not require any data persisted between process restarts. Some components are stateful and rely on non-volatile storage to prevent data loss between process restarts. For details about each component, see its page in [Components]({{< relref "components/" >}}).
+Most components are stateless and do not require any data persisted between process restarts. Some components are stateful and rely on non-volatile storage to prevent data loss between process restarts. For details about each component, see its page in [Components]({{< relref "components/_index.md" >}}).
 
 ### The write path
 

--- a/docs/sources/operators-guide/architecture/components/_index.md
+++ b/docs/sources/operators-guide/architecture/components/_index.md
@@ -20,4 +20,4 @@ keywords:
 
 Grafana Mimir includes a set of components that interact to form a cluster.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/configuring/_index.md
+++ b/docs/sources/operators-guide/configuring/_index.md
@@ -11,4 +11,4 @@ keywords:
 
 Grafana Mimir's flexibility is achieved through configuration.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/_index.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/_index.md
@@ -15,4 +15,4 @@ keywords:
 Grafana Labs publishes [Jsonnet](https://jsonnet.org/) files that you can use to deploy Grafana Mimir in [microservices mode]({{< relref "../../architecture/deployment-modes/index.md#microservices-mode" >}}).
 Jsonnet files are located in the [Mimir repository](https://github.com/grafana/mimir/tree/main/operations/mimir).
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring Grafana Mimir"
-menuTitle: "Monitoring Grafana Mimir"
+menuTitle: "Monitoring"
 description: "View example Grafana Mimir dashboards."
 weight: 50
 keywords:

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
@@ -13,4 +13,4 @@ aliases:
 
 The following topics guide you in preparing your environment to display dashboards that you can use to monitor Grafana Mimir.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring Grafana Mimir"
-menuTitle: "Monitoring"
+menuTitle: "Monitoring Mimir"
 description: "View example Grafana Mimir dashboards."
 weight: 50
 keywords:

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/_index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/_index.md
@@ -11,4 +11,4 @@ aliases:
 
 Grafana Mimir provides the following production-ready dashboards.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/running-production-environment/_index.md
+++ b/docs/sources/operators-guide/running-production-environment/_index.md
@@ -9,4 +9,4 @@ weight: 80
 
 The following topics provide guidance for you to consider when you run Grafana Mimir in a production environment.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/running-production-environment/_index.md
+++ b/docs/sources/operators-guide/running-production-environment/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Running Grafana Mimir in production"
-menuTitle: "Running Grafana Mimir in production"
+menuTitle: "Running in production"
 description: "Learn how to run Grafana Mimir in production."
 weight: 80
 ---

--- a/docs/sources/operators-guide/running-production-environment/scaling-out.md
+++ b/docs/sources/operators-guide/running-production-environment/scaling-out.md
@@ -1,6 +1,6 @@
 ---
 title: "Scaling out Grafana Mimir"
-menuTitle: "Scaling out Grafana Mimir"
+menuTitle: "Scaling out"
 description: "Learn how to scale out Grafana Mimir."
 weight: 30
 ---

--- a/docs/sources/operators-guide/securing/_index.md
+++ b/docs/sources/operators-guide/securing/_index.md
@@ -15,4 +15,4 @@ keywords:
 
 These sections explain how to secure Grafana Mimir data and communication paths.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/securing/_index.md
+++ b/docs/sources/operators-guide/securing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing Grafana Mimir"
-menuTitle: "Securing Grafana Mimir"
+menuTitle: "Securing"
 description: "Learn how to secure Grafana Mimir data and communication paths."
 weight: 70
 keywords:

--- a/docs/sources/operators-guide/tools/_index.md
+++ b/docs/sources/operators-guide/tools/_index.md
@@ -9,4 +9,4 @@ weight: 100
 
 Tools for Grafana Mimir aid in administration and troubleshooting tasks.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/tools/_index.md
+++ b/docs/sources/operators-guide/tools/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Grafana Mimir tools"
-menuTitle: "Grafana Mimir tools"
+menuTitle: "Tools"
 description: "Tools for Grafana Mimir aid in administration and troubleshooting tasks."
 weight: 100
 ---

--- a/docs/sources/operators-guide/using-exemplars/_index.md
+++ b/docs/sources/operators-guide/using-exemplars/_index.md
@@ -11,4 +11,4 @@ keywords:
 
 This following topics describe how to use exemplars to identify higher cardinality metadata from specific events within time series data.
 
-{{< section >}}
+{{< section menuTitle="true" >}}

--- a/docs/sources/operators-guide/using-exemplars/_index.md
+++ b/docs/sources/operators-guide/using-exemplars/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Using exemplars with Grafana Mimir"
-menuTitle: "Using exemplars with Grafana Mimir"
-description: "Learn how to use examplars with Grafana Mimir."
+menuTitle: "Using exemplars"
+description: "Learn how to use exemplars with Grafana Mimir."
 weight: 40
 keywords:
   - Mimir exemplars

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -9,4 +9,4 @@ keywords:
 
 # Grafana Mimir release notes
 
-{{< section >}}
+{{< section menuTitle="true" >}}


### PR DESCRIPTION
#### What this PR does

Uses the `menuTitle` parameter of the `section` shortcode to reduce stuttering throughout the documentation.
Titles include "Grafana Mimir" as context when the page turns up on search engine results but when you are in the documentation, this is already implied.

#### Checklist

- [x] Documentation added
