### PR TITLE
markblocks now uploads markers for multiple blocks concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@
 
 ### Tools
 
-* [ENHANCEMENT] `markblocks` now processes multiple blocks concurrently. #
+* [ENHANCEMENT] `markblocks` now processes multiple blocks concurrently. #2677
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@
 * [ENHANCEMENT] Referenced `mimirtool` commands in the HTTP API documentation. #2516
 * [ENHANCEMENT] Improved DNS service discovery documentation. #2513
 
+### Tools
+
+* [ENHANCEMENT] `markblocks` now processes multiple blocks concurrently. #
+
 ## 2.2.0
 
 ### Grafana Mimir


### PR DESCRIPTION
#### What this PR does

This PR modifies `markblocks` tool to process multiple blocks concurrently. Markblocks still exits on first failure with status code 1.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
