### PR TITLE
Add distributor inflight request size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [ENHANCEMENT] Store-gateway, listblocks: list of blocks now includes stats from `meta.json` file: number of series, samples and chunks. #2425
 * [ENHANCEMENT] Added more buckets to `cortex_ingester_client_request_duration_seconds` histogram metric, to correctly track requests taking longer than 1s (up until 16s). #2445
 * [ENHANCEMENT] Azure client: Improve memory usage for large object storage downloads. #2408
-* [ENHANCEMENT] Distributor: Add `-distributor.instance-limits.max-inflight-push-requests-total-size`. This limit protects the distributor against multiple large requests that together may cause an OOM, but are only a few, so do not trigger the `max-inflight-push-requests` limit. #2413
+* [ENHANCEMENT] Distributor: Add `-distributor.instance-limits.max-inflight-push-requests-bytes`. This limit protects the distributor against multiple large requests that together may cause an OOM, but are only a few, so do not trigger the `max-inflight-push-requests` limit. #2413
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Store-gateway, listblocks: list of blocks now includes stats from `meta.json` file: number of series, samples and chunks. #2425
 * [ENHANCEMENT] Added more buckets to `cortex_ingester_client_request_duration_seconds` histogram metric, to correctly track requests taking longer than 1s (up until 16s). #2445
 * [ENHANCEMENT] Azure client: Improve memory usage for large object storage downloads. #2408
+* [ENHANCEMENT] Distributor: Add `-distributor.instance-limits.max-inflight-push-requests-total-size`. This limit protects the distributor against multiple large requests that together may cause an OOM, but are only a few, so do not trigger the `max-inflight-push-requests` limit. #2413
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1333,6 +1333,17 @@
               "fieldFlag": "distributor.instance-limits.max-inflight-push-requests",
               "fieldType": "int",
               "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "max_inflight_push_requests_total_size",
+              "required": false,
+              "desc": "The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "distributor.instance-limits.max-inflight-push-requests-total-size",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1336,12 +1336,12 @@
             },
             {
               "kind": "field",
-              "name": "max_inflight_push_requests_total_size",
+              "name": "max_inflight_push_requests_bytes",
               "required": false,
               "desc": "The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.",
               "fieldValue": null,
               "fieldDefaultValue": 0,
-              "fieldFlag": "distributor.instance-limits.max-inflight-push-requests-total-size",
+              "fieldFlag": "distributor.instance-limits.max-inflight-push-requests-total-bytes",
               "fieldType": "int",
               "fieldCategory": "advanced"
             }

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1341,7 +1341,7 @@
               "desc": "The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.",
               "fieldValue": null,
               "fieldDefaultValue": 0,
-              "fieldFlag": "distributor.instance-limits.max-inflight-push-requests-total-bytes",
+              "fieldFlag": "distributor.instance-limits.max-inflight-push-requests-bytes",
               "fieldType": "int",
               "fieldCategory": "advanced"
             }

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -830,7 +830,7 @@ Usage of ./cmd/mimir/mimir:
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.instance-limits.max-inflight-push-requests int
     	Max inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited. (default 2000)
-  -distributor.instance-limits.max-inflight-push-requests-total-size int
+  -distributor.instance-limits.max-inflight-push-requests-total-bytes int
     	The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.
   -distributor.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -830,6 +830,8 @@ Usage of ./cmd/mimir/mimir:
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.instance-limits.max-inflight-push-requests int
     	Max inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited. (default 2000)
+  -distributor.instance-limits.max-inflight-push-requests-total-size int
+    	The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.
   -distributor.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
   -distributor.max-recv-msg-size int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -830,7 +830,7 @@ Usage of ./cmd/mimir/mimir:
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.instance-limits.max-inflight-push-requests int
     	Max inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited. (default 2000)
-  -distributor.instance-limits.max-inflight-push-requests-total-bytes int
+  -distributor.instance-limits.max-inflight-push-requests-bytes int
     	The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.
   -distributor.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -599,6 +599,12 @@ instance_limits:
   # CLI flag: -distributor.instance-limits.max-inflight-push-requests
   [max_inflight_push_requests: <int> | default = 2000]
 
+  # (advanced) The sum of the request sizes in bytes of inflight push requests
+  # that this distributor can handle. This limit is per-distributor, not
+  # per-tenant. Additional requests will be rejected. 0 = unlimited.
+  # CLI flag: -distributor.instance-limits.max-inflight-push-requests-total-size
+  [max_inflight_push_requests_total_size: <int> | default = 0]
+
 forwarding:
   # (experimental) Enables the feature to forward certain metrics in
   # remote_write requests, depending on defined rules.

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -602,8 +602,8 @@ instance_limits:
   # (advanced) The sum of the request sizes in bytes of inflight push requests
   # that this distributor can handle. This limit is per-distributor, not
   # per-tenant. Additional requests will be rejected. 0 = unlimited.
-  # CLI flag: -distributor.instance-limits.max-inflight-push-requests-total-size
-  [max_inflight_push_requests_total_size: <int> | default = 0]
+  # CLI flag: -distributor.instance-limits.max-inflight-push-requests-total-bytes
+  [max_inflight_push_requests_bytes: <int> | default = 0]
 
 forwarding:
   # (experimental) Enables the feature to forward certain metrics in

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -602,7 +602,7 @@ instance_limits:
   # (advanced) The sum of the request sizes in bytes of inflight push requests
   # that this distributor can handle. This limit is per-distributor, not
   # per-tenant. Additional requests will be rejected. 0 = unlimited.
-  # CLI flag: -distributor.instance-limits.max-inflight-push-requests-total-bytes
+  # CLI flag: -distributor.instance-limits.max-inflight-push-requests-bytes
   [max_inflight_push_requests_bytes: <int> | default = 0]
 
 forwarding:

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1186,19 +1186,19 @@ How to **fix** it:
 - Check the write requests latency through the `Mimir / Writes` dashboard and come back to investigate the root cause of high latency (the higher the latency, the higher the number of in-flight write requests).
 - Consider scaling out the distributors.
 
-### err-mimir-distributor-max-inflight-push-requests-total-size
+### err-mimir-distributor-max-inflight-push-requests-bytes
 
-This error occurs when a distributor rejects a write request because the total size of all in-flight requests limit has been reached.
+This error occurs when a distributor rejects a write request because the total size in bytes of all in-flight requests limit has been reached.
 
 How it **works**:
 
-- The distributor has a per-instance limit on the total size of all in-flight write (push) requests.
-- The limit applies to all in-flight write requests, across all tenants, and it protects the distributor from becoming overloaded in case of high traffic.
-- To configure the limit, set the `-distributor.instance-limits.max-inflight-push-requests-total-size` option.
+- The distributor has a per-instance limit on the total size in bytes of all in-flight write (push) requests.
+- The limit applies to all in-flight write requests, across all tenants, and it protects the distributor from going out of memory in case of high traffic or high latency on the write path.
+- To configure the limit, set the `-distributor.instance-limits.max-inflight-push-requests-bytes` option.
 
 How to **fix** it:
 
-- Increase the limit by setting the `-distributor.instance-limits.max-inflight-push-requests-total-size` option.
+- Increase the limit by setting the `-distributor.instance-limits.max-inflight-push-requests-bytes` option.
 - Check the write requests latency through the `Mimir / Writes` dashboard and come back to investigate the root cause of the increased size of requests or the increased latency (the higher the latency, the higher the number of in-flight write requests, the higher their combined size).
 - Consider scaling out the distributors.
 

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1186,6 +1186,22 @@ How to **fix** it:
 - Check the write requests latency through the `Mimir / Writes` dashboard and come back to investigate the root cause of high latency (the higher the latency, the higher the number of in-flight write requests).
 - Consider scaling out the distributors.
 
+### err-mimir-distributor-max-inflight-push-requests-total-size
+
+This error occurs when a distributor rejects a write request because the total size of all in-flight requests limit has been reached.
+
+How it **works**:
+
+- The distributor has a per-instance limit on the total size of all in-flight write (push) requests.
+- The limit applies to all in-flight write requests, across all tenants, and it protects the distributor from becoming overloaded in case of high traffic.
+- To configure the limit, set the `-distributor.instance-limits.max-inflight-push-requests-total-size` option.
+
+How to **fix** it:
+
+- Increase the limit by setting the `-distributor.instance-limits.max-inflight-push-requests-total-size` option.
+- Check the write requests latency through the `Mimir / Writes` dashboard and come back to investigate the root cause of the increased size of requests or the increased latency (the higher the latency, the higher the number of in-flight write requests, the higher their combined size).
+- Consider scaling out the distributors.
+
 ### err-mimir-ingester-max-ingestion-rate
 
 This critical error occurs when the rate of received samples per second is exceeded in an ingester.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -166,7 +166,7 @@ type Config struct {
 type InstanceLimits struct {
 	MaxIngestionRate                 float64 `yaml:"max_ingestion_rate" category:"advanced"`
 	MaxInflightPushRequests          int     `yaml:"max_inflight_push_requests" category:"advanced"`
-	MaxInflightPushRequestsTotalSize int64   `yaml:"max_inflight_push_requests_total_size" category:"advanced"`
+	MaxInflightPushRequestsTotalSize int     `yaml:"max_inflight_push_requests_total_size" category:"advanced"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -181,7 +181,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	flagext.DeprecatedFlag(f, "distributor.extend-writes", "Deprecated: this setting was used to try writing to an additional ingester in the presence of an ingester not in the ACTIVE state. Mimir now behaves as this setting is always disabled.", logger)
 	f.Float64Var(&cfg.InstanceLimits.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
 	f.IntVar(&cfg.InstanceLimits.MaxInflightPushRequests, maxInflightPushRequestsFlag, 2000, "Max inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.")
-	f.Int64Var(&cfg.InstanceLimits.MaxInflightPushRequestsTotalSize, maxInflightPushRequestsTotalSizeFlag, 0, "The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.")
+	f.IntVar(&cfg.InstanceLimits.MaxInflightPushRequestsTotalSize, maxInflightPushRequestsTotalSizeFlag, 0, "The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.")
 }
 
 // Validate config and returns error on failure
@@ -645,7 +645,7 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 		}
 	}
 
-	if d.cfg.InstanceLimits.MaxInflightPushRequestsTotalSize > 0 && inflightSize > d.cfg.InstanceLimits.MaxInflightPushRequestsTotalSize {
+	if d.cfg.InstanceLimits.MaxInflightPushRequestsTotalSize > 0 && inflightSize > int64(d.cfg.InstanceLimits.MaxInflightPushRequestsTotalSize) {
 		return nil, errMaxInflightRequestsTotalSizeReached
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -610,13 +610,14 @@ func (d *Distributor) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mim
 func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteRequest, callerCleanup func()) (*mimirpb.WriteResponse, error) {
 	// We will report *this* request in the error too.
 	inflight := d.inflightPushRequests.Inc()
-	inflightSize := d.inflightPushRequestsSize.Add(int64(req.Size()))
+	reqSize := int64(req.Size())
+	inflightSize := d.inflightPushRequestsSize.Add(reqSize)
 
 	// Decrement counter after all ingester calls have finished or been cancelled.
 	cleanup := func() {
 		callerCleanup()
 		d.inflightPushRequests.Dec()
-		d.inflightPushRequestsSize.Sub(int64(req.Size()))
+		d.inflightPushRequestsSize.Sub(reqSize)
 	}
 	cleanupInDefer := true
 	defer func() {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -54,7 +54,7 @@ import (
 const (
 	maxIngestionRateFlag             = "distributor.instance-limits.max-ingestion-rate"
 	maxInflightPushRequestsFlag      = "distributor.instance-limits.max-inflight-push-requests"
-	maxInflightPushRequestsBytesFlag = "distributor.instance-limits.max-inflight-push-requests-total-bytes"
+	maxInflightPushRequestsBytesFlag = "distributor.instance-limits.max-inflight-push-requests-bytes"
 )
 
 var (

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -333,7 +333,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		return float64(d.inflightPushRequests.Load())
 	})
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cortex_distributor_inflight_push_requests_size",
+		Name: "cortex_distributor_inflight_push_requests_bytes",
 		Help: "Current sum of inflight push requests in distributor in bytes.",
 	}, func() float64 {
 		return float64(d.inflightPushRequestsBytes.Load())

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -318,6 +318,11 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Name:        instanceLimitsMetric,
 		Help:        instanceLimitsMetricHelp,
+		ConstLabels: map[string]string{limitLabel: "max_inflight_push_requests_bytes"},
+	}).Set(float64(cfg.InstanceLimits.MaxInflightPushRequestsBytes))
+	promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		Name:        instanceLimitsMetric,
+		Help:        instanceLimitsMetricHelp,
 		ConstLabels: map[string]string{limitLabel: "max_ingestion_rate"},
 	}).Set(cfg.InstanceLimits.MaxIngestionRate)
 
@@ -326,6 +331,12 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		Help: "Current number of inflight push requests in distributor.",
 	}, func() float64 {
 		return float64(d.inflightPushRequests.Load())
+	})
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "cortex_distributor_inflight_push_requests_size",
+		Help: "Current sum of inflight push requests in distributor in bytes.",
+	}, func() float64 {
+		return float64(d.inflightPushRequestsBytes.Load())
 	})
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "cortex_distributor_ingestion_rate_samples_per_second",

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -610,7 +610,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 
 		// limits
 		inflightLimit      int
-		inflightSizeLimit  int64
+		inflightSizeLimit  int
 		ingestionRateLimit float64
 
 		metricNames     []string
@@ -701,7 +701,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 		},
 
 		"below inflight size limit": {
-			inflightSizeLimit: int64(makeWriteRequest(0, 100, 1, false).Size()),
+			inflightSizeLimit: makeWriteRequest(0, 100, 1, false).Size(),
 
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
@@ -709,7 +709,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 		},
 
 		"hits inflight size limit": {
-			inflightSizeLimit: int64(makeWriteRequest(0, 100, 1, false).Size()),
+			inflightSizeLimit: makeWriteRequest(0, 100, 1, false).Size(),
 
 			pushes: []testPush{
 				{samples: 101, expectedError: errMaxInflightRequestsTotalSizeReached},
@@ -2737,7 +2737,7 @@ type prepConfig struct {
 	numDistributors              int
 	skipLabelNameValidation      bool
 	maxInflightRequests          int
-	maxInflightRequestsTotalSize int64
+	maxInflightRequestsTotalSize int
 	maxIngestionRate             float64
 	replicationFactor            int
 	enableTracker                bool

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -610,7 +610,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 
 		// limits
 		inflightLimit      int
-		inflightSizeLimit  int
+		inflightBytesLimit int
 		ingestionRateLimit float64
 
 		metricNames     []string
@@ -701,7 +701,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 		},
 
 		"below inflight size limit": {
-			inflightSizeLimit: makeWriteRequest(0, 100, 1, false).Size(),
+			inflightBytesLimit: makeWriteRequest(0, 100, 1, false).Size(),
 
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
@@ -709,10 +709,10 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 		},
 
 		"hits inflight size limit": {
-			inflightSizeLimit: makeWriteRequest(0, 100, 1, false).Size(),
+			inflightBytesLimit: makeWriteRequest(0, 100, 1, false).Size(),
 
 			pushes: []testPush{
-				{samples: 101, expectedError: errMaxInflightRequestsTotalSizeReached},
+				{samples: 101, expectedError: errMaxInflightRequestsBytesReached},
 			},
 		},
 	}
@@ -726,13 +726,13 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 
 			// Start all expected distributors
 			distributors, _, regs := prepare(t, prepConfig{
-				numIngesters:                 3,
-				happyIngesters:               3,
-				numDistributors:              1,
-				limits:                       limits,
-				maxInflightRequests:          testData.inflightLimit,
-				maxInflightRequestsTotalSize: testData.inflightSizeLimit,
-				maxIngestionRate:             testData.ingestionRateLimit,
+				numIngesters:             3,
+				happyIngesters:           3,
+				numDistributors:          1,
+				limits:                   limits,
+				maxInflightRequests:      testData.inflightLimit,
+				maxInflightRequestsBytes: testData.inflightBytesLimit,
+				maxIngestionRate:         testData.ingestionRateLimit,
 			})
 
 			d := distributors[0]
@@ -2737,7 +2737,7 @@ type prepConfig struct {
 	numDistributors              int
 	skipLabelNameValidation      bool
 	maxInflightRequests          int
-	maxInflightRequestsTotalSize int
+	maxInflightRequestsBytes     int
 	maxIngestionRate             float64
 	replicationFactor            int
 	enableTracker                bool
@@ -2845,7 +2845,7 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, []*p
 		distributorCfg.DistributorRing.InstanceAddr = "127.0.0.1"
 		distributorCfg.SkipLabelNameValidation = cfg.skipLabelNameValidation
 		distributorCfg.InstanceLimits.MaxInflightPushRequests = cfg.maxInflightRequests
-		distributorCfg.InstanceLimits.MaxInflightPushRequestsTotalSize = cfg.maxInflightRequestsTotalSize
+		distributorCfg.InstanceLimits.MaxInflightPushRequestsBytes = cfg.maxInflightRequestsBytes
 		distributorCfg.InstanceLimits.MaxIngestionRate = cfg.maxIngestionRate
 		distributorCfg.ShuffleShardingLookbackPeriod = time.Hour
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -709,12 +709,12 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
 			},
-			metricNames: []string{instanceLimitsMetric, "cortex_distributor_inflight_push_requests_size"},
+			metricNames: []string{instanceLimitsMetric, "cortex_distributor_inflight_push_requests_bytes"},
 
 			expectedMetrics: `
-				# HELP cortex_distributor_inflight_push_requests_size Current sum of inflight push requests in distributor in bytes.
-				# TYPE cortex_distributor_inflight_push_requests_size gauge
-				cortex_distributor_inflight_push_requests_size 0
+				# HELP cortex_distributor_inflight_push_requests_bytes Current sum of inflight push requests in distributor in bytes.
+				# TYPE cortex_distributor_inflight_push_requests_bytes gauge
+				cortex_distributor_inflight_push_requests_bytes 0
 
 				# HELP cortex_distributor_instance_limits Instance limits used by this distributor.
 				# TYPE cortex_distributor_instance_limits gauge

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -31,9 +31,9 @@ const (
 	MaxSeriesPerQuery             ID = "max-series-per-query"
 	MaxChunkBytesPerQuery         ID = "max-chunks-bytes-per-query"
 
-	DistributorMaxIngestionRate                 ID = "distributor-max-ingestion-rate"
-	DistributorMaxInflightPushRequests          ID = "distributor-max-inflight-push-requests"
-	DistributorMaxInflightPushRequestsTotalSize ID = "distributor-max-inflight-push-requests-total-size"
+	DistributorMaxIngestionRate             ID = "distributor-max-ingestion-rate"
+	DistributorMaxInflightPushRequests      ID = "distributor-max-inflight-push-requests"
+	DistributorMaxInflightPushRequestsBytes ID = "distributor-max-inflight-push-requests-bytes"
 
 	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
 	IngesterMaxTenants              ID = "ingester-max-tenants"

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -31,8 +31,9 @@ const (
 	MaxSeriesPerQuery             ID = "max-series-per-query"
 	MaxChunkBytesPerQuery         ID = "max-chunks-bytes-per-query"
 
-	DistributorMaxIngestionRate        ID = "distributor-max-ingestion-rate"
-	DistributorMaxInflightPushRequests ID = "distributor-max-inflight-push-requests"
+	DistributorMaxIngestionRate                 ID = "distributor-max-ingestion-rate"
+	DistributorMaxInflightPushRequests          ID = "distributor-max-inflight-push-requests"
+	DistributorMaxInflightPushRequestsTotalSize ID = "distributor-max-inflight-push-requests-total-size"
 
 	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
 	IngesterMaxTenants              ID = "ingester-max-tenants"


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Introduces a limit for the total size of the inflight push requests in the distributor `-distributor.instance-limits.max-inflight-push-requests-total-size`.

This limit is useful in combination with the existing `-distributor.instance-limits.max-inflight-push-requests`. The existing limit does not account for large requests that may be below the inflight requests count. The new limit is meant to protect the distributor against multiple large requests. 

By default the limit is disabled because it will limit memory utilization on existing Mimir installations.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2226

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
