### PR TITLE
Added ruler-querier autoscaling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@
     - `querier_topology_spread_max_skew`
     - `ruler_topology_spread_max_skew`
 * [FEATURE] Memberlist: added support for experimental memberlist cluster label, through the jsonnet configuration options `memberlist_cluster_label` and `memberlist_cluster_label_verification_disabled`. #2349
+* [FEATURE] Added ruler-querier autoscaling support. It requires [KEDA](https://keda.sh) installed in the Kubernetes cluster. Ruler-querier autoscaler can be enabled and configure through the following options in the jsonnet config: #2545
+  * `autoscaling_ruler_querier_enabled`: `true` to enable autoscaling.
+  * `autoscaling_ruler_querier_min_replicas`: minimum number of ruler-querier replicas.
+  * `autoscaling_ruler_querier_max_replicas`: maximum number of ruler-querier replicas.
+  * `autoscaling_prometheus_url`: Prometheus base URL from which to scrape Mimir metrics (e.g. `http://prometheus.default:9090/prometheus`).
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -348,6 +348,84 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    name: ruler-querier
+  name: ruler-querier
+  namespace: default
+spec:
+  ports:
+  - name: ruler-querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ruler-querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ruler-querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-frontend
+  name: ruler-query-frontend
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ruler-query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-scheduler
+  name: ruler-query-scheduler
+  namespace: default
+spec:
+  ports:
+  - name: ruler-query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-scheduler
+  name: ruler-query-scheduler-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ruler-query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: ruler-query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
     name: store-gateway
   name: store-gateway
   namespace: default
@@ -722,6 +800,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
+        - -ruler.query-frontend.address=dns:///ruler-query-frontend.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -765,6 +844,229 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: ruler-querier
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.backend=gcs
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -distributor.health-check-ingesters=true
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.bind-port=7946
+        - -memberlist.join=gossip-ring.default.svc.cluster.local:7946
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -server.http-write-timeout=1m
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store.max-query-length=768h
+        - -target=querier
+        env:
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1024"
+        image: grafana/mimir:2.2.0
+        imagePullPolicy: IfNotPresent
+        name: ruler-querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: ruler-query-frontend
+    spec:
+      containers:
+      - args:
+        - -query-frontend.align-querier-with-step=false
+        - -query-frontend.cache-results=false
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -server.http-write-timeout=1m
+        - -store.max-query-length=12000h
+        - -target=query-frontend
+        image: grafana/mimir:2.2.0
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 1200Mi
+          requests:
+            cpu: "2"
+            memory: 600Mi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-scheduler
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: ruler-query-scheduler
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ruler-query-scheduler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        image: grafana/mimir:2.2.0
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
       volumes:
       - configMap:
           name: overrides
@@ -1436,4 +1738,23 @@ spec:
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.75"}[5m]))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ruler-querier
+  namespace: default
+spec:
+  maxReplicaCount: 30
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: ruler-querier
+  triggers:
+  - metadata:
+      metricName: cortex_ruler_querier_hpa_default
+      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))[15m:])
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1"
     type: prometheus

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -11,6 +11,7 @@ mimir {
     query_scheduler_enabled: true,
 
     ruler_enabled: true,
+    ruler_remote_evaluation_enabled: true,
     ruler_client_type: 'gcs',
     ruler_storage_bucket_name: 'rules-bucket',
 
@@ -21,5 +22,9 @@ mimir {
     autoscaling_querier_enabled: true,
     autoscaling_querier_min_replicas: 3,
     autoscaling_querier_max_replicas: 30,
+
+    autoscaling_ruler_querier_enabled: true,
+    autoscaling_ruler_querier_min_replicas: 3,
+    autoscaling_ruler_querier_max_replicas: 30,
   },
 }


### PR DESCRIPTION
#### What this PR does
In this PR I'm upstreaming the ruler-querier autoscaling jsonnet config we use at Grafana Labs.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
