### PR TITLE
Remove active_series_custom_trackers from Ingester config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 * [CHANGE] Change default value for `-distributor.ha-tracker.max-clusters` to `100` to provide a DoS protection. #2465
 * [CHANGE] Experimental block upload API exposed by compactor has changed: Previous `/api/v1/upload/block/{block}` endpoint for starting block upload is now `/api/v1/upload/block/{block}/start`, and previous endpoint `/api/v1/upload/block/{block}?uploadComplete=true` for finishing block upload is now `/api/v1/upload/block/{block}/finish`. New API endpoint has been added: `/api/v1/upload/block/{block}/check`. #2486 #2548
 * [CHANGE] Compactor: changed `-compactor.max-compaction-time` default from `0s` (disabled) to `1h`. When compacting blocks for a tenant, the compactor will move to compact blocks of another tenant or re-plan blocks to compact at least every 1h. #2514
-* [CHANGE] Distributor: removed previously deprecated `extend_writes` (see #1856) YAML key and `-distributor.extend-writes` CLI flag from the Distributor config. #2551
+* [CHANGE] Distributor: removed previously deprecated `extend_writes` (see #1856) YAML key and `-distributor.extend-writes` CLI flag from the distributor config. #2551
+* [CHANGE] Ingester: removed previously deprecated `active_series_custom_trackers` (see #1188) YAML key from the ingester config. #2552
 * [FEATURE] Compactor: Adds the ability to delete partial blocks after a configurable delay. This option can be configured per tenant. #2285
   - `-compactor.partial-block-deletion-delay`, as a duration string, allows you to set the delay since a partial block has been modified before marking it for deletion. A value of `0`, the default, disables this feature.
   - The metric `cortex_compactor_blocks_marked_for_deletion_total` has a new value for the `reason` label `reason="partial"`, when a block deletion marker is triggered by the partial block deletion delay.

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2351,16 +2351,6 @@
         },
         {
           "kind": "field",
-          "name": "active_series_custom_trackers",
-          "required": false,
-          "desc": "[Deprecated] This config has been moved to the limits config, please set it there. Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero).",
-          "fieldValue": null,
-          "fieldDefaultValue": {},
-          "fieldType": "map of tracker name (string) to matcher (string)",
-          "fieldCategory": "advanced"
-        },
-        {
-          "kind": "field",
           "name": "tsdb_config_update_period",
           "required": false,
           "desc": "Period with which to update the per-tenant TSDB configuration.",

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -779,21 +779,6 @@ ring:
 # CLI flag: -ingester.active-series-metrics-idle-timeout
 [active_series_metrics_idle_timeout: <duration> | default = 10m]
 
-# (advanced) [Deprecated] This config has been moved to the limits config,
-# please set it there. Additional custom trackers for active metrics. If there
-# are active series matching a provided matcher (map value), the count will be
-# exposed in the custom trackers metric labeled using the tracker name (map
-# key). Zero valued counts are not exposed (and removed when they go back to
-# zero).
-# Example:
-#   The following configuration will count the active series coming from dev and
-#   prod namespaces for each tenant and label them as {name="dev"} and
-#   {name="prod"} in the cortex_ingester_active_series_custom_tracker metric.
-#   active_series_custom_trackers:
-#       dev: '{namespace=~"dev-.*"}'
-#       prod: '{namespace=~"prod-.*"}'
-[active_series_custom_trackers: <map of tracker name (string) to matcher (string)> | default = ]
-
 # (experimental) Period with which to update the per-tenant TSDB configuration.
 # CLI flag: -ingester.tsdb-config-update-period
 [tsdb_config_update_period: <duration> | default = 15s]

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -118,10 +118,9 @@ type Config struct {
 
 	RateUpdatePeriod time.Duration `yaml:"rate_update_period" category:"advanced"`
 
-	ActiveSeriesMetricsEnabled      bool                              `yaml:"active_series_metrics_enabled" category:"advanced"`
-	ActiveSeriesMetricsUpdatePeriod time.Duration                     `yaml:"active_series_metrics_update_period" category:"advanced"`
-	ActiveSeriesMetricsIdleTimeout  time.Duration                     `yaml:"active_series_metrics_idle_timeout" category:"advanced"`
-	ActiveSeriesCustomTrackers      activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" doc:"description=[Deprecated] This config has been moved to the limits config, please set it there. Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
+	ActiveSeriesMetricsEnabled      bool          `yaml:"active_series_metrics_enabled" category:"advanced"`
+	ActiveSeriesMetricsUpdatePeriod time.Duration `yaml:"active_series_metrics_update_period" category:"advanced"`
+	ActiveSeriesMetricsIdleTimeout  time.Duration `yaml:"active_series_metrics_idle_timeout" category:"advanced"`
 
 	TSDBConfigUpdatePeriod time.Duration `yaml:"tsdb_config_update_period" category:"experimental"`
 

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -25,10 +24,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
-	"github.com/grafana/dskit/modules"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +41,6 @@ import (
 	"github.com/grafana/mimir/pkg/distributor"
 	"github.com/grafana/mimir/pkg/frontend/v1/frontendv1pb"
 	"github.com/grafana/mimir/pkg/ingester"
-	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/grafana/mimir/pkg/ruler/rulestore"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
@@ -480,86 +476,6 @@ func TestFlagDefaults(t *testing.T) {
 
 	require.Equal(t, true, c.Server.GRPCServerPingWithoutStreamAllowed)
 	require.Equal(t, 10*time.Second, c.Server.GRPCServerMinTimeBetweenPings)
-}
-
-// TODO Remove in Mimir 2.3.
-func (t *Mimir) initTest() (services.Service, error) {
-
-	return services.NewBasicService(
-		nil,
-		func(_ context.Context) error {
-			// Sleep to avoid issue https://github.com/grafana/dskit/issues/151 .
-			time.Sleep(100 * time.Millisecond)
-			if t.Overrides.ActiveSeriesCustomTrackersConfig("1235").Empty() {
-				return errors.New("active series config should not be empty")
-			}
-			return modules.ErrStopProcess
-		},
-		nil), nil
-}
-
-// TODO Remove in Mimir 2.3.
-//      Previously ActiveSeriesCustomTrackers was an ingester config, now it's in LimitsConfig.
-//      We provide backwards compatibility for it by parsing the old YAML location and copying it to LimitsConfig here,
-//      unless it's also defined in the limits, which is invalid.
-//		This needs to be set before setting default limits for unmarshalling.
-// 		For more context see https://github.com/grafana/mimir/pull/1188#discussion_r830129443
-func TestActiveSeriesDeprecationDefaultOverrideWithSomeRuntimeOverrides(t *testing.T) {
-	prepareGlobalMetricsRegistry(t)
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	yamlContent := `
-overrides:
-  '1235':
-    ingestion_burst_size: 15000
-    ingestion_rate: 1500
-    max_global_series_per_metric: 7000
-    max_global_series_per_user: 15000
-    ruler_max_rule_groups_per_tenant: 20
-    ruler_max_rules_per_rule_group: 20
-`
-	TestModuleName := "test"
-	cfg := Config{}
-
-	// This sets default values from flags to the config.
-	flagext.RegisterFlagsWithLogger(log.NewNopLogger(), &cfg)
-
-	// Creating test file with runtime overrides.
-	tmpDir := t.TempDir()
-	cfg.RuntimeConfig.LoadPath = filepath.Join(tmpDir, "overrides.yml")
-	err := ioutil.WriteFile(cfg.RuntimeConfig.LoadPath, []byte(yamlContent), 0777)
-	require.NoError(t, err, "Failed to write test override.yml.")
-
-	// Setting up tracker config value as an deprecated ingester config.
-	cfg.Ingester.ActiveSeriesCustomTrackers, err = activeseries.NewCustomTrackersConfig(map[string]string{
-		"bool_is_true_flag-based": `{bool="true"}`,
-		"bool_is_false_flagbased": `{bool="false"}`,
-	})
-	require.NoError(t, err)
-
-	cfg.Target = []string{TestModuleName}
-	cfg.Server = getServerConfig(t)
-	require.NoError(t, cfg.Server.LogFormat.Set("logfmt"))
-	require.NoError(t, cfg.Server.LogLevel.Set("debug"))
-	util_log.InitLogger(&cfg.Server)
-
-	c, err := New(cfg)
-	require.NoError(t, err)
-	// Creating a test module to ensure that runtime config check happens after initialization.
-	c.ModuleManager.RegisterModule(TestModuleName, c.initTest)
-	err = c.ModuleManager.AddDependency(TestModuleName, Overrides)
-	require.NoError(t, err)
-
-	errCh := make(chan error)
-	go func() {
-		errCh <- c.Run()
-	}()
-
-	select {
-	case <-time.After(5 * time.Second):
-		require.Fail(t, "Mimir didn't stop in time")
-	case err := <-errCh:
-		require.NoError(t, err, "Active series deprecation override not in place!")
-	}
 }
 
 // Generates server config, with gRPC listening on random port.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/modules"
@@ -211,20 +210,6 @@ func (t *Mimir) initRing() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initRuntimeConfig() (services.Service, error) {
-	// TODO Remove in Mimir 2.3.
-	//      Previously ActiveSeriesCustomTrackers was an ingester config, now it's in LimitsConfig.
-	//      We provide backwards compatibility for it by parsing the old YAML location and copying it to LimitsConfig here,
-	//      unless it's also defined in the limits, which is invalid.
-	//      This needs to be set before setting default limits for unmarshalling.
-	if !t.Cfg.Ingester.ActiveSeriesCustomTrackers.Empty() {
-		if !t.Cfg.LimitsConfig.ActiveSeriesCustomTrackersConfig.Empty() {
-			return nil, fmt.Errorf("can't define active series custom trackers in both ingester and limits config, please define them only in the limits")
-		}
-		level.Warn(util_log.Logger).Log("msg", "active_series_custom_trackers is defined as an ingester config, this location is deprecated, please move it to the limits config")
-		flagext.DeprecatedFlagsUsed.Inc()
-		t.Cfg.LimitsConfig.ActiveSeriesCustomTrackersConfig = t.Cfg.Ingester.ActiveSeriesCustomTrackers
-	}
-
 	if t.Cfg.RuntimeConfig.LoadPath == "" {
 		// no need to initialize module if load path is empty
 		return nil, nil


### PR DESCRIPTION
#### What this PR does

Removes a deprecated config.
This is scheduled for 2.3, so it's a good moment to do this.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
