### PR TITLE
Revert tutorial's common config usage

### DIFF
--- a/docs/sources/tutorials/play-with-grafana-mimir/config/mimir.yaml
+++ b/docs/sources/tutorials/play-with-grafana-mimir/config/mimir.yaml
@@ -3,20 +3,15 @@
 # Run Mimir in single process mode, with all components running in 1 process. 
 target: all,alertmanager,overrides-exporter
 
-# Configure Mimir to use Minio as object storage backend.
-common:
-  storage:
-    backend: s3
-    s3:
-      endpoint: minio:9000
-      access_key_id: mimir
-      secret_access_key: supersecret
-      insecure: true
-      bucket_name: mimir
-
-# Blocks storage requires a prefix when using a common object storage bucket.
+# Configure Mimir to use Minio as its object storage backend. 
 blocks_storage:
-  storage_prefix: blocks
+  backend: s3
+  s3:
+    endpoint: minio:9000
+    bucket_name: mimir-blocks
+    access_key_id: mimir
+    secret_access_key: supersecret
+    insecure: true
   tsdb:
     dir: /data/ingester
 
@@ -32,10 +27,28 @@ ruler:
     heartbeat_period: 2s
     heartbeat_timeout: 10s
 
+ruler_storage:
+  backend: s3
+  s3:
+    endpoint: minio:9000
+    bucket_name: mimir-ruler
+    access_key_id: mimir
+    secret_access_key: supersecret
+    insecure: true
+
 alertmanager:
   data_dir: /data/alertmanager
   fallback_config_file: /etc/alertmanager-fallback-config.yaml
   external_url: http://localhost:9009/alertmanager
+
+alertmanager_storage:
+  backend: s3
+  s3:
+    endpoint: minio:9000
+    bucket_name: mimir-alertmanager
+    access_key_id: mimir
+    secret_access_key: supersecret
+    insecure: true
 
 server:
   log_level: warn

--- a/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
+++ b/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   minio:
     image: minio/minio
     entrypoint: [""]
-    command: ["sh", "-c", "mkdir -p /data/mimir && minio server --quiet /data"]
+    command: ["sh", "-c", "mkdir -p /data/mimir-blocks /data/mimir-ruler /data/mimir-alertmanager && minio server --quiet /data"]
     environment:
       - MINIO_ACCESS_KEY=mimir
       - MINIO_SECRET_KEY=supersecret

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -20,17 +20,18 @@ import (
 )
 
 const (
-	userID             = "e2e-user"
-	defaultNetworkName = "e2e-mimir-test"
-	mimirBucketName    = "mimir"
-	blocksBucketName   = "mimir-blocks"
-	alertsBucketName   = "mimir-alerts"
-	mimirConfigFile    = "config.yaml"
-	clientCertFile     = "certs/client.crt"
-	clientKeyFile      = "certs/client.key"
-	caCertFile         = "certs/root.crt"
-	serverCertFile     = "certs/server.crt"
-	serverKeyFile      = "certs/server.key"
+	userID              = "e2e-user"
+	defaultNetworkName  = "e2e-mimir-test"
+	mimirBucketName     = "mimir"
+	blocksBucketName    = "mimir-blocks"
+	alertsBucketName    = "mimir-alerts"
+	rulestoreBucketName = "mimir-ruler"
+	mimirConfigFile     = "config.yaml"
+	clientCertFile      = "certs/client.crt"
+	clientKeyFile       = "certs/client.key"
+	caCertFile          = "certs/root.crt"
+	serverCertFile      = "certs/server.crt"
+	serverKeyFile       = "certs/server.key"
 )
 
 // GetNetworkName returns the docker network name to run tests within.


### PR DESCRIPTION
#### What this PR does

Tutorial can't use common config yet as it will be released in 2.3.
This reverts the common config usage, and I'll create an issue to bring it back after releasing 2.3. Edit: issue https://github.com/grafana/mimir/issues/2377

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2374

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
