### PR TITLE
Move purger API endpoints to compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Distributor: removed previously deprecated `extend_writes` (see #1856) YAML key and `-distributor.extend-writes` CLI flag from the distributor config. #2551
 * [CHANGE] Ingester: removed previously deprecated `active_series_custom_trackers` (see #1188) YAML key from the ingester config. #2552
 * [CHANGE] The tenant ID `__mimir_cluster` is reserved by Mimir and not allowed to store metrics. #2643
+* [CHANGE] Purger/Compactor: remove the purger component and move endpoints `/purger/delete_tenant` and `/purger/delete_tenant_status` to the compactor, both now `/compactor/delete_tenant...`. #2644
 * [FEATURE] Compactor: Adds the ability to delete partial blocks after a configurable delay. This option can be configured per tenant. #2285
   - `-compactor.partial-block-deletion-delay`, as a duration string, allows you to set the delay since a partial block has been modified before marking it for deletion. A value of `0`, the default, disables this feature.
   - The metric `cortex_compactor_blocks_marked_for_deletion_total` has a new value for the `reason` label `reason="partial"`, when a block deletion marker is triggered by the partial block deletion delay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [CHANGE] Distributor: removed previously deprecated `extend_writes` (see #1856) YAML key and `-distributor.extend-writes` CLI flag from the distributor config. #2551
 * [CHANGE] Ingester: removed previously deprecated `active_series_custom_trackers` (see #1188) YAML key from the ingester config. #2552
 * [CHANGE] The tenant ID `__mimir_cluster` is reserved by Mimir and not allowed to store metrics. #2643
-* [CHANGE] Purger/Compactor: remove the purger component and move endpoints `/purger/delete_tenant` and `/purger/delete_tenant_status` to the compactor, both now `/compactor/delete_tenant...`. #2644
+* [CHANGE] Purger: removed the purger component and moved its API endpoints `/purger/delete_tenant` and `/purger/delete_tenant_status` to the compactor at `/compactor/delete_tenant` and `/compactor/delete_tenant_status`. #2644
 * [FEATURE] Compactor: Adds the ability to delete partial blocks after a configurable delay. This option can be configured per tenant. #2285
   - `-compactor.partial-block-deletion-delay`, as a duration string, allows you to set the delay since a partial block has been modified before marking it for deletion. A value of `0`, the default, disables this feature.
   - The metric `cortex_compactor_blocks_marked_for_deletion_total` has a new value for the `reason` label `reason="partial"`, when a block deletion marker is triggered by the partial block deletion delay.

--- a/development/tsdb-blocks-storage-s3/docker-compose.jsonnet
+++ b/development/tsdb-blocks-storage-s3/docker-compose.jsonnet
@@ -25,7 +25,7 @@ std.manifestYamlDoc({
     self.store_gateways +
     self.compactor +
     self.rulers(2) +
-    self.alertmanagers(3) + 
+    self.alertmanagers(3) +
     self.minio +
     self.prometheus +
     self.grafana_agent +

--- a/development/tsdb-blocks-storage-s3/docker-compose.jsonnet
+++ b/development/tsdb-blocks-storage-s3/docker-compose.jsonnet
@@ -25,8 +25,7 @@ std.manifestYamlDoc({
     self.store_gateways +
     self.compactor +
     self.rulers(2) +
-    self.alertmanagers(3) +
-    self.purger +
+    self.alertmanagers(3) + 
     self.minio +
     self.prometheus +
     self.grafana_agent +
@@ -130,13 +129,6 @@ std.manifestYamlDoc({
       target: 'store-gateway',
       httpPort: 8009,
       jaegerApp: 'store-gateway-2',
-    }),
-  },
-
-  purger:: {
-    purger: mimirService({
-      target: 'purger',
-      httpPort: 8014,
     }),
   },
 

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -228,29 +228,6 @@
       - "9090:9090"
     "volumes":
       - "./config:/etc/prometheus"
-  "purger":
-    "build":
-      "context": "."
-      "dockerfile": "dev.dockerfile"
-    "command":
-      - "sh"
-      - "-c"
-      - "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=purger -server.http-listen-port=8014 -server.grpc-listen-port=9014 -activity-tracker.filepath=/activity/purger-8014  -memberlist.nodename=purger -memberlist.bind-port=10014 -ingester.ring.store=memberlist -distributor.ring.store=memberlist -compactor.ring.store=memberlist -store-gateway.sharding-ring.store=memberlist -ruler.ring.store=memberlist -alertmanager.sharding-ring.store=memberlist"
-    "depends_on":
-      - "minio"
-      - "distributor-1"
-    "environment":
-      - "JAEGER_AGENT_HOST=jaeger"
-      - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_SAMPLER_PARAM=1"
-      - "JAEGER_SAMPLER_TYPE=const"
-      - "JAEGER_TAGS=app=purger"
-    "image": "mimir"
-    "ports":
-      - "8014:8014"
-    "volumes":
-      - "./config:/mimir/config"
-      - "./activity:/activity"
   "querier":
     "build":
       "context": "."

--- a/docs/sources/operators-guide/configure/about-versioning.md
+++ b/docs/sources/operators-guide/configure/about-versioning.md
@@ -54,7 +54,6 @@ The following features are currently experimental:
     - `-distributor.request-rate-limit`
     - `-distributor.request-burst-limit`
   - OTLP ingestion path
-- Purger: Tenant deletion API
 - Exemplar storage
   - `-ingester.max-global-exemplars-per-user`
   - `-ingester.exemplars-update-period`
@@ -96,6 +95,7 @@ The following features are currently experimental:
   - `-ruler-storage.storage-prefix`
 - Compactor
   - HTTP API for uploading TSDB blocks
+  - Tenant deletion API
 
 ## Deprecated features
 

--- a/docs/sources/operators-guide/reference-http-api/index.md
+++ b/docs/sources/operators-guide/reference-http-api/index.md
@@ -71,8 +71,6 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Get Alertmanager configuration](#get-alertmanager-configuration)                     | Alertmanager            | `GET /api/v1/alerts`                                                      |
 | [Set Alertmanager configuration](#set-alertmanager-configuration)                     | Alertmanager            | `POST /api/v1/alerts`                                                     |
 | [Delete Alertmanager configuration](#delete-alertmanager-configuration)               | Alertmanager            | `DELETE /api/v1/alerts`                                                   |
-| [Tenant delete request](#tenant-delete-request)                                       | Purger                  | `POST /purger/delete_tenant`                                              |
-| [Tenant delete status](#tenant-delete-status)                                         | Purger                  | `GET /purger/delete_tenant_status`                                        |
 | [Store-gateway ring status](#store-gateway-ring-status)                               | Store-gateway           | `GET /store-gateway/ring`                                                 |
 | [Store-gateway tenants](#store-gateway-tenants)                                       | Store-gateway           | `GET /store-gateway/tenants`                                              |
 | [Store-gateway tenant blocks](#store-gateway-tenant-blocks)                           | Store-gateway           | `GET /store-gateway/tenant/{tenant}/blocks`                               |
@@ -81,6 +79,8 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Upload block file](#upload-block-file)                                               | Compactor               | `POST /api/v1/upload/block/{block}/files?path={path}`                     |
 | [Complete block upload](#complete-block-upload)                                       | Compactor               | `POST /api/v1/upload/block/{block}/finish`                                |
 | [Check block upload](#check-block-upload)                                             | Compactor               | `GET /api/v1/upload/block/{block}/check`                                  |
+| [Tenant delete request](#tenant-delete-request)                                       | Compactor               | `POST /compactor/delete_tenant`                                           |
+| [Tenant delete status](#tenant-delete-status)                                         | Compactor               | `GET /compactor/delete_tenant_status`                                     |
 
 ### Path prefixes
 
@@ -862,30 +862,6 @@ Requires [authentication](#authentication).
 
 > **Note:** To delete a tenant's Alertmanager configuration from Mimir, use [`mimirtool alertmanager delete` command]({{< relref "../tools/mimirtool.md#delete-alertmanager-configuration" >}}).
 
-## Purger
-
-The Purger service provides APIs for requesting tenant deletion.
-
-### Tenant Delete Request
-
-```
-POST /purger/delete_tenant
-```
-
-Request deletion of ALL tenant data. Experimental.
-
-Requires [authentication](#authentication).
-
-### Tenant Delete Status
-
-```
-GET /purger/delete_tenant_status
-```
-
-Returns status of tenant deletion. Output format to be defined. Experimental.
-
-Requires [authentication](#authentication).
-
 ## Store-gateway
 
 ### Store-gateway ring status
@@ -1014,3 +990,23 @@ Returns state of the block upload. State is returned as JSON object with field `
 Requires [authentication](#authentication).
 
 This API endpoint is experimental and subject to change.
+
+### Tenant Delete Request
+
+```
+POST /compactor/delete_tenant
+```
+
+Request deletion of ALL tenant data. Experimental.
+
+Requires [authentication](#authentication).
+
+### Tenant Delete Status
+
+```
+GET /compactor/delete_tenant_status
+```
+
+Returns status of tenant deletion. Output format to be defined. Experimental.
+
+Requires [authentication](#authentication).

--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -28,7 +28,6 @@ const (
 	AlertManager
 	Ruler
 	StoreGateway
-	Purger
 )
 
 var (
@@ -42,7 +41,6 @@ var (
 		AlertManager:   {"cortex_alertmanager"},
 		Ruler:          {},
 		StoreGateway:   {"!cortex_storegateway_client", "cortex_storegateway"}, // The metrics prefix cortex_storegateway_client may be used by other components so we ignore it.
-		Purger:         {"cortex_purger"},
 	}
 
 	// Blacklisted metrics prefixes across any Mimir service.

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -260,20 +260,6 @@ func NewRuler(name string, consulAddress string, flags map[string]string, option
 	)
 }
 
-func NewPurger(name string, flags map[string]string, options ...Option) *MimirService {
-	return newMimirServiceFromOptions(
-		name,
-		map[string]string{
-			"-target":                   "purger",
-			"-log.level":                "warn",
-			"-purger.object-store-type": "filesystem",
-			"-local.chunk-directory":    e2e.ContainerSharedDir,
-		},
-		flags,
-		options...,
-	)
-}
-
 // Options holds a set of options for running services, they can be altered passing Option funcs.
 type Options struct {
 	Image      string

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -33,7 +33,6 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
-	"github.com/grafana/mimir/pkg/purger"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/grafana/mimir/pkg/scheduler"
@@ -280,11 +279,6 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, i.PushWithCleanup), true, false, "POST") // For testing and debugging.
 }
 
-func (a *API) RegisterTenantDeletion(api *purger.TenantDeletionAPI) {
-	a.RegisterRoute("/purger/delete_tenant", http.HandlerFunc(api.DeleteTenant), true, true, "POST")
-	a.RegisterRoute("/purger/delete_tenant_status", http.HandlerFunc(api.DeleteTenantStatus), true, true, "GET")
-}
-
 // RegisterRuler registers routes associated with the Ruler service.
 func (a *API) RegisterRuler(r *ruler.Ruler) {
 	a.indexPage.AddLinks(defaultWeight, "Ruler", []IndexPageLink{
@@ -351,6 +345,8 @@ func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
 	a.RegisterRoute("/api/v1/upload/block/{block}/files", http.HandlerFunc(c.UploadBlockFile), true, false, http.MethodPost)
 	a.RegisterRoute("/api/v1/upload/block/{block}/finish", http.HandlerFunc(c.FinishBlockUpload), true, false, http.MethodPost)
 	a.RegisterRoute("/api/v1/upload/block/{block}/check", http.HandlerFunc(c.GetBlockUploadStateHandler), true, false, http.MethodGet)
+	a.RegisterRoute("/compactor/delete_tenant", http.HandlerFunc(c.DeleteTenant), true, true, "POST")
+	a.RegisterRoute("/compactor/delete_tenant_status", http.HandlerFunc(c.DeleteTenantStatus), true, true, "GET")
 }
 
 type Distributor interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR moves the purger API endpoints to the compactor component.

There are two implementation decisions I made but am not entirely sure about:
* The endpoints are now under `/compactor`, not `/purger`.
* Internally, the endpoints were part of a seperate module: `TenantDeletion`. When transferring over the endpoints I merged them directly into the `Compactor` module instead of keeping the separate `TenantDeletion` module. My reasoning was that none of the other compactor API endpoints are part of a separate module.

#### Which issue(s) this PR fixes or relates to

Fixes #2190

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
