### PR TITLE
distributor: remove labels with empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
+* [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 
 ### Mixin

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -589,6 +589,15 @@ func removeLabel(labelName string, labels *[]mimirpb.LabelAdapter) {
 	}
 }
 
+// Remove labels with value=="" from a slice of LabelPairs, updating the slice in-place.
+func removeEmptyLabelValues(labels *[]mimirpb.LabelAdapter) {
+	for i := len(*labels) - 1; i >= 0; i-- {
+		if (*labels)[i].Value == "" {
+			*labels = append((*labels)[:i], (*labels)[i+1:]...)
+		}
+	}
+}
+
 // Returns a boolean that indicates whether or not we want to remove the replica label going forward,
 // and an error that indicates whether we want to accept samples based on the cluster/replica found in ts.
 // nil for the error means accept the sample.
@@ -794,6 +803,9 @@ func (d *Distributor) prePushRelabelMiddleware(next push.Func) push.Func {
 			for _, labelName := range d.limits.DropLabels(userID) {
 				removeLabel(labelName, &ts.Labels)
 			}
+
+			// Prometheus strips empty values before storing; drop them now, before sharding to ingesters.
+			removeEmptyLabelValues(&ts.Labels)
 
 			if len(ts.Labels) == 0 {
 				removeTsIndexes = append(removeTsIndexes, tsIdx)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1249,6 +1249,18 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 			inputSeries:    labels.FromStrings("__name__", "some_metric", "blank", "", "foo", "bar"),
 			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
 		},
+		{
+			inputSeries:    labels.FromStrings("__name__", "some_metric", "foo", "bar", "zzz_blank", ""),
+			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+		},
+		{
+			inputSeries:    labels.FromStrings("__blank__", "", "__name__", "some_metric", "foo", "bar"),
+			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+		},
+		{
+			inputSeries:    labels.FromStrings("__blank__", "", "__name__", "some_metric", "foo", "bar", "zzz_blank", ""),
+			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+		},
 		// Don't remove any labels.
 		{
 			removeReplica:  false,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1244,6 +1244,11 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 				"foo", "bar", "some", "thing"),
 			expectedSeries: labels.FromStrings("__name__", "some_metric", "cluster", "one"),
 		},
+		// Remove blank labels.
+		{
+			inputSeries:    labels.FromStrings("__name__", "some_metric", "blank", "", "foo", "bar"),
+			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+		},
 		// Don't remove any labels.
 		{
 			removeReplica:  false,


### PR DESCRIPTION
Empty labels are stripped when the series reaches TSDB, so we should remove them earlier to keep things consistent.

#### Checklist

- [x] Tests updated
- NA Documentation added - this is not user-visible; we are just stripping them earlier.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
