### PR TITLE
Baremetal dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [CHANGE] Dashboards: remove the "Cache - Latency (old)" panel from the "Mimir / Queries" dashboard. #2796
 * [FEATURE] Dashboards: added support to experimental read-write deployment mode. #2780
 * [ENHANCEMENT] Dashboards: added support to query-tee in front of ruler-query-frontend in the "Remote ruler reads" dashboard. #2761
+* [ENHANCEMENT] Dashboards: Introduce support for baremetal deployment, setting `deployment_type: 'baremetal'` in the mixin `_config`. #2657
 * [BUGFIX] Dashboards: stop setting 'interval' in dashboards; it should be set on your datasource. #2802
 
 ### Jsonnet

--- a/docs/sources/operators-guide/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/requirements.md
@@ -24,6 +24,11 @@ The following table shows the required label names and whether they can be custo
 
 For rules and alerts to function properly, you must configure your Prometheus or Grafana Agent to scrape metrics from Grafana Mimir at an interval of `15s` or shorter.
 
+## Deployment type
+
+By default, Grafana Mimir dashboards assume Mimir is deployed in containers orchestrated by Kubernetes.
+If you're running Mimir on baremental, you should set the configuration field `deployment_type: 'baremetal'` and [re-compile the dashboards]({{< relref "installing-dashboards-and-alerts.md" >}}).
+
 ## Job selection
 
 A metric could be exposed by multiple Grafana Mimir components, or even different applications running in the same namespace.

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -78,6 +78,58 @@
       gateway: helmCompatibleName('(gateway|cortex-gw|cortex-gw).*'),
     },
 
+    deployment_type: 'container',
+    resources_panel_queries: {
+      container: {
+        cpu_usage: 'sum by(%s) (rate(container_cpu_usage_seconds_total{%s,container=~"%s"}[$__rate_interval]))',
+        cpu_limit: 'min(container_spec_cpu_quota{%s,container=~"%s"} / container_spec_cpu_period{%s,container=~"%s"})',
+        cpu_request: 'min(kube_pod_container_resource_requests{%s,container=~"%s",resource="cpu"})',
+        // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
+        // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
+        memory_working_usage: 'max by(%s) (container_memory_working_set_bytes{%s,container=~"%s"})',
+        memory_working_limit: 'min(container_spec_memory_limit_bytes{%s,container=~"%s"} > 0)',
+        memory_working_request: 'min(kube_pod_container_resource_requests{%s,container=~"%s",resource="memory"})',
+        // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
+        // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
+        memory_rss_usage: 'max by(%s) (container_memory_rss{%s,container=~"%s"})',
+        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%s,container=~"%s"} > 0)',
+        memory_rss_request: 'min(kube_pod_container_resource_requests{%s,container=~"%s",resource="memory"})',
+        network: 'sum by(%(instance)s) (rate(%(metric)s{%(namespace)s,%(instance)s=~"%(instanceName)s"}[$__rate_interval]))',
+        disk_writes:
+          |||
+            sum by(%s, %s, device) (
+              rate(
+                node_disk_written_bytes_total[$__rate_interval]
+              )
+            )
+            +
+            %s
+          |||,
+        disk_reads:
+          |||
+            sum by(%s, %s, device) (
+              rate(
+                node_disk_read_bytes_total[$__rate_interval]
+              )
+            ) + %s
+          |||,
+        disk_utilization:
+          |||
+            max by(persistentvolumeclaim) (
+              kubelet_volume_stats_used_bytes{%(namespace)s} /
+              kubelet_volume_stats_capacity_bytes{%(namespace)s}
+            )
+            and
+            count by(persistentvolumeclaim) (
+              kube_persistentvolumeclaim_labels{
+                %(namespace)s,
+                %(label)s
+              }
+            )
+          |||,
+      },
+    },
+
     // The label used to differentiate between different nodes (i.e. servers).
     per_node_label: 'instance',
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -79,6 +79,12 @@
     },
 
     deployment_type: 'container',
+    resources_panel_series: {
+      container: {
+        network_receive_bytes_metrics: 'container_network_receive_bytes_total',
+        network_transmit_bytes_metrics: 'container_network_transmit_bytes_total',
+      },
+    },
     resources_panel_queries: {
       container: {
         cpu_usage: 'sum by(%(instance)s) (rate(container_cpu_usage_seconds_total{%(namespace)s,container=~"%(instanceName)s"}[$__rate_interval]))',

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -78,12 +78,12 @@
       gateway: helmCompatibleName('(gateway|cortex-gw|cortex-gw).*'),
     },
 
-    deployment_type: 'container',
+    deployment_type: 'kubernetes',
     // System mount point where mimir stores its data, used for baremetal
     // deployment only.
     instance_data_mountpoint: '/',
     resources_panel_series: {
-      container: {
+      kubernetes: {
         network_receive_bytes_metrics: 'container_network_receive_bytes_total',
         network_transmit_bytes_metrics: 'container_network_transmit_bytes_total',
       },
@@ -93,7 +93,7 @@
       },
     },
     resources_panel_queries: {
-      container: {
+      kubernetes: {
         cpu_usage: 'sum by(%(instance)s) (rate(container_cpu_usage_seconds_total{%(namespace)s,container=~"%(instanceName)s"}[$__rate_interval]))',
         cpu_limit: 'min(container_spec_cpu_quota{%(namespace)s,container=~"%(instanceName)s"} / container_spec_cpu_period{%(namespace)s,container=~"%(instanceName)s"})',
         cpu_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="cpu"})',

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -81,37 +81,37 @@
     deployment_type: 'container',
     resources_panel_queries: {
       container: {
-        cpu_usage: 'sum by(%s) (rate(container_cpu_usage_seconds_total{%s,container=~"%s"}[$__rate_interval]))',
-        cpu_limit: 'min(container_spec_cpu_quota{%s,container=~"%s"} / container_spec_cpu_period{%s,container=~"%s"})',
-        cpu_request: 'min(kube_pod_container_resource_requests{%s,container=~"%s",resource="cpu"})',
+        cpu_usage: 'sum by(%(instance)s) (rate(container_cpu_usage_seconds_total{%(namespace)s,container=~"%(instanceName)s"}[$__rate_interval]))',
+        cpu_limit: 'min(container_spec_cpu_quota{%(namespace)s,container=~"%(containerName)s"} / container_spec_cpu_period{%(namespace)s,container=~"%(containerName)s"})',
+        cpu_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="cpu"})',
         // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
         // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-        memory_working_usage: 'max by(%s) (container_memory_working_set_bytes{%s,container=~"%s"})',
-        memory_working_limit: 'min(container_spec_memory_limit_bytes{%s,container=~"%s"} > 0)',
-        memory_working_request: 'min(kube_pod_container_resource_requests{%s,container=~"%s",resource="memory"})',
+        memory_working_usage: 'max by(%(instance)s) (container_memory_working_set_bytes{%(namespace)s,container=~"%(containerName)s"})',
+        memory_working_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
+        memory_working_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
         // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
         // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-        memory_rss_usage: 'max by(%s) (container_memory_rss{%s,container=~"%s"})',
-        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%s,container=~"%s"} > 0)',
-        memory_rss_request: 'min(kube_pod_container_resource_requests{%s,container=~"%s",resource="memory"})',
+        memory_rss_usage: 'max by(%(instance)s) (container_memory_rss{%(namespace)s,container=~"%(containerName)s"})',
+        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
+        memory_rss_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
         network: 'sum by(%(instance)s) (rate(%(metric)s{%(namespace)s,%(instance)s=~"%(instanceName)s"}[$__rate_interval]))',
         disk_writes:
           |||
-            sum by(%s, %s, device) (
+            sum by(%(instanceLabel)s, %(instance)s, device) (
               rate(
                 node_disk_written_bytes_total[$__rate_interval]
               )
             )
             +
-            %s
+            %(filterNodeDiskContainer)s
           |||,
         disk_reads:
           |||
-            sum by(%s, %s, device) (
+            sum by(%(instanceLabel)s, %(instance)s, device) (
               rate(
                 node_disk_read_bytes_total[$__rate_interval]
               )
-            ) + %s
+            ) + %(filterNodeDiskContainer)s
           |||,
         disk_utilization:
           |||

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -95,18 +95,18 @@
     resources_panel_queries: {
       container: {
         cpu_usage: 'sum by(%(instance)s) (rate(container_cpu_usage_seconds_total{%(namespace)s,container=~"%(instanceName)s"}[$__rate_interval]))',
-        cpu_limit: 'min(container_spec_cpu_quota{%(namespace)s,container=~"%(containerName)s"} / container_spec_cpu_period{%(namespace)s,container=~"%(containerName)s"})',
-        cpu_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="cpu"})',
+        cpu_limit: 'min(container_spec_cpu_quota{%(namespace)s,container=~"%(instanceName)s"} / container_spec_cpu_period{%(namespace)s,container=~"%(instanceName)s"})',
+        cpu_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="cpu"})',
         // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
         // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-        memory_working_usage: 'max by(%(instance)s) (container_memory_working_set_bytes{%(namespace)s,container=~"%(containerName)s"})',
-        memory_working_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
-        memory_working_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
+        memory_working_usage: 'max by(%(instance)s) (container_memory_working_set_bytes{%(namespace)s,container=~"%(instanceName)s"})',
+        memory_working_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(instanceName)s"} > 0)',
+        memory_working_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="memory"})',
         // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
         // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-        memory_rss_usage: 'max by(%(instance)s) (container_memory_rss{%(namespace)s,container=~"%(containerName)s"})',
-        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
-        memory_rss_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
+        memory_rss_usage: 'max by(%(instance)s) (container_memory_rss{%(namespace)s,container=~"%(instanceName)s"})',
+        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(instanceName)s"} > 0)',
+        memory_rss_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="memory"})',
         network: 'sum by(%(instance)s) (rate(%(metric)s{%(namespace)s,%(instance)s=~"%(instanceName)s"}[$__rate_interval]))',
         disk_writes:
           |||
@@ -142,32 +142,32 @@
           |||,
       },
       baremetal: {
-        // Somes queries does not makes sens when running mimir on baremetal
+        // Somes queries does not makes sense when running mimir on baremetal
         // no need to define them
         cpu_usage: 'sum by(%(instance)s) (rate(node_cpu_seconds_total{mode="user",%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]))',
         memory_working_usage:
           |||
-            node_memory_MemTotal_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            - node_memory_MemFree_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            - node_memory_Buffers_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            - node_memory_Cached_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            - node_memory_Slab_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            - node_memory_PageTables_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            - node_memory_SwapCached_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
+            node_memory_MemTotal_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            - node_memory_MemFree_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            - node_memory_Buffers_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            - node_memory_Cached_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            - node_memory_Slab_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            - node_memory_PageTables_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            - node_memory_SwapCached_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
           |||,
         // From cAdvisor code, the memory RSS is:
         // The amount of anonymous and swap cache memory (includes transparent hugepages).
         memory_rss_usage:
           |||
-            node_memory_Active_anon_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
-            + node_memory_SwapCached_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}
+            node_memory_Active_anon_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            + node_memory_SwapCached_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
           |||,
         network: 'sum by(%(instance)s) (rate(%(metric)s{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]))',
         disk_writes:
           |||
             sum by(%(instanceLabel)s, %(instance)s, device) (
               rate(
-                node_disk_written_bytes_total{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}[$__rate_interval]
+                node_disk_written_bytes_total{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]
               )
             )
           |||,
@@ -175,14 +175,14 @@
           |||
             sum by(%(instanceLabel)s, %(instance)s, device) (
               rate(
-                node_disk_read_bytes_total{%(namespace)s,%(instance)s=~".*%(containerName)s.*"}[$__rate_interval]
+                node_disk_read_bytes_total{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]
               )
             )
           |||,
         disk_utilization:
           |||
-            1 - ((node_filesystem_avail_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*", mountpoint="%(instanceDataDir)s"})
-                / node_filesystem_size_bytes{%(namespace)s,%(instance)s=~".*%(containerName)s.*", mountpoint="%(instanceDataDir)s"})
+            1 - ((node_filesystem_avail_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*", mountpoint="%(instanceDataDir)s"})
+                / node_filesystem_size_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*", mountpoint="%(instanceDataDir)s"})
           |||,
       },
     },

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -179,13 +179,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
 
   resourcesPanelLegend(first_legend)::
-    if $._config.deployment_type == 'container'
+    if $._config.deployment_type == 'kubernetes'
     then [first_legend, 'limit', 'request']
     // limit and request does not makes sense when running on baremetal
     else [first_legend],
 
   resourcesPanelQueries(metric, instanceName)::
-    if $._config.deployment_type == 'container'
+    if $._config.deployment_type == 'kubernetes'
     then [
       $._config.resources_panel_queries[$._config.deployment_type]['%s_usage' % metric] % {
         instance: $._config.per_instance_label,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -272,10 +272,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     { yaxes: $.yaxes('Bps') },
 
   containerNetworkReceiveBytesPanel(instanceName)::
-    $.containerNetworkPanel('Receive bandwidth', 'container_network_receive_bytes_total', instanceName),
+    $.containerNetworkPanel('Receive bandwidth', $._config.resources_panel_series[$._config.deployment_type].network_receive_bytes_metrics, instanceName),
 
   containerNetworkTransmitBytesPanel(instanceName)::
-    $.containerNetworkPanel('Transmit bandwidth', 'container_network_transmit_bytes_total', instanceName),
+    $.containerNetworkPanel('Transmit bandwidth', $._config.resources_panel_series[$._config.deployment_type].network_transmit_bytes_metrics, instanceName),
 
   containerDiskWritesPanel(title, containerName)::
     $.panel(title) +

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -181,39 +181,37 @@ local utils = import 'mixin-utils/utils.libsonnet';
   resourcesPanelLegend(first_legend)::
     if $._config.deployment_type == 'container'
     then [first_legend, 'limit', 'request']
-    // limit and request does not makes sens when running on baremetal
+    // limit and request does not makes sense when running on baremetal
     else [first_legend],
 
-  resourcesPanelQueries(metric, containerName)::
+  resourcesPanelQueries(metric, instanceName)::
     if $._config.deployment_type == 'container'
     then [
       $._config.resources_panel_queries[$._config.deployment_type]['%s_usage' % metric] % {
         instance: $._config.per_instance_label,
         namespace: $.namespaceMatcher(),
-        instanceName: containerName,
-        containerName: containerName,
+        instanceName: instanceName,
       },
       $._config.resources_panel_queries[$._config.deployment_type]['%s_limit' % metric] % {
         namespace: $.namespaceMatcher(),
-        containerName: containerName,
+        instanceName: instanceName,
       },
       $._config.resources_panel_queries[$._config.deployment_type]['%s_request' % metric] % {
         namespace: $.namespaceMatcher(),
-        containerName: containerName,
+        instanceName: instanceName,
       },
     ]
     else [
       $._config.resources_panel_queries[$._config.deployment_type]['%s_usage' % metric] % {
         instance: $._config.per_instance_label,
         namespace: $.namespaceMatcher(),
-        instanceName: containerName,
-        containerName: containerName,
+        instanceName: instanceName,
       },
     ],
 
-  containerCPUUsagePanel(title, containerName)::
+  containerCPUUsagePanel(title, instanceName)::
     $.panel(title) +
-    $.queryPanel($.resourcesPanelQueries('cpu', containerName), $.resourcesPanelLegend('{{%s}}' % $._config.per_instance_label)) +
+    $.queryPanel($.resourcesPanelQueries('cpu', instanceName), $.resourcesPanelLegend('{{%s}}' % $._config.per_instance_label)) +
     {
       seriesOverrides: [
         resourceRequestStyle,
@@ -223,9 +221,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  containerMemoryWorkingSetPanel(title, containerName)::
+  containerMemoryWorkingSetPanel(title, instanceName)::
     $.panel(title) +
-    $.queryPanel($.resourcesPanelQueries('memory_working', containerName), $.resourcesPanelLegend('{{%s}}' % $._config.per_instance_label)) +
+    $.queryPanel($.resourcesPanelQueries('memory_working', instanceName), $.resourcesPanelLegend('{{%s}}' % $._config.per_instance_label)) +
     {
       seriesOverrides: [
         resourceRequestStyle,
@@ -236,9 +234,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  containerMemoryRSSPanel(title, containerName)::
+  containerMemoryRSSPanel(title, instanceName)::
     $.panel(title) +
-    $.queryPanel($.resourcesPanelQueries('memory_rss', containerName), $.resourcesPanelLegend('{{%s}}' % $._config.per_instance_label)) +
+    $.queryPanel($.resourcesPanelQueries('memory_rss', instanceName), $.resourcesPanelLegend('{{%s}}' % $._config.per_instance_label)) +
     {
       seriesOverrides: [
         resourceRequestStyle,
@@ -268,44 +266,44 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerNetworkTransmitBytesPanel(instanceName)::
     $.containerNetworkPanel('Transmit bandwidth', $._config.resources_panel_series[$._config.deployment_type].network_transmit_bytes_metrics, instanceName),
 
-  containerDiskWritesPanel(title, containerName)::
+  containerDiskWritesPanel(title, instanceName)::
     $.panel(title) +
     $.queryPanel(
       $._config.resources_panel_queries[$._config.deployment_type].disk_writes % {
         namespace: $.namespaceMatcher(),
         instanceLabel: $._config.per_node_label,
         instance: $._config.per_instance_label,
-        filterNodeDiskContainer: $.filterNodeDiskContainer(containerName),
-        containerName: containerName,
+        filterNodeDiskContainer: $.filterNodeDiskContainer(instanceName),
+        instanceName: instanceName,
       },
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
     $.stack +
     { yaxes: $.yaxes('Bps') },
 
-  containerDiskReadsPanel(title, containerName)::
+  containerDiskReadsPanel(title, instanceName)::
     $.panel(title) +
     $.queryPanel(
       $._config.resources_panel_queries[$._config.deployment_type].disk_reads % {
         namespace: $.namespaceMatcher(),
         instanceLabel: $._config.per_node_label,
         instance: $._config.per_instance_label,
-        filterNodeDiskContainer: $.filterNodeDiskContainer(containerName),
-        containerName: containerName,
+        filterNodeDiskContainer: $.filterNodeDiskContainer(instanceName),
+        instanceName: instanceName,
       },
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
     $.stack +
     { yaxes: $.yaxes('Bps') },
 
-  containerDiskSpaceUtilization(title, containerName)::
+  containerDiskSpaceUtilization(title, instanceName)::
     $.panel(title) +
     $.queryPanel(
       $._config.resources_panel_queries[$._config.deployment_type].disk_utilization % {
         namespace: $.namespaceMatcher(),
-        label: $.containerLabelMatcher(containerName),
+        label: $.containerLabelMatcher(instanceName),
         instance: $._config.per_instance_label,
-        containerName: containerName,
+        instanceName: instanceName,
         instanceDataDir: $._config.instance_data_mountpoint,
       }, '{{persistentvolumeclaim}}'
     ) +
@@ -314,10 +312,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  containerLabelMatcher(containerName)::
-    if containerName == 'ingester' then 'label_name=~"ingester.*"'
-    else if containerName == 'store-gateway' then 'label_name=~"store-gateway.*"'
-    else 'label_name="%s"' % containerName,
+  containerLabelMatcher(instanceName)::
+    if instanceName == 'ingester' then 'label_name=~"ingester.*"'
+    else if instanceName == 'store-gateway' then 'label_name=~"store-gateway.*"'
+    else 'label_name="%s"' % instanceName,
 
   jobNetworkingRow(title, name)::
     local vars = $._config {
@@ -559,7 +557,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { yaxes: $.yaxes('percentunit') }
     ),
 
-  filterNodeDiskContainer(containerName)::
+  filterNodeDiskContainer(instanceName)::
     |||
       ignoring(%s) group_right() (
         label_replace(
@@ -586,7 +584,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $._config.per_node_label,
       $._config.per_instance_label,
       $.namespaceMatcher(),
-      containerName,
+      instanceName,
     ],
 
   filterKedaMetricByHPA(query, hpa_name)::

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -181,9 +181,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerCPUUsagePanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([
-      $._config.resources_panel_queries[$._config.deployment_type].cpu_usage % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
-      $._config.resources_panel_queries[$._config.deployment_type].cpu_limit % [$.namespaceMatcher(), containerName, $.namespaceMatcher(), containerName],
-      $._config.resources_panel_queries[$._config.deployment_type].cpu_request % [$.namespaceMatcher(), containerName],
+      $._config.resources_panel_queries[$._config.deployment_type].cpu_usage % {
+        instance: $._config.per_instance_label,
+        namespace: $.namespaceMatcher(),
+        instanceName: containerName,
+      },
+      $._config.resources_panel_queries[$._config.deployment_type].cpu_limit % {
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
+      $._config.resources_panel_queries[$._config.deployment_type].cpu_request % {
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
     ], ['{{%s}}' % $._config.per_instance_label, 'limit', 'request']) +
     {
       seriesOverrides: [
@@ -197,9 +207,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerMemoryWorkingSetPanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([
-      $._config.resources_panel_queries[$._config.deployment_type].memory_working_usage % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
-      $._config.resources_panel_queries[$._config.deployment_type].memory_working_limit % [$.namespaceMatcher(), containerName],
-      $._config.resources_panel_queries[$._config.deployment_type].memory_working_request % [$.namespaceMatcher(), containerName],
+      $._config.resources_panel_queries[$._config.deployment_type].memory_working_usage % {
+        instance: $._config.per_instance_label,
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
+      $._config.resources_panel_queries[$._config.deployment_type].memory_working_limit % {
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
+      $._config.resources_panel_queries[$._config.deployment_type].memory_working_request % {
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
     ], ['{{%s}}' % $._config.per_instance_label, 'limit', 'request']) +
     {
       seriesOverrides: [
@@ -214,9 +234,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerMemoryRSSPanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([
-      $._config.resources_panel_queries[$._config.deployment_type].memory_rss_usage % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
-      $._config.resources_panel_queries[$._config.deployment_type].memory_rss_limit % [$.namespaceMatcher(), containerName],
-      $._config.resources_panel_queries[$._config.deployment_type].memory_rss_request % [$.namespaceMatcher(), containerName],
+      $._config.resources_panel_queries[$._config.deployment_type].memory_rss_usage % {
+        instance: $._config.per_instance_label,
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
+      $._config.resources_panel_queries[$._config.deployment_type].memory_rss_limit % {
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
+      $._config.resources_panel_queries[$._config.deployment_type].memory_rss_request % {
+        namespace: $.namespaceMatcher(),
+        containerName: containerName,
+      },
     ], ['{{%s}}' % $._config.per_instance_label, 'limit', 'request']) +
     {
       seriesOverrides: [
@@ -250,11 +280,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerDiskWritesPanel(title, containerName)::
     $.panel(title) +
     $.queryPanel(
-      $._config.resources_panel_queries[$._config.deployment_type].disk_writes % [
-        $._config.per_node_label,
-        $._config.per_instance_label,
-        $.filterNodeDiskContainer(containerName),
-      ],
+      $._config.resources_panel_queries[$._config.deployment_type].disk_writes % {
+        instanceLabel: $._config.per_node_label,
+        instance: $._config.per_instance_label,
+        filterNodeDiskContainer: $.filterNodeDiskContainer(containerName),
+      },
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
     $.stack +
@@ -263,11 +293,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerDiskReadsPanel(title, containerName)::
     $.panel(title) +
     $.queryPanel(
-      $._config.resources_panel_queries[$._config.deployment_type].disk_reads % [
-        $._config.per_node_label,
-        $._config.per_instance_label,
-        $.filterNodeDiskContainer(containerName),
-      ],
+      $._config.resources_panel_queries[$._config.deployment_type].disk_reads % {
+        instanceLabel: $._config.per_node_label,
+        instance: $._config.per_instance_label,
+        filterNodeDiskContainer: $.filterNodeDiskContainer(containerName),
+      },
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
     $.stack +


### PR DESCRIPTION
#### What this PR does

Add support for baremetal deployments for the *resources* dashboards.
The default remains `deployment_type: 'container'`, hence the mixin-compiled remains unchanged.
To test new dashboards update the configuration to `deployment_type: 'baremetal'` then build the mixins.

#### Which issue(s) this PR fixes or relates to

Relates #1642

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
