### PR TITLE
Fix log messages for unready services

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -636,8 +636,7 @@ func (t *Mimir) readyHandler(sm *services.Manager) http.HandlerFunc {
 				}
 			}
 
-			logMessage := "some services are not Running: " + strings.Join(serviceNamesStates, ", ")
-			level.Debug(util_log.Logger).Log("msg", logMessage)
+			level.Debug(util_log.Logger).Log("msg", "some services are not Running", "services", serviceNamesStates)
 
 			httpResponse := "Some services are not Running:\n" + strings.Join(serviceNamesStates, "\n")
 			http.Error(w, httpResponse, http.StatusServiceUnavailable)


### PR DESCRIPTION
Log lines now looks like

```
11:28:52 compactor: level=debug ts=2022-07-14T09:28:52.169964509Z caller=mimir.go:643 msg="some services are not Running" services="compactor: Starting, distributor: Starting"
```

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
