### PR TITLE
Add gzip compression support to OTLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   - `-compactor.partial-block-deletion-delay`, as a duration string, allows you to set the delay since a partial block has been modified before marking it for deletion. A value of `0`, the default, disables this feature.
   - The metric `cortex_compactor_blocks_marked_for_deletion_total` has a new value for the `reason` label `reason="partial"`, when a block deletion marker is triggered by the partial block deletion delay.
 * [FEATURE] Querier: enabled support for queries with negative offsets, which are not cached in the query results cache. #2429
-* [FEATURE] EXPERIMENTAL: OpenTelemetry Metrics ingestion path on `/otlp/v1/metrics`. #695 #2436
+* [FEATURE] EXPERIMENTAL: OpenTelemetry Metrics ingestion path on `/otlp/v1/metrics`. #695 #2436 #2461
 * [FEATURE] Querier: Added support for tenant federation to metric metadata endpoint. #2467
 * [ENHANCEMENT] Distributor: Decreased distributor tests execution time. #2562
 * [ENHANCEMENT] Alertmanager: Allow the HTTP `proxy_url` configuration option in the receiver's configuration. #2317

--- a/development/tsdb-blocks-storage-s3/config/otel-collector.yaml
+++ b/development/tsdb-blocks-storage-s3/config/otel-collector.yaml
@@ -2,7 +2,6 @@ exporters:
   prometheus:
     endpoint: :8083
   otlphttp:
-    compression: none
     endpoint: http://distributor-1:8000/otlp
 
 

--- a/pkg/util/push/otel.go
+++ b/pkg/util/push/otel.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -16,12 +15,14 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/middleware"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -62,14 +63,14 @@ func OTLPHandler(
 			}
 
 		default:
-			return nil, fmt.Errorf("unsupported content type: %s, supported: [%s, %s]", contentType, jsonContentType, pbContentType)
+			return nil, httpgrpc.Errorf(http.StatusUnsupportedMediaType, "unsupported content type: %s, supported: [%s, %s]", contentType, jsonContentType, pbContentType)
 		}
 
 		if r.ContentLength > int64(maxRecvMsgSize) {
-			return nil, fmt.Errorf(messageSizeLargerErrFmt, r.ContentLength, maxRecvMsgSize)
+			return nil, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, messageSizeLargerErrFmt, r.ContentLength, maxRecvMsgSize)
 		}
 
-		reader := http.MaxBytesReader(nil, r.Body, int64(maxRecvMsgSize))
+		reader := r.Body
 		// Handle compression.
 		switch r.Header.Get("Content-Encoding") {
 		case "gzip":
@@ -77,19 +78,26 @@ func OTLPHandler(
 			if err != nil {
 				return nil, err
 			}
-			// Protect against compression blowing up too.
-			reader = http.MaxBytesReader(nil, gr, int64(maxRecvMsgSize))
+			reader = gr
 
 		case "":
 			// No compression.
 
 		default:
-			return nil, fmt.Errorf("unsupported compression: %s. Only \"none\" and \"gzip\" supported", r.Header.Get("Content-Encoding"))
+			return nil, httpgrpc.Errorf(http.StatusUnsupportedMediaType, "unsupported compression: %s. Only \"gzip\" or no compression supported", r.Header.Get("Content-Encoding"))
 		}
+
+		// Protect against a large input.
+		reader = http.MaxBytesReader(nil, reader, int64(maxRecvMsgSize))
 
 		body, err := io.ReadAll(reader)
 		if err != nil {
 			r.Body.Close()
+
+			if util.IsRequestBodyTooLarge(err) {
+				return body, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, err.Error())
+			}
+
 			return body, err
 		}
 

--- a/pkg/util/push/otel.go
+++ b/pkg/util/push/otel.go
@@ -77,7 +77,8 @@ func OTLPHandler(
 			if err != nil {
 				return nil, err
 			}
-			reader = gr
+			// Protect against compression blowing up too.
+			reader = http.MaxBytesReader(nil, gr, int64(maxRecvMsgSize))
 
 		case "":
 			// No compression.

--- a/pkg/util/push/push.go
+++ b/pkg/util/push/push.go
@@ -74,14 +74,12 @@ func handler(maxRecvMsgSize int,
 			level.Error(logger).Log("err", err.Error())
 
 			// Check for httpgrpc error.
-			resp, ok := httpgrpc.HTTPResponseFromError(err)
-			if !ok {
+			if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+				http.Error(w, string(resp.Body), int(resp.Code))
+			} else {
 				http.Error(w, err.Error(), http.StatusBadRequest)
-				bufferPool.Put(bufHolder)
-				return
 			}
 
-			http.Error(w, string(resp.Body), int(resp.Code))
 			bufferPool.Put(bufHolder)
 			return
 		}


### PR DESCRIPTION
#### What this PR does

Adds gzip compression support to OTLP (which is on by default).

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`