### PR TITLE
Add more buckets to cortex_ingester_client_request_duration_seconds histogram metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] Object storage can now be configured for all components using the `common` YAML config option key (or `-common.storage.*` CLI flags). #2330
 * [ENHANCEMENT] Go: updated to go 1.18.4. #2400
 * [ENHANCEMENT] Store-gateway, listblocks: list of blocks now includes stats from `meta.json` file: number of series, samples and chunks. #2425
+* [ENHANCEMENT] Added more buckets to `cortex_ingester_client_request_duration_seconds` histogram metric, to correctly track requests taking longer than 1s (up until 16s). #2445
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -17,10 +17,9 @@ import (
 )
 
 var ingesterClientRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "cortex",
-	Name:      "ingester_client_request_duration_seconds",
-	Help:      "Time spent doing Ingester requests.",
-	Buckets:   prometheus.ExponentialBuckets(0.001, 4, 6),
+	Name:    "cortex_ingester_client_request_duration_seconds",
+	Help:    "Time spent doing Ingester requests.",
+	Buckets: prometheus.ExponentialBuckets(0.001, 4, 8),
 }, []string{"operation", "status_code"})
 
 // HealthAndIngesterClient is the union of IngesterClient and grpc_health_v1.HealthClient.


### PR DESCRIPTION
#### What this PR does
When investigating a recent outage, it was annoying to check how long it took sending requests to ingesters via `cortex_ingester_client_request_duration_seconds` metric because buckets are capped to 1s. In this PR I propose to add 2 more buckets, covering the ranges 1s-4s and 4s-16s.

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
