### PR TITLE
Parse push request after distributor, ingester validate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3143
 * [ENHANCEMENT] Store-gateway: added extra span logging to improve observability. #3131
 * [ENHANCEMENT] Compactor: cleaning up different tenants' old blocks and updating bucket indexes is now more independent. This prevents a single tenant from delaying cleanup for other tenants. #2631
-* [ENHANCEMENT] Distributor: most limits are now enforce before reading and parsing the body of the request. This makes the distributor more resilient against a burst of invalid requests or requests over the rate limit. #2419
+* [ENHANCEMENT] Distributor: request rate, ingestion rate, and inflight requests limits are now enforced before reading and parsing the body of the request. This makes the distributor more resilient against a burst of requests over those limit. #2419
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3143
 * [ENHANCEMENT] Store-gateway: added extra span logging to improve observability. #3131
 * [ENHANCEMENT] Compactor: cleaning up different tenants' old blocks and updating bucket indexes is now more independent. This prevents a single tenant from delaying cleanup for other tenants. #2631
+* [ENHANCEMENT] Distributor: most limits are now enforce before reading and parsing the body of the request. This makes the distributor more resilient against a burst of invalid requests or requests over the rate limit. #2419
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -263,7 +263,7 @@ type Ingester interface {
 	client.IngesterServer
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)
-	PushWithCleanup(context.Context, *mimirpb.WriteRequest, func()) (*mimirpb.WriteResponse, error)
+	PushWithCleanup(context.Context, *push.Request) (*mimirpb.WriteResponse, error)
 }
 
 // RegisterIngester registers the ingesters HTTP and GRPC service

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
+	"github.com/grafana/mimir/pkg/util/push"
 )
 
 // ActivityTrackerWrapper is a wrapper around Ingester that adds queries to activity tracker.
@@ -35,9 +36,9 @@ func (i *ActivityTrackerWrapper) Push(ctx context.Context, request *mimirpb.Writ
 	return i.ing.Push(ctx, request)
 }
 
-func (i *ActivityTrackerWrapper) PushWithCleanup(ctx context.Context, w *mimirpb.WriteRequest, c func()) (*mimirpb.WriteResponse, error) {
+func (i *ActivityTrackerWrapper) PushWithCleanup(ctx context.Context, r *push.Request) (*mimirpb.WriteResponse, error) {
 	// No tracking in PushWithCleanup
-	return i.ing.PushWithCleanup(ctx, w, c)
+	return i.ing.PushWithCleanup(ctx, r)
 }
 
 func (i *ActivityTrackerWrapper) QueryStream(request *client.QueryRequest, server client.Ingester_QueryStreamServer) error {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/chunkcompat"
 	util_math "github.com/grafana/mimir/pkg/util/math"
+	"github.com/grafana/mimir/pkg/util/push"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
@@ -736,7 +737,7 @@ func TestIngester_Push(t *testing.T) {
 			// Push timeseries
 			for idx, req := range testData.reqs {
 				// Push metrics to the ingester. Override the default cleanup method of mimirpb.ReuseSlice with a no-op one.
-				_, err := i.PushWithCleanup(ctx, req, func() {})
+				_, err := i.PushWithCleanup(ctx, push.NewParsedRequest(req))
 
 				// We expect no error on any request except the last one
 				// which may error (and in that case we assert on it)

--- a/pkg/util/push/request.go
+++ b/pkg/util/push/request.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package push
+
+import (
+	"fmt"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+// supplierFunc should return either a non-nil body or a non-nil error. The cleanup function can be nil.
+type supplierFunc func() (*mimirpb.WriteRequest, func(), error)
+
+// Request represents a push request. It allows lazy body reading from the underlying http request
+// and adding cleanups that should be done after the request is completed.
+type Request struct {
+	cleanups []func()
+
+	getRequest supplierFunc
+
+	request *mimirpb.WriteRequest
+	err     error
+}
+
+func newRequest(p supplierFunc) *Request {
+	return &Request{
+		cleanups:   make([]func(), 0, 10),
+		getRequest: p,
+	}
+}
+
+func NewParsedRequest(r *mimirpb.WriteRequest) *Request {
+	return newRequest(func() (*mimirpb.WriteRequest, func(), error) {
+		return r, nil, nil
+	})
+}
+
+// WriteRequest returns request from supplier function. Function is only called once,
+// and subsequent calls to WriteRequest return the same value.
+func (r *Request) WriteRequest() (*mimirpb.WriteRequest, error) {
+	if r.request == nil && r.err == nil {
+		var cleanup func()
+		r.request, cleanup, r.err = r.getRequest()
+		if r.request == nil && r.err == nil {
+			r.err = fmt.Errorf("push.Request supplierFunc returned a nil body and a nil error, either should be non-nil")
+		}
+		r.AddCleanup(cleanup)
+	}
+	return r.request, r.err
+}
+
+// AddCleanup adds a function that will be called once CleanUp is called. If f is nil, it will not be invoked.
+func (r *Request) AddCleanup(f func()) {
+	if f == nil {
+		return
+	}
+	r.cleanups = append(r.cleanups, f)
+}
+
+// CleanUp calls all added cleanups.
+func (r *Request) CleanUp() {
+	for _, f := range r.cleanups {
+		f()
+	}
+}

--- a/pkg/util/push/request.go
+++ b/pkg/util/push/request.go
@@ -60,9 +60,11 @@ func (r *Request) AddCleanup(f func()) {
 	r.cleanups = append(r.cleanups, f)
 }
 
-// CleanUp calls all added cleanups in reverse order - the last added is the first invoked.
+// CleanUp calls all added cleanups in reverse order - the last added is the first invoked. CleanUp removes
+// each called cleanup function from the list of cleanups. So subsequent calls to CleanUp will not invoke the same cleanup functions.
 func (r *Request) CleanUp() {
 	for i := len(r.cleanups) - 1; i >= 0; i-- {
 		r.cleanups[i]()
 	}
+	r.cleanups = r.cleanups[:0]
 }

--- a/pkg/util/push/request.go
+++ b/pkg/util/push/request.go
@@ -62,7 +62,7 @@ func (r *Request) AddCleanup(f func()) {
 
 // CleanUp calls all added cleanups.
 func (r *Request) CleanUp() {
-	for _, f := range r.cleanups {
-		f()
+	for i := len(r.cleanups) - 1; i >= 0; i-- {
+		r.cleanups[i]()
 	}
 }

--- a/pkg/util/push/request.go
+++ b/pkg/util/push/request.go
@@ -60,7 +60,7 @@ func (r *Request) AddCleanup(f func()) {
 	r.cleanups = append(r.cleanups, f)
 }
 
-// CleanUp calls all added cleanups.
+// CleanUp calls all added cleanups in reverse order - the last added is the first invoked.
 func (r *Request) CleanUp() {
 	for i := len(r.cleanups) - 1; i >= 0; i-- {
 		r.cleanups[i]()

--- a/pkg/util/push/request.go
+++ b/pkg/util/push/request.go
@@ -8,11 +8,11 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-// supplierFunc should return either a non-nil body or a non-nil error. The cleanup function can be nil.
-type supplierFunc func() (*mimirpb.WriteRequest, func(), error)
+// supplierFunc should return either a non-nil body or a non-nil error. The returned cleanup function can be nil.
+type supplierFunc func() (req *mimirpb.WriteRequest, cleanup func(), err error)
 
 // Request represents a push request. It allows lazy body reading from the underlying http request
-// and adding cleanups that should be done after the request is completed.
+// and adding cleanup functions that should be called after the request has been handled.
 type Request struct {
 	cleanups []func()
 

--- a/pkg/util/push/request_test.go
+++ b/pkg/util/push/request_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package push
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+var noopParser = supplierFunc(func() (*mimirpb.WriteRequest, func(), error) {
+	return &mimirpb.WriteRequest{}, nil, nil
+})
+
+func TestRequest_CleanUpOrder(t *testing.T) {
+	var cleanupOrder []int
+	cleanupOne := func() {
+		cleanupOrder = append(cleanupOrder, 1)
+	}
+	cleanupTwo := func() {
+		cleanupOrder = append(cleanupOrder, 2)
+	}
+
+	r := newRequest(noopParser)
+
+	r.AddCleanup(cleanupOne)
+	r.AddCleanup(cleanupTwo)
+	r.CleanUp()
+
+	assert.Equal(t, []int{1, 2}, cleanupOrder)
+}
+
+func TestRequest_WriteRequestIsParsedOnlyOnce(t *testing.T) {
+	parseCount := 0
+	p := supplierFunc(func() (*mimirpb.WriteRequest, func(), error) {
+		parseCount++
+		return &mimirpb.WriteRequest{}, nil, nil
+	})
+
+	r := newRequest(p)
+	_, _ = r.WriteRequest()
+	_, _ = r.WriteRequest()
+	assert.Equal(t, 1, parseCount)
+}

--- a/pkg/util/push/request_test.go
+++ b/pkg/util/push/request_test.go
@@ -14,6 +14,8 @@ var noopParser = supplierFunc(func() (*mimirpb.WriteRequest, func(), error) {
 	return &mimirpb.WriteRequest{}, nil, nil
 })
 
+// TestRequest_CleanUpOrder tests that the semantics of cleanups is similar to stacking defer statements:
+// last one is the first to be executed.
 func TestRequest_CleanUpOrder(t *testing.T) {
 	var cleanupOrder []int
 	cleanupOne := func() {
@@ -29,7 +31,7 @@ func TestRequest_CleanUpOrder(t *testing.T) {
 	r.AddCleanup(cleanupTwo)
 	r.CleanUp()
 
-	assert.Equal(t, []int{1, 2}, cleanupOrder)
+	assert.Equal(t, []int{2, 1}, cleanupOrder)
 }
 
 func TestRequest_WriteRequestIsParsedOnlyOnce(t *testing.T) {

--- a/pkg/util/push/request_test.go
+++ b/pkg/util/push/request_test.go
@@ -34,6 +34,19 @@ func TestRequest_CleanUpOrder(t *testing.T) {
 	assert.Equal(t, []int{2, 1}, cleanupOrder)
 }
 
+// TestRequest_CleanUpDoubleCalling tests that calling CleanUp twice doesn't invoke the functions again.
+func TestRequest_CleanUpDoubleCalling(t *testing.T) {
+	invocations := 0
+
+	r := newRequest(noopParser)
+
+	r.AddCleanup(func() { invocations++ })
+	r.CleanUp()
+	r.CleanUp()
+
+	assert.Equal(t, 1, invocations)
+}
+
 func TestRequest_WriteRequestIsParsedOnlyOnce(t *testing.T) {
 	parseCount := 0
 	p := supplierFunc(func() (*mimirpb.WriteRequest, func(), error) {


### PR DESCRIPTION


Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The ingester and distributor push functions have some  limit validations
 on push requests that do not depend on the push request itself (e.g.
 request rate or inflight requests). This PR makes parsing of request
 happen only after the distributor and ingester have validated as many
 of their instance limits as possible. This should reduce utilization
 when the distributor and ingesters are under load.

Originally the issue was for the distributor only, but since their `PushWithCleanup` methods both confirm to the `push.Func` signature, I decided it is easier to change both of them.

I am submitting this PR as a draft because it complicates the code,
and only helps when requests in the distributor start taking a very long time and when effectively all incoming requests get counted as over the inflight limit. So I am not sure if this is something we want to include.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2327

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
