### PR TITLE
Revert changes from gerunds to imperatives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ If you're migrating to Grafana Mimir, refer to the following documents:
 
 ## Deploying Grafana Mimir
 
-For information about how to deploy Grafana Mimir, refer to [Deploy Grafana Mimir](https://grafana.com/docs/mimir/latest/operators-guide/deploy-grafana-mimir/).
+For information about how to deploy Grafana Mimir, refer to [Deploy Grafana Mimir](https://grafana.com/docs/mimir/latest/operators-guide/deploying-grafana-mimir/).
 
 ## Getting started
 
-If you’re new to Grafana Mimir, read the [Get started guide](https://grafana.com/docs/mimir/latest/operators-guide/get-started/).
+If you’re new to Grafana Mimir, read the [Getting started guide](https://grafana.com/docs/mimir/latest/operators-guide/getting-started/).
 
 Before deploying Grafana Mimir in a production environment, read:
 
 1. [An overview of Grafana Mimir’s architecture](https://grafana.com/docs/mimir/latest/operators-guide/architecture/)
-1. [Configure Grafana Mimir](https://grafana.com/docs/mimir/latest/operators-guide/configure/)
-1. [Run Grafana Mimir in production](https://grafana.com/docs/mimir/latest/operators-guide/run-production-environment/)
+1. [Configure Grafana Mimir](https://grafana.com/docs/mimir/latest/operators-guide/configuring/)
+1. [Run Grafana Mimir in production](https://grafana.com/docs/mimir/latest/operators-guide/running-production-environment/)
 
 ## Documentation
 


### PR DESCRIPTION
The work to align with the style guide with regard to imperatives for tasks is going into release 2.3. This PR reverts some of the needed changes for that temporarily until we can get the links sorted out.