### PR TITLE
Show block stats when listing blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Memberlist: added experimental memberlist cluster label support via `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` CLI flags (and their respective YAML config options). #2354
 * [ENHANCEMENT] Object storage can now be configured for all components using the `common` YAML config option key (or `-common.storage.*` CLI flags). #2330
 * [ENHANCEMENT] Go: updated to go 1.18.4. #2400
+* [ENHANCEMENT] Store-gateway, listblocks: list of blocks now includes stats from `meta.json` file: number of series, samples and chunks. #2425
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289

--- a/pkg/storegateway/blocks.gohtml
+++ b/pkg/storegateway/blocks.gohtml
@@ -37,6 +37,9 @@
         <th>Deletion Time</th>{{ end }}
         <th>Lvl</th>
         <th>Size</th>
+        <th>Series</th>
+        <th>Samples</th>
+        <th>Chunks</th>
         <th>Labels</th>
         {{ if .ShowSources }}
         <th>Sources</th>{{ end }}
@@ -59,6 +62,9 @@
             <td>{{ .DeletedTime }}</td>{{ end }}
             <td>{{ .CompactionLevel }}</td>
             <td>{{ .BlockSize }}</td>
+            <td>{{ .Stats.NumSeries }}</td>
+            <td>{{ .Stats.NumSamples }}</td>
+            <td>{{ .Stats.NumChunks }}</td>
             <td>{{ .Labels }}</td>
             {{ if $page.ShowSources }}
                 <td>

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/prometheus/model/labels"
+	prom_tsdb "github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb"
@@ -52,6 +53,7 @@ type formattedBlockData struct {
 	Labels          string
 	Sources         []string
 	Parents         []string
+	Stats           prom_tsdb.BlockStats
 }
 
 type richMeta struct {
@@ -127,6 +129,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 			Labels:          lbls.String(),
 			Sources:         sources,
 			Parents:         parents,
+			Stats:           m.Stats,
 		})
 		var deletedAt *int64
 		if dt, ok := deletedTimes[m.ULID]; ok {

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -35,6 +35,7 @@ type config struct {
 	showParents         bool
 	showCompactionLevel bool
 	showBlockSize       bool
+	showStats           bool
 	splitCount          int
 	minTime             flagext.Time
 	maxTime             flagext.Time
@@ -57,6 +58,7 @@ func main() {
 	flag.Var(&cfg.minTime, "min-time", "If set, only blocks with MinTime >= this value are printed")
 	flag.Var(&cfg.maxTime, "max-time", "If set, only blocks with MaxTime <= this value are printed")
 	flag.BoolVar(&cfg.useUlidTimeForMinTimeCheck, "use-ulid-time-for-min-time-check", false, "If true, meta.json files for blocks with ULID time before min-time are not loaded. This may incorrectly skip blocks that have data from the future (minT/maxT higher than ULID).")
+	flag.BoolVar(&cfg.showStats, "show-stats", false, "Show block stats (number of series, chunks, samples)")
 	flag.Parse()
 
 	if cfg.userID == "" {
@@ -113,6 +115,11 @@ func printMetas(metas map[ulid.ULID]*metadata.Meta, deletedTimes map[ulid.ULID]t
 	if cfg.showBlockSize {
 		fmt.Fprintf(tabber, "Size\t")
 	}
+	if cfg.showStats {
+		fmt.Fprintf(tabber, "Series\t")
+		fmt.Fprintf(tabber, "Samples\t")
+		fmt.Fprintf(tabber, "Chunks\t")
+	}
 	if cfg.showLabels {
 		fmt.Fprintf(tabber, "Labels\t")
 	}
@@ -161,6 +168,12 @@ func printMetas(metas map[ulid.ULID]*metadata.Meta, deletedTimes map[ulid.ULID]t
 
 		if cfg.showBlockSize {
 			fmt.Fprintf(tabber, "%s\t", listblocks.GetFormattedBlockSize(b))
+		}
+
+		if cfg.showStats {
+			fmt.Fprintf(tabber, "%d\t", b.Stats.NumSeries)
+			fmt.Fprintf(tabber, "%d\t", b.Stats.NumSamples)
+			fmt.Fprintf(tabber, "%d\t", b.Stats.NumChunks)
 		}
 
 		if cfg.showLabels {


### PR DESCRIPTION
#### What this PR does

This PR extends listing of blocks with block stats (number of series, samples and chunks). This is done both at web page (exposed by store-gateway) and in `listblocks` CLI tool (requires new option `-show-stats`).

<img width="1569" alt="Screenshot 2022-07-15 at 09 00 37" src="https://user-images.githubusercontent.com/895919/179169563-03abfccd-f4af-44a1-b6ec-839b3db7d4a1.png">

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
