### PR TITLE
Helm: inject the no_auth_tenant as default in nginx

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -21,7 +21,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `namespace` to smoke-test helm template to allow the job to be deployed within the same namespace as the rest of the deployment. #2515
 * [ENHANCEMENT] Memberlist now uses DNS service-discovery by default. #2549 #2561
 * [ENHANCEMENT] The Mimir configuration parameters `server.http_listen_port` and `server.grpc_listen_port` are now configurable in `mimir.structuredConfig`. #2561
-* [ENHANCEMENT] Default to injecting the `no_auth_tenant` into `X-Scope-OrgID` via nginx. #2614
+* [ENHANCEMENT] Default to injecting the `no_auth_tenant` from the Mimir configuration as the value for `X-Scope-OrgID` in nginx. #2614
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 * [BUGFIX] Add missing `containerSecurityContext` to alertmanager and tokengen job. #2416
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -21,6 +21,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `namespace` to smoke-test helm template to allow the job to be deployed within the same namespace as the rest of the deployment. #2515
 * [ENHANCEMENT] Memberlist now uses DNS service-discovery by default. #2549 #2561
 * [ENHANCEMENT] The Mimir configuration parameters `server.http_listen_port` and `server.grpc_listen_port` are now configurable in `mimir.structuredConfig`. #2561
+* [ENHANCEMENT] Default to injecting the `no_auth_tenant` into `X-Scope-OrgID` via nginx. #2614
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 * [BUGFIX] Add missing `containerSecurityContext` to alertmanager and tokengen job. #2416
 

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -330,3 +330,10 @@ Expects the component name in .component on the passed context
 {{- define "mimir.componentSectionFromName" -}}
 {{- .component | replace "-" "_" -}}
 {{- end -}}
+
+{{/*
+Get the no_auth_tenant from the configuration
+*/}}
+{{- define "mimir.noAuthTenant" -}}
+{{- (include "mimir.calculatedConfig" . | fromYaml).no_auth_tenant | default "anonymous" -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1541,10 +1541,10 @@ nginx:
         {{ . | nindent 2 }}
         {{- end }}
 
-        # Ensure that X-Scope-OrgID is always present, default to "anonymous" for backwards compatibility when multi-tenancy was turned off.
+        # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.
         map $http_x_scope_orgid $ensured_x_scope_orgid {
           default $http_x_scope_orgid;
-          "" "anonymous";
+          "" "{{ include "mimir.noAuthTenant" . }}";
         }
 
         server {

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -39,7 +39,7 @@ data:
       tcp_nopush   on;
       resolver kube-dns.kube-system.svc.cluster.local;
     
-      # Ensure that X-Scope-OrgID is always present, default to "anonymous" for backwards compatibility when multi-tenancy was turned off.
+      # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.
       map $http_x_scope_orgid $ensured_x_scope_orgid {
         default $http_x_scope_orgid;
         "" "anonymous";


### PR DESCRIPTION
#### What this PR does

Currently if someone is migrating from cortex,
they set "fake" as the no_auth_tenant, but Helm installed nginx 
will try to inject "anonymous".

This commit fixes that and injects the value set in the mimir config
into X-Scope-OrgID.

#### Which issue(s) this PR fixes or relates to

Fixes #2563 

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
