### PR TITLE
Vendor latest mimir-prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -227,7 +227,7 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110
 replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220704133518-c6f3d4ab339a
 
 // Out of order Support forces us to fork thanos because we've changed the ChunkReader interface.
 // Once the out of order support is upstreamed and Thanos has vendored it, we can remove this override.

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/grafana/e2e v0.1.1-0.20220519104354-1db01e4751fe h1:mxrRWDjKtob43xF9n
 github.com/grafana/e2e v0.1.1-0.20220519104354-1db01e4751fe/go.mod h1:+26VJWpczg2OU3D0537acnHSHzhJORpxOs6F+M27tZo=
 github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167 h1:PgEQkGHR4YimSCEGT5IoswN9gJKZDVskf+he6UClCLw=
 github.com/grafana/memberlist v0.3.1-0.20220425183535-6b97a09b7167/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5 h1:xlK4WGUnyG7odN0XeMGHzGB7s1/uuEKacl2X9fXcUbA=
-github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
+github.com/grafana/mimir-prometheus v0.0.0-20220704133518-c6f3d4ab339a h1:MNziksIRCy+CvMHYPSAmzP9B+R15PEhsgdl42uUuVV0=
+github.com/grafana/mimir-prometheus v0.0.0-20220704133518-c6f3d4ab339a/go.mod h1:evpqrqffGRI38M1zH3IHpmXTeho8IfX5Qpx6Ixpqhyk=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317 h1:DG++oZD7E6YUm8YNZOu7RwZ8J/Slhcx3iOlKQBY6Oh0=

--- a/vendor/github.com/prometheus/prometheus/tsdb/db.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/db.go
@@ -711,14 +711,6 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 
 	walDir := filepath.Join(dir, "wal")
 	wblDir := filepath.Join(dir, wal.WblDirName)
-	// TODO(jesus.vazquez) Remove the block of code below, only necessary until all ooo_wbl dirs in prod have been replaced with wbl
-	oldWblDir := filepath.Join(dir, "ooo_wbl")
-	if _, err := os.Stat(oldWblDir); err == nil {
-		err = fileutil.Rename(oldWblDir, wblDir)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to move old wbl dir to new wbl dir")
-		}
-	}
 
 	// Migrate old WAL if one exists.
 	if err := MigrateWAL(l, walDir); err != nil {
@@ -1652,14 +1644,6 @@ func (db *DB) inOrderBlocksMaxTime() (maxt int64, ok bool) {
 			ok = true
 			maxt = b.meta.MaxTime
 		}
-	}
-	if !hasOOO && ok && db.opts.OutOfOrderTimeWindow > 0 {
-		// Temporary patch. To be removed by mid July 2022.
-		// Before this patch, blocks did not have "out_of_order" in their meta, so we cannot
-		// say which block has the out_of_order data. In that case the out-of-order block can be
-		// up to 2 block ranges ahead of the latest in-order block.
-		// Note: if hasOOO was true, it means the latest block has the new meta and is taken care in inOrderBlocksMaxTime().
-		maxt -= 2 * db.opts.MinBlockDuration
 	}
 	return maxt, ok
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -717,7 +717,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519 => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
+# github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519 => github.com/grafana/mimir-prometheus v0.0.0-20220704133518-c6f3d4ab339a
 ## explicit; go 1.17
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1227,7 +1227,7 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220627145625-5e8406a1d4a5
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20220704133518-c6f3d4ab339a
 # github.com/thanos-io/thanos => github.com/grafana/thanos v0.19.1-0.20220610094531-ab07eb568317
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2


### PR DESCRIPTION
This vendoring brings in https://github.com/grafana/mimir-prometheus/pull/283, which removes a couple of temporary patches made for out-of-order support that are no longer required.