### PR TITLE
helm: do not render `PodSecurityPolicy` manifest on gke >= 1.25

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.rbac.create (eq .Values.rbac.type "psp") }}
+{{- $pspAvailable := (semverCompare "<1.25-0" (include "mimir.kubeVersion" .)) -}}
+{{- if and $pspAvailable .Values.rbac.create (eq .Values.rbac.type "psp") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`PodSecurityPolicy` resource will be completely removed from GKE in the future. This PR prevents it from being rendered on versions greater than 1.25.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
