### PR TITLE
mimirtool: validate that overwriting objects is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] Added `mimirtool backfill` command to upload Prometheus blocks using API available in the compactor. #1822
+* [ENHANCEMENT] mimirtool bucket-validation: Verify existing objects can be overwritten by subsequent uploads. #2491
 * [BUGFIX] mimirtool analyze: Fix dashboard JSON unmarshalling errors by using custom parsing. #2386
 
 ### Mimir Continuous Test


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Validate that the object storage backend supports `Upload`s to existing
objects and will overwrite their contents.

#### Which issue(s) this PR fixes or relates to

Fixes #2490

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
