### PR TITLE
Allow extending common config in upstream projects

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -166,13 +166,21 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	// First unmarshal common into the specific locations.
+	specificStorageLocations := specificLocationsUnmarshaler{
+		"blocks_storage":       &c.BlocksStorage.Bucket.StorageBackendConfig,
+		"ruler_storage":        &c.RulerStorage.StorageBackendConfig,
+		"alertmanager_storage": &c.AlertmanagerStorage.StorageBackendConfig,
+	}
+	for name, loc := range c.Common.ExtraSpecificStorageConfigs {
+		if _, dup := specificStorageLocations[name]; dup {
+			return fmt.Errorf("implementation error: specific storage location %q was defined in both mimir and extra locations", name)
+		}
+		specificStorageLocations[name] = loc
+	}
+
 	common := configWithCustomCommonUnmarshaler{
 		Common: &commonConfigUnmarshaler{
-			Storage: &specificLocationsUnmarshaler{
-				"blocks_storage":       &c.BlocksStorage.Bucket.StorageBackendConfig,
-				"ruler_storage":        &c.RulerStorage.StorageBackendConfig,
-				"alertmanager_storage": &c.AlertmanagerStorage.StorageBackendConfig,
-			},
+			Storage: &specificStorageLocations,
 		},
 	}
 	if err := value.DecodeWithOptions(&common, yaml.DecodeOptions{KnownFields: true}); err != nil {
@@ -190,11 +198,27 @@ func (c *Config) InheritCommonFlagValues(log log.Logger, fs *flag.FlagSet) error
 	setFlags := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
 
-	return multierror.New(
-		inheritFlags(log, c.Common.Storage.RegisteredFlags, c.BlocksStorage.Bucket.RegisteredFlags, setFlags),
-		inheritFlags(log, c.Common.Storage.RegisteredFlags, c.RulerStorage.RegisteredFlags, setFlags),
-		inheritFlags(log, c.Common.Storage.RegisteredFlags, c.AlertmanagerStorage.RegisteredFlags, setFlags),
-	).Err()
+	type flagInheritance struct{ common, specific util.RegisteredFlags }
+	inheritance := map[string]flagInheritance{
+		"blocks_storage":       {c.Common.Storage.RegisteredFlags, c.BlocksStorage.Bucket.RegisteredFlags},
+		"ruler_storage":        {c.Common.Storage.RegisteredFlags, c.RulerStorage.RegisteredFlags},
+		"alertmanager_storage": {c.Common.Storage.RegisteredFlags, c.AlertmanagerStorage.RegisteredFlags},
+	}
+
+	for name, sc := range c.Common.ExtraSpecificStorageConfigs {
+		if _, dup := inheritance[name]; dup {
+			return fmt.Errorf("implementation error: tried to redefine flag inheritance %q by providing extra storage configs", name)
+		}
+		inheritance[name] = flagInheritance{c.Common.Storage.RegisteredFlags, sc.RegisteredFlags}
+	}
+
+	for name, f := range inheritance {
+		if err := inheritFlags(log, f.common, f.specific, setFlags); err != nil {
+			return fmt.Errorf("can't inherit common flags for %q: %w", name, err)
+		}
+	}
+
+	return nil
 }
 
 // inheritFlags takes flags from the origin set and sets them to the equivalent flags in the dest set, unless those are already set.
@@ -368,7 +392,8 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 }
 
 type CommonConfig struct {
-	Storage bucket.StorageBackendConfig `yaml:"storage"`
+	Storage                     bucket.StorageBackendConfig             `yaml:"storage"`
+	ExtraSpecificStorageConfigs map[string]*bucket.StorageBackendConfig `yaml:"-"`
 }
 
 // RegisterFlags registers flag.

--- a/pkg/mimir/mimir_common_config_test.go
+++ b/pkg/mimir/mimir_common_config_test.go
@@ -1,0 +1,72 @@
+package mimir_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/mimir/pkg/mimir"
+	"github.com/grafana/mimir/pkg/storage/bucket"
+)
+
+func TestCommonConfigCanBeExtended(t *testing.T) {
+	t.Run("flag inheritance", func(t *testing.T) {
+		var cfg customExtendedConfig
+		cfg.MimirConfig.Common.ExtraSpecificStorageConfigs = map[string]*bucket.StorageBackendConfig{
+			"custom_storage": &cfg.CustomStorage.StorageBackendConfig,
+		}
+
+		fs := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlags(fs, log.NewNopLogger())
+
+		args := []string{"-common.storage.backend", "s3"}
+		require.NoError(t, fs.Parse(args))
+
+		require.NoError(t, cfg.MimirConfig.InheritCommonFlagValues(log.NewNopLogger(), fs))
+
+		// Value should be properly inherited.
+		require.Equal(t, "s3", cfg.CustomStorage.Backend)
+
+		// Mimir's inheritance should still work.
+		require.Equal(t, "s3", cfg.MimirConfig.BlocksStorage.Bucket.Backend)
+	})
+
+	t.Run("yaml inheritance", func(t *testing.T) {
+		const commonYAMLConfig = `
+common:
+  storage:
+    backend: s3
+`
+
+		var cfg customExtendedConfig
+		cfg.MimirConfig.Common.ExtraSpecificStorageConfigs = map[string]*bucket.StorageBackendConfig{
+			"custom_storage": &cfg.CustomStorage.StorageBackendConfig,
+		}
+
+		fs := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlags(fs, log.NewNopLogger())
+
+		err := yaml.Unmarshal([]byte(commonYAMLConfig), &cfg)
+		require.NoError(t, err)
+
+		// Value should be properly inherited.
+		require.Equal(t, "s3", cfg.CustomStorage.Backend)
+
+		// Mimir's inheritance should still work.
+		require.Equal(t, "s3", cfg.MimirConfig.BlocksStorage.Bucket.Backend)
+	})
+
+}
+
+type customExtendedConfig struct {
+	MimirConfig   mimir.Config  `yaml:",inline"`
+	CustomStorage bucket.Config `yaml:"custom_storage"`
+}
+
+func (c *customExtendedConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+	c.MimirConfig.RegisterFlags(f, logger)
+	c.CustomStorage.RegisterFlagsWithPrefix("custom-storage", f)
+}


### PR DESCRIPTION
#### What this PR does

Whe upstream projects, like GEM, are extending Mimir, they may want to unmarshal common config into extra locations (becaue more components may use bucket storage, for instance).

This is one of multiple approaches I considered for this, being this one less extensible but easier to use.

The test included serves as documentation on how to use the extension.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
