### PR TITLE
Move split instant queries by interval to per-tenant config

### DIFF
--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -49,6 +49,9 @@ type Limits interface {
 	// be run for a given received query. 0 to disable limit.
 	QueryShardingMaxShardedQueries(userID string) int
 
+	// SplitInstantQueriesByInterval returns the time interval to split instant queries for a given tenant.
+	SplitInstantQueriesByInterval(userID string) time.Duration
+
 	// CompactorSplitAndMergeShards returns the number of shards to use when splitting blocks
 	// This method is copied from compactor.ConfigProvider.
 	CompactorSplitAndMergeShards(userID string) int

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -196,13 +196,14 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 }
 
 type mockLimits struct {
-	maxQueryLookback    time.Duration
-	maxQueryLength      time.Duration
-	maxCacheFreshness   time.Duration
-	maxQueryParallelism int
-	maxShardedQueries   int
-	totalShards         int
-	compactorShards     int
+	maxQueryLookback            time.Duration
+	maxQueryLength              time.Duration
+	maxCacheFreshness           time.Duration
+	maxQueryParallelism         int
+	maxShardedQueries           int
+	splitInstantQueriesInterval time.Duration
+	totalShards                 int
+	compactorShards             int
 }
 
 func (m mockLimits) MaxQueryLookback(string) time.Duration {
@@ -230,6 +231,10 @@ func (m mockLimits) QueryShardingTotalShards(string) int {
 
 func (m mockLimits) QueryShardingMaxShardedQueries(string) int {
 	return m.maxShardedQueries
+}
+
+func (m mockLimits) SplitInstantQueriesByInterval(string) time.Duration {
+	return m.splitInstantQueriesInterval
 }
 
 func (m mockLimits) CompactorSplitAndMergeShards(userID string) int {

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -4,7 +4,6 @@ package querymiddleware
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -18,6 +17,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/storage/lazyquery"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 const (
@@ -33,8 +33,6 @@ type splitInstantQueryByIntervalMiddleware struct {
 	logger log.Logger
 
 	engine *promql.Engine
-
-	splitInterval time.Duration
 
 	metrics instantQuerySplittingMetrics
 }
@@ -82,7 +80,6 @@ func newInstantQuerySplittingMetrics(registerer prometheus.Registerer) instantQu
 
 // newSplitInstantQueryByIntervalMiddleware makes a new splitInstantQueryByIntervalMiddleware.
 func newSplitInstantQueryByIntervalMiddleware(
-	splitInterval time.Duration,
 	limits Limits,
 	logger log.Logger,
 	engine *promql.Engine,
@@ -91,12 +88,11 @@ func newSplitInstantQueryByIntervalMiddleware(
 
 	return MiddlewareFunc(func(next Handler) Handler {
 		return &splitInstantQueryByIntervalMiddleware{
-			next:          next,
-			limits:        limits,
-			splitInterval: splitInterval,
-			logger:        logger,
-			engine:        engine,
-			metrics:       metrics,
+			next:    next,
+			limits:  limits,
+			logger:  logger,
+			engine:  engine,
+			metrics: metrics,
 		}
 	})
 }
@@ -108,12 +104,13 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Requ
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, logger, "splitInstantQueryByIntervalMiddleware.Do")
 	defer spanLog.Span.Finish()
 
-	_, err := tenant.TenantIDs(ctx)
+	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
-	if s.splitInterval <= 0 {
+	splitInterval := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, s.limits.SplitInstantQueriesByInterval)
+	if splitInterval <= 0 {
 		return s.next.Do(ctx, req)
 	}
 
@@ -121,7 +118,7 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Requ
 	s.metrics.splittingAttempts.Inc()
 
 	stats := astmapper.NewMapperStats()
-	mapper := astmapper.NewInstantQuerySplitter(s.splitInterval, s.logger, stats)
+	mapper := astmapper.NewInstantQuerySplitter(splitInterval, s.logger, stats)
 
 	expr, err := parser.ParseExpr(req.GetQuery())
 	if err != nil {

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -485,7 +485,7 @@ func TestQuerySplittingCorrectness(t *testing.T) {
 							require.NotEmpty(t, expectedPrometheusRes.Data.Result)
 							requireValidSamples(t, expectedPrometheusRes.Data.Result)
 
-							splittingware := newSplitInstantQueryByIntervalMiddleware(1*time.Minute, mockLimits{}, log.NewNopLogger(), engine, reg)
+							splittingware := newSplitInstantQueryByIntervalMiddleware(mockLimits{splitInstantQueriesInterval: 1 * time.Minute}, log.NewNopLogger(), engine, reg)
 
 							// Run the query with splitting
 							splitRes, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -113,6 +113,7 @@ type Limits struct {
 	MaxQueriersPerTenant           int            `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 	QueryShardingTotalShards       int            `yaml:"query_sharding_total_shards" json:"query_sharding_total_shards"`
 	QueryShardingMaxShardedQueries int            `yaml:"query_sharding_max_sharded_queries" json:"query_sharding_max_sharded_queries"`
+	SplitInstantQueriesByInterval  time.Duration  `yaml:"split_instant_queries_by_interval" category:"experimental"`
 	// Cardinality
 	CardinalityAnalysisEnabled                    bool `yaml:"cardinality_analysis_enabled" json:"cardinality_analysis_enabled"`
 	LabelNamesAndValuesResultsMaxSizeBytes        int  `yaml:"label_names_and_values_results_max_size_bytes" json:"label_names_and_values_results_max_size_bytes"`
@@ -202,6 +203,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxQueriersPerTenant, "query-frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
 	f.IntVar(&l.QueryShardingTotalShards, "query-frontend.query-sharding-total-shards", 16, "The amount of shards to use when doing parallelisation via query sharding by tenant. 0 to disable query sharding for tenant. Query sharding implementation will adjust the number of query shards based on compactor shards. This allows querier to not search the blocks which cannot possibly have the series for given query shard.")
 	f.IntVar(&l.QueryShardingMaxShardedQueries, "query-frontend.query-sharding-max-sharded-queries", 128, "The max number of sharded queries that can be run for a given received query. 0 to disable limit.")
+	f.DurationVar(&l.SplitInstantQueriesByInterval, "query-frontend.split-instant-queries-by-interval", 0, "Split instant queries by an interval and execute in parallel. 0 to disable it.")
 
 	f.Var(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.")
@@ -483,6 +485,12 @@ func (o *Overrides) QueryShardingTotalShards(userID string) int {
 // be run for a given received query. 0 to disable limit.
 func (o *Overrides) QueryShardingMaxShardedQueries(userID string) int {
 	return o.getOverridesForUser(userID).QueryShardingMaxShardedQueries
+}
+
+// SplitInstantQueriesByInterval returns the split time interval to use when splitting an instant query
+// via the query-frontend. 0 to disable limit.
+func (o *Overrides) SplitInstantQueriesByInterval(userID string) time.Duration {
+	return o.getOverridesForUser(userID).SplitInstantQueriesByInterval
 }
 
 // EnforceMetadataMetricName whether to enforce the presence of a metric name on metadata.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Move split instant queries by interval from query-frontend config to a per-tenant config

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
