### PR TITLE
Update build image after PR 2400.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
+      image: grafana/mimir-build-image:main-0e429b778
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
+      image: grafana/mimir-build-image:main-0e429b778
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
+      image: grafana/mimir-build-image:main-0e429b778
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
+      image: grafana/mimir-build-image:main-0e429b778
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -135,7 +135,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
+      image: grafana/mimir-build-image:main-0e429b778
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -219,7 +219,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:publish-multiarch-images-7a4b40a6d
+      image: grafana/mimir-build-image:main-0e429b778
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= publish-multiarch-images-7a4b40a6d
+LATEST_BUILD_IMAGE_TAG ?= main-0e429b778
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden


### PR DESCRIPTION
#### What this PR does

This PR updates reference to `mimir-build-image`, rebuilt after PR #2400 was merged.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
