### PR TITLE
Hide stale jsonnet <> helm diff comments

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -13,14 +13,6 @@ jobs:
   compare-manifests:
     runs-on: ubuntu-latest
     steps:
-    - name: Find Comment
-      uses: peter-evans/find-comment@v2
-      id: fc
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: '**Helm <> Jsonnet Diff**'
-
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
@@ -74,12 +66,16 @@ jobs:
           echo "::set-output name=diff::$OUTPUT"
         fi
 
+    - uses: int128/hide-comment-action@v1
+      with:
+        authors: 'github-actions[bot]'
+        starts-with: '**Helm <> Jsonnet Diff**'
+
     - name: Create or update comment
       continue-on-error: true
       uses: peter-evans/create-or-update-comment@v2
       if: ${{ steps.compare-manifests.outputs.changed == 'true' }}
       with:
-        comment-id: ${{ steps.progress-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           **Helm <> Jsonnet Diff**
@@ -107,4 +103,3 @@ jobs:
           ```
 
           </details>
-        edit-mode: replace


### PR DESCRIPTION
#### What this PR does

Change the Helm <> Jsonnet diff behavior to hide old comments instead of trying to edit an existing comment.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
