### PR TITLE
missing memcachedExporter resources + imagePullSecrets

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -12,6 +12,9 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
+* [ENHANCEMENT] Update memcached statefulset manifest
+  - Added imagePullSecrets block to pull images from private registry
+  - Added resources block for memcachedExporter
 * [CHANGE] **breaking change** The minimal Kubernetes version is now 1.20. This reflects the fact that Grafana does not test with older versions. #2297
 * [CHANGE] **breaking change** Make `ConfigMap` the default for `configStorageType`. This means that the Mimir (or Enterprise Metrics) configuration is now created in and loaded from a ConfigMap instead of a Secret. #2277
   - Set to `Secret` to keep existing way of working. See related #2031, #2017, #2089.

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -12,7 +12,7 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
-* [ENHANCEMENT] Update memcached statefulset manifest
+* [ENHANCEMENT] Update memcached statefulset manifest #2321
   - Added imagePullSecrets block to pull images from private registry
   - Added resources block for memcachedExporter
 * [CHANGE] **breaking change** The minimal Kubernetes version is now 1.20. This reflects the fact that Grafana does not test with older versions. #2297

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -12,9 +12,6 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
-* [ENHANCEMENT] Update memcached statefulset manifest #2321
-  - Added imagePullSecrets block to pull images from private registry
-  - Added resources block for memcachedExporter
 * [CHANGE] **breaking change** The minimal Kubernetes version is now 1.20. This reflects the fact that Grafana does not test with older versions. #2297
 * [CHANGE] **breaking change** Make `ConfigMap` the default for `configStorageType`. This means that the Mimir (or Enterprise Metrics) configuration is now created in and loaded from a ConfigMap instead of a Secret. #2277
   - Set to `Secret` to keep existing way of working. See related #2031, #2017, #2089.
@@ -47,6 +44,9 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Remove setting `server.grpc_server_max_recv_msg_size` and `server.grpc_server_max_send_msg_size` to 100MB, since it is the default now, see #1884. #2300
 * [FEATURE] Add `mimir-continuous-test` in smoke-test mode. Use `helm test` to run a smoke test of the read + write path.
 * [FEATURE] Add meta-monitoring via the Grafana Agent Kubernetes operator: scrape metrics and collect logs from Mimir pods and ship them to a remote. #2068
+* [ENHANCEMENT] Update memcached statefulset manifest #2321
+  - Added imagePullSecrets block to pull images from private registry
+  - Added resources block for memcachedExporter
 * [ENHANCEMENT] ServiceMonitor object will now have default values based on release namesapce in the `namespace` and `namespaceSelector` fields. #2123
 * [ENHANCEMENT] Set the `namespace` metadata field for all kubernetes objects to enable using `--namespace` correctly with Helm even if the specified namespace does not exist. #2123
 * [ENHANCEMENT] The new value `serviceMonitor.clusterLabel` controls whether to add a `cluster` label and with what content to ServiceMonitor metrics. #2125

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -54,9 +54,9 @@ spec:
       tolerations:
         {{- toYaml .tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
-      {{- if $.ctx.Values.memcached.image.pullSecrets }}
+      {{- if $.ctx.Values.image.pullSecrets }}
       imagePullSecrets:
-      {{- range $.ctx.Values.memcached.image.pullSecrets }}
+      {{- range $.ctx.Values.image.pullSecrets }}
         - name: {{ . }}
       {{- end }}
       {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -54,6 +54,12 @@ spec:
       tolerations:
         {{- toYaml .tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+      {{- if $.ctx.Values.memcached.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $.ctx.Values.memcached.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         {{- if .extraContainers }}
         {{ toYaml .extraContainers | nindent 8 }}
@@ -110,6 +116,8 @@ spec:
           args:
             - "--memcached.address=localhost:{{ .port }}"
             - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            {{- toYaml $.ctx.Values.memcachedExporter.resources | nindent 12 }}
       {{- end }}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1026,6 +1026,7 @@ memcached:
     tag: 1.6.9-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
+    pullSecrets: []
 
   # -- The SecurityContext for memcached pods
   podSecurityContext:
@@ -1051,8 +1052,8 @@ memcachedExporter:
     tag: v0.6.0
     pullPolicy: IfNotPresent
 
-chunks-cache:
-  # -- Specifies whether memcached based chunks-cache should be enabled
+memcached-chunks:
+  # -- Specifies whether memcached-chunks should be enabled
   enabled: false
 
   # -- Total number of chunks-cache replicas

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1055,8 +1055,8 @@ memcachedExporter:
     requests: {}
     limits: {}
 
-memcached-chunks:
-  # -- Specifies whether memcached-chunks should be enabled
+chunks-cache:
+  # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: false
 
   # -- Total number of chunks-cache replicas

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1026,7 +1026,6 @@ memcached:
     tag: 1.6.9-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
-    pullSecrets: []
 
   # -- The SecurityContext for memcached pods
   podSecurityContext:
@@ -1051,6 +1050,10 @@ memcachedExporter:
     repository: prom/memcached-exporter
     tag: v0.6.0
     pullPolicy: IfNotPresent
+
+  resources:
+    requests: {}
+    limits: {}
 
 memcached-chunks:
   # -- Specifies whether memcached-chunks should be enabled

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -89,3 +89,6 @@ spec:
           args:
             - "--memcached.address=localhost:11211"
             - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -89,3 +89,6 @@ spec:
           args:
             - "--memcached.address=localhost:11211"
             - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -89,3 +89,6 @@ spec:
           args:
             - "--memcached.address=localhost:11211"
             - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -89,3 +89,6 @@ spec:
           args:
             - "--memcached.address=localhost:11211"
             - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
- availability to pull image from private registry (like artifactory)
- missing resources block for memcachedExporter

#### Which issue(s) this PR fixes or relates to

Fixes #2320 

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
