### PR TITLE
[release-2.2] Helm: bump minimum Kubernetes version for the helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -12,6 +12,7 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
+* [CHANGE] **breaking change** The minimal Kubernetes version is now 1.20. This reflects the fact that Grafana does not test with older versions. #2297
 * [CHANGE] **breaking change** Make `ConfigMap` the default for `configStorageType`. This means that the Mimir (or Enterprise Metrics) configuration is now created in and loaded from a ConfigMap instead of a Secret. #2277
   - Set to `Secret` to keep existing way of working. See related #2031, #2017, #2089.
   - In case the configuration is loaded from an external Secret, `useExternalConfig=true`, then `configStorageType` must be set to `Secret`.

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 2.1.0
 description: "Grafana Mimir"
 home: https://grafana.com/docs/mimir/v2.1.x/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg
-kubeVersion: ^1.10.0-0
+kubeVersion: ^1.20.0-0
 name: mimir-distributed
 dependencies:
   - name: minio

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -10,7 +10,7 @@ Grafana Mimir
 
 ## Requirements
 
-Kubernetes: `^1.10.0-0`
+Kubernetes: `^1.20.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|


### PR DESCRIPTION
backport https://github.com/grafana/mimir/commit/df12d7b26ea0b8f311beb373528b15c23953eee6 from https://github.com/grafana/mimir/pull/2297