### PR TITLE
Restructure configuring out-of-order docs

### DIFF
--- a/docs/sources/operators-guide/architecture/components/ingester.md
+++ b/docs/sources/operators-guide/architecture/components/ingester.md
@@ -91,4 +91,4 @@ For more information on shuffle sharding, refer to [Configuring shuffle sharding
 
 Out-of-order samples are discarded by default. If the system writing samples to Mimir produces out-of-order samples, you can enable ingestion of such samples.
 
-For more information about out-of-order samples ingestion, refer to [Configuring out of order samples ingestion]({{< relref "../../configure/configuring-out-of-order-samples-ingestion.md" >}}).
+For more information about out-of-order samples ingestion, refer to [Configuring out of order samples ingestion]({{< relref "../../configure/configure-out-of-order-samples-ingestion.md" >}}).

--- a/docs/sources/operators-guide/configure/configure-out-of-order-samples-ingestion.md
+++ b/docs/sources/operators-guide/configure/configure-out-of-order-samples-ingestion.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/mimir/latest/operators-guide/configure/configure-out-of-order-samples-ingestion/
 description: Learn how to configure Grafana Mimir to handle out-of-order samples ingestion.
 menuTitle: Configure out-of-order samples ingestion
 title: Configure out-of-order samples ingestion

--- a/docs/sources/operators-guide/configure/configuring-out-of-order-samples-ingestion.md
+++ b/docs/sources/operators-guide/configure/configuring-out-of-order-samples-ingestion.md
@@ -9,19 +9,7 @@ weight: 120
 
 # Configuring out-of-order samples ingestion
 
-Grafana Mimir and the Prometheus TSDB understand out-of-order as follows.
-
-The moment that a new series sample arrives, Mimir need to determine if the series already exists, and whether or not the sample is too old:
-
-- If the series exists, the incoming sample must have a newer timestamp than the latest sample that is stored for the series.
-  Otherwise, it is considered out-of-order and will be dropped by the ingesters.
-- If the series does not exist, then the sample has to be within bounds, which go back 1 hour from TSDB's head-block max time (when using 2 hour block range). If it fails to be within bounds, then it is also considered out-of-bounds and will be dropped by the ingesters.
-
-> **Note:** If you're writing metrics using Prometheus remote write or the Grafana Agent, then out-of-order samples are unexpected.
-> Prometheus and Grafana Agent guarantee that samples are written in-order for the same series.
-
-If you have out-of-order samples due to the nature of your architecture or the system that is being observed, then you can configure Grafana Mimir to set an out-of-order time-window threshold for how old samples can be ingested.
-As a result, none of the preceding samples will be dropped if they are within the configured time window.
+Grafana Mimir allows ingesting out-of-order samples from 2.2 release onwards. It is currently an experimental feature.
 
 ## Configuring out-of-order samples ingestion instance wide
 
@@ -64,3 +52,19 @@ Similar to the problem above with query caching, the samples recorded via the re
 So you should expect some difference in results if you happen to run the raw query of the recording rule. The difference highly depends on your out-of-order ingestion pattern.
 
 If you happen to have a shorter `out_of_order_time_window`, say less than 10 minutes, then you can use `-ruler.evaluation-delay-duration` to delay your rule evaluation up to that time.
+
+## Meaning of out-of-order
+
+Grafana Mimir and the Prometheus TSDB understand out-of-order as follows.
+
+The moment that a new series sample arrives, Mimir need to determine if the series already exists, and whether or not the sample is too old:
+
+- If the series exists, the incoming sample must have a newer timestamp than the latest sample that is stored for the series.
+  Otherwise, it is considered out-of-order and will be dropped by the ingesters.
+- If the series does not exist, then the sample has to be within bounds, which go back 1 hour from TSDB's head-block max time (when using 2 hour block range). If it fails to be within bounds, then it is also considered out-of-bounds and will be dropped by the ingesters.
+
+> **Note:** If you're writing metrics using Prometheus remote write or the Grafana Agent, then out-of-order samples are unexpected.
+> Prometheus and Grafana Agent guarantee that samples are written in-order for the same series.
+
+If you have out-of-order samples due to the nature of your architecture or the system that is being observed, then you can configure Grafana Mimir to set an out-of-order time-window threshold for how old samples can be ingested.
+As a result, none of the preceding samples will be dropped if they are within the configured time window.


### PR DESCRIPTION
#### What this PR does

This restructure is based on an offline feedback. It also now explicitly mentions that out-of-order is an experimental feature.

#### Checklist

- [X] Documentation added
