### PR TITLE
Instant query split by interval: fix pushdown of all vector selectors and split binary operations when only one leg is splittable

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -269,7 +269,7 @@ func (i *instantSplitter) mapCallAvgOverTime(expr *parser.Call, stats *MapperSta
 func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
 	// In case the range interval is smaller than the configured split interval,
 	// don't split it and don't map further nodes (finished=true).
-	rangeInterval, canSplit := i.assertRangeInterval(expr)
+	rangeInterval, canSplit := i.assertSplittableRangeInterval(expr)
 	if !canSplit {
 		return expr, true, nil
 	}
@@ -307,7 +307,7 @@ func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (ma
 func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, stats *MapperStats, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
 	// In case the range interval is smaller than the configured split interval,
 	// don't split it and don't map further nodes (finished=true).
-	rangeInterval, canSplit := i.assertRangeInterval(expr)
+	rangeInterval, canSplit := i.assertSplittableRangeInterval(expr)
 	if !canSplit {
 		return expr, true, nil
 	}
@@ -391,9 +391,9 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, stats *MapperSta
 	return squashExpr, true, nil
 }
 
-// assertRangeInterval returns the range interval specified in the input expr and whether it is greater than
+// assertSplittableRangeInterval returns the range interval specified in the input expr and whether it is greater than
 // the configured split interval.
-func (i *instantSplitter) assertRangeInterval(expr parser.Expr) (rangeInterval time.Duration, canSplit bool) {
+func (i *instantSplitter) assertSplittableRangeInterval(expr parser.Expr) (rangeInterval time.Duration, canSplit bool) {
 	rangeInterval = getRangeInterval(expr)
 	if rangeInterval > i.interval {
 		return rangeInterval, true

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -316,7 +316,6 @@ func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, stats *Map
 }
 
 func (i *instantSplitter) mapCallByRangeInterval(expr *parser.Call, stats *MapperStats, rangeInterval time.Duration, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
-
 	// Default grouping is 'without' for concatenating the embedded queries
 	var grouping []string
 	groupingWithout := true

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -64,11 +64,16 @@ var splittableRangeVectorAggregators = map[string]bool{
 
 // NewInstantQuerySplitter creates a new query range mapper.
 func NewInstantQuerySplitter(interval time.Duration, logger log.Logger) ASTMapper {
-	return NewASTExprMapper(
+	instantQueryMapper := NewASTExprMapper(
 		&instantSplitter{
 			interval: interval,
 			logger:   logger,
 		},
+	)
+
+	return NewMultiMapper(
+		instantQueryMapper,
+		newSubtreeFolder(),
 	)
 }
 
@@ -216,28 +221,21 @@ func (i *instantSplitter) mapParenExpr(expr *parser.ParenExpr, stats *MapperStat
 
 // mapCall maps a function call if it's a range vector aggregator.
 func (i *instantSplitter) mapCall(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
-	// In case the range interval is smaller than the configured split interval,
-	// don't split it and don't map further nodes (finished=true)
-	rangeInterval := getRangeInterval(expr)
-	if rangeInterval <= i.interval {
-		level.Debug(i.logger).Log("msg", "unable to split expression because range interval is smaller than configured split interval", "expr", expr, "interval", i.interval)
-		return expr, true, nil
-	}
-
 	switch expr.Func.Name {
 	case avgOverTime:
 		return i.mapCallAvgOverTime(expr, stats)
 	case countOverTime:
-		return i.mapCallByRangeInterval(expr, stats, rangeInterval, parser.SUM)
+		return i.mapCallVectorAggregation(expr, stats, parser.SUM)
 	case maxOverTime:
-		return i.mapCallByRangeInterval(expr, stats, rangeInterval, parser.MAX)
+		return i.mapCallVectorAggregation(expr, stats, parser.MAX)
 	case minOverTime:
-		return i.mapCallByRangeInterval(expr, stats, rangeInterval, parser.MIN)
+		return i.mapCallVectorAggregation(expr, stats, parser.MIN)
 	case rate:
-		return i.mapCallRate(expr, stats, rangeInterval)
+		return i.mapCallRate(expr, stats)
 	case sumOverTime:
-		return i.mapCallByRangeInterval(expr, stats, rangeInterval, parser.SUM)
+		return i.mapCallVectorAggregation(expr, stats, parser.SUM)
 	default:
+		// Continue the mapping on child expressions.
 		return expr, false, nil
 	}
 }
@@ -268,7 +266,14 @@ func (i *instantSplitter) mapCallAvgOverTime(expr *parser.Call, stats *MapperSta
 }
 
 // mapCallRate maps a rate function to expression increase / rangeInterval
-func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats, rangeInterval time.Duration) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+	// In case the range interval is smaller than the configured split interval,
+	// don't split it and don't map further nodes (finished=true).
+	rangeInterval, canSplit := i.assertRangeInterval(expr)
+	if !canSplit {
+		return expr, true, nil
+	}
+
 	increaseExpr := &parser.Call{
 		Func:     parser.Functions[increase],
 		Args:     expr.Args,
@@ -299,7 +304,19 @@ func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats, ran
 	}, true, nil
 }
 
+func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, stats *MapperStats, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
+	// In case the range interval is smaller than the configured split interval,
+	// don't split it and don't map further nodes (finished=true).
+	rangeInterval, canSplit := i.assertRangeInterval(expr)
+	if !canSplit {
+		return expr, true, nil
+	}
+
+	return i.mapCallByRangeInterval(expr, stats, rangeInterval, op)
+}
+
 func (i *instantSplitter) mapCallByRangeInterval(expr *parser.Call, stats *MapperStats, rangeInterval time.Duration, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
+
 	// Default grouping is 'without' for concatenating the embedded queries
 	var grouping []string
 	groupingWithout := true
@@ -373,6 +390,18 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, stats *MapperSta
 	stats.AddShardedQueries(splitCount)
 
 	return squashExpr, true, nil
+}
+
+// assertRangeInterval returns the range interval specified in the input expr and whether it is greater than
+// the configured split interval.
+func (i *instantSplitter) assertRangeInterval(expr parser.Expr) (rangeInterval time.Duration, canSplit bool) {
+	rangeInterval = getRangeInterval(expr)
+	if rangeInterval > i.interval {
+		return rangeInterval, true
+	}
+
+	level.Debug(i.logger).Log("msg", "unable to split expression because range interval is smaller than configured split interval", "expr", expr, "range_interval", rangeInterval, "split_interval", i.interval)
+	return time.Duration(0), false
 }
 
 // getRangeInterval returns the range interval in the range vector expression

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -145,13 +145,13 @@ func TestInstantSplitter(t *testing.T) {
 		// Should map only left-hand side operand of inner binary operation, if right-hand side range interval is too small
 		{
 			in:                   `sum(sum_over_time({app="foo"}[3m]) + count_over_time({app="foo"}[1m]))`,
-			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) + (count_over_time({app="foo"}[1m])))`,
+			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) + ` + concat(`(count_over_time({app="foo"}[1m]))`) + `)`,
 			expectedSplitQueries: 3,
 		},
 		// Should map only right-hand side operand of inner binary operation, if left-hand side range interval is too small
 		{
 			in:                   `sum(sum_over_time({app="foo"}[1m]) + count_over_time({app="foo"}[3m]))`,
-			out:                  `sum ((sum_over_time({app="foo"}[1m])) + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
+			out:                  `sum (` + concat(`(sum_over_time({app="foo"}[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
 			expectedSplitQueries: 3,
 		},
 		// Parenthesis expression
@@ -176,6 +176,17 @@ func TestInstantSplitter(t *testing.T) {
 		{
 			in:                   `sum(max(rate({app="foo"}[3m])))`,
 			out:                  `sum(max(sum (` + concatOffsets(splitInterval, 3, `sum(max(increase({app="foo"}[x]y)))`) + `) / 180))`,
+			expectedSplitQueries: 3,
+		},
+		// Non-aggregative functions should not stop the mapping, cause children could be split anyway.
+		{
+			in:                   `label_replace(sum(sum_over_time(up[1m]) + count_over_time(up[3m])), "dst", "$1", "src", "(.*)")`,
+			out:                  `label_replace(sum(` + concat(`(sum_over_time(up[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time(up[x]y)`) + `))), "dst", "$1", "src", "(.*)")`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `ceil(sum(sum_over_time(up[1m]) + count_over_time(up[3m])))`,
+			out:                  `ceil(sum(` + concat(`(sum_over_time(up[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time(up[x]y)`) + `))))`,
 			expectedSplitQueries: 3,
 		},
 	} {
@@ -306,10 +317,12 @@ func TestInstantSplitterNoOp(t *testing.T) {
 			require.NoError(t, err)
 
 			stats := NewMapperStats()
-			mapped, err := splitter.Map(expr, stats)
-			require.NoError(t, err)
-			require.Equal(t, expr.String(), mapped.String())
 
+			// Do not assert if the mapped expression is equal to the input one, because it could actually be slightly
+			// transformed (e.g. added parenthesis). The actual way to check if it was split or not is to read it from
+			// the statistics.
+			_, err = splitter.Map(expr, stats)
+			require.NoError(t, err)
 			assert.Equal(t, 0, stats.GetShardedQueries())
 		})
 	}

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -148,10 +148,20 @@ func TestInstantSplitter(t *testing.T) {
 			out:                  `sum ((sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) + ` + concat(`(count_over_time({app="foo"}[1m]))`) + `)`,
 			expectedSplitQueries: 3,
 		},
+		{
+			in:                   `sum_over_time({app="foo"}[3m]) * count_over_time({app="foo"}[1m])`,
+			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, `sum_over_time({app="foo"}[x]y)`) + `)) * ` + concat(`(count_over_time({app="foo"}[1m]))`),
+			expectedSplitQueries: 3,
+		},
 		// Should map only right-hand side operand of inner binary operation, if left-hand side range interval is too small
 		{
 			in:                   `sum(sum_over_time({app="foo"}[1m]) + count_over_time({app="foo"}[3m]))`,
 			out:                  `sum (` + concat(`(sum_over_time({app="foo"}[1m]))`) + ` + (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `)))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `sum_over_time({app="foo"}[1m]) * count_over_time({app="foo"}[3m])`,
+			out:                  concat(`(sum_over_time({app="foo"}[1m]))`) + ` * (sum without() (` + concatOffsets(splitInterval, 3, `count_over_time({app="foo"}[x]y)`) + `))`,
 			expectedSplitQueries: 3,
 		},
 		// Parenthesis expression

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -183,6 +183,19 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 			query:                `sum(sum_over_time(metric_counter[1h:5m]) * 60) by (group_1)`,
 			expectedSplitQueries: 0,
 		},
+		// Splittable aggregations wrapped by non-aggregative functions.
+		"ceil(sum(sum_over_time()))": {
+			query:                `ceil(sum(sum_over_time(metric_counter[3m])))`,
+			expectedSplitQueries: 3,
+		},
+		"ceil(sum(sum_over_time()) + sum(sum_over_time())) and both legs of the binary operation are splittable": {
+			query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[3m])))`,
+			expectedSplitQueries: 6,
+		},
+		"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only right leg of the binary operation is splittable": {
+			query:                `ceil(sum(sum_over_time(metric_counter[1m])) + sum(sum_over_time(metric_counter[3m])))`,
+			expectedSplitQueries: 3,
+		},
 	}
 
 	series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -196,6 +196,10 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 			query:                `ceil(sum(sum_over_time(metric_counter[1m])) + sum(sum_over_time(metric_counter[3m])))`,
 			expectedSplitQueries: 3,
 		},
+		"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only left leg of the binary operation is splittable": {
+			query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[1m])))`,
+			expectedSplitQueries: 3,
+		},
 	}
 
 	series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))


### PR DESCRIPTION
#### What this PR does
This PR fixes three issues which are all correlated:
1. Fix pushdown of all vector selectors (I think this is a serious one)
2. Split binary operations when only one leg is splittable (i.e. only one leg has a range interval > split interval)

##### Fix pushdown of all vector selectors

The query-frontend is **not** capable of fetching any samples to run a PromQL query directly from ingesters or store-gateways. This means that every single vector selector needs to be pushed down to queriers. The way this is implemented in the query sharding is using `subtreeFolder`. This PR fixes it using it for instant queries splitting too.

##### Split binary operations when only one leg is splittable

To fix this, I've changed the logic in `instantSplitter.mapCall()`. We need to make sure the expression range interval is detected as latest as possible, so I pushed it down to `instantSplitter.mapCallXXX()` functions.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
