### PR TITLE
Add support for range vector aggregators

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -37,7 +37,6 @@ const (
 	avgOverTime     = "avg_over_time"
 	countOverTime   = "count_over_time"
 	increase        = "increase"
-	irate           = "irate"
 	maxOverTime     = "max_over_time"
 	minOverTime     = "min_over_time"
 	presentOverTime = "present_over_time"
@@ -198,8 +197,6 @@ func (i *instantSplitter) mapCall(expr *parser.Call) (mapped parser.Expr, finish
 		return i.mapCallVectorAggregation(expr, parser.SUM)
 	case increase:
 		return i.mapCallVectorAggregation(expr, parser.SUM)
-	case irate:
-		return i.mapCallRate(expr)
 	case maxOverTime:
 		return i.mapCallVectorAggregation(expr, parser.MAX)
 	case minOverTime:

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -202,6 +202,8 @@ func (i *instantSplitter) mapCall(expr *parser.Call) (mapped parser.Expr, finish
 	case minOverTime:
 		return i.mapCallVectorAggregation(expr, parser.MIN)
 	case presentOverTime:
+		// present_over_time returns the value 1 for any series in the specified interval,
+		// therefore, using aggregator MAX enforces that all 1 values are returned.
 		return i.mapCallVectorAggregation(expr, parser.MAX)
 	case rate:
 		return i.mapCallRate(expr)

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -34,13 +34,16 @@ var splittableVectorAggregators = map[parser.ItemType]bool{
 // Supported range vector aggregators
 
 const (
-	avgOverTime   = "avg_over_time"
-	countOverTime = "count_over_time"
-	increase      = "increase"
-	maxOverTime   = "max_over_time"
-	minOverTime   = "min_over_time"
-	rate          = "rate"
-	sumOverTime   = "sum_over_time"
+	avgOverTime     = "avg_over_time"
+	countOverTime   = "count_over_time"
+	increase        = "increase"
+	irate           = "irate"
+	maxOverTime     = "max_over_time"
+	minOverTime     = "min_over_time"
+	presentOverTime = "present_over_time"
+	rate            = "rate"
+	resets          = "resets"
+	sumOverTime     = "sum_over_time"
 )
 
 // cannotDoubleCountBoundaries is the list of functions that cannot double count the boundaries points when being split by range.
@@ -194,12 +197,20 @@ func (i *instantSplitter) mapCall(expr *parser.Call) (mapped parser.Expr, finish
 		return i.mapCallAvgOverTime(expr)
 	case countOverTime:
 		return i.mapCallVectorAggregation(expr, parser.SUM)
+	case increase:
+		return i.mapCallVectorAggregation(expr, parser.SUM)
+	case irate:
+		return i.mapCallRate(expr)
 	case maxOverTime:
 		return i.mapCallVectorAggregation(expr, parser.MAX)
 	case minOverTime:
 		return i.mapCallVectorAggregation(expr, parser.MIN)
+	case presentOverTime:
+		return i.mapCallVectorAggregation(expr, parser.MAX)
 	case rate:
 		return i.mapCallRate(expr)
+	case resets:
+		return i.mapCallVectorAggregation(expr, parser.SUM)
 	case sumOverTime:
 		return i.mapCallVectorAggregation(expr, parser.SUM)
 	default:

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -42,7 +42,6 @@ const (
 	minOverTime     = "min_over_time"
 	presentOverTime = "present_over_time"
 	rate            = "rate"
-	resets          = "resets"
 	sumOverTime     = "sum_over_time"
 )
 

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -209,8 +209,6 @@ func (i *instantSplitter) mapCall(expr *parser.Call) (mapped parser.Expr, finish
 		return i.mapCallVectorAggregation(expr, parser.MAX)
 	case rate:
 		return i.mapCallRate(expr)
-	case resets:
-		return i.mapCallVectorAggregation(expr, parser.SUM)
 	case sumOverTime:
 		return i.mapCallVectorAggregation(expr, parser.SUM)
 	default:

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -23,7 +23,7 @@ func TestInstantSplitter(t *testing.T) {
 		out                  string
 		expectedSplitQueries int
 	}{
-		// Range vector aggregators
+		// Splittable range vector aggregators
 		{
 			in:                   `avg_over_time({app="foo"}[3m])`,
 			out:                  `(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)) / (sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `))`,
@@ -32,6 +32,16 @@ func TestInstantSplitter(t *testing.T) {
 		{
 			in:                   `count_over_time({app="foo"}[3m])`,
 			out:                  `sum without() (` + concatOffsets(splitInterval, 3, false, `count_over_time({app="foo"}[x]y)`) + `)`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `increase({app="foo"}[3m])`,
+			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `)`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `irate({app="foo"}[3m])`,
+			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180`,
 			expectedSplitQueries: 3,
 		},
 		{
@@ -45,13 +55,114 @@ func TestInstantSplitter(t *testing.T) {
 			expectedSplitQueries: 3,
 		},
 		{
+			in:                   `present_over_time({app="foo"}[3m])`,
+			out:                  `max without() (` + concatOffsets(splitInterval, 3, true, `present_over_time({app="foo"}[x]y)`) + `)`,
+			expectedSplitQueries: 3,
+		},
+		{
 			in:                   `rate({app="foo"}[3m])`,
 			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180`,
 			expectedSplitQueries: 3,
 		},
 		{
+			in:                   `resets({app="foo"}[3m])`,
+			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `resets({app="foo"}[x]y)`) + `)`,
+			expectedSplitQueries: 3,
+		},
+		{
 			in:                   `sum_over_time({app="foo"}[3m])`,
 			out:                  `sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)`,
+			expectedSplitQueries: 3,
+		},
+		// Splittable aggregations wrapped by non-aggregative functions.
+		{
+			in:                   `absent(sum_over_time({app="foo"}[3m]))`,
+			out:                  `absent(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `ceil(sum_over_time({app="foo"}[3m]))`,
+			out:                  `ceil(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `clamp(sum_over_time({app="foo"}[3m]), 1, 10)`,
+			out:                  `clamp(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `), 1, 10)`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `clamp_max(sum_over_time({app="foo"}[3m]), 10)`,
+			out:                  `clamp_max(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `), 10)`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `clamp_min(sum_over_time({app="foo"}[3m]), 1)`,
+			out:                  `clamp_min(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `), 1)`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `exp(sum_over_time({app="foo"}[3m]))`,
+			out:                  `exp(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `floor(sum_over_time({app="foo"}[3m]))`,
+			out:                  `floor(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `histogram_quantile(0.9, sum_over_time({app="foo"}[3m]))`,
+			out:                  `histogram_quantile(0.9, sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `) )`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `label_join(sum_over_time({app="foo"}[3m]), "foo", ",", "group_1", "group_2", "const")`,
+			out:                  `label_join(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `), "foo", ",", "group_1", "group_2", "const")`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `label_replace(sum_over_time({app="foo"}[3m]), "foo", "bar$1", "group_2", "(.*)")`,
+			out:                  `label_replace(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `), "foo", "bar$1", "group_2", "(.*)")`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `ln(sum_over_time({app="foo"}[3m]))`,
+			out:                  `ln(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `log2(sum_over_time({app="foo"}[3m]))`,
+			out:                  `log2(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `round(sum_over_time({app="foo"}[3m]))`,
+			out:                  `round(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `scalar(sum_over_time({app="foo"}[3m]))`,
+			out:                  `scalar(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `sgn(sum_over_time({app="foo"}[3m]))`,
+			out:                  `sgn(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `sort(sum_over_time({app="foo"}[3m]))`,
+			out:                  `sort(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `sort_desc(sum_over_time({app="foo"}[3m]))`,
+			out:                  `sort_desc(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
+			expectedSplitQueries: 3,
+		},
+		{
+			in:                   `sqrt(sum_over_time({app="foo"}[3m]))`,
+			out:                  `sqrt(sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `))`,
 			expectedSplitQueries: 3,
 		},
 		// Vector aggregators
@@ -344,12 +455,49 @@ func TestInstantSplitterNoOp(t *testing.T) {
 	for _, tt := range []struct {
 		query string
 	}{
-		// should be noop if expression is not splittable
+		// should be noop if range vector aggregator is not splittable
+		{
+			query: `absent_over_time({app="foo"}[3m])`,
+		},
+		{
+			query: `changes({app="foo"}[3m])`,
+		},
+		{
+			query: `delta({app="foo"}[3m])`,
+		},
+		{
+			query: `deriv({app="foo"}[3m])`,
+		},
+		{
+			query: `holt_winters({app="foo"}[3m], 1, 10)`,
+		},
+		{
+			query: `idelta({app="foo"}[3m])`,
+		},
+		{
+			query: `last_over_time({app="foo"}[3m])`,
+		},
+		{
+			query: `predict_linear({app="foo"}[3m], 1)`,
+		},
 		{
 			query: `quantile_over_time(0.95, foo[3m])`,
 		},
 		{
-			query: `topk(10, histogram_quantile(0.9, irate({app="foo"}[3m])))`,
+			query: `stddev_over_time(foo[3m])`,
+		},
+		{
+			query: `stdvar_over_time(foo[3m])`,
+		},
+		{
+			query: `time()`,
+		},
+		{
+			query: `vector(10)`,
+		},
+		// should be noop if expression is not splittable
+		{
+			query: `topk(10, histogram_quantile(0.9, delta({app="foo"}[3m])))`,
 		},
 		// should be noop if range interval is lower or equal to split interval (1m)
 		{

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -40,11 +40,6 @@ func TestInstantSplitter(t *testing.T) {
 			expectedSplitQueries: 3,
 		},
 		{
-			in:                   `irate({app="foo"}[3m])`,
-			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `increase({app="foo"}[x]y)`) + `) / 180`,
-			expectedSplitQueries: 3,
-		},
-		{
 			in:                   `max_over_time({app="foo"}[3m])`,
 			out:                  `max without() (` + concatOffsets(splitInterval, 3, true, `max_over_time({app="foo"}[x]y)`) + `)`,
 			expectedSplitQueries: 3,
@@ -468,6 +463,9 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		},
 		{
 			query: `idelta({app="foo"}[3m])`,
+		},
+		{
+			query: `irate({app="foo"}[3m])`,
 		},
 		{
 			query: `last_over_time({app="foo"}[3m])`,

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -65,11 +65,6 @@ func TestInstantSplitter(t *testing.T) {
 			expectedSplitQueries: 3,
 		},
 		{
-			in:                   `resets({app="foo"}[3m])`,
-			out:                  `sum without() (` + concatOffsets(splitInterval, 3, true, `resets({app="foo"}[x]y)`) + `)`,
-			expectedSplitQueries: 3,
-		},
-		{
 			in:                   `sum_over_time({app="foo"}[3m])`,
 			out:                  `sum without() (` + concatOffsets(splitInterval, 3, false, `sum_over_time({app="foo"}[x]y)`) + `)`,
 			expectedSplitQueries: 3,
@@ -482,6 +477,9 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		},
 		{
 			query: `quantile_over_time(0.95, foo[3m])`,
+		},
+		{
+			query: `resets(foo[3m])`,
 		},
 		{
 			query: `stddev_over_time(foo[3m])`,

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -77,10 +77,6 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					query:                `rate(metric_counter[3m])`,
 					expectedSplitQueries: 3,
 				},
-				"resets": {
-					query:                `resets(metric_counter[3m])`,
-					expectedSplitQueries: 3,
-				},
 				"sum_over_time": {
 					query:                `sum_over_time(metric_counter[3m])`,
 					expectedSplitQueries: 3,
@@ -378,6 +374,10 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 				},
 				"quantile_over_time": {
 					query:                `quantile_over_time(0.95, metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"resets": {
+					query:                `resets(metric_counter[3m])`,
 					expectedSplitQueries: 0,
 				},
 				"stddev_over_time": {

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -57,10 +57,6 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					query:                `increase(metric_counter[3m])`,
 					expectedSplitQueries: 3,
 				},
-				"irate": {
-					query:                `irate(metric_counter[3m])`,
-					expectedSplitQueries: 3,
-				},
 				"max_over_time": {
 					query:                `max_over_time(metric_counter[3m])`,
 					expectedSplitQueries: 3,
@@ -362,6 +358,10 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 				},
 				"idelta": {
 					query:                `idelta(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"irate": {
+					query:                `irate(metric_counter[3m])`,
 					expectedSplitQueries: 0,
 				},
 				"last_over_time": {

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -44,13 +44,21 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 				query                string
 				expectedSplitQueries int
 			}{
-				// Range vector aggregators
+				// Splittable range vector aggregators
 				"avg_over_time": {
 					query:                `avg_over_time(metric_counter[3m])`,
 					expectedSplitQueries: 6,
 				},
 				"count_over_time": {
 					query:                `count_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"increase": {
+					query:                `increase(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				"irate": {
+					query:                `irate(metric_counter[3m])`,
 					expectedSplitQueries: 3,
 				},
 				"max_over_time": {
@@ -61,12 +69,101 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					query:                `min_over_time(metric_counter[3m])`,
 					expectedSplitQueries: 3,
 				},
+				"present_over_time": {
+					query:                `present_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
 				"rate": {
 					query:                `rate(metric_counter[3m])`,
 					expectedSplitQueries: 3,
 				},
+				"resets": {
+					query:                `resets(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
 				"sum_over_time": {
 					query:                `sum_over_time(metric_counter[3m])`,
+					expectedSplitQueries: 3,
+				},
+				// Splittable aggregations wrapped by non-aggregative functions.
+				"absent": {
+					query:                `absent(sum_over_time(nonexistent[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"ceil(sum(sum_over_time()))": {
+					query:                `ceil(sum(sum_over_time(metric_counter[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and both legs of the binary operation are splittable": {
+					query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[3m])))`,
+					expectedSplitQueries: 6,
+				},
+				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only right leg of the binary operation is splittable": {
+					query:                `ceil(sum(sum_over_time(metric_counter[1m])) + sum(sum_over_time(metric_counter[3m])))`,
+					expectedSplitQueries: 3,
+				},
+				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only left leg of the binary operation is splittable": {
+					query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[1m])))`,
+					expectedSplitQueries: 3,
+				},
+				"clamp": {
+					query:                `clamp(sum_over_time(metric_counter[3m]), 1, 10)`,
+					expectedSplitQueries: 3,
+				},
+				"clamp_max": {
+					query:                `clamp_max(sum_over_time(metric_counter[3m]), 10)`,
+					expectedSplitQueries: 3,
+				},
+				"clamp_min": {
+					query:                `clamp_min(sum_over_time(metric_counter[3m]), 1)`,
+					expectedSplitQueries: 3,
+				},
+				"exp": {
+					query:                `exp(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"floor": {
+					query:                `floor(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"histogram_quantile": {
+					query:                `histogram_quantile(0.5, rate(metric_histogram_bucket[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"label_join": {
+					query:                `label_join(sum_over_time(metric_counter{group_1="0"}[3m]), "foo", ",", "group_1", "group_2", "const")`,
+					expectedSplitQueries: 3,
+				},
+				"label_replace": {
+					query:                `label_replace(sum_over_time(metric_counter{group_1="0"}[3m]), "foo", "bar$1", "group_2", "(.*)")`,
+					expectedSplitQueries: 3,
+				},
+				"ln": {
+					query:                `ln(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"log2": {
+					query:                `log2(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"round": {
+					query:                `round(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sgn": {
+					query:                `sgn(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sort": {
+					query:                `sort(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sort_desc": {
+					query:                `sort_desc(sum_over_time(metric_counter[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sqrt": {
+					query:                `sqrt(sum_over_time(metric_counter[3m]))`,
 					expectedSplitQueries: 3,
 				},
 				// Vector aggregators
@@ -163,13 +260,6 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					query:                `rate(metric_counter[3m]) / rate(metric_counter[3m]) > 0.5`,
 					expectedSplitQueries: 6,
 				},
-				// should not be mapped if both operands are not splittable
-				//   - first operand `rate(metric_counter[1m])` has a smaller range interval than the configured splitting
-				//   - second operand `rate(metric_counter[5h:5m])` is a subquery
-				"rate(1m) / rate(subquery) > 0.5": {
-					query:                `rate(metric_counter[1m]) / rate(metric_counter[5h:5m]) > 0.5`,
-					expectedSplitQueries: 0,
-				},
 				// Offset operator
 				"sum_over_time[3m] offset 3m": {
 					query:                `sum_over_time(metric_counter[3m] offset 3m)`,
@@ -246,22 +336,65 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 					query:                `sum(sum_over_time(metric_counter[1h:5m]) * 60) by (group_1)`,
 					expectedSplitQueries: 0,
 				},
-				// Splittable aggregations wrapped by non-aggregative functions.
-				"ceil(sum(sum_over_time()))": {
-					query:                `ceil(sum(sum_over_time(metric_counter[3m])))`,
-					expectedSplitQueries: 3,
+				// should not be mapped if both operands are not splittable
+				//   - first operand `rate(metric_counter[1m])` has a smaller range interval than the configured splitting
+				//   - second operand `rate(metric_counter[5h:5m])` is a subquery
+				"rate(1m) / rate(subquery) > 0.5": {
+					query:                `rate(metric_counter[1m]) / rate(metric_counter[5h:5m]) > 0.5`,
+					expectedSplitQueries: 0,
 				},
-				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and both legs of the binary operation are splittable": {
-					query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[3m])))`,
-					expectedSplitQueries: 6,
+				// should not be mapped if range vector aggregator is not splittable
+				"absent_over_time": {
+					query:                `absent_over_time(nonexistent[1m])`,
+					expectedSplitQueries: 0,
 				},
-				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only right leg of the binary operation is splittable": {
-					query:                `ceil(sum(sum_over_time(metric_counter[1m])) + sum(sum_over_time(metric_counter[3m])))`,
-					expectedSplitQueries: 3,
+				"changes": {
+					query:                `changes(metric_counter[1m])`,
+					expectedSplitQueries: 0,
 				},
-				"ceil(sum(sum_over_time()) + sum(sum_over_time())) and only left leg of the binary operation is splittable": {
-					query:                `ceil(sum(sum_over_time(metric_counter[3m])) + sum(sum_over_time(metric_counter[1m])))`,
-					expectedSplitQueries: 3,
+				"delta": {
+					query:                `delta(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"deriv": {
+					query:                `deriv(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"holt_winters": {
+					query:                `holt_winters(metric_counter[1m], 0.5, 0.9)`,
+					expectedSplitQueries: 0,
+				},
+				"idelta": {
+					query:                `idelta(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"last_over_time": {
+					query:                `last_over_time(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"predict_linear": {
+					query:                `last_over_time(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"quantile_over_time": {
+					query:                `quantile_over_time(0.95, metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"stddev_over_time": {
+					query:                `stddev_over_time(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"stdvar_over_time": {
+					query:                `stdvar_over_time(metric_counter[1m])`,
+					expectedSplitQueries: 0,
+				},
+				"time()": {
+					query:                `time()`,
+					expectedSplitQueries: 0,
+				},
+				"vector(10)": {
+					query:                `vector(10)`,
+					expectedSplitQueries: 0,
 				},
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Note for reviewers:** please read the PR description containing the list of supported expressions before reviewing this PR.

#### What this PR does

This PR introduces the support of new range vector aggregators. This was done by taking into account 2 sources of data:
1) expressions that can be parallelized in the sharding AST mapper: https://github.com/grafana/mimir/blob/7f14ac6fc1094bceebbb0379c330db49b123577c/pkg/frontend/querymiddleware/astmapper/parallel.go#L25-L34
2) the list of Prometheus query functions: https://prometheus.io/docs/prometheus/latest/querying/functions/#functions

**Sharding AST mapper parallel expressions:**
By analyzing the expression list from the 1st point, the same result was concluded except for expressions sorting expressions:
* [absent](https://prometheus.io/docs/prometheus/latest/querying/functions/#absent): shardable ❌  splittable ❌ 
* [absent_over_time](https://prometheus.io/docs/prometheus/latest/querying/functions/#absent_over_time) shardable ❌  splittable ❌
* [histogram_quantile](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) shardable ❌  splittable ❌
* [sort_desc](https://prometheus.io/docs/prometheus/latest/querying/functions/#sort_desc) shardable ❌  splittable ✅ 
* [sort](https://prometheus.io/docs/prometheus/latest/querying/functions/#sort) shardable ❌  splittable ✅ 
* [time](https://prometheus.io/docs/prometheus/latest/querying/functions/#sort_desc) shardable ❌  splittable ❌ 
* [vector](https://prometheus.io/docs/prometheus/latest/querying/functions/#vector) shardable ❌  splittable ❌

Note that although the other expressions are not splittable their inner children may be and the algorithm will always attempt to split them.

For the `sort` and `sort_desc` expressions, the `cannotDoubleCountBoundaries` map needs to be updated to check possible inner calls. 
E.g., 
```
sort(sum_over_time({app="foo"}[3m]))
```
should be converted to 
```
sort(sum without() (__embedded_queries__{__queries__="\"Concat\":[\"sort(sum_over_time({app=\\\"foo\\\"}[1m] offset 2m))\",\"sort(sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 1m))\",\"sort(sum_over_time({app=\\\"foo\\\"}[59s999ms]))\"]}\"}))"
```

This was tested in a separate commit to validate the solution: https://github.com/grafana/mimir/commit/6b109549fb4e678c46d47a5a5140a15c6823fd49
Questions:
* Is this a good approach? Is it worth adding 2 levels of sorting 1) queries and 2) query-frontend
* Is there any drawback on pushing the `sort` downstream to the queriers?
* Should we apply this same logic to other expression types?

**Prometheus expressions**
By analyzing the expression list from the 2nd point, the following expressions were introduced:
* [increase](https://prometheus.io/docs/prometheus/latest/querying/functions/#increase)
* [~irate~](https://prometheus.io/docs/prometheus/latest/querying/functions/#irate) (see [comment](https://github.com/grafana/mimir/pull/2601#discussion_r934313738))
* [present_over_time](https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time): this expression returns the value 1 for any series in the specified interval. In the implementation, since all series return 1, the aggregator `MAX` was used, but the `MIN` operator can also be used.
* [~resets~](https://prometheus.io/docs/prometheus/latest/querying/functions/#resets) (see [comment](https://github.com/grafana/mimir/pull/2601#discussion_r933366071))

Questions:
* [changes](https://prometheus.io/docs/prometheus/latest/querying/functions/#changes): returns the number of times its value has changed within the provided time range as an instant vector. Therefore, couldn't this be split and aggregated with a `sum without`?

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
