### PR TITLE
Fix -compactor.consistency-delay description

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5486,7 +5486,7 @@
           "kind": "field",
           "name": "consistency_delay",
           "required": false,
-          "desc": "Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and 48h0m0s will be removed.",
+          "desc": "Minimum age of fresh (non-compacted) blocks before they are being processed.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
           "fieldFlag": "compactor.consistency-delay",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -546,7 +546,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.compactor-tenant-shard-size int
     	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.consistency-delay duration
-    	Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and 48h0m0s will be removed.
+    	Minimum age of fresh (non-compacted) blocks before they are being processed.
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
   -compactor.deletion-delay duration

--- a/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configuring/reference-configuration-parameters/index.md
@@ -3559,8 +3559,7 @@ The `compactor` block configures the compactor component.
 [meta_sync_concurrency: <int> | default = 20]
 
 # (advanced) Minimum age of fresh (non-compacted) blocks before they are being
-# processed. Malformed blocks older than the maximum of consistency-delay and
-# 48h0m0s will be removed.
+# processed.
 # CLI flag: -compactor.consistency-delay
 [consistency_delay: <duration> | default = 0s]
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -45,10 +45,6 @@ const (
 const (
 	blocksMarkedForDeletionName = "cortex_compactor_blocks_marked_for_deletion_total"
 	blocksMarkedForDeletionHelp = "Total number of blocks marked for deletion in compactor."
-
-	// PartialUploadThresholdAge is a time after partial block is assumed aborted and ready to be cleaned.
-	// Keep it long as it is based on block creation time not upload start time.
-	PartialUploadThresholdAge = 2 * 24 * time.Hour
 )
 
 var (
@@ -127,7 +123,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.retryMaxBackoff = time.Minute
 
 	f.Var(&cfg.BlockRanges, "compactor.block-ranges", "List of compaction time ranges.")
-	f.DurationVar(&cfg.ConsistencyDelay, "compactor.consistency-delay", 0, fmt.Sprintf("Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and %s will be removed.", PartialUploadThresholdAge))
+	f.DurationVar(&cfg.ConsistencyDelay, "compactor.consistency-delay", 0, "Minimum age of fresh (non-compacted) blocks before they are being processed.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "compactor.block-sync-concurrency", 8, "Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "compactor.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from the long term storage.")
 	f.StringVar(&cfg.DataDir, "compactor.data-dir", "./data-compactor/", "Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts.")


### PR DESCRIPTION
#### What this PR does
The comment https://github.com/grafana/mimir/issues/1291#issuecomment-1102999139 made me realise that the `-compactor.consistency-delay` description is incorrect. Mimir doesn't delete partial blocks unless they already have a deletion mark. Also the `PartialUploadThresholdAge` constant was inherited from Thanos but it's not really used by Mimir.

This PR fixed it.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
