### PR TITLE
helm: Add the /ingester endpoint to the nginx.conf template

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -15,6 +15,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [ENHANCEMENT] Add backfill endpoints to Nginx configuration. #2478
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
+* [BUGFIX] Add the `/ingester` endpoint to the nginx template.  This allows the
+  ingester ring status to be pulled via `/ingester/ring`.
 
 ## 3.0.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1607,6 +1607,11 @@ nginx:
             proxy_pass      http://{{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
+          # Ingester endpoint (for ring information)
+          location /ingester {
+            proxy_pass      http://{{ template "mimir.fullname" . }}-ingester.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+          }
+
           {{- with .Values.nginx.nginxConfig.serverSnippet }}
           {{ . | nindent 4 }}
           {{- end }}


### PR DESCRIPTION
#### What this PR does

- Add the /ingester endpoint to the Helm `nginx.conf` template.  This allows the `/ingester/ring` state to be retrieved.

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
