### PR TITLE
Helm: Add ruler endpoint to nginx proxy

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1580,6 +1580,9 @@ nginx:
           location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/rules {
             proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
+          location /api/v1/rules {
+            proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+          }
 
           location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/alerts {
             proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -81,6 +81,9 @@ data:
         location /prometheus/api/v1/rules {
           proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
         }
+        location /api/v1/rules {
+          proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+        }
     
         location /prometheus/api/v1/alerts {
           proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;


### PR DESCRIPTION
mimirtool fail to manage rules if you point it to nginx service since it use `/api/v1/rules` to manage rule operations.

* Make `api/v1/rules` proxy to ruler service