### PR TITLE
Add instant splitter metrics stats

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -20,7 +20,7 @@ type instantSplitter struct {
 	// by queriers, and therefore minimize the merging of results in the query-frontend.
 	outerAggregationExpr *parser.AggregateExpr
 	logger               log.Logger
-	stats                *MapperStats
+	stats                *InstantSplitterStats
 }
 
 // Supported vector aggregators
@@ -56,7 +56,7 @@ var cannotDoubleCountBoundaries = map[string]bool{
 }
 
 // NewInstantQuerySplitter creates a new query range mapper.
-func NewInstantQuerySplitter(interval time.Duration, logger log.Logger, stats *MapperStats) ASTMapper {
+func NewInstantQuerySplitter(interval time.Duration, logger log.Logger, stats *InstantSplitterStats) ASTMapper {
 	instantQueryMapper := NewASTExprMapper(
 		&instantSplitter{
 			interval: interval,
@@ -160,7 +160,7 @@ func (i *instantSplitter) mapBinaryExpr(expr *parser.BinaryExpr) (mapped parser.
 	}
 	// if query was split and at least one operand successfully finished, the binary operations is mapped.
 	// The binary operands need to be wrapped in a parentheses' expression to ensure operator precedence.
-	if i.stats.GetShardedQueries() > 0 && (lhsFinished || rhsFinished) {
+	if i.stats.GetSplitQueries() > 0 && (lhsFinished || rhsFinished) {
 		expr.LHS = &parser.ParenExpr{
 			Expr: lhsMapped,
 		}
@@ -373,7 +373,7 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, rangeInterval ti
 	}
 
 	// Update stats
-	i.stats.AddShardedQueries(splitCount)
+	i.stats.AddSplitQueries(splitCount)
 
 	return squashExpr, true, nil
 }

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_stats.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_stats.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package astmapper
+
+type InstantSplitterStats struct {
+	splitQueries int
+}
+
+func NewInstantSplitterStats() *InstantSplitterStats {
+	return &InstantSplitterStats{}
+}
+
+// AddSplitQueries add num split queries to the counter.
+func (s *InstantSplitterStats) AddSplitQueries(num int) {
+	s.splitQueries += num
+}
+
+// GetSplitQueries returns the number of split queries.
+func (s *InstantSplitterStats) GetSplitQueries() int {
+	return s.splitQueries
+}

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -372,7 +372,7 @@ func TestInstantSplitter(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.in, func(t *testing.T) {
-			stats := NewMapperStats()
+			stats := NewInstantSplitterStats()
 			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
 
 			expr, err := parser.ParseExpr(tt.in)
@@ -384,7 +384,7 @@ func TestInstantSplitter(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, out.String(), mapped.String())
 
-			assert.Equal(t, tt.expectedSplitQueries, stats.GetShardedQueries())
+			assert.Equal(t, tt.expectedSplitQueries, stats.GetSplitQueries())
 		})
 	}
 }
@@ -422,7 +422,7 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.in, func(t *testing.T) {
-			stats := NewMapperStats()
+			stats := NewInstantSplitterStats()
 			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
 
 			expr, err := parser.ParseExpr(tt.in)
@@ -434,7 +434,7 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, out.String(), mapped.String())
 
-			assert.Equal(t, tt.expectedSplitQueries, stats.GetShardedQueries())
+			assert.Equal(t, tt.expectedSplitQueries, stats.GetSplitQueries())
 		})
 	}
 }
@@ -569,7 +569,7 @@ func TestInstantSplitterNoOp(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.query, func(t *testing.T) {
-			stats := NewMapperStats()
+			stats := NewInstantSplitterStats()
 			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
 
 			expr, err := parser.ParseExpr(tt.query)
@@ -580,7 +580,7 @@ func TestInstantSplitterNoOp(t *testing.T) {
 			// the statistics.
 			_, err = mapper.Map(expr)
 			require.NoError(t, err)
-			assert.Equal(t, 0, stats.GetShardedQueries())
+			assert.Equal(t, 0, stats.GetSplitQueries())
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add instant splitting specific metric stats for instant query time splitting.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
