### PR TITLE
Add TLS config to S3 client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [ENHANCEMENT] Azure client: Improve memory usage for large object storage downloads. #2408
 * [ENHANCEMENT] Distributor: Add `-distributor.instance-limits.max-inflight-push-requests-bytes`. This limit protects the distributor against multiple large requests that together may cause an OOM, but are only a few, so do not trigger the `max-inflight-push-requests` limit. #2413
 * [ENHANCEMENT] Distributor: Drop exemplars in distributor for tenants where exemplars are disabled. #2504
+* [ENHANCEMENT] Expose TLS config for the S3 backend client. #2652
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4095,6 +4095,60 @@
                   "fieldFlag": "blocks-storage.s3.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "tls_config",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "ca_file",
+                      "required": false,
+                      "desc": "The CA certificate file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "blocks-storage.s3.http.tls.ca-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "cert_file",
+                      "required": false,
+                      "desc": "The client certificate file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "blocks-storage.s3.http.tls.cert-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "key_file",
+                      "required": false,
+                      "desc": "The client key file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "blocks-storage.s3.http.tls.key-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "server_name",
+                      "required": false,
+                      "desc": "The name of the server for verification.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "blocks-storage.s3.http.tls.server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
                 }
               ],
               "fieldValue": null,
@@ -7931,6 +7985,60 @@
                   "fieldFlag": "ruler-storage.s3.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "tls_config",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "ca_file",
+                      "required": false,
+                      "desc": "The CA certificate file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "ruler-storage.s3.http.tls.ca-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "cert_file",
+                      "required": false,
+                      "desc": "The client certificate file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "ruler-storage.s3.http.tls.cert-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "key_file",
+                      "required": false,
+                      "desc": "The client key file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "ruler-storage.s3.http.tls.key-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "server_name",
+                      "required": false,
+                      "desc": "The name of the server for verification.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "ruler-storage.s3.http.tls.server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
                 }
               ],
               "fieldValue": null,
@@ -9260,6 +9368,60 @@
                   "fieldFlag": "alertmanager-storage.s3.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "tls_config",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "ca_file",
+                      "required": false,
+                      "desc": "The CA certificate file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "alertmanager-storage.s3.http.tls.ca-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "cert_file",
+                      "required": false,
+                      "desc": "The client certificate file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "alertmanager-storage.s3.http.tls.cert-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "key_file",
+                      "required": false,
+                      "desc": "The client key file path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "alertmanager-storage.s3.http.tls.key-file",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "server_name",
+                      "required": false,
+                      "desc": "The name of the server for verification.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "alertmanager-storage.s3.http.tls.server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
                 }
               ],
               "fieldValue": null,
@@ -10498,6 +10660,60 @@
                       "fieldFlag": "common.storage.s3.max-connections-per-host",
                       "fieldType": "int",
                       "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "block",
+                      "name": "tls_config",
+                      "required": false,
+                      "desc": "",
+                      "blockEntries": [
+                        {
+                          "kind": "field",
+                          "name": "ca_file",
+                          "required": false,
+                          "desc": "The CA certificate file path.",
+                          "fieldValue": null,
+                          "fieldDefaultValue": "",
+                          "fieldFlag": "common.storage.s3.http.tls.ca-file",
+                          "fieldType": "string",
+                          "fieldCategory": "advanced"
+                        },
+                        {
+                          "kind": "field",
+                          "name": "cert_file",
+                          "required": false,
+                          "desc": "The client certificate file path.",
+                          "fieldValue": null,
+                          "fieldDefaultValue": "",
+                          "fieldFlag": "common.storage.s3.http.tls.cert-file",
+                          "fieldType": "string",
+                          "fieldCategory": "advanced"
+                        },
+                        {
+                          "kind": "field",
+                          "name": "key_file",
+                          "required": false,
+                          "desc": "The client key file path.",
+                          "fieldValue": null,
+                          "fieldDefaultValue": "",
+                          "fieldFlag": "common.storage.s3.http.tls.key-file",
+                          "fieldType": "string",
+                          "fieldCategory": "advanced"
+                        },
+                        {
+                          "kind": "field",
+                          "name": "server_name",
+                          "required": false,
+                          "desc": "The name of the server for verification.",
+                          "fieldValue": null,
+                          "fieldDefaultValue": "",
+                          "fieldFlag": "common.storage.s3.http.tls.server-name",
+                          "fieldType": "string",
+                          "fieldCategory": "advanced"
+                        }
+                      ],
+                      "fieldValue": null,
+                      "fieldDefaultValue": null
                     }
                   ],
                   "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -44,6 +44,14 @@ Usage of ./cmd/mimir/mimir:
     	If the client connects to S3 via HTTPS and this option is enabled, the client will accept any certificate and hostname.
   -alertmanager-storage.s3.http.response-header-timeout duration
     	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -alertmanager-storage.s3.http.tls.ca-file string
+    	The CA certificate file path.
+  -alertmanager-storage.s3.http.tls.cert-file string
+    	The client certificate file path.
+  -alertmanager-storage.s3.http.tls.key-file string
+    	The client key file path.
+  -alertmanager-storage.s3.http.tls.server-name string
+    	The name of the server for verification.
   -alertmanager-storage.s3.insecure
     	If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.
   -alertmanager-storage.s3.max-connections-per-host int
@@ -419,6 +427,14 @@ Usage of ./cmd/mimir/mimir:
     	If the client connects to S3 via HTTPS and this option is enabled, the client will accept any certificate and hostname.
   -blocks-storage.s3.http.response-header-timeout duration
     	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -blocks-storage.s3.http.tls.ca-file string
+    	The CA certificate file path.
+  -blocks-storage.s3.http.tls.cert-file string
+    	The client certificate file path.
+  -blocks-storage.s3.http.tls.key-file string
+    	The client key file path.
+  -blocks-storage.s3.http.tls.server-name string
+    	The name of the server for verification.
   -blocks-storage.s3.insecure
     	If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.
   -blocks-storage.s3.max-connections-per-host int
@@ -564,6 +580,14 @@ Usage of ./cmd/mimir/mimir:
     	If the client connects to S3 via HTTPS and this option is enabled, the client will accept any certificate and hostname.
   -common.storage.s3.http.response-header-timeout duration
     	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -common.storage.s3.http.tls.ca-file string
+    	The CA certificate file path.
+  -common.storage.s3.http.tls.cert-file string
+    	The client certificate file path.
+  -common.storage.s3.http.tls.key-file string
+    	The client key file path.
+  -common.storage.s3.http.tls.server-name string
+    	The name of the server for verification.
   -common.storage.s3.insecure
     	If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.
   -common.storage.s3.max-connections-per-host int
@@ -1403,6 +1427,14 @@ Usage of ./cmd/mimir/mimir:
     	If the client connects to S3 via HTTPS and this option is enabled, the client will accept any certificate and hostname.
   -ruler-storage.s3.http.response-header-timeout duration
     	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -ruler-storage.s3.http.tls.ca-file string
+    	The CA certificate file path.
+  -ruler-storage.s3.http.tls.cert-file string
+    	The client certificate file path.
+  -ruler-storage.s3.http.tls.key-file string
+    	The client key file path.
+  -ruler-storage.s3.http.tls.server-name string
+    	The name of the server for verification.
   -ruler-storage.s3.insecure
     	If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.
   -ruler-storage.s3.max-connections-per-host int

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -3501,6 +3501,23 @@ http:
   # (advanced) Maximum number of connections per host. 0 means no limit.
   # CLI flag: -<prefix>.s3.max-connections-per-host
   [max_connections_per_host: <int> | default = 0]
+
+  tls_config:
+    # (advanced) The CA certificate file path.
+    # CLI flag: -<prefix>.s3.http.tls.ca-file
+    [ca_file: <string> | default = ""]
+
+    # (advanced) The client certificate file path.
+    # CLI flag: -<prefix>.s3.http.tls.cert-file
+    [cert_file: <string> | default = ""]
+
+    # (advanced) The client key file path.
+    # CLI flag: -<prefix>.s3.http.tls.key-file
+    [key_file: <string> | default: ""]
+
+    # (advanced) The name of the server for verification.
+    # CLI flag: -<prefix>.s3.http.tls.server-name
+    [server_name: <string> | default: ""]
 ```
 
 ### gcs_storage_backend

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -8,6 +8,7 @@ package s3
 import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
+	"github.com/thanos-io/thanos/pkg/exthttp"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/objstore/s3"
 )
@@ -56,6 +57,12 @@ func newS3Config(cfg Config) (s3.Config, error) {
 			MaxIdleConnsPerHost:   cfg.HTTP.MaxIdleConnsPerHost,
 			MaxConnsPerHost:       cfg.HTTP.MaxConnsPerHost,
 			Transport:             cfg.HTTP.Transport,
+			TLSConfig: exthttp.TLSConfig{
+				CAFile:     cfg.HTTP.TLSConfig.CAFile,
+				CertFile:   cfg.HTTP.TLSConfig.CertFile,
+				KeyFile:    cfg.HTTP.TLSConfig.KeyFile,
+				ServerName: cfg.HTTP.TLSConfig.ServerName,
+			},
 		},
 		// Enforce signature version 2 if CLI flag is set
 		SignatureV2: cfg.SignatureVersion == SignatureVersionV2,

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -55,6 +55,16 @@ type HTTPConfig struct {
 
 	// Allow upstream callers to inject a round tripper
 	Transport http.RoundTripper `yaml:"-"`
+
+	TLSConfig TLSConfig `yaml:"tls_config"`
+}
+
+// TLSConfig configures the options for TLS connections.
+type TLSConfig struct {
+	CAFile     string `yaml:"ca_file" category:"advanced"`
+	CertFile   string `yaml:"cert_file" category:"advanced"`
+	KeyFile    string `yaml:"key_file" category:"advanced"`
+	ServerName string `yaml:"server_name" category:"advanced"`
 }
 
 // RegisterFlagsWithPrefix registers the flags for s3 storage with the provided prefix
@@ -67,6 +77,15 @@ func (cfg *HTTPConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxIdleConns, prefix+"s3.max-idle-connections", 100, "Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.")
 	f.IntVar(&cfg.MaxIdleConnsPerHost, prefix+"s3.max-idle-connections-per-host", 100, "Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used.")
 	f.IntVar(&cfg.MaxConnsPerHost, prefix+"s3.max-connections-per-host", 0, "Maximum number of connections per host. 0 means no limit.")
+	cfg.TLSConfig.RegisterFlagsWithPrefix(prefix, f)
+}
+
+// RegisterFlagsWithPrefix registers the flags for s3 storage with the provided prefix.
+func (cfg *TLSConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.CAFile, prefix+"s3.http.tls.ca-file", "", "The CA certificate file path.")
+	f.StringVar(&cfg.CertFile, prefix+"s3.http.tls.cert-file", "", "The client certificate file path.")
+	f.StringVar(&cfg.KeyFile, prefix+"s3.http.tls.key-file", "", "The client key file path.")
+	f.StringVar(&cfg.ServerName, prefix+"s3.http.tls.server-name", "", "The name of the server for verification.")
 }
 
 // Config holds the config options for an S3 backend


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds the ability to configure the TLS config for the Thanos S3 client.

Note: Although I mostly copied the TLS config from Thanos, I omitted `insecure_skip_verify` because its value is overridden by the field of the same name in the parent HTTP config and is seemingly useless:

https://github.com/grafana/mimir/blob/7d70e629d44e9d04adb9d98723b68db8b2b41443/vendor/github.com/thanos-io/thanos/pkg/exthttp/transport.go#L38-L42 

#### Which issue(s) this PR fixes or relates to

Fixes #1981, Fixes #1796

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
