### PR TITLE
Helm: update readme with 2.2 release notes link

### DIFF
--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -2,6 +2,8 @@
 
 Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.2.x/) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.2.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
 
+See the [Release Notes](https://grafana.com/docs/mimir/v2.2.x/release-notes/v2.2/) for changes from the previous version and instructions on how to upgrade from the previous version.
+
 # mimir-distributed
 
 ![Version: 3.0.0-rc.3](https://img.shields.io/badge/Version-3.0.0--rc.3-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
@@ -86,7 +88,7 @@ To install the chart with licensed features enabled, using a local Grafana Enter
 helm install <cluster name> grafana/mimir-distributed --set 'enterprise.enabled=true' --set-file 'license.contents=./license.jwt'
 ```
 
-### Upgrade from a previous version of Grafana Enterprise Metrics
+### Upgrade from version 1.7 of Grafana Enterprise Metrics
 
 Please consult the [migration guide](https://grafana.com/docs/enterprise-metrics/v2.2.x/migrating-from-gem-1.7/) for details on how to prepare the configuration. Prepare a custom values file, with the contents:
 

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.2.x/) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.2.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
 
-See the [Release Notes](https://grafana.com/docs/mimir/v2.2.x/release-notes/v2.2/) for changes from the previous version and instructions on how to upgrade from the previous version.
+See the [Grafana Mimir version 2.2 release notes](https://grafana.com/docs/mimir/v2.2.x/release-notes/v2.2/) and [Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0](https://grafana.com/docs/mimir/latest/operators-guide/deploy-grafana-mimir/upgrade-helm-chart-2.1-to-3.0/).
 
 # mimir-distributed
 

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -91,7 +91,7 @@ helm install <cluster name> grafana/mimir-distributed --set 'enterprise.enabled=
 ### Upgrade from version 1.7 of Grafana Enterprise Metrics
 
 To make the necessary configuration changes, see [Migrating from Grafana Enterprise Metrics 1.7](https://grafana.com/docs/enterprise-metrics/latest/migrating-from-gem-1.7/).
-Prepare a custom-values file, with the contents:
+Prepare a custom values file, with the contents:
 
 ```yaml
 enterprise:

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -90,7 +90,8 @@ helm install <cluster name> grafana/mimir-distributed --set 'enterprise.enabled=
 
 ### Upgrade from version 1.7 of Grafana Enterprise Metrics
 
-Please consult the [migration guide](https://grafana.com/docs/enterprise-metrics/v2.2.x/migrating-from-gem-1.7/) for details on how to prepare the configuration. Prepare a custom values file, with the contents:
+To make the necessary configuration changes, see [Migrating from Grafana Enterprise Metrics 1.7](https://grafana.com/docs/enterprise-metrics/latest/migrating-from-gem-1.7/).
+Prepare a custom-values file, with the contents:
 
 ```yaml
 enterprise:

--- a/operations/helm/charts/mimir-distributed/README.md.gotmpl
+++ b/operations/helm/charts/mimir-distributed/README.md.gotmpl
@@ -86,7 +86,8 @@ helm install <cluster name> grafana/mimir-distributed --set 'enterprise.enabled=
 
 ### Upgrade from version 1.7 of Grafana Enterprise Metrics
 
-Please consult the [migration guide](https://grafana.com/docs/enterprise-metrics/v2.2.x/migrating-from-gem-1.7/) for details on how to prepare the configuration. Prepare a custom values file, with the contents:
+To make the necessary configuration changes, see [Migrating from Grafana Enterprise Metrics 1.7](https://grafana.com/docs/enterprise-metrics/latest/migrating-from-gem-1.7/).
+Prepare a custom values file, with the contents:
 
 ```yaml
 enterprise:

--- a/operations/helm/charts/mimir-distributed/README.md.gotmpl
+++ b/operations/helm/charts/mimir-distributed/README.md.gotmpl
@@ -2,6 +2,8 @@
 
 Helm chart for deploying [Grafana Mimir]({{ template "chart.homepage" . }}) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.2.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
 
+See the [Release Notes]({{ template "chart.homepage" . }}release-notes/v2.2/) for changes from the previous version and instructions on how to upgrade from the previous version.
+
 {{ template "chart.header" . }}
 
 {{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
@@ -82,7 +84,7 @@ To install the chart with licensed features enabled, using a local Grafana Enter
 helm install <cluster name> grafana/mimir-distributed --set 'enterprise.enabled=true' --set-file 'license.contents=./license.jwt'
 ```
 
-### Upgrade from a previous version of Grafana Enterprise Metrics
+### Upgrade from version 1.7 of Grafana Enterprise Metrics
 
 Please consult the [migration guide](https://grafana.com/docs/enterprise-metrics/v2.2.x/migrating-from-gem-1.7/) for details on how to prepare the configuration. Prepare a custom values file, with the contents:
 

--- a/operations/helm/charts/mimir-distributed/README.md.gotmpl
+++ b/operations/helm/charts/mimir-distributed/README.md.gotmpl
@@ -2,7 +2,7 @@
 
 Helm chart for deploying [Grafana Mimir]({{ template "chart.homepage" . }}) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.2.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
 
-See the [Release Notes]({{ template "chart.homepage" . }}release-notes/v2.2/) for changes from the previous version and instructions on how to upgrade from the previous version.
+See the [Grafana Mimir version 2.2 release notes](https://grafana.com/docs/mimir/v2.2.x/release-notes/v2.2/) and [Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0](https://grafana.com/docs/mimir/latest/operators-guide/deploy-grafana-mimir/upgrade-helm-chart-2.1-to-3.0/).
 
 {{ template "chart.header" . }}
 


### PR DESCRIPTION
Add release notes link.
Fix the upgrade from previous version text, since that complicated upgrade procedure is only applicable between 1.7 and 2.x versions.