### PR TITLE
Clarify query results cache panels in 'Mimir / Queries' dashboard

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -765,7 +765,7 @@
                         "format": "time_series",
                         "interval": "15s",
                         "intervalFactor": 2,
-                        "legendFormat": "Hit rate",
+                        "legendFormat": "Hit ratio",
                         "legendLink": null,
                         "step": 10
                      }
@@ -773,7 +773,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Results cache hit %",
+                  "title": "Query results cache hit ratio",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -842,7 +842,7 @@
                         "format": "time_series",
                         "interval": "15s",
                         "intervalFactor": 2,
-                        "legendFormat": "Miss rate",
+                        "legendFormat": "Missed query results per second",
                         "legendLink": null,
                         "step": 10
                      }
@@ -850,7 +850,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Results cache misses",
+                  "title": "Query results cache misses",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -65,7 +65,7 @@ local filename = 'mimir-queries.json';
         ),
       )
       .addPanel(
-        $.panel('Results cache hit %') +
+        $.panel('Query results cache hit ratio') +
         $.queryPanel(
           |||
             # Query metrics before and after migration to new memcached backend.
@@ -83,12 +83,12 @@ local filename = 'mimir-queries.json';
           ||| % {
             frontend: $.jobMatcher($._config.job_names.query_frontend),
           },
-          'Hit rate',
+          'Hit ratio',
         ) +
         { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
       )
       .addPanel(
-        $.panel('Results cache misses') +
+        $.panel('Query results cache misses') +
         $.queryPanel(
           |||
             # Query metrics before and after migration to new memcached backend.
@@ -106,7 +106,7 @@ local filename = 'mimir-queries.json';
           ||| % {
             frontend: $.jobMatcher($._config.job_names.query_frontend),
           },
-          'Miss rate'
+          'Missed query results per second'
         ),
       )
     )


### PR DESCRIPTION
#### What this PR does
A couple of changes to clarify the query results cache panels in "Mimir / Queries" dashboard:

- Renamed cache "Hit rate" to "Hit ratio" to keep consistency with the other dashboards
- Renamed "Miss rate" to "Missed query results per second" to clarify it's the number of missed query results per second and not a %

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
