### PR TITLE
Helm: remove appVersion from golden record

### DIFF
--- a/operations/helm/tests/build.sh
+++ b/operations/helm/tests/build.sh
@@ -25,7 +25,7 @@ for FILEPATH in $TESTS; do
   echo "Templating $TEST_NAME"
   helm template "${TEST_NAME}" ${CHART_PATH} -f "${FILEPATH}" --output-dir "${OUTPUT_DIR}" --namespace citestns
 
-  echo "Removing mutable config checksum, helm chart, image tag version for clarity"
-  find "${OUTPUT_DIR}/$(basename ${CHART_PATH})/templates" -type f -print0 | xargs -0 "${SED}" -E -i -- "/^\s+(checksum\/config|(helm.sh\/)?chart|image: \"grafana\/(mimir|mimir-continuous-test|enterprise-metrics)):/d"
+  echo "Removing mutable config checksum, helm chart, application, image tag version for clarity"
+  find "${OUTPUT_DIR}/$(basename ${CHART_PATH})/templates" -type f -print0 | xargs -0 "${SED}" -E -i -- "/^\s+(checksum\/config|(helm.sh\/)?chart|app.kubernetes.io\/version|image: \"grafana\/(mimir|mimir-continuous-test|enterprise-metrics)):/d"
 
 done

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: admin-api
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-enterprise-configmap-values-mimir-admin-api
   namespace: "citestns"
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admin-api
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: admin-api
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-enterprise-configmap-values-mimir-gateway
   namespace: "citestns"
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: gateway
       annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: gossip-ring
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/license-secret.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/license-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/minio-secrets.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/minio-secrets.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 type: Opaque

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: overrides-exporter
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-enterprise-configmap-values-mimir-overrides-exporter
   namespace: "citestns"
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: overrides-exporter
       annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: overrides-exporter
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/role.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/role.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 rules:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 roleRef:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/runtime-configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: store-gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: tokengen
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": post-install
@@ -23,7 +22,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-configmap-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: admin-api
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-enterprise-values-mimir-admin-api
   namespace: "citestns"
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admin-api
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: admin-api
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-enterprise-values-mimir-gateway
   namespace: "citestns"
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: gateway
       annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: gossip-ring
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/license-secret.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/license-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: overrides-exporter
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-enterprise-values-mimir-overrides-exporter
   namespace: "citestns"
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: overrides-exporter
       annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: overrides-exporter
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/role.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/role.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 rules:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 roleRef:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/runtime-configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: tokengen
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": post-install
@@ -23,7 +22,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-enterprise-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: chunks-cache
       annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: chunks-cache
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: gossip-ring
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: index-cache
       annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: index-cache
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metadata-cache
       annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: metadata-cache
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/minio-secrets.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/minio-secrets.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 type: Opaque

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: nginx
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: nginx
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: nginx
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: nginx
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: overrides-exporter
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   name: test-oss-values-mimir-overrides-exporter
   namespace: "citestns"
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: overrides-exporter
       annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: overrides-exporter
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,7 +29,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: results-cache
       annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: results-cache
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/role.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/role.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 rules:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 roleRef:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -31,7 +30,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/runtime-configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 data:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: smoke-test
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -23,7 +22,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: smoke-test
     spec:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: store-gateway
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -29,7 +28,6 @@ spec:
       labels:
         app.kubernetes.io/name: mimir
         app.kubernetes.io/instance: test-oss-values
-        app.kubernetes.io/version: "2.2.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
   annotations:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.2.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}


### PR DESCRIPTION
We want to update the appVersion in weekly releases.
Should not distract from PR review.

