### PR TITLE
Optimize distributor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Grafana Mimir
 
-* [ENHANCEMENT] Distributor: Decreased distributor tests execution time. #2557
 * [CHANGE] Ingester: Added user label to ingester metric `cortex_ingester_tsdb_out_of_order_samples_appended_total`. On multitenant clusters this helps us find the rate of appended out-of-order samples for a specific tenant. #2493
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288
@@ -23,6 +22,7 @@
 * [FEATURE] Querier: enabled support for queries with negative offsets, which are not cached in the query results cache. #2429
 * [FEATURE] EXPERIMENTAL: OpenTelemetry Metrics ingestion path on `/otlp/v1/metrics`. #695 #2436
 * [FEATURE] Querier: Added support for tenant federation to metric metadata endpoint. #2467
+* [ENHANCEMENT] Distributor: Decreased distributor tests execution time. #2557
 * [ENHANCEMENT] Alertmanager: Allow the HTTP `proxy_url` configuration option in the receiver's configuration. #2317
 * [ENHANCEMENT] ring: optimize shuffle-shard computation when lookback is used, and all instances have registered timestamp within the lookback window. In that case we can immediately return origial ring, because we would select all instances anyway. #2309
 * [ENHANCEMENT] Memberlist: added experimental memberlist cluster label support via `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` CLI flags (and their respective YAML config options). #2354

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [ENHANCEMENT] Distributor: Decreased distributor tests execution time. #2557
 * [CHANGE] Ingester: Added user label to ingester metric `cortex_ingester_tsdb_out_of_order_samples_appended_total`. On multitenant clusters this helps us find the rate of appended out-of-order samples for a specific tenant. #2493
 * [CHANGE] Compactor: delete source and output blocks from local disk on compaction failed, to reduce likelihood that subsequent compactions fail because of no space left on disk. #2261
 * [CHANGE] Ruler: Remove unused CLI flags `-ruler.search-pending-for` and `-ruler.flush-period` (and their respective YAML config options). #2288

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * [FEATURE] Querier: enabled support for queries with negative offsets, which are not cached in the query results cache. #2429
 * [FEATURE] EXPERIMENTAL: OpenTelemetry Metrics ingestion path on `/otlp/v1/metrics`. #695 #2436
 * [FEATURE] Querier: Added support for tenant federation to metric metadata endpoint. #2467
-* [ENHANCEMENT] Distributor: Decreased distributor tests execution time. #2557
+* [ENHANCEMENT] Distributor: Decreased distributor tests execution time. #2562
 * [ENHANCEMENT] Alertmanager: Allow the HTTP `proxy_url` configuration option in the receiver's configuration. #2317
 * [ENHANCEMENT] ring: optimize shuffle-shard computation when lookback is used, and all instances have registered timestamp within the lookback window. In that case we can immediately return origial ring, because we would select all instances anyway. #2309
 * [ENHANCEMENT] Memberlist: added experimental memberlist cluster label support via `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` CLI flags (and their respective YAML config options). #2354

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1015,6 +1015,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 		}(tc)
 
 	}
+	wg.Wait()
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReached(t *testing.T) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -971,43 +971,49 @@ func TestDistributor_PushQuery(t *testing.T) {
 		}
 	}
 
+	wg := sync.WaitGroup{}
+	wg.Add(len(testcases))
 	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := prepConfig{
-				numIngesters:    tc.numIngesters,
-				happyIngesters:  tc.happyIngesters,
-				numDistributors: 1,
-			}
+		go func(tc testcase) {
+			defer wg.Done()
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := prepConfig{
+					numIngesters:    tc.numIngesters,
+					happyIngesters:  tc.happyIngesters,
+					numDistributors: 1,
+				}
 
-			cfg.shuffleShardSize = tc.shuffleShardSize
+				cfg.shuffleShardSize = tc.shuffleShardSize
 
-			ds, ingesters, _ := prepare(t, cfg)
+				ds, ingesters, _ := prepare(t, cfg)
 
-			request := makeWriteRequest(0, tc.samples, tc.metadata, false)
-			writeResponse, err := ds[0].Push(ctx, request)
-			assert.Equal(t, &mimirpb.WriteResponse{}, writeResponse)
-			assert.Nil(t, err)
+				request := makeWriteRequest(0, tc.samples, tc.metadata, false)
+				writeResponse, err := ds[0].Push(ctx, request)
+				assert.Equal(t, &mimirpb.WriteResponse{}, writeResponse)
+				assert.Nil(t, err)
 
-			series, err := ds[0].QueryStream(ctx, 0, 10, tc.matchers...)
-			assert.Equal(t, tc.expectedError, err)
+				series, err := ds[0].QueryStream(ctx, 0, 10, tc.matchers...)
+				assert.Equal(t, tc.expectedError, err)
 
-			var response model.Matrix
-			if series == nil {
-				response, err = chunkcompat.SeriesChunksToMatrix(0, 10, nil)
-			} else {
-				response, err = chunkcompat.SeriesChunksToMatrix(0, 10, series.Chunkseries)
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedResponse.String(), response.String())
+				var response model.Matrix
+				if series == nil {
+					response, err = chunkcompat.SeriesChunksToMatrix(0, 10, nil)
+				} else {
+					response, err = chunkcompat.SeriesChunksToMatrix(0, 10, series.Chunkseries)
+				}
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResponse.String(), response.String())
 
-			// Check how many ingesters have been queried.
-			// Due to the quorum the distributor could cancel the last request towards ingesters
-			// if all other ones are successful, so we're good either has been queried X or X-1
-			// ingesters.
-			if tc.expectedError == nil {
-				assert.Contains(t, []int{tc.expectedIngesters, tc.expectedIngesters - 1}, countMockIngestersCalls(ingesters, "QueryStream"))
-			}
-		})
+				// Check how many ingesters have been queried.
+				// Due to the quorum the distributor could cancel the last request towards ingesters
+				// if all other ones are successful, so we're good either has been queried X or X-1
+				// ingesters.
+				if tc.expectedError == nil {
+					assert.Contains(t, []int{tc.expectedIngesters, tc.expectedIngesters - 1}, countMockIngestersCalls(ingesters, "QueryStream"))
+				}
+			})
+		}(tc)
+
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Decrease tests execution time

Results in my machine:
Before:
```bash
go test -count=1 ./pkg/distributor/...
ok      github.com/grafana/mimir/pkg/distributor        91.661s
?       github.com/grafana/mimir/pkg/distributor/distributorpb  [no test files]
ok      github.com/grafana/mimir/pkg/distributor/forwarding     0.470s
```
After:
```bash
go test -count=1 ./pkg/distributor/... 
ok      github.com/grafana/mimir/pkg/distributor        34.071s
?       github.com/grafana/mimir/pkg/distributor/distributorpb  [no test files]
ok      github.com/grafana/mimir/pkg/distributor/forwarding     0.171s
```

#### Which issue(s) this PR fixes or relates to

Fixes #2557

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
