### PR TITLE
Fix isSubquery() when a parenthesis expression is between the function call and its argument

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -549,7 +549,7 @@ func TestShardSummerWithEncoding(t *testing.T) {
 	}
 }
 
-func TestIsSubquery(t *testing.T) {
+func TestIsSubqueryCall(t *testing.T) {
 	tests := []struct {
 		query    string
 		expected bool
@@ -586,7 +586,7 @@ func TestIsSubquery(t *testing.T) {
 			call, ok := expr.(*parser.Call)
 			require.True(t, ok)
 
-			assert.Equal(t, testData.expected, isSubquery(call))
+			assert.Equal(t, testData.expected, isSubqueryCall(call))
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -220,6 +220,24 @@ func TestShardSummer(t *testing.T) {
 			3,
 		},
 		{
+			// Parenthesis expression between the parallelizeable function call and the subquery.
+			`max_over_time((
+				stddev_over_time(
+					deriv(
+						rate(metric_counter[10m])
+					[5m:1m])
+				[2m:])
+			[10m:]))`,
+			concatShards(3, `max_over_time((
+					stddev_over_time(
+						deriv(
+							rate(metric_counter{__query_shard__="x_of_y"}[10m])
+						[5m:1m])
+					[2m:])
+				[10m:]))`),
+			3,
+		},
+		{
 			`rate(
 				sum by(group_1) (
 					rate(metric_counter[5m])
@@ -527,6 +545,48 @@ func TestShardSummerWithEncoding(t *testing.T) {
 			require.Nil(t, err)
 
 			require.Equal(t, expected.String(), res.String())
+		})
+	}
+}
+
+func TestIsSubquery(t *testing.T) {
+	tests := []struct {
+		query    string
+		expected bool
+	}{
+		{
+			query:    `time()`,
+			expected: false,
+		}, {
+			query:    `rate(metric[1m])`,
+			expected: false,
+		}, {
+			query:    `rate(metric[1h:5m])`,
+			expected: true,
+		}, {
+			query:    `quantile_over_time(1, metric[1h:5m])`,
+			expected: true,
+		}, {
+			// Parenthesis expression between sum_over_time() and the subquery.
+			query:    `sum_over_time((metric_counter[30m:5s]))`,
+			expected: true,
+		},
+		{
+			// Multiple parenthesis expressions between sum_over_time() and the subquery.
+			query:    `sum_over_time((((metric_counter[30m:5s]))))`,
+			expected: true,
+		},
+	}
+
+	for _, testData := range tests {
+		t.Run(testData.query, func(t *testing.T) {
+			expr, err := parser.ParseExpr(testData.query)
+			require.NoError(t, err)
+
+			call, ok := expr.(*parser.Call)
+			require.True(t, ok)
+
+			assert.Equal(t, testData.expected, isSubquery(call))
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does
While working on #2575 I've realized `isSubquery()` util, used by query sharding, doesn't correctly detect a subquery function call argument wrapped by parenthesis.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
