### PR TITLE
Return status code `412` and log when alertmanager config is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [CHANGE] The tenant ID `__mimir_cluster` is reserved by Mimir and not allowed to store metrics. #2643
 * [CHANGE] Purger: removed the purger component and moved its API endpoints `/purger/delete_tenant` and `/purger/delete_tenant_status` to the compactor at `/compactor/delete_tenant` and `/compactor/delete_tenant_status`. #2644
 * [CHANGE] Memberlist: Change the leave timeout duration (`-memberlist.leave-timeout duration`) from 5s to 20s and connection timeout (`-memberlist.packet-dial-timeout`) from 5s to 2s. This makes leave timeout 10x the connection timeout, so that we can communicate the leave to at least 1 node, if the first 9 we try to contact times out. #2669
+* [CHANGE] Alertmanager: return status code `412 Precondition Failed` and log info message when alertmanager isn't configured for a tenant. #2635
 * [FEATURE] Compactor: Adds the ability to delete partial blocks after a configurable delay. This option can be configured per tenant. #2285
   - `-compactor.partial-block-deletion-delay`, as a duration string, allows you to set the delay since a partial block has been modified before marking it for deletion. A value of `0`, the default, disables this feature.
   - The metric `cortex_compactor_blocks_marked_for_deletion_total` has a new value for the `reason` label `reason="partial"`, when a block deletion marker is triggered by the partial block deletion delay.

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -187,7 +187,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 
 	_, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
-	require.EqualError(t, err, e2emimir.ErrNotFound.Error())
+	require.EqualError(t, err, "getting config failed with status 412 and error the Alertmanager is not configured\n")
 
 	err = c.SetAlertmanagerConfig(context.Background(), mimirAlertmanagerUserConfigYaml, map[string]string{})
 	require.NoError(t, err)
@@ -230,7 +230,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
 	require.Nil(t, cfg)
-	require.EqualError(t, err, "not found")
+	require.EqualError(t, err, "getting config failed with status 412 and error the Alertmanager is not configured\n")
 }
 
 func TestAlertmanagerSharding(t *testing.T) {

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -75,8 +75,7 @@ func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.
 	cfg, err := am.store.GetAlertConfig(r.Context(), userID)
 	if err != nil {
 		if err == alertspb.ErrNotFound {
-			level.Info(logger).Log("msg", "config requested for user but alertmanager is not configured for that user", "user", userID)
-			http.Error(w, err.Error(), http.StatusPreconditionFailed)
+			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -75,7 +75,8 @@ func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.
 	cfg, err := am.store.GetAlertConfig(r.Context(), userID)
 	if err != nil {
 		if err == alertspb.ErrNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
+			level.Info(logger).Log("msg", "config requested for user but alertmanager is not configured for that user", "user", userID)
+			http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -834,8 +834,8 @@ func (am *MultitenantAlertmanager) serveRequest(w http.ResponseWriter, req *http
 		return
 	}
 
-	level.Debug(am.logger).Log("msg", "the Alertmanager has no configuration and no fallback specified", "user", userID)
-	http.Error(w, "the Alertmanager is not configured", http.StatusNotFound)
+	level.Info(am.logger).Log("msg", "the Alertmanager has no configuration and no fallback specified", "user", userID)
+	http.Error(w, "the Alertmanager is not configured", http.StatusPreconditionFailed)
 }
 
 func (am *MultitenantAlertmanager) alertmanagerFromFallbackConfig(ctx context.Context, userID string) (*Alertmanager, error) {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -868,7 +868,7 @@ func TestMultitenantAlertmanager_ServeHTTP(t *testing.T) {
 
 		resp := w.Result()
 		body, _ := ioutil.ReadAll(resp.Body)
-		require.Equal(t, 404, w.Code)
+		require.Equal(t, 412, w.Code)
 		require.Equal(t, "the Alertmanager is not configured\n", string(body))
 	}
 
@@ -927,7 +927,7 @@ func TestMultitenantAlertmanager_ServeHTTP(t *testing.T) {
 
 		resp := w.Result()
 		body, _ := ioutil.ReadAll(resp.Body)
-		require.Equal(t, 404, w.Code)
+		require.Equal(t, 412, w.Code)
 		require.Equal(t, "the Alertmanager is not configured\n", string(body))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Changes the status code when alertmanager isn't configured for a tenant to `412 Precondition Failed` and logs an info message

#### Which issue(s) this PR fixes or relates to

Fixes #2265

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
