### PR TITLE
Ensure binary operation is not mapped if operands are not split

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -184,18 +184,18 @@ func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr, stats *MapperSt
 	if err != nil {
 		return nil, false, err
 	}
-	finished = lhsFinished || rhsFinished
-	// Wrap binary operands in parentheses expression
-	if finished {
+	// if query was split and at least one operand successfully finished, the binary operations is mapped.
+	// The binary operands need to be wrapped in a parentheses' expression to ensure operator precedence.
+	if stats.GetShardedQueries() > 0 && (lhsFinished || rhsFinished) {
 		expr.LHS = &parser.ParenExpr{
 			Expr: lhsMapped,
 		}
 		expr.RHS = &parser.ParenExpr{
 			Expr: rhsMapped,
 		}
+		return expr, true, nil
 	}
-
-	return expr, finished, nil
+	return expr, false, nil
 }
 
 // mapParenExpr maps parenthesis expression expr

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -267,6 +267,14 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		{
 			noop: `20 / 10`,
 		},
+		// should be noop if binary operation is not mapped
+		{
+			noop: `rate({app="foo"}[1m]) / rate({app="bar"}[1m]) > 0.5`,
+		},
+		// should be noop if inner binary operation is not mapped
+		{
+			noop: `sum(rate({app="foo"}[1h:5m]) * 60) by (bar)`,
+		},
 	} {
 		tt := tt
 

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -273,6 +273,14 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		{
 			query: `(20) / (10)`,
 		},
+		// should be noop if binary operation is not mapped
+		{
+			query: `rate({app="foo"}[1m]) / rate({app="bar"}[1m]) > 0.5`,
+		},
+		// should be noop if inner binary operation is not mapped
+		{
+			query: `sum(rate({app="foo"}[1h:5m]) * 60) by (bar)`,
+		},
 		// should be noop if subquery
 		{
 			query: `sum_over_time(metric_counter[1h:5m])`,
@@ -282,14 +290,6 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		},
 		{
 			query: `sum(avg_over_time(metric_counter[1h:5m])) by (bar)`,
-		},
-		// should be noop if binary operation is not mapped
-		{
-			noop: `rate({app="foo"}[1m]) / rate({app="bar"}[1m]) > 0.5`,
-		},
-		// should be noop if inner binary operation is not mapped
-		{
-			noop: `sum(rate({app="foo"}[1h:5m]) * 60) by (bar)`,
 		},
 	} {
 		tt := tt

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -131,6 +131,11 @@ func TestInstantSplitter(t *testing.T) {
 			out:                  `(10) / (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)`,
 			expectedSplitQueries: 3,
 		},
+		{
+			in:                   `rate({app="foo"}[3m]) / rate({app="foo"}[3m]) > 0.5`,
+			out:                  `((sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180) / (sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180)) > (0.5)`,
+			expectedSplitQueries: 6,
+		},
 		// Should map inner binary operations
 		{
 			in:                   `sum(sum_over_time({app="foo"}[3m]) + count_over_time({app="foo"}[3m]))`,
@@ -274,8 +279,10 @@ func TestInstantSplitterNoOp(t *testing.T) {
 			query: `(20) / (10)`,
 		},
 		// should be noop if binary operation is not mapped
+		//   - first operand `rate(metric_counter[1m])` has a smaller range interval than the configured splitting
+		//   - second operand `rate(metric_counter[5h:5m])` is a subquery
 		{
-			query: `rate({app="foo"}[1m]) / rate({app="bar"}[1m]) > 0.5`,
+			query: `rate({app="foo"}[1m]) / rate({app="bar"}[5h:5m]) > 0.5`,
 		},
 		// should be noop if inner binary operation is not mapped
 		{

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -142,6 +142,10 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 			query:                `sum(max(rate(metric_counter[3m])))`,
 			expectedSplitQueries: 3,
 		},
+		"rate / rate > 0.5": {
+			query:                `rate(metric_counter[1m]) / rate(metric_counter[1m]) > 0.5`,
+			expectedSplitQueries: 0,
+		},
 		// Histograms
 		"histogram_quantile() grouping only 'by' le": {
 			query:                `histogram_quantile(0.5, sum by(le) (rate(metric_histogram_bucket[3m])))`,
@@ -161,7 +165,7 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 		},
 		// Subqueries
 		"subquery": {
-			query:                `sum(sum_over_time(metric_counter[1h:1m]) * 60) by (group_1)`,
+			query:                `sum(sum_over_time(metric_counter[1h:5m]) * 60) by (group_1)`,
 			expectedSplitQueries: 0,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Ensure binary operation is not mapped if operands are not split. This is done by checking the `stats.GetShardedQueries()` metric.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
