### PR TITLE
Don't shard binary ops of only constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [BUGFIX] Ingester: fix misfiring `MimirIngesterHasUnshippedBlocks` and stale `cortex_ingester_oldest_unshipped_block_timestamp_seconds` when some block uploads fail. #2435
 * [BUGFIX] Query-frontend: fix incorrect mapping of http status codes 429 to 500 when request queue is full. #2447
 * [BUGFIX] Memberlist: Fix problem with ring being empty right after startup. Memberlist KV store now tries to "fast-join" the cluster to avoid serving empty KV store. #2505
+* [BUGFIX] Query-frontend: fix wrong query sharding results for queries with boolean result like `1 < bool 0`. #2558
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -66,12 +66,16 @@ func CanParallelize(expr parser.Expr, logger log.Logger) bool {
 		return err == nil && !nestedAggrs && CanParallelize(e.Expr, logger)
 
 	case *parser.BinaryExpr:
-		// Binary expressions can be parallelised when one of the sides is a constant scalar value
-		// and the other one can be parallelised and does not contain agggregations.
+		// Binary expressions can be parallelised when:
+		// - It's not a bool expr: bool expression should yield only one result, but sharding would provide many.
+		// - One of the sides is a constant scalar value
+		// - The other side:
+		//   - Is not a constant scalar value (because why would we shard then?)
+		//   - Does not contain aggregations
+		//
 		// If one side contained aggregations, like sum(foo) > 0, then aggregated values from different shards can cancel
 		// each other, like foo{shard="1"}=1 and foo{shard="2"}=-1: aggregated sum is zero, but if we concat results from different shards it's not.
-		// Both comparison and arithmetic binary operations _can_ be parallelised, but not all of them are worth parallelising,
-		// this function doesn't decide that.
+		//
 		// Since we don't care about the order in which binary op is written, we extract the condition into a lambda and check both ways.
 		parallelisable := func(a, b parser.Expr) bool {
 			return CanParallelize(a, logger) && noAggregates(a) && !isConstantScalar(a) && isConstantScalar(b)

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -74,7 +74,7 @@ func CanParallelize(expr parser.Expr, logger log.Logger) bool {
 		// this function doesn't decide that.
 		// Since we don't care about the order in which binary op is written, we extract the condition into a lambda and check both ways.
 		parallelisable := func(a, b parser.Expr) bool {
-			return CanParallelize(a, logger) && noAggregates(a) && isConstantScalar(b)
+			return CanParallelize(a, logger) && noAggregates(a) && !isConstantScalar(a) && isConstantScalar(b)
 		}
 		// If e.VectorMatching is not nil, then both hands are vector operators, so none of them is a constant scalar, so we can't shard it.
 		// It is just a shortcut, but the other two operations should imply the same.

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -78,7 +78,7 @@ func CanParallelize(expr parser.Expr, logger log.Logger) bool {
 		}
 		// If e.VectorMatching is not nil, then both hands are vector operators, so none of them is a constant scalar, so we can't shard it.
 		// It is just a shortcut, but the other two operations should imply the same.
-		return e.VectorMatching == nil && (parallelisable(e.LHS, e.RHS) || parallelisable(e.RHS, e.LHS))
+		return e.VectorMatching == nil && !e.ReturnBool && (parallelisable(e.LHS, e.RHS) || parallelisable(e.RHS, e.LHS))
 
 	case *parser.Call:
 		if e.Func == nil {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -60,6 +60,14 @@ func mockHandlerWith(resp *PrometheusResponse, err error) Handler {
 	})
 }
 
+func sampleStreamsStrings(ss []SampleStream) []string {
+	strs := make([]string, len(ss))
+	for i := range ss {
+		strs[i] = mimirpb.FromLabelAdaptersToMetric(ss[i].Labels).String()
+	}
+	return strs
+}
+
 // approximatelyEquals ensures two responses are approximately equal, up to 6 decimals precision per sample
 func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
 	// Ensure both queries succeeded.
@@ -71,7 +79,7 @@ func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
 	bs, err := responseToSamples(b)
 	require.Nil(t, err)
 
-	require.Equal(t, len(as), len(bs), "expected same number of series")
+	require.Equalf(t, len(as), len(bs), "expected same number of series: one contains %v, other %v", sampleStreamsStrings(as), sampleStreamsStrings(bs))
 
 	for i := 0; i < len(as); i++ {
 		a := as[i]
@@ -494,6 +502,14 @@ func TestQueryShardingCorrectness(t *testing.T) {
 		"0 < bool 1": {
 			query:                  `0 < bool 1`,
 			expectedShardedQueries: 0,
+		},
+		"scalar(metric_counter{const=\"fixed\"}) < bool 1": {
+			query:                  `scalar(metric_counter{const="fixed"}) < bool 1`,
+			expectedShardedQueries: 0,
+		},
+		"scalar(sum(metric_counter)) < bool 1": {
+			query:                  `scalar(sum(metric_counter)) < bool 1`,
+			expectedShardedQueries: 1,
 		},
 	}
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -491,6 +491,10 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			query:                  `month(sum(metric_counter)) > 0 and vector(1)`,
 			expectedShardedQueries: 1, // Sharded because the contents of `sum()` is sharded.
 		},
+		"0 < bool 1": {
+			query:                  `0 < bool 1`,
+			expectedShardedQueries: 0,
+		},
 	}
 
 	series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))


### PR DESCRIPTION
#### What this PR does

When both sides are constant scalar values, it doesn't make sense to shard them (plus it provides duplicate series).

#### Which issue(s) this PR fixes or relates to

No issue was created.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
