### PR TITLE
Chore: do not pass enabled flag to newSplitInstantQueryByIntervalMiddleware()

### DIFF
--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -221,7 +221,7 @@ func newQueryTripperware(
 	if cfg.SplitInstantQueriesByInterval > 0 {
 		queryInstantMiddleware = append(
 			queryInstantMiddleware,
-			newSplitInstantQueryByIntervalMiddleware(cfg.SplitInstantQueriesByInterval > 0, cfg.SplitInstantQueriesByInterval, limits, log, engine, registerer),
+			newSplitInstantQueryByIntervalMiddleware(cfg.SplitInstantQueriesByInterval, limits, log, engine, registerer),
 		)
 	}
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -28,7 +28,6 @@ type splitInstantQueryByIntervalMiddleware struct {
 
 	engine *promql.Engine
 
-	splitEnabled  bool
 	splitInterval time.Duration
 
 	instantQuerySplittingMetrics
@@ -76,7 +75,6 @@ func newInstantQuerySplittingMetrics(registerer prometheus.Registerer) instantQu
 
 // newSplitInstantQueryByIntervalMiddleware makes a new splitInstantQueryByIntervalMiddleware.
 func newSplitInstantQueryByIntervalMiddleware(
-	splitEnabled bool,
 	splitInterval time.Duration,
 	limits Limits,
 	logger log.Logger,
@@ -86,7 +84,6 @@ func newSplitInstantQueryByIntervalMiddleware(
 
 	return MiddlewareFunc(func(next Handler) Handler {
 		return &splitInstantQueryByIntervalMiddleware{
-			splitEnabled:                 splitEnabled,
 			next:                         next,
 			limits:                       limits,
 			splitInterval:                splitInterval,
@@ -109,7 +106,7 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Requ
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
-	if !s.splitEnabled || s.splitInterval <= 0 {
+	if s.splitInterval <= 0 {
 		return s.next.Do(ctx, req)
 	}
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -256,7 +256,7 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					require.NotEmpty(t, expectedPrometheusRes.Data.Result)
 					requireValidSamples(t, expectedPrometheusRes.Data.Result)
 
-					splittingware := newSplitInstantQueryByIntervalMiddleware(true, 1*time.Minute, mockLimits{}, log.NewNopLogger(), engine, reg)
+					splittingware := newSplitInstantQueryByIntervalMiddleware(1*time.Minute, mockLimits{}, log.NewNopLogger(), engine, reg)
 
 					// Run the query with splitting
 					splitRes, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)


### PR DESCRIPTION
#### What this PR does
We plug the middleware only when splitting has been enabled in the config, so there's no need to pass the `splittingEnabled bool` too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
