### PR TITLE
Added missed rule evaluations to the "Evaluations per second" panel in the "Mimir / Ruler" dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Dashboards: added missed rule evaluations to the "Evaluations per second" panel in the "Mimir / Ruler" dashboard. #2314
+
 ### Jsonnet
 
 ### Mimirtool

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -398,12 +398,21 @@
                         "legendFormat": "failed",
                         "legendLink": null,
                         "step": 10
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_rule_group_iterations_missed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir))\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "interval": "15s",
+                        "intervalFactor": 2,
+                        "legendFormat": "missed",
+                        "legendLink": null,
+                        "step": 10
                      }
                   ],
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "EPS",
+                  "title": "Evaluations per second",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -19,6 +19,7 @@ local filename = 'mimir-ruler.json';
             /
           sum (rate(cortex_prometheus_rule_evaluation_duration_seconds_count{%s}[$__rate_interval]))
         |||,
+      missedIterations: 'sum(rate(cortex_prometheus_rule_group_iterations_missed_total{%s}[$__rate_interval]))',
     },
     perUserPerGroupEvaluations: {
       failure: 'sum by(rule_group) (rate(cortex_prometheus_rule_evaluation_failures_total{%s}[$__rate_interval])) > 0',
@@ -87,13 +88,14 @@ local filename = 'mimir-ruler.json';
     .addRow(
       $.row('Rule evaluations global')
       .addPanel(
-        $.panel('EPS') +
+        $.panel('Evaluations per second') +
         $.queryPanel(
           [
             $.rulerQueries.ruleEvaluations.success % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)],
             $.rulerQueries.ruleEvaluations.failure % $.jobMatcher($._config.job_names.ruler),
+            $.rulerQueries.ruleEvaluations.missedIterations % $.jobMatcher($._config.job_names.ruler),
           ],
-          ['success', 'failed'],
+          ['success', 'failed', 'missed'],
         ),
       )
       .addPanel(


### PR DESCRIPTION
#### What this PR does
If there're no failures in rule evaluations, it doesn't necessarily mean everything is just fine. Rules could be slow to evaluate and so we could miss some rule evaluation iterations. That's why we also have the alert `MimirRulerMissedEvaluations`.

Missed rule evaluations are not clearly visible in the "Mimir / Ruler" dashboard (they're just displayed on a per-tenant basis down the dashboard, in a row which is collapsed by default).

I propose to add it to the "Evaluations per second" panel, to make it more visible.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
