### PR TITLE
Use parser.Expr in frontend's astmapper

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -94,70 +94,70 @@ func (em ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return expr, nil
 	}
 
-	switch n := expr.(type) {
+	switch e := expr.(type) {
 	case nil:
 		// nil handles cases where we check optional fields that are not set
 		return nil, nil
 
 	case *parser.AggregateExpr:
-		expr, err := em.Map(n.Expr, stats)
+		expr, err := em.Map(e.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = expr
-		return n, nil
+		e.Expr = expr
+		return e, nil
 
 	case *parser.BinaryExpr:
-		lhs, err := em.Map(n.LHS, stats)
+		lhs, err := em.Map(e.LHS, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.LHS = lhs
+		e.LHS = lhs
 
-		rhs, err := em.Map(n.RHS, stats)
+		rhs, err := em.Map(e.RHS, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.RHS = rhs
+		e.RHS = rhs
 
-		return n, nil
+		return e, nil
 
 	case *parser.Call:
-		for i, e := range n.Args {
-			mapped, err := em.Map(e, stats)
+		for i, arg := range e.Args {
+			mapped, err := em.Map(arg, stats)
 			if err != nil {
 				return nil, err
 			}
-			n.Args[i] = mapped
+			e.Args[i] = mapped
 		}
-		return n, nil
+		return e, nil
 
 	case *parser.SubqueryExpr:
-		mapped, err := em.Map(n.Expr, stats)
+		mapped, err := em.Map(e.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = mapped
-		return n, nil
+		e.Expr = mapped
+		return e, nil
 
 	case *parser.ParenExpr:
-		mapped, err := em.Map(n.Expr, stats)
+		mapped, err := em.Map(e.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = mapped
-		return n, nil
+		e.Expr = mapped
+		return e, nil
 
 	case *parser.UnaryExpr:
-		mapped, err := em.Map(n.Expr, stats)
+		mapped, err := em.Map(e.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = mapped
-		return n, nil
+		e.Expr = mapped
+		return e, nil
 
 	case *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector, *parser.MatrixSelector:
-		return n, nil
+		return e, nil
 
 	default:
 		return nil, errors.Errorf("ASTExprMapper: unhandled expr type %T", expr)

--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -84,8 +84,8 @@ type ASTExprMapper struct {
 }
 
 // Map implements ASTMapper from a ExprMapper
-func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, error) {
-	expr, finished, err := nm.MapExpr(expr, stats)
+func (em ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, error) {
+	expr, finished, err := em.MapExpr(expr, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return nil, nil
 
 	case *parser.AggregateExpr:
-		expr, err := nm.Map(n.Expr, stats)
+		expr, err := em.Map(n.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
@@ -108,13 +108,13 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return n, nil
 
 	case *parser.BinaryExpr:
-		lhs, err := nm.Map(n.LHS, stats)
+		lhs, err := em.Map(n.LHS, stats)
 		if err != nil {
 			return nil, err
 		}
 		n.LHS = lhs
 
-		rhs, err := nm.Map(n.RHS, stats)
+		rhs, err := em.Map(n.RHS, stats)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +124,7 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 
 	case *parser.Call:
 		for i, e := range n.Args {
-			mapped, err := nm.Map(e, stats)
+			mapped, err := em.Map(e, stats)
 			if err != nil {
 				return nil, err
 			}
@@ -133,7 +133,7 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return n, nil
 
 	case *parser.SubqueryExpr:
-		mapped, err := nm.Map(n.Expr, stats)
+		mapped, err := em.Map(n.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return n, nil
 
 	case *parser.ParenExpr:
-		mapped, err := nm.Map(n.Expr, stats)
+		mapped, err := em.Map(n.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return n, nil
 
 	case *parser.UnaryExpr:
-		mapped, err := nm.Map(n.Expr, stats)
+		mapped, err := em.Map(n.Expr, stats)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -12,8 +12,8 @@ import (
 
 // ASTMapper is the exported interface for mapping between multiple AST representations
 type ASTMapper interface {
-	// Map the input node and returns the mapped node.
-	Map(node parser.Node, stats *MapperStats) (mapped parser.Node, err error)
+	// Map the input expr and returns the mapped expr.
+	Map(expr parser.Expr, stats *MapperStats) (mapped parser.Expr, err error)
 }
 
 // MultiMapper can compose multiple ASTMappers
@@ -22,8 +22,8 @@ type MultiMapper struct {
 }
 
 // Map implements ASTMapper
-func (m *MultiMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, error) {
-	var result = node
+func (m *MultiMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, error) {
+	var result = expr
 	var err error
 
 	if len(m.mappers) == 0 {
@@ -42,7 +42,7 @@ func (m *MultiMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, er
 
 // Register adds ASTMappers into a multimapper.
 // Since registered functions are applied in the order they're registered, it's advised to register them
-// in decreasing priority and only operate on nodes that each function cares about, defaulting to cloneNode.
+// in decreasing priority and only operate on exprs that each function cares about, defaulting to cloneExpr.
 func (m *MultiMapper) Register(xs ...ASTMapper) {
 	m.mappers = append(m.mappers, xs...)
 }
@@ -54,67 +54,57 @@ func NewMultiMapper(xs ...ASTMapper) *MultiMapper {
 	return m
 }
 
-// cloneNode is a helper function to clone a node.
-func cloneNode(node parser.Node) (parser.Node, error) {
-	return parser.ParseExpr(node.String())
+// cloneExpr is a helper function to clone an expr.
+func cloneExpr(expr parser.Expr) (parser.Expr, error) {
+	return parser.ParseExpr(expr.String())
 }
 
-func cloneAndMap(mapper ASTNodeMapper, node parser.Expr, stats *MapperStats) (parser.Node, error) {
-	cloned, err := cloneNode(node)
+func cloneAndMap(mapper ASTExprMapper, expr parser.Expr, stats *MapperStats) (parser.Expr, error) {
+	cloned, err := cloneExpr(expr)
 	if err != nil {
 		return nil, err
 	}
 	return mapper.Map(cloned, stats)
 }
 
-type NodeMapper interface {
-	// MapNode either maps a single AST node or returns the unaltered node.
+type ExprMapper interface {
+	// MapExpr either maps a single AST expr or returns the unaltered expr.
 	// It returns a finished bool to signal whether no further recursion is necessary.
-	MapNode(node parser.Node, stats *MapperStats) (mapped parser.Node, finished bool, err error)
+	MapExpr(expr parser.Expr, stats *MapperStats) (mapped parser.Expr, finished bool, err error)
 }
 
-// NewASTNodeMapper creates an ASTMapper from a NodeMapper
-func NewASTNodeMapper(mapper NodeMapper) ASTNodeMapper {
-	return ASTNodeMapper{mapper}
+// NewASTExprMapper creates an ASTMapper from a ExprMapper
+func NewASTExprMapper(mapper ExprMapper) ASTExprMapper {
+	return ASTExprMapper{mapper}
 }
 
-// ASTNodeMapper is an ASTMapper adapter which uses a NodeMapper internally.
-type ASTNodeMapper struct {
-	NodeMapper
+// ASTExprMapper is an ASTMapper adapter which uses a ExprMapper internally.
+type ASTExprMapper struct {
+	ExprMapper
 }
 
-// Map implements ASTMapper from a NodeMapper
-func (nm ASTNodeMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, error) {
-	node, finished, err := nm.MapNode(node, stats)
+// Map implements ASTMapper from a ExprMapper
+func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, error) {
+	expr, finished, err := nm.MapExpr(expr, stats)
 	if err != nil {
 		return nil, err
 	}
 
 	if finished {
-		return node, nil
+		return expr, nil
 	}
 
-	switch n := node.(type) {
+	switch n := expr.(type) {
 	case nil:
 		// nil handles cases where we check optional fields that are not set
 		return nil, nil
-
-	case parser.Expressions:
-		for i, e := range n {
-			mapped, err := nm.Map(e, stats)
-			if err != nil {
-				return nil, err
-			}
-			n[i] = mapped.(parser.Expr)
-		}
-		return n, nil
 
 	case *parser.AggregateExpr:
 		expr, err := nm.Map(n.Expr, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = expr.(parser.Expr)
+		n.Expr = expr
 		return n, nil
 
 	case *parser.BinaryExpr:
@@ -122,13 +112,13 @@ func (nm ASTNodeMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, 
 		if err != nil {
 			return nil, err
 		}
-		n.LHS = lhs.(parser.Expr)
+		n.LHS = lhs
 
 		rhs, err := nm.Map(n.RHS, stats)
 		if err != nil {
 			return nil, err
 		}
-		n.RHS = rhs.(parser.Expr)
+		n.RHS = rhs
 
 		return n, nil
 
@@ -138,7 +128,7 @@ func (nm ASTNodeMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, 
 			if err != nil {
 				return nil, err
 			}
-			n.Args[i] = mapped.(parser.Expr)
+			n.Args[i] = mapped
 		}
 		return n, nil
 
@@ -147,7 +137,7 @@ func (nm ASTNodeMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, 
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = mapped.(parser.Expr)
+		n.Expr = mapped
 		return n, nil
 
 	case *parser.ParenExpr:
@@ -155,7 +145,7 @@ func (nm ASTNodeMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, 
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = mapped.(parser.Expr)
+		n.Expr = mapped
 		return n, nil
 
 	case *parser.UnaryExpr:
@@ -163,21 +153,13 @@ func (nm ASTNodeMapper) Map(node parser.Node, stats *MapperStats) (parser.Node, 
 		if err != nil {
 			return nil, err
 		}
-		n.Expr = mapped.(parser.Expr)
-		return n, nil
-
-	case *parser.EvalStmt:
-		mapped, err := nm.Map(n.Expr, stats)
-		if err != nil {
-			return nil, err
-		}
-		n.Expr = mapped.(parser.Expr)
+		n.Expr = mapped
 		return n, nil
 
 	case *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector, *parser.MatrixSelector:
 		return n, nil
 
 	default:
-		return nil, errors.Errorf("nodeMapper: unhandled node type %T", node)
+		return nil, errors.Errorf("exprMapper: unhandled expr type %T", expr)
 	}
 }

--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -160,6 +160,6 @@ func (nm ASTExprMapper) Map(expr parser.Expr, stats *MapperStats) (parser.Expr, 
 		return n, nil
 
 	default:
-		return nil, errors.Errorf("exprMapper: unhandled expr type %T", expr)
+		return nil, errors.Errorf("ASTExprMapper: unhandled expr type %T", expr)
 	}
 }

--- a/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCloneNode(t *testing.T) {
+func TestCloneExpr(t *testing.T) {
 	var testExpr = []struct {
 		input    parser.Expr
 		expected parser.Expr
@@ -69,14 +69,14 @@ func TestCloneNode(t *testing.T) {
 
 	for i, c := range testExpr {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			res, err := cloneNode(c.input)
+			res, err := cloneExpr(c.input)
 			require.NoError(t, err)
 			require.Equal(t, c.expected, res)
 		})
 	}
 }
 
-func TestCloneNode_String(t *testing.T) {
+func TestCloneExpr_String(t *testing.T) {
 	var testExpr = []struct {
 		input    string
 		expected string
@@ -99,7 +99,7 @@ sum(rate(http_requests_total{cluster="ops-tools1"}[1m]))
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			expr, err := parser.ParseExpr(c.input)
 			require.Nil(t, err)
-			res, err := cloneNode(expr)
+			res, err := cloneExpr(expr)
 			require.Nil(t, err)
 			require.Equal(t, c.expected, res.String())
 		})

--- a/pkg/frontend/querymiddleware/astmapper/embedded.go
+++ b/pkg/frontend/querymiddleware/astmapper/embedded.go
@@ -60,13 +60,13 @@ func (c jsonCodec) Decode(encoded string) (queries []string, err error) {
 }
 
 // VectorSquash reduces an AST into a single vector query which can be hijacked by a Queryable impl.
-// It always uses a VectorSelector as the substitution node.
+// It always uses a VectorSelector as the substitution expr.
 // This is important because logical/set binops can only be applied against vectors and not matrices.
-func vectorSquasher(nodes ...parser.Node) (parser.Expr, error) {
+func vectorSquasher(exprs ...parser.Expr) (parser.Expr, error) {
 	// concat OR legs
-	strs := make([]string, 0, len(nodes))
-	for _, node := range nodes {
-		strs = append(strs, node.String())
+	strs := make([]string, 0, len(exprs))
+	for _, expr := range exprs {
+		strs = append(strs, expr.String())
 	}
 
 	encoded, err := JSONCodec.Encode(strs)

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -111,7 +111,7 @@ func CanParallelize(expr parser.Expr, logger log.Logger) bool {
 		return true
 
 	default:
-		level.Error(logger).Log("err", fmt.Sprintf("CanParallel: unhandled expr type %T", expr)) //lint:ignore faillint allow global logger for now
+		level.Error(logger).Log("err", fmt.Sprintf("CanParallelize: unhandled expr type %T", expr)) //lint:ignore faillint allow global logger for now
 		return false
 	}
 }

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -48,30 +48,22 @@ var FuncsWithDefaultTimeArg = []string{
 
 // CanParallelize tests if a subtree is parallelizable.
 // A subtree is parallelizable if all of its components are parallelizable.
-func CanParallelize(node parser.Node, logger log.Logger) bool {
-	switch n := node.(type) {
+func CanParallelize(expr parser.Expr, logger log.Logger) bool {
+	switch e := expr.(type) {
 	case nil:
 		// nil handles cases where we check optional fields that are not set
 		return true
 
-	case parser.Expressions:
-		for _, e := range n {
-			if !CanParallelize(e, logger) {
-				return false
-			}
-		}
-		return true
-
 	case *parser.AggregateExpr:
-		_, ok := summableAggregates[n.Op]
+		_, ok := summableAggregates[e.Op]
 		if !ok {
 			return false
 		}
 
 		// Ensure there are no nested aggregations
-		nestedAggrs, err := anyNode(n.Expr, isAggregateExpr)
+		nestedAggrs, err := anyNode(e.Expr, isAggregateExpr)
 
-		return err == nil && !nestedAggrs && CanParallelize(n.Expr, logger)
+		return err == nil && !nestedAggrs && CanParallelize(e.Expr, logger)
 
 	case *parser.BinaryExpr:
 		// Binary expressions can be parallelised when one of the sides is a constant scalar value
@@ -81,22 +73,22 @@ func CanParallelize(node parser.Node, logger log.Logger) bool {
 		// Both comparison and arithmetic binary operations _can_ be parallelised, but not all of them are worth parallelising,
 		// this function doesn't decide that.
 		// Since we don't care about the order in which binary op is written, we extract the condition into a lambda and check both ways.
-		parallelisable := func(a, b parser.Node) bool {
+		parallelisable := func(a, b parser.Expr) bool {
 			return CanParallelize(a, logger) && noAggregates(a) && isConstantScalar(b)
 		}
-		// If n.VectorMatching is not nil, then both hands are vector operators, so none of them is a constant scalar, so we can't shard it.
+		// If e.VectorMatching is not nil, then both hands are vector operators, so none of them is a constant scalar, so we can't shard it.
 		// It is just a shortcut, but the other two operations should imply the same.
-		return n.VectorMatching == nil && (parallelisable(n.LHS, n.RHS) || parallelisable(n.RHS, n.LHS))
+		return e.VectorMatching == nil && (parallelisable(e.LHS, e.RHS) || parallelisable(e.RHS, e.LHS))
 
 	case *parser.Call:
-		if n.Func == nil {
+		if e.Func == nil {
 			return false
 		}
-		if !ParallelizableFunc(*n.Func) {
+		if !ParallelizableFunc(*e.Func) {
 			return false
 		}
 
-		for _, e := range argsWithDefaults(n) {
+		for _, e := range argsWithDefaults(e) {
 			if !CanParallelize(e, logger) {
 				return false
 			}
@@ -105,31 +97,28 @@ func CanParallelize(node parser.Node, logger log.Logger) bool {
 
 	case *parser.SubqueryExpr:
 		// Subqueries are parallelizable if they are parallelizable themselves
-		// and they don't contain aggregations over series in children nodes.
-		return !containsAggregateExpr(n) && CanParallelize(n.Expr, logger)
+		// and they don't contain aggregations over series in children exprs.
+		return !containsAggregateExpr(e) && CanParallelize(e.Expr, logger)
 
 	case *parser.ParenExpr:
-		return CanParallelize(n.Expr, logger)
+		return CanParallelize(e.Expr, logger)
 
 	case *parser.UnaryExpr:
 		// Since these are only currently supported for Scalars, should be parallel-compatible
 		return true
 
-	case *parser.EvalStmt:
-		return CanParallelize(n.Expr, logger)
-
 	case *parser.MatrixSelector, *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector:
 		return true
 
 	default:
-		level.Error(logger).Log("err", fmt.Sprintf("CanParallel: unhandled node type %T", node)) //lint:ignore faillint allow global logger for now
+		level.Error(logger).Log("err", fmt.Sprintf("CanParallel: unhandled expr type %T", expr)) //lint:ignore faillint allow global logger for now
 		return false
 	}
 }
 
-// containsAggregateExpr returns true if the given node contains an aggregate expression within its children.
-func containsAggregateExpr(n parser.Node) bool {
-	containsAggregate, _ := anyNode(n, isAggregateExpr)
+// containsAggregateExpr returns true if the given expr contains an aggregate expression within its children.
+func containsAggregateExpr(e parser.Expr) bool {
+	containsAggregate, _ := anyNode(e, isAggregateExpr)
 	return containsAggregate
 }
 

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -485,16 +485,16 @@ func concatShards(shards int, queryTemplate string) string {
 }
 
 func concat(queries ...string) string {
-	nodes := make([]parser.Node, 0, len(queries))
+	exprs := make([]parser.Expr, 0, len(queries))
 	for _, q := range queries {
 		n, err := parser.ParseExpr(q)
 		if err != nil {
 			panic(err)
 		}
-		nodes = append(nodes, n)
+		exprs = append(exprs, n)
 
 	}
-	mapped, err := vectorSquasher(nodes...)
+	mapped, err := vectorSquasher(exprs...)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
-// subtreeFolder is a NodeMapper which embeds an entire parser.Node in an embedded query,
+// subtreeFolder is a ExprMapper which embeds an entire parser.Expr in an embedded query,
 // if it does not contain any previously embedded queries. This allows the query-frontend
 // to "zip up" entire subtrees of an AST that have not already been parallelized.
 type subtreeFolder struct{}
@@ -17,35 +17,35 @@ type subtreeFolder struct{}
 // newSubtreeFolder creates a subtreeFolder which can reduce an AST
 // to one embedded query if it contains no embedded queries yet.
 func newSubtreeFolder() ASTMapper {
-	return NewASTNodeMapper(&subtreeFolder{})
+	return NewASTExprMapper(&subtreeFolder{})
 }
 
-// MapNode implements NodeMapper.
-func (f *subtreeFolder) MapNode(node parser.Node, _ *MapperStats) (mapped parser.Node, finished bool, err error) {
-	hasEmbeddedQueries, err := anyNode(node, hasEmbeddedQueries)
+// MapExpr implements ExprMapper.
+func (f *subtreeFolder) MapExpr(expr parser.Expr, _ *MapperStats) (mapped parser.Expr, finished bool, err error) {
+	hasEmbeddedQueries, err := anyNode(expr, hasEmbeddedQueries)
 	if err != nil {
 		return nil, true, err
 	}
 
-	// Don't change the node if it already contains embedded queries.
+	// Don't change the expr if it already contains embedded queries.
 	if hasEmbeddedQueries {
-		return node, false, nil
+		return expr, false, nil
 	}
 
-	hasVectorSelector, err := anyNode(node, isVectorSelector)
+	hasVectorSelector, err := anyNode(expr, isVectorSelector)
 	if err != nil {
 		return nil, true, err
 	}
 
-	// Change the node if it contains vector selectors, as only those need to be embedded.
+	// Change the expr if it contains vector selectors, as only those need to be embedded.
 	if hasVectorSelector {
-		expr, err := vectorSquasher(node)
+		expr, err := vectorSquasher(expr)
 		return expr, true, err
 	}
-	return node, false, nil
+	return expr, false, nil
 }
 
-// hasEmbeddedQueries returns whether the node has embedded queries.
+// hasEmbeddedQueries returns whether the expr has embedded queries.
 func hasEmbeddedQueries(node parser.Node) (bool, error) {
 	switch n := node.(type) {
 	case *parser.VectorSelector:
@@ -56,7 +56,7 @@ func hasEmbeddedQueries(node parser.Node) (bool, error) {
 	return false, nil
 }
 
-// hasEmbeddedQueries returns whether the node is a vector selector.
+// hasEmbeddedQueries returns whether the expr is a vector selector.
 func isVectorSelector(n parser.Node) (bool, error) {
 	_, ok := n.(*parser.VectorSelector)
 	return ok, nil


### PR DESCRIPTION
#### What this PR does

We use `parser.Node` in astmapper, but our input is the result of a `ParseExpr` which is an Expr, and we return an Expr.

By restricting this type, we remove a lot of type assertions (which were true anyway).

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/2469

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
