### PR TITLE
fix: mixin compactor dashboard "last successful run" render issues in Grafana 8.5+

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -359,19 +359,6 @@
                         }
                      },
                      {
-                        "id": "calculateField",
-                        "options": {
-                           "alias": "Status",
-                           "binary": {
-                              "left": "Last run",
-                              "operator": "*",
-                              "right": 1
-                           },
-                           "mode": "binary",
-                           "replaceFields": false
-                        }
-                     },
-                     {
                         "id": "sortBy",
                         "options": {
                            "sort": [
@@ -598,19 +585,6 @@
                         }
                      },
                      {
-                        "id": "calculateField",
-                        "options": {
-                           "alias": "Status",
-                           "binary": {
-                              "left": "Last run",
-                              "operator": "*",
-                              "right": 1
-                           },
-                           "mode": "binary",
-                           "replaceFields": false
-                        }
-                     },
-                     {
                         "id": "sortBy",
                         "options": {
                            "sort": [
@@ -619,6 +593,32 @@
                                  "field": "Last run"
                               }
                            ]
+                        }
+                     },
+                     {
+                        "id": "calculateField",
+                        "options": {
+                           "alias": "One",
+                           "binary": {
+                              "left": "Last run",
+                              "operator": "/",
+                              "right": "Last run"
+                           },
+                           "mode": "binary",
+                           "replaceFields": false
+                        }
+                     },
+                     {
+                        "id": "calculateField",
+                        "options": {
+                           "alias": "Status",
+                           "binary": {
+                              "left": "Last run",
+                              "operator": "*",
+                              "right": "One"
+                           },
+                           "mode": "binary",
+                           "replaceFields": false
                         }
                      },
                      {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Two recently added panels in the Compactor dashboard were not rendering properly:
- Longest time since last successful run
- Last successful run per-compactor replica

The issue was the use of the "Status" field.
The "Status" text field may no longer be calculated using the direct value of "1" as of Grafana 8.5.
A "One" field is created to serve this purpose.
Further, "Status" has been removed from "Longest time since last successful run" since it is not being used there anymore.

#### Which issue(s) this PR fixes or relates to
Fixes #2315

#### Checklist

- [x] Tests updated
- [ ] ~Documentation added~
- [ ] ~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~

Assuming that mixins do not go into the CHANGELOG.md

