### PR TITLE
Fix panic when starting Mimir targeting modules that don't depend on the API

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -547,7 +547,7 @@ func (t *Mimir) Run() error {
 
 	for _, module := range t.Cfg.Target {
 		if !t.ModuleManager.IsUserVisibleModule(module) {
-			level.Warn(util_log.Logger).Log("msg", "selected target is an internal module, is this intended?", "target", module)
+			return fmt.Errorf("selected target (%s) is an internal module, which is not allowed", module)
 		}
 	}
 

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -186,7 +186,7 @@ func TestMimirServerShutdownWithActivityTrackerEnabled(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg.ActivityTracker.Filepath = filepath.Join(tmpDir, "activity.log") // Enable activity tracker
 
-	cfg.Target = []string{API}
+	cfg.Target = []string{Querier}
 	cfg.Server = getServerConfig(t)
 	require.NoError(t, cfg.Server.LogFormat.Set("logfmt"))
 	require.NoError(t, cfg.Server.LogLevel.Set("debug"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes a bug where Mimir panics if started targeting a module which doesn't depend on the API ~~, as `t.API` is thus not initialized when accessed in `RegisterServiceMapHandler()`~~ by just erroring when starting with any internal module.

```
➜  mimir git:(main) ✗ ./mimir --config.file=demo.yaml -target=server
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x19ca69d]

goroutine 1 [running]:
github.com/grafana/mimir/pkg/api.(*API).RegisterServiceMapHandler(0x0, {0x2571120, 0xc00084eb10})
        /home/levi/Desktop/projects/grafana/mimir/pkg/api/api.go:410 +0x5d
github.com/grafana/mimir/pkg/mimir.(*Mimir).Run(0xc0007fca00)
        /home/levi/Desktop/projects/grafana/mimir/pkg/mimir/mimir.go:560 +0x2b3
main.main()
        /home/levi/Desktop/projects/grafana/mimir/cmd/mimir/main.go:212 +0xb30
```

#### Which issue(s) this PR fixes or relates to
#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
