### PR TITLE
Allow injection of CacheSplitter into querymiddleware

### DIFF
--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -147,14 +147,14 @@ func (PrometheusResponseExtractor) ResponseWithoutHeaders(resp Response) Respons
 // CacheSplitter generates cache keys. This is a useful interface for downstream
 // consumers who wish to implement their own strategies.
 type CacheSplitter interface {
-	GenerateCacheKey(userID string, r Request) string
+	GenerateCacheKey(ctx context.Context, userID string, r Request) string
 }
 
-// constSplitter is a utility for using a constant split interval when determining cache keys
-type constSplitter time.Duration
+// ConstSplitter is a utility for using a constant split interval when determining cache keys
+type ConstSplitter time.Duration
 
 // GenerateCacheKey generates a cache key based on the userID, Request and interval.
-func (t constSplitter) GenerateCacheKey(userID string, r Request) string {
+func (t ConstSplitter) GenerateCacheKey(_ context.Context, userID string, r Request) string {
 	startInterval := r.GetStart() / time.Duration(t).Milliseconds()
 	stepOffset := r.GetStart() % r.GetStep()
 

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -6,6 +6,7 @@
 package querymiddleware
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -528,6 +529,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 
 func TestConstSplitter_generateCacheKey(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	tests := []struct {
 		name     string
@@ -548,7 +550,7 @@ func TestConstSplitter_generateCacheKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s - %s", tt.name, tt.interval), func(t *testing.T) {
-			if got := constSplitter(tt.interval).GenerateCacheKey("fake", tt.r); got != tt.want {
+			if got := ConstSplitter(tt.interval).GenerateCacheKey(ctx, "fake", tt.r); got != tt.want {
 				t.Errorf("generateKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -143,7 +143,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 				continue
 			}
 
-			splitReq.cacheKey = s.splitter.GenerateCacheKey(tenant.JoinTenantIDs(tenantIDs), splitReq.orig)
+			splitReq.cacheKey = s.splitter.GenerateCacheKey(ctx, tenant.JoinTenantIDs(tenantIDs), splitReq.orig)
 			lookupKeys = append(lookupKeys, splitReq.cacheKey)
 			lookupReqs = append(lookupReqs, splitReq)
 		}

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -141,7 +141,7 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		PrometheusCodec,
 		cacheBackend,
-		constSplitter(day),
+		ConstSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -214,7 +214,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotLookupCacheIfStepIsNotAli
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		PrometheusCodec,
 		cacheBackend,
-		constSplitter(day),
+		ConstSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -275,7 +275,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_EnabledCachingOfStepUnalignedReque
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		PrometheusCodec,
 		cacheBackend,
-		constSplitter(day),
+		ConstSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -395,7 +395,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cacheBackend := cache.NewMockCache()
-			cacheSplitter := constSplitter(day)
+			cacheSplitter := ConstSplitter(day)
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No interval splitting.
@@ -448,7 +448,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 			require.Equal(t, testData.downstreamResponse, resp)
 
 			// Check if the response was cached.
-			cacheKey := cacheHashKey(cacheSplitter.GenerateCacheKey(userID, req))
+			cacheKey := cacheHashKey(cacheSplitter.GenerateCacheKey(ctx, userID, req))
 			found := cacheBackend.Fetch(ctx, []string{cacheKey})
 
 			if len(testData.expectedCachedResponses) == 0 {
@@ -613,7 +613,7 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 					},
 					PrometheusCodec,
 					cache.NewMockCache(),
-					constSplitter(day),
+					ConstSplitter(day),
 					PrometheusResponseExtractor{},
 					resultsCacheAlwaysEnabled,
 					log.NewNopLogger(),
@@ -839,7 +839,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), userID)
 			cacheBackend := cache.NewInstrumentedMockCache()
-			cacheSplitter := constSplitter(day)
+			cacheSplitter := ConstSplitter(day)
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No splitting.
@@ -859,7 +859,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 			})).(*splitAndCacheMiddleware)
 
 			// Store all extents fixtures in the cache.
-			cacheKey := cacheSplitter.GenerateCacheKey(userID, testData.req)
+			cacheKey := cacheSplitter.GenerateCacheKey(ctx, userID, testData.req)
 			mw.storeCacheExtents(ctx, cacheKey, testData.cachedExtents)
 
 			// Run the request.
@@ -894,7 +894,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		mockLimits{},
 		PrometheusCodec,
 		cacheBackend,
-		constSplitter(day),
+		ConstSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -941,7 +941,7 @@ func TestSplitAndCacheMiddleware_WrapMultipleTimes(t *testing.T) {
 		mockLimits{},
 		PrometheusCodec,
 		cache.NewMockCache(),
-		constSplitter(day),
+		ConstSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Allow injection of CacheSplitter into querymiddleware

This is useful for when the caching strategy for the request
depends on something external, such as access control applied
to the query before it got to the querymiddleware.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
