### PR TITLE
Automate weekly helm development release (without docs)

### DIFF
--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -5,9 +5,6 @@ on:
     - cron: '0 10 * * 1-5' # 10 UTC on weekdays; if we miss published images one day, they should align the day after
 
   workflow_dispatch: # for manual testing
-  push:
-    branches:
-      - dimitar/helm-weekly-release
 
 jobs:
   weekly-release-pr:

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * 1' # 12 UTC on Mondays for weekly release; images for GEM and Mimir should have already been pushed
 
   workflow_dispatch: # for manual testing
+  push:
+    branches:
+      - dimitar/helm-weekly-release
 
 jobs:
   weekly-release-pr:

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -2,7 +2,7 @@ name: helm-weekly-release-pr
 
 on:
   schedule:
-    - cron: '0 12 * * 1' # 12 UTC on Mondays for weekly release; images for GEM and Mimir should have already been pushed
+    - cron: '0 10 * * 1-5' # 10 UTC on weekdays; if we miss published images one day, they should align the day after
 
   workflow_dispatch: # for manual testing
   push:

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -1,0 +1,30 @@
+name: helm-weekly-release-pr
+
+on:
+  schedule:
+    - cron: '0 12 * * 1' # 12 UTC on Mondays for weekly release; images for GEM and Mimir should have already been pushed
+
+  workflow_dispatch: # for manual testing
+
+jobs:
+  weekly-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: imjasonh/setup-crane@v0.1
+
+      - name: Update/regenerate files
+        id: update
+        run: bash .github/workflows/scripts/helm-weekly-release.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          title: Release mimir-distributed Helm chart ${{ steps.update.outputs.new_chart_version }}
+          body: Automated PR created by [helm-weekly-release-pr.yaml](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-weekly-release-pr.yaml)
+          commit-message: Update mimir-distributed chart to ${{ steps.update.outputs.new_chart_version }}
+          author: grafanabot <grafanabot@grafana.com>
+          branch: helm-chart-weekly-${{ steps.update.outputs.new_chart_version }}
+          base: main
+          labels: helm

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -92,6 +92,6 @@ update_yaml_node $values_file .enterprise.image.tag $latest_gem_tag
 update_yaml_node $chart_file .appVersion $(extract_r_version $latest_mimir_tag)
 update_yaml_node $chart_file .version $new_chart_version
 
-make TTY='' build-helm-tests doc
+make TTY='' doc
 
 echo "::set-output name=new_chart_version::$new_chart_version"

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 
 set -exo pipefail
 

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+# Uses docker hub image tags to figure out what is the latest image tag
+find_latest_image_tag() {
+  docker_hub_repo=$1
+  echo $(crane ls "${docker_hub_repo}" | grep -P 'r\d+-[a-z0-9]+' | sort -Vur | head -1)
+}
+
+# This generates a new file where the yaml node is updated.
+# The problem is that yq strips new lines when you update the file.
+# So we use a workaround from https://github.com/mikefarah/yq/issues/515 which:
+# generates the new file, diffs it with the original, removes all non-whitespace changes, and applies that to the original file.
+update_yaml_node() {
+  filename=$1
+  yaml_node=$2
+  new_value=$3
+  patch "$filename" <<< $(diff -U0 -w -b --ignore-blank-lines $filename <(yq eval "$yaml_node = \"$new_value\"" $filename))
+}
+
+get_yaml_node() {
+  filename=$1
+  yaml_node=$2
+  echo $(yq $yaml_node $filename)
+}
+
+# Increments the part of the string
+# $1: version itself
+# $2: number of part: 0 – major, 1 – minor, 2 – patch
+increment_semver() {
+  local delimiter=.
+  local array=($(echo "$1" | tr $delimiter '\n'))
+  array[$2]=$((array[$2]+1))
+  echo $(local IFS=$delimiter ; echo "${array[*]}")
+}
+
+latest_mimir_tag=$(find_latest_image_tag grafana/mimir)
+latest_gem_tag=$(find_latest_image_tag grafana/enterprise-metrics)
+
+values_file=operations/helm/charts/mimir-distributed/values.yaml
+chart_file=operations/helm/charts/mimir-distributed/Chart.yaml
+
+calculate_next_chart_version() {
+  current_chart_version=$(get_yaml_node $chart_file .version)
+  current_chart_semver=$(echo $current_chart_version | grep -P -o '^(\d+.){2}\d+')
+  new_chart_weekly=$(echo $latest_mimir_tag | grep -P -o 'r\d+' | grep -P -o '\d+')
+  new_chart_semver=$current_chart_semver
+  if [[ $current_chart_version != *weekly* ]]; then
+    # If previous version was not a weekly, then it was a stable release.
+    # _This_ weekly release should have a semver that's one above the
+    new_chart_semver=$(increment_semver $current_chart_semver 1)
+  fi
+  echo "$new_chart_semver-weekly.$new_chart_weekly"
+}
+
+new_chart_version=$(calculate_next_chart_version)
+
+update_yaml_node $values_file .image.tag $latest_mimir_tag
+update_yaml_node $values_file .smoke_test.image.tag $latest_mimir_tag
+update_yaml_node $values_file .enterprise.image.tag $latest_gem_tag
+update_yaml_node $chart_file .appVersion $latest_mimir_tag
+update_yaml_node $chart_file .version $new_chart_version
+
+make TTY='' build-helm-tests doc
+
+echo "::set-output name=new_chart_version::$new_chart_version"

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -63,15 +63,15 @@ validate_version_update() {
   local latest_gem_tag=$3
   local latest_mimir_tag=$4
 
-  if [[ $new_chart_version -eq $current_chart_version ]]; then
+  if [[ "$new_chart_version" == "$current_chart_version" ]]; then
     echo "New chart version ($new_chart_version) is the same as current version ($current_chart_version); not submitting weekly PR"
     exit 1
   fi
 
   local gem_weekly_version=$(extract_r_version $latest_gem_tag)
   local mimir_weekly_version=$(extract_r_version $latest_mimir_tag)
-  if [[ $gem_weekly_number -ne $mimir_weekly_version ]]; then
-    echo "GEM weekly version ($gem_weekly_number) does not match Mimir weekly version ($mimir_weekly_version); not submitting PR"
+  if [[ "$gem_weekly_version" != "$mimir_weekly_version" ]]; then
+    echo "GEM weekly version ($gem_weekly_version) does not match Mimir weekly version ($mimir_weekly_version); not submitting PR"
     exit 1
   fi
 }

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -5,8 +5,14 @@ set -exo pipefail
 
 # Uses docker hub image tags to figure out what is the latest image tag
 find_latest_image_tag() {
-  docker_hub_repo=$1
+  local docker_hub_repo=$1
   echo $(crane ls "${docker_hub_repo}" | grep -P 'r\d+-[a-z0-9]+' | sort -Vur | head -1)
+}
+
+# takes r197-abcdef and returns r197
+extract_r_version() {
+  local version=$1
+  echo $(grep -P -o 'r\d+' <<< $version)
 }
 
 # This generates a new file where the yaml node is updated.
@@ -14,15 +20,15 @@ find_latest_image_tag() {
 # So we use a workaround from https://github.com/mikefarah/yq/issues/515 which:
 # generates the new file, diffs it with the original, removes all non-whitespace changes, and applies that to the original file.
 update_yaml_node() {
-  filename=$1
-  yaml_node=$2
-  new_value=$3
+  local filename=$1
+  local yaml_node=$2
+  local new_value=$3
   patch "$filename" <<< $(diff -U0 -w -b --ignore-blank-lines $filename <(yq eval "$yaml_node = \"$new_value\"" $filename))
 }
 
 get_yaml_node() {
-  filename=$1
-  yaml_node=$2
+  local filename=$1
+  local yaml_node=$2
   echo $(yq $yaml_node $filename)
 }
 
@@ -36,17 +42,13 @@ increment_semver() {
   echo $(local IFS=$delimiter ; echo "${array[*]}")
 }
 
-latest_mimir_tag=$(find_latest_image_tag grafana/mimir)
-latest_gem_tag=$(find_latest_image_tag grafana/enterprise-metrics)
-
-values_file=operations/helm/charts/mimir-distributed/values.yaml
-chart_file=operations/helm/charts/mimir-distributed/Chart.yaml
-
 calculate_next_chart_version() {
-  current_chart_version=$(get_yaml_node $chart_file .version)
-  current_chart_semver=$(echo $current_chart_version | grep -P -o '^(\d+.){2}\d+')
-  new_chart_weekly=$(echo $latest_mimir_tag | grep -P -o 'r\d+' | grep -P -o '\d+')
-  new_chart_semver=$current_chart_semver
+  local current_chart_version=$1
+  local latest_image_tag=$2
+
+  local current_chart_semver=$(echo $current_chart_version | grep -P -o '^(\d+.){2}\d+')
+  local new_chart_weekly=$(extract_r_version $latest_image_tag | grep -P -o '\d+')
+  local new_chart_semver=$current_chart_semver
   if [[ $current_chart_version != *weekly* ]]; then
     # If previous version was not a weekly, then it was a stable release.
     # _This_ weekly release should have a semver that's one above the
@@ -55,12 +57,39 @@ calculate_next_chart_version() {
   echo "$new_chart_semver-weekly.$new_chart_weekly"
 }
 
-new_chart_version=$(calculate_next_chart_version)
+validate_version_update() {
+  local new_chart_version=$1
+  local current_chart_version=$2
+  local latest_gem_tag=$3
+  local latest_mimir_tag=$4
+
+  if [[ $new_chart_version -eq $current_chart_version ]]; then
+    echo "New chart version ($new_chart_version) is the same as current version ($current_chart_version); not submitting weekly PR"
+    exit 1
+  fi
+
+  local gem_weekly_version=$(extract_r_version $latest_gem_tag)
+  local mimir_weekly_version=$(extract_r_version $latest_mimir_tag)
+  if [[ $gem_weekly_number -ne $mimir_weekly_version ]]; then
+    echo "GEM weekly version ($gem_weekly_number) does not match Mimir weekly version ($mimir_weekly_version); not submitting PR"
+    exit 1
+  fi
+}
+
+values_file=operations/helm/charts/mimir-distributed/values.yaml
+chart_file=operations/helm/charts/mimir-distributed/Chart.yaml
+
+latest_mimir_tag=$(find_latest_image_tag grafana/mimir)
+latest_gem_tag=$(find_latest_image_tag grafana/enterprise-metrics)
+current_chart_version=$(get_yaml_node $chart_file .version)
+new_chart_version=$(calculate_next_chart_version $current_chart_version $latest_mimir_tag)
+
+validate_version_update $new_chart_version $current_chart_version $latest_gem_tag $latest_mimir_tag
 
 update_yaml_node $values_file .image.tag $latest_mimir_tag
 update_yaml_node $values_file .smoke_test.image.tag $latest_mimir_tag
 update_yaml_node $values_file .enterprise.image.tag $latest_gem_tag
-update_yaml_node $chart_file .appVersion $latest_mimir_tag
+update_yaml_node $chart_file .appVersion $(extract_r_version $latest_mimir_tag)
 update_yaml_node $chart_file .version $new_chart_version
 
 make TTY='' build-helm-tests doc

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -218,7 +218,6 @@ Either:
 
 1. To make a release you have to merge a version bump to the Helm chart to a branch that allows Helm release (e.g. main, release-x.y), see current list in [helm-release.yaml](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-release.yaml) github action.
 
-   1. Open a PR
    1. Set the image versions in [values.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml) as needed. See values:
       - `image.tag` (Mimir)
       - `enterprise.image.tag` (GEM)
@@ -226,6 +225,7 @@ Either:
    1. For final versions, update the [Helm changelog](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md)
    1. Set the version in the Helm [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml)
    1. Run `make doc`, to update [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) from its template
+   1. Open a PR
    1. Merge the PR after review
 
    The release process checks and creates a git tag formatted as mimir-distributed-_version_ (e.g. mimir-distributed-3.1.0-weekly.196) on the merge commit. The release process fails if the tag already exists to prevent releasing the same version with different content. The release is published in the [Grafana helm-charts](https://grafana.github.io/helm-charts/) Helm repository.


### PR DESCRIPTION
#### What this PR does
Adds a github actions job that creates a PR which updates the helm chart. https://github.com/grafana/mimir/pull/2622 is a PR created via the action.

The action runs at 12:00 UTC on Mondays and can also be triggered manually.