### PR TITLE
Store-gateway: use text field to control split count

### DIFF
--- a/pkg/storegateway/blocks.gohtml
+++ b/pkg/storegateway/blocks.gohtml
@@ -1,6 +1,6 @@
-{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.blocksContents */ -}}
+{{- /*gotype: github.com/grafana/mimir/pkg/storegateway.blocksPageContents*/ -}}
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/html">
 <head>
     <meta charset="UTF-8">
     <title>Store-gateway: bucket tenant blocks</title>
@@ -8,26 +8,23 @@
 <body>
 <h1>Store-gateway: bucket tenant blocks</h1>
 <p>Current time: {{ .Now }}</p>
-<p>Showing blocks for tenant: {{ .Tenant }}</p>
+<p>Showing blocks for tenant: <strong>{{ .Tenant }}</strong></p>
 <p>
-    {{ if not .ShowDeleted }}
-        <a href="{{ .ShowDeletedQuery }}">Show Deleted</a>
-    {{ end }}
-    {{ if not .ShowSources }}
-        <a href="{{ .ShowSourcesQuery }}">Show Sources</a>
-    {{ end }}
-    {{ if not .ShowParents }}
-        <a href="{{ .ShowParentsQuery }}">Show Parents</a>
-    {{ end }}
-</p>
-<p>
-    Use ?split_count= query param to show split compactor count preview.
+    <form>
+        <input type="checkbox" id="show-deleted" name="show_deleted" {{ if .ShowDeleted }} checked {{ end }}>&nbsp;<label for="show-deleted">Show Deleted</label> &nbsp;&nbsp;
+        <input type="checkbox" id="show-sources" name="show_sources" {{ if .ShowSources }} checked {{ end }}>&nbsp;<label for="show-sources">Show Sources</label> &nbsp;&nbsp;
+        <input type="checkbox" id="show-parents" name="show_parents" {{ if .ShowParents }} checked {{ end }}>&nbsp;<label for="show-parents">Show Parents</label> &nbsp;&nbsp;
+        <label for="split-count">Split count (non-zero value shows block split ID):</label>&nbsp;<input id="split-count" name="split_count" type="text" value="{{ .SplitCount }}" style="width: 6em;" />
+        <button type="submit" style="background-color: lightgrey;">
+            <span style="padding: 0.5em 1em; font-size: 125%;">Reload</span>
+        </button>
+    </form>
 </p>
 <table border="1" cellpadding="5" style="border-collapse: collapse">
     <thead>
     <tr>
         <th>Block ID</th>
-        {{ if .ShowSplitCount }}
+        {{ if gt .SplitCount 0 }}
         <th>Split ID</th>{{ end }}
         <th>ULID Time</th>
         <th>Min Time</th>
@@ -52,8 +49,8 @@
     {{ range .FormattedBlocks }}
         <tr>
             <td>{{ .ULID }}</td>
-            {{ if $page.ShowSplitCount }}
-            <td>{{ .SplitCount }}</td>{{ end }}
+            {{ if gt $page.SplitCount 0 }}
+            <td>{{ .SplitID }}</td>{{ end }}
             <td>{{ .ULIDTime }}</td>
             <td>{{ .MinTime }}</td>
             <td>{{ .MaxTime }}</td>

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -31,19 +30,15 @@ type blocksPageContents struct {
 	RichMetas       []richMeta           `json:"metas"`
 	FormattedBlocks []formattedBlockData `json:"-"`
 	ShowDeleted     bool                 `json:"-"`
-	ShowSplitCount  bool                 `json:"-"`
 	ShowSources     bool                 `json:"-"`
 	ShowParents     bool                 `json:"-"`
-
-	ShowDeletedQuery string `json:"-"`
-	ShowSourcesQuery string `json:"-"`
-	ShowParentsQuery string `json:"-"`
+	SplitCount      int                  `json:"-"`
 }
 
 type formattedBlockData struct {
 	ULID            string
 	ULIDTime        string
-	SplitCount      *uint32
+	SplitID         *uint32
 	MinTime         string
 	MaxTime         string
 	Duration        string
@@ -75,16 +70,14 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	showDeleted := req.Form.Get("show_deleted") == "true"
-	showSources := req.Form.Get("show_sources") == "true"
-	showParents := req.Form.Get("show_parents") == "true"
+	showDeleted := req.Form.Get("show_deleted") == "on"
+	showSources := req.Form.Get("show_sources") == "on"
+	showParents := req.Form.Get("show_parents") == "on"
 	var splitCount int
 	if sc := req.Form.Get("split_count"); sc != "" {
-		var err error
-		splitCount, err = strconv.Atoi(sc)
-		if err != nil {
-			util.WriteTextResponse(w, fmt.Sprintf("Bad split_count param: %s", err))
-			return
+		splitCount, _ = strconv.Atoi(sc)
+		if splitCount < 0 {
+			splitCount = 0
 		}
 	}
 
@@ -119,7 +112,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		formattedBlocks = append(formattedBlocks, formattedBlockData{
 			ULID:            m.ULID.String(),
 			ULIDTime:        util.TimeFromMillis(int64(m.ULID.Time())).UTC().Format(time.RFC3339),
-			SplitCount:      blockSplitID,
+			SplitID:         blockSplitID,
 			MinTime:         util.TimeFromMillis(m.MinTime).UTC().Format(time.RFC3339),
 			MaxTime:         util.TimeFromMillis(m.MaxTime).UTC().Format(time.RFC3339),
 			Duration:        util.TimeFromMillis(m.MaxTime).Sub(util.TimeFromMillis(m.MinTime)).String(),
@@ -149,27 +142,11 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		RichMetas:       richMetas,
 		FormattedBlocks: formattedBlocks,
 
-		ShowSplitCount: splitCount > 0,
-		ShowDeleted:    showDeleted,
-		ShowSources:    showSources,
-		ShowParents:    showParents,
-
-		ShowDeletedQuery: queryWithTrueBoolParam(*req.URL, req.Form, "show_deleted"),
-		ShowSourcesQuery: queryWithTrueBoolParam(*req.URL, req.Form, "show_sources"),
-		ShowParentsQuery: queryWithTrueBoolParam(*req.URL, req.Form, "show_parents"),
+		SplitCount:  splitCount,
+		ShowDeleted: showDeleted,
+		ShowSources: showSources,
+		ShowParents: showParents,
 	}, blocksPageTemplate, req)
-}
-
-func queryWithTrueBoolParam(u url.URL, form url.Values, boolParam string) string {
-	q := u.Query()
-	for k, vs := range form {
-		for _, val := range vs {
-			// Yes, we set only the last value, but otherwise the logic just gets too complicated.
-			q.Set(k, val)
-		}
-	}
-	q.Set(boolParam, "true")
-	return "?" + q.Encode()
 }
 
 func formatTimeIfNotZero(t time.Time, format string) string {


### PR DESCRIPTION
#### What this PR does

This PR updates UI for controlling list of blocks. Most notably, it removes "Use ?split_count= query ..." hint, and provides text field instead. Links to enable/disable options were also replaced with HTML form elements.

Before:

<img width="2076" alt="Screenshot 2022-07-19 at 11 35 10" src="https://user-images.githubusercontent.com/895919/179718771-f41e42ae-77d0-46d1-b539-9dac6de3af5b.png">

After:

<img width="2076" alt="Screenshot 2022-07-19 at 11 34 38" src="https://user-images.githubusercontent.com/895919/179718680-80c40923-a84b-473d-beb1-b806fa41121d.png">

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
