### PR TITLE
Install go 1.18 for comparing helm vs jsonnet

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -22,6 +22,9 @@ jobs:
         body-includes: '**Helm <> Jsonnet Diff**'
 
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.18.4'
     - uses: helm/kind-action@v1.2.0
     - uses: frenck/action-setup-yq@a2ad11c46c5d7ba576861216963c9365b53f35bc
     - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
@@ -38,15 +41,17 @@ jobs:
         file: 'jb-linux-amd64'
         target: 'bin/jb'
         token: ${{ secrets.GITHUB_TOKEN }}
-    - run: |
+    - name: Configure dependencies
+      run: |
         set -e
         chmod +x $PWD/bin/tk
         chmod +x $PWD/bin/jb
         echo $PWD/bin >> $GITHUB_PATH
-
-    - id: compare-manifests
-      run: |
         set +e
+
+    - name: Compare manifests
+      id: compare-manifests
+      run: |
         # Make dependencies first so their output doesn't appear in the PR comment
         make operations/helm/charts/mimir-distributed/charts
         make build-jsonnet-tests


### PR DESCRIPTION
Also give meaningful names to steps that were called just "set -e" and "set +e".

Fixes https://github.com/grafana/mimir/issues/2607
