### PR TITLE
Move stats to mapper initialization

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -20,6 +20,7 @@ type instantSplitter struct {
 	// by queriers, and therefore minimize the merging of results in the query-frontend.
 	outerAggregationExpr *parser.AggregateExpr
 	logger               log.Logger
+	stats                *MapperStats
 }
 
 // Supported vector aggregators
@@ -43,11 +44,12 @@ const (
 )
 
 // NewInstantQuerySplitter creates a new query range mapper.
-func NewInstantQuerySplitter(interval time.Duration, logger log.Logger) ASTMapper {
+func NewInstantQuerySplitter(interval time.Duration, logger log.Logger, stats *MapperStats) ASTMapper {
 	instantQueryMapper := NewASTExprMapper(
 		&instantSplitter{
 			interval: interval,
 			logger:   logger,
+			stats:    stats,
 		},
 	)
 
@@ -58,7 +60,7 @@ func NewInstantQuerySplitter(interval time.Duration, logger log.Logger) ASTMappe
 }
 
 // MapExpr returns expr mapped as embedded queries
-func (i *instantSplitter) MapExpr(expr parser.Expr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) MapExpr(expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 	// Immediately clone the expr to avoid mutating the original
 	expr, err = cloneExpr(expr)
 	if err != nil {
@@ -67,18 +69,18 @@ func (i *instantSplitter) MapExpr(expr parser.Expr, stats *MapperStats) (mapped 
 
 	switch e := expr.(type) {
 	case *parser.AggregateExpr:
-		return i.mapAggregatorExpr(e, stats)
+		return i.mapAggregatorExpr(e)
 	case *parser.BinaryExpr:
-		return i.mapBinaryExpr(e, stats)
+		return i.mapBinaryExpr(e)
 	case *parser.Call:
 		if isSubqueryCall(e) {
 			// Subqueries are currently not supported by splitting, so we stop the mapping here.
 			return e, true, nil
 		}
 
-		return i.mapCall(e, stats)
+		return i.mapCall(e)
 	case *parser.ParenExpr:
-		return i.mapParenExpr(e, stats)
+		return i.mapParenExpr(e)
 	case *parser.SubqueryExpr:
 		// Subqueries are currently not supported by splitting, so we stop the mapping here.
 		return e, true, nil
@@ -96,15 +98,15 @@ func (i *instantSplitter) copyWithEmbeddedExpr(embeddedExpr *parser.AggregateExp
 }
 
 // mapAggregatorExpr maps vector aggregator expression expr
-func (i *instantSplitter) mapAggregatorExpr(expr *parser.AggregateExpr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapAggregatorExpr(expr *parser.AggregateExpr) (mapped parser.Expr, finished bool, err error) {
 	var mappedExpr parser.Expr
 
 	// If the outerAggregationExpr is not set, update it.
 	// Note: vector aggregators avg, count and topk are supported but not splittable, so cannot be sent downstream.
 	if i.outerAggregationExpr == nil && splittableVectorAggregators[expr.Op] {
-		mappedExpr, finished, err = NewASTExprMapper(i.copyWithEmbeddedExpr(expr)).MapExpr(expr.Expr, stats)
+		mappedExpr, finished, err = NewASTExprMapper(i.copyWithEmbeddedExpr(expr)).MapExpr(expr.Expr)
 	} else {
-		mappedExpr, finished, err = i.MapExpr(expr.Expr, stats)
+		mappedExpr, finished, err = i.MapExpr(expr.Expr)
 	}
 	if err != nil {
 		return nil, false, err
@@ -124,7 +126,7 @@ func (i *instantSplitter) mapAggregatorExpr(expr *parser.AggregateExpr, stats *M
 }
 
 // mapBinaryExpr maps binary expression expr
-func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr) (mapped parser.Expr, finished bool, err error) {
 	// Binary expressions cannot be sent downstream, only their respective operands.
 	// Therefore, the embedded aggregator expression needs to be reset.
 	i.outerAggregationExpr = nil
@@ -136,17 +138,17 @@ func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr, stats *MapperSt
 		return expr, true, nil
 	}
 
-	lhsMapped, lhsFinished, err := i.MapExpr(expr.LHS, stats)
+	lhsMapped, lhsFinished, err := i.MapExpr(expr.LHS)
 	if err != nil {
 		return nil, false, err
 	}
-	rhsMapped, rhsFinished, err := i.MapExpr(expr.RHS, stats)
+	rhsMapped, rhsFinished, err := i.MapExpr(expr.RHS)
 	if err != nil {
 		return nil, false, err
 	}
 	// if query was split and at least one operand successfully finished, the binary operations is mapped.
 	// The binary operands need to be wrapped in a parentheses' expression to ensure operator precedence.
-	if stats.GetShardedQueries() > 0 && (lhsFinished || rhsFinished) {
+	if i.stats.GetShardedQueries() > 0 && (lhsFinished || rhsFinished) {
 		expr.LHS = &parser.ParenExpr{
 			Expr: lhsMapped,
 		}
@@ -159,8 +161,8 @@ func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr, stats *MapperSt
 }
 
 // mapParenExpr maps parenthesis expression expr
-func (i *instantSplitter) mapParenExpr(expr *parser.ParenExpr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
-	parenExpr, finished, err := i.MapExpr(expr.Expr, stats)
+func (i *instantSplitter) mapParenExpr(expr *parser.ParenExpr) (mapped parser.Expr, finished bool, err error) {
+	parenExpr, finished, err := i.MapExpr(expr.Expr)
 	if err != nil {
 		return nil, false, err
 	}
@@ -175,20 +177,20 @@ func (i *instantSplitter) mapParenExpr(expr *parser.ParenExpr, stats *MapperStat
 }
 
 // mapCall maps a function call if it's a range vector aggregator.
-func (i *instantSplitter) mapCall(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapCall(expr *parser.Call) (mapped parser.Expr, finished bool, err error) {
 	switch expr.Func.Name {
 	case avgOverTime:
-		return i.mapCallAvgOverTime(expr, stats)
+		return i.mapCallAvgOverTime(expr)
 	case countOverTime:
-		return i.mapCallVectorAggregation(expr, stats, parser.SUM)
+		return i.mapCallVectorAggregation(expr, parser.SUM)
 	case maxOverTime:
-		return i.mapCallVectorAggregation(expr, stats, parser.MAX)
+		return i.mapCallVectorAggregation(expr, parser.MAX)
 	case minOverTime:
-		return i.mapCallVectorAggregation(expr, stats, parser.MIN)
+		return i.mapCallVectorAggregation(expr, parser.MIN)
 	case rate:
-		return i.mapCallRate(expr, stats)
+		return i.mapCallRate(expr)
 	case sumOverTime:
-		return i.mapCallVectorAggregation(expr, stats, parser.SUM)
+		return i.mapCallVectorAggregation(expr, parser.SUM)
 	default:
 		// Continue the mapping on child expressions.
 		return expr, false, nil
@@ -196,7 +198,7 @@ func (i *instantSplitter) mapCall(expr *parser.Call, stats *MapperStats) (mapped
 }
 
 // mapCallAvgOverTime maps an avg_over_time function to expression sum_over_time / count_over_time
-func (i *instantSplitter) mapCallAvgOverTime(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapCallAvgOverTime(expr *parser.Call) (mapped parser.Expr, finished bool, err error) {
 	avgOverTimeExpr := &parser.BinaryExpr{
 		Op: parser.DIV,
 		LHS: &parser.Call{
@@ -217,11 +219,11 @@ func (i *instantSplitter) mapCallAvgOverTime(expr *parser.Call, stats *MapperSta
 		i.outerAggregationExpr = nil
 	}
 
-	return i.MapExpr(avgOverTimeExpr, stats)
+	return i.MapExpr(avgOverTimeExpr)
 }
 
 // mapCallRate maps a rate function to expression increase / rangeInterval
-func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapCallRate(expr *parser.Call) (mapped parser.Expr, finished bool, err error) {
 	// In case the range interval is smaller than the configured split interval,
 	// don't split it and don't map further nodes (finished=true).
 	rangeInterval, canSplit, err := i.assertSplittableRangeInterval(expr)
@@ -247,7 +249,7 @@ func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (ma
 		}
 	}
 
-	mappedExpr, finished, err := i.mapCallByRangeInterval(increaseExpr, stats, rangeInterval, parser.SUM)
+	mappedExpr, finished, err := i.mapCallByRangeInterval(increaseExpr, rangeInterval, parser.SUM)
 	if err != nil {
 		return nil, false, err
 	}
@@ -262,7 +264,7 @@ func (i *instantSplitter) mapCallRate(expr *parser.Call, stats *MapperStats) (ma
 	}, true, nil
 }
 
-func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, stats *MapperStats, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
 	// In case the range interval is smaller than the configured split interval,
 	// don't split it and don't map further nodes (finished=true).
 	rangeInterval, canSplit, err := i.assertSplittableRangeInterval(expr)
@@ -273,10 +275,10 @@ func (i *instantSplitter) mapCallVectorAggregation(expr *parser.Call, stats *Map
 		return expr, true, nil
 	}
 
-	return i.mapCallByRangeInterval(expr, stats, rangeInterval, op)
+	return i.mapCallByRangeInterval(expr, rangeInterval, op)
 }
 
-func (i *instantSplitter) mapCallByRangeInterval(expr *parser.Call, stats *MapperStats, rangeInterval time.Duration, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) mapCallByRangeInterval(expr *parser.Call, rangeInterval time.Duration, op parser.ItemType) (mapped parser.Expr, finished bool, err error) {
 	// Default grouping is 'without' for concatenating the embedded queries
 	var grouping []string
 	groupingWithout := true
@@ -285,7 +287,7 @@ func (i *instantSplitter) mapCallByRangeInterval(expr *parser.Call, stats *Mappe
 		groupingWithout = i.outerAggregationExpr.Without
 	}
 
-	embeddedExpr, finished, err := i.splitAndSquashCall(expr, stats, rangeInterval)
+	embeddedExpr, finished, err := i.splitAndSquashCall(expr, rangeInterval)
 	if err != nil {
 		return nil, false, err
 	}
@@ -307,7 +309,7 @@ func (i *instantSplitter) mapCallByRangeInterval(expr *parser.Call, stats *Mappe
 // If the outer expression is a vector aggregator, r.outerAggregationExpr will contain the expression
 // In this case, the vector aggregator should be downstream to the embedded queries in order to limit
 // the label cardinality of the parallel queries
-func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, stats *MapperStats, rangeInterval time.Duration) (mapped parser.Expr, finished bool, err error) {
+func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, rangeInterval time.Duration) (mapped parser.Expr, finished bool, err error) {
 	splitCount := int(math.Ceil(float64(rangeInterval) / float64(i.interval)))
 	if splitCount <= 1 {
 		return expr, false, nil
@@ -350,7 +352,7 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, stats *MapperSta
 	}
 
 	// Update stats
-	stats.AddShardedQueries(splitCount)
+	i.stats.AddShardedQueries(splitCount)
 
 	return squashExpr, true, nil
 }

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestInstantSplitter(t *testing.T) {
 	splitInterval := 1 * time.Minute
-	splitter := NewInstantQuerySplitter(splitInterval, log.NewNopLogger())
 
 	for _, tt := range []struct {
 		in                   string
@@ -244,13 +243,15 @@ func TestInstantSplitter(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.in, func(t *testing.T) {
+			stats := NewMapperStats()
+			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
+
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
 			out, err := parser.ParseExpr(tt.out)
 			require.NoError(t, err)
 
-			stats := NewMapperStats()
-			mapped, err := splitter.Map(expr, stats)
+			mapped, err := mapper.Map(expr)
 			require.NoError(t, err)
 			require.Equal(t, out.String(), mapped.String())
 
@@ -261,7 +262,6 @@ func TestInstantSplitter(t *testing.T) {
 
 func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 	splitInterval := 2 * time.Minute
-	splitter := NewInstantQuerySplitter(splitInterval, log.NewNopLogger())
 
 	for _, tt := range []struct {
 		in                   string
@@ -293,13 +293,15 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.in, func(t *testing.T) {
+			stats := NewMapperStats()
+			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
+
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
 			out, err := parser.ParseExpr(tt.out)
 			require.NoError(t, err)
 
-			stats := NewMapperStats()
-			mapped, err := splitter.Map(expr, stats)
+			mapped, err := mapper.Map(expr)
 			require.NoError(t, err)
 			require.Equal(t, out.String(), mapped.String())
 
@@ -310,7 +312,6 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 
 func TestInstantSplitterNoOp(t *testing.T) {
 	splitInterval := 1 * time.Minute
-	splitter := NewInstantQuerySplitter(splitInterval, log.NewNopLogger())
 
 	for _, tt := range []struct {
 		query string
@@ -396,15 +397,16 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.query, func(t *testing.T) {
+			stats := NewMapperStats()
+			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
+
 			expr, err := parser.ParseExpr(tt.query)
 			require.NoError(t, err)
-
-			stats := NewMapperStats()
 
 			// Do not assert if the mapped expression is equal to the input one, because it could actually be slightly
 			// transformed (e.g. added parenthesis). The actual way to check if it was split or not is to read it from
 			// the statistics.
-			_, err = splitter.Map(expr, stats)
+			_, err = mapper.Map(expr)
 			require.NoError(t, err)
 			assert.Equal(t, 0, stats.GetShardedQueries())
 		})

--- a/pkg/frontend/querymiddleware/astmapper/sharding.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding.go
@@ -9,16 +9,15 @@ import (
 	"fmt"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/mimir/pkg/storage/sharding"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-
-	"github.com/grafana/mimir/pkg/storage/sharding"
 )
 
 // NewSharding creates a new query sharding mapper.
-func NewSharding(shards int, logger log.Logger) (ASTMapper, error) {
-	shardSummer, err := newShardSummer(shards, vectorSquasher, logger)
+func NewSharding(shards int, logger log.Logger, stats *MapperStats) (ASTMapper, error) {
+	shardSummer, err := newShardSummer(shards, vectorSquasher, logger, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -36,10 +35,11 @@ type shardSummer struct {
 	currentShard *int
 	squash       squasher
 	logger       log.Logger
+	stats        *MapperStats
 }
 
 // newShardSummer instantiates an ASTMapper which will fan out sum queries by shard
-func newShardSummer(shards int, squasher squasher, logger log.Logger) (ASTMapper, error) {
+func newShardSummer(shards int, squasher squasher, logger log.Logger, stats *MapperStats) (ASTMapper, error) {
 	if squasher == nil {
 		return nil, errors.Errorf("squasher required and not passed")
 	}
@@ -49,6 +49,7 @@ func newShardSummer(shards int, squasher squasher, logger log.Logger) (ASTMapper
 		squash:       squasher,
 		currentShard: nil,
 		logger:       logger,
+		stats:        stats,
 	}), nil
 }
 
@@ -62,14 +63,14 @@ func (summer *shardSummer) CopyWithCurShard(curshard int) *shardSummer {
 // MapExpr processes the input expr and checks if it can be sharded. If so, it returns
 // a new expr which is expected to provide the same output when executed but splitting
 // the execution into multiple shards.
-func (summer *shardSummer) MapExpr(expr parser.Expr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (summer *shardSummer) MapExpr(expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 	switch e := expr.(type) {
 	case *parser.AggregateExpr:
 		if summer.currentShard != nil {
 			return e, false, nil
 		}
 		if CanParallelize(e, summer.logger) {
-			return summer.shardAggregate(e, stats)
+			return summer.shardAggregate(e)
 		}
 		return e, false, nil
 
@@ -99,7 +100,7 @@ func (summer *shardSummer) MapExpr(expr parser.Expr, stats *MapperStats) (mapped
 				if !CanParallelize(e, summer.logger) {
 					return e, true, nil
 				}
-				return summer.shardAndSquashFuncCall(e, stats)
+				return summer.shardAndSquashFuncCall(e)
 			}
 			return e, false, nil
 		}
@@ -111,7 +112,7 @@ func (summer *shardSummer) MapExpr(expr parser.Expr, stats *MapperStats) (mapped
 				return e, false, nil
 			}
 
-			return summer.shardBinOp(e, stats)
+			return summer.shardBinOp(e)
 		}
 		return e, false, nil
 
@@ -133,7 +134,7 @@ func (summer *shardSummer) MapExpr(expr parser.Expr, stats *MapperStats) (mapped
 }
 
 // shardAndSquashFuncCall shards the given function call by cloning it and adding the shard label to the most outer matrix/vector selector.
-func (summer *shardSummer) shardAndSquashFuncCall(expr *parser.Call, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (summer *shardSummer) shardAndSquashFuncCall(expr *parser.Call) (mapped parser.Expr, finished bool, err error) {
 	/*
 		parallelizing a func call (and subqueries) is representable naively as
 
@@ -167,14 +168,14 @@ func (summer *shardSummer) shardAndSquashFuncCall(expr *parser.Call, stats *Mapp
 		for i, arg := range clonedCall.Args {
 			switch typedArg := arg.(type) {
 			case *parser.SubqueryExpr:
-				subExprMapped, err := subSummer.Map(typedArg.Expr, nil)
+				subExprMapped, err := subSummer.Map(typedArg.Expr)
 				if err != nil {
 					return nil, true, err
 				}
 				typedArg.Expr = subExprMapped
 				clonedCall.Args[i] = arg
 			default:
-				mapped, err := subSummer.Map(typedArg, stats)
+				mapped, err := subSummer.Map(typedArg)
 				if err != nil {
 					return nil, true, err
 				}
@@ -186,7 +187,7 @@ func (summer *shardSummer) shardAndSquashFuncCall(expr *parser.Call, stats *Mapp
 	}
 
 	// Update stats.
-	stats.AddShardedQueries(summer.shards)
+	summer.stats.AddShardedQueries(summer.shards)
 	squashed, err := summer.squash(children...)
 	if err != nil {
 		return nil, true, err
@@ -195,28 +196,28 @@ func (summer *shardSummer) shardAndSquashFuncCall(expr *parser.Call, stats *Mapp
 }
 
 // shardAggregate attempts to shard the given aggregation expression.
-func (summer *shardSummer) shardAggregate(expr *parser.AggregateExpr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (summer *shardSummer) shardAggregate(expr *parser.AggregateExpr) (mapped parser.Expr, finished bool, err error) {
 	switch expr.Op {
 	case parser.SUM:
-		mapped, err = summer.shardSum(expr, stats)
+		mapped, err = summer.shardSum(expr)
 		if err != nil {
 			return nil, false, err
 		}
 		return mapped, true, nil
 	case parser.COUNT:
-		mapped, err = summer.shardCount(expr, stats)
+		mapped, err = summer.shardCount(expr)
 		if err != nil {
 			return nil, false, err
 		}
 		return mapped, true, nil
 	case parser.MAX, parser.MIN:
-		mapped, err = summer.shardMinMax(expr, stats)
+		mapped, err = summer.shardMinMax(expr)
 		if err != nil {
 			return nil, false, err
 		}
 		return mapped, true, nil
 	case parser.AVG:
-		mapped, err = summer.shardAvg(expr, stats)
+		mapped, err = summer.shardAvg(expr)
 		if err != nil {
 			return nil, false, err
 		}
@@ -229,7 +230,7 @@ func (summer *shardSummer) shardAggregate(expr *parser.AggregateExpr, stats *Map
 }
 
 // shardSum attempts to shard the given SUM aggregation expression.
-func (summer *shardSummer) shardSum(expr *parser.AggregateExpr, stats *MapperStats) (result *parser.AggregateExpr, err error) {
+func (summer *shardSummer) shardSum(expr *parser.AggregateExpr) (result *parser.AggregateExpr, err error) {
 	/*
 		parallelizing a sum using without(foo) is representable naively as
 		sum without(foo) (
@@ -251,7 +252,7 @@ func (summer *shardSummer) shardSum(expr *parser.AggregateExpr, stats *MapperSta
 	*/
 
 	// Create a SUM sub-query for each shard and squash it into a CONCAT expression.
-	sharded, err := summer.shardAndSquashAggregateExpr(expr, parser.SUM, stats)
+	sharded, err := summer.shardAndSquashAggregateExpr(expr, parser.SUM)
 	if err != nil {
 		return nil, err
 	}
@@ -267,10 +268,10 @@ func (summer *shardSummer) shardSum(expr *parser.AggregateExpr, stats *MapperSta
 }
 
 // shardCount attempts to shard the given COUNT aggregation expression.
-func (summer *shardSummer) shardCount(expr *parser.AggregateExpr, stats *MapperStats) (result *parser.AggregateExpr, err error) {
+func (summer *shardSummer) shardCount(expr *parser.AggregateExpr) (result *parser.AggregateExpr, err error) {
 	// The COUNT aggregation can be parallelized as the SUM of per-shard COUNT.
 	// Create a COUNT sub-query for each shard and squash it into a CONCAT expression.
-	sharded, err := summer.shardAndSquashAggregateExpr(expr, parser.COUNT, stats)
+	sharded, err := summer.shardAndSquashAggregateExpr(expr, parser.COUNT)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +286,7 @@ func (summer *shardSummer) shardCount(expr *parser.AggregateExpr, stats *MapperS
 }
 
 // shardMinMax attempts to shard the given MIN/MAX aggregation expression.
-func (summer *shardSummer) shardMinMax(expr *parser.AggregateExpr, stats *MapperStats) (result parser.Expr, err error) {
+func (summer *shardSummer) shardMinMax(expr *parser.AggregateExpr) (result parser.Expr, err error) {
 	// We expect the given aggregation is either a MIN or MAX.
 	if expr.Op != parser.MIN && expr.Op != parser.MAX {
 		return nil, errors.Errorf("expected MIN or MAX aggregation while got %s", expr.Op.String())
@@ -293,7 +294,7 @@ func (summer *shardSummer) shardMinMax(expr *parser.AggregateExpr, stats *Mapper
 
 	// The MIN/MAX aggregation can be parallelized as the MIN/MAX of per-shard MIN/MAX.
 	// Create a MIN/MAX sub-query for each shard and squash it into a CONCAT expression.
-	sharded, err := summer.shardAndSquashAggregateExpr(expr, expr.Op, stats)
+	sharded, err := summer.shardAndSquashAggregateExpr(expr, expr.Op)
 	if err != nil {
 		return nil, err
 	}
@@ -308,14 +309,14 @@ func (summer *shardSummer) shardMinMax(expr *parser.AggregateExpr, stats *Mapper
 }
 
 // shardAvg attempts to shard the given AVG aggregation expression.
-func (summer *shardSummer) shardAvg(expr *parser.AggregateExpr, stats *MapperStats) (result parser.Expr, err error) {
+func (summer *shardSummer) shardAvg(expr *parser.AggregateExpr) (result parser.Expr, err error) {
 	// The AVG aggregation can be parallelized as per-shard SUM() divided by per-shard COUNT().
-	sumExpr, err := summer.shardSum(expr, stats)
+	sumExpr, err := summer.shardSum(expr)
 	if err != nil {
 		return nil, err
 	}
 
-	countExpr, err := summer.shardCount(expr, stats)
+	countExpr, err := summer.shardCount(expr)
 	if err != nil {
 		return nil, err
 	}
@@ -332,12 +333,12 @@ func (summer *shardSummer) shardAvg(expr *parser.AggregateExpr, stats *MapperSta
 // shardAndSquashAggregateExpr returns a squashed CONCAT expression including N embedded
 // queries, where N is the number of shards and each sub-query queries a different shard
 // with the given "op" aggregation operation.
-func (summer *shardSummer) shardAndSquashAggregateExpr(expr *parser.AggregateExpr, op parser.ItemType, stats *MapperStats) (parser.Expr, error) {
+func (summer *shardSummer) shardAndSquashAggregateExpr(expr *parser.AggregateExpr, op parser.ItemType) (parser.Expr, error) {
 	children := make([]parser.Expr, 0, summer.shards)
 
 	// Create sub-query for each shard.
 	for i := 0; i < summer.shards; i++ {
-		sharded, err := cloneAndMap(NewASTExprMapper(summer.CopyWithCurShard(i)), expr.Expr, stats)
+		sharded, err := cloneAndMap(NewASTExprMapper(summer.CopyWithCurShard(i)), expr.Expr)
 		if err != nil {
 			return nil, err
 		}
@@ -354,19 +355,19 @@ func (summer *shardSummer) shardAndSquashAggregateExpr(expr *parser.AggregateExp
 	}
 
 	// Update stats.
-	stats.AddShardedQueries(summer.shards)
+	summer.stats.AddShardedQueries(summer.shards)
 
 	return summer.squash(children...)
 }
 
 // shardBinOp attempts to shard the given binary operation expression.
-func (summer *shardSummer) shardBinOp(expr *parser.BinaryExpr, stats *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (summer *shardSummer) shardBinOp(expr *parser.BinaryExpr) (mapped parser.Expr, finished bool, err error) {
 	switch expr.Op {
 	case parser.GTR,
 		parser.GTE,
 		parser.LSS,
 		parser.LTE:
-		mapped, err = summer.shardAndSquashBinOp(expr, stats)
+		mapped, err = summer.shardAndSquashBinOp(expr)
 		if err != nil {
 			return nil, false, err
 		}
@@ -379,7 +380,7 @@ func (summer *shardSummer) shardBinOp(expr *parser.BinaryExpr, stats *MapperStat
 // shardAndSquashBinOp returns a squashed CONCAT expression including N embedded
 // queries, where N is the number of shards and each sub-query queries a different shard
 // with the same binary operation.
-func (summer *shardSummer) shardAndSquashBinOp(expr *parser.BinaryExpr, stats *MapperStats) (parser.Expr, error) {
+func (summer *shardSummer) shardAndSquashBinOp(expr *parser.BinaryExpr) (parser.Expr, error) {
 	if expr.VectorMatching != nil {
 		// We shouldn't ever reach this point with a vector matching binary expression,
 		// but it's better to check twice than completely mess it up with the results.
@@ -389,11 +390,11 @@ func (summer *shardSummer) shardAndSquashBinOp(expr *parser.BinaryExpr, stats *M
 	children := make([]parser.Expr, 0, summer.shards)
 	// Create sub-query for each shard.
 	for i := 0; i < summer.shards; i++ {
-		shardedLHS, err := cloneAndMap(NewASTExprMapper(summer.CopyWithCurShard(i)), expr.LHS, stats)
+		shardedLHS, err := cloneAndMap(NewASTExprMapper(summer.CopyWithCurShard(i)), expr.LHS)
 		if err != nil {
 			return nil, err
 		}
-		shardedRHS, err := cloneAndMap(NewASTExprMapper(summer.CopyWithCurShard(i)), expr.RHS, stats)
+		shardedRHS, err := cloneAndMap(NewASTExprMapper(summer.CopyWithCurShard(i)), expr.RHS)
 		if err != nil {
 			return nil, err
 		}
@@ -407,7 +408,7 @@ func (summer *shardSummer) shardAndSquashBinOp(expr *parser.BinaryExpr, stats *M
 	}
 
 	// Update stats.
-	stats.AddShardedQueries(summer.shards)
+	summer.stats.AddShardedQueries(summer.shards)
 
 	return summer.squash(children...)
 }

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -11,11 +11,10 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/mimir/pkg/storage/sharding"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/mimir/pkg/storage/sharding"
 )
 
 func TestShardSummer(t *testing.T) {
@@ -478,15 +477,15 @@ func TestShardSummer(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.in, func(t *testing.T) {
-			mapper, err := NewSharding(3, log.NewNopLogger())
+			stats := NewMapperStats()
+			mapper, err := NewSharding(3, log.NewNopLogger(), stats)
 			require.NoError(t, err)
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
 			out, err := parser.ParseExpr(tt.out)
 			require.NoError(t, err)
 
-			stats := NewMapperStats()
-			mapped, err := mapper.Map(expr, stats)
+			mapped, err := mapper.Map(expr)
 			require.NoError(t, err)
 			require.Equal(t, out.String(), mapped.String())
 			assert.Equal(t, tt.expectedShardedQueries, stats.GetShardedQueries())
@@ -532,13 +531,13 @@ func TestShardSummerWithEncoding(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			summer, err := newShardSummer(c.shards, vectorSquasher, log.NewNopLogger())
+			stats := NewMapperStats()
+			summer, err := newShardSummer(c.shards, vectorSquasher, log.NewNopLogger(), stats)
 			require.Nil(t, err)
 			expr, err := parser.ParseExpr(c.input)
 			require.Nil(t, err)
 
-			stats := NewMapperStats()
-			res, err := summer.Map(expr, stats)
+			res, err := summer.Map(expr)
 			require.Nil(t, err)
 			assert.Equal(t, c.shards, stats.GetShardedQueries())
 			expected, err := parser.ParseExpr(c.expected)

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
@@ -21,7 +21,7 @@ func newSubtreeFolder() ASTMapper {
 }
 
 // MapExpr implements ExprMapper.
-func (f *subtreeFolder) MapExpr(expr parser.Expr, _ *MapperStats) (mapped parser.Expr, finished bool, err error) {
+func (f *subtreeFolder) MapExpr(expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 	hasEmbeddedQueries, err := anyNode(expr, hasEmbeddedQueries)
 	if err != nil {
 		return nil, true, err

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder_test.go
@@ -101,7 +101,7 @@ func TestSubtreeFolder(t *testing.T) {
 
 			expr, err := parser.ParseExpr(tc.input)
 			require.Nil(t, err)
-			res, err := mapper.Map(expr, NewMapperStats())
+			res, err := mapper.Map(expr)
 			require.Nil(t, err)
 
 			expected, err := parser.ParseExpr(tc.expected)

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -13,15 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/status"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/storage"
-
 	"github.com/grafana/dskit/tenant"
-
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -31,6 +23,12 @@ import (
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
 )
 
 type querySharding struct {
@@ -224,7 +222,8 @@ func mapEngineError(err error) error {
 // to be executed by PromQL engine with shardedQueryable or an empty string if the input query
 // can't be sharded.
 func (s *querySharding) shardQuery(query string, totalShards int) (string, *astmapper.MapperStats, error) {
-	mapper, err := astmapper.NewSharding(totalShards, s.logger)
+	stats := astmapper.NewMapperStats()
+	mapper, err := astmapper.NewSharding(totalShards, s.logger, stats)
 	if err != nil {
 		return "", nil, err
 	}
@@ -234,8 +233,7 @@ func (s *querySharding) shardQuery(query string, totalShards int) (string, *astm
 		return "", nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
-	stats := astmapper.NewMapperStats()
-	shardedQuery, err := mapper.Map(expr, stats)
+	shardedQuery, err := mapper.Map(expr)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Move the stats to the mapper initialization. This way it is possible to have different stats types depending on the mapper type, e.g. sharding stats and splitting stats.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
