### PR TITLE
Order team members alphabetically

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -56,10 +56,10 @@ The current team members are:
 - Mauro Stettler — [@replay](https://github.com/replay) ([Grafana Labs](https://grafana.com/))
 - Nick Pillitteri — [@56quarters](https://github.com/56quarters) ([Grafana Labs](https://grafana.com/))
 - Oleg Zaytsev — [@colega](https://github.com/colega) ([Grafana Labs](https://grafana.com/))
+- Patrick Oyarzun - [@Logiraptor](https://github.com/Logiraptor) ([Grafana Labs](https://grafana.com/))
 - Peter Štibraný — [@pstibrany](https://github.com/pstibrany) ([Grafana Labs](https://grafana.com/))
 - Steve Simpson - [@stevesg](https://github.com/stevesg) ([Grafana Labs](https://grafana.com/))
 - Tyler Reid — [@treid314](https://github.com/treid314) ([Grafana Labs](https://grafana.com/))
-- Patrick Oyarzun - [@Logiraptor](https://github.com/Logiraptor) ([Grafana Labs](https://grafana.com/))
 
 Previous team members:
 


### PR DESCRIPTION
#### What this PR does
Re-orders team list to be alphabetical again.

NB: As per governance, Grafana Labs can update governance. That being said, I would prefer a few +1 just to make sure there's consensus, however uncontroversial this change should be.