### PR TITLE
Dashboards: use dashed lines for resources request/limit and do not fill area in the per-pod panels

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -40,7 +40,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 1,
                   "legend": {
                      "avg": false,
@@ -63,11 +63,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -167,11 +171,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -248,7 +256,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 3,
                   "legend": {
                      "avg": false,
@@ -335,7 +343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 4,
                   "legend": {
                      "avg": false,
@@ -358,11 +366,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -462,11 +474,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -543,7 +559,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 6,
                   "legend": {
                      "avg": false,
@@ -962,7 +978,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 11,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -148,7 +148,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 2,
                   "legend": {
                      "avg": false,
@@ -451,7 +451,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 5,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -40,7 +40,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 1,
                   "legend": {
                      "avg": false,
@@ -63,11 +63,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -144,7 +148,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 2,
                   "legend": {
                      "avg": false,
@@ -231,7 +235,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 3,
                   "legend": {
                      "avg": false,
@@ -254,11 +258,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -358,11 +366,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -771,7 +783,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 9,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -343,7 +343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 4,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2556,7 +2556,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 29,
                   "legend": {
                      "avg": false,
@@ -2823,7 +2823,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 32,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -148,7 +148,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 2,
                   "legend": {
                      "avg": false,
@@ -451,7 +451,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 5,
                   "legend": {
                      "avg": false,
@@ -754,7 +754,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 8,
                   "legend": {
                      "avg": false,
@@ -1252,7 +1252,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 13,
                   "legend": {
                      "avg": false,
@@ -1569,7 +1569,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 16,
                   "legend": {
                      "avg": false,
@@ -2067,7 +2067,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 21,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -40,7 +40,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 1,
                   "legend": {
                      "avg": false,
@@ -63,11 +63,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -167,11 +171,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -248,7 +256,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 3,
                   "legend": {
                      "avg": false,
@@ -335,7 +343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 4,
                   "legend": {
                      "avg": false,
@@ -358,11 +366,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -462,11 +474,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -543,7 +559,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 6,
                   "legend": {
                      "avg": false,
@@ -630,7 +646,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 7,
                   "legend": {
                      "avg": false,
@@ -653,11 +669,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -757,11 +777,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -838,7 +862,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 9,
                   "legend": {
                      "avg": false,
@@ -925,7 +949,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 10,
                   "legend": {
                      "avg": false,
@@ -948,11 +972,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -1029,7 +1057,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 11,
                   "legend": {
                      "avg": false,
@@ -1116,7 +1144,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 12,
                   "legend": {
                      "avg": false,
@@ -1139,11 +1167,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -1243,11 +1275,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -1413,7 +1449,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 15,
                   "legend": {
                      "avg": false,
@@ -1436,11 +1472,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -1552,11 +1592,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -1633,7 +1677,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 17,
                   "legend": {
                      "avg": false,
@@ -1720,7 +1764,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 18,
                   "legend": {
                      "avg": false,
@@ -1743,11 +1787,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -1824,7 +1872,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 19,
                   "legend": {
                      "avg": false,
@@ -1911,7 +1959,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 20,
                   "legend": {
                      "avg": false,
@@ -1934,11 +1982,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -2038,11 +2090,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -2285,7 +2341,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 24,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
@@ -40,7 +40,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 1,
                   "legend": {
                      "avg": false,
@@ -63,11 +63,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -167,11 +171,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -248,7 +256,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 3,
                   "legend": {
                      "avg": false,
@@ -335,7 +343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 4,
                   "legend": {
                      "avg": false,
@@ -358,11 +366,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -462,11 +474,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -543,7 +559,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 6,
                   "legend": {
                      "avg": false,
@@ -630,7 +646,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 7,
                   "legend": {
                      "avg": false,
@@ -653,11 +669,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -757,11 +777,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -838,7 +862,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 9,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
@@ -148,7 +148,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 2,
                   "legend": {
                      "avg": false,
@@ -451,7 +451,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 5,
                   "legend": {
                      "avg": false,
@@ -754,7 +754,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 8,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -40,7 +40,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 1,
                   "legend": {
                      "avg": false,
@@ -63,11 +63,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -167,11 +171,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -248,7 +256,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 3,
                   "legend": {
                      "avg": false,
@@ -335,7 +343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 4,
                   "legend": {
                      "avg": false,
@@ -410,7 +418,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 5,
                   "legend": {
                      "avg": false,
@@ -433,11 +441,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -526,7 +538,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 6,
                   "legend": {
                      "avg": false,
@@ -549,11 +561,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -653,11 +669,15 @@
                      {
                         "alias": "request",
                         "color": "#FFC000",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      },
                      {
                         "alias": "limit",
                         "color": "#E02F44",
+                        "dashLength": 5,
+                        "dashes": true,
                         "fill": 0
                      }
                   ],
@@ -734,7 +754,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 8,
                   "legend": {
                      "avg": false,
@@ -975,7 +995,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 11,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -148,7 +148,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 2,
                   "legend": {
                      "avg": false,
@@ -646,7 +646,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 0,
                   "id": 7,
                   "legend": {
                      "avg": false,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1,6 +1,8 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'grafana-builder/grafana.libsonnet') {
+  local resourceRequestStyle = { alias: 'request', color: '#FFC000', fill: 0, dashes: true, dashLength: 5 },
+  local resourceLimitStyle = { alias: 'limit', color: '#E02F44', fill: 0, dashes: true, dashLength: 5 },
 
   local resourceRequestColor = '#FFC000',
   local resourceLimitColor = '#E02F44',
@@ -214,18 +216,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ], ['{{%s}}' % $._config.per_instance_label, 'limit', 'request']) +
     {
       seriesOverrides: [
-        {
-          alias: 'request',
-          color: resourceRequestColor,
-          fill: 0,
-        },
-        {
-          alias: 'limit',
-          color: resourceLimitColor,
-          fill: 0,
-        },
+        resourceRequestStyle,
+        resourceLimitStyle,
       ],
       tooltip: { sort: 2 },  // Sort descending.
+      fill: 0,
     },
 
   containerMemoryWorkingSetPanel(title, containerName)::
@@ -239,16 +234,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ], ['{{%s}}' % $._config.per_instance_label, 'limit', 'request']) +
     {
       seriesOverrides: [
-        {
-          alias: 'request',
-          color: resourceRequestColor,
-          fill: 0,
-        },
-        {
-          alias: 'limit',
-          color: resourceLimitColor,
-          fill: 0,
-        },
+        resourceRequestStyle,
+        resourceLimitStyle,
       ],
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.
@@ -265,19 +252,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ], ['{{%s}}' % $._config.per_instance_label, 'limit', 'request']) +
     {
       seriesOverrides: [
-        {
-          alias: 'request',
-          color: resourceRequestColor,
-          fill: 0,
-        },
-        {
-          alias: 'limit',
-          color: resourceLimitColor,
-          fill: 0,
-        },
+        resourceRequestStyle,
+        resourceLimitStyle,
       ],
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.
+      fill: 0,
     },
 
   containerNetworkPanel(title, metric, instanceName)::
@@ -359,7 +339,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         label: $.containerLabelMatcher(containerName),
       }, '{{persistentvolumeclaim}}'
     ) +
-    { yaxes: $.yaxes('percentunit') },
+    {
+      yaxes: $.yaxes('percentunit'),
+      fill: 0,
+    },
 
   containerLabelMatcher(containerName)::
     if containerName == 'ingester' then 'label_name=~"ingester.*"'
@@ -412,6 +395,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     {
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.
+      fill: 0,
     },
 
   newStatPanel(queries, legends='', unit='percentunit', decimals=1, thresholds=[], instant=false, novalue='')::

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -239,6 +239,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.
+      fill: 0,
     },
 
   containerMemoryRSSPanel(title, containerName)::

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -247,7 +247,8 @@ local filename = 'mimir-queries.json';
       $.row('')
       .addPanel(
         $.panel('Blocks currently loaded') +
-        $.queryPanel('cortex_bucket_store_blocks_loaded{component="store-gateway",%s}' % $.jobMatcher($._config.job_names.store_gateway), '{{%s}}' % $._config.per_instance_label)
+        $.queryPanel('cortex_bucket_store_blocks_loaded{component="store-gateway",%s}' % $.jobMatcher($._config.job_names.store_gateway), '{{%s}}' % $._config.per_instance_label) +
+        { fill: 0 }
       )
       .addPanel(
         $.successFailurePanel(
@@ -268,7 +269,8 @@ local filename = 'mimir-queries.json';
       $.row('')
       .addPanel(
         $.panel('Lazy loaded index-headers') +
-        $.queryPanel('cortex_bucket_store_indexheader_lazy_load_total{%s} - cortex_bucket_store_indexheader_lazy_unload_total{%s}' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)], '{{%s}}' % $._config.per_instance_label)
+        $.queryPanel('cortex_bucket_store_indexheader_lazy_load_total{%s} - cortex_bucket_store_indexheader_lazy_unload_total{%s}' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)], '{{%s}}' % $._config.per_instance_label) +
+        { fill: 0 }
       )
       .addPanel(
         $.panel('Index-header lazy load duration') +

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -40,6 +40,7 @@ local filename = 'mimir-writes-resources.json';
         ) +
         {
           tooltip: { sort: 2 },  // Sort descending.
+          fill: 0,
         },
       )
       .addPanel(


### PR DESCRIPTION
#### What this PR does
The panels showing per-pod metrics can have many lines. In such cases, sometimes I find it difficult to visually see outliers with values below the average, because the "area filling" gets very dark (the more series you have above you, the darker is the area behind you).

Some per-pod panels (e.g. networking) were already configured with no area filling, so in this PR I'm proposing to make it consistent across all dashboards and disable the area filling for all per-pod panels.

With the aim to make the visualization even more clear, I'm also proposing to use dashed lines for resources request/limit, to distingues them better.

**Before:**
![Screenshot 2022-07-20 at 12 10 33](https://user-images.githubusercontent.com/1701904/179957345-fc04b4df-345d-4da8-8e10-5b9123ea44f2.png)

**After:**
![Screenshot 2022-07-20 at 12 06 57](https://user-images.githubusercontent.com/1701904/179957371-bdc96394-89ea-4b8e-b4d7-638c2486ef5e.png)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
