### PR TITLE
Add self-referencing alias to all pages

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,7 +1,6 @@
 ---
-title: "Grafana Mimir documentation"
-menuTitle: "Grafana Mimir"
-weight: 1
+aliases:
+  - /docs/mimir/latest/
 keywords:
   - Grafana Mimir
   - Grafana metrics
@@ -12,6 +11,9 @@ keywords:
   - metrics storage
   - metrics datastore
   - observability
+menuTitle: Grafana Mimir
+title: Grafana Mimir documentation
+weight: 1
 ---
 
 # Grafana Mimir documentation

--- a/docs/sources/migration-guide/_index.md
+++ b/docs/sources/migration-guide/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir migration guides"
-menuTitle: "Migration guides"
-description: "Refer to these guides when migrating to Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/migration-guide/
+description: Refer to these guides when migrating to Grafana Mimir.
+menuTitle: Migration guides
+title: Grafana Mimir migration guides
 weight: 30
 ---
 

--- a/docs/sources/migration-guide/migrating-from-cortex.md
+++ b/docs/sources/migration-guide/migrating-from-cortex.md
@@ -1,7 +1,12 @@
 ---
-title: "Migrating from Cortex to Grafana Mimir"
-menuTitle: "Migrating from Cortex"
-description: "Learn how to migrate your deployment of Cortex to Grafana Mimir to simplify the deployment and continued operation of a horizontally scalable, multi-tenant time series database with long-term storage."
+aliases:
+  - /docs/mimir/latest/migration-guide/migrating-from-cortex/
+description:
+  Learn how to migrate your deployment of Cortex to Grafana Mimir to simplify
+  the deployment and continued operation of a horizontally scalable, multi-tenant
+  time series database with long-term storage.
+menuTitle: Migrating from Cortex
+title: Migrating from Cortex to Grafana Mimir
 weight: 10
 ---
 

--- a/docs/sources/migration-guide/migrating-from-thanos-or-prometheus.md
+++ b/docs/sources/migration-guide/migrating-from-thanos-or-prometheus.md
@@ -1,7 +1,9 @@
 ---
-title: "Migrating from Thanos or Prometheus to Grafana Mimir"
-menuTitle: "Migrating from Thanos or Prometheus"
-description: "Learn how to migrate from Thanos or Prometheus to Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/migration-guide/migrating-from-thanos-or-prometheus/
+description: Learn how to migrate from Thanos or Prometheus to Grafana Mimir.
+menuTitle: Migrating from Thanos or Prometheus
+title: Migrating from Thanos or Prometheus to Grafana Mimir
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/_index.md
+++ b/docs/sources/operators-guide/_index.md
@@ -1,8 +1,9 @@
 ---
-title: "Grafana Mimir operator and user guide"
-menuTitle: "Operator and user guide"
-description: "This guide contains information about deploying, configuring, and maintaining Grafana Mimir."
-weight: 20
+aliases:
+  - /docs/mimir/latest/operators-guide/
+description:
+  This guide contains information about deploying, configuring, and maintaining
+  Grafana Mimir.
 keywords:
   - Grafana Mimir architecture
   - Mimir architecture
@@ -10,6 +11,9 @@ keywords:
   - query sharding
   - Mimir deployment
   - deploying Mimir
+menuTitle: Operator and user guide
+title: Grafana Mimir operator and user guide
+weight: 20
 ---
 
 # Grafana Mimir operator and user guide

--- a/docs/sources/operators-guide/architecture/_index.md
+++ b/docs/sources/operators-guide/architecture/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir architecture"
-menuTitle: "Architecture"
-description: "Learn about the Grafana Mimir architecture components and services."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/
+description: Learn about the Grafana Mimir architecture components and services.
+menuTitle: Architecture
+title: Grafana Mimir architecture
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
+++ b/docs/sources/operators-guide/architecture/about-grafana-mimir-architecture/index.md
@@ -1,7 +1,9 @@
 ---
-title: "About the Grafana Mimir architecture"
-menuTitle: "About the architecture"
-description: "Learn about the Grafana Mimir architecture."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/about-grafana-mimir-architecture/
+description: Learn about the Grafana Mimir architecture.
+menuTitle: About the architecture
+title: About the Grafana Mimir architecture
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/architecture/binary-index-header.md
+++ b/docs/sources/operators-guide/architecture/binary-index-header.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir binary index-header"
-menuTitle: "Binary index-header"
-description: "The binary index-header contains information that the store-gateway uses at query time."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/binary-index-header/
+description:
+  The binary index-header contains information that the store-gateway uses
+  at query time.
+menuTitle: Binary index-header
+title: Grafana Mimir binary index-header
 weight: 40
 ---
 

--- a/docs/sources/operators-guide/architecture/bucket-index/index.md
+++ b/docs/sources/operators-guide/architecture/bucket-index/index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir bucket index"
-menuTitle: "Bucket index"
-description: "The bucket index enhances query performance."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/bucket-index/
+description: The bucket index enhances query performance.
+menuTitle: Bucket index
+title: Grafana Mimir bucket index
 weight: 50
 ---
 

--- a/docs/sources/operators-guide/architecture/components/_index.md
+++ b/docs/sources/operators-guide/architecture/components/_index.md
@@ -1,8 +1,7 @@
 ---
-title: "Grafana Mimir components"
-menuTitle: "Components"
-description: "Grafana Mimir includes a set of components that interact to form a cluster."
-weight: 30
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/
+description: Grafana Mimir includes a set of components that interact to form a cluster.
 keywords:
   - Mimir components
   - Mimir compactor
@@ -14,6 +13,9 @@ keywords:
   - Mimir overrides-exporter
   - Mimir query-scheduler
   - Mimir ruler
+menuTitle: Components
+title: Grafana Mimir components
+weight: 30
 ---
 
 # Grafana Mimir components

--- a/docs/sources/operators-guide/architecture/components/alertmanager.md
+++ b/docs/sources/operators-guide/architecture/components/alertmanager.md
@@ -1,7 +1,11 @@
 ---
-title: "(Optional) Grafana Mimir Alertmanager"
-menuTitle: "(Optional) Alertmanager"
-description: "The Alertmanager groups alert notifications and routes them to various notification channels."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/alertmanager/
+description:
+  The Alertmanager groups alert notifications and routes them to various
+  notification channels.
+menuTitle: (Optional) Alertmanager
+title: (Optional) Grafana Mimir Alertmanager
 weight: 100
 ---
 

--- a/docs/sources/operators-guide/architecture/components/compactor/index.md
+++ b/docs/sources/operators-guide/architecture/components/compactor/index.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir compactor"
-menuTitle: "Compactor"
-description: "The compactor increases query performance and reduces long-term storage usage."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/compactor/
+description:
+  The compactor increases query performance and reduces long-term storage
+  usage.
+menuTitle: Compactor
+title: Grafana Mimir compactor
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/architecture/components/distributor.md
+++ b/docs/sources/operators-guide/architecture/components/distributor.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir distributor"
-menuTitle: "Distributor"
-description: "The distributor validates time-series data and sends the data to ingesters."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/distributor/
+description: The distributor validates time-series data and sends the data to ingesters.
+menuTitle: Distributor
+title: Grafana Mimir distributor
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/architecture/components/ingester.md
+++ b/docs/sources/operators-guide/architecture/components/ingester.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir ingester"
-menuTitle: "Ingester"
-description: "The ingester writes incoming series to long-term storage."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/ingester/
+description: The ingester writes incoming series to long-term storage.
+menuTitle: Ingester
+title: Grafana Mimir ingester
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/architecture/components/overrides-exporter.md
+++ b/docs/sources/operators-guide/architecture/components/overrides-exporter.md
@@ -1,7 +1,11 @@
 ---
-title: "(Optional) Grafana Mimir overrides-exporter"
-menuTitle: "(Optional) Overrides-exporter"
-description: "The overrides-exporter exports Prometheus metrics containing the configured per-tenant limits."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/overrides-exporter/
+description:
+  The overrides-exporter exports Prometheus metrics containing the configured
+  per-tenant limits.
+menuTitle: (Optional) Overrides-exporter
+title: (Optional) Grafana Mimir overrides-exporter
 weight: 110
 ---
 

--- a/docs/sources/operators-guide/architecture/components/querier.md
+++ b/docs/sources/operators-guide/architecture/components/querier.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir querier"
-menuTitle: "Querier"
-description: "The querier evaluates PromQL expressions."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/querier/
+description: The querier evaluates PromQL expressions.
+menuTitle: Querier
+title: Grafana Mimir querier
 weight: 50
 ---
 

--- a/docs/sources/operators-guide/architecture/components/query-frontend/index.md
+++ b/docs/sources/operators-guide/architecture/components/query-frontend/index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir query-frontend"
-menuTitle: "Query-frontend"
-description: "The query-frontend accelerates queries."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/query-frontend/
+description: The query-frontend accelerates queries.
+menuTitle: Query-frontend
+title: Grafana Mimir query-frontend
 weight: 60
 ---
 

--- a/docs/sources/operators-guide/architecture/components/query-scheduler/index.md
+++ b/docs/sources/operators-guide/architecture/components/query-scheduler/index.md
@@ -1,7 +1,9 @@
 ---
-title: "(Optional) Grafana Mimir query-scheduler"
-menuTitle: "(Optional) Query-scheduler"
-description: "The query-scheduler distributes work to queriers."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/query-scheduler/
+description: The query-scheduler distributes work to queriers.
+menuTitle: (Optional) Query-scheduler
+title: (Optional) Grafana Mimir query-scheduler
 weight: 120
 ---
 

--- a/docs/sources/operators-guide/architecture/components/ruler/index.md
+++ b/docs/sources/operators-guide/architecture/components/ruler/index.md
@@ -1,7 +1,11 @@
 ---
-title: "(Optional) Grafana Mimir ruler"
-menuTitle: "(Optional) Ruler"
-description: "The ruler evaluates PromQL expressions defined in recording and alerting rules."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/ruler/
+description:
+  The ruler evaluates PromQL expressions defined in recording and alerting
+  rules.
+menuTitle: (Optional) Ruler
+title: (Optional) Grafana Mimir ruler
 weight: 130
 ---
 

--- a/docs/sources/operators-guide/architecture/components/store-gateway.md
+++ b/docs/sources/operators-guide/architecture/components/store-gateway.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir store-gateway"
-menuTitle: "Store-gateway"
-description: "The store-gateway queries blocks from long-term storage."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/components/store-gateway/
+description: The store-gateway queries blocks from long-term storage.
+menuTitle: Store-gateway
+title: Grafana Mimir store-gateway
 weight: 70
 ---
 

--- a/docs/sources/operators-guide/architecture/deployment-modes/index.md
+++ b/docs/sources/operators-guide/architecture/deployment-modes/index.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir deployment modes"
-menuTitle: "Deployment modes"
-description: "You can deploy Grafana Mimir in either monolithic mode or microservices mode."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/deployment-modes/
+description:
+  You can deploy Grafana Mimir in either monolithic mode or microservices
+  mode.
+menuTitle: Deployment modes
+title: Grafana Mimir deployment modes
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/architecture/hash-ring/index.md
+++ b/docs/sources/operators-guide/architecture/hash-ring/index.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir hash rings"
-menuTitle: "Hash rings"
-description: "Hash rings distribute sharding and replication work among Grafana Mimir components."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/hash-ring/
+description:
+  Hash rings distribute sharding and replication work among Grafana Mimir
+  components.
+menuTitle: Hash rings
+title: Grafana Mimir hash rings
 weight: 60
 ---
 

--- a/docs/sources/operators-guide/architecture/key-value-store.md
+++ b/docs/sources/operators-guide/architecture/key-value-store.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir key-value store"
-menuTitle: "Key-value store"
-description: "The key-value store is a database that stores data indexed by key."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/key-value-store/
+description: The key-value store is a database that stores data indexed by key.
+menuTitle: Key-value store
+title: Grafana Mimir key-value store
 weight: 70
 ---
 

--- a/docs/sources/operators-guide/architecture/memberlist-and-the-gossip-protocol.md
+++ b/docs/sources/operators-guide/architecture/memberlist-and-the-gossip-protocol.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir memberlist and gossip protocol"
-menuTitle: "Memberlist and gossip protocol"
-description: "Memberlist manages Grafana Mimir cluster membership and node detection failure."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/memberlist-and-the-gossip-protocol/
+description:
+  Memberlist manages Grafana Mimir cluster membership and node detection
+  failure.
+menuTitle: Memberlist and gossip protocol
+title: Grafana Mimir memberlist and gossip protocol
 weight: 80
 ---
 

--- a/docs/sources/operators-guide/architecture/query-sharding/index.md
+++ b/docs/sources/operators-guide/architecture/query-sharding/index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir query sharding"
-menuTitle: "Query sharding"
-description: "Query sharding parallelizes query execution."
+aliases:
+  - /docs/mimir/latest/operators-guide/architecture/query-sharding/
+description: Query sharding parallelizes query execution.
+menuTitle: Query sharding
+title: Grafana Mimir query sharding
 weight: 90
 ---
 

--- a/docs/sources/operators-guide/configuring/_index.md
+++ b/docs/sources/operators-guide/configuring/_index.md
@@ -1,10 +1,12 @@
 ---
-title: "Configuring Grafana Mimir"
-menuTitle: "Configuration"
-description: "This section provides links to Grafana Mimir configuration topics."
-weight: 30
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/
+description: This section provides links to Grafana Mimir configuration topics.
 keywords:
   - Mimir configuration
+menuTitle: Configuration
+title: Configuring Grafana Mimir
+weight: 30
 ---
 
 # Configuring Grafana Mimir

--- a/docs/sources/operators-guide/configuring/about-configurations.md
+++ b/docs/sources/operators-guide/configuring/about-configurations.md
@@ -1,7 +1,9 @@
 ---
-title: "About Grafana Mimir configurations"
-menuTitle: "About configurations"
-description: "Learn about Grafana Mimir configuration and key guidelines to consider."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/about-configurations/
+description: Learn about Grafana Mimir configuration and key guidelines to consider.
+menuTitle: About configurations
+title: About Grafana Mimir configurations
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/configuring/about-dns-service-discovery.md
+++ b/docs/sources/operators-guide/configuring/about-dns-service-discovery.md
@@ -1,7 +1,11 @@
 ---
-title: "About Grafana Mimir DNS service discovery"
-menuTitle: "About DNS service discovery"
-description: "DNS service discovery finds addresses of backend services to which Grafana Mimir connects."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/about-dns-service-discovery/
+description:
+  DNS service discovery finds addresses of backend services to which Grafana
+  Mimir connects.
+menuTitle: About DNS service discovery
+title: About Grafana Mimir DNS service discovery
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/configuring/about-ip-address-logging.md
+++ b/docs/sources/operators-guide/configuring/about-ip-address-logging.md
@@ -1,7 +1,9 @@
 ---
-title: "About Grafana Mimir IP address logging of a reverse proxy"
-menuTitle: "About IP address logging of a reverse proxy"
-description: "Troubleshoot errors by logging IP addresses of reverse proxies."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/about-ip-address-logging/
+description: Troubleshoot errors by logging IP addresses of reverse proxies.
+menuTitle: About IP address logging of a reverse proxy
+title: About Grafana Mimir IP address logging of a reverse proxy
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/configuring/about-runtime-configuration.md
+++ b/docs/sources/operators-guide/configuring/about-runtime-configuration.md
@@ -1,7 +1,11 @@
 ---
-title: "About Grafana Mimir runtime configuration"
-menuTitle: "About runtime configuration"
-description: "Runtime configuration enables you to change a subset of configurations without restarting Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/about-runtime-configuration/
+description:
+  Runtime configuration enables you to change a subset of configurations
+  without restarting Grafana Mimir.
+menuTitle: About runtime configuration
+title: About Grafana Mimir runtime configuration
 weight: 40
 ---
 

--- a/docs/sources/operators-guide/configuring/about-tenant-ids.md
+++ b/docs/sources/operators-guide/configuring/about-tenant-ids.md
@@ -1,7 +1,9 @@
 ---
-title: "About Grafana Mimir tenant IDs"
-menuTitle: "About tenant IDs"
-description: "Learn about tenant ID restrictions."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/about-tenant-ids/
+description: Learn about tenant ID restrictions.
+menuTitle: About tenant IDs
+title: About Grafana Mimir tenant IDs
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/configuring/about-versioning.md
+++ b/docs/sources/operators-guide/configuring/about-versioning.md
@@ -1,7 +1,9 @@
 ---
-title: "About Grafana Mimir versioning"
-menuTitle: "About versioning"
-description: "Learn about guarantees for this Grafana Mimir major release."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/about-versioning/
+description: Learn about guarantees for this Grafana Mimir major release.
+menuTitle: About versioning
+title: About Grafana Mimir versioning
 weight: 50
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-custom-trackers.md
+++ b/docs/sources/operators-guide/configuring/configuring-custom-trackers.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring custom active series trackers"
-menuTitle: "Configuring custom active series trackers"
-description: "Use the custom tracker to count the number of active series on an ingester."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-custom-trackers/
+description: Use the custom tracker to count the number of active series on an ingester.
+menuTitle: Configuring custom active series trackers
+title: Configuring custom active series trackers
 weight: 55
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-hash-rings.md
+++ b/docs/sources/operators-guide/configuring/configuring-hash-rings.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir hash rings"
-menuTitle: "Configuring hash rings"
-description: "Learn how to configure Grafana Mimir hash rings."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-hash-rings/
+description: Learn how to configure Grafana Mimir hash rings.
+menuTitle: Configuring hash rings
+title: Configuring Grafana Mimir hash rings
 weight: 60
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-high-availability-deduplication.md
+++ b/docs/sources/operators-guide/configuring/configuring-high-availability-deduplication.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir high-availability deduplication"
-menuTitle: "Configuring high-availability deduplication"
-description: "Learn how to configure Grafana Mimir to handle HA Prometheus server deduplication."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-high-availability-deduplication/
+description: Learn how to configure Grafana Mimir to handle HA Prometheus server deduplication.
+menuTitle: Configuring high-availability deduplication
+title: Configuring Grafana Mimir high-availability deduplication
 weight: 70
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-out-of-order-samples-ingestion.md
+++ b/docs/sources/operators-guide/configuring/configuring-out-of-order-samples-ingestion.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring out-of-order samples ingestion"
-menuTitle: "Configuring out-of-order samples ingestion"
-description: "Learn how to configure Grafana Mimir to handle out-of-order samples ingestion."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-out-of-order-samples-ingestion/
+description: Learn how to configure Grafana Mimir to handle out-of-order samples ingestion.
+menuTitle: Configuring out-of-order samples ingestion
+title: Configuring out-of-order samples ingestion
 weight: 120
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-shuffle-sharding/index.md
+++ b/docs/sources/operators-guide/configuring/configuring-shuffle-sharding/index.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir shuffle sharding"
-menuTitle: "Configuring shuffle sharding"
-description: "Learn how to configure shuffle sharding."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-shuffle-sharding/
+description: Learn how to configure shuffle sharding.
+menuTitle: Configuring shuffle sharding
+title: Configuring Grafana Mimir shuffle sharding
 weight: 80
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-the-query-frontend-work-with-prometheus.md
+++ b/docs/sources/operators-guide/configuring/configuring-the-query-frontend-work-with-prometheus.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring the Grafana Mimir query-frontend to work with Prometheus"
-menuTitle: "Configuring the query-frontend to work with Prometheus"
-description: "Learn how to configure the query-frontend to work with Prometheus."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-the-query-frontend-work-with-prometheus/
+description: Learn how to configure the query-frontend to work with Prometheus.
+menuTitle: Configuring the query-frontend to work with Prometheus
+title: Configuring the Grafana Mimir query-frontend to work with Prometheus
 weight: 90
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-tracing.md
+++ b/docs/sources/operators-guide/configuring/configuring-tracing.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir tracing"
-menuTitle: "Configuring tracing"
-description: "Learn how to configure Grafana Mimir to send traces to Jaeger."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-tracing/
+description: Learn how to configure Grafana Mimir to send traces to Jaeger.
+menuTitle: Configuring tracing
+title: Configuring Grafana Mimir tracing
 weight: 100
 ---
 

--- a/docs/sources/operators-guide/configuring/configuring-zone-aware-replication.md
+++ b/docs/sources/operators-guide/configuring/configuring-zone-aware-replication.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir zone-aware replication"
-menuTitle: "Configuring zone-aware replication"
-description: "Learn how to replicate data across failure domains."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/configuring-zone-aware-replication/
+description: Learn how to replicate data across failure domains.
+menuTitle: Configuring zone-aware replication
+title: Configuring Grafana Mimir zone-aware replication
 weight: 110
 ---
 

--- a/docs/sources/operators-guide/configuring/mirroring-requests-to-a-second-cluster/index.md
+++ b/docs/sources/operators-guide/configuring/mirroring-requests-to-a-second-cluster/index.md
@@ -1,7 +1,11 @@
 ---
-title: "Mirroring requests to a second Grafana Mimir cluster"
-menuTitle: "Mirroring requests to a second cluster"
-description: "Learn how to set up a testing cluster that receives the same series of the primary cluster."
+aliases:
+  - /docs/mimir/latest/operators-guide/configuring/mirroring-requests-to-a-second-cluster/
+description:
+  Learn how to set up a testing cluster that receives the same series of
+  the primary cluster.
+menuTitle: Mirroring requests to a second cluster
+title: Mirroring requests to a second Grafana Mimir cluster
 weight: 120
 ---
 

--- a/docs/sources/operators-guide/deploying-grafana-mimir/_index.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/_index.md
@@ -1,11 +1,13 @@
 ---
-title: "Deploying Grafana Mimir on Kubernetes"
-menuTitle: "Deploying on Kubernetes"
-description: "Learn how to deploy Grafana Mimir on Kubernetes."
-weight: 12
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/
+description: Learn how to deploy Grafana Mimir on Kubernetes.
 keywords:
   - Mimir deployment
   - Mimir Kubernetes
+menuTitle: Deploying on Kubernetes
+title: Deploying Grafana Mimir on Kubernetes
+weight: 12
 ---
 
 # Deploying Grafana Mimir on Kubernetes

--- a/docs/sources/operators-guide/deploying-grafana-mimir/getting-started-helm-charts/_index.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/getting-started-helm-charts/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "Getting started with Grafana Mimir using the Helm chart"
-menuTitle: "Getting started using the Helm chart"
-description: "Learn how to get started with Grafana Mimir using the Helm chart."
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/getting-started-helm-charts/
+description: Learn how to get started with Grafana Mimir using the Helm chart.
+menuTitle: Getting started using the Helm chart
+title: Getting started with Grafana Mimir using the Helm chart
 weight: 25
 ---
 

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/_index.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/_index.md
@@ -1,13 +1,15 @@
 ---
-title: "Deploying Grafana Mimir with Jsonnet and Tanka"
-menuTitle: "Deploying with Jsonnet and Tanka"
-description: "Learn how to deploy Grafana Mimir on Kubernetes with Jsonnet and Tanka."
-weight: 50
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/
+description: Learn how to deploy Grafana Mimir on Kubernetes with Jsonnet and Tanka.
 keywords:
   - Mimir deployment
   - Kubernetes
   - Jsonnet
   - Tanka
+menuTitle: Deploying with Jsonnet and Tanka
+title: Deploying Grafana Mimir with Jsonnet and Tanka
+weight: 50
 ---
 
 # Deploying Grafana Mimir with Jsonnet and Tanka

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/configuring-autoscaling.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/configuring-autoscaling.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir autoscaling with Jsonnet"
-menuTitle: "Configuring autoscaling"
-description: "Learn how to configure Grafana Mimir autoscaling when using Jsonnet."
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/configuring-autoscaling/
+description: Learn how to configure Grafana Mimir autoscaling when using Jsonnet.
+menuTitle: Configuring autoscaling
+title: Configuring Grafana Mimir autoscaling with Jsonnet
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/configuring-low-resources.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/configuring-low-resources.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring Grafana Mimir to use low resources with Jsonnet"
-menuTitle: "Configuring low resources"
-description: "Learn how to configure Grafana Mimir when using Jsonnet."
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/configuring-low-resources/
+description: Learn how to configure Grafana Mimir when using Jsonnet.
+menuTitle: Configuring low resources
+title: Configuring Grafana Mimir to use low resources with Jsonnet
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/configuring-ruler.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/configuring-ruler.md
@@ -1,7 +1,9 @@
 ---
-title: "Configuring the Grafana Mimir ruler with Jsonnet"
-menuTitle: "Configuring ruler"
-description: "Learn how to configure the Grafana Mimir ruler when using Jsonnet."
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/configuring-ruler/
+description: Learn how to configure the Grafana Mimir ruler when using Jsonnet.
+menuTitle: Configuring ruler
+title: Configuring the Grafana Mimir ruler with Jsonnet
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/deploying.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/deploying.md
@@ -1,7 +1,9 @@
 ---
-title: "Deploying Grafana Mimir with Jsonnet and Tanka"
-menuTitle: "Deploying with Jsonnet"
-description: "Learn how to deploy Grafana Mimir on Kubernetes with Jsonnet and Tanka."
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/deploying/
+description: Learn how to deploy Grafana Mimir on Kubernetes with Jsonnet and Tanka.
+menuTitle: Deploying with Jsonnet
+title: Deploying Grafana Mimir with Jsonnet and Tanka
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/migrating-from-consul-to-memberlist.md
+++ b/docs/sources/operators-guide/deploying-grafana-mimir/jsonnet/migrating-from-consul-to-memberlist.md
@@ -1,7 +1,11 @@
 ---
-title: "Migrating from Consul to memberlist KV store for hash rings without downtime"
-menuTitle: "Migrating from Consul to memberlist"
-description: "Learn how to migrate from using Consul as KV store for hash rings to using memberlist without any downtime."
+aliases:
+  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/migrating-from-consul-to-memberlist/
+description:
+  Learn how to migrate from using Consul as KV store for hash rings to
+  using memberlist without any downtime.
+menuTitle: Migrating from Consul to memberlist
+title: Migrating from Consul to memberlist KV store for hash rings without downtime
 weight: 40
 ---
 

--- a/docs/sources/operators-guide/getting-started/_index.md
+++ b/docs/sources/operators-guide/getting-started/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "Getting started with Grafana Mimir"
-menuTitle: "Getting started"
-description: "Learn how to get started with Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/getting-started/
+description: Learn how to get started with Grafana Mimir.
+menuTitle: Getting started
+title: Getting started with Grafana Mimir
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1,10 +1,12 @@
 ---
-title: "Grafana Mimir runbooks"
-menuTitle: "Runbooks"
-description: "Grafana Mimir runbooks."
-weight: 110
+aliases:
+  - /docs/mimir/latest/operators-guide/mimir-runbooks/
+description: Grafana Mimir runbooks.
 keywords:
   - Mimir runbooks
+menuTitle: Runbooks
+title: Grafana Mimir runbooks
+weight: 110
 ---
 
 # Grafana Mimir runbooks

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/_index.md
@@ -1,12 +1,13 @@
 ---
-title: "Monitoring Grafana Mimir"
-menuTitle: "Monitoring Mimir"
-description: "View example Grafana Mimir dashboards."
-weight: 50
+aliases:
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/
+  - /visualizing-metrics/
+description: View example Grafana Mimir dashboards.
 keywords:
   - Mimir dashboards
-aliases:
-  - visualizing-metrics/
+menuTitle: Monitoring Mimir
+title: Monitoring Grafana Mimir
+weight: 50
 ---
 
 # Monitoring Grafana Mimir

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/_index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/_index.md
@@ -1,10 +1,11 @@
 ---
-title: "Viewing Grafana Mimir dashboards"
-menuTitle: "Viewing dashboards"
-description: "View examples of production-ready Grafana Mimir dashboards."
-weight: 40
 aliases:
-  - ../visualizing-metrics/dashboards/
+  - /../visualizing-metrics/dashboards/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/
+description: View examples of production-ready Grafana Mimir dashboards.
+menuTitle: Viewing dashboards
+title: Viewing Grafana Mimir dashboards
+weight: 40
 ---
 
 # Viewing Grafana Mimir dashboards

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager-resources/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager-resources/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Alertmanager resources dashboard"
-menuTitle: "Alertmanager resources"
-description: "View an example Alertmanager resources dashboard."
-weight: 20
 aliases:
-  - ../../visualizing-metrics/dashboards/alertmanager-resources/
+  - /../../visualizing-metrics/dashboards/alertmanager-resources/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager-resources/
+description: View an example Alertmanager resources dashboard.
+menuTitle: Alertmanager resources
+title: Grafana Mimir Alertmanager resources dashboard
+weight: 20
 ---
 
 # Grafana Mimir Alertmanager resources dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Alertmanager dashboard"
-menuTitle: "Alertmanager"
-description: "View an example Alertmanager dashboard."
-weight: 10
 aliases:
-  - ../../visualizing-metrics/dashboards/alertmanager/
+  - /../../visualizing-metrics/dashboards/alertmanager/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager/
+description: View an example Alertmanager dashboard.
+menuTitle: Alertmanager
+title: Grafana Mimir Alertmanager dashboard
+weight: 10
 ---
 
 # Grafana Mimir Alertmanager dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/compactor-resources/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/compactor-resources/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Compactor resources dashboard"
-menuTitle: "Compactor resources"
-description: "View an example Compactor resources dashboard."
-weight: 40
 aliases:
-  - ../../visualizing-metrics/dashboards/compactor-resources/
+  - /../../visualizing-metrics/dashboards/compactor-resources/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/compactor-resources/
+description: View an example Compactor resources dashboard.
+menuTitle: Compactor resources
+title: Grafana Mimir Compactor resources dashboard
+weight: 40
 ---
 
 # Grafana Mimir Compactor resources dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/compactor/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/compactor/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Compactor dashboard"
-menuTitle: "Compactor"
-description: "View an example Compactor dashboard."
-weight: 30
 aliases:
-  - ../../visualizing-metrics/dashboards/compactor/
+  - /../../visualizing-metrics/dashboards/compactor/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/compactor/
+description: View an example Compactor dashboard.
+menuTitle: Compactor
+title: Grafana Mimir Compactor dashboard
+weight: 30
 ---
 
 # Grafana Mimir Compactor dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/config/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/config/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Config dashboard"
-menuTitle: "Config"
-description: "View an example Config dashboard."
-weight: 50
 aliases:
-  - ../../visualizing-metrics/dashboards/config/
+  - /../../visualizing-metrics/dashboards/config/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/config/
+description: View an example Config dashboard.
+menuTitle: Config
+title: Grafana Mimir Config dashboard
+weight: 50
 ---
 
 # Grafana Mimir Config dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/object-store/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/object-store/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Object Store dashboard"
-menuTitle: "Object Store"
-description: "View an example Object Store dashboard."
-weight: 60
 aliases:
-  - ../../visualizing-metrics/dashboards/object-store/
+  - /../../visualizing-metrics/dashboards/object-store/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/object-store/
+description: View an example Object Store dashboard.
+menuTitle: Object Store
+title: Grafana Mimir Object Store dashboard
+weight: 60
 ---
 
 # Grafana Mimir Object Store dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/overrides/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/overrides/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Overrides dashboard"
-menuTitle: "Overrides"
-description: "View an example Overrides dashboard."
-weight: 70
 aliases:
-  - ../../visualizing-metrics/dashboards/overrides/
+  - /../../visualizing-metrics/dashboards/overrides/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/overrides/
+description: View an example Overrides dashboard.
+menuTitle: Overrides
+title: Grafana Mimir Overrides dashboard
+weight: 70
 ---
 
 # Grafana Mimir Overrides dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/queries/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/queries/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Queries dashboard"
-menuTitle: "Queries"
-description: "View an example Queries dashboard."
-weight: 80
 aliases:
-  - ../../visualizing-metrics/dashboards/queries/
+  - /../../visualizing-metrics/dashboards/queries/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/queries/
+description: View an example Queries dashboard.
+menuTitle: Queries
+title: Grafana Mimir Queries dashboard
+weight: 80
 ---
 
 # Grafana Mimir Queries dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/reads-networking/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/reads-networking/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Reads networking dashboard"
-menuTitle: "Reads networking"
-description: "View an example Reads networking dashboard."
-weight: 100
 aliases:
-  - ../../visualizing-metrics/dashboards/reads-networking/
+  - /../../visualizing-metrics/dashboards/reads-networking/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/reads-networking/
+description: View an example Reads networking dashboard.
+menuTitle: Reads networking
+title: Grafana Mimir Reads networking dashboard
+weight: 100
 ---
 
 # Grafana Mimir Reads networking dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/reads-resources/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/reads-resources/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Reads resources dashboard"
-menuTitle: "Reads resources"
-description: "View an example Reads resources dashboard."
-weight: 110
 aliases:
-  - ../../visualizing-metrics/dashboards/reads-resources/
+  - /../../visualizing-metrics/dashboards/reads-resources/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/reads-resources/
+description: View an example Reads resources dashboard.
+menuTitle: Reads resources
+title: Grafana Mimir Reads resources dashboard
+weight: 110
 ---
 
 # Grafana Mimir Reads resources dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/reads/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/reads/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Reads dashboard"
-menuTitle: "Reads"
-description: "View an example Reads dashboard."
-weight: 90
 aliases:
-  - ../../visualizing-metrics/dashboards/reads/
+  - /../../visualizing-metrics/dashboards/reads/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/reads/
+description: View an example Reads dashboard.
+menuTitle: Reads
+title: Grafana Mimir Reads dashboard
+weight: 90
 ---
 
 # Grafana Mimir Reads dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads-resources/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads-resources/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Remote ruler reads resources dashboard"
-menuTitle: "Remote ruler reads resources"
-description: "View an example Remote ruler reads resources dashboard."
-weight: 110
 aliases:
-  - ../../visualizing-metrics/dashboards/remote-ruler-reads-resources/
+  - /../../visualizing-metrics/dashboards/remote-ruler-reads-resources/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads-resources/
+description: View an example Remote ruler reads resources dashboard.
+menuTitle: Remote ruler reads resources
+title: Grafana Mimir Remote ruler reads resources dashboard
+weight: 110
 ---
 
 # Grafana Mimir Remote ruler reads resources dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Remote ruler reads dashboard"
-menuTitle: "Remote ruler reads"
-description: "View an example Remote ruler reads dashboard."
-weight: 90
 aliases:
-  - ../../visualizing-metrics/dashboards/remote-ruler-reads/
+  - /../../visualizing-metrics/dashboards/remote-ruler-reads/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads/
+description: View an example Remote ruler reads dashboard.
+menuTitle: Remote ruler reads
+title: Grafana Mimir Remote ruler reads dashboard
+weight: 90
 ---
 
 # Grafana Mimir Remote ruler reads dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/rollout-progress/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/rollout-progress/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Rollout progress dashboard"
-menuTitle: "Rollout progress"
-description: "View an example Rollout progress dashboard."
-weight: 120
 aliases:
-  - ../../visualizing-metrics/dashboards/rollout-progress/
+  - /../../visualizing-metrics/dashboards/rollout-progress/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/rollout-progress/
+description: View an example Rollout progress dashboard.
+menuTitle: Rollout progress
+title: Grafana Mimir Rollout progress dashboard
+weight: 120
 ---
 
 # Grafana Mimir Rollout progress dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/ruler/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/ruler/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Ruler dashboard"
-menuTitle: "Ruler"
-description: "View an example Ruler dashboard."
-weight: 130
 aliases:
-  - ../../visualizing-metrics/dashboards/ruler/
+  - /../../visualizing-metrics/dashboards/ruler/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/ruler/
+description: View an example Ruler dashboard.
+menuTitle: Ruler
+title: Grafana Mimir Ruler dashboard
+weight: 130
 ---
 
 # Grafana Mimir Ruler dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/scaling/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/scaling/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir scaling dashboard"
-menuTitle: "Scaling"
-description: "View an example Scaling dashboard."
-weight: 140
 aliases:
-  - ../../visualizing-metrics/dashboards/scaling/
+  - /../../visualizing-metrics/dashboards/scaling/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/scaling/
+description: View an example Scaling dashboard.
+menuTitle: Scaling
+title: Grafana Mimir scaling dashboard
+weight: 140
 ---
 
 # Grafana Mimir scaling dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/slow-queries/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/slow-queries/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Slow queries dashboard"
-menuTitle: "Slow queries"
-description: "Review a description of the Slow queries dashboard."
-weight: 150
 aliases:
-  - ../../visualizing-metrics/dashboards/slow-queries/
+  - /../../visualizing-metrics/dashboards/slow-queries/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/slow-queries/
+description: Review a description of the Slow queries dashboard.
+menuTitle: Slow queries
+title: Grafana Mimir Slow queries dashboard
+weight: 150
 ---
 
 # Grafana Mimir Slow queries dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/tenants/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/tenants/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Tenants dashboard"
-menuTitle: "Tenants"
-description: "View an example Tenants dashboard."
-weight: 160
 aliases:
-  - ../../visualizing-metrics/dashboards/tenants/
+  - /../../visualizing-metrics/dashboards/tenants/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/tenants/
+description: View an example Tenants dashboard.
+menuTitle: Tenants
+title: Grafana Mimir Tenants dashboard
+weight: 160
 ---
 
 # Grafana Mimir Tenants dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/top-tenants/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/top-tenants/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Top tenants dashboard"
-menuTitle: "Top tenants"
-description: "Review a description of the Top tenants dashboard."
-weight: 170
 aliases:
-  - ../../visualizing-metrics/dashboards/top-tenants/
+  - /../../visualizing-metrics/dashboards/top-tenants/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/top-tenants/
+description: Review a description of the Top tenants dashboard.
+menuTitle: Top tenants
+title: Grafana Mimir Top tenants dashboard
+weight: 170
 ---
 
 # Grafana Mimir Top tenants dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/writes-networking/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/writes-networking/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Writes networking dashboard"
-menuTitle: "Writes networking"
-description: "View an example Writes networking dashboard."
-weight: 190
 aliases:
-  - ../../visualizing-metrics/dashboards/writes-networking/
+  - /../../visualizing-metrics/dashboards/writes-networking/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/writes-networking/
+description: View an example Writes networking dashboard.
+menuTitle: Writes networking
+title: Grafana Mimir Writes networking dashboard
+weight: 190
 ---
 
 # Grafana Mimir Writes networking dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/writes-resources/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/writes-resources/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Writes resources dashboard"
-menuTitle: "Writes resources"
-description: "View an example Writes resources dashboard."
-weight: 200
 aliases:
-  - ../../visualizing-metrics/dashboards/writes-resources/
+  - /../../visualizing-metrics/dashboards/writes-resources/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/writes-resources/
+description: View an example Writes resources dashboard.
+menuTitle: Writes resources
+title: Grafana Mimir Writes resources dashboard
+weight: 200
 ---
 
 # Grafana Mimir Writes resources dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/writes/index.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/dashboards/writes/index.md
@@ -1,10 +1,11 @@
 ---
-title: "Grafana Mimir Writes dashboard"
-menuTitle: "Writes"
-description: "View an example Writes dashboard."
-weight: 180
 aliases:
-  - ../../visualizing-metrics/dashboards/writes/
+  - /../../visualizing-metrics/dashboards/writes/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/writes/
+description: View an example Writes dashboard.
+menuTitle: Writes
+title: Grafana Mimir Writes dashboard
+weight: 180
 ---
 
 # Grafana Mimir Writes dashboard

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/deploying-monitoring-mixin.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/deploying-monitoring-mixin.md
@@ -1,10 +1,11 @@
 ---
-title: "Deploying the Grafana Mimir monitoring mixin"
-menuTitle: "Deploying the monitoring mixin"
-description: "Learn how to deploy the Grafana Mimir monitoring mixin."
-weight: 20
 aliases:
-  - ../visualizing-metrics/deploying-monitor-mixin/
+  - /../visualizing-metrics/deploying-monitor-mixin/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/deploying-monitoring-mixin/
+description: Learn how to deploy the Grafana Mimir monitoring mixin.
+menuTitle: Deploying the monitoring mixin
+title: Deploying the Grafana Mimir monitoring mixin
+weight: 20
 ---
 
 # Deploying the Grafana Mimir monitoring mixin

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts.md
@@ -1,10 +1,11 @@
 ---
-title: "Installing Grafana Mimir dashboards and alerts"
-menuTitle: "Installing dashboards and alerts"
-description: "Learn how to install Grafana Mimir dashboards and alerts."
-weight: 30
 aliases:
-  - ../visualizing-metrics/installing-dashboards-and-alerts/
+  - /../visualizing-metrics/installing-dashboards-and-alerts/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts/
+description: Learn how to install Grafana Mimir dashboards and alerts.
+menuTitle: Installing dashboards and alerts
+title: Installing Grafana Mimir dashboards and alerts
+weight: 30
 ---
 
 # Installing Grafana Mimir dashboards and alerts

--- a/docs/sources/operators-guide/monitoring-grafana-mimir/requirements.md
+++ b/docs/sources/operators-guide/monitoring-grafana-mimir/requirements.md
@@ -1,10 +1,11 @@
 ---
-title: "About Grafana Mimir dashboards and alerts requirements"
-menuTitle: "About dashboards and alerts requirements"
-description: "Requirements for installing Grafana Mimir dashboards and alerts."
-weight: 10
 aliases:
-  - ../visualizing-metrics/requirements/
+  - /../visualizing-metrics/requirements/
+  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/requirements/
+description: Requirements for installing Grafana Mimir dashboards and alerts.
+menuTitle: About dashboards and alerts requirements
+title: About Grafana Mimir dashboards and alerts requirements
+weight: 10
 ---
 
 # About Grafana Mimir dashboards and alerts requirements

--- a/docs/sources/operators-guide/reference-glossary.md
+++ b/docs/sources/operators-guide/reference-glossary.md
@@ -1,7 +1,9 @@
 ---
-title: "Reference: Grafana Mimir glossary"
+aliases:
+  - /docs/mimir/latest/operators-guide/reference-glossary/
+description: Grafana Mimir glossary terms.
 menuTitle: "Reference: Glossary"
-description: "Grafana Mimir glossary terms."
+title: "Reference: Grafana Mimir glossary"
 weight: 130
 ---
 

--- a/docs/sources/operators-guide/reference-http-api/index.md
+++ b/docs/sources/operators-guide/reference-http-api/index.md
@@ -1,13 +1,17 @@
 ---
-title: "Reference: Grafana Mimir HTTP API"
-menuTitle: "Reference: HTTP API"
-description: "Use the HTTP API to write and query time-series data and operate a Grafana Mimir cluster."
-weight: 120
+aliases:
+  - /docs/mimir/latest/operators-guide/reference-http-api/
+description:
+  Use the HTTP API to write and query time-series data and operate a Grafana
+  Mimir cluster.
 keywords:
   - Mimir API
   - Mimir endpoints
   - Mimir communication
   - Mimir querying
+menuTitle: "Reference: HTTP API"
+title: "Reference: Grafana Mimir HTTP API"
+weight: 120
 ---
 
 # Reference: Grafana Mimir HTTP API

--- a/docs/sources/operators-guide/reference-learning-resources/_index.md
+++ b/docs/sources/operators-guide/reference-learning-resources/_index.md
@@ -1,10 +1,12 @@
 ---
-title: "Reference: Learning resources"
-menuTitle: "Reference: Learning resources"
-description: "Blog posts, podcasts, and videos about Grafana Mimir"
-weight: 130
+aliases:
+  - /docs/mimir/latest/operators-guide/reference-learning-resources/
+description: Blog posts, podcasts, and videos about Grafana Mimir
 keywords:
   - Grafana Mimir blog posts, podcasts, and videos
+menuTitle: "Reference: Learning resources"
+title: "Reference: Learning resources"
+weight: 130
 ---
 
 # Reference: Learning resources

--- a/docs/sources/operators-guide/running-production-environment/_index.md
+++ b/docs/sources/operators-guide/running-production-environment/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "Running Grafana Mimir in production"
-menuTitle: "Running in production"
-description: "Learn how to run Grafana Mimir in production."
+aliases:
+  - /docs/mimir/latest/operators-guide/running-production-environment/
+description: Learn how to run Grafana Mimir in production.
+menuTitle: Running in production
+title: Running Grafana Mimir in production
 weight: 80
 ---
 

--- a/docs/sources/operators-guide/running-production-environment/performing-a-rolling-update.md
+++ b/docs/sources/operators-guide/running-production-environment/performing-a-rolling-update.md
@@ -1,7 +1,9 @@
 ---
-title: "Performing a rolling update to Grafana Mimir"
-menuTitle: "Performing a rolling update"
-description: "Learn how to perform a rolling update to Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/running-production-environment/performing-a-rolling-update/
+description: Learn how to perform a rolling update to Grafana Mimir.
+menuTitle: Performing a rolling update
+title: Performing a rolling update to Grafana Mimir
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/running-production-environment/planning-capacity.md
+++ b/docs/sources/operators-guide/running-production-environment/planning-capacity.md
@@ -1,7 +1,9 @@
 ---
-title: "Planning Grafana Mimir capacity"
-menuTitle: "Planning capacity"
-description: "Learn how to plan the resources required to deploy Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/running-production-environment/planning-capacity/
+description: Learn how to plan the resources required to deploy Grafana Mimir.
+menuTitle: Planning capacity
+title: Planning Grafana Mimir capacity
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/running-production-environment/production-tips/index.md
+++ b/docs/sources/operators-guide/running-production-environment/production-tips/index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir production tips"
-menuTitle: "Production tips"
-description: "Learn tips for setting up a production Grafana Mimir cluster."
+aliases:
+  - /docs/mimir/latest/operators-guide/running-production-environment/production-tips/
+description: Learn tips for setting up a production Grafana Mimir cluster.
+menuTitle: Production tips
+title: Grafana Mimir production tips
 weight: 40
 ---
 

--- a/docs/sources/operators-guide/running-production-environment/scaling-out.md
+++ b/docs/sources/operators-guide/running-production-environment/scaling-out.md
@@ -1,7 +1,9 @@
 ---
-title: "Scaling out Grafana Mimir"
-menuTitle: "Scaling out"
-description: "Learn how to scale out Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/running-production-environment/scaling-out/
+description: Learn how to scale out Grafana Mimir.
+menuTitle: Scaling out
+title: Scaling out Grafana Mimir
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/securing/_index.md
+++ b/docs/sources/operators-guide/securing/_index.md
@@ -1,14 +1,16 @@
 ---
-title: "Securing Grafana Mimir"
-menuTitle: "Securing"
-description: "Learn how to secure Grafana Mimir data and communication paths."
-weight: 70
+aliases:
+  - /docs/mimir/latest/operators-guide/securing/
+description: Learn how to secure Grafana Mimir data and communication paths.
 keywords:
   - Mimir security
   - Mimir authentication
   - Mimir authorization
   - Mimir encrypt data at rest
   - Mimir TLS
+menuTitle: Securing
+title: Securing Grafana Mimir
+weight: 70
 ---
 
 # Securing Grafana Mimir

--- a/docs/sources/operators-guide/securing/authentication-and-authorization.md
+++ b/docs/sources/operators-guide/securing/authentication-and-authorization.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir authentication and authorization"
-menuTitle: "Authentication and authorization"
-description: "Learn how to configure and run Grafana Mimir with multi-tenancy."
+aliases:
+  - /docs/mimir/latest/operators-guide/securing/authentication-and-authorization/
+description: Learn how to configure and run Grafana Mimir with multi-tenancy.
+menuTitle: Authentication and authorization
+title: Grafana Mimir authentication and authorization
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/securing/encrypting-data-at-rest.md
+++ b/docs/sources/operators-guide/securing/encrypting-data-at-rest.md
@@ -1,7 +1,9 @@
 ---
-title: "Encrypting Grafana Mimir data at rest"
-menuTitle: "Encrypting data at rest"
-description: "Learn how to configure object storage encryption."
+aliases:
+  - /docs/mimir/latest/operators-guide/securing/encrypting-data-at-rest/
+description: Learn how to configure object storage encryption.
+menuTitle: Encrypting data at rest
+title: Encrypting Grafana Mimir data at rest
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/securing/securing-alertmanager.md
+++ b/docs/sources/operators-guide/securing/securing-alertmanager.md
@@ -1,7 +1,9 @@
 ---
-title: "Securing Grafana Mimir Alertmanager"
-menuTitle: "Securing Alertmanager"
-description: "Learn how to secure the Alertmanager."
+aliases:
+  - /docs/mimir/latest/operators-guide/securing/securing-alertmanager/
+description: Learn how to secure the Alertmanager.
+menuTitle: Securing Alertmanager
+title: Securing Grafana Mimir Alertmanager
 weight: 40
 ---
 

--- a/docs/sources/operators-guide/securing/securing-communications-with-tls.md
+++ b/docs/sources/operators-guide/securing/securing-communications-with-tls.md
@@ -1,7 +1,9 @@
 ---
-title: "Securing Grafana Mimir communications with TLS"
-menuTitle: "Securing communications with TLS"
-description: "Learn how to configure TLS between Grafana Mimir components."
+aliases:
+  - /docs/mimir/latest/operators-guide/securing/securing-communications-with-tls/
+description: Learn how to configure TLS between Grafana Mimir components.
+menuTitle: Securing communications with TLS
+title: Securing Grafana Mimir communications with TLS
 weight: 50
 ---
 

--- a/docs/sources/operators-guide/tools/_index.md
+++ b/docs/sources/operators-guide/tools/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir tools"
-menuTitle: "Tools"
-description: "Tools for Grafana Mimir aid in administration and troubleshooting tasks."
+aliases:
+  - /docs/mimir/latest/operators-guide/tools/
+description: Tools for Grafana Mimir aid in administration and troubleshooting tasks.
+menuTitle: Tools
+title: Grafana Mimir tools
 weight: 100
 ---
 

--- a/docs/sources/operators-guide/tools/listblocks.md
+++ b/docs/sources/operators-guide/tools/listblocks.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir listblocks"
-menuTitle: "Listblocks"
-description: "Listblocks show the block details of a tenant."
+aliases:
+  - /docs/mimir/latest/operators-guide/tools/listblocks/
+description: Listblocks show the block details of a tenant.
+menuTitle: Listblocks
+title: Grafana Mimir listblocks
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/tools/mimir-continuous-test.md
+++ b/docs/sources/operators-guide/tools/mimir-continuous-test.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana mimir-continuous-test"
-menuTitle: "Mimir-continuous-test"
-description: "Use mimir-continuous-test to continuously run smoke tests on live Grafana Mimir clusters."
+aliases:
+  - /docs/mimir/latest/operators-guide/tools/mimir-continuous-test/
+description:
+  Use mimir-continuous-test to continuously run smoke tests on live Grafana
+  Mimir clusters.
+menuTitle: Mimir-continuous-test
+title: Grafana mimir-continuous-test
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/tools/mimirtool.md
+++ b/docs/sources/operators-guide/tools/mimirtool.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimirtool"
-menuTitle: "Mimirtool"
-description: "Use Mimirtool to perform common tasks in Grafana Mimir or Grafana Cloud Metrics."
+aliases:
+  - /docs/mimir/latest/operators-guide/tools/mimirtool/
+description:
+  Use Mimirtool to perform common tasks in Grafana Mimir or Grafana Cloud
+  Metrics.
+menuTitle: Mimirtool
+title: Grafana Mimirtool
 weight: 40
 ---
 

--- a/docs/sources/operators-guide/tools/query-tee.md
+++ b/docs/sources/operators-guide/tools/query-tee.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir query-tee"
-menuTitle: "Query-tee"
-description: "Use query-tee to compare query results and performance between two Grafana Mimir clusters."
+aliases:
+  - /docs/mimir/latest/operators-guide/tools/query-tee/
+description:
+  Use query-tee to compare query results and performance between two Grafana
+  Mimir clusters.
+menuTitle: Query-tee
+title: Grafana Mimir query-tee
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/tools/tenant-injector.md
+++ b/docs/sources/operators-guide/tools/tenant-injector.md
@@ -1,7 +1,11 @@
 ---
-title: "Grafana Mimir tenant injector"
-menuTitle: "Tenant injector"
-description: "Use the tenant injector to query data for a tenant during development and troubleshooting."
+aliases:
+  - /docs/mimir/latest/operators-guide/tools/tenant-injector/
+description:
+  Use the tenant injector to query data for a tenant during development
+  and troubleshooting.
+menuTitle: Tenant injector
+title: Grafana Mimir tenant injector
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/using-exemplars/_index.md
+++ b/docs/sources/operators-guide/using-exemplars/_index.md
@@ -1,10 +1,12 @@
 ---
-title: "Using exemplars with Grafana Mimir"
-menuTitle: "Using exemplars"
-description: "Learn how to use exemplars with Grafana Mimir."
-weight: 40
+aliases:
+  - /docs/mimir/latest/operators-guide/using-exemplars/
+description: Learn how to use exemplars with Grafana Mimir.
 keywords:
   - Mimir exemplars
+menuTitle: Using exemplars
+title: Using exemplars with Grafana Mimir
+weight: 40
 ---
 
 # Using exemplars with Grafana Mimir

--- a/docs/sources/operators-guide/using-exemplars/about-exemplars.md
+++ b/docs/sources/operators-guide/using-exemplars/about-exemplars.md
@@ -1,7 +1,11 @@
 ---
-title: "About Grafana Mimir exemplars"
-menuTitle: "About exemplars"
-description: "Learn about using exemplars in Grafana Mimir to identify high cardinality in time series events."
+aliases:
+  - /docs/mimir/latest/operators-guide/using-exemplars/about-exemplars/
+description:
+  Learn about using exemplars in Grafana Mimir to identify high cardinality
+  in time series events.
+menuTitle: About exemplars
+title: About Grafana Mimir exemplars
 weight: 10
 ---
 

--- a/docs/sources/operators-guide/using-exemplars/before-you-begin.md
+++ b/docs/sources/operators-guide/using-exemplars/before-you-begin.md
@@ -1,7 +1,9 @@
 ---
-title: "Before you begin using exemplars with Grafana Mimir"
-menuTitle: "Before you begin"
-description: "Refer to this checklist before you begin using exemplars in Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/using-exemplars/before-you-begin/
+description: Refer to this checklist before you begin using exemplars in Grafana Mimir.
+menuTitle: Before you begin
+title: Before you begin using exemplars with Grafana Mimir
 weight: 20
 ---
 

--- a/docs/sources/operators-guide/using-exemplars/storing-exemplars.md
+++ b/docs/sources/operators-guide/using-exemplars/storing-exemplars.md
@@ -1,7 +1,9 @@
 ---
-title: "Storing exemplars in Grafana Mimir"
-menuTitle: "Storing exemplars"
-description: "Learn how to store exemplars in Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/using-exemplars/storing-exemplars/
+description: Learn how to store exemplars in Grafana Mimir.
+menuTitle: Storing exemplars
+title: Storing exemplars in Grafana Mimir
 weight: 30
 ---
 

--- a/docs/sources/operators-guide/using-exemplars/viewing-exemplar-data.md
+++ b/docs/sources/operators-guide/using-exemplars/viewing-exemplar-data.md
@@ -1,7 +1,9 @@
 ---
-title: "Viewing exemplar data in Grafana Explore"
-menuTitle: "Viewing exemplar data"
-description: "Learn how to view exemplar data in Grafana Mimir."
+aliases:
+  - /docs/mimir/latest/operators-guide/using-exemplars/viewing-exemplar-data/
+description: Learn how to view exemplar data in Grafana Mimir.
+menuTitle: Viewing exemplar data
+title: Viewing exemplar data in Grafana Explore
 weight: 40
 ---
 

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -1,10 +1,12 @@
 ---
-title: "Grafana Mimir release notes"
-menuTitle: "Release notes"
-description: "Release notes for all versions of Grafana Mimir."
-weight: 10
+aliases:
+  - /docs/mimir/latest/release-notes/
+description: Release notes for all versions of Grafana Mimir.
 keywords:
   - Grafana Mimir release notes
+menuTitle: Release notes
+title: Grafana Mimir release notes
+weight: 10
 ---
 
 # Grafana Mimir release notes

--- a/docs/sources/release-notes/v2.0.md
+++ b/docs/sources/release-notes/v2.0.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir version 2.0 release notes"
-menuTitle: "V2.0 release notes"
-description: "Release notes for Grafana Mimir version 2.0"
+aliases:
+  - /docs/mimir/latest/release-notes/v2.0/
+description: Release notes for Grafana Mimir version 2.0
+menuTitle: V2.0 release notes
+title: Grafana Mimir version 2.0 release notes
 weight: 100
 ---
 

--- a/docs/sources/release-notes/v2.1.md
+++ b/docs/sources/release-notes/v2.1.md
@@ -1,7 +1,9 @@
 ---
-title: "Grafana Mimir version 2.1 release notes"
-menuTitle: "V2.1 release notes"
-description: "Release notes for Grafana Mimir version 2.1"
+aliases:
+  - /docs/mimir/latest/release-notes/v2.1/
+description: Release notes for Grafana Mimir version 2.1
+menuTitle: V2.1 release notes
+title: Grafana Mimir version 2.1 release notes
 weight: 200
 ---
 

--- a/docs/sources/tutorials/_index.md
+++ b/docs/sources/tutorials/_index.md
@@ -1,6 +1,8 @@
 ---
-title: "Tutorials"
-menuTitle: "Tutorials"
+aliases:
+  - /docs/mimir/latest/tutorials/
+menuTitle: Tutorials
+title: Tutorials
 weight: 40
 ---
 

--- a/docs/sources/tutorials/play-with-grafana-mimir/index.md
+++ b/docs/sources/tutorials/play-with-grafana-mimir/index.md
@@ -1,8 +1,13 @@
 ---
-title: "Play with Grafana Mimir"
-menuTitle: "Play with Grafana Mimir"
-description: "This tutorial helps you learn about Grafana Mimir, which provides distributed, horizontally scalable, and highly available long term storage for Prometheus."
-weight: 1
+aliases:
+  - /docs/mimir/latest/tutorials/play-with-grafana-mimir/
+associated_technologies:
+  - mimir
+author:
+  - marco
+description:
+  This tutorial helps you learn about Grafana Mimir, which provides distributed,
+  horizontally scalable, and highly available long term storage for Prometheus.
 keywords:
   - mimir tutorial
   - learn mimir
@@ -15,10 +20,9 @@ keywords:
   - metrics datastore
   - observability
   - Prometheus read write
-author:
-  - marco
-associated_technologies:
-  - mimir
+menuTitle: Play with Grafana Mimir
+title: Play with Grafana Mimir
+weight: 1
 ---
 
 # Play with Grafana Mimir


### PR DESCRIPTION
This is a no-op as Hugo will not build a redirect page in place of an
existing page with content. The value in this change is that when we
move any files, Hugo will automatically put in a redirect page for the
aliased URL path.

Relates to #1663.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
Co-authored-by: Ursula Kallio <ursula.kallio@grafana.com>