### PR TITLE
Add user label to ingester out-of-order appended samples metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Ingester: Added user label to ingester metric `cortex_ingester_tsdb_out_of_order_samples_appended_total`. On multitenant clusters this helps us find the rate of appended out-of-order samples for a specific tenant. #2493
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
 * [CHANGE] Successful gRPC requests are no longer logged (only affects internal API calls). #2309

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -510,7 +510,7 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 		tsdbOOOAppendedSamples: prometheus.NewDesc(
 			"cortex_ingester_tsdb_out_of_order_samples_appended_total",
 			"Total number of out-of-order samples appended.",
-			nil, nil),
+			[]string{"user"}, nil),
 
 		memSeriesCreatedTotal: prometheus.NewDesc(
 			"cortex_ingester_memory_series_created_total",
@@ -624,7 +624,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfGaugesPerUser(out, sm.tsdbExemplarLastTs, "prometheus_tsdb_exemplar_last_exemplars_timestamp_seconds")
 	data.SendSumOfCounters(out, sm.tsdbExemplarsOutOfOrder, "prometheus_tsdb_exemplar_out_of_order_exemplars_total")
 
-	data.SendSumOfCounters(out, sm.tsdbOOOAppendedSamples, "prometheus_tsdb_head_out_of_order_samples_appended_total")
+	data.SendSumOfCountersPerUser(out, sm.tsdbOOOAppendedSamples, "prometheus_tsdb_head_out_of_order_samples_appended_total")
 
 	data.SendSumOfCountersPerUser(out, sm.memSeriesCreatedTotal, "prometheus_tsdb_head_series_created_total")
 	data.SendSumOfCountersPerUser(out, sm.memSeriesRemovedTotal, "prometheus_tsdb_head_series_removed_total")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -243,7 +243,9 @@ func TestTSDBMetrics(t *testing.T) {
 
 			# HELP cortex_ingester_tsdb_out_of_order_samples_appended_total Total number of out-of-order samples appended.
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_appended_total counter
-			cortex_ingester_tsdb_out_of_order_samples_appended_total 9
+			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user1"} 3
+			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user2"} 3
+			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user3"} 3
 
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -478,7 +478,8 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 
 			# HELP cortex_ingester_tsdb_out_of_order_samples_appended_total Total number of out-of-order samples appended.
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_appended_total counter
-			cortex_ingester_tsdb_out_of_order_samples_appended_total 9
+			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user1"} 3
+			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user2"} 3
 	`))
 	require.NoError(t, err)
 }


### PR DESCRIPTION
#### What this PR does

Adds tenant label to `cortex_ingester_tsdb_out_of_order_samples_appended_total`.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
