### PR TITLE
remove confusing comment

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -536,6 +536,8 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 	// At this point we know we have both HA labels, we should lookup
 	// the cluster/instance here to see if we want to accept this sample.
 	err := d.HATracker.checkReplica(ctx, userID, cluster, replica, time.Now())
+	// checkReplica would only have returned an error if there was a real error talking to Consul,
+	// or if the replica is not the currently elected replica.
 	if err != nil { // Don't accept the sample.
 		return false, err
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -536,7 +536,7 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 	// At this point we know we have both HA labels, we should lookup
 	// the cluster/instance here to see if we want to accept this sample.
 	err := d.HATracker.checkReplica(ctx, userID, cluster, replica, time.Now())
-	// checkReplica would only have returned an error if there was a real error talking to Consul,
+	// checkReplica would have returned an error if there was a real error talking to Consul,
 	// or if the replica is not the currently elected replica.
 	if err != nil { // Don't accept the sample.
 		return false, err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -536,7 +536,6 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 	// At this point we know we have both HA labels, we should lookup
 	// the cluster/instance here to see if we want to accept this sample.
 	err := d.HATracker.checkReplica(ctx, userID, cluster, replica, time.Now())
-	// checkReplica should only have returned an error if there was a real error talking to Consul, or if the replica labels don't match.
 	if err != nil { // Don't accept the sample.
 		return false, err
 	}


### PR DESCRIPTION
I believe this comment is confusing. I noticed it because I've been trying to understand how the HA-deduping works and it didn't make sense to me until I realized this... The wording `checkReplica should only have returned an error if there was a real error` sounded to me like it would exclude the possibility that `checkReplica` returned an error simply because the current replica is not the elected replica.