### PR TITLE
Block file download and basic validation after upload

### DIFF
--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -1140,8 +1140,8 @@ func TestMultitenantCompactor_HandleBlockUpload_Complete(t *testing.T) {
 				metaJSON, err := json.Marshal(validMeta)
 				require.NoError(t, err)
 				setUpGet(bkt, uploadingMetaPath, metaJSON, nil)
-				bkt.MockIter(path.Join(tenantID, blockID), nil, nil)
 				bkt.MockUpload(metaPath, fmt.Errorf("test"))
+				bkt.MockIter(path.Join(tenantID, blockID), nil, nil)
 			},
 			expInternalServerError: true,
 		},


### PR DESCRIPTION
#### What this PR does
The PR implements the first stage of block validation after a block upload. The files in the block are downloaded locally on the compactor and checked for expected name and file sizes.

Progress is sent throughout via an http.ResponseWriter


#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
