### PR TITLE
Query sharding: shard binary operations only if it doesn't lead to non-shardable vector selectors in one of the operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [ENHANCEMENT] Distributor: Add `-distributor.instance-limits.max-inflight-push-requests-bytes`. This limit protects the distributor against multiple large requests that together may cause an OOM, but are only a few, so do not trigger the `max-inflight-push-requests` limit. #2413
 * [ENHANCEMENT] Distributor: Drop exemplars in distributor for tenants where exemplars are disabled. #2504
 * [ENHANCEMENT] Runtime Config: Allow operator to specify multiple comma-separated yaml files in `-runtime-config.file` that will be merged in left to right order. #2583
+* [ENHANCEMENT] Query sharding: shard binary operations only if it doesn't lead to non-shardable vector selectors in one of the operands. #2696
 * [BUGFIX] Compactor: log the actual error on compaction failed. #2261
 * [BUGFIX] Alertmanager: restore state from storage even when running a single replica. #2293
 * [BUGFIX] Ruler: do not block "List Prometheus rules" API endpoint while syncing rules. #2289

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -126,6 +126,19 @@ func containsAggregateExpr(e parser.Expr) bool {
 	return containsAggregate
 }
 
+// countVectorSelectors returns the number of vector selectors in the input expression.
+func countVectorSelectors(e parser.Expr) int {
+	count := 0
+
+	visitNode(e, func(node parser.Node) {
+		if ok, _ := isVectorSelector(node); ok {
+			count++
+		}
+	})
+
+	return count
+}
+
 func isAggregateExpr(n parser.Node) (bool, error) {
 	_, ok := n.(*parser.AggregateExpr)
 	return ok, nil

--- a/pkg/frontend/querymiddleware/astmapper/parallel_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -214,6 +215,38 @@ func TestFunctionsWithDefaultsIsUpToDate(t *testing.T) {
 
 			// Rest of the functions with known defaults are functions with a default time() argument.
 			require.Containsf(t, FuncsWithDefaultTimeArg, name, "Function %q has variable arguments, and it's not in the list of functions with default time() argument.")
+		})
+	}
+}
+
+func TestCountVectorSelectors(t *testing.T) {
+	tests := map[string]struct {
+		expr     string
+		expected int
+	}{
+		"no vector selectors": {
+			expr:     "1",
+			expected: 0,
+		},
+		"input is a vector selector": {
+			expr:     "metric",
+			expected: 1,
+		},
+		"input expr contains a vector selector": {
+			expr:     "1 + metric",
+			expected: 1,
+		},
+		"input expr contains multiple vector selectors": {
+			expr:     "1 + metric + sum(metric) + sum(rate(metric[1m]))",
+			expected: 3,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			expr, err := parser.ParseExpr(testData.expr)
+			require.Nil(t, err)
+			assert.Equal(t, testData.expected, countVectorSelectors(expr))
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -265,14 +265,14 @@ func TestQueryShardingCorrectness(t *testing.T) {
 				avg(rate(metric_counter[1m]))`,
 			expectedShardedQueries: 3, // avg() is parallelized as sum()/count().
 		},
-		"sum by(unique) on (unique) group_left (group_1) * avg by (unique, group_1)": {
+		"sum by(unique) * on (unique) group_left (group_1) avg by (unique, group_1)": {
 			// ensure that avg transformation into sum/count does not break label matching in previous binop.
 			query: `
-				metric_counter
+				sum by(unique) (metric_counter)
 				*
 				on (unique) group_left (group_1) 
 				avg by (unique, group_1) (metric_counter)`,
-			expectedShardedQueries: 2,
+			expectedShardedQueries: 3,
 		},
 		"sum by (rate()) / 2 ^ 2": {
 			query: `
@@ -392,8 +392,8 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			expectedShardedQueries: 1,
 		},
 		`filtering binary operation with non constant`: {
-			query:                  `max_over_time(metric_counter[5m]) > scalar(min(metric_counter))`,
-			expectedShardedQueries: 1, // scalar on the right should be sharded, but not the binary op itself, hence 1
+			query:                  `max by(unique) (max_over_time(metric_counter[5m])) > scalar(min(metric_counter))`,
+			expectedShardedQueries: 2,
 		},
 		//
 		// The following queries are not expected to be shardable.


### PR DESCRIPTION
#### What this PR does
We are seeing some queries with binary operations which get sharded, they legit from a correctness perspective, but perform badly because they have to transfer huge responses for partial queries from querier to query-frontend bcause one of the legs are not shardable or not aggregatable.

For example, consider this query:
```
max by(pod) (
    max without(prometheus_replica, instance, node) (kube_pod_labels{namespace="test"})
    *
    on(cluster, pod, namespace) group_right() pod:container_cpu_usage:sum
)
```

Currently it gets sharded as:
```
max by(pod) (
    max without(prometheus_replica, instance, node) (
        concat(
                max without(prometheus_replica, instance, node) (kube_pod_labels{namespace="test",shard="1"}
                max without(prometheus_replica, instance, node) (kube_pod_labels{namespace="test",shard="2"}
                max without(prometheus_replica, instance, node) (kube_pod_labels{namespace="test",shard="3"}
        )
    )
    *
    on(cluster, pod, namespace) group_right() pod:container_cpu_usage:sum
)
```

However, the right left of the `*` binary operations is not sharded but the `pod:container_cpu_usage:sum` vector selector is still executed by a querier. `pod:container_cpu_usage:sum` result could be very high cardinality and result in a huge response to send back from querier to query-frontend (e.g. in our case we're seeing a response > 1GB) because `pod:container_cpu_usage:sum` has no label matcher reducing the set while `kube_pod_labels{namespace="test"}` only selects series from the `test` namespace.

Since we can't estimate the cardinality of a vector selector, we prefer to take a pessimistic approach and not shard the query at all if we can't shard all vector selectors of a binary operation, which is what I'm proposing in this PR.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
