### PR TITLE
Fix per-instance limits error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [BUGFIX] Memberlist: Fix problem with ring being empty right after startup. Memberlist KV store now tries to "fast-join" the cluster to avoid serving empty KV store. #2505
 * [BUGFIX] Compactor: Fix bug when using `-compactor.partial-block-deletion-delay`: compactor didn't correctly check for modification time of all block files. #2559
 * [BUGFIX] Query-frontend: fix wrong query sharding results for queries with boolean result like `1 < bool 0`. #2558
+* [BUGFIX] Fixed error messages related to per-instance limits incorrectly reporting they can be set on a per-tenant basis. #2610
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -62,9 +62,9 @@ var (
 	errInvalidTenantShardSize = errors.New("invalid tenant shard size, the value must be greater or equal to zero")
 
 	// Distributor instance limits errors.
-	errMaxInflightRequestsReached      = errors.New(globalerror.DistributorMaxInflightPushRequests.MessageWithLimitConfig("the write request has been rejected because the distributor exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
-	errMaxIngestionRateReached         = errors.New(globalerror.DistributorMaxIngestionRate.MessageWithLimitConfig("the write request has been rejected because the distributor exceeded the ingestion rate limit", maxIngestionRateFlag))
-	errMaxInflightRequestsBytesReached = errors.New(globalerror.DistributorMaxInflightPushRequestsBytes.MessageWithLimitConfig("the write request has been rejected because the distributor exceeded the allowed total size in bytes of inflight push requests", maxInflightPushRequestsBytesFlag))
+	errMaxInflightRequestsReached      = errors.New(globalerror.DistributorMaxInflightPushRequests.MessageWithPerTenantLimitConfig("the write request has been rejected because the distributor exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached         = errors.New(globalerror.DistributorMaxIngestionRate.MessageWithPerTenantLimitConfig("the write request has been rejected because the distributor exceeded the ingestion rate limit", maxIngestionRateFlag))
+	errMaxInflightRequestsBytesReached = errors.New(globalerror.DistributorMaxInflightPushRequestsBytes.MessageWithPerTenantLimitConfig("the write request has been rejected because the distributor exceeded the allowed total size in bytes of inflight push requests", maxInflightPushRequestsBytesFlag))
 )
 
 const (

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -62,9 +62,9 @@ var (
 	errInvalidTenantShardSize = errors.New("invalid tenant shard size, the value must be greater or equal to zero")
 
 	// Distributor instance limits errors.
-	errMaxInflightRequestsReached      = errors.New(globalerror.DistributorMaxInflightPushRequests.MessageWithPerTenantLimitConfig("the write request has been rejected because the distributor exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
-	errMaxIngestionRateReached         = errors.New(globalerror.DistributorMaxIngestionRate.MessageWithPerTenantLimitConfig("the write request has been rejected because the distributor exceeded the ingestion rate limit", maxIngestionRateFlag))
-	errMaxInflightRequestsBytesReached = errors.New(globalerror.DistributorMaxInflightPushRequestsBytes.MessageWithPerTenantLimitConfig("the write request has been rejected because the distributor exceeded the allowed total size in bytes of inflight push requests", maxInflightPushRequestsBytesFlag))
+	errMaxInflightRequestsReached      = errors.New(globalerror.DistributorMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the distributor exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached         = errors.New(globalerror.DistributorMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the distributor exceeded the ingestion rate limit", maxIngestionRateFlag))
+	errMaxInflightRequestsBytesReached = errors.New(globalerror.DistributorMaxInflightPushRequestsBytes.MessageWithPerInstanceLimitConfig("the write request has been rejected because the distributor exceeded the allowed total size in bytes of inflight push requests", maxInflightPushRequestsBytesFlag))
 )
 
 const (

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -530,7 +530,7 @@ type tooManyClustersError struct {
 }
 
 func (e tooManyClustersError) Error() string {
-	return globalerror.TooManyHAClusters.MessageWithLimitConfig(
+	return globalerror.TooManyHAClusters.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("the write request has been rejected because the maximum number of high-availability (HA) clusters has been reached for this tenant (limit: %d)", e.limit),
 		validation.HATrackerMaxClustersFlag)
 }

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -23,10 +23,10 @@ const (
 
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
-	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
-	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
-	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
-	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
+	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
+	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
+	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -23,10 +23,10 @@ const (
 
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
-	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
-	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
-	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
-	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerTenantLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
+	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
+	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
+	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -116,7 +116,7 @@ func (l *Limiter) FormatError(userID string, err error) error {
 func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
 
-	return errors.New(globalerror.MaxSeriesPerUser.MessageWithLimitConfig(
+	return errors.New(globalerror.MaxSeriesPerUser.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-user series limit of %d exceeded", globalLimit),
 		validation.MaxSeriesPerUserFlag,
 	))
@@ -125,7 +125,7 @@ func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
 
-	return errors.New(globalerror.MaxSeriesPerMetric.MessageWithLimitConfig(
+	return errors.New(globalerror.MaxSeriesPerMetric.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-metric series limit of %d exceeded", globalLimit),
 		validation.MaxSeriesPerMetricFlag,
 	))
@@ -134,7 +134,7 @@ func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
 	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
 
-	return errors.New(globalerror.MaxMetadataPerUser.MessageWithLimitConfig(
+	return errors.New(globalerror.MaxMetadataPerUser.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-user metric metadata limit of %d exceeded", globalLimit),
 		validation.MaxMetadataPerUserFlag,
 	))
@@ -143,7 +143,7 @@ func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
 func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
 	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
 
-	return errors.New(globalerror.MaxMetadataPerMetric.MessageWithLimitConfig(
+	return errors.New(globalerror.MaxMetadataPerMetric.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-metric metadata limit of %d exceeded", globalLimit),
 		validation.MaxMetadataPerMetricFlag,
 	))

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -64,7 +64,7 @@ const (
 )
 
 var (
-	maxChunksPerQueryLimitMsgFormat = globalerror.MaxChunksPerQuery.MessageWithLimitConfig(
+	maxChunksPerQueryLimitMsgFormat = globalerror.MaxChunksPerQuery.MessageWithPerTenantLimitConfig(
 		"the query exceeded the maximum number of chunks fetched from store-gateways when querying '%s' (limit: %d)",
 		validation.MaxChunksPerQueryFlag,
 	)

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -68,9 +68,9 @@ func (id ID) Message(msg string) string {
 	return fmt.Sprintf("%s (%s%s)", msg, errPrefix, id)
 }
 
-// MessageWithLimitConfig returns the provided msg, appending the error id and a suggestion on
+// MessageWithPerTenantLimitConfig returns the provided msg, appending the error id and a suggestion on
 // which configuration flag(s) to use to change the limit.
-func (id ID) MessageWithLimitConfig(msg, flag string, addFlags ...string) string {
+func (id ID) MessageWithPerTenantLimitConfig(msg, flag string, addFlags ...string) string {
 	var sb strings.Builder
 	sb.WriteString("-")
 	sb.WriteString(flag)

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -68,9 +68,21 @@ func (id ID) Message(msg string) string {
 	return fmt.Sprintf("%s (%s%s)", msg, errPrefix, id)
 }
 
+// MessageWithPerInstanceLimitConfig returns the provided msg, appending the error id and a suggestion on
+// which configuration flag(s) to use to change the per-instance limit.
+func (id ID) MessageWithPerInstanceLimitConfig(msg, flag string, addFlags ...string) string {
+	flagsList, plural := buildFlagsList(flag, addFlags...)
+	return fmt.Sprintf("%s (%s%s). To adjust the related limit%s, configure %s, or contact your service administrator.", msg, errPrefix, id, plural, flagsList)
+}
+
 // MessageWithPerTenantLimitConfig returns the provided msg, appending the error id and a suggestion on
-// which configuration flag(s) to use to change the limit.
+// which configuration flag(s) to use to change the per-tenant limit.
 func (id ID) MessageWithPerTenantLimitConfig(msg, flag string, addFlags ...string) string {
+	flagsList, plural := buildFlagsList(flag, addFlags...)
+	return fmt.Sprintf("%s (%s%s). To adjust the related per-tenant limit%s, configure %s, or contact your service administrator.", msg, errPrefix, id, plural, flagsList)
+}
+
+func buildFlagsList(flag string, addFlags ...string) (string, string) {
 	var sb strings.Builder
 	sb.WriteString("-")
 	sb.WriteString(flag)
@@ -84,5 +96,6 @@ func (id ID) MessageWithPerTenantLimitConfig(msg, flag string, addFlags ...strin
 		sb.WriteString(" and -")
 		sb.WriteString(addFlags[len(addFlags)-1])
 	}
-	return fmt.Sprintf("%s (%s%s). To adjust the related per-tenant limit%s, configure %s, or contact your service administrator.", msg, errPrefix, id, plural, sb.String())
+
+	return sb.String(), plural
 }

--- a/pkg/util/globalerror/errors_test.go
+++ b/pkg/util/globalerror/errors_test.go
@@ -15,22 +15,22 @@ func TestID_Message(t *testing.T) {
 		MissingMetricName.Message("an error"))
 }
 
-func TestID_MessageWithLimitConfig(t *testing.T) {
+func TestID_MessageWithPerTenantLimitConfig(t *testing.T) {
 	for _, tc := range []struct {
 		expected string
 		actual   string
 	}{
 		{
 			expected: "an error (err-mimir-missing-metric-name). To adjust the related per-tenant limit, configure -my-flag1, or contact your service administrator.",
-			actual:   MissingMetricName.MessageWithLimitConfig("an error", "my-flag1"),
+			actual:   MissingMetricName.MessageWithPerTenantLimitConfig("an error", "my-flag1"),
 		},
 		{
 			expected: "an error (err-mimir-missing-metric-name). To adjust the related per-tenant limits, configure -my-flag1 and -my-flag2, or contact your service administrator.",
-			actual:   MissingMetricName.MessageWithLimitConfig("an error", "my-flag1", "my-flag2"),
+			actual:   MissingMetricName.MessageWithPerTenantLimitConfig("an error", "my-flag1", "my-flag2"),
 		},
 		{
 			expected: "an error (err-mimir-missing-metric-name). To adjust the related per-tenant limits, configure -my-flag1, -my-flag2 and -my-flag3, or contact your service administrator.",
-			actual:   MissingMetricName.MessageWithLimitConfig("an error", "my-flag1", "my-flag2", "my-flag3"),
+			actual:   MissingMetricName.MessageWithPerTenantLimitConfig("an error", "my-flag1", "my-flag2", "my-flag3"),
 		},
 	} {
 		assert.Equal(t, tc.expected, tc.actual)

--- a/pkg/util/globalerror/errors_test.go
+++ b/pkg/util/globalerror/errors_test.go
@@ -15,6 +15,28 @@ func TestID_Message(t *testing.T) {
 		MissingMetricName.Message("an error"))
 }
 
+func TestID_MessageWithPerInstanceLimitConfig(t *testing.T) {
+	for _, tc := range []struct {
+		expected string
+		actual   string
+	}{
+		{
+			expected: "an error (err-mimir-missing-metric-name). To adjust the related limit, configure -my-flag1, or contact your service administrator.",
+			actual:   MissingMetricName.MessageWithPerInstanceLimitConfig("an error", "my-flag1"),
+		},
+		{
+			expected: "an error (err-mimir-missing-metric-name). To adjust the related limits, configure -my-flag1 and -my-flag2, or contact your service administrator.",
+			actual:   MissingMetricName.MessageWithPerInstanceLimitConfig("an error", "my-flag1", "my-flag2"),
+		},
+		{
+			expected: "an error (err-mimir-missing-metric-name). To adjust the related limits, configure -my-flag1, -my-flag2 and -my-flag3, or contact your service administrator.",
+			actual:   MissingMetricName.MessageWithPerInstanceLimitConfig("an error", "my-flag1", "my-flag2", "my-flag3"),
+		},
+	} {
+		assert.Equal(t, tc.expected, tc.actual)
+	}
+}
+
 func TestID_MessageWithPerTenantLimitConfig(t *testing.T) {
 	for _, tc := range []struct {
 		expected string

--- a/pkg/util/limiter/query_limiter.go
+++ b/pkg/util/limiter/query_limiter.go
@@ -24,15 +24,15 @@ type queryLimiterCtxKey struct{}
 
 var (
 	ctxKey                = &queryLimiterCtxKey{}
-	MaxSeriesHitMsgFormat = globalerror.MaxSeriesPerQuery.MessageWithLimitConfig(
+	MaxSeriesHitMsgFormat = globalerror.MaxSeriesPerQuery.MessageWithPerTenantLimitConfig(
 		"the query exceeded the maximum number of series (limit: %d series)",
 		validation.MaxSeriesPerQueryFlag,
 	)
-	MaxChunkBytesHitMsgFormat = globalerror.MaxChunkBytesPerQuery.MessageWithLimitConfig(
+	MaxChunkBytesHitMsgFormat = globalerror.MaxChunkBytesPerQuery.MessageWithPerTenantLimitConfig(
 		"the query exceeded the aggregated chunks size limit (limit: %d bytes)",
 		validation.MaxChunkBytesPerQueryFlag,
 	)
-	MaxChunksPerQueryLimitMsgFormat = globalerror.MaxChunksPerQuery.MessageWithLimitConfig(
+	MaxChunksPerQueryLimitMsgFormat = globalerror.MaxChunksPerQuery.MessageWithPerTenantLimitConfig(
 		"the query exceeded the maximum number of chunks (limit: %d chunks)",
 		validation.MaxChunksPerQueryFlag,
 	)

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -33,7 +33,7 @@ func (e genericValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.cause, formatLabelSet(e.series))
 }
 
-var labelNameTooLongMsgFormat = globalerror.SeriesLabelNameTooLong.MessageWithLimitConfig(
+var labelNameTooLongMsgFormat = globalerror.SeriesLabelNameTooLong.MessageWithPerTenantLimitConfig(
 	"received a series whose label name length exceeds the limit, label: '%.200s' series: '%.200s'",
 	maxLabelNameLengthFlag)
 
@@ -53,7 +53,7 @@ type labelValueTooLongError struct {
 }
 
 func (e labelValueTooLongError) Error() string {
-	return globalerror.SeriesLabelValueTooLong.MessageWithLimitConfig(
+	return globalerror.SeriesLabelValueTooLong.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("received a series whose label value length exceeds the limit, value: '%.200s' (truncated) series: '%.200s'", e.labelValue, formatLabelSet(e.series)),
 		maxLabelValueLengthFlag)
 }
@@ -111,7 +111,7 @@ func newTooManyLabelsError(series []mimirpb.LabelAdapter, limit int) ValidationE
 }
 
 func (e tooManyLabelsError) Error() string {
-	return globalerror.MaxLabelNamesPerSeries.MessageWithLimitConfig(
+	return globalerror.MaxLabelNamesPerSeries.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("received a series whose number of labels exceeds the limit (actual: %d, limit: %d) series: '%.200s'", len(e.series), e.limit, mimirpb.FromLabelAdaptersToMetric(e.series).String()),
 		maxLabelNamesPerSeriesFlag)
 }
@@ -151,7 +151,7 @@ func (e sampleValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.timestamp, e.metricName)
 }
 
-var sampleTimestampTooNewMsgFormat = globalerror.SampleTooFarInFuture.MessageWithLimitConfig(
+var sampleTimestampTooNewMsgFormat = globalerror.SampleTooFarInFuture.MessageWithPerTenantLimitConfig(
 	"received a sample whose timestamp is too far in the future, timestamp: %d series: '%.200s'",
 	creationGracePeriodFlag)
 
@@ -232,7 +232,7 @@ func (e metadataValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.cause, e.metricName)
 }
 
-var metadataMetricNameTooLongMsgFormat = globalerror.MetricMetadataMetricNameTooLong.MessageWithLimitConfig(
+var metadataMetricNameTooLongMsgFormat = globalerror.MetricMetadataMetricNameTooLong.MessageWithPerTenantLimitConfig(
 	// When formatting this error the "cause" will always be an empty string.
 	"received a metric metadata whose metric name length exceeds the limit, metric name: '%.200[2]s'",
 	maxMetadataLengthFlag)
@@ -245,7 +245,7 @@ func newMetadataMetricNameTooLongError(metadata *mimirpb.MetricMetadata) Validat
 	}
 }
 
-var metadataHelpTooLongMsgFormat = globalerror.MetricMetadataHelpTooLong.MessageWithLimitConfig(
+var metadataHelpTooLongMsgFormat = globalerror.MetricMetadataHelpTooLong.MessageWithPerTenantLimitConfig(
 	"received a metric metadata whose help description length exceeds the limit, help: '%.200s' metric name: '%.200s'",
 	maxMetadataLengthFlag)
 
@@ -257,7 +257,7 @@ func newMetadataHelpTooLongError(metadata *mimirpb.MetricMetadata) ValidationErr
 	}
 }
 
-var metadataUnitTooLongMsgFormat = globalerror.MetricMetadataUnitTooLong.MessageWithLimitConfig(
+var metadataUnitTooLongMsgFormat = globalerror.MetricMetadataUnitTooLong.MessageWithPerTenantLimitConfig(
 	"received a metric metadata whose unit name length exceeds the limit, unit: '%.200s' metric name: '%.200s'",
 	maxMetadataLengthFlag)
 
@@ -270,19 +270,19 @@ func newMetadataUnitTooLongError(metadata *mimirpb.MetricMetadata) ValidationErr
 }
 
 func NewMaxQueryLengthError(actualQueryLen, maxQueryLength time.Duration) LimitError {
-	return LimitError(globalerror.MaxQueryLength.MessageWithLimitConfig(
+	return LimitError(globalerror.MaxQueryLength.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("the query time range exceeds the limit (query length: %s, limit: %s)", actualQueryLen, maxQueryLength),
 		maxQueryLengthFlag))
 }
 
 func NewRequestRateLimitedError(limit float64, burst int) LimitError {
-	return LimitError(globalerror.RequestRateLimited.MessageWithLimitConfig(
+	return LimitError(globalerror.RequestRateLimited.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("the request has been rejected because the tenant exceeded the request rate limit, set to %v requests/s across all distributors with a maximum allowed burst of %d", limit, burst),
 		requestRateFlag, requestBurstSizeFlag))
 }
 
 func NewIngestionRateLimitedError(limit float64, burst int) LimitError {
-	return LimitError(globalerror.IngestionRateLimited.MessageWithLimitConfig(
+	return LimitError(globalerror.IngestionRateLimited.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("the request has been rejected because the tenant exceeded the ingestion rate limit, set to %v items/s with a maximum allowed burst of %d. This limit is applied on the total number of samples, exemplars and metadata received across all distributors", limit, burst),
 		ingestionRateFlag, ingestionBurstSizeFlag))
 }


### PR DESCRIPTION
#### What this PR does
The error messages related to per-instance limits say the limit can be set on a per-tenant basis, which is wrong. For example:

```
the write request has been rejected because the ingester exceeded the samples ingestion rate limit (err-mimir-ingester-max-ingestion-rate). To adjust the related per-tenant limit, configure -ingester.instance-limits.max-ingestion-rate, or contact your service administrator.
```

In this PR I'm fixing it. As separate commits:
- [Renamed MessageWithLimitConfig() to MessageWithPerTenantLimitConfig()](https://github.com/grafana/mimir/commit/a75cdabdf906ce0901ec7c6cf36e6048c58cbcaa)
- [Fix error message for per-instance limits](https://github.com/grafana/mimir/commit/51bc2e9752c7dcaef8bc76bae7a5d54ea369b2b0)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
