### PR TITLE
Fix sharding of `vector` and `time` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while synching rules. #2289
+* [BUGFIX] Query-frontend: `vector` and `time` functions were sharded, which made expressions like `vector(1) > 0 and vector(1)` fail. #2355
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -160,16 +160,6 @@ func argsWithDefaults(call *parser.Call) parser.Expressions {
 	return call.Args
 }
 
-// VariadicDateFunc retuns true if .
-func VariadicDateFunc(f parser.Function) bool {
-	for _, v := range NonParallelFuncs {
-		if v == f.Name {
-			return false
-		}
-	}
-	return true
-}
-
 func noAggregates(n parser.Node) bool {
 	hasAggregates, _ := anyNode(n, isAggregateExpr)
 	return !hasAggregates

--- a/pkg/frontend/querymiddleware/astmapper/parallel_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel_test.go
@@ -196,3 +196,24 @@ func TestCanParallel_String(t *testing.T) {
 		})
 	}
 }
+
+func TestFunctionsWithDefaultsIsUpToDate(t *testing.T) {
+	for name, f := range parser.Functions {
+		t.Run(name, func(t *testing.T) {
+			if f.Variadic == 0 {
+				return
+			}
+			if f.Name == "label_join" {
+				// label_join has no defaults, it just accepts any number of labels
+				return
+			}
+			if f.Name == "round" {
+				// round has a default value for the second scalar value, which is not relevant for sharding purposes.
+				return
+			}
+
+			// Rest of the functions with known defaults are functions with a default time() argument.
+			require.Containsf(t, FuncsWithDefaultTimeArg, name, "Function %q has variable arguments, and it's not in the list of functions with default time() argument.")
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -446,6 +446,16 @@ func TestShardSummer(t *testing.T) {
 				`)`,
 			expectedShardedQueries: 6,
 		},
+		{
+			in:                     `vector(1) > 0 and vector(1)`,
+			out:                    `vector(1) > 0 and vector(1)`,
+			expectedShardedQueries: 0,
+		},
+		{
+			in:                     `sum(foo) > 0 and vector(1)`,
+			out:                    `sum(` + concatShards(3, `sum(foo{__query_shard__="x_of_y"})`) + `) > 0 and vector(1)`,
+			expectedShardedQueries: 3,
+		},
 	} {
 		tt := tt
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -468,7 +468,7 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			expectedShardedQueries: 0,
 		},
 		"time()": {
-			query:                  `vector()`,
+			query:                  `time()`,
 			expectedShardedQueries: 0,
 		},
 		"month(sum(metric_counter))": {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -447,6 +447,38 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			expectedShardedQueries: 0,
 			noRangeQuery:           true,
 		},
+		"day_of_month() >= 1 and day_of_month()": {
+			query:                  `day_of_month() >= 1 and day_of_month()`,
+			expectedShardedQueries: 0,
+		},
+		"month() >= 1 and month()": {
+			query:                  `month() >= 1 and month()`,
+			expectedShardedQueries: 0,
+		},
+		"vector(1) > 0 and vector(1)": {
+			query:                  `vector(1) > 0 and vector(1)`,
+			expectedShardedQueries: 0,
+		},
+		"sum(metric_counter) > 0 and vector(1)": {
+			query:                  `sum(metric_counter) > 0 and vector(1)`,
+			expectedShardedQueries: 1,
+		},
+		"vector(1)": {
+			query:                  `vector(1)`,
+			expectedShardedQueries: 0,
+		},
+		"time()": {
+			query:                  `vector()`,
+			expectedShardedQueries: 0,
+		},
+		"month(sum(metric_counter))": {
+			query:                  `month(sum(metric_counter))`,
+			expectedShardedQueries: 1, // Sharded because the contents of `sum()` is sharded.
+		},
+		"month(sum(metric_counter)) > 0 and vector(1)": {
+			query:                  `month(sum(metric_counter)) > 0 and vector(1)`,
+			expectedShardedQueries: 1, // Sharded because the contents of `sum()` is sharded.
+		},
 	}
 
 	series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))


### PR DESCRIPTION
#### What this PR does

Functions `vector` and `time` can't be sharded, as they produce same set of series (with zero labels) and can't be concatenated later.

Additionally, functions that have a default `time()` argument, like `month()`, were not propagating the shardeability checks properly.

#### Which issue(s) this PR fixes or relates to

None, internal.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
