### PR TITLE
Support remapping flags for overriden images

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -9,31 +9,3 @@ import "github.com/grafana/mimir/integration/e2emimir"
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.2.0": e2emimir.NoopFlagMapper,
 }
-
-var (
-	// cortexFlagMapper sets flags that are needed for cortex.
-	cortexFlagMapper = e2emimir.SetFlagMapper(map[string]string{
-		"-store.engine":                   "blocks",
-		"-server.http-listen-port":        "8080",
-		"-store-gateway.sharding-enabled": "true",
-	})
-
-	// revertRenameFrontendToQueryFrontendFlagMapper reverts the `-frontend` to `-query-frontend` flag renaming that happened in:
-	// https://github.com/grafana/mimir/issues/859
-	revertRenameFrontendToQueryFrontendFlagMapper = e2emimir.RenameFlagMapper(map[string]string{
-		// Map new name to old name.
-		"-query-frontend.scheduler-dns-lookup-period": "-frontend.scheduler-dns-lookup-period",
-	})
-
-	ingesterRingRename = e2emimir.RenameFlagMapper(map[string]string{
-		"-ingester.ring.store":              "-ring.store",
-		"-ingester.ring.consul.hostname":    "-consul.hostname",
-		"-ingester.ring.min-ready-duration": "-ingester.min-ready-duration",
-		"-ingester.ring.num-tokens":         "-ingester.num-tokens",
-		"-ingester.ring.replication-factor": "-distributor.replication-factor",
-	})
-
-	ingesterRingNewFeatures = e2emimir.RemoveFlagMapper([]string{
-		"-ingester.ring.readiness-check-ring-health",
-	})
-)


### PR DESCRIPTION
#### What this PR does

When overriding previous image versions, it is useful to also remap flags, as those images may have had different flag names.

This implements that feature by unmarshalling flag mappers from a JSON definition.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
