### PR TITLE
Add mixin alert for ring member mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 ### Mixin
+* [ENHANCEMENT] Alerts: Add MimirRingMembersMismatch firing when a component does not have the expected number of running jobs. #2404
 
 ### Jsonnet
 

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1057,7 +1057,7 @@ How it **works**:
 
 How to **investigate**:
 
-- Check the [hash ring web page]({{< relref "../../reference-http-api/index.md#ingesters-ring-status" >}}) for the component for which the alert has fired, and look for unexpected instances in the list.
+- Check the [hash ring web page]({{< relref "../reference-http-api/index.md#ingesters-ring-status" >}}) for the component for which the alert has fired, and look for unexpected instances in the list.
 - Consider manually forgetting unexpected instances in `Unhealthy` state.
 - Ensure all the registered instances in the ring belong to the Mimir cluster for which the alert fired.
 

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1047,6 +1047,20 @@ How to **investigate**:
   1. The alert fired because of a bug in Mimir: fix it.
   1. The alert fired because of a bug or edge case in the continuous test tool, causing a false positive: fix it.
 
+### MimirRingMembersMismatch
+
+This alert fires when the number of ring members does not match the number of running replicas.
+
+How it **works**:
+
+- The alert compares each component (one of `compactor`, `distributor`, `ingester`, `ruler`, or `store-gateway`) against the number of `up` instances for the component in that namespace/cluster.
+
+How to **investigate**:
+
+- Check the [hash ring web page]({{< relref "../../reference-http-api/index.md#ingesters-ring-status" >}}) for the component for which the alert has fired, and look for unexpected instances in the list.
+- Consider manually forgetting unexpected instances in `Unhealthy` state.
+- Ensure all the registered instances in the ring belong to the Mimir cluster for which the alert fired.
+
 ### RolloutOperatorNotReconciling
 
 This alert fires if the [`rollout-operator`](https://github.com/grafana/rollout-operator) is not successfully reconciling in a namespace.

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1053,12 +1053,12 @@ This alert fires when the number of ring members does not match the number of ru
 
 How it **works**:
 
-- The alert compares each component (currently just `ingester`) against the number of `up` instances for the component in that namespace/cluster.
+- The alert compares each component (currently just `ingester`) against the number of `up` instances for the component in that cluster.
 
 How to **investigate**:
 
 - Check the [hash ring web page]({{< relref "../reference-http-api/index.md#ingesters-ring-status" >}}) for the component for which the alert has fired, and look for unexpected instances in the list.
-- Consider manually forgetting unexpected instances in `Unhealthy` state.
+- Consider manually forgetting unexpected instances in an `Unhealthy` state.
 - Ensure all the registered instances in the ring belong to the Mimir cluster for which the alert fired.
 
 ### RolloutOperatorNotReconciling

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1078,18 +1078,6 @@ How to **investigate**:
   {name="rollout-operator",namespace="<namespace>"}
   ```
 
-### MimirRingMembersMismatch
-
-How it **works**:
-
-This alert fires when the number of ring members is not as expected. It compares each component (one of `compactor`, `distributor`, `ingester`, `ruler`, or `store-gateway`) against the number of `up` jobs for the component
-in that namespace/cluster.
-
-How to **investigate**:
-
-- Check the jsonnet for the environment matches the expected number of components. (TODO)
-- TODO
-
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1053,7 +1053,7 @@ This alert fires when the number of ring members does not match the number of ru
 
 How it **works**:
 
-- The alert compares each component (one of `compactor`, `distributor`, `ingester`, `ruler`, or `store-gateway`) against the number of `up` instances for the component in that namespace/cluster.
+- The alert compares each component (currently just `ingester`) against the number of `up` instances for the component in that namespace/cluster.
 
 How to **investigate**:
 

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1064,6 +1064,18 @@ How to **investigate**:
   {name="rollout-operator",namespace="<namespace>"}
   ```
 
+### MimirRingMembersMismatch
+
+How it **works**:
+
+This alert fires when the number of ring members is not as expected. It compares each component (one of `compactor`, `distributor`, `ingester`, `ruler`, or `store-gateway`) against the number of `up` jobs for the component
+in that namespace/cluster.
+
+How to **investigate**:
+
+- Check the jsonnet for the environment matches the expected number of components. (TODO)
+- TODO
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -131,8 +131,8 @@ groups:
         Number of members in Mimir compactor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"compactor.*|cortex|mimir|mimir-backend",job=~".*/compactor"}))
-        != sum by(cluster, namespace) (up{job=~".*/compactor"})
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"compactor.*|cortex|mimir|mimir-backend",job=~"(.*/)?compactor.*|cortex|mimir|mimir-backend"}))
+        != sum by(cluster, namespace) (up{job=~"(.*/)?compactor.*|cortex|mimir|mimir-backend"})
       )
       and
       (
@@ -148,8 +148,8 @@ groups:
         Number of members in Mimir distributor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(distributor|cortex|mimir|mimir-write)",job=~".*/distributor"}))
-        != sum by(cluster, namespace) (up{job=~".*/distributor"})
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(distributor|cortex|mimir|mimir-write)",job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"}))
+        != sum by(cluster, namespace) (up{job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"})
       )
       and
       (
@@ -165,8 +165,8 @@ groups:
         Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ingester.*|cortex|mimir|mimir-write)",job=~".*/ingester.*"}))
-        != sum by(cluster, namespace) (up{job=~".*/ingester.*"})
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ingester.*|cortex|mimir|mimir-write)",job=~"(.*/)?(ingester.*|cortex|mimir|mimir-write)"}))
+        != sum by(cluster, namespace) (up{job=~"(.*/)?(ingester.*|cortex|mimir|mimir-write)"})
       )
       and
       (
@@ -182,8 +182,8 @@ groups:
         Number of members in Mimir ruler hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ruler|cortex|mimir|mimir-backend)",job=~".*/ruler"}))
-        != sum by(cluster, namespace) (up{job=~".*/ruler"})
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ruler|cortex|mimir|mimir-backend)",job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"}))
+        != sum by(cluster, namespace) (up{job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"})
       )
       and
       (
@@ -199,8 +199,8 @@ groups:
         Number of members in Mimir store-gateway hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(store-gateway.*|cortex|mimir|mimir-backend)",job=~".*/store-gateway.*"}))
-        != sum by(cluster, namespace) (up{job=~".*/store-gateway.*"})
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(store-gateway.*|cortex|mimir|mimir-backend)",job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"}))
+        != sum by(cluster, namespace) (up{job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"})
       )
       and
       (

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -125,7 +125,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: MimirMimirRingMembersMismatch
+  - alert: MimirRingMembersMismatch
     annotations:
       message: |
         Number of members in Mimir compactor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -142,7 +142,7 @@ groups:
     labels:
       component: compactor
       severity: warning
-  - alert: MimirMimirRingMembersMismatch
+  - alert: MimirRingMembersMismatch
     annotations:
       message: |
         Number of members in Mimir distributor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -159,7 +159,7 @@ groups:
     labels:
       component: distributor
       severity: warning
-  - alert: MimirMimirRingMembersMismatch
+  - alert: MimirRingMembersMismatch
     annotations:
       message: |
         Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -176,7 +176,7 @@ groups:
     labels:
       component: ingester
       severity: warning
-  - alert: MimirMimirRingMembersMismatch
+  - alert: MimirRingMembersMismatch
     annotations:
       message: |
         Number of members in Mimir ruler hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
@@ -193,7 +193,7 @@ groups:
     labels:
       component: ruler
       severity: warning
-  - alert: MimirMimirRingMembersMismatch
+  - alert: MimirRingMembersMismatch
     annotations:
       message: |
         Number of members in Mimir store-gateway hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -131,8 +131,8 @@ groups:
         Number of members in Mimir compactor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"compactor.*|cortex|mimir|mimir-backend",job=~"(.*/)?compactor.*|cortex|mimir|mimir-backend"}))
-        != sum by(cluster, namespace) (up{job=~"(.*/)?compactor.*|cortex|mimir|mimir-backend"})
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="compactor",job=~"(.*/)?(compactor.*|cortex|mimir|mimir-backend)"}))
+        != sum by(cluster, namespace) (up{job=~"(.*/)?(compactor.*|cortex|mimir|mimir-backend)"})
       )
       and
       (
@@ -148,7 +148,7 @@ groups:
         Number of members in Mimir distributor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(distributor|cortex|mimir|mimir-write)",job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="distributor",job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"}))
         != sum by(cluster, namespace) (up{job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"})
       )
       and
@@ -165,7 +165,7 @@ groups:
         Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ingester.*|cortex|mimir|mimir-write)",job=~"(.*/)?(ingester.*|cortex|mimir|mimir-write)"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ingester",job=~"(.*/)?(ingester.*|cortex|mimir|mimir-write)"}))
         != sum by(cluster, namespace) (up{job=~"(.*/)?(ingester.*|cortex|mimir|mimir-write)"})
       )
       and
@@ -182,7 +182,7 @@ groups:
         Number of members in Mimir ruler hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ruler|cortex|mimir|mimir-backend)",job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ruler",job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"}))
         != sum by(cluster, namespace) (up{job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"})
       )
       and
@@ -199,7 +199,7 @@ groups:
         Number of members in Mimir store-gateway hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(store-gateway.*|cortex|mimir|mimir-backend)",job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="store-gateway",job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"}))
         != sum by(cluster, namespace) (up{job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"})
       )
       and

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -128,40 +128,6 @@ groups:
   - alert: MimirRingMembersMismatch
     annotations:
       message: |
-        Number of members in Mimir compactor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-    expr: |
-      (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="compactor",job=~"(.*/)?(compactor.*|cortex|mimir|mimir-backend)"}))
-        != sum by(cluster, namespace) (up{job=~"(.*/)?(compactor.*|cortex|mimir|mimir-backend)"})
-      )
-      and
-      (
-        count by(cluster, namespace) (cortex_build_info) > 0
-      )
-    for: 15m
-    labels:
-      component: compactor
-      severity: warning
-  - alert: MimirRingMembersMismatch
-    annotations:
-      message: |
-        Number of members in Mimir distributor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-    expr: |
-      (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="distributor",job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"}))
-        != sum by(cluster, namespace) (up{job=~"(.*/)?(distributor|cortex|mimir|mimir-write)"})
-      )
-      and
-      (
-        count by(cluster, namespace) (cortex_build_info) > 0
-      )
-    for: 15m
-    labels:
-      component: distributor
-      severity: warning
-  - alert: MimirRingMembersMismatch
-    annotations:
-      message: |
         Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
@@ -175,40 +141,6 @@ groups:
     for: 15m
     labels:
       component: ingester
-      severity: warning
-  - alert: MimirRingMembersMismatch
-    annotations:
-      message: |
-        Number of members in Mimir ruler hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-    expr: |
-      (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ruler",job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"}))
-        != sum by(cluster, namespace) (up{job=~"(.*/)?(ruler|cortex|mimir|mimir-backend)"})
-      )
-      and
-      (
-        count by(cluster, namespace) (cortex_build_info) > 0
-      )
-    for: 15m
-    labels:
-      component: ruler
-      severity: warning
-  - alert: MimirRingMembersMismatch
-    annotations:
-      message: |
-        Number of members in Mimir store-gateway hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-    expr: |
-      (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="store-gateway",job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"}))
-        != sum by(cluster, namespace) (up{job=~"(.*/)?(store-gateway.*|cortex|mimir|mimir-backend)"})
-      )
-      and
-      (
-        count by(cluster, namespace) (cortex_build_info) > 0
-      )
-    for: 15m
-    labels:
-      component: store-gateway
       severity: warning
 - name: mimir_instance_limits_alerts
   rules:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -125,6 +125,91 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirMimirRingMembersMismatch
+    annotations:
+      message: |
+        Number of members in Mimir compactor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
+    expr: |
+      (
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="compactor",job=~".*/compactor"}))
+        != sum by(cluster, namespace) (up{job=~".*/compactor"})
+      )
+      and
+      (
+        count by(cluster, namespace) (cortex_build_info) > 0
+      )
+    for: 15m
+    labels:
+      component: compactor
+      severity: warning
+  - alert: MimirMimirRingMembersMismatch
+    annotations:
+      message: |
+        Number of members in Mimir distributor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
+    expr: |
+      (
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="distributor",job=~".*/distributor"}))
+        != sum by(cluster, namespace) (up{job=~".*/distributor"})
+      )
+      and
+      (
+        count by(cluster, namespace) (cortex_build_info) > 0
+      )
+    for: 15m
+    labels:
+      component: distributor
+      severity: warning
+  - alert: MimirMimirRingMembersMismatch
+    annotations:
+      message: |
+        Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
+    expr: |
+      (
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ingester",job=~".*/ingester.*"}))
+        != sum by(cluster, namespace) (up{job=~".*/ingester.*"})
+      )
+      and
+      (
+        count by(cluster, namespace) (cortex_build_info) > 0
+      )
+    for: 15m
+    labels:
+      component: ingester
+      severity: warning
+  - alert: MimirMimirRingMembersMismatch
+    annotations:
+      message: |
+        Number of members in Mimir ruler hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
+    expr: |
+      (
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ruler",job=~".*/ruler"}))
+        != sum by(cluster, namespace) (up{job=~".*/ruler"})
+      )
+      and
+      (
+        count by(cluster, namespace) (cortex_build_info) > 0
+      )
+    for: 15m
+    labels:
+      component: ruler
+      severity: warning
+  - alert: MimirMimirRingMembersMismatch
+    annotations:
+      message: |
+        Number of members in Mimir store-gateway hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
+    expr: |
+      (
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="store-gateway",job=~".*/store-gateway.*"}))
+        != sum by(cluster, namespace) (up{job=~".*/store-gateway.*"})
+      )
+      and
+      (
+        count by(cluster, namespace) (cortex_build_info) > 0
+      )
+    for: 15m
+    labels:
+      component: store-gateway
+      severity: warning
 - name: mimir_instance_limits_alerts
   rules:
   - alert: MimirIngesterReachingSeriesLimit

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -131,7 +131,7 @@ groups:
         Number of members in Mimir compactor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="compactor",job=~".*/compactor"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"compactor.*|cortex|mimir|mimir-backend",job=~".*/compactor"}))
         != sum by(cluster, namespace) (up{job=~".*/compactor"})
       )
       and
@@ -148,7 +148,7 @@ groups:
         Number of members in Mimir distributor hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="distributor",job=~".*/distributor"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(distributor|cortex|mimir|mimir-write)",job=~".*/distributor"}))
         != sum by(cluster, namespace) (up{job=~".*/distributor"})
       )
       and
@@ -165,7 +165,7 @@ groups:
         Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ingester",job=~".*/ingester.*"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ingester.*|cortex|mimir|mimir-write)",job=~".*/ingester.*"}))
         != sum by(cluster, namespace) (up{job=~".*/ingester.*"})
       )
       and
@@ -182,7 +182,7 @@ groups:
         Number of members in Mimir ruler hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="ruler",job=~".*/ruler"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(ruler|cortex|mimir|mimir-backend)",job=~".*/ruler"}))
         != sum by(cluster, namespace) (up{job=~".*/ruler"})
       )
       and
@@ -199,7 +199,7 @@ groups:
         Number of members in Mimir store-gateway hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       (
-        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name="store-gateway",job=~".*/store-gateway.*"}))
+        avg by(cluster, namespace) (sum by(cluster, namespace, pod) (cortex_ring_members{name=~"(store-gateway.*|cortex|mimir|mimir-backend)",job=~".*/store-gateway.*"}))
         != sum by(cluster, namespace) (up{job=~".*/store-gateway.*"})
       )
       and

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -223,7 +223,7 @@
         },
       ] + [
         {
-          alert: $.alertName('MimirRingMembersMismatch'),
+          alert: $.alertName('RingMembersMismatch'),
           expr: |||
             (
               avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, pod) (cortex_ring_members{name="%(component)s",job=~"%(job)s"}))

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -236,8 +236,8 @@
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            component: component_job[0],
-            job: component_job[1],
+            component: component_job[1],
+            job: component_job[2],
           },
           'for': '15m',
           labels: {
@@ -251,11 +251,11 @@
           },
         }
         for component_job in [
-          ['compactor', '.*/compactor'],
-          ['distributor', '.*/distributor'],
-          ['ingester', '.*/ingester.*'],
-          ['ruler', '.*/ruler'],
-          ['store-gateway', '.*/store-gateway.*'],
+          ['compactor', $._config.job_names['compactor'], '.*/compactor'],
+          ['distributor', $._config.job_names['distributor'], '.*/distributor'],
+          ['ingester', $._config.job_names['ingester'], '.*/ingester.*'],
+          ['ruler', $._config.job_names['ruler'], '.*/ruler'],
+          ['store-gateway', $._config.job_names['store_gateway'], '.*/store-gateway.*'],
         ]
       ],
     },

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -251,11 +251,11 @@
           },
         }
         for component_job in [
-          ['compactor', $._config.job_names['compactor'], '.*/compactor'],
-          ['distributor', $._config.job_names['distributor'], '.*/distributor'],
-          ['ingester', $._config.job_names['ingester'], '.*/ingester.*'],
-          ['ruler', $._config.job_names['ruler'], '.*/ruler'],
-          ['store-gateway', $._config.job_names['store_gateway'], '.*/store-gateway.*'],
+          ['compactor', $._config.job_names.compactor, '.*/compactor'],
+          ['distributor', $._config.job_names.distributor, '.*/distributor'],
+          ['ingester', $._config.job_names.ingester, '.*/ingester.*'],
+          ['ruler', $._config.job_names.ruler, '.*/ruler'],
+          ['store-gateway', $._config.job_names.store_gateway, '.*/store-gateway.*'],
         ]
       ],
     },

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -226,7 +226,7 @@
           alert: $.alertName('RingMembersMismatch'),
           expr: |||
             (
-              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, pod) (cortex_ring_members{name="%(component)s",job=~"%(job)s"}))
+              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name="%(component)s",job=~"%(job)s"}))
               != sum by(%(alert_aggregation_labels)s) (up{job=~"%(job)s"})
             )
             and
@@ -235,6 +235,7 @@
             )
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
+            per_instance_label: $._config.per_instance_label,
             component: component_job[0],
             job: component_job[1],
           },
@@ -245,8 +246,8 @@
           },
           annotations: {
             message: |||
-              Number of members in Mimir %(component)s hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            ||| % { component: component_job[0] },
+              Number of members in Mimir %(component)s hash ring does not match the expected number in %(alert_aggregation_variables)s.
+            ||| % { component: component_job[0], alert_aggregation_variables: $._config.alert_aggregation_variables },
           },
         }
         for component_job in [

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -226,7 +226,7 @@
           alert: $.alertName('RingMembersMismatch'),
           expr: |||
             (
-              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name=~"%(job)s",job=~"(.*/)?%(job)s"}))
+              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name="%(component)s",job=~"(.*/)?%(job)s"}))
               != sum by(%(alert_aggregation_labels)s) (up{job=~"(.*/)?%(job)s"})
             )
             and
@@ -236,6 +236,7 @@
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
+            component: component_job[0],
             job: component_job[1],
           },
           'for': '15m',

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -226,7 +226,7 @@
           alert: $.alertName('RingMembersMismatch'),
           expr: |||
             (
-              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name="%(component)s",job=~"%(job)s"}))
+              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name=~"%(component)s",job=~"%(job)s"}))
               != sum by(%(alert_aggregation_labels)s) (up{job=~"%(job)s"})
             )
             and

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -226,8 +226,8 @@
           alert: $.alertName('RingMembersMismatch'),
           expr: |||
             (
-              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name=~"%(component)s",job=~"%(job)s"}))
-              != sum by(%(alert_aggregation_labels)s) (up{job=~"%(job)s"})
+              avg by(%(alert_aggregation_labels)s) (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ring_members{name=~"%(job)s",job=~"(.*/)?%(job)s"}))
+              != sum by(%(alert_aggregation_labels)s) (up{job=~"(.*/)?%(job)s"})
             )
             and
             (
@@ -236,8 +236,7 @@
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            component: component_job[1],
-            job: component_job[2],
+            job: component_job[1],
           },
           'for': '15m',
           labels: {
@@ -251,11 +250,11 @@
           },
         }
         for component_job in [
-          ['compactor', $._config.job_names.compactor, '.*/compactor'],
-          ['distributor', $._config.job_names.distributor, '.*/distributor'],
-          ['ingester', $._config.job_names.ingester, '.*/ingester.*'],
-          ['ruler', $._config.job_names.ruler, '.*/ruler'],
-          ['store-gateway', $._config.job_names.store_gateway, '.*/store-gateway.*'],
+          ['compactor', $._config.job_names.compactor],
+          ['distributor', $._config.job_names.distributor],
+          ['ingester', $._config.job_names.ingester],
+          ['ruler', $._config.job_names.ruler],
+          ['store-gateway', $._config.job_names.store_gateway],
         ]
       ],
     },

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -250,12 +250,14 @@
             ||| % { component: component_job[0], alert_aggregation_variables: $._config.alert_aggregation_variables },
           },
         }
+        // NOTE(jhesketh): It is expected that the stateless components may trigger this alert
+        //                 too often. Just alert on ingester for now.
         for component_job in [
-          ['compactor', $._config.job_names.compactor],
-          ['distributor', $._config.job_names.distributor],
+          // ['compactor', $._config.job_names.compactor],
+          // ['distributor', $._config.job_names.distributor],
           ['ingester', $._config.job_names.ingester],
-          ['ruler', $._config.job_names.ruler],
-          ['store-gateway', $._config.job_names.store_gateway],
+          // ['ruler', $._config.job_names.ruler],
+          // ['store-gateway', $._config.job_names.store_gateway],
         ]
       ],
     },


### PR DESCRIPTION
This alert fires when the expected number of ring members does not
match the running number for each component (one of `compactor`,
`distributor`, `ingester`, `ruler`, or `store-gateway`).


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #1960

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
