### PR TITLE
Add plurals to list config parameters

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -734,7 +734,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ha-tracker.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1065,7 +1065,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1278,7 +1278,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "distributor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -1945,7 +1945,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ingester.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -2210,7 +2210,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "ingester.ring.instance-interface-names",
-              "fieldType": "list of string",
+              "fieldType": "list of strings",
               "fieldCategory": "advanced"
             },
             {
@@ -2557,7 +2557,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "distributor.drop-label",
-          "fieldType": "list of string",
+          "fieldType": "list of strings",
           "fieldCategory": "advanced"
         },
         {
@@ -3639,7 +3639,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "query-frontend.instance-interface-names",
-          "fieldType": "list of string",
+          "fieldType": "list of strings",
           "fieldCategory": "advanced"
         },
         {
@@ -5279,7 +5279,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "blocks-storage.tsdb.block-ranges-period",
-              "fieldType": "list of duration",
+              "fieldType": "list of durations",
               "fieldCategory": "advanced"
             },
             {
@@ -5534,7 +5534,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "compactor.block-ranges",
-          "fieldType": "list of duration",
+          "fieldType": "list of durations",
           "fieldCategory": "advanced"
         },
         {
@@ -5856,7 +5856,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "compactor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -6091,7 +6091,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "compactor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -6284,7 +6284,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "store-gateway.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -6550,7 +6550,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "store-gateway.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -7180,7 +7180,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ruler.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -7393,7 +7393,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "ruler.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -8504,7 +8504,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "alertmanager.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -8739,7 +8739,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "alertmanager.sharding-ring.instance-interface-names",
-              "fieldType": "list of string",
+              "fieldType": "list of strings",
               "fieldCategory": "advanced"
             },
             {
@@ -9827,7 +9827,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.join",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -9924,7 +9924,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.bind-addr",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -166,7 +166,7 @@ Usage of ./cmd/mimir/mimir:
     	Time to wait between peers to send notifications. (default 15s)
   -alertmanager.persist-interval duration
     	The interval between persisting the current alertmanager state (notification log and silences) to object storage. This is only used when sharding is enabled. This state is read when all replicas for a shard can not be contacted. In this scenario, having persisted the state more frequently will result in potentially fewer lost silences, and fewer duplicate notifications. (default 15m0s)
-  -alertmanager.receivers-firewall-block-cidr-networks comma-separated-list-of-string
+  -alertmanager.receivers-firewall-block-cidr-networks comma-separated-list-of-strings
     	Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.
   -alertmanager.receivers-firewall-block-private-addresses
     	True to block private and local addresses in Alertmanager receiver integrations. It blocks private addresses defined by  RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses), as well as loopback, local unicast and local multicast addresses.
@@ -479,7 +479,7 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -blocks-storage.swift.username string
     	OpenStack Swift username.
-  -blocks-storage.tsdb.block-ranges-period comma-separated-list-of-duration
+  -blocks-storage.tsdb.block-ranges-period comma-separated-list-of-durations
     	TSDB blocks range period. (default 2h0m0s)
   -blocks-storage.tsdb.close-idle-tsdb-timeout duration
     	If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB. (default 13h0m0s)
@@ -622,7 +622,7 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -common.storage.swift.username string
     	OpenStack Swift username.
-  -compactor.block-ranges comma-separated-list-of-duration
+  -compactor.block-ranges comma-separated-list-of-durations
     	List of compaction time ranges. (default 2h0m0s,12h0m0s,24h0m0s)
   -compactor.block-sync-concurrency int
     	Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
@@ -650,9 +650,9 @@ Usage of ./cmd/mimir/mimir:
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
   -compactor.deletion-delay duration
     	Time before a block marked for deletion is deleted from bucket. If not 0, blocks will be marked for deletion and compactor component will permanently delete blocks marked for deletion from the bucket. If 0, blocks will be deleted straight away. Note that deleting blocks immediately can cause query failures. (default 12h0m0s)
-  -compactor.disabled-tenants comma-separated-list-of-string
+  -compactor.disabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.
-  -compactor.enabled-tenants comma-separated-list-of-string
+  -compactor.enabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.
   -compactor.max-closing-blocks-concurrency int
     	Max number of blocks that can be closed concurrently during split compaction. Note that closing of newly compacted block uses a lot of memory for writing index. (default 1)
@@ -1016,7 +1016,7 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -ingester.ring.etcd.username string
     	Etcd username.
-  -ingester.ring.excluded-zones comma-separated-list-of-string
+  -ingester.ring.excluded-zones comma-separated-list-of-strings
     	Comma-separated list of zones to exclude from the ring. Instances in excluded zones will be filtered out from the ring. This option needs be set on ingesters, distributors, queriers and rulers when running in microservices mode.
   -ingester.ring.final-sleep duration
     	Duration to sleep for before exiting, to ensure metrics are scraped.
@@ -1511,11 +1511,11 @@ Usage of ./cmd/mimir/mimir:
     	Path to the key file for the client certificate. Also requires the client certificate to be configured.
   -ruler.client.tls-server-name string
     	Override the expected name on the server certificate.
-  -ruler.disabled-tenants comma-separated-list-of-string
+  -ruler.disabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants whose rules this ruler cannot evaluate. If specified, a ruler that would normally pick the specified tenant(s) for processing will ignore them instead. Subject to sharding.
   -ruler.enable-api
     	Enable the ruler config API. (default true)
-  -ruler.enabled-tenants comma-separated-list-of-string
+  -ruler.enabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.
   -ruler.evaluation-delay-duration duration
     	Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.
@@ -1797,7 +1797,7 @@ Usage of ./cmd/mimir/mimir:
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -store.max-query-length duration
     	Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
-  -target comma-separated-list-of-string
+  -target comma-separated-list-of-strings
     	Comma-separated list of components to include in the instantiated process. The default value 'all' includes all components that are required to form a functional Grafana Mimir instance in single-binary mode. Use the '-modules' command line flag to get a list of available components, and to see which components are included with 'all'. (default all)
   -tenant-federation.enabled
     	If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1641,7 +1641,7 @@ Usage of ./cmd/mimir/mimir:
     	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's 'source_tenants' field. If this flag is set to 'false' when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
   -ruler.tenant-shard-size int
     	The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.
-  -runtime-config.file comma-separated-list-of-string
+  -runtime-config.file comma-separated-list-of-strings
     	Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.
   -runtime-config.reload-period duration
     	How often to check runtime config files. (default 10s)

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -86,7 +86,7 @@ Usage of ./cmd/mimir/mimir:
     	Per-tenant rate limit for sending notifications from Alertmanager in notifications/sec. 0 = rate limit disabled. Negative value = no notifications are allowed.
   -alertmanager.notification-rate-limit-per-integration value
     	Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: webhook, email, pagerduty, opsgenie, wechat, slack, victorops, pushover, sns. (default {})
-  -alertmanager.receivers-firewall-block-cidr-networks comma-separated-list-of-string
+  -alertmanager.receivers-firewall-block-cidr-networks comma-separated-list-of-strings
     	Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.
   -alertmanager.receivers-firewall-block-private-addresses
     	True to block private and local addresses in Alertmanager receiver integrations. It blocks private addresses defined by  RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses), as well as loopback, local unicast and local multicast addresses.
@@ -573,7 +573,7 @@ Usage of ./cmd/mimir/mimir:
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -store.max-query-length duration
     	Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
-  -target comma-separated-list-of-string
+  -target comma-separated-list-of-strings
     	Comma-separated list of components to include in the instantiated process. The default value 'all' includes all components that are required to form a functional Grafana Mimir instance in single-binary mode. Use the '-modules' command line flag to get a list of available components, and to see which components are included with 'all'. (default all)
   -tenant-federation.enabled
     	If enabled on all services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a '|' character in the 'X-Scope-OrgID' header.

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -537,7 +537,7 @@ Usage of ./cmd/mimir/mimir:
     	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's 'source_tenants' field. If this flag is set to 'false' when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
   -ruler.tenant-shard-size int
     	The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.
-  -runtime-config.file comma-separated-list-of-string
+  -runtime-config.file comma-separated-list-of-strings
     	Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.
   -server.grpc-listen-address string
     	gRPC server listen address.

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -580,7 +580,7 @@ ring:
   # List of network interface names to look up when finding the instance IP
   # address.
   # CLI flag: -distributor.ring.instance-interface-names
-  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
   # (advanced) Port to advertise in the ring (defaults to
   # -server.grpc-listen-port).
@@ -723,7 +723,7 @@ ring:
   # (advanced) List of network interface names to look up when finding the
   # instance IP address.
   # CLI flag: -ingester.ring.instance-interface-names
-  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
   # (advanced) Port to advertise in the ring (defaults to
   # -server.grpc-listen-port).
@@ -1039,7 +1039,7 @@ grpc_client_config:
 # instance IP address. This address is sent to query-scheduler and querier,
 # which uses it to send the query response back to query-frontend.
 # CLI flag: -query-frontend.instance-interface-names
-[instance_interface_names: <list of string> | default = [<private network interfaces>]]
+[instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
 # (advanced) IP address to advertise to the querier (via scheduler) (default is
 # auto-detected from network interfaces).
@@ -1400,7 +1400,7 @@ ring:
   # List of network interface names to look up when finding the instance IP
   # address.
   # CLI flag: -ruler.ring.instance-interface-names
-  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
   # (advanced) Port to advertise in the ring (defaults to
   # -server.grpc-listen-port).
@@ -1665,7 +1665,7 @@ sharding_ring:
   # (advanced) List of network interface names to look up when finding the
   # instance IP address.
   # CLI flag: -alertmanager.sharding-ring.instance-interface-names
-  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
   # (advanced) Port to advertise in the ring (defaults to
   # -server.grpc-listen-port).
@@ -2026,7 +2026,7 @@ The `etcd` block configures the etcd client. The supported CLI flags `<prefix>` 
 ```yaml
 # The etcd endpoints to connect to.
 # CLI flag: -<prefix>.etcd.endpoints
-[endpoints: <list of string> | default = []]
+[endpoints: <list of strings> | default = []]
 
 # (advanced) The dial timeout for the etcd connection.
 # CLI flag: -<prefix>.etcd.dial-timeout
@@ -2195,7 +2195,7 @@ The `memberlist` block configures the Gossip memberlist.
 # Other cluster members to join. Can be specified multiple times. It can be an
 # IP, hostname or an entry specified in the DNS Service Discovery format.
 # CLI flag: -memberlist.join
-[join_members: <list of string> | default = []]
+[join_members: <list of strings> | default = []]
 
 # (advanced) Min backoff duration to join other cluster members.
 # CLI flag: -memberlist.min-join-backoff
@@ -2238,7 +2238,7 @@ The `memberlist` block configures the Gossip memberlist.
 # IP address to listen on for gossip messages. Multiple addresses may be
 # specified. Defaults to 0.0.0.0
 # CLI flag: -memberlist.bind-addr
-[bind_addr: <list of string> | default = []]
+[bind_addr: <list of strings> | default = []]
 
 # Port to listen on for gossip messages.
 # CLI flag: -memberlist.bind-port
@@ -2324,7 +2324,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # sample ingestion within the distributor and can be repeated in order to drop
 # multiple labels.
 # CLI flag: -distributor.drop-label
-[drop_labels: <list of string> | default = []]
+[drop_labels: <list of strings> | default = []]
 
 # Maximum length accepted for label names
 # CLI flag: -validation.max-length-label-name
@@ -2933,7 +2933,7 @@ tsdb:
 
   # (advanced) TSDB blocks range period.
   # CLI flag: -blocks-storage.tsdb.block-ranges-period
-  [block_ranges_period: <list of duration> | default = 2h0m0s]
+  [block_ranges_period: <list of durations> | default = 2h0m0s]
 
   # TSDB blocks retention in the ingester before a block is removed, relative to
   # the newest block written for the tenant. This should be larger than the
@@ -3061,7 +3061,7 @@ The `compactor` block configures the compactor component.
 ```yaml
 # (advanced) List of compaction time ranges.
 # CLI flag: -compactor.block-ranges
-[block_ranges: <list of duration> | default = 2h0m0s,12h0m0s,24h0m0s]
+[block_ranges: <list of durations> | default = 2h0m0s,12h0m0s,24h0m0s]
 
 # (advanced) Number of Go routines to use when downloading blocks for compaction
 # and uploading resulting blocks.
@@ -3216,7 +3216,7 @@ sharding_ring:
   # List of network interface names to look up when finding the instance IP
   # address.
   # CLI flag: -compactor.ring.instance-interface-names
-  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
   # (advanced) Port to advertise in the ring (defaults to
   # -server.grpc-listen-port).
@@ -3331,7 +3331,7 @@ sharding_ring:
   # List of network interface names to look up when finding the instance IP
   # address.
   # CLI flag: -store-gateway.sharding-ring.instance-interface-names
-  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
   # (advanced) Port to advertise in the ring (defaults to
   # -server.grpc-listen-port).

--- a/pkg/mimirtool/config/descriptors/cortex-v1.11.0.json
+++ b/pkg/mimirtool/config/descriptors/cortex-v1.11.0.json
@@ -596,7 +596,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ha-tracker.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -897,7 +897,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1074,7 +1074,7 @@
                 "en0"
               ],
               "fieldFlag": "distributor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -1694,7 +1694,7 @@
                           "desc": "The etcd endpoints to connect to.",
                           "fieldDefaultValue": [],
                           "fieldFlag": "etcd.endpoints",
-                          "fieldType": "list of string"
+                          "fieldType": "list of strings"
                         },
                         {
                           "kind": "field",
@@ -1918,7 +1918,7 @@
                 "en0"
               ],
               "fieldFlag": "ingester.lifecycler.interface",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -3064,7 +3064,7 @@
               "desc": "If set, when authenticating with cassandra a custom authenticator will be expected during the handshake. This flag can be set multiple times.",
               "fieldDefaultValue": [],
               "fieldFlag": "cassandra.custom-authenticator",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -4754,7 +4754,7 @@
           "desc": "This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.",
           "fieldDefaultValue": [],
           "fieldFlag": "distributor.drop-label",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -5665,7 +5665,7 @@
             "en0"
           ],
           "fieldFlag": "frontend.instance-interface-names",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -8037,7 +8037,7 @@
               "desc": "TSDB blocks range period.",
               "fieldDefaultValue": [],
               "fieldFlag": "blocks-storage.tsdb.block-ranges-period",
-              "fieldType": "list of duration"
+              "fieldType": "list of durations"
             },
             {
               "kind": "field",
@@ -8182,7 +8182,7 @@
           "desc": "List of compaction time ranges.",
           "fieldDefaultValue": [],
           "fieldFlag": "compactor.block-ranges",
-          "fieldType": "list of duration"
+          "fieldType": "list of durations"
         },
         {
           "kind": "field",
@@ -8424,7 +8424,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldDefaultValue": [],
                       "fieldFlag": "compactor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -8619,7 +8619,7 @@
                 "en0"
               ],
               "fieldFlag": "compactor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -8772,7 +8772,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldDefaultValue": [],
                       "fieldFlag": "store-gateway.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -8994,7 +8994,7 @@
                 "en0"
               ],
               "fieldFlag": "store-gateway.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -10168,7 +10168,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldDefaultValue": [],
                       "fieldFlag": "ruler.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -10345,7 +10345,7 @@
                 "en0"
               ],
               "fieldFlag": "ruler.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -11222,7 +11222,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldDefaultValue": [],
                       "fieldFlag": "alertmanager.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -11417,7 +11417,7 @@
                 "en0"
               ],
               "fieldFlag": "alertmanager.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -12729,7 +12729,7 @@
           "desc": "Other cluster members to join. Can be specified multiple times. It can be an IP, hostname or an entry specified in the DNS Service Discovery format.",
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.join",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -12810,7 +12810,7 @@
           "desc": "IP address to listen on for gossip messages. Multiple addresses may be specified. Defaults to 0.0.0.0",
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.bind-addr",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",

--- a/pkg/mimirtool/config/descriptors/gem-v1.7.0.json
+++ b/pkg/mimirtool/config/descriptors/gem-v1.7.0.json
@@ -676,7 +676,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ha-tracker.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1016,7 +1016,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1217,7 +1217,7 @@
                 "en0"
               ],
               "fieldFlag": "distributor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -1915,7 +1915,7 @@
                           "fieldValue": null,
                           "fieldDefaultValue": [],
                           "fieldFlag": "etcd.endpoints",
-                          "fieldType": "list of string"
+                          "fieldType": "list of strings"
                         },
                         {
                           "kind": "field",
@@ -2180,7 +2180,7 @@
                 "en0"
               ],
               "fieldFlag": "ingester.lifecycler.interface",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -3500,7 +3500,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "cassandra.custom-authenticator",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -5411,7 +5411,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "distributor.drop-label",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -6510,7 +6510,7 @@
             "en0"
           ],
           "fieldFlag": "frontend.instance-interface-names",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -9195,7 +9195,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "blocks-storage.tsdb.block-ranges-period",
-              "fieldType": "list of duration"
+              "fieldType": "list of durations"
             },
             {
               "kind": "field",
@@ -9389,7 +9389,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "compactor.block-ranges",
-          "fieldType": "list of duration"
+          "fieldType": "list of durations"
         },
         {
           "kind": "field",
@@ -9647,7 +9647,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "compactor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -9868,7 +9868,7 @@
                 "en0"
               ],
               "fieldFlag": "compactor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -10070,7 +10070,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "store-gateway.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -10321,7 +10321,7 @@
                 "en0"
               ],
               "fieldFlag": "store-gateway.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -11563,7 +11563,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ruler.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -11764,7 +11764,7 @@
                 "en0"
               ],
               "fieldFlag": "ruler.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -12646,7 +12646,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "alertmanager.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -12867,7 +12867,7 @@
                 "en0"
               ],
               "fieldFlag": "alertmanager.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -14211,7 +14211,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.join",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -14301,7 +14301,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.bind-addr",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -14745,7 +14745,7 @@
                           "fieldValue": null,
                           "fieldDefaultValue": [],
                           "fieldFlag": "admin-api.leader-election.ring.etcd.endpoints",
-                          "fieldType": "list of string"
+                          "fieldType": "list of strings"
                         },
                         {
                           "kind": "field",
@@ -14956,7 +14956,7 @@
                     "en0"
                   ],
                   "fieldFlag": "admin-api.leader-election.ring.instance-interface-names",
-                  "fieldType": "list of string"
+                  "fieldType": "list of strings"
                 },
                 {
                   "kind": "field",

--- a/pkg/mimirtool/config/descriptors/gem-v2.3.0.json
+++ b/pkg/mimirtool/config/descriptors/gem-v2.3.0.json
@@ -734,7 +734,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ha-tracker.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1065,7 +1065,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1278,7 +1278,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "distributor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -1934,7 +1934,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ingester.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -2199,7 +2199,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "ingester.ring.instance-interface-names",
-              "fieldType": "list of string",
+              "fieldType": "list of strings",
               "fieldCategory": "advanced"
             },
             {
@@ -2546,7 +2546,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "distributor.drop-label",
-          "fieldType": "list of string",
+          "fieldType": "list of strings",
           "fieldCategory": "advanced"
         },
         {
@@ -3617,7 +3617,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "query-frontend.instance-interface-names",
-          "fieldType": "list of string",
+          "fieldType": "list of strings",
           "fieldCategory": "advanced"
         },
         {
@@ -5268,7 +5268,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "blocks-storage.tsdb.block-ranges-period",
-              "fieldType": "list of duration",
+              "fieldType": "list of durations",
               "fieldCategory": "advanced"
             },
             {
@@ -5543,7 +5543,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "compactor.block-ranges",
-          "fieldType": "list of duration",
+          "fieldType": "list of durations",
           "fieldCategory": "advanced"
         },
         {
@@ -5865,7 +5865,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "compactor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -6100,7 +6100,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "compactor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -6293,7 +6293,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "store-gateway.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -6559,7 +6559,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "store-gateway.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -7189,7 +7189,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ruler.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -7402,7 +7402,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "ruler.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -8583,7 +8583,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "alertmanager.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -8818,7 +8818,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "alertmanager.sharding-ring.instance-interface-names",
-              "fieldType": "list of string",
+              "fieldType": "list of strings",
               "fieldCategory": "advanced"
             },
             {
@@ -9906,7 +9906,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.join",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -10003,7 +10003,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.bind-addr",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -11066,7 +11066,7 @@
                           "fieldValue": null,
                           "fieldDefaultValue": [],
                           "fieldFlag": "admin-api.leader-election.ring.etcd.endpoints",
-                          "fieldType": "list of string"
+                          "fieldType": "list of strings"
                         },
                         {
                           "kind": "field",
@@ -11290,7 +11290,7 @@
                   "fieldValue": null,
                   "fieldDefaultValue": [],
                   "fieldFlag": "admin-api.leader-election.ring.instance-interface-names",
-                  "fieldType": "list of string"
+                  "fieldType": "list of strings"
                 },
                 {
                   "kind": "field",

--- a/pkg/mimirtool/config/descriptors/mimir-v2.3.0.json
+++ b/pkg/mimirtool/config/descriptors/mimir-v2.3.0.json
@@ -734,7 +734,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ha-tracker.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1065,7 +1065,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "distributor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -1278,7 +1278,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "distributor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -1945,7 +1945,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ingester.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -2210,7 +2210,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "ingester.ring.instance-interface-names",
-              "fieldType": "list of string",
+              "fieldType": "list of strings",
               "fieldCategory": "advanced"
             },
             {
@@ -2557,7 +2557,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "distributor.drop-label",
-          "fieldType": "list of string",
+          "fieldType": "list of strings",
           "fieldCategory": "advanced"
         },
         {
@@ -3628,7 +3628,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "query-frontend.instance-interface-names",
-          "fieldType": "list of string",
+          "fieldType": "list of strings",
           "fieldCategory": "advanced"
         },
         {
@@ -5279,7 +5279,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "blocks-storage.tsdb.block-ranges-period",
-              "fieldType": "list of duration",
+              "fieldType": "list of durations",
               "fieldCategory": "advanced"
             },
             {
@@ -5534,7 +5534,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "compactor.block-ranges",
-          "fieldType": "list of duration",
+          "fieldType": "list of durations",
           "fieldCategory": "advanced"
         },
         {
@@ -5856,7 +5856,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "compactor.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -6091,7 +6091,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "compactor.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -6284,7 +6284,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "store-gateway.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -6550,7 +6550,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "store-gateway.sharding-ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -7180,7 +7180,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "ruler.ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -7393,7 +7393,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "ruler.ring.instance-interface-names",
-              "fieldType": "list of string"
+              "fieldType": "list of strings"
             },
             {
               "kind": "field",
@@ -8504,7 +8504,7 @@
                       "fieldValue": null,
                       "fieldDefaultValue": [],
                       "fieldFlag": "alertmanager.sharding-ring.etcd.endpoints",
-                      "fieldType": "list of string"
+                      "fieldType": "list of strings"
                     },
                     {
                       "kind": "field",
@@ -8739,7 +8739,7 @@
               "fieldValue": null,
               "fieldDefaultValue": [],
               "fieldFlag": "alertmanager.sharding-ring.instance-interface-names",
-              "fieldType": "list of string",
+              "fieldType": "list of strings",
               "fieldCategory": "advanced"
             },
             {
@@ -9827,7 +9827,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.join",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",
@@ -9924,7 +9924,7 @@
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldFlag": "memberlist.bind-addr",
-          "fieldType": "list of string"
+          "fieldType": "list of strings"
         },
         {
           "kind": "field",

--- a/pkg/mimirtool/config/inspect.go
+++ b/pkg/mimirtool/config/inspect.go
@@ -257,7 +257,7 @@ func (i *InspectedEntry) zeroValuePtr() Value {
 	case "duration":
 		d := duration(0)
 		typ = reflect.TypeOf(&d)
-	case "list of string":
+	case "list of strings":
 		typ = reflect.TypeOf(stringSlice{})
 	default:
 		typ = parse.ReflectType(i.FieldType)
@@ -282,7 +282,7 @@ func (i *InspectedEntry) decodeValue(decoder decoder) (Value, error) {
 	case "duration":
 		value := decoded.AsInterface().(**duration)
 		return DurationValue(time.Duration(**value)), err
-	case "list of string":
+	case "list of strings":
 		return InterfaceValue(*decoded.AsInterface().(*stringSlice)), nil
 	default:
 		// return a dereferenced typed value

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -201,9 +201,9 @@ func getFlagName(fl *flag.Flag) string {
 		case "*flagext.StringSlice":
 			return "string"
 		case "*flagext.StringSliceCSV":
-			return "comma-separated list of string"
+			return "comma-separated list of strings"
 		case "*flagext.CIDRSliceCSV":
-			return "comma-separated list of string"
+			return "comma-separated list of strings"
 		case "*flagext.URLValue":
 			return "string"
 		case "*url.URL":
@@ -211,7 +211,7 @@ func getFlagName(fl *flag.Flag) string {
 		case "*model.Duration":
 			return "duration"
 		case "*tsdb.DurationList":
-			return "comma-separated list of duration"
+			return "comma-separated list of durations"
 		}
 	}
 

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -399,7 +399,7 @@ func getFieldType(t reflect.Type) (string, error) {
 			return "", err
 		}
 
-		return "list of " + elemType, nil
+		return "list of " + elemType + "s", nil
 	case reflect.Map:
 		return fmt.Sprintf("map of %s to %s", t.Key(), t.Elem().String()), nil
 
@@ -449,7 +449,7 @@ func ReflectType(typ string) reflect.Type {
 		return reflect.TypeOf(0)
 	case "float":
 		return reflect.TypeOf(0.0)
-	case "list of string":
+	case "list of strings":
 		return reflect.TypeOf(flagext.StringSliceCSV{})
 	case "map of string to string":
 		fallthrough
@@ -459,7 +459,7 @@ func ReflectType(typ string) reflect.Type {
 		return reflect.TypeOf([]*relabel.Config{})
 	case "map of string to float64":
 		return reflect.TypeOf(map[string]float64{})
-	case "list of duration":
+	case "list of durations":
 		return reflect.TypeOf(tsdb.DurationList{})
 	case "map of string to validation.ForwardingRule":
 		return reflect.TypeOf(map[string]validation.ForwardingRule{})


### PR DESCRIPTION
#### What this PR does
In the auto-generated config we have data types described as "list of X". Currently "X" is singular. I think plural is more correct, so I'm proposing to add an ending "s" like "list of strings" or "list of durations".

@dimitarvdimitrov Are the changes to the config conversion tool legit?

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
