### PR TITLE
Report previously failed shipped blocks in shipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289
 * [BUGFIX] Alertmanager: ensure the configured `-alertmanager.web.external-url` is a full URL, including the scheme and hostname. #2381
 * [BUGFIX] Memberlist: fix problem with loss of some packets, typically ring updates when instances were removed from the ring during shutdown. #2418
+* [BUGFIX] Ingester: fix misfiring `MimirIngesterHasUnshippedBlocks` and stale `cortex_ingester_oldest_unshipped_block_timestamp_seconds` when some block uploads fail. #2435
 
 ### Mixin
 

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -151,6 +151,7 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 		}
 		if ok {
 			meta.Uploaded = append(meta.Uploaded, m.ULID)
+			uploaded++ // the last upload must have failed, report the block as if it was uploaded successfully now
 			continue
 		}
 

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -7,6 +7,8 @@ package ingester
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"path"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
 )
@@ -144,4 +147,65 @@ func TestShipper(t *testing.T) {
 	})
 
 	t.Log(logs.String())
+}
+
+// deceivingUploadBucket proxies the calls to the underlying bucket. On uploads and when
+// the base name of the object matches objectBaseName, after proxying the call
+// an error is returned regardless of what the underlying Bucket returned.
+// Useful for when you want to simulate a particular file _appearing_ to fail uploading, but actually succeeding.
+type deceivingUploadBucket struct {
+	objstore.Bucket
+
+	objectBaseName string
+}
+
+func (b deceivingUploadBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	actualErr := b.Bucket.Upload(ctx, name, r)
+	if actualErr != nil {
+		return actualErr
+	} else if path.Base(name) == b.objectBaseName {
+		return fmt.Errorf("base name matches, will fail upload")
+	}
+	return nil
+}
+
+func TestShipper_DeceivingUploadErrors(t *testing.T) {
+	blocksDir := t.TempDir()
+	bucketDir := t.TempDir()
+
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: bucketDir})
+	require.NoError(t, err)
+	// Wrap bucket in a decorator so that meta.json file uploads always fail
+	bkt = deceivingUploadBucket{Bucket: bkt, objectBaseName: block.MetaFilename}
+
+	logs := &concurrency.SyncBuffer{}
+	logger := log.NewLogfmtLogger(logs)
+
+	s := NewShipper(logger, nil, blocksDir, bkt, metadata.TestSource, metadata.NoneFunc)
+
+	// Create and upload a block
+	id1 := ulid.MustNew(1, nil)
+	createBlock(t, blocksDir, id1, metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id1,
+			MaxTime: 2000,
+			MinTime: 1000,
+			Version: 1,
+			Stats: tsdb.BlockStats{
+				NumSamples: 100, // Shipper checks if number of samples is greater than 0.
+			},
+		},
+		Thanos: metadata.Thanos{Labels: map[string]string{"a": "b"}},
+	})
+
+	// Let shipper sync the blocks, expecting the meta.json upload to fail.
+	uploaded, err := s.Sync(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 0, uploaded)
+
+	// Sync again. This time the shipper should find the meta.json existing in the bucket and
+	// should report an uploaded block without retrying to upload the whole block again.
+	uploaded, err = s.Sync(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, uploaded)
 }

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -178,9 +178,7 @@ func TestShipper_DeceivingUploadErrors(t *testing.T) {
 	// Wrap bucket in a decorator so that meta.json file uploads always fail
 	bkt = deceivingUploadBucket{Bucket: bkt, objectBaseName: block.MetaFilename}
 
-	logs := &concurrency.SyncBuffer{}
-	logger := log.NewLogfmtLogger(logs)
-
+	logger := log.NewLogfmtLogger(os.Stderr)
 	s := NewShipper(logger, nil, blocksDir, bkt, metadata.TestSource, metadata.NoneFunc)
 
 	// Create and upload a block


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When a block upload appears to have failed, but later the shipper
discovers that the upload actually succeeded, the shipper does not
upload it again. But the ingester still reports the block as unhsipped.
This lead to a false positive alert (`MimirIngesterHasUnshippedBlocks`)
and stale value for `cortex_ingester_oldest_unshipped_block_timestamp_seconds`.

This PR changes the shipper to report an upload when it discovers
such a block. This helps with invalidating the cached shipper meta file
and reporting correct metrics.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/1997

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
