### PR TITLE
Helm: Add new compactor endpoints for backfill to nginx configuration.

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -62,6 +62,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `NOTES.txt` to show endpoints URLs for the user at install/upgrade. #2189
 * [ENHANCEMENT] Add ServiceMonitor for overrides-exporter. #2068
 * [ENHANCEMENT] Add `nginx.resolver` for allow custom resolver in nginx configuration and `nginx.extraContainers` which allow add side containers to the nginx deployment #2196
+* [ENHANCEMENT] Add backfill endpoints to Nginx configuration. #2478
 
 ## 2.1.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1602,6 +1602,11 @@ nginx:
             proxy_pass      http://{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
+          # Compactor endpoint for uploading blocks
+          location /api/v1/upload/block/ {
+            proxy_pass      http://{{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+          }
+
           {{- with .Values.nginx.nginxConfig.serverSnippet }}
           {{ . | nindent 4 }}
           {{- end }}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -98,5 +98,10 @@ data:
         location = /api/v1/status/buildinfo {
           proxy_pass      http://test-oss-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
         }
+    
+        # Compactor endpoint for uploading blocks
+        location /api/v1/upload/block/ {
+          proxy_pass      http://test-oss-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+        }
       }
     }


### PR DESCRIPTION
#### What this PR does

This PR adds new compactor endpoints for backfilling into Nginx configuration in Helm chart.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
