### PR TITLE
implement HA dedupe as middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [BUGFIX] Compactor: Fix bug when using `-compactor.partial-block-deletion-delay`: compactor didn't correctly check for modification time of all block files. #2559
 * [BUGFIX] Query-frontend: fix wrong query sharding results for queries with boolean result like `1 < bool 0`. #2558
 * [BUGFIX] Fixed error messages related to per-instance limits incorrectly reporting they can be set on a per-tenant basis. #2610
+* [BUGFIX] Perform HA-deduplication before forwarding samples according to forwarding rules in the distributor. #2603
 
 ### Mixin
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -240,7 +240,11 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc) {
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	wrappedDistributor := d.PrePushForwardingMiddleware(a.cfg.wrapDistributorPush(d))
+	wrappedDistributor := d.PrePushForwardingMiddleware(
+		d.PrePushHaDedupeMiddleware(
+			a.cfg.wrapDistributorPush(d),
+		),
+	)
 
 	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, wrappedDistributor), true, false, "POST")
 	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, wrappedDistributor), true, false, "POST")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -240,6 +240,7 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc) {
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
+	// TODO(replay) implement better way to chain middlewares.
 	wrappedDistributor := d.PrePushForwardingMiddleware(
 		d.PrePushHaDedupeMiddleware(
 			a.cfg.wrapDistributorPush(d),

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -240,12 +240,9 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc) {
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	// TODO(replay) implement better way to chain middlewares.
-	wrappedDistributor := d.PrePushForwardingMiddleware(
-		d.PrePushHaDedupeMiddleware(
-			a.cfg.wrapDistributorPush(d),
-		),
-	)
+	wrappedDistributor := a.cfg.wrapDistributorPush(d)
+	wrappedDistributor = d.PrePushForwardingMiddleware(wrappedDistributor)
+	wrappedDistributor = d.PrePushHaDedupeMiddleware(wrappedDistributor)
 
 	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, wrappedDistributor), true, false, "POST")
 	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, wrappedDistributor), true, false, "POST")

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -614,7 +614,7 @@ func (d *Distributor) pushWithMiddlewares() push.Func {
 	var middlewares []func(push.Func) push.Func
 
 	// The middlewares will be applied in the order of the slice "middlewares",
-	// requests will traverse them in the reverse order.
+	// requests will traverse them in the reverse order and the first middleware will wrap the second one, etc.
 	middlewares = append(middlewares, d.prePushForwardingMiddleware)
 	middlewares = append(middlewares, d.prePushHaDedupeMiddleware)
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -652,8 +652,8 @@ func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
 		for _, ts := range req.Timeseries {
 			numSamples += len(ts.Samples)
 		}
-		removeReplica := false
-		removeReplica, err = d.checkSample(ctx, userID, cluster, replica)
+
+		removeReplica, err := d.checkSample(ctx, userID, cluster, replica)
 		if err != nil {
 			if errors.Is(err, replicasNotMatchError{}) {
 				// These samples have been deduped.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -634,7 +634,8 @@ func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
 		}
 
 		if d.limits.AcceptHASamples(userID) && len(req.Timeseries) > 0 {
-			cluster, replica := findHALabels(d.limits.HAReplicaLabel(userID), d.limits.HAClusterLabel(userID), req.Timeseries[0].Labels)
+			haReplicaLabel := d.limits.HAReplicaLabel(userID)
+			cluster, replica := findHALabels(haReplicaLabel, d.limits.HAClusterLabel(userID), req.Timeseries[0].Labels)
 			// Make a copy of these, since they may be retained as labels on our metrics, e.g. dedupedSamples.
 			cluster, replica = copyString(cluster), copyString(replica)
 
@@ -664,7 +665,7 @@ func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
 				// storing series in Mimir. If we kept the replica label we would end up with another series for the same
 				// series we're trying to dedupe when HA tracking moves over to a different replica.
 				for _, ts := range req.Timeseries {
-					removeLabel(d.limits.HAReplicaLabel(userID), &ts.Labels)
+					removeLabel(haReplicaLabel, &ts.Labels)
 				}
 			} else {
 				// If there wasn't an error but removeReplica is false that means we didn't find both HA labels.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -639,6 +639,12 @@ func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
 			// Make a copy of these, since they may be retained as labels on our metrics, e.g. dedupedSamples.
 			cluster, replica = copyString(cluster), copyString(replica)
 
+			span := opentracing.SpanFromContext(ctx)
+			if span != nil {
+				span.SetTag("cluster", cluster)
+				span.SetTag("replica", replica)
+			}
+
 			numSamples := 0
 			for _, ts := range req.Timeseries {
 				numSamples += len(ts.Samples)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -615,8 +615,8 @@ func (d *Distributor) pushWithMiddlewares() push.Func {
 
 	// The middlewares will be applied in the order of the slice "middlewares",
 	// requests will traverse them in the reverse order.
-	middlewares = append(middlewares, d.PrePushForwardingMiddleware)
-	middlewares = append(middlewares, d.PrePushHaDedupeMiddleware)
+	middlewares = append(middlewares, d.prePushForwardingMiddleware)
+	middlewares = append(middlewares, d.prePushHaDedupeMiddleware)
 
 	push := d.PushWithCleanup
 	for _, middleware := range middlewares {
@@ -626,7 +626,7 @@ func (d *Distributor) pushWithMiddlewares() push.Func {
 	return push
 }
 
-func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
+func (d *Distributor) prePushHaDedupeMiddleware(next push.Func) push.Func {
 	return func(ctx context.Context, req *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error) {
 		userID, err := tenant.TenantID(ctx)
 		if err != nil {
@@ -685,9 +685,9 @@ func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
 	}
 }
 
-// PrePushForwardingMiddleware is used as push.Func middleware in front of PushWithCleanup method.
+// prePushForwardingMiddleware is used as push.Func middleware in front of PushWithCleanup method.
 // It forwards time series to configured remote_write endpoints if the forwarding rules say so.
-func (d *Distributor) PrePushForwardingMiddleware(next push.Func) push.Func {
+func (d *Distributor) prePushForwardingMiddleware(next push.Func) push.Func {
 	if d.forwarder == nil {
 		// Forwarding is disabled, no need to wrap "next".
 		return next

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -630,6 +630,7 @@ func (d *Distributor) prePushHaDedupeMiddleware(next push.Func) push.Func {
 	return func(ctx context.Context, req *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error) {
 		userID, err := tenant.TenantID(ctx)
 		if err != nil {
+			cleanup()
 			return nil, err
 		}
 
@@ -655,6 +656,8 @@ func (d *Distributor) prePushHaDedupeMiddleware(next push.Func) push.Func {
 
 		removeReplica, err := d.checkSample(ctx, userID, cluster, replica)
 		if err != nil {
+			cleanup()
+
 			if errors.Is(err, replicasNotMatchError{}) {
 				// These samples have been deduped.
 				d.dedupedSamples.WithLabelValues(userID, cluster).Add(float64(numSamples))

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -623,7 +623,10 @@ func (d *Distributor) PrePushHaDedupeMiddleware(next push.Func) push.Func {
 			// Make a copy of these, since they may be retained as labels on our metrics, e.g. dedupedSamples.
 			cluster, replica = copyString(cluster), copyString(replica)
 
-			numSamples := 0 // TODO(replay) fix this
+			numSamples := 0
+			for _, ts := range req.Timeseries {
+				numSamples += len(ts.Samples)
+			}
 			removeReplica := false
 			removeReplica, err = d.checkSample(ctx, userID, cluster, replica)
 			if err != nil {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2488,7 +2488,7 @@ func TestDistributor_IngestionIsControlledByForwarder(t *testing.T) {
 				getForwarder:      getForwarder,
 			})
 
-			wrappedPush := distributors[0].PrePushForwardingMiddleware(distributors[0].PushWithCleanup)
+			wrappedPush := distributors[0].prePushForwardingMiddleware(distributors[0].PushWithCleanup)
 			response, err := wrappedPush(ctx, tc.request, func() {})
 			assert.NoError(t, err)
 			assert.Equal(t, emptyResponse, response)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2488,8 +2488,7 @@ func TestDistributor_IngestionIsControlledByForwarder(t *testing.T) {
 				getForwarder:      getForwarder,
 			})
 
-			wrappedPush := distributors[0].prePushForwardingMiddleware(distributors[0].PushWithCleanup)
-			response, err := wrappedPush(ctx, tc.request, func() {})
+			response, err := distributors[0].Push(ctx, tc.request)
 			assert.NoError(t, err)
 			assert.Equal(t, emptyResponse, response)
 			assert.Equal(t, 1, int(forwardReqCnt.Load()))


### PR DESCRIPTION
Currently the HA-deduplication happens after the forwarding in the distributor, meaning that forwarding targets get the raw samples before deduplication. We'll want to move the HA-deduplication in front of the forwarding so that forwarding targets can also take advantage of the HA-deduplication.

This change also breaks up the distributor's giant `PushWithCleanup` method, which I think is a benefit because it's too large and hard to understand at the moment.

Fixes: https://github.com/grafana/mimir-squad/issues/784