### PR TITLE
Add check to ensure we never parse multiple range intervals when mapping an instant query for splitting

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -71,7 +71,7 @@ func (i *instantSplitter) MapExpr(expr parser.Expr, stats *MapperStats) (mapped 
 	case *parser.BinaryExpr:
 		return i.mapBinaryExpr(e, stats)
 	case *parser.Call:
-		if isSubquery(e) {
+		if isSubqueryCall(e) {
 			// Subqueries are currently not supported by splitting, so we stop the mapping here.
 			return e, true, nil
 		}

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -216,7 +216,10 @@ func (i *instantSplitter) mapCallAvgOverTime(expr *parser.Call, stats *MapperSta
 func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
 	// In case the range interval is smaller than the configured split interval,
 	// don't split it and don't map further nodes (finished=true).
-	rangeInterval, canSplit := i.assertSplittableRangeInterval(expr)
+	rangeInterval, canSplit, err := i.assertSplittableRangeInterval(expr)
+	if err != nil {
+		return nil, true, err
+	}
 	if !canSplit {
 		return expr, true, nil
 	}
@@ -254,7 +257,10 @@ func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (ma
 func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, stats *MapperStats, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
 	// In case the range interval is smaller than the configured split interval,
 	// don't split it and don't map further nodes (finished=true).
-	rangeInterval, canSplit := i.assertSplittableRangeInterval(expr)
+	rangeInterval, canSplit, err := i.assertSplittableRangeInterval(expr)
+	if err != nil {
+		return nil, false, err
+	}
 	if !canSplit {
 		return expr, true, nil
 	}
@@ -340,37 +346,42 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, stats *MapperSta
 
 // assertSplittableRangeInterval returns the range interval specified in the input expr and whether it is greater than
 // the configured split interval.
-func (i *instantSplitter) assertSplittableRangeInterval(expr parser.Expr) (rangeInterval time.Duration, canSplit bool) {
-	rangeInterval = getRangeInterval(expr)
+func (i *instantSplitter) assertSplittableRangeInterval(expr parser.Expr) (rangeInterval time.Duration, canSplit bool, err error) {
+	rangeIntervals := getRangeIntervals(expr)
+	if len(rangeIntervals) == 0 {
+		return time.Duration(0), false, nil
+	}
+	if len(rangeIntervals) > 1 {
+		return time.Duration(0), false, fmt.Errorf("found %d range intervals while expecting at most 1", len(rangeIntervals))
+	}
+
+	rangeInterval = rangeIntervals[0]
 	if rangeInterval > i.interval {
-		return rangeInterval, true
+		return rangeInterval, true, nil
 	}
 
 	level.Debug(i.logger).Log("msg", "unable to split expression because range interval is smaller than configured split interval", "expr", expr, "range_interval", rangeInterval, "split_interval", i.interval)
-	return time.Duration(0), false
+	return time.Duration(0), false, nil
 }
 
-// getRangeInterval returns the range interval in the range vector expression
-// Returns 0 if no range interval is found
-// Example: expression `count_over_time({app="foo"}[10m])` returns 10m
-func getRangeInterval(expr parser.Expr) time.Duration {
-	switch e := expr.(type) {
-	case *parser.AggregateExpr:
-		return getRangeInterval(e.Expr)
-	case *parser.Call:
-		// Iterate over Call's arguments until a MatrixSelector and a valid range interval are found
-		for _, arg := range e.Args {
-			if argRangeInterval := getRangeInterval(arg); argRangeInterval != 0 {
-				return argRangeInterval
-			}
+// getRangeIntervals recursively visit the input expr and returns a slice containing all range intervals found.
+func getRangeIntervals(expr parser.Expr) []time.Duration {
+	// Due to how this function is used, we expect to always find at most 1 range interval
+	// so we preallocate it accordingly.
+	ranges := make([]time.Duration, 0, 1)
+
+	// Ignore the error since we never return it.
+	_, _ = anyNode(expr, func(entry parser.Node) (bool, error) {
+		matrix, ok := entry.(*parser.MatrixSelector)
+		if !ok {
+			return false, nil
 		}
-		return time.Duration(0)
-	case *parser.MatrixSelector:
-		return e.Range
-	default:
-		// parser.SubqueryExpr and parser.BinaryExpr should return 0
-		return 0
-	}
+
+		ranges = append(ranges, matrix.Range)
+		return false, nil
+	})
+
+	return ranges
 }
 
 // getOffset returns the offset interval in the range vector expression

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -351,6 +351,32 @@ func TestInstantSplitterNoOp(t *testing.T) {
 	}
 }
 
+func TestGetRangeIntervals(t *testing.T) {
+	tests := []struct {
+		query    string
+		expected []time.Duration
+	}{
+		{
+			query:    `time()`,
+			expected: []time.Duration{},
+		}, {
+			query:    `sum(rate(metric[1m]))`,
+			expected: []time.Duration{time.Minute},
+		}, {
+			query:    `sum(rate(metric[1m])) + sum(rate(metric[5m]))`,
+			expected: []time.Duration{time.Minute, 5 * time.Minute},
+		},
+	}
+
+	for _, testData := range tests {
+		t.Run(testData.query, func(t *testing.T) {
+			expr, err := parser.ParseExpr(testData.query)
+			require.NoError(t, err)
+			assert.Equal(t, testData.expected, getRangeIntervals(expr))
+		})
+	}
+}
+
 func concatOffsets(splitInterval time.Duration, offsets int, queryTemplate string) string {
 	queries := make([]string, offsets)
 	offsetIndex := offsets

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -365,6 +365,9 @@ func TestGetRangeIntervals(t *testing.T) {
 		}, {
 			query:    `sum(rate(metric[1m])) + sum(rate(metric[5m]))`,
 			expected: []time.Duration{time.Minute, 5 * time.Minute},
+		}, {
+			query:    `sum_over_time(rate(metric[1m])[1h:5m])`,
+			expected: []time.Duration{time.Hour, time.Minute},
 		},
 	}
 

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -332,6 +332,24 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		{
 			query: `sum(avg_over_time(metric_counter[1h:5m])) by (bar)`,
 		},
+		{
+			query: `min_over_time(sum by(group_1) (rate(metric_counter[5m]))[10m:2m])`,
+		},
+		{
+			query: `max_over_time(stddev_over_time(deriv(rate(metric_counter[10m])[5m:1m])[2m:])[10m:])`,
+		},
+		{
+			query: `rate(sum by(group_1) (rate(metric_counter[5m]))[10m:])`,
+		},
+		{
+			query: `absent_over_time(rate(metric_counter[5m])[10m:])`,
+		},
+		{
+			query: `max_over_time(stddev_over_time(deriv(sort(metric_counter)[5m:1m])[2m:])[10m:])`,
+		},
+		{
+			query: `max_over_time(absent_over_time(deriv(rate(metric_counter[1m])[5m:1m])[2m:])[10m:])`,
+		},
 	} {
 		tt := tt
 

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -330,6 +330,14 @@ func TestInstantSplitterNoOp(t *testing.T) {
 			query: `sum(rate(metric_counter[30m:5s]))`,
 		},
 		{
+			// Parenthesis expression between sum_over_time() and the subquery.
+			query: `sum_over_time((metric_counter[30m:5s]))`,
+		},
+		{
+			// Multiple parenthesis expressions between sum_over_time() and the subquery.
+			query: `sum_over_time((((metric_counter[30m:5s]))))`,
+		},
+		{
 			query: `quantile_over_time(1, metric_counter[10m:1m])`,
 		},
 		{

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -330,6 +330,9 @@ func TestInstantSplitterNoOp(t *testing.T) {
 			query: `sum(rate(metric_counter[30m:5s]))`,
 		},
 		{
+			query: `quantile_over_time(1, metric_counter[10m:1m])`,
+		},
+		{
 			query: `sum(avg_over_time(metric_counter[1h:5m])) by (bar)`,
 		},
 		{

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -549,7 +549,11 @@ func TestShardSummerWithEncoding(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestIsSubqueryCall(t *testing.T) {
+=======
+func TestIsSubquery(t *testing.T) {
+>>>>>>> 3646b1db7... Fix isSubquery() to work with quantile_over_time() too
 	tests := []struct {
 		query    string
 		expected bool
@@ -585,7 +589,6 @@ func TestIsSubqueryCall(t *testing.T) {
 
 			call, ok := expr.(*parser.Call)
 			require.True(t, ok)
-
 			assert.Equal(t, testData.expected, isSubqueryCall(call))
 		})
 	}

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -549,11 +549,7 @@ func TestShardSummerWithEncoding(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestIsSubqueryCall(t *testing.T) {
-=======
-func TestIsSubquery(t *testing.T) {
->>>>>>> 3646b1db7... Fix isSubquery() to work with quantile_over_time() too
 	tests := []struct {
 		query    string
 		expected bool


### PR DESCRIPTION
#### What this PR does
`getRangeInterval()` makes me uncomfortable because it returns the 1st range interval found. Theoretically, due to how we use it, we should never call it with an `expr` that could have 2+ matrix selectors, but it's not enforced in the code.

In this PR I'm enforcing it, adding a check that will fail the mapping if we call it with an `expr` containing 2+ matrix selectors.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
