### PR TITLE
Split start and finish block upload endpoints.

### DIFF
--- a/docs/sources/operators-guide/reference-http-api/index.md
+++ b/docs/sources/operators-guide/reference-http-api/index.md
@@ -77,9 +77,9 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Store-gateway tenants](#store-gateway-tenants)                                       | Store-gateway           | `GET /store-gateway/tenants`                                              |
 | [Store-gateway tenant blocks](#store-gateway-tenant-blocks)                           | Store-gateway           | `GET /store-gateway/tenant/{tenant}/blocks`                               |
 | [Compactor ring status](#compactor-ring-status)                                       | Compactor               | `GET /compactor/ring`                                                     |
-| [Start block upload](#start-block-upload)                                             | Compactor               | `POST /api/v1/upload/block/{block}`                                       |
+| [Start block upload](#start-block-upload)                                             | Compactor               | `POST /api/v1/upload/block/{block}/start`                                 |
 | [Upload block file](#upload-block-file)                                               | Compactor               | `POST /api/v1/upload/block/{block}/files?path={path}`                     |
-| [Complete block upload](#complete-block-upload)                                       | Compactor               | `POST /api/v1/upload/block/{block}?uploadComplete=true`                   |
+| [Complete block upload](#complete-block-upload)                                       | Compactor               | `POST /api/v1/upload/block/{block}/finish`                                |
 
 ### Path prefixes
 
@@ -953,7 +953,7 @@ Requires [authentication](#authentication).
 ### Complete block upload
 
 ```
-POST /api/v1/upload/block/{block}?uploadComplete=true
+POST /api/v1/upload/block/{block}/finish
 ```
 
 Completes the uploading of a TSDB block with a given ID to object storage. If the complete block already

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -345,10 +345,9 @@ func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
 		{Desc: "Ring status", Path: "/compactor/ring"},
 	})
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, true, "GET", "POST")
-	a.RegisterRoute("/api/v1/upload/block/{block}", http.HandlerFunc(c.HandleBlockUpload), true,
-		false, http.MethodPost)
-	a.RegisterRoute("/api/v1/upload/block/{block}/files", http.HandlerFunc(c.UploadBlockFile),
-		true, false, http.MethodPost)
+	a.RegisterRoute("/api/v1/upload/block/{block}/start", http.HandlerFunc(c.StartBlockUpload), true, false, http.MethodPost)
+	a.RegisterRoute("/api/v1/upload/block/{block}/files", http.HandlerFunc(c.UploadBlockFile), true, false, http.MethodPost)
+	a.RegisterRoute("/api/v1/upload/block/{block}/finish", http.HandlerFunc(c.FinishBlockUpload), true, false, http.MethodPost)
 }
 
 type Distributor interface {

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -519,7 +519,7 @@ func TestMultitenantCompactor_HandleBlockUpload_Create(t *testing.T) {
 				require.NoError(t, json.NewEncoder(buf).Encode(tc.meta))
 				rdr = buf
 			}
-			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s", tc.blockID), rdr)
+			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/start", tc.blockID), rdr)
 			if tc.tenantID != "" {
 				r = r.WithContext(user.InjectOrgID(r.Context(), tc.tenantID))
 			}
@@ -527,7 +527,7 @@ func TestMultitenantCompactor_HandleBlockUpload_Create(t *testing.T) {
 				r = mux.SetURLVars(r, map[string]string{"block": tc.blockID})
 			}
 			w := httptest.NewRecorder()
-			c.HandleBlockUpload(w, r)
+			c.StartBlockUpload(w, r)
 
 			resp := w.Result()
 			body, err := io.ReadAll(resp.Body)
@@ -655,11 +655,11 @@ func TestMultitenantCompactor_HandleBlockUpload_Create(t *testing.T) {
 				bucketClient: bkt,
 				cfgProvider:  cfgProvider,
 			}
-			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s", blockID), bytes.NewReader(metaJSON))
+			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/start", blockID), bytes.NewReader(metaJSON))
 			r = r.WithContext(user.InjectOrgID(r.Context(), tenantID))
 			r = mux.SetURLVars(r, map[string]string{"block": blockID})
 			w := httptest.NewRecorder()
-			c.HandleBlockUpload(w, r)
+			c.StartBlockUpload(w, r)
 
 			resp := w.Result()
 			body, err := io.ReadAll(resp.Body)
@@ -888,8 +888,7 @@ func TestMultitenantCompactor_UploadBlockFile(t *testing.T) {
 			if tc.body != "" {
 				rdr = strings.NewReader(tc.body)
 			}
-			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf(
-				"/api/v1/upload/block/%s/files?path=%s", blockID, url.QueryEscape(tc.path)), rdr)
+			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/files?path=%s", blockID, url.QueryEscape(tc.path)), rdr)
 			if tc.tenantID != "" {
 				r = r.WithContext(user.InjectOrgID(r.Context(), tenantID))
 			}
@@ -986,8 +985,7 @@ func TestMultitenantCompactor_UploadBlockFile(t *testing.T) {
 
 			for _, f := range tc.files {
 				rdr := strings.NewReader(f.content)
-				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf(
-					"/api/v1/upload/block/%s/files?path=%s", blockID, url.QueryEscape(f.path)), rdr)
+				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/files?path=%s", blockID, url.QueryEscape(f.path)), rdr)
 				urlVars := map[string]string{
 					"block": blockID,
 				}
@@ -1183,8 +1181,7 @@ func TestMultitenantCompactor_HandleBlockUpload_Complete(t *testing.T) {
 				bucketClient: &bkt,
 				cfgProvider:  cfgProvider,
 			}
-			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf(
-				"/api/v1/upload/block/%s?uploadComplete=true", tc.blockID), nil)
+			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/finish", tc.blockID), nil)
 			if tc.tenantID != "" {
 				r = r.WithContext(user.InjectOrgID(r.Context(), tenantID))
 			}
@@ -1192,7 +1189,7 @@ func TestMultitenantCompactor_HandleBlockUpload_Complete(t *testing.T) {
 				r = mux.SetURLVars(r, map[string]string{"block": tc.blockID})
 			}
 			w := httptest.NewRecorder()
-			c.HandleBlockUpload(w, r)
+			c.FinishBlockUpload(w, r)
 
 			resp := w.Result()
 			body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
#### What this PR does

This PR splits existing block upload endpoint `/api/v1/upload/block/{block}" into two:
* `/api/v1/upload/block/{block}/start`
* `/api/v1/upload/block/{block}/finish`

Primary motivation is that in PR https://github.com/grafana/mimir/pull/2471 we are going to change output of `/api/v1/upload/block/{block}/finish` to send progress of validation.

Handling both operations in single handler, each with different outputs was cumbersome. "start" only returns HTTP status code, while "finish" will send HTTP status code but also json objects, and client will need to parse the output to discover if upload of the block finished successfully or not. (This will be true after https://github.com/grafana/mimir/pull/2471 is ready)

Note that block upload API is still experimental and subject to change.

#### Checklist

- [na] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
