### PR TITLE
Added RolloutOperatorNotReconciling alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * [ENHANCEMENT] Dashboards: add RSS memory utilization panel for ingesters, store-gateways and compactors. #2479
 * [ENHANCEMENT] Dashboards: allow to configure graph tooltip. #2647
 * [ENHANCEMENT] Alerts: MimirFrontendQueriesStuck and MimirSchedulerQueriesStuck alerts are more reliable now as they consider all the intermediate samples in the minute prior to the evaluation. #2630
+* [ENHANCEMENT] Alerts: added `RolloutOperatorNotReconciling` alert, firing if the optional rollout-operator is not successfully reconciling. #2700
 * [BUGFIX] Dashboards: fixed unit of latency panels in the "Mimir / Ruler" dashboard. #2312
 * [BUGFIX] Dashboards: fixed "Intervals per query" panel in the "Mimir / Queries" dashboard. #2308
 * [BUGFIX] Dashboards: Make "Slow Queries" dashboard works with Grafana 9.0. #2223

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1044,9 +1044,9 @@ This alert fires if the [`rollout-operator`](https://github.com/grafana/rollout-
 
 How it **works**:
 
-- The operator coordinates the rollout of pods between different StatefulSets within a specific namespace and is used to manage multi-zone deployments
-- The operator is deployed in Mimir cells where some services (e.g. ingesters) are deployed in multi-zone
-- The operator reconciles as soon as there's any change in observed Kubernetes resources or every 5m at most
+- The rollout-operator coordinates the rollout of pods between different StatefulSets within a specific namespace and is used to manage multi-zone deployments
+- The rollout-operator is deployed in namespaces where some Mimir components (e.g. ingesters) are deployed in multi-zone
+- The rollout-operator reconciles as soon as there's any change in observed Kubernetes resources or every 5m at most
 
 How to **investigate**:
 

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1038,6 +1038,23 @@ How to **investigate**:
   1. The alert fired because of a bug in Mimir: fix it.
   1. The alert fired because of a bug or edge case in the continuous test tool, causing a false positive: fix it.
 
+### RolloutOperatorNotReconciling
+
+This alert fires if the [`rollout-operator`](https://github.com/grafana/rollout-operator) is not successfully reconciling in a namespace.
+
+How it **works**:
+
+- The operator coordinates the rollout of pods between different StatefulSets within a specific namespace and is used to manage multi-zone deployments
+- The operator is deployed in Mimir cells where some services (e.g. ingesters) are deployed in multi-zone
+- The operator reconciles as soon as there's any change in observed Kubernetes resources or every 5m at most
+
+How to **investigate**:
+
+- Check rollout-operator logs to find more details about the error, e.g. with the following Grafana Loki query:
+  ```
+  {name="rollout-operator",namespace="<namespace>"}
+  ```
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -250,8 +250,8 @@ groups:
       severity: warning
   - alert: RolloutOperatorNotReconciling
     annotations:
-      message: Rollout operator in {{ $labels.cluster }}/{{ $labels.namespace }} is
-        not reconciling the rollout group {{ $labels.rollout_group }}.
+      message: |
+        Rollout operator is not reconciling the rollout group {{ $labels.rollout_group }} in {{ $labels.cluster }}/{{ $labels.namespace }}.
     expr: |
       max by(cluster, namespace, rollout_group) (time() - rollout_operator_last_successful_group_reconcile_timestamp_seconds) > 600
     for: 5m

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -248,6 +248,15 @@ groups:
     for: 30m
     labels:
       severity: warning
+  - alert: RolloutOperatorNotReconciling
+    annotations:
+      message: Rollout operator in {{ $labels.cluster }}/{{ $labels.namespace }} is
+        not reconciling the rollout group {{ $labels.rollout_group }}.
+    expr: |
+      max by(cluster, namespace, rollout_group) (time() - rollout_operator_last_successful_group_reconcile_timestamp_seconds) > 600
+    for: 5m
+    labels:
+      severity: critical
 - name: mimir-provisioning
   rules:
   - alert: MimirProvisioningTooManyActiveSeries

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -408,6 +408,19 @@
             ||| % $._config,
           },
         },
+        {
+          alert: 'RolloutOperatorNotReconciling',
+          expr: |||
+            max by(%s, rollout_group) (time() - rollout_operator_last_successful_group_reconcile_timestamp_seconds) > 600
+          ||| % $._config.alert_aggregation_labels,
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Rollout operator in {{ $labels.cluster }}/{{ $labels.namespace }} is not reconciling the rollout group {{ $labels.rollout_group }}.',
+          },
+        },
       ],
     },
     {

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -418,7 +418,9 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Rollout operator in {{ $labels.cluster }}/{{ $labels.namespace }} is not reconciling the rollout group {{ $labels.rollout_group }}.',
+            message: |||
+              Rollout operator is not reconciling the rollout group {{ $labels.rollout_group }} in %(alert_aggregation_variables)s.
+            ||| % $._config,
           },
         },
       ],


### PR DESCRIPTION
#### What this PR does
When I upstreamed the multi-zone support to jsonnet (https://github.com/grafana/mimir/pull/1352) I forgot to upstream the `RolloutOperatorNotReconciling` alert we're using at Grafana Labs. Doing it in this PR.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
