### PR TITLE
Fixed custom data type detection in --help and --help-all

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -166,7 +166,7 @@ Usage of ./cmd/mimir/mimir:
     	Time to wait between peers to send notifications. (default 15s)
   -alertmanager.persist-interval duration
     	The interval between persisting the current alertmanager state (notification log and silences) to object storage. This is only used when sharding is enabled. This state is read when all replicas for a shard can not be contacted. In this scenario, having persisted the state more frequently will result in potentially fewer lost silences, and fewer duplicate notifications. (default 15m0s)
-  -alertmanager.receivers-firewall-block-cidr-networks value
+  -alertmanager.receivers-firewall-block-cidr-networks comma-separated-list-of-string
     	Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.
   -alertmanager.receivers-firewall-block-private-addresses
     	True to block private and local addresses in Alertmanager receiver integrations. It blocks private addresses defined by  RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses), as well as loopback, local unicast and local multicast addresses.
@@ -186,7 +186,7 @@ Usage of ./cmd/mimir/mimir:
     	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -alertmanager.sharding-ring.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -alertmanager.sharding-ring.etcd.endpoints value
+  -alertmanager.sharding-ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -alertmanager.sharding-ring.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -216,7 +216,7 @@ Usage of ./cmd/mimir/mimir:
     	The availability zone where this instance is running. Required if zone-awareness is enabled.
   -alertmanager.sharding-ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
-  -alertmanager.sharding-ring.instance-interface-names value
+  -alertmanager.sharding-ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -alertmanager.sharding-ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
@@ -240,7 +240,7 @@ Usage of ./cmd/mimir/mimir:
     	Directory to store Alertmanager state and temporarily configuration files. The content of this directory is not required to be persisted between restarts unless Alertmanager replication has been disabled. (default "./data-alertmanager/")
   -alertmanager.storage.retention duration
     	How long should we store stateful data (notification logs and silences). For notification log entries, refers to how long should we keep entries before they expire and are deleted. For silences, refers to how long should tenants view silences after they expire and are deleted. (default 120h0m0s)
-  -alertmanager.web.external-url value
+  -alertmanager.web.external-url string
     	The URL under which Alertmanager is externally reachable (eg. could be different than -http.alertmanager-http-prefix in case Alertmanager is served via a reverse proxy). This setting is used both to configure the internal requests router and to generate links in alert templates. If the external URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager, both the UI and API. (default http://localhost:8080/alertmanager)
   -api.skip-label-name-validation-header-enabled
     	Allows to skip label name validation via X-Mimir-SkipLabelNameValidation header on the http write path. Use with caution as it breaks PromQL. Allowing this for external clients allows any client to send invalid label names. After enabling it, requests with a specific HTTP header set to true will not have label names validated.
@@ -479,7 +479,7 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -blocks-storage.swift.username string
     	OpenStack Swift username.
-  -blocks-storage.tsdb.block-ranges-period value
+  -blocks-storage.tsdb.block-ranges-period comma-separated-list-of-duration
     	TSDB blocks range period. (default 2h0m0s)
   -blocks-storage.tsdb.close-idle-tsdb-timeout duration
     	If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB. (default 13h0m0s)
@@ -622,13 +622,13 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -common.storage.swift.username string
     	OpenStack Swift username.
-  -compactor.block-ranges value
+  -compactor.block-ranges comma-separated-list-of-duration
     	List of compaction time ranges. (default 2h0m0s,12h0m0s,24h0m0s)
   -compactor.block-sync-concurrency int
     	Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
   -compactor.block-upload-enabled
     	Enable block upload API for the tenant.
-  -compactor.blocks-retention-period value
+  -compactor.blocks-retention-period duration
     	Delete blocks containing samples older than the specified retention period. 0 to disable.
   -compactor.cleanup-concurrency int
     	Max number of tenants for which blocks cleanup and maintenance should run concurrently. (default 20)
@@ -650,9 +650,9 @@ Usage of ./cmd/mimir/mimir:
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
   -compactor.deletion-delay duration
     	Time before a block marked for deletion is deleted from bucket. If not 0, blocks will be marked for deletion and compactor component will permanently delete blocks marked for deletion from the bucket. If 0, blocks will be deleted straight away. Note that deleting blocks immediately can cause query failures. (default 12h0m0s)
-  -compactor.disabled-tenants value
+  -compactor.disabled-tenants comma-separated-list-of-string
     	Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.
-  -compactor.enabled-tenants value
+  -compactor.enabled-tenants comma-separated-list-of-string
     	Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.
   -compactor.max-closing-blocks-concurrency int
     	Max number of blocks that can be closed concurrently during split compaction. Note that closing of newly compacted block uses a lot of memory for writing index. (default 1)
@@ -662,7 +662,7 @@ Usage of ./cmd/mimir/mimir:
     	Number of goroutines opening blocks before compaction. (default 1)
   -compactor.meta-sync-concurrency int
     	Number of Go routines to use when syncing block meta files from the long term storage. (default 20)
-  -compactor.partial-block-deletion-delay value
+  -compactor.partial-block-deletion-delay duration
     	If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. 0 to disable.
   -compactor.ring.consul.acl-token string
     	ACL Token used to interact with Consul.
@@ -680,7 +680,7 @@ Usage of ./cmd/mimir/mimir:
     	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -compactor.ring.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -compactor.ring.etcd.endpoints value
+  -compactor.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -compactor.ring.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -708,7 +708,7 @@ Usage of ./cmd/mimir/mimir:
     	IP address to advertise in the ring. Default is auto-detected.
   -compactor.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
-  -compactor.ring.instance-interface-names value
+  -compactor.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -compactor.ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
@@ -748,7 +748,7 @@ Usage of ./cmd/mimir/mimir:
     	Fraction of mutex contention events that are reported in the mutex profile. On average 1/rate events are reported. 0 to disable.
   -distributor.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
-  -distributor.drop-label value
+  -distributor.drop-label string
     	This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.
   -distributor.forwarding.enabled
     	[experimental] Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.
@@ -780,7 +780,7 @@ Usage of ./cmd/mimir/mimir:
     	Flag to enable, for all tenants, handling of samples with external labels identifying replicas in an HA Prometheus setup.
   -distributor.ha-tracker.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -distributor.ha-tracker.etcd.endpoints value
+  -distributor.ha-tracker.etcd.endpoints string
     	The etcd endpoints to connect to.
   -distributor.ha-tracker.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -860,7 +860,7 @@ Usage of ./cmd/mimir/mimir:
     	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -distributor.ring.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -distributor.ring.etcd.endpoints value
+  -distributor.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -distributor.ring.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -888,7 +888,7 @@ Usage of ./cmd/mimir/mimir:
     	IP address to advertise in the ring. Default is auto-detected.
   -distributor.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
-  -distributor.ring.instance-interface-names value
+  -distributor.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
@@ -976,7 +976,7 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable. (default 150000)
   -ingester.metadata-retain-period duration
     	Period at which metadata we have not seen will remain in memory before being deleted. (default 10m0s)
-  -ingester.out-of-order-time-window value
+  -ingester.out-of-order-time-window duration
     	[experimental] Non-zero value enables out-of-order support for most recent samples that are within the time window in relation to the following two conditions: (1) The newest sample for that time series, if it exists. For example, within [series.maxTime-timeWindow, series.maxTime]). (2) The TSDB's maximum time, if the series does not exist. For example, within [db.maxTime-timeWindow, db.maxTime]). The ingester will need more memory as a factor of rate of out-of-order samples being ingested and the number of series that are getting out-of-order samples.
   -ingester.rate-update-period duration
     	Period with which to update the per-tenant ingestion rates. (default 15s)
@@ -996,7 +996,7 @@ Usage of ./cmd/mimir/mimir:
     	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -ingester.ring.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -ingester.ring.etcd.endpoints value
+  -ingester.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -ingester.ring.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -1016,7 +1016,7 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -ingester.ring.etcd.username string
     	Etcd username.
-  -ingester.ring.excluded-zones value
+  -ingester.ring.excluded-zones comma-separated-list-of-string
     	Comma-separated list of zones to exclude from the ring. Instances in excluded zones will be filtered out from the ring. This option needs be set on ingesters, distributors, queriers and rulers when running in microservices mode.
   -ingester.ring.final-sleep duration
     	Duration to sleep for before exiting, to ensure metrics are scraped.
@@ -1030,7 +1030,7 @@ Usage of ./cmd/mimir/mimir:
     	The availability zone where this instance is running.
   -ingester.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
-  -ingester.ring.instance-interface-names value
+  -ingester.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -ingester.ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
@@ -1078,7 +1078,7 @@ Usage of ./cmd/mimir/mimir:
     	Gossip address to advertise to other members in the cluster. Used for NAT traversal.
   -memberlist.advertise-port int
     	Gossip port to advertise to other members in the cluster. Used for NAT traversal. (default 7946)
-  -memberlist.bind-addr value
+  -memberlist.bind-addr string
     	IP address to listen on for gossip messages. Multiple addresses may be specified. Defaults to 0.0.0.0
   -memberlist.bind-port int
     	Port to listen on for gossip messages. (default 7946)
@@ -1096,7 +1096,7 @@ Usage of ./cmd/mimir/mimir:
     	How many nodes to gossip to. (default 3)
   -memberlist.gossip-to-dead-nodes-time duration
     	How long to keep gossiping to dead nodes, to give them chance to refute their death. (default 30s)
-  -memberlist.join value
+  -memberlist.join string
     	Other cluster members to join. Can be specified multiple times. It can be an IP, hostname or an entry specified in the DNS Service Discovery format.
   -memberlist.leave-timeout duration
     	Timeout for leaving memberlist cluster. (default 5s)
@@ -1206,7 +1206,7 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429. (default 100)
   -querier.max-query-into-future duration
     	Maximum duration into the future you can query. 0 to disable. (default 10m0s)
-  -querier.max-query-lookback value
+  -querier.max-query-lookback duration
     	Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. This limit is enforced in the query-frontend, querier and ruler. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -querier.max-query-parallelism int
     	Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers. (default 14)
@@ -1274,7 +1274,7 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -query-frontend.instance-addr string
     	IP address to advertise to the querier (via scheduler) (default is auto-detected from network interfaces).
-  -query-frontend.instance-interface-names value
+  -query-frontend.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend. (default [<private network interfaces>])
   -query-frontend.instance-port int
     	Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).
@@ -1282,7 +1282,7 @@ Usage of ./cmd/mimir/mimir:
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.max-body-size int
     	Max body size for downstream prometheus. (default 10485760)
-  -query-frontend.max-cache-freshness value
+  -query-frontend.max-cache-freshness duration
     	Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux. (default 1m)
   -query-frontend.max-queriers-per-tenant int
     	Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.
@@ -1324,7 +1324,7 @@ Usage of ./cmd/mimir/mimir:
     	How often to resolve the scheduler-address, in order to look for new query-scheduler instances. (default 10s)
   -query-frontend.scheduler-worker-concurrency int
     	Number of concurrent workers forwarding queries to single query-scheduler. (default 5)
-  -query-frontend.split-instant-queries-by-interval value
+  -query-frontend.split-instant-queries-by-interval duration
     	[experimental] Split instant queries by an interval and execute in parallel. 0 to disable it.
   -query-frontend.split-queries-by-interval duration
     	Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it. (default 24h0m0s)
@@ -1511,17 +1511,17 @@ Usage of ./cmd/mimir/mimir:
     	Path to the key file for the client certificate. Also requires the client certificate to be configured.
   -ruler.client.tls-server-name string
     	Override the expected name on the server certificate.
-  -ruler.disabled-tenants value
+  -ruler.disabled-tenants comma-separated-list-of-string
     	Comma separated list of tenants whose rules this ruler cannot evaluate. If specified, a ruler that would normally pick the specified tenant(s) for processing will ignore them instead. Subject to sharding.
   -ruler.enable-api
     	Enable the ruler config API. (default true)
-  -ruler.enabled-tenants value
+  -ruler.enabled-tenants comma-separated-list-of-string
     	Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.
-  -ruler.evaluation-delay-duration value
+  -ruler.evaluation-delay-duration duration
     	Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.
   -ruler.evaluation-interval duration
     	How frequently to evaluate rules (default 1m0s)
-  -ruler.external.url value
+  -ruler.external.url string
     	URL of alerts return path.
   -ruler.for-grace-period duration
     	Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. (default 10m0s)
@@ -1589,7 +1589,7 @@ Usage of ./cmd/mimir/mimir:
     	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -ruler.ring.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -ruler.ring.etcd.endpoints value
+  -ruler.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -ruler.ring.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -1617,7 +1617,7 @@ Usage of ./cmd/mimir/mimir:
     	IP address to advertise in the ring. Default is auto-detected.
   -ruler.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
-  -ruler.ring.instance-interface-names value
+  -ruler.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -ruler.ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
@@ -1733,7 +1733,7 @@ Usage of ./cmd/mimir/mimir:
     	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -store-gateway.sharding-ring.etcd.dial-timeout duration
     	The dial timeout for the etcd connection. (default 10s)
-  -store-gateway.sharding-ring.etcd.endpoints value
+  -store-gateway.sharding-ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -store-gateway.sharding-ring.etcd.max-retries int
     	The maximum number of retries to do for failed ops. (default 10)
@@ -1763,7 +1763,7 @@ Usage of ./cmd/mimir/mimir:
     	The availability zone where this instance is running. Required if zone-awareness is enabled.
   -store-gateway.sharding-ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
-  -store-gateway.sharding-ring.instance-interface-names value
+  -store-gateway.sharding-ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -store-gateway.sharding-ring.instance-port int
     	Port to advertise in the ring (defaults to -server.grpc-listen-port).
@@ -1793,17 +1793,17 @@ Usage of ./cmd/mimir/mimir:
     	True to enable zone-awareness and replicate blocks across different availability zones. This option needs be set both on the store-gateway, querier and ruler when running in microservices mode.
   -store-gateway.tenant-shard-size int
     	The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.
-  -store.max-labels-query-length value
+  -store.max-labels-query-length duration
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
-  -store.max-query-length value
+  -store.max-query-length duration
     	Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
-  -target value
+  -target comma-separated-list-of-string
     	Comma-separated list of components to include in the instantiated process. The default value 'all' includes all components that are required to form a functional Grafana Mimir instance in single-binary mode. Use the '-modules' command line flag to get a list of available components, and to see which components are included with 'all'. (default all)
   -tenant-federation.enabled
     	If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.
   -usage-stats.enabled
     	[experimental] Enable anonymous usage reporting.
-  -validation.create-grace-period value
+  -validation.create-grace-period duration
     	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`. (default 10m)
   -validation.enforce-metadata-metric-name
     	Enforce every metadata has a metric name. (default true)

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -86,13 +86,13 @@ Usage of ./cmd/mimir/mimir:
     	Per-tenant rate limit for sending notifications from Alertmanager in notifications/sec. 0 = rate limit disabled. Negative value = no notifications are allowed.
   -alertmanager.notification-rate-limit-per-integration value
     	Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: webhook, email, pagerduty, opsgenie, wechat, slack, victorops, pushover, sns. (default {})
-  -alertmanager.receivers-firewall-block-cidr-networks value
+  -alertmanager.receivers-firewall-block-cidr-networks comma-separated-list-of-string
     	Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.
   -alertmanager.receivers-firewall-block-private-addresses
     	True to block private and local addresses in Alertmanager receiver integrations. It blocks private addresses defined by  RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses), as well as loopback, local unicast and local multicast addresses.
   -alertmanager.sharding-ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
-  -alertmanager.sharding-ring.etcd.endpoints value
+  -alertmanager.sharding-ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -alertmanager.sharding-ring.etcd.password string
     	Etcd password.
@@ -102,7 +102,7 @@ Usage of ./cmd/mimir/mimir:
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -alertmanager.storage.path string
     	Directory to store Alertmanager state and temporarily configuration files. The content of this directory is not required to be persisted between restarts unless Alertmanager replication has been disabled. (default "./data-alertmanager/")
-  -alertmanager.web.external-url value
+  -alertmanager.web.external-url string
     	The URL under which Alertmanager is externally reachable (eg. could be different than -http.alertmanager-http-prefix in case Alertmanager is served via a reverse proxy). This setting is used both to configure the internal requests router and to generate links in alert templates. If the external URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager, both the UI and API. (default http://localhost:8080/alertmanager)
   -auth.multitenancy-enabled
     	When set to true, incoming HTTP requests must specify tenant ID in HTTP X-Scope-OrgId header. When set to false, tenant ID from -auth.no-auth-tenant is used instead. (default true)
@@ -266,23 +266,23 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift username.
   -compactor.block-upload-enabled
     	Enable block upload API for the tenant.
-  -compactor.blocks-retention-period value
+  -compactor.blocks-retention-period duration
     	Delete blocks containing samples older than the specified retention period. 0 to disable.
   -compactor.compactor-tenant-shard-size int
     	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
-  -compactor.partial-block-deletion-delay value
+  -compactor.partial-block-deletion-delay duration
     	If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. 0 to disable.
   -compactor.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
-  -compactor.ring.etcd.endpoints value
+  -compactor.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -compactor.ring.etcd.password string
     	Etcd password.
   -compactor.ring.etcd.username string
     	Etcd username.
-  -compactor.ring.instance-interface-names value
+  -compactor.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -compactor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
@@ -302,7 +302,7 @@ Usage of ./cmd/mimir/mimir:
     	Enable the distributors HA tracker so that it can accept samples from Prometheus HA replicas gracefully (requires labels).
   -distributor.ha-tracker.enable-for-all-users
     	Flag to enable, for all tenants, handling of samples with external labels identifying replicas in an HA Prometheus setup.
-  -distributor.ha-tracker.etcd.endpoints value
+  -distributor.ha-tracker.etcd.endpoints string
     	The etcd endpoints to connect to.
   -distributor.ha-tracker.etcd.password string
     	Etcd password.
@@ -322,13 +322,13 @@ Usage of ./cmd/mimir/mimir:
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
-  -distributor.ring.etcd.endpoints value
+  -distributor.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -distributor.ring.etcd.password string
     	Etcd password.
   -distributor.ring.etcd.username string
     	Etcd username.
-  -distributor.ring.instance-interface-names value
+  -distributor.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
@@ -348,7 +348,7 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable. (default 150000)
   -ingester.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
-  -ingester.ring.etcd.endpoints value
+  -ingester.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -ingester.ring.etcd.password string
     	Etcd password.
@@ -372,11 +372,11 @@ Usage of ./cmd/mimir/mimir:
     	Gossip address to advertise to other members in the cluster. Used for NAT traversal.
   -memberlist.advertise-port int
     	Gossip port to advertise to other members in the cluster. Used for NAT traversal. (default 7946)
-  -memberlist.bind-addr value
+  -memberlist.bind-addr string
     	IP address to listen on for gossip messages. Multiple addresses may be specified. Defaults to 0.0.0.0
   -memberlist.bind-port int
     	Port to listen on for gossip messages. (default 7946)
-  -memberlist.join value
+  -memberlist.join string
     	Other cluster members to join. Can be specified multiple times. It can be an IP, hostname or an entry specified in the DNS Service Discovery format.
   -modules
     	List available values that can be used as target.
@@ -398,7 +398,7 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of chunks that can be fetched in a single query from ingesters and long-term storage. This limit is enforced in the querier, ruler and store-gateway. 0 to disable. (default 2000000)
   -querier.max-fetched-series-per-query int
     	The maximum number of unique series for which a query can fetch samples from each ingesters and storage. This limit is enforced in the querier and ruler. 0 to disable
-  -querier.max-query-lookback value
+  -querier.max-query-lookback duration
     	Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. This limit is enforced in the query-frontend, querier and ruler. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -querier.max-query-parallelism int
     	Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers. (default 14)
@@ -509,9 +509,9 @@ Usage of ./cmd/mimir/mimir:
     	Comma-separated list of URL(s) of the Alertmanager(s) to send notifications to. Each URL is treated as a separate group. Multiple Alertmanagers in HA per group can be supported by using DNS service discovery format. Basic auth is supported as part of the URL.
   -ruler.enable-api
     	Enable the ruler config API. (default true)
-  -ruler.evaluation-delay-duration value
+  -ruler.evaluation-delay-duration duration
     	Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.
-  -ruler.external.url value
+  -ruler.external.url string
     	URL of alerts return path.
   -ruler.max-rule-groups-per-tenant int
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
@@ -521,13 +521,13 @@ Usage of ./cmd/mimir/mimir:
     	GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) to enable client side load balancing.
   -ruler.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
-  -ruler.ring.etcd.endpoints value
+  -ruler.ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -ruler.ring.etcd.password string
     	Etcd password.
   -ruler.ring.etcd.username string
     	Etcd username.
-  -ruler.ring.instance-interface-names value
+  -ruler.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -ruler.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
@@ -549,7 +549,7 @@ Usage of ./cmd/mimir/mimir:
     	HTTP server listen port. (default 8080)
   -store-gateway.sharding-ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
-  -store-gateway.sharding-ring.etcd.endpoints value
+  -store-gateway.sharding-ring.etcd.endpoints string
     	The etcd endpoints to connect to.
   -store-gateway.sharding-ring.etcd.password string
     	Etcd password.
@@ -557,7 +557,7 @@ Usage of ./cmd/mimir/mimir:
     	Etcd username.
   -store-gateway.sharding-ring.instance-availability-zone string
     	The availability zone where this instance is running. Required if zone-awareness is enabled.
-  -store-gateway.sharding-ring.instance-interface-names value
+  -store-gateway.sharding-ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -store-gateway.sharding-ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
@@ -569,11 +569,11 @@ Usage of ./cmd/mimir/mimir:
     	True to enable zone-awareness and replicate blocks across different availability zones. This option needs be set both on the store-gateway, querier and ruler when running in microservices mode.
   -store-gateway.tenant-shard-size int
     	The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.
-  -store.max-labels-query-length value
+  -store.max-labels-query-length duration
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
-  -store.max-query-length value
+  -store.max-query-length duration
     	Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
-  -target value
+  -target comma-separated-list-of-string
     	Comma-separated list of components to include in the instantiated process. The default value 'all' includes all components that are required to form a functional Grafana Mimir instance in single-binary mode. Use the '-modules' command line flag to get a list of available components, and to see which components are included with 'all'. (default all)
   -tenant-federation.enabled
     	If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -65,7 +65,7 @@ func Usage(printAll bool, configs ...interface{}) error {
 		name := getFlagName(fl)
 		if len(name) > 0 {
 			b.WriteString(" ")
-			b.WriteString(name)
+			b.WriteString(strings.ReplaceAll(name, " ", "-"))
 		}
 		// Four spaces before the tab triggers good alignment
 		// for both 4- and 8-space tab stops.
@@ -198,6 +198,20 @@ func getFlagName(fl *flag.Flag) string {
 		switch v.Type().String() {
 		case "*flagext.Secret":
 			return "string"
+		case "*flagext.StringSlice":
+			return "string"
+		case "*flagext.StringSliceCSV":
+			return "comma-separated list of string"
+		case "*flagext.CIDRSliceCSV":
+			return "comma-separated list of string"
+		case "*flagext.URLValue":
+			return "string"
+		case "*url.URL":
+			return "string"
+		case "*model.Duration":
+			return "duration"
+		case "*tsdb.DurationList":
+			return "comma-separated list of duration"
 		}
 	}
 


### PR DESCRIPTION
#### What this PR does
While reviewing #2633, I've realized `model.Duration` and few other data types are not correctly detected when building `--help`. This PR fixes it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
