### PR TITLE
Fix ruler alert state restoration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709
 * [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703
 * [BUGFIX] Distributor: Register `cortex_discarded_requests_total` metric, which previously was not registered and therefore not exported. #2712
+* [BUGFIX] Ruler: fix not restoring alerts' state at startup. #2648
 
 ### Mixin
 

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/prometheus/prompb" // OTLP protos are not compatible with gogo
 	yaml "gopkg.in/yaml.v3"
 
-	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/grafana/mimir/pkg/util/push"
 )
 
@@ -298,7 +297,7 @@ type ServerStatus struct {
 }
 
 // GetPrometheusRules fetches the rules from the Prometheus endpoint /api/v1/rules.
-func (c *Client) GetPrometheusRules() ([]*ruler.RuleGroup, error) {
+func (c *Client) GetPrometheusRules() ([]*promv1.RuleGroup, error) {
 	// Create HTTP request
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/prometheus/api/v1/rules", c.rulerAddress), nil)
 	if err != nil {
@@ -323,8 +322,10 @@ func (c *Client) GetPrometheusRules() ([]*ruler.RuleGroup, error) {
 
 	// Decode the response.
 	type response struct {
-		Status string              `json:"status"`
-		Data   ruler.RuleDiscovery `json:"data"`
+		Status string `json:"status"`
+		Data   struct {
+			RuleGroups []*promv1.RuleGroup `json:"groups"`
+		} `json:"data"`
 	}
 
 	decoded := &response{}

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -86,7 +86,10 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 	spanlog, ctx := spanlogger.NewWithLogger(q.ctx, q.logger, "distributorQuerier.Select")
 	defer spanlog.Finish()
 
-	minT, maxT := sp.Start, sp.End
+	minT, maxT := q.mint, q.maxt
+	if sp != nil {
+		minT, maxT = sp.Start, sp.End
+	}
 
 	// If queryIngestersWithin is enabled, we do manipulate the query mint to query samples up until
 	// now - queryIngestersWithin, because older time ranges are covered by the storage. This
@@ -99,7 +102,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 		return storage.EmptySeriesSet()
 	}
 
-	if sp.Func == "series" {
+	if sp != nil && sp.Func == "series" {
 		ms, err := q.distributor.MetricsForLabelMatchers(ctx, model.Time(minT), model.Time(maxT), matchers...)
 		if err != nil {
 			return storage.ErrSeriesSet(err)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -244,7 +244,6 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	// See: https://github.com/prometheus/prometheus/pull/8050
 	if sp == nil {
 		sp = &storage.SelectHints{
-			Func:  "series",
 			Start: q.mint,
 			End:   q.maxt,
 		}
@@ -312,7 +311,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	return q.mergeSeriesSets(result)
 }
 
-// LabelsValue implements storage.Querier.
+// LabelValues implements storage.Querier.
 func (q querier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	if len(q.queriers) == 1 {
 		return q.queriers[0].LabelValues(name, matchers...)
@@ -486,7 +485,7 @@ func (alwaysTrueFilterQueryable) UseQueryable(_ time.Time, _, _ int64) bool {
 	return true
 }
 
-// Wraps storage.Queryable into QueryableWithFilter, with no query filtering.
+// UseAlwaysQueryable wraps storage.Queryable into QueryableWithFilter, with no query filtering.
 func UseAlwaysQueryable(q storage.Queryable) QueryableWithFilter {
 	return alwaysTrueFilterQueryable{Queryable: q}
 }
@@ -503,7 +502,7 @@ func (u useBeforeTimestampQueryable) UseQueryable(_ time.Time, queryMinT, _ int6
 	return queryMinT < u.ts
 }
 
-// Returns QueryableWithFilter, that is used only if query starts before given timestamp.
+// UseBeforeTimestampQueryable returns QueryableWithFilter, that is used only if query starts before given timestamp.
 // If timestamp is zero (time.IsZero), queryable is always used.
 func UseBeforeTimestampQueryable(queryable storage.Queryable, ts time.Time) QueryableWithFilter {
 	t := int64(0)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -238,10 +238,6 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	log, ctx := spanlogger.NewWithLogger(q.ctx, q.logger, "querier.Select")
 	defer log.Span.Finish()
 
-	// Older Prometheus passes nil SelectHints if it is doing a 'series' operation,
-	// which needs only metadata.
-	// Recent versions of Prometheus pass in the hint but with Func set to "series".
-	// See: https://github.com/prometheus/prometheus/pull/8050
 	if sp == nil {
 		sp = &storage.SelectHints{
 			Start: q.mint,


### PR DESCRIPTION
#### What this PR does

Addresses a bug in which alert states are not restored.

After starting the prometheus ruler tries to restore the "firing" state for all alerts that are active. The way it does this is by:
1. evaluating all groups twice ([code](https://github.com/grafana/mimir/blob/8fca3461c1e9f74cdbc98a8fc1fcfbbdcbbe24da/vendor/github.com/prometheus/prometheus/rules/manager.go#L410-L432)):
  * once so most evaluate to active or non-active
  * once more to make sure that it has scraped enough metrics for alerts to be able to evaluate to active/non-active (in case of Mimir "to make sure that Mimir has ingested enough metrics for alerts to be able to ...")
2. compares the rule groups' "for" period to its for grace period ([code](https://github.com/grafana/mimir/blob/8fca3461c1e9f74cdbc98a8fc1fcfbbdcbbe24da/vendor/github.com/prometheus/prometheus/rules/manager.go#L790-L797))
  * if the "for" duration is less than the grace period, the ruler just lets the alert evaluate as many times as needed by the "for" period
  * if the "for" duration is more than the grace period, the ruler queries the `ALERTS_FOR_STATE` metric to calculate if the alert should already be firing or how much longer it should be pending

When the ruler queries the `ALERTS_FOR_STATE` metric it does not pass any hints to the querier implementation ([code](https://github.com/grafana/mimir/blob/8fca3461c1e9f74cdbc98a8fc1fcfbbdcbbe24da/vendor/github.com/prometheus/prometheus/rules/alerting.go#L268)). The bug is introduced as Mimir's querier implementation assumes that no hints == series lookup. And a series lookup returns no samples. This assumption was introduced in a cortex PR from 2018 as an optimization for  versions of prometheus that use the remote-read API and pass no hints when they want just the series ([PR](https://github.com/cortexproject/cortex/pull/802/files#diff-a0b881d1b7b99f439716f189b50eef90ccdaea00845b087c0dbce0e148aa2c0eR201)).

Because the querier code returns no samples for the series, the ruler cannot correctly restore the state.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
