### PR TITLE
compactor: Use block.MetaFilename constant

### DIFF
--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -71,7 +71,7 @@ func (c *MultitenantCompactor) StartBlockUpload(w http.ResponseWriter, r *http.R
 
 // FinishBlockUpload handles request for finishing block upload.
 //
-// Finishing block upload performs block valiation, and if all checks pass, marks block as finished
+// Finishing block upload performs block validation, and if all checks pass, marks block as finished
 // by uploading meta.json file.
 func (c *MultitenantCompactor) FinishBlockUpload(w http.ResponseWriter, r *http.Request) {
 	blockID, tenantID, err := c.parseBlockUploadParameters(r)
@@ -235,7 +235,7 @@ func (c *MultitenantCompactor) UploadBlockFile(w http.ResponseWriter, r *http.Re
 			found = true
 
 			if r.ContentLength != f.SizeBytes {
-				http.Error(w, "file size doesn't match meta.json", http.StatusBadRequest)
+				http.Error(w, fmt.Sprintf("file size doesn't match %s", block.MetaFilename), http.StatusBadRequest)
 				return
 			}
 		}
@@ -501,7 +501,7 @@ func (c *MultitenantCompactor) getBlockUploadState(ctx context.Context, userBkt 
 	if err != nil {
 		return blockStateUnknown, nil, nil, err
 	}
-	// If neither meta.json nor uploading-meta.json file don't exist, we say that block doesn't exist.
+	// If neither meta.json nor uploading-meta.json file exist, we say that the block doesn't exist.
 	if meta == nil {
 		return blockUploadNotStarted, nil, nil, err
 	}


### PR DESCRIPTION
#### What this PR does
Fix compactor code to use `block.MetaFilename` constant, also improve language in a couple of comments.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
