### PR TITLE
helm: Fix nginx and memcached extraArgs

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -67,7 +67,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `NOTES.txt` to show endpoints URLs for the user at install/upgrade. #2189
 * [ENHANCEMENT] Add ServiceMonitor for overrides-exporter. #2068
 * [ENHANCEMENT] Add `nginx.resolver` for allow custom resolver in nginx configuration and `nginx.extraContainers` which allow add side containers to the nginx deployment #2196
-* [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container.
+* [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 
 ## 2.1.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -67,6 +67,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `NOTES.txt` to show endpoints URLs for the user at install/upgrade. #2189
 * [ENHANCEMENT] Add ServiceMonitor for overrides-exporter. #2068
 * [ENHANCEMENT] Add `nginx.resolver` for allow custom resolver in nginx configuration and `nginx.extraContainers` which allow add side containers to the nginx deployment #2196
+* [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container.
 
 ## 2.1.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [ENHANCEMENT] Add backfill endpoints to Nginx configuration. #2478
+* [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 
 ## 3.0.0
 
@@ -67,7 +68,6 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `NOTES.txt` to show endpoints URLs for the user at install/upgrade. #2189
 * [ENHANCEMENT] Add ServiceMonitor for overrides-exporter. #2068
 * [ENHANCEMENT] Add `nginx.resolver` for allow custom resolver in nginx configuration and `nginx.extraContainers` which allow add side containers to the nginx deployment #2196
-* [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 
 ## 2.1.0
 

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -52,6 +52,12 @@ spec:
         - name: nginx
           image: {{ .Values.nginx.image.registry }}/{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          {{- with .Values.nginx.extraArgs }}
+          args:
+            {{- range $key, $value := . }}
+            - "-{{ $key }} {{ $value }}"
+            {{- end }}
+          {{- end }}
           ports:
             - name: http-metric
               containerPort: 8080

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1361,7 +1361,7 @@ nginx:
   # -- Pod Disruption Budget
   podDisruptionBudget: {}
   # -- Additional CLI args for nginx
-  extraArgs: []
+  extraArgs: {}
   # -- Environment variables to add to the nginx pods
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the nginx pods

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1100,7 +1100,7 @@ chunks-cache:
     type: RollingUpdate
 
   # -- Additional CLI args for chunks-cache
-  extraArgs: []
+  extraArgs: {}
 
   # -- Additional containers to be added to the chunks-cache pod.
   extraContainers: []
@@ -1159,7 +1159,7 @@ index-cache:
     type: RollingUpdate
 
   # -- Additional CLI args for index-cache
-  extraArgs: []
+  extraArgs: {}
 
   # -- Additional containers to be added to the index-cache pod.
   extraContainers: []
@@ -1218,7 +1218,7 @@ metadata-cache:
     type: RollingUpdate
 
   # -- Additional CLI args for metadata-cache
-  extraArgs: []
+  extraArgs: {}
 
   # -- Additional containers to be added to the metadata-cache pod.
   extraContainers: []
@@ -1277,7 +1277,7 @@ results-cache:
     type: RollingUpdate
 
   # -- Additional CLI args for results-cache
-  extraArgs: []
+  extraArgs: {}
 
   # -- Additional containers to be added to the results-cache pod.
   extraContainers: []


### PR DESCRIPTION
#### What this PR does

1. Nginx wasn't using the `extraArgs` from the values file.
2. memcached had the `extraArgs` as an array, but they are used as a dictionary. This PR changes the type to a dictionary.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2335

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
