### PR TITLE
Allow "all" clusters in dashboard templating vars

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -1080,14 +1080,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -893,7 +893,7 @@
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": true,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
@@ -164,14 +164,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -1788,14 +1788,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -2443,14 +2443,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
@@ -962,14 +962,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -1338,14 +1338,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -193,14 +193,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -747,14 +747,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -1097,14 +1097,14 @@
                "type": "datasource"
             },
             {
-               "allValue": null,
+               "allValue": ".*",
                "current": {
                   "text": "prod",
                   "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
-               "includeAll": false,
+               "includeAll": true,
                "label": "cluster",
                "multi": false,
                "name": "cluster",

--- a/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
@@ -46,9 +46,9 @@ local filename = 'mimir-compactor-resources.json';
     ) + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // Do not allow to include all namespaces otherwise this dashboard
           // risks to explode because it shows resources per pod.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           if $._config.singleBinary
           then d.addTemplate('job', 'cortex_build_info', 'job')
           else d
-               .addTemplate('cluster', 'cortex_build_info', '%s' % $._config.per_cluster_label)
+               .addTemplate('cluster', 'cortex_build_info', '%s' % $._config.per_cluster_label, allValue='.*', includeAll=true)
                .addTemplate('namespace', 'cortex_build_info{%s=~"$cluster"}' % $._config.per_cluster_label, 'namespace'),
 
       addActiveUserSelectorTemplates()::

--- a/operations/mimir-mixin/dashboards/overrides.libsonnet
+++ b/operations/mimir-mixin/dashboards/overrides.libsonnet
@@ -141,7 +141,7 @@ local filename = 'mimir-overrides.json';
         list: [
           // Do not allow to include all clusters/namespaces otherwise this dashboard
           // risks to explode because it shows limits per tenant.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/reads-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-networking.libsonnet
@@ -14,8 +14,8 @@ local filename = 'mimir-reads-networking.json';
     + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          // Do not allow to include all namespaces.
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-resources.libsonnet
@@ -126,9 +126,9 @@ local filename = 'mimir-reads-resources.json';
     ) + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // Do not allow to include all namespaces otherwise this dashboard
           // risks to explode because it shows resources per pod.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
@@ -43,9 +43,9 @@ local filename = 'mimir-remote-ruler-reads-resources.json';
     ) + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // Do not allow to include all namespaces otherwise this dashboard
           // risks to explode because it shows resources per pod.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
@@ -308,9 +308,9 @@ local filename = 'mimir-rollout-progress.json';
 
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces cause this dashboard is designed to show
+          // Do not allow to include all namespaces cause this dashboard is designed to show
           // 1 cluster at a time.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -175,9 +175,9 @@ local filename = 'mimir-slow-queries.json';
     } + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // Do not allow to include all namespaces otherwise this dashboard
           // risks to explode because it shows resources per pod.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/writes-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-networking.libsonnet
@@ -11,8 +11,8 @@ local filename = 'mimir-writes-networking.json';
     + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          // Do not allow to include all namespaces.
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -74,9 +74,9 @@ local filename = 'mimir-writes-resources.json';
     + {
       templating+: {
         list: [
-          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // Do not allow to include all namespaces otherwise this dashboard
           // risks to explode because it shows resources per pod.
-          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          l + (if (l.name == 'namespace') then { includeAll: false } else {})
           for l in super.list
         ],
       },

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "72c850dd4ca2a9bb7ee1c9fe17bb72d653df571a",
-      "sum": "TieGrr7GyKjURk1+wXHFpdoCiwNaIVfZvyc5mbI9OM0="
+      "version": "da70df69e80ff98173883268a57b980d8022c395",
+      "sum": "1Ge62JmmPDq7fWyDAt3uCTobGEj4sJdbkqxRGWK22p0="
     },
     {
       "source": {


### PR DESCRIPTION
I understand why we don't want to select all namespaces in the variables, as that would query too many metrics, bringing a useless amount of series to the frontend.

However, allowing "All" on the "cluster" variable, allows selecting the namespaces without having to select the cluster (which is often redundant), while it still requires selecting one specific namespace.

<img width="682" alt="image" src="https://user-images.githubusercontent.com/1511481/182367971-c2c30c5b-0d7a-490e-ae43-617dbdc7e49e.png">

