### PR TITLE
Dashboards: allow to configure graph tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [ENHANCEMENT] Dashboards: added missed rule evaluations to the "Evaluations per second" panel in the "Mimir / Ruler" dashboard. #2314
 * [ENHANCEMENT] Dashboards: add k8s resource requests to CPU and memory panels. #2346
 * [ENHANCEMENT] Dashboards: add RSS memory utilization panel for ingesters, store-gateways and compactors. #2479
+* [ENHANCEMENT] Dashboards: allow to configure graph tooltip. #2647
 * [ENHANCEMENT] Alerts: MimirFrontendQueriesStuck and MimirSchedulerQueriesStuck alerts are more reliable now as they consider all the intermediate samples in the minute prior to the evaluation. #2630
 * [BUGFIX] Dashboards: fixed unit of latency panels in the "Mimir / Ruler" dashboard. #2312
 * [BUGFIX] Dashboards: fixed "Intervals per query" panel in the "Mimir / Queries" dashboard. #2308

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -8,6 +8,12 @@
 
     // The prefix including product name used when building dashboards.
     dashboard_prefix: '%(product)s / ' % $._config.product,
+    // Controls tooltip and hover highlight behavior across different panels
+    // 0: Default, the cross hair will appear on only one panel
+    // 1: Shared crosshair, the crosshair will appear on all panels but the
+    // tooltip will  appear only on the panel under the cursor
+    // 2: Shared Tooltip, both crosshair and tooltip will appear on all panels
+    graph_tooltip: 0,
 
     // Tags for dashboards.
     tags: ['mimir'],

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -27,6 +27,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       datasource=$._config.dashboard_datasource,
       datasource_regex=$._config.datasource_regex
     ) + {
+      graphTooltip: $._config.graph_tooltip,
       __requires: [
         {
           id: 'grafana',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR allow to configure graph tooltip.
I’ve attached two screenshots, one is showing where is the option in the dashboard setting and the other one showing the result.
We can see the red vertical bar shared across all panels (but not the tooltips)

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

![settings](https://user-images.githubusercontent.com/12611310/182866987-59b60d37-6b72-49fe-b2b1-b2345e739e38.png)
![result](https://user-images.githubusercontent.com/12611310/182866976-e6b2c722-c6bc-4524-ad46-34711ae530e2.png)