### PR TITLE
Option to override default volumeclaimtemplate for statefulsets

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -18,6 +18,10 @@ spec:
     {{- toYaml .Values.alertmanager.statefulStrategy | nindent 4 }}
   serviceName: {{ template "mimir.fullname" . }}-alertmanager
   {{- if .Values.alertmanager.persistentVolume.enabled }}
+  {{- if .Values.alertmanager.persistentVolume.volumeClaimTemplates }}
+  volumeClaimTemplates:
+      {{- toYaml .Values.alertmanager.persistentVolume.volumeClaimTemplates | nindent 4}}
+  {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -38,6 +42,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.alertmanager.persistentVolume.size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -16,6 +16,10 @@ spec:
     {{- toYaml .Values.compactor.strategy | nindent 4 }}
   serviceName: {{ template "mimir.fullname" . }}-compactor
   {{- if .Values.compactor.persistentVolume.enabled }}
+  {{- if .Values.compactor.persistentVolume.volumeClaimTemplates }}
+  volumeClaimTemplates:
+      {{- toYaml .Values.compactor.persistentVolume.volumeClaimTemplates | nindent 4}}
+  {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -36,6 +40,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.compactor.persistentVolume.size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -18,6 +18,10 @@ spec:
     {{- toYaml .Values.ingester.statefulStrategy | nindent 4 }}
   serviceName: {{ template "mimir.fullname" . }}-ingester{{- if not .Values.enterprise.legacyLabels -}}-headless{{- end -}}
   {{- if .Values.ingester.persistentVolume.enabled }}
+  {{- if .Values.ingester.persistentVolume.volumeClaimTemplates }}
+  volumeClaimTemplates:
+      {{- toYaml .Values.ingester.persistentVolume.volumeClaimTemplates | nindent 4}}
+  {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -38,6 +42,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.ingester.persistentVolume.size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -16,6 +16,10 @@ spec:
     {{- toYaml .Values.store_gateway.strategy | nindent 4 }}
   serviceName: {{ template "mimir.fullname" . }}-store-gateway{{- if not .Values.enterprise.legacyLabels -}}-headless{{- end -}}
   {{- if .Values.store_gateway.persistentVolume.enabled }}
+  {{- if .Values.store_gateway.persistentVolume.volumeClaimTemplates }}
+  volumeClaimTemplates:
+      {{- toYaml .Values.store_gateway.persistentVolume.volumeClaimTemplates | nindent 4}}
+  {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -36,6 +40,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.store_gateway.persistentVolume.size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -334,6 +334,9 @@ alertmanager:
     #
     # storageClass: "-"
 
+    # Allows you to override default volumeClaimTemplates
+    volumeClaimTemplates: []
+
   readinessProbe:
     httpGet:
       path: /ready
@@ -529,6 +532,9 @@ ingester:
     #
     # storageClass: "-"
 
+    # Allows you to override default volumeClaimTemplates
+    volumeClaimTemplates: []
+  
   readinessProbe:
     httpGet:
       path: /ready
@@ -896,6 +902,9 @@ store_gateway:
     #
     # storageClass: "-"
 
+    # Allows you to override default volumeClaimTemplates
+    volumeClaimTemplates: []
+
   readinessProbe:
     httpGet:
       path: /ready
@@ -995,6 +1004,9 @@ compactor:
     #   GKE, AWS & OpenStack)
     #
     # storageClass: "-"
+
+    # Allows you to override default volumeClaimTemplates
+    volumeClaimTemplates: []
 
   readinessProbe:
     httpGet:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adding an option to helm chart to be able to override the default `volumeClaimTemplates` which is very limited in terms of customization and you can't apply for example local-volume storage or so.

This is not a breaking change and it's fully compatible with current installations.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
