### PR TITLE
Helm: allow setting security context for memcached exporter

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -56,9 +56,12 @@ jobs:
         make operations/helm/charts/mimir-distributed/charts
         make build-jsonnet-tests
 
+        set +e
         OUTPUT="$(./operations/compare-helm-with-jsonnet/compare-helm-with-jsonnet.sh 2>&1)"
+        RC=$?
+        set -e
 
-        if [ $? -eq 0 ]; then
+        if [ "${RC}" -eq 0 ]; then
           echo "::set-output name=changed::false"
         else
           echo "$OUTPUT"

--- a/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
@@ -39,6 +39,14 @@ patches:
       - op: remove
         path: /spec/template/spec/volumes/1
 
+  # Helm sets a security context on memcached containers
+  - target:
+      kind: 'StatefulSet'
+      name: 'mimir-.+-cache'
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/1/securityContext
+
   # Minor Difference: Helm names the overrides volume slightly differently
   - target:
       name: mimir-(distributor|query-frontend|overrides-exporter|ruler|querier|alertmanager|ingester|store-gateway|compactor)

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -24,6 +24,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Default to injecting the `no_auth_tenant` from the Mimir configuration as the value for `X-Scope-OrgID` in nginx. #2614
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 * [BUGFIX] Add missing `containerSecurityContext` to alertmanager and tokengen job. #2416
+* [BUGFIX] Add missing `containerSecutiryContext` to memcached exporter containers. #2666
 
 ## 3.0.0
 

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -118,6 +118,8 @@ spec:
             - "--web.listen-address=0.0.0.0:9150"
           resources:
             {{- toYaml $.ctx.Values.memcachedExporter.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml $.ctx.Values.memcachedExporter.containerSecurityContext | nindent 12 }}
       {{- end }}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1059,6 +1059,14 @@ memcachedExporter:
     requests: {}
     limits: {}
 
+  # -- The SecurityContext for memcached containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+
 chunks-cache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: false

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1059,7 +1059,7 @@ memcachedExporter:
     requests: {}
     limits: {}
 
-  # -- The SecurityContext for memcached containers
+  # -- The SecurityContext for memcached exporter containers
   containerSecurityContext:
     readOnlyRootFilesystem: true
     capabilities:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -90,3 +90,9 @@ spec:
           resources:
             limits: {}
             requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -90,3 +90,9 @@ spec:
           resources:
             limits: {}
             requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -90,3 +90,9 @@ spec:
           resources:
             limits: {}
             requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -90,3 +90,9 @@ spec:
           resources:
             limits: {}
             requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true


### PR DESCRIPTION
#### What this PR does

Have default and allow setting security context for memcached exporter.

#### Which issue(s) this PR fixes or relates to

Request from GEM customer.
Mimir support esc 3505

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
