### PR TITLE
Periodically send anonymous usage stats report

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -545,6 +545,9 @@ func (t *Mimir) Run() error {
 		level.Warn(util_log.Logger).Log("msg", "skipped registration of custom process metrics collector", "err", err)
 	}
 
+	// Update the usage stats before we initialize modules.
+	usagestats.SetTarget(t.Cfg.Target.String())
+
 	for _, module := range t.Cfg.Target {
 		if !t.ModuleManager.IsUserVisibleModule(module) {
 			level.Warn(util_log.Logger).Log("msg", "selected target is an internal module, is this intended?", "target", module)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -760,7 +760,7 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 		return nil, err
 	}
 
-	t.UsageStatsReporter = usagestats.NewReporter(bucketClient, util_log.Logger)
+	t.UsageStatsReporter = usagestats.NewReporter(bucketClient, util_log.Logger, prometheus.DefaultRegisterer)
 	return t.UsageStatsReporter, nil
 }
 

--- a/pkg/usagestats/report.go
+++ b/pkg/usagestats/report.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagestats
+
+import (
+	"expvar"
+	"runtime"
+	"time"
+
+	prom "github.com/prometheus/prometheus/web/api/v1"
+
+	"github.com/grafana/mimir/pkg/util/version"
+)
+
+// Report is the JSON object sent to the stats server
+type Report struct {
+	// ClusterID is the unique Mimir cluster ID.
+	ClusterID string `json:"clusterID"`
+
+	// CreatedAt is when the cluster was created.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// Interval is when the report was created (value is aligned across all replicas of the same Mimir cluster).
+	Interval time.Time `json:"interval"`
+
+	// IntervalPeriod is how frequently the report is sent, in seconds.
+	IntervalPeriod float64 `json:"intervalPeriod"`
+
+	// Target used to run Mimir.
+	Target string `json:"target"`
+
+	// Version holds information about the Mimir version.
+	Version prom.PrometheusVersion `json:"version"`
+
+	// Os is the operating system where Mimir is running.
+	Os string `json:"os"`
+
+	// Arch is the architecture where Mimir is running.
+	Arch string `json:"arch"`
+
+	// Edition is the Mimir edition ("oss" or "enterprise").
+	Edition string `json:"edition"`
+
+	// Metrics holds custom metrics tracked by Mimir. Can contain nested objects.
+	Metrics map[string]interface{} `json:"metrics"`
+}
+
+// buildReport builds the report to be sent to the stats server.
+func buildReport(seed ClusterSeed, reportAt time.Time, reportInterval time.Duration) Report {
+	var (
+		targetName  string
+		editionName string
+	)
+	if target := expvar.Get(statsPrefix + targetKey); target != nil {
+		if target, ok := target.(*expvar.String); ok {
+			targetName = target.Value()
+		}
+	}
+	if edition := expvar.Get(statsPrefix + editionKey); edition != nil {
+		if edition, ok := edition.(*expvar.String); ok {
+			editionName = edition.Value()
+		}
+	}
+
+	return Report{
+		ClusterID:      seed.UID,
+		CreatedAt:      seed.CreatedAt,
+		Version:        buildVersion(),
+		Interval:       reportAt,
+		IntervalPeriod: reportInterval.Seconds(),
+		Os:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		Target:         targetName,
+		Edition:        editionName,
+		Metrics:        buildMetrics(),
+	}
+}
+
+// buildMetrics builds the metrics part of the report to be sent to the stats server.
+func buildMetrics() map[string]interface{} {
+	return map[string]interface{}{
+		"memstats":      buildMemstats(),
+		"num_cpu":       runtime.NumCPU(),
+		"num_goroutine": runtime.NumGoroutine(),
+	}
+}
+
+func buildMemstats() interface{} {
+	stats := new(runtime.MemStats)
+	runtime.ReadMemStats(stats)
+
+	return map[string]interface{}{
+		"alloc":           stats.Alloc,
+		"total_alloc":     stats.TotalAlloc,
+		"sys":             stats.Sys,
+		"heap_alloc":      stats.HeapAlloc,
+		"heap_inuse":      stats.HeapInuse,
+		"stack_inuse":     stats.StackInuse,
+		"pause_total_ns":  stats.PauseTotalNs,
+		"num_gc":          stats.NumGC,
+		"gc_cpu_fraction": stats.GCCPUFraction,
+	}
+}
+
+func buildVersion() prom.PrometheusVersion {
+	return prom.PrometheusVersion{
+		Version:   version.Version,
+		Revision:  version.Revision,
+		Branch:    version.Branch,
+		GoVersion: version.GoVersion,
+	}
+}

--- a/pkg/usagestats/report_test.go
+++ b/pkg/usagestats/report_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagestats
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mimir/pkg/util/version"
+)
+
+func TestBuildReport(t *testing.T) {
+	var (
+		clusterCreatedAt = time.Now().Add(-time.Hour)
+		seed             = ClusterSeed{UID: "test", CreatedAt: clusterCreatedAt}
+		reportAt         = time.Now()
+		reportInterval   = time.Hour
+	)
+
+	SetTarget("all")
+	version.Version = "dev-version"
+	version.Branch = "dev-branch"
+	version.Revision = "dev-revision"
+
+	report := buildReport(seed, reportAt, reportInterval)
+	assert.Equal(t, "test", report.ClusterID)
+	assert.Equal(t, clusterCreatedAt, report.CreatedAt)
+	assert.Equal(t, reportAt, report.Interval)
+	assert.Equal(t, reportInterval.Seconds(), report.IntervalPeriod)
+	assert.Equal(t, "all", report.Target)
+	assert.Equal(t, runtime.GOOS, report.Os)
+	assert.Equal(t, runtime.GOARCH, report.Arch)
+	assert.Equal(t, "oss", report.Edition)
+	assert.NotNil(t, report.Metrics["memstats"])
+	assert.Equal(t, "dev-version", report.Version.Version)
+	assert.Equal(t, "dev-branch", report.Version.Branch)
+	assert.Equal(t, "dev-revision", report.Version.Revision)
+	assert.Equal(t, runtime.Version(), report.Version.GoVersion)
+}

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -160,17 +160,17 @@ func (r *Reporter) sendReport(ctx context.Context, report Report) (returnErr err
 
 	data, err := json.Marshal(report)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal the report")
+		return errors.Wrap(err, "marshal the report")
 	}
-	req, err := http.NewRequest(http.MethodPost, r.serverURL, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPost, r.serverURL, bytes.NewReader(data))
 	if err != nil {
-		return errors.Wrap(err, "failed to create the request")
+		return errors.Wrap(err, "create the request")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := r.client.Do(req.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "failed to send the report to the stats server")
+		return errors.Wrap(err, "send the report to the stats server")
 	}
 
 	// Ensure the body reader is always closed.
@@ -179,7 +179,7 @@ func (r *Reporter) sendReport(ctx context.Context, report Report) (returnErr err
 	// Consume all the response.
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Wrap(err, "failed to read the response from the stats server")
+		return errors.Wrap(err, "read the response from the stats server")
 	}
 
 	if resp.StatusCode/100 != 2 {
@@ -188,7 +188,7 @@ func (r *Reporter) sendReport(ctx context.Context, report Report) (returnErr err
 		if len(body) > maxBodyLength {
 			body = body[:maxBodyLength]
 		}
-		return fmt.Errorf("failed to send the report to the stats server, received status code: %s and body: %q", resp.Status, string(body))
+		return fmt.Errorf("received status code: %s and body: %q", resp.Status, string(body))
 	}
 
 	return nil

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -3,16 +3,32 @@
 package usagestats
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/thanos-io/thanos/pkg/objstore"
 
+	"github.com/grafana/dskit/services"
+
 	"github.com/grafana/mimir/pkg/storage/bucket"
+)
+
+const (
+	defaultReportCheckInterval = time.Minute
+	defaultReportSendInterval  = 4 * time.Hour
+	defaultStatsServerURL      = "https://stats.grafana.org/mimir-usage-report"
 )
 
 type Config struct {
@@ -28,16 +44,52 @@ type Reporter struct {
 	logger log.Logger
 	bucket objstore.InstrumentedBucket
 
+	// How frequently check if there's a report to send.
+	reportCheckInterval time.Duration
+
+	// How frequently send a new report.
+	reportSendInterval time.Duration
+
+	// How long to wait for a cluster seed file creation before using it.
+	seedFileMinStability time.Duration
+
+	client    http.Client
+	serverURL string
+
 	services.Service
+
+	// Metrics.
+	requestsTotal       prometheus.Counter
+	requestsFailedTotal prometheus.Counter
+	requestsLatency     prometheus.Histogram
 }
 
-func NewReporter(bucketClient objstore.InstrumentedBucket, logger log.Logger) *Reporter {
+func NewReporter(bucketClient objstore.InstrumentedBucket, logger log.Logger, reg prometheus.Registerer) *Reporter {
 	// The cluster seed file is stored in a prefix dedicated to Mimir internals.
 	bucketClient = bucket.NewPrefixedBucketClient(bucketClient, bucket.MimirInternalsPrefix)
 
 	r := &Reporter{
-		logger: logger,
-		bucket: bucketClient,
+		logger:               logger,
+		bucket:               bucketClient,
+		client:               http.Client{Timeout: 5 * time.Second},
+		serverURL:            defaultStatsServerURL,
+		reportCheckInterval:  defaultReportCheckInterval,
+		reportSendInterval:   defaultReportSendInterval,
+		seedFileMinStability: clusterSeedFileMinStability,
+
+		requestsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_usage_stats_report_sends_total",
+			Help: "The total number of attempted send requests.",
+		}),
+		requestsFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_usage_stats_report_sends_failed_total",
+			Help: "The total number of failed send requests.",
+		}),
+		requestsLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_usage_stats_report_sends_latency_seconds",
+			Help:    "The latency of report send requests in seconds (include both succeeded and failed requests).",
+			Buckets: prometheus.DefBuckets,
+		}),
 	}
 	r.Service = services.NewBasicService(nil, r.running, nil)
 	return r
@@ -45,7 +97,7 @@ func NewReporter(bucketClient objstore.InstrumentedBucket, logger log.Logger) *R
 
 func (r *Reporter) running(ctx context.Context) error {
 	// Init or get the cluster seed.
-	seed, err := initSeedFile(ctx, r.bucket, clusterSeedFileMinStability, r.logger)
+	seed, err := initSeedFile(ctx, r.bucket, r.seedFileMinStability, r.logger)
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}
@@ -55,7 +107,96 @@ func (r *Reporter) running(ctx context.Context) error {
 
 	level.Info(r.logger).Log("msg", "usage stats reporter initialized", "cluster_id", seed.UID)
 
-	// TODO Periodically send usage report.
+	// Find when to send the next report. We want all instances of the same Mimir cluster computing the same value.
+	nextReportAt := nextReport(r.reportSendInterval, seed.CreatedAt, time.Now())
+
+	ticker := time.NewTicker(r.reportCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if time.Now().Before(nextReportAt) {
+				continue
+			}
+
+			// If the send is failing since a long time and the report is falling behind,
+			// we'll skip this one and try to send the next one.
+			if time.Since(nextReportAt) >= r.reportSendInterval {
+				nextReportAt = nextReport(r.reportSendInterval, seed.CreatedAt, time.Now())
+				level.Info(r.logger).Log("msg", "failed to send anonymous usage stats report for too long, skipping to next report", "next_report_at", nextReportAt.String())
+				continue
+			}
+
+			level.Debug(r.logger).Log("msg", "sending anonymous usage stats report")
+			if err := r.sendReport(ctx, buildReport(seed, nextReportAt, r.reportSendInterval)); err != nil {
+				level.Info(r.logger).Log("msg", "failed to send anonymous usage stats report", "err", err)
+
+				// We'll try at the next check interval.
+				continue
+			}
+
+			nextReportAt = nextReport(r.reportSendInterval, seed.CreatedAt, time.Now())
+		case <-ctx.Done():
+			if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
+// sendReport sends the report to the stats server.
+func (r *Reporter) sendReport(ctx context.Context, report Report) (returnErr error) {
+	startTime := time.Now()
+	r.requestsTotal.Inc()
+
+	defer func() {
+		r.requestsLatency.Observe(time.Since(startTime).Seconds())
+		if returnErr != nil {
+			r.requestsFailedTotal.Inc()
+		}
+	}()
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal the report")
+	}
+	req, err := http.NewRequest(http.MethodPost, r.serverURL, bytes.NewBuffer(data))
+	if err != nil {
+		return errors.Wrap(err, "failed to create the request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return errors.Wrap(err, "failed to send the report to the stats server")
+	}
+
+	// Ensure the body reader is always closed.
+	defer resp.Body.Close()
+
+	// Consume all the response.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read the response from the stats server")
+	}
+
+	if resp.StatusCode/100 != 2 {
+		// Limit the body response that we log.
+		maxBodyLength := 128
+		if len(body) > maxBodyLength {
+			body = body[:maxBodyLength]
+		}
+		return fmt.Errorf("failed to send the report to the stats server, received status code: %s and body: %q", resp.Status, string(body))
+	}
 
 	return nil
+}
+
+// nextReport compute the next report time based on the interval.
+// The interval is based off the creation of the cluster seed to avoid all cluster reporting at the same time.
+func nextReport(interval time.Duration, createdAt, now time.Time) time.Time {
+	// createdAt * (x * interval ) >= now
+	return createdAt.Add(time.Duration(math.Ceil(float64(now.Sub(createdAt))/float64(interval))) * interval)
 }

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagestats
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
+)
+
+func TestNextReport(t *testing.T) {
+	fixtures := map[string]struct {
+		interval  time.Duration
+		createdAt time.Time
+		now       time.Time
+
+		next time.Time
+	}{
+		"createdAt aligned with interval and now": {
+			interval:  1 * time.Hour,
+			createdAt: time.Unix(0, time.Hour.Nanoseconds()),
+			now:       time.Unix(0, 2*time.Hour.Nanoseconds()),
+			next:      time.Unix(0, 2*time.Hour.Nanoseconds()),
+		},
+		"createdAt aligned with interval": {
+			interval:  1 * time.Hour,
+			createdAt: time.Unix(0, time.Hour.Nanoseconds()),
+			now:       time.Unix(0, 2*time.Hour.Nanoseconds()+1),
+			next:      time.Unix(0, 3*time.Hour.Nanoseconds()),
+		},
+		"createdAt not aligned": {
+			interval:  1 * time.Hour,
+			createdAt: time.Unix(0, time.Hour.Nanoseconds()+18*time.Minute.Nanoseconds()+20*time.Millisecond.Nanoseconds()),
+			now:       time.Unix(0, 2*time.Hour.Nanoseconds()+1),
+			next:      time.Unix(0, 2*time.Hour.Nanoseconds()+18*time.Minute.Nanoseconds()+20*time.Millisecond.Nanoseconds()),
+		},
+	}
+	for name, f := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			next := nextReport(f.interval, f.createdAt, f.now)
+			require.Equal(t, f.next, next)
+		})
+	}
+}
+
+func TestSendReport(t *testing.T) {
+	serverInvoked := atomic.NewBool(false)
+
+	// Create a local HTTP server.
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		serverInvoked.Store(true)
+
+		switch request.URL.Path {
+		case "/success":
+			writer.WriteHeader(http.StatusOK)
+		default:
+			writer.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer server.Close()
+
+	tests := map[string]func(t *testing.T){
+		"server returns 2xx": func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			reporter := NewReporter(prepareLocalBucketClient(t), log.NewNopLogger(), reg)
+			reporter.serverURL = server.URL + "/success"
+
+			err := reporter.sendReport(context.Background(), buildReport(newClusterSeed(), time.Now(), time.Hour))
+			require.NoError(t, err)
+			require.True(t, serverInvoked.Load())
+
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_usage_stats_report_sends_total The total number of attempted send requests.
+				# TYPE cortex_usage_stats_report_sends_total counter
+				cortex_usage_stats_report_sends_total 1
+
+				# HELP cortex_usage_stats_report_sends_failed_total The total number of failed send requests.
+				# TYPE cortex_usage_stats_report_sends_failed_total counter
+				cortex_usage_stats_report_sends_failed_total 0
+			`), "cortex_usage_stats_report_sends_total", "cortex_usage_stats_report_sends_failed_total"))
+		},
+		"server returns 5xx": func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			reporter := NewReporter(prepareLocalBucketClient(t), log.NewNopLogger(), reg)
+			reporter.serverURL = server.URL + "/failure"
+
+			err := reporter.sendReport(context.Background(), buildReport(newClusterSeed(), time.Now(), time.Hour))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "failed to send the report to the stats server")
+			require.True(t, serverInvoked.Load())
+
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_usage_stats_report_sends_total The total number of attempted send requests.
+				# TYPE cortex_usage_stats_report_sends_total counter
+				cortex_usage_stats_report_sends_total 1
+
+				# HELP cortex_usage_stats_report_sends_failed_total The total number of failed send requests.
+				# TYPE cortex_usage_stats_report_sends_failed_total counter
+				cortex_usage_stats_report_sends_failed_total 1
+			`), "cortex_usage_stats_report_sends_total", "cortex_usage_stats_report_sends_failed_total"))
+		},
+		"server is not running": func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			reporter := NewReporter(prepareLocalBucketClient(t), log.NewNopLogger(), reg)
+			reporter.serverURL = "http://127.0.0.1:12345"
+
+			err := reporter.sendReport(context.Background(), buildReport(newClusterSeed(), time.Now(), time.Hour))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "failed to send the report to the stats server")
+			require.False(t, serverInvoked.Load())
+
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_usage_stats_report_sends_total The total number of attempted send requests.
+				# TYPE cortex_usage_stats_report_sends_total counter
+				cortex_usage_stats_report_sends_total 1
+
+				# HELP cortex_usage_stats_report_sends_failed_total The total number of failed send requests.
+				# TYPE cortex_usage_stats_report_sends_failed_total counter
+				cortex_usage_stats_report_sends_failed_total 1
+			`), "cortex_usage_stats_report_sends_total", "cortex_usage_stats_report_sends_failed_total"))
+		},
+	}
+
+	for testName, testRun := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Reset.
+			serverInvoked.Store(false)
+
+			testRun(t)
+		})
+	}
+}
+
+func TestReporter_SendReportPeriodically(t *testing.T) {
+	tests := map[string]struct {
+		failOneRequestEvery int
+	}{
+		"all requests to stats server succeed": {
+			failOneRequestEvery: 0,
+		},
+		"some requests to stats server fail and they get retried": {
+			failOneRequestEvery: 2,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				ctx           = context.Background()
+				bucketClient  = prepareLocalBucketClient(t)
+				reportsMx     sync.Mutex
+				reports       []Report
+				requestsCount = atomic.NewInt32(0)
+			)
+
+			// Mock the stats server.
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				requestsCount.Inc()
+				if testData.failOneRequestEvery > 0 && requestsCount.Load()%int32(testData.failOneRequestEvery) == 0 {
+					writer.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+
+				data, err := io.ReadAll(request.Body)
+				require.NoError(t, err)
+
+				report := Report{}
+				require.NoError(t, json.Unmarshal(data, &report))
+
+				reportsMx.Lock()
+				reports = append(reports, report)
+				reportsMx.Unlock()
+
+				writer.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			r := NewReporter(bucketClient, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			r.serverURL = server.URL
+			r.reportCheckInterval = 100 * time.Millisecond
+			r.reportSendInterval = time.Second
+
+			// Upload the seed file.
+			seed := newClusterSeed()
+			seed.CreatedAt = time.Now().Add(-time.Hour)
+			require.NoError(t, writeSeedFile(ctx, r.bucket, seed))
+
+			// Start the reporter.
+			require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+			})
+
+			// Wait some time and check the received reports.
+			time.Sleep(6 * time.Second)
+
+			reportsMx.Lock()
+			defer reportsMx.Unlock()
+
+			// We expect to have received at least 4 reports in 6 seconds (there's some overhead for the initial seed check).
+			require.GreaterOrEqual(t, len(reports), 4)
+
+			// We expect each report interval to be exactly at 1s apart from the previous one.
+			for i := 1; i < len(reports); i++ {
+				require.Equal(t, reports[i-1].Interval.Add(time.Second), reports[i].Interval)
+			}
+		})
+	}
+}
+
+func TestReporter_SendReportShouldSkipToNextReportOnLongFailure(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx           = context.Background()
+		bucketClient  = prepareLocalBucketClient(t)
+		reportsMx     sync.Mutex
+		reports       []Report
+		requestsCount = atomic.NewInt32(0)
+	)
+
+	// Mock the stats server.
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestsCount.Inc()
+
+		// Fail 10 requests after the 1st one (we expect 1 retry every 100ms in this test).
+		if requestsCount.Load() > 1 && requestsCount.Load() <= 11 {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		data, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+
+		report := Report{}
+		require.NoError(t, json.Unmarshal(data, &report))
+
+		reportsMx.Lock()
+		reports = append(reports, report)
+		reportsMx.Unlock()
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	r := NewReporter(bucketClient, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	r.serverURL = server.URL
+	r.reportCheckInterval = 100 * time.Millisecond
+	r.reportSendInterval = time.Second
+
+	// Upload the seed file.
+	seed := newClusterSeed()
+	seed.CreatedAt = time.Now().Add(-time.Hour)
+	require.NoError(t, writeSeedFile(ctx, r.bucket, seed))
+
+	// Start the reporter.
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	// Wait some time and check the received reports.
+	time.Sleep(6 * time.Second)
+
+	reportsMx.Lock()
+	defer reportsMx.Unlock()
+
+	// We expect to have received at least 2 reports in 6 seconds (there's some overhead for the initial seed check).
+	require.GreaterOrEqual(t, len(reports), 2)
+
+	// We expect the report timestamp to have been updated during the long failure.
+	require.GreaterOrEqual(t, reports[1].Interval, reports[0].Interval.Add(2*time.Second))
+}
+
+func prepareLocalBucketClient(t *testing.T) objstore.InstrumentedBucket {
+	bucketClient, err := filesystem.NewBucketClient(filesystem.Config{Directory: t.TempDir()})
+	require.NoError(t, err)
+
+	return objstore.BucketWithMetrics("", bucketClient, nil)
+}

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -194,7 +194,7 @@ func TestReporter_SendReportPeriodically(t *testing.T) {
 
 				writer.WriteHeader(http.StatusOK)
 			}))
-			defer server.Close()
+			t.Cleanup(server.Close)
 
 			r := NewReporter(bucketClient, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 			r.serverURL = server.URL

--- a/pkg/usagestats/seed_test.go
+++ b/pkg/usagestats/seed_test.go
@@ -244,13 +244,11 @@ func TestInitSeedFile(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			bucketClient, err := filesystem.NewBucketClient(filesystem.Config{Directory: t.TempDir()})
-			require.NoError(t, err)
-
+			bucketClient := prepareLocalBucketClient(t)
 			testData := testSetup(t, bucketClient)
 
 			startTime := time.Now()
-			actualSeed, err := initSeedFile(context.Background(), objstore.BucketWithMetrics("", bucketClient, nil), minStability, log.NewNopLogger())
+			actualSeed, err := initSeedFile(context.Background(), bucketClient, minStability, log.NewNopLogger())
 			if testData.expectedErr != nil {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), testData.expectedErr.Error())
@@ -258,7 +256,7 @@ func TestInitSeedFile(t *testing.T) {
 				require.NoError(t, err)
 
 				// We expect the seed stored in the bucket.
-				expectedSeed, err := readSeedFile(context.Background(), objstore.BucketWithMetrics("", bucketClient, nil), log.NewNopLogger())
+				expectedSeed, err := readSeedFile(context.Background(), bucketClient, log.NewNopLogger())
 				require.NoError(t, err)
 				require.Equal(t, expectedSeed.UID, actualSeed.UID)
 				require.Equal(t, expectedSeed.CreatedAt.Unix(), actualSeed.CreatedAt.Unix())

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -22,17 +22,17 @@ func init() {
 
 // SetTarget sets the target name.
 func SetTarget(target string) {
-	NewString(targetKey).Set(target)
+	getString(targetKey).Set(target)
 }
 
 // SetEdition sets the edition name.
 func SetEdition(edition string) {
-	NewString(editionKey).Set(edition)
+	getString(editionKey).Set(edition)
 }
 
-// NewString returns a new String stats object.
-// If a String stats object with the same name already exists it is returned.
-func NewString(name string) *expvar.String {
+// getString returns the String stats object for the given name.
+// It creates the stats object if doesn't exist yet.
+func getString(name string) *expvar.String {
 	existing := expvar.Get(statsPrefix + name)
 	if existing != nil {
 		if s, ok := existing.(*expvar.String); ok {

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagestats
+
+import (
+	"expvar"
+	"fmt"
+)
+
+const (
+	statsPrefix = "github.com/grafana/mimir/"
+	targetKey   = "target"
+	editionKey  = "edition"
+
+	EditionOSS        = "oss"
+	EditionEnterprise = "enterprise"
+)
+
+func init() {
+	SetEdition(EditionOSS)
+}
+
+// SetTarget sets the target name.
+func SetTarget(target string) {
+	NewString(targetKey).Set(target)
+}
+
+// SetEdition sets the edition name.
+func SetEdition(edition string) {
+	NewString(editionKey).Set(edition)
+}
+
+// NewString returns a new String stats object.
+// If a String stats object with the same name already exists it is returned.
+func NewString(name string) *expvar.String {
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if s, ok := existing.(*expvar.String); ok {
+			return s
+		}
+		panic(fmt.Sprintf("%v is set to a non-string value", name))
+	}
+	return expvar.NewString(statsPrefix + name)
+}


### PR DESCRIPTION
#### What this PR does
In this PR I'm adding the logic to periodically send anonymous usage stats report. The report doesn't contain custom metrics yet (will be done in in the next PR). The default stats we send (and the frequency) are the exact same of the ones sent by Loki, to keep consistency.

#### Which issue(s) this PR fixes or relates to

Part of #1815

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
