### PR TITLE
Fix Grafana dashboards reload after rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,11 @@ dist: ## Generates binaries for a Mimir release.
 		touch $@
 
 build-mixin: check-mixin-jb
-	@rm -rf $(MIXIN_OUT_PATH) && mkdir $(MIXIN_OUT_PATH)
+	# Empty the compiled mixin directories content, without removing the directories itself,
+	# so that Grafana can refresh re-build dashboards when using "make mixin-serve".
+	@mkdir -p $(MIXIN_OUT_PATH)
+	@find $(MIXIN_OUT_PATH) -type f -delete
+
 	@mixtool generate all --output-alerts $(MIXIN_OUT_PATH)/alerts.yaml --output-rules $(MIXIN_OUT_PATH)/rules.yaml --directory $(MIXIN_OUT_PATH)/dashboards ${MIXIN_PATH}/mixin-compiled.libsonnet
 	@./tools/check-rules.sh $(MIXIN_OUT_PATH)/rules.yaml 20 # If any rule group has more than 20 rules, fail. 20 is our default per-tenant limit in the ruler.
 	@cd $(MIXIN_OUT_PATH)/.. && zip -q -r mimir-mixin.zip $$(basename "$(MIXIN_OUT_PATH)")

--- a/operations/mimir-mixin-tools/serve/run.sh
+++ b/operations/mimir-mixin-tools/serve/run.sh
@@ -56,6 +56,9 @@ function cleanup() {
 cleanup
 trap cleanup EXIT
 
+# Ensure we run on Grafana latest.
+docker pull grafana/grafana:latest
+
 # Run Grafana.
 echo "Starting Grafana container with name ${DOCKER_CONTAINER_NAME} listening on host port ${GRAFANA_PUBLISHED_PORT}"
 docker run \


### PR DESCRIPTION
#### What this PR does
We have a command `make mixin-serve` which runs a Grafana locally and serves the dashboards from the compiled dashboards. The typically workflow is to run `make mixin-serve`, then do changes to dashboards and after each change run `make build-mixin` to see the changes live in Grafana.

Unfortunately, the workflow described above doesn't work and requires to re-run `make mixin-serve` after each `make build-mixin`. The reason is that we mount `operations/mimir-mixin-compiled/dashboards/` into the Grafana container, but that directory is deleted each time you run `make build-mixin`.

This PR fixes it, making `build-mixin` to only delete files and not directories, so that the directories tree is preserved and rebuilt dashboards are live reloaded in Grafana. I manually tested it.

_I also took the opportunity to ensure we always run on latest Grafana._

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
