### PR TITLE
Allow inlining `mimir.Config`

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -255,7 +255,9 @@ func LoadConfig(filename string, expandEnv bool, cfg *mimir.Config) error {
 
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
 	dec.KnownFields(true)
-	if err := dec.Decode(cfg); err != nil {
+
+	// Unmarshal with common config unmarshaler.
+	if err := dec.Decode((*mimir.ConfigWithCommon)(cfg)); err != nil {
 		return errors.Wrap(err, "Error parsing config file")
 	}
 

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -131,7 +131,7 @@ func main() {
 		return
 	}
 
-	if err := cfg.InheritCommonFlagValues(util_log.Logger, flag.CommandLine); err != nil {
+	if err := mimir.InheritCommonFlagValues(util_log.Logger, flag.CommandLine, cfg.Common, &cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "error inheriting common flag values: %v\n", err)
 		if !testMode {
 			os.Exit(1)

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -164,7 +164,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.Common.RegisterFlags(f)
 }
 
-func (c *Config) UnmarshalYAML(value *yaml.Node) error {
+func (c *Config) UnmarshalCommonYAML(value *yaml.Node) error {
 	// First unmarshal common into the specific locations.
 	specificStorageLocations := specificLocationsUnmarshaler{
 		"blocks_storage":       &c.BlocksStorage.Bucket.StorageBackendConfig,
@@ -185,6 +185,14 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	}
 	if err := value.DecodeWithOptions(&common, yaml.DecodeOptions{KnownFields: true}); err != nil {
 		return fmt.Errorf("can't unmarshal common config: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Config) UnmarshalYAML(value *yaml.Node) error {
+	if err := c.UnmarshalCommonYAML(value); err != nil {
+		return err
 	}
 
 	// Then unmarshal config in a standard way.

--- a/pkg/mimir/mimir_config_test.go
+++ b/pkg/mimir/mimir_config_test.go
@@ -17,17 +17,13 @@ import (
 func TestCommonConfigCanBeExtended(t *testing.T) {
 	t.Run("flag inheritance", func(t *testing.T) {
 		var cfg customExtendedConfig
-		cfg.MimirConfig.Common.ExtraSpecificStorageConfigs = map[string]*bucket.StorageBackendConfig{
-			"custom_storage": &cfg.CustomStorage.StorageBackendConfig,
-		}
-
 		fs := flag.NewFlagSet("test", flag.PanicOnError)
 		cfg.RegisterFlags(fs, log.NewNopLogger())
 
 		args := []string{"-common.storage.backend", "s3"}
 		require.NoError(t, fs.Parse(args))
 
-		require.NoError(t, (&cfg.MimirConfig).InheritCommonFlagValues(log.NewNopLogger(), fs))
+		require.NoError(t, mimir.InheritCommonFlagValues(log.NewNopLogger(), fs, cfg.MimirConfig.Common, &cfg.MimirConfig, &cfg))
 
 		// Value should be properly inherited.
 		require.Equal(t, "s3", cfg.CustomStorage.Backend)
@@ -44,10 +40,6 @@ common:
 `
 
 		var cfg customExtendedConfig
-		cfg.MimirConfig.Common.ExtraSpecificStorageConfigs = map[string]*bucket.StorageBackendConfig{
-			"custom_storage": &cfg.CustomStorage.StorageBackendConfig,
-		}
-
 		fs := flag.NewFlagSet("test", flag.PanicOnError)
 		cfg.RegisterFlags(fs, log.NewNopLogger())
 
@@ -72,8 +64,16 @@ func (c *customExtendedConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger)
 	c.CustomStorage.RegisterFlagsWithPrefix("custom-storage", f)
 }
 
+func (c *customExtendedConfig) CommonConfigInheritance() mimir.CommonConfigInheritance {
+	return mimir.CommonConfigInheritance{
+		Storage: map[string]*bucket.StorageBackendConfig{
+			"custom": &c.CustomStorage.StorageBackendConfig,
+		},
+	}
+}
+
 func (c *customExtendedConfig) UnmarshalYAML(value *yaml.Node) error {
-	if err := c.MimirConfig.UnmarshalCommonYAML(value); err != nil {
+	if err := mimir.UnmarshalCommonYAML(value, &c.MimirConfig, c); err != nil {
 		return err
 	}
 
@@ -88,10 +88,6 @@ custom_storage:
 `
 
 	var cfg customExtendedConfig
-	cfg.MimirConfig.Common.ExtraSpecificStorageConfigs = map[string]*bucket.StorageBackendConfig{
-		"custom_storage": &cfg.CustomStorage.StorageBackendConfig,
-	}
-
 	fs := flag.NewFlagSet("test", flag.PanicOnError)
 	cfg.RegisterFlags(fs, log.NewNopLogger())
 

--- a/pkg/mimir/mimir_config_test.go
+++ b/pkg/mimir/mimir_config_test.go
@@ -27,7 +27,7 @@ func TestCommonConfigCanBeExtended(t *testing.T) {
 		args := []string{"-common.storage.backend", "s3"}
 		require.NoError(t, fs.Parse(args))
 
-		require.NoError(t, (*mimir.Config)(&cfg.MimirConfig).InheritCommonFlagValues(log.NewNopLogger(), fs))
+		require.NoError(t, (&cfg.MimirConfig).InheritCommonFlagValues(log.NewNopLogger(), fs))
 
 		// Value should be properly inherited.
 		require.Equal(t, "s3", cfg.CustomStorage.Backend)
@@ -62,20 +62,18 @@ common:
 	})
 }
 
-type inlinedMimirConfig mimir.Config
-
 type customExtendedConfig struct {
-	MimirConfig   inlinedMimirConfig `yaml:",inline"`
-	CustomStorage bucket.Config      `yaml:"custom_storage"`
+	MimirConfig   mimir.Config  `yaml:",inline"`
+	CustomStorage bucket.Config `yaml:"custom_storage"`
 }
 
 func (c *customExtendedConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	(*mimir.Config)(&c.MimirConfig).RegisterFlags(f, logger)
+	c.MimirConfig.RegisterFlags(f, logger)
 	c.CustomStorage.RegisterFlagsWithPrefix("custom-storage", f)
 }
 
 func (c *customExtendedConfig) UnmarshalYAML(value *yaml.Node) error {
-	if err := (*mimir.Config)(&c.MimirConfig).UnmarshalCommonYAML(value); err != nil {
+	if err := c.MimirConfig.UnmarshalCommonYAML(value); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What this PR does

When projects based on Mimir try to inline Mimir's config, let's say:

```go
type customExtendedConfig struct {
	MimirConfig   mimir.Config  `yaml:",inline"`
	CustomStorage bucket.Config `yaml:"custom_storage"`
}
```

And we try to unmarshal a yaml that has a `custom_storage` field, we call `mimir.Config.UnmarshalYAML(*yaml.Node)` with the entire root node, and when it tries to decode it into `mimir.Config`, it fails because it doesn't know about `custom_storage`.

The first commit of this PR is a test showing that.

In order to solve it, I've extracted the `UnmarshalCommonYAML`, and changed the extended config to use a `type inlinedMimirConfig mimir.Config` so it wouldn't call mimir's custom unmarshaling. Then I implemented custom unmarshaling on the extended config, but I had to convert the `inlinedMimirConfig` back to `mimir.Config` in order to call any of it's methods.

This was the second commit of this PR, and while it solved the issue, I didn't like having to convert the config type into a custom one to hide the UnmarshalYAML implementation, and then convert it back again to call `mimir.Config`'s methods when needed (like RegisterFlags).

In order to solve that back-and-forth conversion, I removed the custom `UnmarshalYAML` implementaiton from `mimir.Config`, and added a `mimir.ConfigWithCommon` instead, which implements that method. This type is only used to wrap the config passed to YAML unmarshaler, and now the upstream projects extending Mimir will implement a similar type.

Once I was there, I felt that the code was a mix of things coupled to `mimir.Config` and decoupled from it, and I didn't like the mix.

I also didn't like the `ExtraSpecificStorageConfigs` in the common config: this added an imperative description to the config (a caller had to assign values there before unmarshaling), mixed with the declarative approach of the rest of the config (an empty type can be unmarshaled without having to prepare it).

I decided to decouple the common config inheritance as much as possible: I added a `CommonConfigInheritance` description type that mimicks the structure of `CommonConfig`, but fields are now collections (maps) of locations where each common config has to be unmarshaled.

I added a `CommonConfigInheriter` interface, implementing a method that provides the inheritance description, and made `mimir.Config` provide its inheritance description.

Then I adapted both `InheritCommonFlagValues` and `UnmarshalCommonYAML` functions to be top level functions in the package, instead of being `mimir.Config`'s receivers, taking a variadic number of common config inheriters.

This is the fourth commit here, where a config extending mimir's config now just has to implement the inheriter interface (if it wants to inherit common values), and use the provided package-level functions to perform the inheritance.

Last commit is just to put the methods in their correct places.

#### Which issue(s) this PR fixes or relates to

Fixes an internal issue.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
