### PR TITLE
make check tests should fail if untracked files found in golden record

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,8 @@ build-helm-tests: operations/helm/charts/mimir-distributed/charts
 	@./operations/helm/tests/build.sh
 
 check-helm-tests: build-helm-tests
-	@git diff --exit-code -- ./operations/helm/tests || (echo "Please rebuild helm tests output 'make build-helm-tests'" && false)
+	@git diff --exit-code -- ./operations/helm/tests || (echo "Difference found. Please rebuild helm tests output 'make build-helm-tests'" && false)
+	@git ls-files --others --exclude-standard | grep "^operations/helm/tests" && (echo "Untracked files found. Please rebuild helm tests output 'make build-helm-tests'" && false) || true
 
 build-jsonnet-tests:
 	@./operations/mimir-tests/build.sh

--- a/Makefile
+++ b/Makefile
@@ -339,11 +339,11 @@ mod-check: ## Check the go mod is clean and tidy.
 	GO111MODULE=on go mod verify
 	GO111MODULE=on go mod tidy
 	GO111MODULE=on go mod vendor
-	@git diff --exit-code -- go.sum go.mod vendor/
+	@./tools/find-diff-or-untracked.sh go.sum go.mod vendor/ || (echo "Please update vendoring by running 'make mod-check'" && false)
 
 check-protos: ## Check the protobuf files are up to date.
 check-protos: clean-protos protos
-	@git diff --exit-code -- $(PROTO_GOS)
+	@./tools/find-diff-or-untracked.sh $(PROTO_GOS) || (echo "Please rebuild protobuf code by running 'check-protos'" && false)
 
 %.md : %.template
 	go run ./tools/doc-generator $< > $@
@@ -472,7 +472,7 @@ check-white-noise: clean-white-noise
 
 check-mixin: build-mixin format-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks
 	@echo "Checking diff:"
-	@git diff --exit-code -- $(MIXIN_PATH) $(MIXIN_OUT_PATH) || (echo "Please build and format mixin by running 'make build-mixin format-mixin'" && false)
+	@./tools/find-diff-or-untracked.sh $(MIXIN_PATH) $(MIXIN_OUT_PATH) || (echo "Please build and format mixin by running 'make build-mixin format-mixin'" && false)
 
 	@cd $(MIXIN_PATH) && \
 	jb install && \
@@ -498,7 +498,7 @@ mixin-screenshots: ## Generates mixin dashboards screenshots.
 
 check-jsonnet-manifests: format-jsonnet-manifests
 	@echo "Checking diff:"
-	@git diff --exit-code -- $(JSONNET_MANIFESTS_PATH) || (echo "Please format jsonnet manifests by running 'make format-jsonnet-manifests'" && false)
+	@./tools/find-diff-or-untracked.sh "$(JSONNET_MANIFESTS_PATH)" || (echo "Please format jsonnet manifests by running 'make format-jsonnet-manifests'" && false)
 
 format-jsonnet-manifests:
 	@find $(JSONNET_MANIFESTS_PATH) -type f -name '*.libsonnet' -print -o -name '*.jsonnet' -print | xargs jsonnetfmt -i
@@ -523,14 +523,13 @@ build-helm-tests: operations/helm/charts/mimir-distributed/charts
 	@./operations/helm/tests/build.sh
 
 check-helm-tests: build-helm-tests
-	@git diff --exit-code -- ./operations/helm/tests || (echo "Difference found. Please rebuild helm tests output 'make build-helm-tests'" && false)
-	@git ls-files --others --exclude-standard | grep "^operations/helm/tests" && (echo "Untracked files found. Please rebuild helm tests output 'make build-helm-tests'" && false) || true
+	@./tools/find-diff-or-untracked.sh operations/helm/tests || (echo "Please rebuild helm tests output 'make build-helm-tests'" && false)
 
 build-jsonnet-tests:
 	@./operations/mimir-tests/build.sh
 
 check-jsonnet-tests: build-jsonnet-tests
-	@git diff --exit-code -- ./operations/mimir-tests || (echo "Please rebuild jsonnet tests output 'make build-jsonnet-tests'" && false)
+	@./tools/find-diff-or-untracked.sh operations/mimir-tests || (echo "Please rebuild jsonnet tests output 'make build-jsonnet-tests'" && false)
 
 check-tsdb-blocks-storage-s3-docker-compose-yaml:
 	cd development/tsdb-blocks-storage-s3 && make check

--- a/tools/find-diff-or-untracked.sh
+++ b/tools/find-diff-or-untracked.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -eu -o pipefail
+
+function join_to_regex {
+    for i in "$@" ; do
+        echo -n "$i|"
+    done
+}
+
+function find_diff_or_untracked {
+    git diff --exit-code -- "$@"
+
+    local regex=$(join_to_regex "$@")
+    regex=${regex::-1}
+    local untracked_files=$(git ls-files --others --exclude-standard)
+    set +e
+	echo "${untracked_files}" | grep -E "^(${regex})"
+    local rc=$?
+    set -e
+    if [ "${rc}" -eq 0 ] ; then  # flip the grep result
+      echo "$0: Untracked files found"
+      return 1
+    fi
+}
+
+if [ $# -eq 0 ] ; then
+  echo "Too few argument to $0. Provide a messages and paths"
+  exit 1
+fi
+
+find_diff_or_untracked "$@"

--- a/tools/find-diff-or-untracked.sh
+++ b/tools/find-diff-or-untracked.sh
@@ -3,24 +3,13 @@
 
 set -eu -o pipefail
 
-function join_to_regex {
-    for i in "$@" ; do
-        echo -n "$i|"
-    done
-}
-
 function find_diff_or_untracked {
     git diff --exit-code -- "$@"
 
-    local regex=$(join_to_regex "$@")
-    regex=${regex::-1}
-    local untracked_files=$(git ls-files --others --exclude-standard)
-    set +e
-	echo "${untracked_files}" | grep -E "^(${regex})"
-    local rc=$?
-    set -e
-    if [ "${rc}" -eq 0 ] ; then  # flip the grep result
-      echo "$0: Untracked files found"
+    local untracked_files=$(git ls-files --others --exclude-standard "$@")
+    if [ -n "${untracked_files}" ] ; then
+      echo "$0: FAIL: untracked files found:"
+      echo "${untracked_files}"
       return 1
     fi
 }

--- a/tools/find-diff-or-untracked.sh
+++ b/tools/find-diff-or-untracked.sh
@@ -15,7 +15,7 @@ function find_diff_or_untracked {
 }
 
 if [ $# -eq 0 ] ; then
-  echo "Too few argument to $0. Provide a messages and paths"
+  echo "Too few arguments to $0. Provide paths to check"
   exit 1
 fi
 


### PR DESCRIPTION
#### What this PR does

git diff does not take into account untracked files
Fix is to list untracked files and assert if there's any in path

Noticed when I accidentally generated an extra kube manifest with make check-helm-test.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
