### PR TITLE
Jsonnet: replaced anti-affinity rules with pod topology spread constraints for distributor, query-frontend, querier and ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,19 @@
 
 ### Jsonnet
 
-* [FEATURE] Memberlist: added support for experimental memberlist cluster label, through the jsonnet configuration options `memberlist_cluster_label` and `memberlist_cluster_label_verification_disabled`. #2349
 * [CHANGE] query-scheduler is enabled by default. We advise to deploy the query-scheduler to improve the scalability of the query-frontend. #2431
+* [CHANGE] Replaced anti-affinity rules with pod topology spread constraints for distributor, query-frontend, querier and ruler.
+  - The following configuration options have been removed:
+    - `distributor_allow_multiple_replicas_on_same_node`
+    - `query_frontend_allow_multiple_replicas_on_same_node`
+    - `querier_allow_multiple_replicas_on_same_node`
+    - `ruler_allow_multiple_replicas_on_same_node`
+  - The following configuration options have been added:
+    - `distributor_topology_spread_max_skew`
+    - `query_frontend_topology_spread_max_skew`
+    - `querier_topology_spread_max_skew`
+    - `ruler_topology_spread_max_skew`
+* [FEATURE] Memberlist: added support for experimental memberlist cluster label, through the jsonnet configuration options `memberlist_cluster_label` and `memberlist_cluster_label_verification_disabled`. #2349
 
 ### Mimirtool
 

--- a/docs/sources/operators-guide/deploy-grafana-mimir/jsonnet/configuring-low-resources.md
+++ b/docs/sources/operators-guide/deploy-grafana-mimir/jsonnet/configuring-low-resources.md
@@ -27,11 +27,7 @@ local mimir = import 'mimir/mimir.libsonnet';
 
 mimir {
   _config+:: {
-    distributor_allow_multiple_replicas_on_same_node: true,
     ingester_allow_multiple_replicas_on_same_node: true,
-    ruler_allow_multiple_replicas_on_same_node: true,
-    querier_allow_multiple_replicas_on_same_node: true,
-    query_frontend_allow_multiple_replicas_on_same_node: true,
     store_gateway_allow_multiple_replicas_on_same_node: true,
   },
 }

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -472,13 +472,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -538,6 +531,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -564,13 +564,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -610,6 +603,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -700,13 +700,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -765,6 +758,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -759,13 +759,6 @@ spec:
       labels:
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -816,6 +809,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -842,13 +842,6 @@ spec:
       labels:
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -906,6 +899,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -932,13 +932,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -978,6 +971,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1067,13 +1067,6 @@ spec:
       labels:
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1133,6 +1126,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -909,13 +909,6 @@ spec:
       labels:
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -967,6 +960,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -993,13 +993,6 @@ spec:
       labels:
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1059,6 +1052,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1085,13 +1085,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1131,6 +1124,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1265,13 +1265,6 @@ spec:
       labels:
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1333,6 +1326,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -741,13 +741,6 @@ spec:
       labels:
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -798,6 +791,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -824,13 +824,6 @@ spec:
       labels:
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -888,6 +881,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -914,13 +914,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -960,6 +953,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -334,13 +334,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -393,6 +386,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -420,13 +420,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -486,6 +479,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -512,13 +512,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -558,6 +551,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -388,13 +388,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -447,6 +440,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -474,13 +474,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -540,6 +533,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -566,13 +566,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -612,6 +605,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -702,13 +702,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -767,6 +760,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -473,13 +473,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -539,6 +532,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -565,13 +565,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -611,6 +604,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -701,13 +701,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -766,6 +759,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -447,6 +440,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -474,13 +474,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -541,6 +534,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -567,13 +567,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -613,6 +606,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -703,13 +703,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -769,6 +762,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -448,6 +441,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -475,13 +475,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -543,6 +536,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -569,13 +569,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -615,6 +608,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -705,13 +705,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -772,6 +765,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -447,6 +440,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -474,13 +474,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -541,6 +534,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -567,13 +567,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -613,6 +606,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -703,13 +703,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -769,6 +762,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -759,13 +759,6 @@ spec:
       labels:
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -816,6 +809,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -842,13 +842,6 @@ spec:
       labels:
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -906,6 +899,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -932,13 +932,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -978,6 +971,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1067,13 +1067,6 @@ spec:
       labels:
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1133,6 +1126,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -796,13 +796,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -861,6 +854,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -888,13 +888,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -960,6 +953,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -986,13 +986,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1032,6 +1025,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1122,13 +1122,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1196,6 +1189,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -796,13 +796,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -861,6 +854,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -888,13 +888,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -960,6 +953,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -986,13 +986,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1032,6 +1025,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1122,13 +1122,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1196,6 +1189,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -796,13 +796,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -861,6 +854,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -888,13 +888,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -960,6 +953,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -986,13 +986,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1032,6 +1025,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1122,13 +1122,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1196,6 +1189,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -796,13 +796,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -861,6 +854,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -888,13 +888,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -960,6 +953,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -986,13 +986,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1032,6 +1025,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -1122,13 +1122,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1196,6 +1189,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -390,13 +390,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -449,6 +442,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -476,13 +476,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -542,6 +535,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -568,13 +568,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -614,6 +607,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -704,13 +704,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -769,6 +762,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -473,13 +473,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -539,6 +532,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -565,13 +565,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -611,6 +604,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -701,13 +701,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -766,6 +759,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -549,13 +549,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -609,6 +602,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -636,13 +636,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -704,6 +697,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -730,13 +730,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -776,6 +769,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -911,13 +911,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -978,6 +971,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -617,13 +617,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -677,6 +670,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -704,13 +704,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -772,6 +765,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -798,13 +798,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -844,6 +837,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -979,13 +979,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -1046,6 +1039,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -473,13 +473,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -539,6 +532,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -565,13 +565,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -querier.max-query-parallelism=240
@@ -616,6 +609,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -706,13 +706,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -771,6 +764,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -465,13 +465,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -524,6 +517,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -551,13 +551,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -617,6 +610,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -643,13 +643,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -689,6 +682,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -779,13 +779,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -845,6 +838,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -871,13 +871,6 @@ spec:
       labels:
         name: ruler-querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler-querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -937,6 +930,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -963,13 +963,6 @@ spec:
       labels:
         name: ruler-query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler-query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1006,6 +999,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -465,13 +465,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -524,6 +517,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -551,13 +551,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -617,6 +610,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -643,13 +643,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -689,6 +682,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -779,13 +779,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -844,6 +837,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -870,13 +870,6 @@ spec:
       labels:
         name: ruler-querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler-querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -936,6 +929,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -962,13 +962,6 @@ spec:
       labels:
         name: ruler-query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler-query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -1005,6 +998,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -447,6 +440,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -474,13 +474,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -542,6 +535,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -568,13 +568,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -615,6 +608,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -706,13 +706,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -774,6 +767,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -447,6 +440,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -474,13 +474,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -542,6 +535,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -568,13 +568,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -615,6 +608,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -706,13 +706,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -775,6 +768,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -473,13 +473,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.azure.account-key=blocks-account-key
@@ -541,6 +534,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -567,13 +567,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -613,6 +606,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -703,13 +703,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.azure.account-key=blocks-account-key
@@ -772,6 +765,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -473,13 +473,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -539,6 +532,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -565,13 +565,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -611,6 +604,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -701,13 +701,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -766,6 +759,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -387,13 +387,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -446,6 +439,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -473,13 +473,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=s3
@@ -540,6 +533,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -566,13 +566,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -612,6 +605,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -702,13 +702,6 @@ spec:
         gossip_ring_member: "true"
         name: ruler
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=s3
@@ -770,6 +763,13 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -296,13 +296,6 @@ spec:
         gossip_ring_member: "true"
         name: distributor
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: distributor
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -distributor.ha-tracker.enable=true
@@ -355,6 +348,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -382,13 +382,6 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: querier
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.backend=gcs
@@ -448,6 +441,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides
@@ -474,13 +474,6 @@ spec:
       labels:
         name: query-frontend
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: query-frontend
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -query-frontend.align-querier-with-step=false
@@ -519,6 +512,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           name: overrides

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -19,12 +19,15 @@
     // Controls whether multiple pods for the same service can be scheduled on the same node.
     // Distributing the pods over different nodes improves performance and also realiability,
     // especially important in case of ingester where losing multiple ingesters can cause data loss.
-    distributor_allow_multiple_replicas_on_same_node: false,
     ingester_allow_multiple_replicas_on_same_node: false,
-    ruler_allow_multiple_replicas_on_same_node: false,
-    querier_allow_multiple_replicas_on_same_node: false,
-    query_frontend_allow_multiple_replicas_on_same_node: false,
     store_gateway_allow_multiple_replicas_on_same_node: false,
+
+    // Controls the max skew for pod topology spread constraints.
+    // See: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+    distributor_topology_spread_max_skew: 1,
+    query_frontend_topology_spread_max_skew: 1,
+    querier_topology_spread_max_skew: 1,
+    ruler_topology_spread_max_skew: 1,
 
     test_exporter_enabled: false,
     test_exporter_start_time: error 'must specify test exporter start time',

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -48,7 +48,7 @@
 
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container]) +
-    (if $._config.distributor_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
+    $.newMimirSpreadTopology('distributor', $._config.distributor_topology_spread_max_skew) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -54,7 +54,7 @@
 
   newQuerierDeployment(name, container)::
     deployment.new(name, $._config.querier.replicas, [container]) +
-    (if $._config.querier_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
+    $.newMimirSpreadTopology(name, $._config.querier_topology_spread_max_skew) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -44,7 +44,7 @@
   newQueryFrontendDeployment(name, container)::
     deployment.new(name, $._config.queryFrontend.replicas, [container]) +
     $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint) +
-    (if $._config.query_frontend_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
+    $.newMimirSpreadTopology(name, $._config.query_frontend_topology_spread_max_skew) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -44,12 +44,14 @@
 
   ruler_deployment:
     if $._config.ruler_enabled then
-      deployment.new('ruler', 2, [$.ruler_container]) +
+      local name = 'ruler';
+
+      deployment.new(name, 2, [$.ruler_container]) +
       (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
-      (if $._config.ruler_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
+      $.newMimirSpreadTopology(name, $._config.querier_topology_spread_max_skew) +
       $.util.configVolumeMount($._config.overrides_configmap, $._config.overrides_configmap_mountpoint)
     else {},
 


### PR DESCRIPTION
#### What this PR does
At Grafana Labs, we moved distributor, query-frontend, querier and ruler anti-affinity rules to pod topology spread constraints, with a less constrained setup (do not strictly require to run on different nodes, but prefer it). We found out placement works pretty well, and I would like to upstream it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
