### PR TITLE
Fix overlapping time ranges when splitting instant queries

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -27,154 +27,154 @@ func TestInstantSplitter(t *testing.T) {
 		// Range vector aggregators
 		{
 			in:                   `avg_over_time({app="foo"}[3m])`,
-			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `))`,
+			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `))`,
 			expectedSplitQueries: 6,
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m])`,
-			out:                  `sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)`,
+			out:                  `sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `max_over_time({app="foo"}[3m])`,
-			out:                  `max without() (` + concatOffsets(splitInterval, 3, `max_over_time({app="foo"}[x]y)`) + `)`,
+			out:                  `max without() (` + concatOffsets(splitInterval, 3, true, `max_over_time({app="foo"}[x]y)`) + `)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `min_over_time({app="foo"}[3m])`,
-			out:                  `min without() (` + concatOffsets(splitInterval, 3, `min_over_time({app="foo"}[x]y)`) + `)`,
+			out:                  `min without() (` + concatOffsets(splitInterval, 3, true, `min_over_time({app="foo"}[x]y)`) + `)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `rate({app="foo"}[3m])`,
-			out:                  `sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180`,
+			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `sum_over_time({app="foo"}[3m])`,
-			out:                  `sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)`,
+			out:                  `sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)`,
 			expectedSplitQueries: 3,
 		},
 		// Vector aggregators
 		{
 			in:                   `avg(rate({app="foo"}[3m]))`,
-			out:                  `avg (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
+			out:                  `avg (sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg by (bar) (rate({app="foo"}[3m]))`,
-			out:                  `avg by (bar) (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
+			out:                  `avg by (bar) (sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `count(rate({app="foo"}[3m]))`,
-			out:                  `count (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
+			out:                  `count (sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `count by (bar) (rate({app="foo"}[3m]))`,
-			out:                  `count by (bar) (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
+			out:                  `count by (bar) (sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `max(rate({app="foo"}[3m]))`,
-			out:                  `max (sum (` + concatOffsets(splitInterval, 3, `max(increase({app="foo"}[x]y))`) + `) / 180)`,
+			out:                  `max (sum (` + concatOffsets(splitInterval, 3, true, `max(increase({app="foo"}[x]y))`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `max by (bar) (rate({app="foo"}[3m]))`,
-			out:                  `max by (bar) (sum by (bar) (` + concatOffsets(splitInterval, 3, `max by (bar) (increase({app="foo"}[x]y))`) + `) / 180)`,
+			out:                  `max by (bar) (sum by (bar) (` + concatOffsets(splitInterval, 3, true, `max by (bar) (increase({app="foo"}[x]y))`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `min(rate({app="foo"}[3m]))`,
-			out:                  `min (sum (` + concatOffsets(splitInterval, 3, `min(increase({app="foo"}[x]y))`) + `) / 180)`,
+			out:                  `min (sum (` + concatOffsets(splitInterval, 3, true, `min(increase({app="foo"}[x]y))`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `min by (bar) (rate({app="foo"}[3m]))`,
-			out:                  `min by (bar) (sum by (bar) (` + concatOffsets(splitInterval, 3, `min by (bar) (increase({app="foo"}[x]y))`) + `) / 180)`,
+			out:                  `min by (bar) (sum by (bar) (` + concatOffsets(splitInterval, 3, true, `min by (bar) (increase({app="foo"}[x]y))`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `sum(rate({app="foo"}[3m]))`,
-			out:                  `sum (sum (` + concatOffsets(splitInterval, 3, `sum(increase({app="foo"}[x]y))`) + `) / 180)`,
+			out:                  `sum (sum (` + concatOffsets(splitInterval, 3, true, `sum(increase({app="foo"}[x]y))`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `sum by (bar) (rate({app="foo"}[3m]))`,
-			out:                  `sum by (bar) (sum by (bar) (` + concatOffsets(splitInterval, 3, `sum by (bar) (increase({app="foo"}[x]y))`) + `) / 180)`,
+			out:                  `sum by (bar) (sum by (bar) (` + concatOffsets(splitInterval, 3, true, `sum by (bar) (increase({app="foo"}[x]y))`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `topk(10, rate({app="foo"}[3m]))`,
-			out:                  `topk(10, sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
+			out:                  `topk(10, sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `topk(10, sum(rate({app="foo"}[3m])))`,
-			out:                  `topk(10, sum(sum(` + concatOffsets(splitInterval, 3, `sum(increase({app="foo"}[x]y))`) + `) / 180))`,
+			out:                  `topk(10, sum(sum(` + concatOffsets(splitInterval, 3, true, `sum(increase({app="foo"}[x]y))`) + `) / 180))`,
 			expectedSplitQueries: 3,
 		},
 		// Binary operations
 		{
 			in:                   `rate({app="foo"}[3m]) / rate({app="baz"}[6m])`,
-			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180) / (sum without() (` + concatOffsets(splitInterval, 6, `increase({app="baz"}[x]y)`) + `) / 360)`,
+			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180) / (sum without() (` + concatOffsets(splitInterval, 6, true, `increase({app="baz"}[x]y)`) + `) / 360)`,
 			expectedSplitQueries: 9,
 		},
 		{
 			in:                   `rate({app="foo"}[3m]) / 10`,
-			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180) / (10)`,
+			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180) / (10)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `10 / rate({app="foo"}[3m])`,
-			out:                  `(10) / (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
+			out:                  `(10) / (sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `rate({app="foo"}[3m]) / rate({app="foo"}[3m]) > 0.5`,
-			out:                  `((sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180) / (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)) > (0.5)`,
+			out:                  `((sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180) / (sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180)) > (0.5)`,
 			expectedSplitQueries: 6,
 		},
 		// Should map inner binary operations
 		{
 			in:                   `sum(sum_over_time({app="foo"}[3m]) + count_over_time({app="foo"}[3m]))`,
-			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
+			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) + (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `)))`,
 			expectedSplitQueries: 6,
 		},
 		// Should map only left-hand side operand of inner binary operation, if right-hand side range interval is too small
 		{
 			in:                   `sum(sum_over_time({app="foo"}[3m]) + count_over_time({app="foo"}[1m]))`,
-			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) + ` + concat(`(count_over_time({app="foo"}[1m]))`) + `)`,
+			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) + ` + concat(`(count_over_time({app="foo"}[1m]))`) + `)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `sum_over_time({app="foo"}[3m]) * count_over_time({app="foo"}[1m])`,
-			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) * ` + concat(`(count_over_time({app="foo"}[1m]))`),
+			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) * ` + concat(`(count_over_time({app="foo"}[1m]))`),
 			expectedSplitQueries: 3,
 		},
 		// Should map only right-hand side operand of inner binary operation, if left-hand side range interval is too small
 		{
 			in:                   `sum(sum_over_time({app="foo"}[1m]) + count_over_time({app="foo"}[3m]))`,
-			out:                  `sum (` + concat(`(sum_over_time({app="foo"}[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
+			out:                  `sum (` + concat(`(sum_over_time({app="foo"}[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `)))`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `sum_over_time({app="foo"}[1m]) * count_over_time({app="foo"}[3m])`,
-			out:                  concat(`(sum_over_time({app="foo"}[1m]))`) + ` * (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `))`,
+			out:                  concat(`(sum_over_time({app="foo"}[1m]))`) + ` * (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `))`,
 			expectedSplitQueries: 3,
 		},
 		// Parenthesis expression
 		{
 			in:                   `(avg_over_time({app="foo"}[3m]))`,
-			out:                  `((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
+			out:                  `((sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `)))`,
 			expectedSplitQueries: 6,
 		},
 		// Vector aggregator of avg_over_time should not be moved downstream
 		{
 			in:                   `sum(avg_over_time({app="foo"}[3m]))`,
-			out:                  `sum((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
+			out:                  `sum((sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `)))`,
 			expectedSplitQueries: 6,
 		},
 		// Offset operator
@@ -185,7 +185,7 @@ func TestInstantSplitter(t *testing.T) {
 		},
 		{
 			in:                   `avg_over_time({app="foo"}[3m] offset 5m)`,
-			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset 7m)\",\"sum_over_time({app=\\\"foo\\\"}[1m] offset 6m)\",\"sum_over_time({app=\\\"foo\\\"}[1m] offset 5m)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 7m)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset 6m)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset 5m)\"]}"}))`,
+			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset 7m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 6m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 5m)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 7m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 6m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 5m)\"]}"}))`,
 			expectedSplitQueries: 6,
 		},
 		{
@@ -195,17 +195,17 @@ func TestInstantSplitter(t *testing.T) {
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m] offset -3m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset -1m)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset -2m)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset -3m)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset -1m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -2m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -3m)\"]}"})`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg_over_time({app="foo"}[3m] offset -5m)`,
-			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset -3m)\",\"sum_over_time({app=\\\"foo\\\"}[1m] offset -4m)\",\"sum_over_time({app=\\\"foo\\\"}[1m] offset -5m)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset -3m)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset -4m)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset -5m)\"]}"}))`,
+			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset -3m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset -4m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset -5m)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset -3m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -4m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -5m)\"]}"}))`,
 			expectedSplitQueries: 6,
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m] offset -30s)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 1m30s)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset 30s)\",\"count_over_time({app=\\\"foo\\\"}[1m] offset -30s)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 1m30s)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 30s)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -30s)\"]}"})`,
 			expectedSplitQueries: 3,
 		},
 		// @ modifier
@@ -216,12 +216,12 @@ func TestInstantSplitter(t *testing.T) {
 		},
 		{
 			in:                   `sum(sum_over_time({app="foo"}[3m] @ end()))`,
-			out:                  `sum(sum(__embedded_queries__{__queries__="{\"Concat\":[\"sum(sum_over_time({app=\\\"foo\\\"}[1m] @ end() offset 2m))\",\"sum(sum_over_time({app=\\\"foo\\\"}[1m] @ end() offset 1m))\",\"sum(sum_over_time({app=\\\"foo\\\"}[1m] @ end()))\"]}"}))`,
+			out:                  `sum(sum(__embedded_queries__{__queries__="{\"Concat\":[\"sum(sum_over_time({app=\\\"foo\\\"}[1m] @ end() offset 2m))\",\"sum(sum_over_time({app=\\\"foo\\\"}[59s999ms] @ end() offset 1m))\",\"sum(sum_over_time({app=\\\"foo\\\"}[59s999ms] @ end()))\"]}"}))`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg(avg_over_time({app="foo"}[3m] @ 1609746000))`,
-			out:                  `avg((sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"sum_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 1m)\",\"sum_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"count_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 1m)\",\"count_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000)\"]}"})))`,
+			out:                  `avg((sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000 offset 1m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000 offset 1m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000)\"]}"})))`,
 			expectedSplitQueries: 6,
 		},
 		// Should support both offset and @ operators
@@ -238,34 +238,34 @@ func TestInstantSplitter(t *testing.T) {
 		// Should split deeper in the tree if an inner expression is splittable
 		{
 			in:                   `topk(10, histogram_quantile(0.9, rate({app="foo"}[3m])))`,
-			out:                  `topk(10, histogram_quantile(0.9, sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180))`,
+			out:                  `topk(10, histogram_quantile(0.9, sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180))`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `stddev(rate(metric[3m]))`,
-			out:                  `stddev(sum without() (` + concatOffsets(splitInterval, 3, `increase(metric[x]y)`) + `) / 180)`,
+			out:                  `stddev(sum without() (` + concatOffsets(splitInterval, 3, true, `increase(metric[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `count_values("dst", count_over_time(metric[3m]))`,
-			out:                  `count_values("dst", sum without() (` + concatOffsets(splitInterval, 3, `count_over_time(metric[x]y)`) + `))`,
+			out:                  `count_values("dst", sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time(metric[x]y)`) + `))`,
 			expectedSplitQueries: 3,
 		},
 		// Multi-level vector aggregators should be moved downstream
 		{
 			in:                   `sum(max(rate({app="foo"}[3m])))`,
-			out:                  `sum(max(sum (` + concatOffsets(splitInterval, 3, `sum(max(increase({app="foo"}[x]y)))`) + `) / 180))`,
+			out:                  `sum(max(sum (` + concatOffsets(splitInterval, 3, true, `sum(max(increase({app="foo"}[x]y)))`) + `) / 180))`,
 			expectedSplitQueries: 3,
 		},
 		// Non-aggregative functions should not stop the mapping, cause children could be split anyway.
 		{
 			in:                   `label_replace(sum(sum_over_time(up[1m]) + count_over_time(up[3m])), "dst", "$1", "src", "(.*)")`,
-			out:                  `label_replace(sum(` + concat(`(sum_over_time(up[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time(up[x]y)`) + `))), "dst", "$1", "src", "(.*)")`,
+			out:                  `label_replace(sum(` + concat(`(sum_over_time(up[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time(up[x]y)`) + `))), "dst", "$1", "src", "(.*)")`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `ceil(sum(sum_over_time(up[1m]) + count_over_time(up[3m])))`,
-			out:                  `ceil(sum(` + concat(`(sum_over_time(up[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time(up[x]y)`) + `))))`,
+			out:                  `ceil(sum(` + concat(`(sum_over_time(up[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time(up[x]y)`) + `))))`,
 			expectedSplitQueries: 3,
 		},
 	} {
@@ -604,13 +604,13 @@ func TestGetOffsets(t *testing.T) {
 	}
 }
 
-func concatOffsets(splitInterval time.Duration, offsets int, queryTemplate string) string {
+func concatOffsets(splitInterval time.Duration, offsets int, overlapping bool, queryTemplate string) string {
 	queries := make([]string, offsets)
 	offsetIndex := offsets
 	for offset := range queries {
 		offsetIndex--
 		offsetSplitInterval := splitInterval
-		if offset > 0 {
+		if offset > 0 && !overlapping {
 			offsetSplitInterval -= time.Millisecond
 		}
 

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -303,18 +303,18 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 		},
 		{
 			in:                   `avg_over_time({app="foo"}[3m])`,
-			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset 2m)\",\"sum_over_time({app=\\\"foo\\\"}[2m])\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 2m)\",\"count_over_time({app=\\\"foo\\\"}[2m])\"]}"}))`,
+			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset 2m)\",\"sum_over_time({app=\\\"foo\\\"}[1m59s999ms])\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 2m)\",\"count_over_time({app=\\\"foo\\\"}[1m59s999ms])\"]}"}))`,
 			expectedSplitQueries: 4,
 		},
 		// Should support expressions with offset operator
 		{
 			in:                   `sum_over_time({app="foo"}[4m] offset 1m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[2m] offset 3m)\",\"sum_over_time({app=\\\"foo\\\"}[2m] offset 1m)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[2m] offset 3m)\",\"sum_over_time({app=\\\"foo\\\"}[1m59s999ms] offset 1m)\"]}"})`,
 			expectedSplitQueries: 2,
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m] offset 1m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 3m)\",\"count_over_time({app=\\\"foo\\\"}[2m] offset 1m)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 3m)\",\"count_over_time({app=\\\"foo\\\"}[1m59s999ms] offset 1m)\"]}"})`,
 			expectedSplitQueries: 2,
 		},
 	} {

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -608,7 +609,12 @@ func concatOffsets(splitInterval time.Duration, offsets int, queryTemplate strin
 	offsetIndex := offsets
 	for offset := range queries {
 		offsetIndex--
-		offsetQuery := fmt.Sprintf("[%s]%s", splitInterval, getSplitOffset(splitInterval, offsetIndex))
+		offsetSplitInterval := splitInterval
+		if offset > 0 {
+			offsetSplitInterval -= time.Millisecond
+		}
+
+		offsetQuery := fmt.Sprintf("[%s]%s", model.Duration(offsetSplitInterval), getSplitOffset(splitInterval, offsetIndex))
 		queries[offset] = strings.ReplaceAll(queryTemplate, "[x]y", offsetQuery)
 	}
 	return concat(queries...)

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -23,345 +23,353 @@ import (
 )
 
 func TestQuerySplittingCorrectness(t *testing.T) {
-	var (
-		numSeries          = 1000
-		numStaleSeries     = 100
-		numHistograms      = 1000
-		numStaleHistograms = 100
-		histogramBuckets   = []float64{1.0, 2.0, 4.0, 10.0, 100.0, math.Inf(1)}
-	)
+	for _, startString := range []string{
+		"2020-01-01T03:00:00.100Z",
+		"2020-01-01T03:00:00Z",
+	} {
+		t.Run(fmt.Sprintf("start=%s", startString), func(t *testing.T) {
+			start, err := time.Parse(time.RFC3339Nano, startString)
+			require.NoError(t, err)
+			end := start.Add(30 * time.Minute)
+			var (
+				numSeries          = 1000
+				numStaleSeries     = 100
+				numHistograms      = 1000
+				numStaleHistograms = 100
+				histogramBuckets   = []float64{1.0, 2.0, 4.0, 10.0, 100.0, math.Inf(1)}
+			)
 
-	tests := map[string]struct {
-		query                string
-		expectedSplitQueries int
-	}{
-		// Range vector aggregators
-		"avg_over_time": {
-			query:                `avg_over_time(metric_counter[3m])`,
-			expectedSplitQueries: 6,
-		},
-		"count_over_time": {
-			query:                `count_over_time(metric_counter[3m])`,
-			expectedSplitQueries: 3,
-		},
-		"max_over_time": {
-			query:                `max_over_time(metric_counter[3m])`,
-			expectedSplitQueries: 3,
-		},
-		"min_over_time": {
-			query:                `min_over_time(metric_counter[3m])`,
-			expectedSplitQueries: 3,
-		},
-		"rate": {
-			query:                `rate(metric_counter[3m])`,
-			expectedSplitQueries: 3,
-		},
-		"sum_over_time": {
-			query:                `sum_over_time(metric_counter[3m])`,
-			expectedSplitQueries: 3,
-		},
-		// Vector aggregators
-		"avg(rate)": {
-			query:                `avg(rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"avg(rate) grouping 'by'": {
-			query:                `avg by(group_1) (rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"count(rate)": {
-			query:                `count(rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"count(rate) grouping 'by'": {
-			query:                `count by(group_1) (rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"max(rate)": {
-			query:                `max(rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"max(rate) grouping 'by'": {
-			query:                `max by(group_1) (rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"min(rate)": {
-			query:                `min(rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"min(rate) grouping 'by'": {
-			query:                `min by(group_1) (rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"sum(rate)": {
-			query:                `sum(rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"sum(rate) grouping 'by'": {
-			query:                `sum by(group_1) (rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"sum(rate() or rate())": {
-			query:                `sum(rate(metric_counter{group_2="0"}[3m]) or rate(metric_counter{group_2="1"}[3m]))`,
-			expectedSplitQueries: 6,
-		},
-		"topk(rate)": {
-			query:                `topk(2, rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"topk(sum(rate))": {
-			query:                `topk(2, sum(rate(metric_counter[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"stddev(rate)": {
-			query:                `stddev(rate(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		"count_values(count_over_time)": {
-			query:                `count_values("dst", count_over_time(metric_counter[3m]))`,
-			expectedSplitQueries: 3,
-		},
-		// Binary operations
-		"rate / rate": {
-			query:                `rate(metric_counter[3m]) / rate(metric_counter[6m])`,
-			expectedSplitQueries: 9,
-		},
-		"rate / 10": {
-			query:                `rate(metric_counter[3m]) / 10`,
-			expectedSplitQueries: 3,
-		},
-		"10 / rate": {
-			query:                `10 / rate(metric_counter[3m])`,
-			expectedSplitQueries: 3,
-		},
-		"sum(sum_over_time + count_over_time)": {
-			query:                `sum(sum_over_time(metric_counter[3m]) + count_over_time(metric_counter[3m]))`,
-			expectedSplitQueries: 6,
-		},
-		"(avg_over_time)": {
-			query:                `(avg_over_time(metric_counter[3m]))`,
-			expectedSplitQueries: 6,
-		},
-		"sum(avg_over_time)": {
-			query:                `sum(avg_over_time(metric_counter[3m]))`,
-			expectedSplitQueries: 6,
-		},
-		"sum(max(rate))": {
-			query:                `sum(max(rate(metric_counter[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"rate(3m) / rate(3m) > 0.5": {
-			query:                `rate(metric_counter[3m]) / rate(metric_counter[3m]) > 0.5`,
-			expectedSplitQueries: 6,
-		},
-		// should not be mapped if both operands are not splittable
-		//   - first operand `rate(metric_counter[1m])` has a smaller range interval than the configured splitting
-		//   - second operand `rate(metric_counter[5h:5m])` is a subquery
-		"rate(1m) / rate(subquery) > 0.5": {
-			query:                `rate(metric_counter[1m]) / rate(metric_counter[5h:5m]) > 0.5`,
-			expectedSplitQueries: 0,
-		},
-		// Offset operator
-		"sum_over_time[3m] offset 3m": {
-			query:                `sum_over_time(metric_counter[3m] offset 3m)`,
-			expectedSplitQueries: 3,
-		},
-		"avg_over_time[3m] offset 5m": {
-			query:                `avg_over_time(metric_counter[3m] offset 5m)`,
-			expectedSplitQueries: 6,
-		},
-		"sum_over_time[3m] offset 30s": {
-			query:                `sum_over_time(metric_counter[3m] offset 30s)`,
-			expectedSplitQueries: 3,
-		},
-		"count_over_time[3m] offset -2m": {
-			query:                `sum_over_time(metric_counter[3m] offset -2m)`,
-			expectedSplitQueries: 3,
-		},
-		"avg_over_time[3m] offset -1m": {
-			query:                `avg_over_time(metric_counter[3m] offset -1m)`,
-			expectedSplitQueries: 6,
-		},
-		"count_over_time[3m] offset -30s": {
-			query:                `count_over_time(metric_counter[3m] offset -30s)`,
-			expectedSplitQueries: 3,
-		},
-		// @ modifier
-		"sum_over_time @ start()": {
-			query:                `sum_over_time(metric_counter[3m] @ start())`,
-			expectedSplitQueries: 3,
-		},
-		"sum(sum_over_time @ end())": {
-			query:                `sum(sum_over_time(metric_counter[3m] @ end()))`,
-			expectedSplitQueries: 3,
-		},
-		"avg(avg_over_time @ time.Now())": {
-			query:                fmt.Sprintf(`avg(avg_over_time(metric_counter[3m] @ %v))`, time.Now().Unix()),
-			expectedSplitQueries: 6,
-		},
-		"max_over_time @ time.Now() offset 1m)": {
-			query:                fmt.Sprintf(`max_over_time(metric_counter[3m] @ %v offset 1m)`, time.Now().Unix()),
-			expectedSplitQueries: 3,
-		},
-		"min_over_time offset 1m @ time.Now())": {
-			query:                fmt.Sprintf(`min_over_time(metric_counter[3m] offset 1m @ %v)`, time.Now().Unix()),
-			expectedSplitQueries: 3,
-		},
-		// Histograms
-		"histogram_quantile() grouping only 'by' le": {
-			query:                `histogram_quantile(0.5, sum by(le) (rate(metric_histogram_bucket[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"histogram_quantile() grouping 'by'": {
-			query:                `histogram_quantile(0.5, sum by(group_1, le) (rate(metric_histogram_bucket[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"histogram_quantile() grouping 'without'": {
-			query:                `histogram_quantile(0.5, sum without(group_1, group_2, unique) (rate(metric_histogram_bucket[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"histogram_quantile() with no effective grouping because all groups have 1 series": {
-			query:                `histogram_quantile(0.5, sum by(unique, le) (rate(metric_histogram_bucket{group_1="0"}[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		// Subqueries
-		"subquery sum_over_time": {
-			query:                `sum_over_time(metric_counter[1h:5m])`,
-			expectedSplitQueries: 0,
-		},
-		"subquery sum(rate)": {
-			query:                `sum(rate(metric_counter[30m:5s]))`,
-			expectedSplitQueries: 0,
-		},
-		"subquery sum grouping 'by'": {
-			query:                `sum(sum_over_time(metric_counter[1h:5m]) * 60) by (group_1)`,
-			expectedSplitQueries: 0,
-		},
-		// Splittable aggregations wrapped by non-aggregative functions.
-		"ceil(sum(sum_over_time()))": {
-			query:                `ceil(sum(sum_over_time(metric_counter[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"ceil(sum(sum_over_time()) + sum(sum_over_time())) and both legs of the binary operation are splittable": {
-			query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[3m])))`,
-			expectedSplitQueries: 6,
-		},
-		"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only right leg of the binary operation is splittable": {
-			query:                `ceil(sum(sum_over_time(metric_counter[1m])) + sum(sum_over_time(metric_counter[3m])))`,
-			expectedSplitQueries: 3,
-		},
-		"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only left leg of the binary operation is splittable": {
-			query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[1m])))`,
-			expectedSplitQueries: 3,
-		},
-	}
-
-	series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))
-	seriesID := 0
-
-	// Add counter series.
-	for i := 0; i < numSeries; i++ {
-		gen := factor(float64(i) * 0.1)
-		if i >= numSeries-numStaleSeries {
-			// Wrap the generator to inject the staleness marker between minute 10 and 20.
-			gen = stale(start.Add(10*time.Minute), start.Add(20*time.Minute), gen)
-		}
-
-		series = append(series, newSeries(newTestCounterLabels(seriesID), start.Add(-lookbackDelta), end, step, gen))
-		seriesID++
-	}
-
-	// Add a special series whose data points end earlier than the end of the queried time range
-	// and has NO stale marker.
-	series = append(series, newSeries(newTestCounterLabels(seriesID),
-		start.Add(-lookbackDelta), end.Add(-5*time.Minute), step, factor(2)))
-	seriesID++
-
-	// Add a special series whose data points end earlier than the end of the queried time range
-	// and HAS a stale marker at the end.
-	series = append(series, newSeries(newTestCounterLabels(seriesID),
-		start.Add(-lookbackDelta), end.Add(-5*time.Minute), step, stale(end.Add(-6*time.Minute), end.Add(-4*time.Minute), factor(2))))
-	seriesID++
-
-	// Add a special series whose data points start later than the start of the queried time range.
-	series = append(series, newSeries(newTestCounterLabels(seriesID),
-		start.Add(5*time.Minute), end, step, factor(2)))
-	seriesID++
-
-	// Add histogram series.
-	for i := 0; i < numHistograms; i++ {
-		for bucketIdx, bucketLe := range histogramBuckets {
-			// We expect each bucket to have a value higher than the previous one.
-			gen := factor(float64(i) * float64(bucketIdx) * 0.1)
-			if i >= numHistograms-numStaleHistograms {
-				// Wrap the generator to inject the staleness marker between minute 10 and 20.
-				gen = stale(start.Add(10*time.Minute), start.Add(20*time.Minute), gen)
-			}
-
-			series = append(series, newSeries(newTestHistogramLabels(seriesID, bucketLe),
-				start.Add(-lookbackDelta), end, step, gen))
-		}
-
-		// Increase the series ID after all per-bucket series have been created.
-		seriesID++
-	}
-
-	// Create a queryable on the fixtures.
-	queryable := storageSeriesQueryable(series)
-
-	for testName, testData := range tests {
-		// Change scope to ensure it work fine when test cases are executed concurrently.
-		testData := testData
-
-		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
-			reqs := []Request{
-				&PrometheusInstantQueryRequest{
-					Path:  "/query",
-					Time:  util.TimeToMillis(end),
-					Query: testData.query,
+			tests := map[string]struct {
+				query                string
+				expectedSplitQueries int
+			}{
+				// Range vector aggregators
+				"avg_over_time": {
+					query:                `avg_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 6,
+				},
+				"count_over_time": {
+					query:                `count_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"max_over_time": {
+					query:                `max_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"min_over_time": {
+					query:                `min_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"rate": {
+					query:                `rate(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"sum_over_time": {
+					query:                `sum_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				// Vector aggregators
+				"avg(rate)": {
+					query:                `avg(rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"avg(rate) grouping 'by'": {
+					query:                `avg by(group_1) (rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"count(rate)": {
+					query:                `count(rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"count(rate) grouping 'by'": {
+					query:                `count by(group_1) (rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"max(rate)": {
+					query:                `max(rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"max(rate) grouping 'by'": {
+					query:                `max by(group_1) (rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"min(rate)": {
+					query:                `min(rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"min(rate) grouping 'by'": {
+					query:                `min by(group_1) (rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sum(rate)": {
+					query:                `sum(rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sum(rate) grouping 'by'": {
+					query:                `sum by(group_1) (rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sum(rate() or rate())": {
+					query:                `sum(rate(metric_counter{group_2="0"}[3m]) or rate(metric_counter{group_2="1"}[3m]))`,
+					expectedSplitQueries: 6,
+				},
+				"topk(rate)": {
+					query:                `topk(2, rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"topk(sum(rate))": {
+					query:                `topk(2, sum(rate(metric_counter[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"stddev(rate)": {
+					query:                `stddev(rate(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"count_values(count_over_time)": {
+					query:                `count_values("dst", count_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				// Binary operations
+				"rate / rate": {
+					query:                `rate(metric_counter[3m]) / rate(metric_counter[6m])`,
+					expectedSplitQueries: 9,
+				},
+				"rate / 10": {
+					query:                `rate(metric_counter[3m]) / 10`,
+					expectedSplitQueries: 3,
+				},
+				"10 / rate": {
+					query:                `10 / rate(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"sum(sum_over_time + count_over_time)": {
+					query:                `sum(sum_over_time(metric_counter[3m]) + count_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 6,
+				},
+				"(avg_over_time)": {
+					query:                `(avg_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 6,
+				},
+				"sum(avg_over_time)": {
+					query:                `sum(avg_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 6,
+				},
+				"sum(max(rate))": {
+					query:                `sum(max(rate(metric_counter[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"rate(3m) / rate(3m) > 0.5": {
+					query:                `rate(metric_counter[3m]) / rate(metric_counter[3m]) > 0.5`,
+					expectedSplitQueries: 6,
+				},
+				// should not be mapped if both operands are not splittable
+				//   - first operand `rate(metric_counter[1m])` has a smaller range interval than the configured splitting
+				//   - second operand `rate(metric_counter[5h:5m])` is a subquery
+				"rate(1m) / rate(subquery) > 0.5": {
+					query:                `rate(metric_counter[1m]) / rate(metric_counter[5h:5m]) > 0.5`,
+					expectedSplitQueries: 0,
+				},
+				// Offset operator
+				"sum_over_time[3m] offset 3m": {
+					query:                `sum_over_time(metric_counter[3m] offset 3m)`,
+					expectedSplitQueries: 3,
+				},
+				"avg_over_time[3m] offset 5m": {
+					query:                `avg_over_time(metric_counter[3m] offset 5m)`,
+					expectedSplitQueries: 6,
+				},
+				"sum_over_time[3m] offset 30s": {
+					query:                `sum_over_time(metric_counter[3m] offset 30s)`,
+					expectedSplitQueries: 3,
+				},
+				"count_over_time[3m] offset -2m": {
+					query:                `sum_over_time(metric_counter[3m] offset -2m)`,
+					expectedSplitQueries: 3,
+				},
+				"avg_over_time[3m] offset -1m": {
+					query:                `avg_over_time(metric_counter[3m] offset -1m)`,
+					expectedSplitQueries: 6,
+				},
+				"count_over_time[3m] offset -30s": {
+					query:                `count_over_time(metric_counter[3m] offset -30s)`,
+					expectedSplitQueries: 3,
+				},
+				// @ modifier
+				"sum_over_time @ start()": {
+					query:                `sum_over_time(metric_counter[3m] @ start())`,
+					expectedSplitQueries: 3,
+				},
+				"sum(sum_over_time @ end())": {
+					query:                `sum(sum_over_time(metric_counter[3m] @ end()))`,
+					expectedSplitQueries: 3,
+				},
+				"avg(avg_over_time @ time.Now())": {
+					query:                fmt.Sprintf(`avg(avg_over_time(metric_counter[3m] @ %v))`, time.Now().Unix()),
+					expectedSplitQueries: 6,
+				},
+				"max_over_time @ time.Now() offset 1m)": {
+					query:                fmt.Sprintf(`max_over_time(metric_counter[3m] @ %v offset 1m)`, time.Now().Unix()),
+					expectedSplitQueries: 3,
+				},
+				"min_over_time offset 1m @ time.Now())": {
+					query:                fmt.Sprintf(`min_over_time(metric_counter[3m] offset 1m @ %v)`, time.Now().Unix()),
+					expectedSplitQueries: 3,
+				},
+				// Histograms
+				"histogram_quantile() grouping only 'by' le": {
+					query:                `histogram_quantile(0.5, sum by(le) (rate(metric_histogram_bucket[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"histogram_quantile() grouping 'by'": {
+					query:                `histogram_quantile(0.5, sum by(group_1, le) (rate(metric_histogram_bucket[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"histogram_quantile() grouping 'without'": {
+					query:                `histogram_quantile(0.5, sum without(group_1, group_2, unique) (rate(metric_histogram_bucket[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"histogram_quantile() with no effective grouping because all groups have 1 series": {
+					query:                `histogram_quantile(0.5, sum by(unique, le) (rate(metric_histogram_bucket{group_1="0"}[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				// Subqueries
+				"subquery sum_over_time": {
+					query:                `sum_over_time(metric_counter[1h:5m])`,
+					expectedSplitQueries: 0,
+				},
+				"subquery sum(rate)": {
+					query:                `sum(rate(metric_counter[30m:5s]))`,
+					expectedSplitQueries: 0,
+				},
+				"subquery sum grouping 'by'": {
+					query:                `sum(sum_over_time(metric_counter[1h:5m]) * 60) by (group_1)`,
+					expectedSplitQueries: 0,
+				},
+				// Splittable aggregations wrapped by non-aggregative functions.
+				"ceil(sum(sum_over_time()))": {
+					query:                `ceil(sum(sum_over_time(metric_counter[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and both legs of the binary operation are splittable": {
+					query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[3m])))`,
+					expectedSplitQueries: 6,
+				},
+				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only right leg of the binary operation is splittable": {
+					query:                `ceil(sum(sum_over_time(metric_counter[1m])) + sum(sum_over_time(metric_counter[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only left leg of the binary operation is splittable": {
+					query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[1m])))`,
+					expectedSplitQueries: 3,
 				},
 			}
 
-			for _, req := range reqs {
-				t.Run(fmt.Sprintf("%T", req), func(t *testing.T) {
-					reg := prometheus.NewPedanticRegistry()
-					engine := newEngine()
-					downstream := &downstreamHandler{
-						engine:    engine,
-						queryable: queryable,
+			series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))
+			seriesID := 0
+
+			// Add counter series.
+			for i := 0; i < numSeries; i++ {
+				gen := factor(float64(i) * 0.1)
+				if i >= numSeries-numStaleSeries {
+					// Wrap the generator to inject the staleness marker between minute 10 and 20.
+					gen = stale(start.Add(10*time.Minute), start.Add(20*time.Minute), gen)
+				}
+
+				series = append(series, newSeries(newTestCounterLabels(seriesID), start.Add(-lookbackDelta), end, step, gen))
+				seriesID++
+			}
+
+			// Add a special series whose data points end earlier than the end of the queried time range
+			// and has NO stale marker.
+			series = append(series, newSeries(newTestCounterLabels(seriesID),
+				start.Add(-lookbackDelta), end.Add(-5*time.Minute), step, factor(2)))
+			seriesID++
+
+			// Add a special series whose data points end earlier than the end of the queried time range
+			// and HAS a stale marker at the end.
+			series = append(series, newSeries(newTestCounterLabels(seriesID),
+				start.Add(-lookbackDelta), end.Add(-5*time.Minute), step, stale(end.Add(-6*time.Minute), end.Add(-4*time.Minute), factor(2))))
+			seriesID++
+
+			// Add a special series whose data points start later than the start of the queried time range.
+			series = append(series, newSeries(newTestCounterLabels(seriesID),
+				start.Add(5*time.Minute), end, step, factor(2)))
+			seriesID++
+
+			// Add histogram series.
+			for i := 0; i < numHistograms; i++ {
+				for bucketIdx, bucketLe := range histogramBuckets {
+					// We expect each bucket to have a value higher than the previous one.
+					gen := factor(float64(i) * float64(bucketIdx) * 0.1)
+					if i >= numHistograms-numStaleHistograms {
+						// Wrap the generator to inject the staleness marker between minute 10 and 20.
+						gen = stale(start.Add(10*time.Minute), start.Add(20*time.Minute), gen)
 					}
 
-					// Run the query with the normal engine
-					expectedRes, err := downstream.Do(context.Background(), req)
-					require.Nil(t, err)
-					expectedPrometheusRes := expectedRes.(*PrometheusResponse)
-					sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
+					series = append(series, newSeries(newTestHistogramLabels(seriesID, bucketLe),
+						start.Add(-lookbackDelta), end, step, gen))
+				}
 
-					// Ensure the query produces some results.
-					require.NotEmpty(t, expectedPrometheusRes.Data.Result)
-					requireValidSamples(t, expectedPrometheusRes.Data.Result)
+				// Increase the series ID after all per-bucket series have been created.
+				seriesID++
+			}
 
-					splittingware := newSplitInstantQueryByIntervalMiddleware(1*time.Minute, mockLimits{}, log.NewNopLogger(), engine, reg)
+			// Create a queryable on the fixtures.
+			queryable := storageSeriesQueryable(series)
 
-					// Run the query with splitting
-					splitRes, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-					require.Nil(t, err)
+			for testName, testData := range tests {
+				// Change scope to ensure it work fine when test cases are executed concurrently.
+				testData := testData
 
-					splitPrometheusRes := splitRes.(*PrometheusResponse)
-					sort.Sort(byLabels(splitPrometheusRes.Data.Result))
-
-					approximatelyEquals(t, expectedPrometheusRes, splitPrometheusRes)
-
-					// Assert metrics
-					expectedSucceeded := 1
-					expectedNoop := 0
-					if testData.expectedSplitQueries == 0 {
-						expectedSucceeded = 0
-						expectedNoop = 1
+				t.Run(testName, func(t *testing.T) {
+					t.Parallel()
+					reqs := []Request{
+						&PrometheusInstantQueryRequest{
+							Path:  "/query",
+							Time:  util.TimeToMillis(end),
+							Query: testData.query,
+						},
 					}
 
-					assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					for _, req := range reqs {
+						t.Run(fmt.Sprintf("%T", req), func(t *testing.T) {
+							reg := prometheus.NewPedanticRegistry()
+							engine := newEngine()
+							downstream := &downstreamHandler{
+								engine:    engine,
+								queryable: queryable,
+							}
+
+							// Run the query with the normal engine
+							expectedRes, err := downstream.Do(context.Background(), req)
+							require.Nil(t, err)
+							expectedPrometheusRes := expectedRes.(*PrometheusResponse)
+							sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
+
+							// Ensure the query produces some results.
+							require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+							requireValidSamples(t, expectedPrometheusRes.Data.Result)
+
+							splittingware := newSplitInstantQueryByIntervalMiddleware(1*time.Minute, mockLimits{}, log.NewNopLogger(), engine, reg)
+
+							// Run the query with splitting
+							splitRes, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+							require.Nil(t, err)
+
+							splitPrometheusRes := splitRes.(*PrometheusResponse)
+							sort.Sort(byLabels(splitPrometheusRes.Data.Result))
+
+							approximatelyEquals(t, expectedPrometheusRes, splitPrometheusRes)
+
+							// Assert metrics
+							expectedSucceeded := 1
+							expectedNoop := 0
+							if testData.expectedSplitQueries == 0 {
+								expectedSucceeded = 0
+								expectedNoop = 1
+							}
+
+							assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 						# HELP cortex_frontend_instant_query_splitting_rewrites_attempted_total Total number of instant queries the query-frontend attempted to split by interval.
 						# TYPE cortex_frontend_instant_query_splitting_rewrites_attempted_total counter
 						cortex_frontend_instant_query_splitting_rewrites_attempted_total 1
@@ -380,10 +388,12 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 						cortex_frontend_instant_query_splitting_rewrites_skipped_total{reason="mapping-failed"} 0
 						cortex_frontend_instant_query_splitting_rewrites_skipped_total{reason="noop"} %d
 					`, testData.expectedSplitQueries, expectedSucceeded, expectedNoop)),
-						"cortex_frontend_instant_query_splitting_rewrites_attempted_total",
-						"cortex_frontend_instant_query_split_queries_total",
-						"cortex_frontend_instant_query_splitting_rewrites_succeeded_total",
-						"cortex_frontend_instant_query_splitting_rewrites_skipped_total"))
+								"cortex_frontend_instant_query_splitting_rewrites_attempted_total",
+								"cortex_frontend_instant_query_split_queries_total",
+								"cortex_frontend_instant_query_splitting_rewrites_succeeded_total",
+								"cortex_frontend_instant_query_splitting_rewrites_skipped_total"))
+						})
+					}
 				})
 			}
 		})

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -204,16 +204,16 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					query:                `sum(sum_over_time(metric_counter[3m] @ end()))`,
 					expectedSplitQueries: 3,
 				},
-				"avg(avg_over_time @ time.Now())": {
-					query:                fmt.Sprintf(`avg(avg_over_time(metric_counter[3m] @ %v))`, time.Now().Unix()),
+				"avg(avg_over_time @ `start`)": {
+					query:                fmt.Sprintf(`avg(avg_over_time(metric_counter[3m] @ %v))`, start.Unix()),
 					expectedSplitQueries: 6,
 				},
-				"max_over_time @ time.Now() offset 1m)": {
-					query:                fmt.Sprintf(`max_over_time(metric_counter[3m] @ %v offset 1m)`, time.Now().Unix()),
+				"max_over_time @ `start` offset 1m)": {
+					query:                fmt.Sprintf(`max_over_time(metric_counter[3m] @ %v offset 1m)`, start.Unix()),
 					expectedSplitQueries: 3,
 				},
-				"min_over_time offset 1m @ time.Now())": {
-					query:                fmt.Sprintf(`min_over_time(metric_counter[3m] offset 1m @ %v)`, time.Now().Unix()),
+				"min_over_time offset 1m @ `start`)": {
+					query:                fmt.Sprintf(`min_over_time(metric_counter[3m] offset 1m @ %v)`, start.Unix()),
 					expectedSplitQueries: 3,
 				},
 				// Histograms

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -31,7 +31,7 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 		t.Run(fmt.Sprintf("start=%s", startString), func(t *testing.T) {
 			start, err := time.Parse(time.RFC3339Nano, startString)
 			require.NoError(t, err)
-			end := start.Add(30 * time.Minute)
+
 			var (
 				numSeries          = 1000
 				numStaleSeries     = 100
@@ -267,6 +267,7 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 
 			series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))
 			seriesID := 0
+			end := start.Add(30 * time.Minute)
 
 			// Add counter series.
 			for i := 0; i < numSeries; i++ {

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -26,6 +26,7 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 	for _, startString := range []string{
 		"2020-01-01T03:00:00.100Z",
 		"2020-01-01T03:00:00Z",
+		time.Now().Format(time.RFC3339Nano),
 	} {
 		t.Run(fmt.Sprintf("start=%s", startString), func(t *testing.T) {
 			start, err := time.Parse(time.RFC3339Nano, startString)


### PR DESCRIPTION
#### What this PR does

Fixes range splitting for `sum_over_time` and `count_over_time`, avoiding the overlaps in the ranges.

See the comment in the code that explains why we have to do this.

First commit is just adding the failing test case: now we run the tests with start aligned to a second, and start not aligned to a second. Honestly, I don't like the fact that with 3 nested tests Goland doesn't allow me run a specific testcase anymore, but I can't find a cleaner way to do this since we should test both.

#### Which issue(s) this PR fixes or relates to

Refers to a task of https://github.com/grafana/mimir-squad/issues/774

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
