### PR TITLE
Fix alertmanager external URL validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,16 @@
 * [ENHANCEMENT] Added more buckets to `cortex_ingester_client_request_duration_seconds` histogram metric, to correctly track requests taking longer than 1s (up until 16s). #2445
 * [ENHANCEMENT] Azure client: Improve memory usage for large object storage downloads. #2408
 * [ENHANCEMENT] Distributor: Add `-distributor.instance-limits.max-inflight-push-requests-bytes`. This limit protects the distributor against multiple large requests that together may cause an OOM, but are only a few, so do not trigger the `max-inflight-push-requests` limit. #2413
+* [ENHANCEMENT] Distributor: Drop exemplars in distributor for tenants where exemplars are disabled. #2504
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289
 * [BUGFIX] Ruler: return proper `*status.Status` error when running in remote operational mode. #2417
-* [BUGFIX] Alertmanager: ensure the configured `-alertmanager.web.external-url` is a full URL, including the scheme and hostname. #2381
+* [BUGFIX] Alertmanager: ensure the configured `-alertmanager.web.external-url` is either a path starting with `/`, or a full URL including the scheme and hostname. #2381 #2542
 * [BUGFIX] Memberlist: fix problem with loss of some packets, typically ring updates when instances were removed from the ring during shutdown. #2418
 * [BUGFIX] Ingester: fix misfiring `MimirIngesterHasUnshippedBlocks` and stale `cortex_ingester_oldest_unshipped_block_timestamp_seconds` when some block uploads fail. #2435
 * [BUGFIX] Query-frontend: fix incorrect mapping of http status codes 429 to 500 when request queue is full. #2447
 * [BUGFIX] Memberlist: Fix problem with ring being empty right after startup. Memberlist KV store now tries to "fast-join" the cluster to avoid serving empty KV store. #2505
-* [ENHANCEMENT] Distributor: Drop exemplars in distributor for tenants where exemplars are disabled. #2504
 
 ### Mixin
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -121,12 +121,15 @@ func (cfg *MultitenantAlertmanagerConfig) Validate() error {
 		return errEmptyExternalURL
 	}
 
-	if cfg.ExternalURL.Scheme == "" {
-		return errInvalidExternalURLMissingScheme
-	}
+	// Either the configured URL is clearly a path (starting with /) or it must be a full URL.
+	if !strings.HasPrefix(cfg.ExternalURL.String(), "/") {
+		if cfg.ExternalURL.Scheme == "" {
+			return errInvalidExternalURLMissingScheme
+		}
 
-	if cfg.ExternalURL.Host == "" {
-		return errInvalidExternalURLMissingHostname
+		if cfg.ExternalURL.Host == "" {
+			return errInvalidExternalURLMissingHostname
+		}
 	}
 
 	if strings.HasSuffix(cfg.ExternalURL.Path, "/") {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -177,6 +177,18 @@ func TestMultitenantAlertmanagerConfig_Validate(t *testing.T) {
 			},
 			expected: errZoneAwarenessEnabledWithoutZoneInfo,
 		},
+		"should pass if the URL just contains the path with the leading /": {
+			setup: func(t *testing.T, cfg *MultitenantAlertmanagerConfig) {
+				require.NoError(t, cfg.ExternalURL.Set("/alertmanager"))
+			},
+			expected: nil,
+		},
+		"should file if the URL just contains the hostname (because it can't be disambiguated with a path)": {
+			setup: func(t *testing.T, cfg *MultitenantAlertmanagerConfig) {
+				require.NoError(t, cfg.ExternalURL.Set("alertmanager"))
+			},
+			expected: errInvalidExternalURLMissingScheme,
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -183,7 +183,7 @@ func TestMultitenantAlertmanagerConfig_Validate(t *testing.T) {
 			},
 			expected: nil,
 		},
-		"should file if the URL just contains the hostname (because it can't be disambiguated with a path)": {
+		"should fail if the URL just contains the hostname (because it can't be disambiguated with a path)": {
 			setup: func(t *testing.T, cfg *MultitenantAlertmanagerConfig) {
 				require.NoError(t, cfg.ExternalURL.Set("alertmanager"))
 			},


### PR DESCRIPTION
#### What this PR does
In #2381  I've introduce a stricter `-alertmanager.external-url` validation to fix https://github.com/grafana/mimir/issues/2357, but I've been too strict and I unintentionally introduced a breaking change: `/path` is not supported anymore, while it should if it the intention it clear (which means if it starts with `/`). This PR fixes it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
