### PR TITLE
Remove upfront check whether an instant query is splittable or not

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -53,15 +53,6 @@ const (
 	sumOverTime   = "sum_over_time"
 )
 
-var splittableRangeVectorAggregators = map[string]bool{
-	avgOverTime:   true,
-	countOverTime: true,
-	maxOverTime:   true,
-	minOverTime:   true,
-	rate:          true,
-	sumOverTime:   true,
-}
-
 // NewInstantQuerySplitter creates a new query range mapper.
 func NewInstantQuerySplitter(interval time.Duration, logger log.Logger) ASTMapper {
 	return NewASTExprMapper(
@@ -74,12 +65,6 @@ func NewInstantQuerySplitter(interval time.Duration, logger log.Logger) ASTMappe
 
 // MapExpr returns expr mapped as embedded queries
 func (i *instantSplitter) MapExpr(expr parser.Expr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
-	if !isSplittable(expr) {
-		level.Debug(i.logger).Log("msg", "expr is not supported for split by interval", "expr", expr)
-		// If no node in the tree is splittable, finish the AST traversal
-		return expr, true, nil
-	}
-
 	// Immediately clone the expr to avoid mutating the original
 	expr, err = cloneExpr(expr)
 	if err != nil {
@@ -106,33 +91,6 @@ func (i *instantSplitter) copyWithEmbeddedExpr(embeddedExpr *parser.AggregateExp
 	instantSplitter := *i
 	instantSplitter.outerAggregationExpr = embeddedExpr
 	return &instantSplitter
-}
-
-// isSplittable returns whether it is possible to optimize the given sample expression.
-func isSplittable(expr parser.Expr) bool {
-	switch e := expr.(type) {
-	case *parser.AggregateExpr:
-		// A vector aggregation is splittable, if the aggregation operation is supported and the inner expression is also splittable.
-		return supportedVectorAggregators[e.Op] && isSplittable(e.Expr)
-	case *parser.BinaryExpr:
-		// A binary expression is splittable, if at least one operand is splittable.
-		return isSplittable(e.LHS) || isSplittable(e.RHS)
-	case *parser.Call:
-		// A range aggregation is splittable, if the aggregation operation is supported.
-		if splittableRangeVectorAggregators[e.Func.Name] {
-			return true
-		}
-		// It is considered splittable if at least a Call argument is splittable
-		for _, arg := range e.Args {
-			if isSplittable(arg) {
-				return true
-			}
-		}
-		return false
-	case *parser.ParenExpr:
-		return isSplittable(e.Expr)
-	}
-	return false
 }
 
 // mapAggregatorExpr maps vector aggregator expression expr
@@ -169,11 +127,11 @@ func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr, stats *MapperSt
 	// Therefore, the embedded aggregator expression needs to be reset.
 	i.outerAggregationExpr = nil
 
-	// Noop if both LHS and RHS are literal numbers
-	_, literalLHS := expr.LHS.(*parser.NumberLiteral)
-	_, literalRHS := expr.RHS.(*parser.NumberLiteral)
-	if literalLHS && literalRHS {
-		return expr, false, fmt.Errorf("both operands of binary expression are number literals '%s'", expr)
+	// Noop if both LHS and RHS are constant scalars.
+	isLHSConst := isConstantScalar(expr.LHS)
+	isRHSConst := isConstantScalar(expr.RHS)
+	if isLHSConst && isRHSConst {
+		return expr, true, nil
 	}
 
 	lhsMapped, lhsFinished, err := i.MapExpr(expr.LHS, stats)

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -24,17 +24,6 @@ type instantSplitter struct {
 
 // Supported vector aggregators
 
-// Note: avg, count and topk are supported, but not splittable, i.e., cannot be sent downstream,
-// but the inner expressions can still be splittable
-var supportedVectorAggregators = map[parser.ItemType]bool{
-	parser.AVG:   true,
-	parser.COUNT: true,
-	parser.MAX:   true,
-	parser.MIN:   true,
-	parser.SUM:   true,
-	parser.TOPK:  true,
-}
-
 var splittableVectorAggregators = map[parser.ItemType]bool{
 	parser.MAX: true,
 	parser.MIN: true,

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -318,14 +318,6 @@ func TestInstantSplitterNoOp(t *testing.T) {
 	}
 }
 
-func TestSplittableVectorAggregators(t *testing.T) {
-	t.Run("splittable vector aggregators should be in supported vector aggregators", func(t *testing.T) {
-		for it := range splittableVectorAggregators {
-			assert.Equal(t, true, supportedVectorAggregators[it], fmt.Sprintf("itemType '%v' not in supported vector aggregators list", it.String()))
-		}
-	})
-}
-
 func concatOffsets(splitInterval time.Duration, offsets int, queryTemplate string) string {
 	queries := make([]string, offsets)
 	offsetIndex := offsets

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -172,6 +172,16 @@ func TestInstantSplitter(t *testing.T) {
 			out:                  `topk(10, histogram_quantile(0.9, sum without() (` + concatOffsets(splitInterval, 3, `increase({app="foo"}[x]y)`) + `) / 180))`,
 			expectedSplitQueries: 3,
 		},
+		{
+			in:                   `stddev(rate(metric[3m]))`,
+			out:                  `stddev(sum without() (` + concatOffsets(splitInterval, 3, `increase(metric[x]y)`) + `) / 180)`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `count_values("dst", count_over_time(metric[3m]))`,
+			out:                  `count_values("dst", sum without() (` + concatOffsets(splitInterval, 3, `count_over_time(metric[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
 		// Multi-level vector aggregators should be moved downstream
 		{
 			in:                   `sum(max(rate({app="foo"}[3m])))`,

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -268,7 +268,7 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		{
 			query: `5`,
 		},
-		// should be noop if binary expression's operands are both number literals
+		// should be noop if binary expression's operands are both constant scalars
 		{
 			query: `20 / 10`,
 		},
@@ -277,6 +277,9 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		},
 		{
 			query: `(20) / (10)`,
+		},
+		{
+			query: `time() != bool 0`,
 		},
 		// should be noop if binary operation is not mapped
 		//   - first operand `rate(metric_counter[1m])` has a smaller range interval than the configured splitting

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -113,6 +113,14 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 			query:                `topk(2, sum(rate(metric_counter[3m])))`,
 			expectedSplitQueries: 3,
 		},
+		"stddev(rate)": {
+			query:                `stddev(rate(metric_counter[3m]))`,
+			expectedSplitQueries: 3,
+		},
+		"count_values(count_over_time)": {
+			query:                `count_values("dst", count_over_time(metric_counter[3m]))`,
+			expectedSplitQueries: 3,
+		},
 		// Binary operations
 		"rate / rate": {
 			query:                `rate(metric_counter[3m]) / rate(metric_counter[6m])`,


### PR DESCRIPTION
#### What this PR does
Currently we need to change logic in 2 places when we add support to split more type of queries: both `isSplittable()` function and the actual `instantSplitter` logic.

I want to remove `isSplittable()` and let go every single query through the mapping logic. At the end of the mapping, we already check if it was successfully split or not, to decide whether it will be executed by the query-frontend (if was split) or just fully run it downstream (if wasn't split).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
