### PR TITLE
Enhance updateRangeInterval() and updateOffset() functions

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -454,6 +454,10 @@ func updateEmbeddedExpr(expr parser.Expr, call *parser.Call) parser.Expr {
 // updateRangeInterval modifies the input expr in-place and updates the range interval on the matrix selector.
 // Returns an error if 0 or 2+ matrix selectors are found.
 func updateRangeInterval(expr parser.Expr, rangeInterval time.Duration) error {
+	if rangeInterval <= 0 {
+		return fmt.Errorf("unable to update range interval on expression, because a negative interval %d was provided: %v", rangeInterval, expr)
+	}
+
 	updates := 0
 
 	// Ignore the error since we never return it.

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -446,6 +446,43 @@ func TestUpdateRangeInterval(t *testing.T) {
 	}
 }
 
+func TestUpdateOffset(t *testing.T) {
+	tests := []struct {
+		expr         string
+		expectedExpr string
+		expectedErr  string
+	}{
+		{
+			expr:        `time()`,
+			expectedErr: "no vector selector has been found",
+		}, {
+			expr:         `sum(rate(metric[1m]))`,
+			expectedExpr: `sum(rate(metric[1m] offset 1h))`,
+		}, {
+			expr:         `sum(label_replace(rate(metric[1m]), "dst", "$1", "src", ".*"))`,
+			expectedExpr: `sum(label_replace(rate(metric[1m] offset 1h), "dst", "$1", "src", ".*"))`,
+		}, {
+			expr:        `sum(rate(metric[1m])) + sum(rate(metric[5m]))`,
+			expectedErr: "multiple vector selectors have been found",
+		},
+	}
+
+	for _, testData := range tests {
+		t.Run(testData.expr, func(t *testing.T) {
+			expr, err := parser.ParseExpr(testData.expr)
+			require.NoError(t, err)
+
+			actualErr := updateOffset(expr, time.Hour)
+			if testData.expectedErr != "" {
+				require.Error(t, actualErr)
+				assert.Contains(t, actualErr.Error(), testData.expectedErr)
+			} else {
+				assert.Equal(t, testData.expectedExpr, expr.String())
+			}
+		})
+	}
+}
+
 func concatOffsets(splitInterval time.Duration, offsets int, queryTemplate string) string {
 	queries := make([]string, offsets)
 	offsetIndex := offsets


### PR DESCRIPTION
#### What this PR does
Similarly to #2575, `updateRangeInterval()` and `updateOffset()` functions make me uncomfortable because if, due to a bug, we call them with an `expr` containing multiple matrix or vector selectors we may end up with nasty bugs. I prefer to get them error out very clearly.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
