### PR TITLE
Fix parsing int 0 as duration in yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -255,5 +255,7 @@ replace github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache 
 // grpc v1.46.0 removed "WithBalancerName()" API, still in use by weaveworks/commons.
 replace google.golang.org/grpc => google.golang.org/grpc v1.45.0
 
-// gopkg.in/yaml.v3 + https://github.com/go-yaml/yaml/pull/691
-replace gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720070545-aaba007ebc22
+// gopkg.in/yaml.v3
+// + https://github.com/go-yaml/yaml/pull/691
+// + https://github.com/go-yaml/yaml/pull/876
+replace gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/colega/go-yaml-yaml v0.0.0-20220720070545-aaba007ebc22 h1:uVG5v+c6ndz9seCorYjQmlVlPbh3OMcMWJzAJZWdM/g=
-github.com/colega/go-yaml-yaml v0.0.0-20220720070545-aaba007ebc22/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094 h1:FpZSn61BWXbtyH68+uSv416veEswX1M2HRyQfdHnOyQ=
+github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/etcd v3.3.25+incompatible h1:0GQEw6h3YnuOVdtwygkIfJ+Omx0tZ8/QkVyXI4LkbeY=
 github.com/coreos/etcd v3.3.25+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/integration/single_binary_test.go
+++ b/integration/single_binary_test.go
@@ -63,7 +63,7 @@ func TestMimirShouldStartInSingleBinaryModeWithAllMemcachedConfigured(t *testing
 }
 
 // TestMimirCanParseIntZeroAsZeroDuration checks that integer 0 can be used as zero duration in the yaml configuration.
-// When parsing config using gopkg.in/yaml.v3 this means that is should include this change: https://github.com/go-yaml/yaml/pull/876
+// When parsing config using gopkg.in/yaml.v3 this means that it should include this change: https://github.com/go-yaml/yaml/pull/876
 // It is written as an acceptance test to ensure that software that vendors this (i.e., GEM) will also run this test.
 func TestMimirCanParseIntZeroAsZeroDuration(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)

--- a/integration/single_binary_test.go
+++ b/integration/single_binary_test.go
@@ -5,6 +5,9 @@
 package integration
 
 import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/grafana/e2e"
@@ -56,5 +59,36 @@ func TestMimirShouldStartInSingleBinaryModeWithAllMemcachedConfigured(t *testing
 
 	// Ensure Mimir successfully starts.
 	mimir := e2emimir.NewSingleBinary("mimir-1", e2e.MergeFlags(DefaultSingleBinaryFlags(), flags))
+	require.NoError(t, s.StartAndWaitReady(mimir))
+}
+
+// TestMimirCanParseIntZeroAsZeroDuration checks that integer 0 can be used as zero duration in the yaml configuration.
+// When parsing config using gopkg.in/yaml.v3 this means that is should include this change: https://github.com/go-yaml/yaml/pull/876
+// It is written as an acceptance test to ensure that software that vendors this (i.e., GEM) will also run this test.
+func TestMimirCanParseIntZeroAsZeroDuration(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	const singleProcessConfigFile = "docs/configurations/single-process-config-blocks.yaml"
+
+	// Use an example single process config file.
+	config, err := ioutil.ReadFile(filepath.Join(getMimirProjectDir(), singleProcessConfigFile))
+	require.NoError(t, err, "unable to read config file")
+
+	// Ensure that there's `server:` to replace in the config, otherwise we're testing nothing.
+	require.Containsf(t, string(config), "server:", "Config file %s doesn't contain a 'server:' section anymore.")
+	// Add a 'graceful_shutdown_timeout: 0' after 'server:'.
+	config = []byte(strings.ReplaceAll(string(config), "server:", "server:\n  graceful_shutdown_timeout: 0"))
+	// Write the config and use it.
+	require.NoError(t, writeFileToSharedDir(s, mimirConfigFile, config))
+
+	// Use filesystem as storage backend to run this test faster without minio.
+	flags := map[string]string{
+		"-common.storage.backend":        "filesystem",
+		"-common.storage.filesystem.dir": "./bucket",
+	}
+
+	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 }

--- a/vendor/gopkg.in/yaml.v3/decode.go
+++ b/vendor/gopkg.in/yaml.v3/decode.go
@@ -627,6 +627,9 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 			if !isDuration && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
 				return true
+			} else if isDuration && resolved == 0 {
+				out.SetInt(0)
+				return true
 			}
 		case int64:
 			if !isDuration && !out.OverflowInt(resolved) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1286,7 +1286,7 @@ gopkg.in/telebot.v3
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
-# gopkg.in/yaml.v3 v3.0.1 => github.com/colega/go-yaml-yaml v0.0.0-20220720070545-aaba007ebc22
+# gopkg.in/yaml.v3 v3.0.1 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 ## explicit
 gopkg.in/yaml.v3
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
@@ -1298,4 +1298,4 @@ gopkg.in/yaml.v3
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 # google.golang.org/grpc => google.golang.org/grpc v1.45.0
-# gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720070545-aaba007ebc22
+# gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094


### PR DESCRIPTION
#### What this PR does

After upgrading to gopkg.in/yaml.v3 in [#2468], @pstibrany noticed that int 0 is no longer a valid time.Duration value.

I've sent a PR to fix that: https://github.com/go-yaml/yaml/pull/876 and cherry-picked the change into the branch we're using in Mimir as the replacement.

No changelog is included as we _broke_ it in the immediately previous PR.

[#2468]: https://github.com/grafana/mimir/pull/2468

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/2468

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
