### PR TITLE
Add `make help` tip to docs and remove useless type declare

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 // configHash exposes information about the loaded config
-var configHash *prometheus.GaugeVec = prometheus.NewGaugeVec(
+var configHash = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "cortex_config_hash",
 		Help: "Hash of the currently active config file.",

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -34,6 +34,7 @@ To build:
 make
 ```
 
+You can use `make help` to see the available targets.
 (By default, the build runs in a Docker container, using an image built
 with all the tools required. The source code is mounted from where you
 run `make` into the build container as a Docker volume.)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Add `make help` tip to docs and remove useless type declare. I think adding a `make help` prompt to the documentation would be very helpful for contributors to start building mimir.

#### Which issue(s) this PR fixes or relates to

None