### PR TITLE
Block validation async

### DIFF
--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"path"
 	"time"
@@ -32,7 +31,10 @@ import (
 )
 
 // Name of file where we store a block's meta file while it's being uploaded.
-const uploadingMetaFilename = "uploading-" + block.MetaFilename
+const (
+	uploadingMetaFilename = "uploading-meta.json"
+	validationFile        = "validation.json"
+)
 
 var rePath = regexp.MustCompile(`^(index|chunks/\d{6})$`)
 
@@ -54,7 +56,7 @@ func (c *MultitenantCompactor) StartBlockUpload(w http.ResponseWriter, r *http.R
 	const op = "start block upload"
 
 	userBkt := bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider)
-	if err := checkForCompleteBlock(ctx, blockID, userBkt); err != nil {
+	if _, _, err := c.checkBlockState(ctx, userBkt, blockID, false); err != nil {
 		writeBlockUploadError(err, op, "while checking for complete block", logger, w)
 		return
 	}
@@ -84,12 +86,20 @@ func (c *MultitenantCompactor) FinishBlockUpload(w http.ResponseWriter, r *http.
 	const op = "complete block upload"
 
 	userBkt := bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider)
-	if err := checkForCompleteBlock(ctx, blockID, userBkt); err != nil {
+	m, _, err := c.checkBlockState(ctx, userBkt, blockID, true)
+	if err != nil {
 		writeBlockUploadError(err, op, "while checking for complete block", logger, w)
 		return
 	}
 
-	if err := c.completeBlockUpload(ctx, r, logger, userBkt, blockID); err != nil {
+	// This should not happen, as checkBlockState with requireUploadInProgress=true returns nil error
+	// only if uploading-meta.json file exists.
+	if m == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := c.completeBlockUpload(ctx, logger, userBkt, blockID, *m); err != nil {
 		writeBlockUploadError(err, op, "", logger, w)
 		return
 	}
@@ -128,33 +138,17 @@ func writeBlockUploadError(err error, op, extra string, logger log.Logger, w htt
 	if extra != "" {
 		extra = " " + extra
 	}
-	level.Error(logger).Log("msg", fmt.Sprintf("an unexpected error occurred%s", extra), "operation", op,
-		"err", err)
+	level.Error(logger).Log("msg", fmt.Sprintf("an unexpected error occurred%s", extra), "operation", op, "err", err)
 	http.Error(w, "internal server error", http.StatusInternalServerError)
-}
-
-// checkForCompleteBlock checks for a complete block with same ID. If one exists, an error is returned.
-func checkForCompleteBlock(ctx context.Context, blockID ulid.ULID, userBkt objstore.Bucket) error {
-	exists, err := userBkt.Exists(ctx, path.Join(blockID.String(), block.MetaFilename))
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to check existence of %s in object storage", block.MetaFilename))
-	}
-	if exists {
-		return httpError{
-			message:    "block already exists in object storage",
-			statusCode: http.StatusConflict,
-		}
-	}
-
-	return nil
 }
 
 func (c *MultitenantCompactor) createBlockUpload(ctx context.Context, r *http.Request,
 	logger log.Logger, userBkt objstore.Bucket, tenantID string, blockID ulid.ULID) error {
 	level.Debug(logger).Log("msg", "starting block upload")
 
-	meta, err := decodeMeta(r.Body, "request body")
-	if err != nil {
+	var meta metadata.Meta
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&meta); err != nil {
 		return httpError{
 			message:    "malformed request body",
 			statusCode: http.StatusBadRequest,
@@ -221,25 +215,35 @@ func (c *MultitenantCompactor) UploadBlockFile(w http.ResponseWriter, r *http.Re
 	logger := log.With(util_log.WithContext(ctx, c.logger), "block", blockID)
 
 	userBkt := bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider)
-	if err := checkForCompleteBlock(ctx, blockID, userBkt); err != nil {
+
+	m, _, err := c.checkBlockState(ctx, userBkt, blockID, true)
+	if err != nil {
 		writeBlockUploadError(err, op, "while checking for complete block", logger, w)
 		return
 	}
 
-	metaPath := path.Join(blockID.String(), uploadingMetaFilename)
-	exists, err := userBkt.Exists(ctx, metaPath)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to check existence in object storage",
-			"path", metaPath, "operation", op, "err", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	if !exists {
-		http.Error(w, fmt.Sprintf("upload of block %s not started yet", blockID), http.StatusNotFound)
+	// This should not happen.
+	if m == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	// TODO: Verify that upload path and length correspond to file index
+	// Check if file was specified in meta.json, and if it has expected size.
+	found := false
+	for _, f := range m.Thanos.Files {
+		if pth == f.RelPath {
+			found = true
+
+			if r.ContentLength != f.SizeBytes {
+				http.Error(w, "file size doesn't match meta.json", http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	if !found {
+		http.Error(w, "unexpected file", http.StatusBadRequest)
+		return
+	}
 
 	dst := path.Join(blockID.String(), pth)
 
@@ -258,40 +262,7 @@ func (c *MultitenantCompactor) UploadBlockFile(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusOK)
 }
 
-func decodeMeta(r io.Reader, name string) (metadata.Meta, error) {
-	dec := json.NewDecoder(r)
-	var meta metadata.Meta
-	if err := dec.Decode(&meta); err != nil {
-		return meta, errors.Wrap(err, fmt.Sprintf("failed decoding %s", name))
-	}
-
-	return meta, nil
-}
-
-func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, r *http.Request,
-	logger log.Logger, userBkt objstore.Bucket, blockID ulid.ULID) error {
-	level.Debug(logger).Log("msg", "received request to complete block upload", "content_length", r.ContentLength)
-
-	uploadingMetaPath := path.Join(blockID.String(), uploadingMetaFilename)
-	rdr, err := userBkt.Get(ctx, uploadingMetaPath)
-	if err != nil {
-		if userBkt.IsObjNotFoundErr(err) {
-			return httpError{
-				message:    fmt.Sprintf("upload of block %s not started yet", blockID),
-				statusCode: http.StatusNotFound,
-			}
-		}
-		return errors.Wrap(err, fmt.Sprintf("failed to download %s from object storage", uploadingMetaFilename))
-	}
-	defer func() {
-		_ = rdr.Close()
-	}()
-
-	meta, err := decodeMeta(rdr, uploadingMetaFilename)
-	if err != nil {
-		return err
-	}
-
+func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, logger log.Logger, userBkt objstore.Bucket, blockID ulid.ULID, meta metadata.Meta) error {
 	level.Debug(logger).Log("msg", "completing block upload", "files", len(meta.Thanos.Files))
 
 	// Upload meta file so block is considered complete
@@ -299,7 +270,7 @@ func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, r *http.
 		return err
 	}
 
-	if err := userBkt.Delete(ctx, uploadingMetaPath); err != nil {
+	if err := userBkt.Delete(ctx, path.Join(blockID.String(), uploadingMetaFilename)); err != nil {
 		level.Warn(logger).Log("msg", fmt.Sprintf(
 			"failed to delete %s from block in object storage", uploadingMetaFilename), "err", err)
 		return nil
@@ -419,4 +390,142 @@ func (r bodyReader) ObjectSize() (int64, error) {
 // Read implements io.Reader.
 func (r bodyReader) Read(b []byte) (int, error) {
 	return r.r.Body.Read(b)
+}
+
+type validation struct {
+	LastUpdate int64  // UnixMillis of last update time.
+	Error      string // Error message if validation failed.
+}
+
+type blockState int
+
+const (
+	blockStateUnknown         blockState = iota // unknown, default value
+	blockIsComplete                             // meta.json file exists
+	blockUploadNotStarted                       // meta.json doesn't exist, uploading-meta.json doesn't exist
+	blockUploadInProgress                       // meta.json doesn't exist, but uploading-meta.json does
+	blockValidationInProgress                   // meta.json doesn't exist, uploading-meta.json exists, validation.json exists and is recent
+	blockValidationFailed
+	blockValidationStale
+)
+
+var blockStateMessages = map[blockState]string{
+	blockStateUnknown:         "unknown",
+	blockIsComplete:           "block is complete",
+	blockUploadNotStarted:     "block upload not started",
+	blockUploadInProgress:     "block upload in progress",
+	blockValidationInProgress: "block validation in progress",
+	blockValidationFailed:     "block validation failed",
+	blockValidationStale:      "block validation stale",
+}
+
+func (s blockState) String() string {
+	msg, ok := blockStateMessages[s]
+	if ok {
+		return msg
+	}
+	return "invalid state"
+}
+
+// checkBlockState checks blocks state and returns various HTTP status codes for individual states if block
+// upload cannot start, finish or file cannot be uploaded to the block.
+func (c *MultitenantCompactor) checkBlockState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID, requireUploadInProgress bool) (*metadata.Meta, *validation, error) {
+	s, m, v, err := c.getBlockState(ctx, userBkt, blockID)
+	if err != nil {
+		return m, v, err
+	}
+
+	switch s {
+	case blockIsComplete:
+		return m, v, httpError{message: s.String(), statusCode: http.StatusConflict}
+	case blockValidationInProgress:
+		return m, v, httpError{message: s.String(), statusCode: http.StatusBadRequest}
+	case blockUploadNotStarted:
+		if requireUploadInProgress {
+			return m, v, httpError{message: s.String(), statusCode: http.StatusBadRequest}
+		} else {
+			return m, v, nil
+		}
+	case blockValidationStale:
+		// if validation is stale, we treat block as being in "upload in progress" state, and validation can start again.
+		fallthrough
+	case blockUploadInProgress:
+		return m, v, nil
+	case blockValidationFailed:
+		return m, v, httpError{message: s.String(), statusCode: http.StatusBadRequest}
+	}
+
+	return m, v, httpError{message: s.String(), statusCode: http.StatusInternalServerError}
+}
+
+func (c *MultitenantCompactor) getBlockState(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (blockState, *metadata.Meta, *validation, error) {
+	exists, err := userBkt.Exists(ctx, path.Join(blockID.String(), block.MetaFilename))
+	if err != nil {
+		return blockStateUnknown, nil, nil, err
+	}
+	if exists {
+		return blockIsComplete, nil, nil, nil
+	}
+
+	meta, err := c.loadUploadingMeta(ctx, userBkt, blockID)
+	if err != nil {
+		return blockStateUnknown, nil, nil, err
+	}
+	// If neither meta.json nor uploading-meta.json file don't exist, we say that block doesn't exist.
+	if meta == nil {
+		return blockUploadNotStarted, nil, nil, err
+	}
+
+	v, err := c.loadValidation(ctx, userBkt, blockID)
+	if err != nil {
+		return blockStateUnknown, meta, nil, err
+	}
+	if v == nil {
+		return blockUploadInProgress, meta, nil, err
+	}
+	if v.Error != "" {
+		return blockValidationFailed, meta, v, err
+	}
+	if time.Since(time.UnixMilli(v.LastUpdate)) < 5*time.Minute {
+		return blockValidationInProgress, meta, v, nil
+	}
+	return blockValidationStale, meta, v, nil
+}
+
+func (c *MultitenantCompactor) loadUploadingMeta(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (*metadata.Meta, error) {
+	r, err := userBkt.Get(ctx, path.Join(blockID.String(), uploadingMetaFilename))
+	if err != nil {
+		if userBkt.IsObjNotFoundErr(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	v := &metadata.Meta{}
+	err = json.NewDecoder(r).Decode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func (c *MultitenantCompactor) loadValidation(ctx context.Context, userBkt objstore.Bucket, blockID ulid.ULID) (*validation, error) {
+	r, err := userBkt.Get(ctx, path.Join(blockID.String(), validationFile))
+	if err != nil {
+		if userBkt.IsObjNotFoundErr(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	v := &validation{}
+	err = json.NewDecoder(r).Decode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }

--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -7,8 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"path"
+	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -71,7 +75,7 @@ func (c *MultitenantCompactor) StartBlockUpload(w http.ResponseWriter, r *http.R
 
 // FinishBlockUpload handles request for finishing block upload.
 //
-// Finishing block upload performs block valiation, and if all checks pass, marks block as finished
+// Finishing block upload performs block validation, and if all checks pass, marks block as finished
 // by uploading meta.json file.
 func (c *MultitenantCompactor) FinishBlockUpload(w http.ResponseWriter, r *http.Request) {
 	blockID, tenantID, err := c.parseBlockUploadParameters(r)
@@ -99,10 +103,12 @@ func (c *MultitenantCompactor) FinishBlockUpload(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if err := c.completeBlockUpload(ctx, logger, userBkt, blockID, *m); err != nil {
-		writeBlockUploadError(err, op, "", logger, w)
-		return
-	}
+	go c.completeBlockUpload(ctx, logger, userBkt, blockID, *m)
+	//
+	//if err := c.completeBlockUpload(ctx, logger, userBkt, blockID, *m); err != nil {
+	//	writeBlockUploadError(err, op, "", logger, w)
+	//	return
+	//}
 
 	w.WriteHeader(http.StatusOK)
 }
@@ -262,22 +268,47 @@ func (c *MultitenantCompactor) UploadBlockFile(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusOK)
 }
 
-func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, logger log.Logger, userBkt objstore.Bucket, blockID ulid.ULID, meta metadata.Meta) error {
+func (c *MultitenantCompactor) completeBlockUpload(ctx context.Context, logger log.Logger, userBkt objstore.Bucket, blockID ulid.ULID, meta metadata.Meta) {
 	level.Debug(logger).Log("msg", "completing block upload", "files", len(meta.Thanos.Files))
+
+	// create validation file
+	if err := c.uploadValidation(ctx, logger, blockID, userBkt); err != nil {
+		level.Error(logger).Log("msg", "error creating validation file in object store", "blockID", blockID)
+		return
+	}
+	// start go routine that updates validation file timestamp once per minute
+	ch := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go c.periodicValidationUpdater(ctx, logger, blockID, userBkt, ch, &wg)
+
+	if err := c.validateBlock(ctx, blockID, userBkt, meta); err != nil {
+		err := c.uploadValidationWithError(ctx, logger, blockID, userBkt, err.Error())
+		if err != nil {
+			level.Error(logger).Log("msg", "error updating validation file after failed validation in object store", "blockID", blockID)
+		}
+		return
+	}
+
+	// use waitgroup to ensure validation ts update is complete
+	ch <- "Done"
+	wg.Wait()
 
 	// Upload meta file so block is considered complete
 	if err := c.uploadMeta(ctx, logger, meta, blockID, block.MetaFilename, userBkt); err != nil {
-		return err
+		//return err
+		// set error message in validation file
 	}
 
 	if err := userBkt.Delete(ctx, path.Join(blockID.String(), uploadingMetaFilename)); err != nil {
 		level.Warn(logger).Log("msg", fmt.Sprintf(
 			"failed to delete %s from block in object storage", uploadingMetaFilename), "err", err)
-		return nil
+		//return nil
+		// set error message in validation file
 	}
 
 	level.Debug(logger).Log("msg", "successfully completed block upload")
-	return nil
+	//return nil
 }
 
 // sanitizeMeta sanitizes and validates a metadata.Meta object. If a validation error occurs, an error
@@ -365,6 +396,75 @@ func (c *MultitenantCompactor) uploadMeta(ctx context.Context, logger log.Logger
 	return nil
 }
 
+func (c *MultitenantCompactor) validateBlock(ctx context.Context, blockID ulid.ULID,
+	userBkt objstore.Bucket, meta metadata.Meta) error {
+	blockDir, err := os.MkdirTemp(filepath.Join(c.compactorCfg.DataDir), "upload")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temp dir")
+	}
+	defer func() {
+		if err := os.RemoveAll(blockDir); err != nil {
+			level.Warn(c.logger).Log("msg", "failed to remove temp dir", "path", blockDir, "err", err)
+		}
+	}()
+
+	var objectCount, objectBytes int64
+	if err := userBkt.Iter(ctx, blockID.String(), func(pth string) error {
+		fname := filepath.Join(blockDir, pth)
+		if pth == uploadingMetaFilename {
+			fname = filepath.Join(blockDir, block.MetaFilename) // rename to final meta.json in temp dir
+		}
+
+		r, err := userBkt.Get(ctx, pth)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to get object %q from object storage", pth))
+		}
+
+		f, err := os.Create(fname)
+		if err != nil {
+			return errors.Wrap(err, "failed creating temp file")
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		bytesWritten, err := io.Copy(f, r)
+		if err != nil {
+			return err
+		}
+		objectCount++
+		objectBytes += bytesWritten
+		if err := f.Close(); err != nil {
+			return errors.Wrap(err, "failed to close temp file")
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "failed to iterate block %s", blockID.String())
+	}
+
+	// Read metadata file, populate mop of file paths and sizes
+	blockMetadata, err := metadata.ReadFromDir(blockDir)
+	if err != nil {
+		return errors.Wrap(err, "error reading block metadata file")
+	}
+
+	for _, f := range blockMetadata.Thanos.Files {
+		fi, err := os.Stat(filepath.Join(blockDir, filepath.FromSlash(f.RelPath)))
+		if err != nil {
+			return errors.Wrapf(err, "failed to stat %s", f.RelPath)
+		}
+
+		if !fi.Mode().IsRegular() {
+			return errors.Errorf("not a file: %s", f.RelPath)
+		}
+
+		if f.RelPath != block.MetaFilename && fi.Size() != f.SizeBytes {
+			return errors.Errorf("file size mismatch for %s", f.RelPath)
+		}
+	}
+
+	return nil
+}
+
 type httpError struct {
 	message    string
 	statusCode int
@@ -443,9 +543,8 @@ func (c *MultitenantCompactor) checkBlockState(ctx context.Context, userBkt objs
 	case blockUploadNotStarted:
 		if requireUploadInProgress {
 			return m, v, httpError{message: s.String(), statusCode: http.StatusNotFound}
-		} else {
-			return m, v, nil
 		}
+		return m, v, nil
 	case blockValidationStale:
 		// if validation is stale, we treat block as being in "upload in progress" state, and validation can start again.
 		fallthrough
@@ -528,4 +627,44 @@ func (c *MultitenantCompactor) loadValidation(ctx context.Context, userBkt objst
 	}
 
 	return v, nil
+}
+
+func (c *MultitenantCompactor) uploadValidationWithError(ctx context.Context, logger log.Logger, blockID ulid.ULID,
+	userBkt objstore.Bucket, errorStr string) error {
+	val := validationFile{
+		LastUpdate: time.Now().UnixMilli(),
+		Error:      errorStr,
+	}
+	dst := path.Join(blockID.String(), validationFilename)
+	level.Debug(logger).Log("msg", fmt.Sprintf("uploading %s to bucket", validationFilename), "dst", dst)
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(val); err != nil {
+		return errors.Wrap(err, "failed to encode block metadata")
+	}
+	if err := userBkt.Upload(ctx, dst, buf); err != nil {
+		return errors.Wrapf(err, "failed uploading %s to bucket", validationFilename)
+	}
+
+	return nil
+}
+
+func (c *MultitenantCompactor) uploadValidation(ctx context.Context, logger log.Logger, blockID ulid.ULID,
+	userBkt objstore.Bucket) error {
+	return c.uploadValidationWithError(ctx, logger, blockID, userBkt, "")
+}
+
+func (c *MultitenantCompactor) periodicValidationUpdater(ctx context.Context, logger log.Logger, blockID ulid.ULID,
+	userBkt objstore.Bucket, ch chan string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ch:
+			return
+		case <-time.After(1 * time.Minute):
+			break
+		}
+	}
+	if err := c.uploadValidation(ctx, logger, blockID, userBkt); err != nil {
+		level.Warn(logger).Log("msg", "error during periodic update of validation file", "blockID", blockID)
+	}
 }


### PR DESCRIPTION
#### What this PR does
This builds off of #2538 and adds 
1. The beginnings of block validation code, which is started asynchronously from `FinishBlockUpload`
2. A periodic background goroutine that updates `validation.json` while block validation is happening.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
