### PR TITLE
Use RSS memory instead of working set memory in the MimirAllocatingTooMuchMemory alert for ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### Mixin
 
 * [CHANGE] Dashboards: "Slow Queries" dashboard no longer works with versions older than Grafana 9.0. #2223
+* [CHANGE] Alerts: use RSS memory instead of working set memory in the `MimirAllocatingTooMuchMemory` alert for ingesters. #2480
 * [ENHANCEMENT] Dashboards: added missed rule evaluations to the "Evaluations per second" panel in the "Mimir / Ruler" dashboard. #2314
 * [ENHANCEMENT] Dashboards: add k8s resource requests to CPU and memory panels. #2346
 * [BUGFIX] Dashboards: fixed unit of latency panels in the "Mimir / Ruler" dashboard. #2312

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -274,7 +274,9 @@ groups:
         Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
     expr: |
       (
-        container_memory_working_set_bytes{container="ingester"}
+        # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
+        # See: https://github.com/grafana/mimir/issues/2466
+        container_memory_rss{container="ingester"}
           /
         ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
       ) > 0.65
@@ -287,7 +289,9 @@ groups:
         Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
     expr: |
       (
-        container_memory_working_set_bytes{container="ingester"}
+        # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
+        # See: https://github.com/grafana/mimir/issues/2466
+        container_memory_rss{container="ingester"}
           /
         ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
       ) > 0.8

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -451,7 +451,9 @@
           alert: $.alertName('AllocatingTooMuchMemory'),
           expr: |||
             (
-              container_memory_working_set_bytes{container="ingester"}
+              # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
+              # See: https://github.com/grafana/mimir/issues/2466
+              container_memory_rss{container="ingester"}
                 /
               ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
             ) > 0.65
@@ -470,7 +472,9 @@
           alert: $.alertName('AllocatingTooMuchMemory'),
           expr: |||
             (
-              container_memory_working_set_bytes{container="ingester"}
+              # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
+              # See: https://github.com/grafana/mimir/issues/2466
+              container_memory_rss{container="ingester"}
                 /
               ( container_spec_memory_limit_bytes{container="ingester"} > 0 )
             ) > 0.8


### PR DESCRIPTION
#### What this PR does
This PR is a follow up of #2479. For the same reason of #2479, I propose to use RSS memory to alert on "ingesters using too much memory".

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/2466

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
