### PR TITLE
Remove http_listen_port from server Agent config

### DIFF
--- a/docs/sources/operators-guide/deploy-grafana-mimir/getting-started-helm-charts/_index.md
+++ b/docs/sources/operators-guide/deploy-grafana-mimir/getting-started-helm-charts/_index.md
@@ -192,10 +192,6 @@ Make a choice based on whether or not you already have a Grafana Agent set up:
   1. Write the following configuration to an `agent.yaml` file:
 
      ```yaml
-     server:
-       http_listen_port: 12345
-       grpc_listen_port: 54321
-
      metrics:
        wal_directory: /tmp/grafana-agent/wal
 

--- a/docs/sources/operators-guide/get-started/_index.md
+++ b/docs/sources/operators-guide/get-started/_index.md
@@ -150,10 +150,6 @@ remote_write:
 The configuration for an Agent that scrapes itself for metrics and writes those metrics to Grafana Mimir looks similar to this:
 
 ```yaml
-server:
-  http_listen_port: 12345
-  grpc_listen_port: 54321
-
 metrics:
   wal_directory: /tmp/grafana-agent/wal
 

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -313,8 +313,6 @@ metrics:
   global:
     scrape_interval: 15s
   wal_directory: /tmp/grafana-agent-wal
-server:
-  http_listen_port: 12345
 ```
 
 ## Collect metrics and logs without the Helm chart


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR removes `http_listen_port` and `grpc_listen_port` fields from `server` config for the Agent.
See more details about the deprecation [here](https://grafana.com/docs/agent/v0.26/upgrade-guide/#breaking-change-deprecated-yaml-fields-in-server-block-removed).


#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
