### PR TITLE
Introduce validation progress and block state.

### DIFF
--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"path"
 	"time"
@@ -32,7 +31,10 @@ import (
 )
 
 // Name of file where we store a block's meta file while it's being uploaded.
-const uploadingMetaFilename = "uploading-" + block.MetaFilename
+const (
+	uploadingMetaFilename = "uploading-meta.json"
+	validationFile        = "validation.json"
+)
 
 var rePath = regexp.MustCompile(`^(index|chunks/\d{6})$`)
 
@@ -54,7 +56,7 @@ func (c *MultitenantCompactor) StartBlockUpload(w http.ResponseWriter, r *http.R
 	const op = "start block upload"
 
 	userBkt := bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider)
-	if err := checkForCompleteBlock(ctx, blockID, userBkt); err != nil {
+	if _, _, err := c.checkBlockState(ctx, userBkt, blockID, false); err != nil {
 		writeBlockUploadError(err, op, "while checking for complete block", logger, w)
 		return
 	}
@@ -84,12 +86,20 @@ func (c *MultitenantCompactor) FinishBlockUpload(w http.ResponseWriter, r *http.
 	const op = "complete block upload"
 
 	userBkt := bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider)
-	if err := checkForCompleteBlock(ctx, blockID, userBkt); err != nil {
+	m, _, err := c.checkBlockState(ctx, userBkt, blockID, true)
+	if err != nil {
 		writeBlockUploadError(err, op, "while checking for complete block", logger, w)
 		return
 	}
 
-	if err := c.completeBlockUpload(ctx, r, logger, userBkt, blockID); err != nil {
+	// This should not happen, as checkBlockState with requireUploadInProgress=true returns nil error
+	// only if uploading-meta.json file exists.
+	if m == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := c.completeBlockUpload(ctx, logger, userBkt, blockID, *m); err != nil {
 		writeBlockUploadError(err, op, "", logger, w)
 		return
 	}
@@ -128,33 +138,17 @@ func writeBlockUploadError(err error, op, extra string, logger log.Logger, w htt
 	if extra != "" {
 		extra = " " + extra
 	}
-	level.Error(logger).Log("msg", fmt.Sprintf("an unexpected error occurred%s", extra), "operation", op,
-		"err", err)
+	level.Error(logger).Log("msg", fmt.Sprintf("an unexpected error occurred%s", extra), "operation", op, "err", err)
 	http.Error(w, "internal server error", http.StatusInternalServerError)
-}
-
-// checkForCompleteBlock checks for a complete block with same ID. If one exists, an error is returned.
-func checkForCompleteBlock(ctx context.Context, blockID ulid.ULID, userBkt objstore.Bucket) error {
-	exists, err := userBkt.Exists(ctx, path.Join(blockID.String(), block.MetaFilename))
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to check existence of %s in object storage", block.MetaFilename))
-	}
-	if exists {
-		return httpError{
-			message:    "block already exists in object storage",
-			statusCode: http.StatusConflict,
-		}
-	}
-
-	return nil
 }
 
 func (c *MultitenantCompactor) createBlockUpload(ctx context.Context, r *http.Request,
 	logger log.Logger, userBkt objstore.Bucket, tenantID string, blockID ulid.ULID) error {
 	level.Debug(logger).Log("msg", "starting block upload")
 
-	meta, err := decodeMeta(r.Body, "request body")
-	if err != nil {
+	var meta metadata.Meta
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&meta); err != nil {
 		return httpError{
 			message:    "malformed request body",
 			statusCode: http.StatusBadRequest,
@@ -221,25 +215,35 @@ func (c *MultitenantCompactor) UploadBlockFile(w http.ResponseWriter, r *http.Re
 	logger := log.With(util_log.WithContext(ctx, c.logger), "block", blockID)
 
 	userBkt := bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider)
-	if err := checkForCompleteBlock(ctx, blockID, userBkt); err != nil {
+
+	m, _, err := c.checkBlockState(ctx, userBkt, blockID, true)
+	if err != nil {
 		writeBlockUploadError(err, op, "while checking for complete block", logger, w)
 		return
 	}
 
-	metaPath := path.Join(blockID.String(), uploadingMetaFilename)
-	exists, err := userBkt.Exists(ctx, metaPath)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to check existence in object storage",
-			"path", metaPath, "operation", op, "err", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	if !exists {
-		http.Error(w, fmt.Sprintf("upload of block %s not started yet", blockID), http.StatusNotFound)
+	// This should not happen.
+	if m == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	// TODO: Verify that upload path and length correspond to file index
+	// Check if file was specified in meta.json, and if it has expected size.
+	found := false
+	for _, f := range m.Thanos.Files {
+		if pth == f.RelPath {
+			found = true
+
+			if r.ContentLength != f.SizeBytes {
+				http.Error(w, "file size doesn't match meta.json", http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	if !found {
+		http.Error(w, "unexpected file", http.StatusBadRequest)
+		return
+	}
 
 	dst := path.Join(blockID.String(), pth)
 
@@ -258,40 +262,7 @@ func (c *MultitenantCompactor) UploadBlockFile(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusOK)
 }
 
-func decodeMeta(r io.Reader, name string) (metadata.Meta, error) {
-	dec := json.NewDecoder(r)
-	var meta metadata.Meta
-	if err := dec.Decode(&meta); err != nil {
-		return meta, errors.Wrap(err, fmt.Sprintf("failed decoding %s", name))
-	}
-
-	return meta, nil
-}
-
-func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, r *http.Request,
-	logger log.Logger, userBkt objstore.Bucket, blockID ulid.ULID) error {
-	level.Debug(logger).Log("msg", "received request to complete block upload", "content_length", r.ContentLength)
-
-	uploadingMetaPath := path.Join(blockID.String(), uploadingMetaFilename)
-	rdr, err := userBkt.Get(ctx, uploadingMetaPath)
-	if err != nil {
-		if userBkt.IsObjNotFoundErr(err) {
-			return httpError{
-				message:    fmt.Sprintf("upload of block %s not started yet", blockID),
-				statusCode: http.StatusNotFound,
-			}
-		}
-		return errors.Wrap(err, fmt.Sprintf("failed to download %s from object storage", uploadingMetaFilename))
-	}
-	defer func() {
-		_ = rdr.Close()
-	}()
-
-	meta, err := decodeMeta(rdr, uploadingMetaFilename)
-	if err != nil {
-		return err
-	}
-
+func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, logger log.Logger, userBkt objstore.Bucket, blockID ulid.ULID, meta metadata.Meta) error {
 	level.Debug(logger).Log("msg", "completing block upload", "files", len(meta.Thanos.Files))
 
 	// Upload meta file so block is considered complete
@@ -299,7 +270,7 @@ func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, r *http.
 		return err
 	}
 
-	if err := userBkt.Delete(ctx, uploadingMetaPath); err != nil {
+	if err := userBkt.Delete(ctx, path.Join(blockID.String(), uploadingMetaFilename)); err != nil {
 		level.Warn(logger).Log("msg", fmt.Sprintf(
 			"failed to delete %s from block in object storage", uploadingMetaFilename), "err", err)
 		return nil
@@ -419,4 +390,142 @@ func (r bodyReader) ObjectSize() (int64, error) {
 // Read implements io.Reader.
 func (r bodyReader) Read(b []byte) (int, error) {
 	return r.r.Body.Read(b)
+}
+
+type validation struct {
+	LastUpdate int64  // UnixMillis of last update time.
+	Error      string // Error message if validation failed.
+}
+
+type blockState int
+
+const (
+	blockStateUnknown         blockState = iota // unknown, default value
+	blockIsComplete                             // meta.json file exists
+	blockUploadNotStarted                       // meta.json doesn't exist, uploading-meta.json doesn't exist
+	blockUploadInProgress                       // meta.json doesn't exist, but uploading-meta.json does
+	blockValidationInProgress                   // meta.json doesn't exist, uploading-meta.json exists, validation.json exists and is recent
+	blockValidationFailed
+	blockValidationStale
+)
+
+var blockStateMessages = map[blockState]string{
+	blockStateUnknown:         "unknown",
+	blockIsComplete:           "block is complete",
+	blockUploadNotStarted:     "block upload not started",
+	blockUploadInProgress:     "block upload in progress",
+	blockValidationInProgress: "block validation in progress",
+	blockValidationFailed:     "block validation failed",
+	blockValidationStale:      "block validation stale",
+}
+
+func (s blockState) String() string {
+	msg, ok := blockStateMessages[s]
+	if ok {
+		return msg
+	}
+	return "invalid state"
+}
+
+// checkBlockState checks blocks state and returns various HTTP status codes for individual states if block
+// upload cannot start, finish or file cannot be uploaded to the block.
+func (c *MultitenantCompactor) checkBlockState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID, requireUploadInProgress bool) (*metadata.Meta, *validation, error) {
+	s, m, v, err := c.getBlockState(ctx, userBkt, blockID)
+	if err != nil {
+		return m, v, err
+	}
+
+	switch s {
+	case blockIsComplete:
+		return m, v, httpError{message: s.String(), statusCode: http.StatusConflict}
+	case blockValidationInProgress:
+		return m, v, httpError{message: s.String(), statusCode: http.StatusBadRequest}
+	case blockUploadNotStarted:
+		if requireUploadInProgress {
+			return m, v, httpError{message: s.String(), statusCode: http.StatusBadRequest}
+		} else {
+			return m, v, nil
+		}
+	case blockValidationStale:
+		// if validation is stale, we treat block as being in "upload in progress" state, and validation can start again.
+		fallthrough
+	case blockUploadInProgress:
+		return m, v, nil
+	case blockValidationFailed:
+		return m, v, httpError{message: s.String(), statusCode: http.StatusBadRequest}
+	}
+
+	return m, v, httpError{message: s.String(), statusCode: http.StatusInternalServerError}
+}
+
+func (c *MultitenantCompactor) getBlockState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (blockState, *metadata.Meta, *validation, error) {
+	exists, err := userBkt.Exists(ctx, path.Join(blockID.String(), block.MetaFilename))
+	if err != nil {
+		return blockStateUnknown, nil, nil, err
+	}
+	if exists {
+		return blockIsComplete, nil, nil, nil
+	}
+
+	meta, err := c.loadUploadingMeta(ctx, userBkt, blockID)
+	if err != nil {
+		return blockStateUnknown, nil, nil, err
+	}
+	// If neither meta.json nor uploading-meta.json file don't exist, we say that block doesn't exist.
+	if meta == nil {
+		return blockUploadNotStarted, nil, nil, err
+	}
+
+	v, err := c.loadValidation(ctx, userBkt, blockID)
+	if err != nil {
+		return blockStateUnknown, meta, nil, err
+	}
+	if v == nil {
+		return blockUploadInProgress, meta, nil, err
+	}
+	if v.Error != "" {
+		return blockValidationFailed, meta, v, err
+	}
+	if time.Since(time.UnixMilli(v.LastUpdate)) < 5*time.Minute {
+		return blockValidationInProgress, meta, v, nil
+	}
+	return blockValidationStale, meta, v, nil
+}
+
+func (c *MultitenantCompactor) loadUploadingMeta(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (*metadata.Meta, error) {
+	r, err := userBkt.Get(ctx, path.Join(blockID.String(), uploadingMetaFilename))
+	if err != nil {
+		if userBkt.IsObjNotFoundErr(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	v := &metadata.Meta{}
+	err = json.NewDecoder(r).Decode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func (c *MultitenantCompactor) loadValidation(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (*validation, error) {
+	r, err := userBkt.Get(ctx, path.Join(blockID.String(), validationFile))
+	if err != nil {
+		if userBkt.IsObjNotFoundErr(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	v := &validation{}
+	err = json.NewDecoder(r).Decode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }

--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -443,9 +443,8 @@ func (c *MultitenantCompactor) checkBlockState(ctx context.Context, userBkt objs
 	case blockUploadNotStarted:
 		if requireUploadInProgress {
 			return m, v, httpError{message: s.String(), statusCode: http.StatusNotFound}
-		} else {
-			return m, v, nil
 		}
+		return m, v, nil
 	case blockValidationStale:
 		// if validation is stale, we treat block as being in "upload in progress" state, and validation can start again.
 		fallthrough

--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -397,19 +397,19 @@ type validationFile struct {
 	Error      string // Error message if validation failed.
 }
 
-type blockState int
+type blockUploadState int
 
 const (
-	blockStateUnknown         blockState = iota // unknown, default value
-	blockIsComplete                             // meta.json file exists
-	blockUploadNotStarted                       // meta.json doesn't exist, uploading-meta.json doesn't exist
-	blockUploadInProgress                       // meta.json doesn't exist, but uploading-meta.json does
-	blockValidationInProgress                   // meta.json doesn't exist, uploading-meta.json exists, validation.json exists and is recent
+	blockStateUnknown         blockUploadState = iota // unknown, default value
+	blockIsComplete                                   // meta.json file exists
+	blockUploadNotStarted                             // meta.json doesn't exist, uploading-meta.json doesn't exist
+	blockUploadInProgress                             // meta.json doesn't exist, but uploading-meta.json does
+	blockValidationInProgress                         // meta.json doesn't exist, uploading-meta.json exists, validation.json exists and is recent
 	blockValidationFailed
 	blockValidationStale
 )
 
-var blockStateMessages = map[blockState]string{
+var blockStateMessages = map[blockUploadState]string{
 	blockStateUnknown:         "unknown",
 	blockIsComplete:           "block already exists",
 	blockUploadNotStarted:     "block upload not started",
@@ -419,7 +419,7 @@ var blockStateMessages = map[blockState]string{
 	blockValidationStale:      "block validation stale",
 }
 
-func (s blockState) String() string {
+func (s blockUploadState) String() string {
 	msg, ok := blockStateMessages[s]
 	if ok {
 		return msg
@@ -430,7 +430,7 @@ func (s blockState) String() string {
 // checkBlockState checks blocks state and returns various HTTP status codes for individual states if block
 // upload cannot start, finish or file cannot be uploaded to the block.
 func (c *MultitenantCompactor) checkBlockState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID, requireUploadInProgress bool) (*metadata.Meta, *validationFile, error) {
-	s, m, v, err := c.getBlockState(ctx, userBkt, blockID)
+	s, m, v, err := c.getBlockUploadState(ctx, userBkt, blockID)
 	if err != nil {
 		return m, v, err
 	}
@@ -457,7 +457,8 @@ func (c *MultitenantCompactor) checkBlockState(ctx context.Context, userBkt objs
 	return m, v, httpError{message: s.String(), statusCode: http.StatusInternalServerError}
 }
 
-func (c *MultitenantCompactor) getBlockState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (blockState, *metadata.Meta, *validationFile, error) {
+// getBlockUploadState returns state of the block upload, and meta and validation objects, if they exist.
+func (c *MultitenantCompactor) getBlockUploadState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (blockUploadState, *metadata.Meta, *validationFile, error) {
 	exists, err := userBkt.Exists(ctx, path.Join(blockID.String(), block.MetaFilename))
 	if err != nil {
 		return blockStateUnknown, nil, nil, err


### PR DESCRIPTION
#### What this PR does

This PR introduces block-validation status json file, and function to check block upload state. This block upload state is used by existing endpoints to verify if given operation (start block, upload file, finish block) can proceed or not. Validation status is not yet used, but will be used by new endpoint.

This PR also adds validation of filename and file length against meta.json when uploading single file.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
