### PR TITLE
Add backport CI job

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,25 @@
+name: Backport PR Creator
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v3
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/backport
+        with:
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          labelsToAdd: "backport"
+          title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
### Summary of changes

**Why is the change needed, what does it improve?**

Adds automatic backporting of PRs with the `backport <release branch>` label.

This means that we can add the `backport release-2.2` to a PR and
after merging the PR grafanabot will open a new PR with the merge commit
 cherry-picked to the `release-2.2` branch.

This makes cherry-picking commits onto release branches faster.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

