### PR TITLE
Get PR 2050 through the finish line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
-* [ENHANCEMENT] Alertmanager: Allow the `proxy_url` configuration option in the receiver's configuration. #2317
+* [ENHANCEMENT] Alertmanager: Allow the HTTP `proxy_url` configuration option in the receiver's configuration. #2317
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
-* [ENHANCEMENT] Alertmanager: Allow the `proxy_url` configuration option in the receivers configuration. #2317
+* [ENHANCEMENT] Alertmanager: Allow the `proxy_url` configuration option in the receiver's configuration. #2317
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
+* [ENHANCEMENT] Alertmanager: Allow the `proxy_url` configuration option in the receivers configuration. #2050
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
-* [ENHANCEMENT] Alertmanager: Allow the `proxy_url` configuration option in the receivers configuration. #2050
+* [ENHANCEMENT] Alertmanager: Allow the `proxy_url` configuration option in the receivers configuration. #2317
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 
 ### Mixin

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -422,14 +422,8 @@ func validateReceiverHTTPConfig(cfg commoncfg.HTTPClientConfig) error {
 	if cfg.BearerTokenFile != "" {
 		return errPasswordFileNotAllowed
 	}
-	if cfg.ProxyURL.URL != nil {
-		return errProxyURLNotAllowed
-	}
 	if cfg.OAuth2 != nil && cfg.OAuth2.ClientSecretFile != "" {
 		return errOAuth2SecretFileNotAllowed
-	}
-	if cfg.OAuth2 != nil && cfg.OAuth2.ProxyURL.URL != nil {
-		return errProxyURLNotAllowed
 	}
 	return validateReceiverTLSConfig(cfg.TLSConfig)
 }

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -49,6 +49,7 @@ const (
 var (
 	errPasswordFileNotAllowed           = errors.New("setting password_file, bearer_token_file and credentials_file is not allowed")
 	errOAuth2SecretFileNotAllowed       = errors.New("setting OAuth2 client_secret_file is not allowed")
+	errProxyURLNotAllowed               = errors.New("setting proxy_url is not allowed")
 	errTLSFileNotAllowed                = errors.New("setting TLS ca_file, cert_file and key_file is not allowed")
 	errSlackAPIURLFileNotAllowed        = errors.New("setting Slack api_url_file and global slack_api_url_file is not allowed")
 	errVictorOpsAPIKeyFileNotAllowed    = errors.New("setting VictorOps api_key_file is not allowed")
@@ -423,6 +424,9 @@ func validateReceiverHTTPConfig(cfg commoncfg.HTTPClientConfig) error {
 	}
 	if cfg.OAuth2 != nil && cfg.OAuth2.ClientSecretFile != "" {
 		return errOAuth2SecretFileNotAllowed
+	}
+	if cfg.OAuth2 != nil && cfg.OAuth2.ProxyURL.URL != nil {
+		return errProxyURLNotAllowed
 	}
 	return validateReceiverTLSConfig(cfg.TLSConfig)
 }

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -49,7 +49,6 @@ const (
 var (
 	errPasswordFileNotAllowed           = errors.New("setting password_file, bearer_token_file and credentials_file is not allowed")
 	errOAuth2SecretFileNotAllowed       = errors.New("setting OAuth2 client_secret_file is not allowed")
-	errProxyURLNotAllowed               = errors.New("setting proxy_url is not allowed")
 	errTLSFileNotAllowed                = errors.New("setting TLS ca_file, cert_file and key_file is not allowed")
 	errSlackAPIURLFileNotAllowed        = errors.New("setting Slack api_url_file and global slack_api_url_file is not allowed")
 	errVictorOpsAPIKeyFileNotAllowed    = errors.New("setting VictorOps api_key_file is not allowed")

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -307,6 +307,24 @@ alertmanager_config: |
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
 		},
 		{
+			name: "Should return error if global OAuth2 proxy_url is set",
+			cfg: `
+alertmanager_config: |
+  global:
+    http_config:
+      oauth2:
+        client_id: test
+        client_secret: xxx
+        token_url: http://example.com
+        proxy_url: http://example.com
+  route:
+    receiver: 'default-receiver'
+  receivers:
+    - name: default-receiver
+`,
+			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
+		},
+		{
 			name: "Should return error if global OAuth2 TLS key_file is set",
 			cfg: `
 alertmanager_config: |
@@ -394,6 +412,25 @@ alertmanager_config: |
     receiver: 'default-receiver'
 `,
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
+		},
+		{
+			name: "Should return error if receiver's OAuth2 proxy_url is set",
+			cfg: `
+alertmanager_config: |
+  receivers:
+    - name: default-receiver
+      webhook_configs:
+        - url: http://localhost
+          http_config:
+            oauth2:
+              client_id: test
+              token_url: http://example.com
+              client_secret: xxx
+              proxy_url: http://localhost
+  route:
+    receiver: 'default-receiver'
+`,
+			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
 		},
 		{
 			name: "Should return error if global slack_api_url_file is set",

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -307,25 +307,6 @@ alertmanager_config: |
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
 		},
 		{
-			name: "Should return error if global OAuth2 proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  global:
-    http_config:
-      oauth2:
-        client_id: test
-        client_secret: xxx
-        token_url: http://example.com
-        proxy_url: http://example.com
-
-  route:
-    receiver: 'default-receiver'
-  receivers:
-    - name: default-receiver
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
-		},
-		{
 			name: "Should return error if global OAuth2 TLS key_file is set",
 			cfg: `
 alertmanager_config: |
@@ -413,42 +394,6 @@ alertmanager_config: |
     receiver: 'default-receiver'
 `,
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
-		},
-		{
-			name: "Should return error if receiver's OAuth2 proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  receivers:
-    - name: default-receiver
-      webhook_configs:
-        - url: http://localhost
-          http_config:
-            oauth2:
-              client_id: test
-              token_url: http://example.com
-              client_secret: xxx
-              proxy_url: http://localhost
-
-  route:
-    receiver: 'default-receiver'
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
-		},
-		{
-			name: "Should return error if receiver's HTTP proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  receivers:
-    - name: default-receiver
-      webhook_configs:
-        - url: http://localhost
-          http_config:
-            proxy_url: http://localhost
-
-  route:
-    receiver: 'default-receiver'
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
 		},
 		{
 			name: "Should return error if global slack_api_url_file is set",


### PR DESCRIPTION
#### What this PR does
This PR is just #2050 (keeping original author commits) + addressing a couple of nits before merging. Contrary to #2050, I've reverted the change on OAuth2 proxy URL because, after adding a unit test on it, I've realized it's not protected by our firewall logic (we need to do changes in `prometheus/common` to set the dial context override on it too).

#### Which issue(s) this PR fixes or relates to
Fixes #2044

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
