### PR TITLE
Mixin: Add missing API routes to Ruler dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [BUGFIX] Dashboards: fixed unit of latency panels in the "Mimir / Ruler" dashboard. #2312
 * [BUGFIX] Dashboards: fixed "Intervals per query" panel in the "Mimir / Queries" dashboard. #2308
 * [BUGFIX] Dashboards: Make "Slow Queries" dashboard works with Grafana 9.0. #2223
+* [BUGFIX] Dashboards: add missing API routes to Ruler dashboard. #2412
 
 ### Jsonnet
 

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -2,7 +2,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
 local filename = 'mimir-ruler.json';
 
 (import 'dashboard-utils.libsonnet') {
-  local ruler_config_api_routes_re = '(prometheus|api_prom)_(rules.*|api_v1_(rules|alerts))',
+  local ruler_config_api_routes_re = '(%s)|(%s)' % [
+    // Prometheus API routes which are also exposed by Mimir.
+    '(api_prom_api_v1|prometheus_api_v1)_(rules|alerts|status_buildinfo)',
+    // Mimir-only API routes used for rule configuration.
+    '(api_prom|api_v1|prometheus|prometheus_config_v1)_rules.*',
+  ],
 
   rulerQueries+:: {
     ruleEvaluations: {


### PR DESCRIPTION
We're missing a lot of API routes for presumably a variety of reasons. Changing the regex to include the following routes:

Prometheus:
```
api_prom_api_v1_rules
api_prom_api_v1_alerts
api_prom_api_v1_status_buildinfo
prometheus_api_v1_rules
prometheus_api_v1_alerts
prometheus_api_v1_status_buildinfo
```

Mimir:

```
api_prom_rules
api_prom_rules_{namespace}
api_prom_rules_{namespace}_{groupName}
api_v1_rules
api_v1_rules_{namespace}
api_v1_rules_{namespace}_{groupName}
prometheus_rules
prometheus_rules_{namespace}
prometheus_rules_{namespace}_{groupName}
prometheus_config_v1_rules
prometheus_config_v1_rules_{namespace}
prometheus_config_v1_rules_{namespace}_{groupName}
```