### PR TITLE
apply relabel and drop_label rules before forwarding rules in distributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710
 * [BUGFIX] Fix reporting of tracing spans from PromQL engine. #2707
 * [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709
+* [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703
 
 ### Mixin
 
@@ -72,7 +73,6 @@
 * [BUGFIX] Query-frontend: fix wrong query sharding results for queries with boolean result like `1 < bool 0`. #2558
 * [BUGFIX] Fixed error messages related to per-instance limits incorrectly reporting they can be set on a per-tenant basis. #2610
 * [BUGFIX] Perform HA-deduplication before forwarding samples according to forwarding rules in the distributor. #2603
-* [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 * [BUGFIX] Query-frontend: fix wrong query sharding results for queries with boolean result like `1 < bool 0`. #2558
 * [BUGFIX] Fixed error messages related to per-instance limits incorrectly reporting they can be set on a per-tenant basis. #2610
 * [BUGFIX] Perform HA-deduplication before forwarding samples according to forwarding rules in the distributor. #2603
-* [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor.
+* [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [BUGFIX] Query-frontend: fix wrong query sharding results for queries with boolean result like `1 < bool 0`. #2558
 * [BUGFIX] Fixed error messages related to per-instance limits incorrectly reporting they can be set on a per-tenant basis. #2610
 * [BUGFIX] Perform HA-deduplication before forwarding samples according to forwarding rules in the distributor. #2603
+* [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor.
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1023,7 +1023,7 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 	initialMetadataIndex := len(seriesKeys)
 
 	// we must not re-use buffers now until all DoBatch goroutines have finished,
-	// so dont cleanup in this function and pass cleanup() to DoBatch instead.
+	// so set this flag false and pass cleanup() to DoBatch.
 	cleanupInDefer = false
 
 	err = ring.DoBatch(ctx, ring.WriteNoExtend, subRing, keys, func(ingester ring.InstanceDesc, indexes []int) error {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -738,7 +738,7 @@ func (d *Distributor) prePushRelabelMiddleware(next push.Func) push.Func {
 		}
 
 		if len(removeTsIndexes) > 0 {
-			req.Timeseries, _, _ = util.RemoveSliceIndexes(req.Timeseries, removeTsIndexes)
+			req.Timeseries = util.RemoveSliceIndexes(req.Timeseries, removeTsIndexes)
 		}
 
 		cleanupInDefer = false

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -724,10 +724,6 @@ func (d *Distributor) prePushRelabelMiddleware(next push.Func) push.Func {
 			}
 
 			if len(ts.Labels) == 0 {
-				if len(removeTsIndexes) == 0 {
-					// If we have to add one index into this slice then there is a good chance that we'll have to add more.
-					removeTsIndexes = make([]int, 0, len(req.Timeseries))
-				}
 				removeTsIndexes = append(removeTsIndexes, tsIdx)
 				continue
 			}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -733,7 +733,9 @@ func (d *Distributor) prePushRelabelMiddleware(next push.Func) push.Func {
 			sortLabelsIfNeeded(ts.Labels)
 		}
 
-		req.Timeseries, _, _ = util.RemoveSliceIndexes(req.Timeseries, removeTsIndexes)
+		if len(removeTsIndexes) > 0 {
+			req.Timeseries, _, _ = util.RemoveSliceIndexes(req.Timeseries, removeTsIndexes)
+		}
 
 		dontCleanup()
 		return next(ctx, req, cleanup)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1023,6 +1023,8 @@ func copyString(s string) string {
 	return string([]byte(s))
 }
 
+// getConditionalCleanup returns two functions, the first one wraps the given cleanup function, the second one is a
+// function which makes the first one not call the given cleanup function if it has been called at least once.
 func getConditionalCleanup(cleanup func()) (func(), func()) {
 	doCleanup := true
 	return func() {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2973,24 +2973,6 @@ func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
 func TestRelabelMiddleware(t *testing.T) {
 	ctxWithUser := user.InjectOrgID(context.Background(), "user")
 
-	labelsForPairs := func(namesValues ...string) func(id int) []mimirpb.LabelAdapter {
-		return func(id int) []mimirpb.LabelAdapter {
-			if len(namesValues)%2 != 0 {
-				t.Fatalf("number of names and values must be even: %q", namesValues)
-			}
-
-			labels := make([]mimirpb.LabelAdapter, 0, len(namesValues)/2)
-			for idx := 0; idx < len(namesValues)/2; idx++ {
-				labels = append(labels, mimirpb.LabelAdapter{
-					Name:  namesValues[2*idx],
-					Value: namesValues[2*idx+1] + strconv.Itoa(id),
-				})
-			}
-
-			return labels
-		}
-	}
-
 	type testCase struct {
 		name           string
 		ctx            context.Context
@@ -3006,15 +2988,15 @@ func TestRelabelMiddleware(t *testing.T) {
 			ctx:            ctxWithUser,
 			relabelConfigs: nil,
 			dropLabels:     nil,
-			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric1", "label", "value_%d"))},
-			expectedReqs:   []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric1", "label", "value_%d"))},
+			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"))},
+			expectedReqs:   []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"))},
 			expectErrs:     []bool{false},
 		}, {
 			name:           "no user in context",
 			ctx:            context.Background(),
 			relabelConfigs: nil,
 			dropLabels:     nil,
-			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric1", "label", "value_%d"))},
+			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"))},
 			expectedReqs:   nil,
 			expectErrs:     []bool{true},
 		}, {
@@ -3023,10 +3005,10 @@ func TestRelabelMiddleware(t *testing.T) {
 			relabelConfigs: nil,
 			dropLabels:     []string{"label1", "label3"},
 			reqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelsForPairs("__name__", "metric1", "label1", "value1", "label2", "value2", "label3", "value3"),
+				labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1", "label2", "value2", "label3", "value3"),
 			)},
 			expectedReqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelsForPairs("__name__", "metric1", "label2", "value2"),
+				labelSetGenForStringPairs(t, "__name__", "metric1", "label2", "value2"),
 			)},
 			expectErrs: []bool{false},
 		}, {
@@ -3042,10 +3024,10 @@ func TestRelabelMiddleware(t *testing.T) {
 				},
 			},
 			reqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelsForPairs("__name__", "metric1", "label1", "value1"),
+				labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1"),
 			)},
 			expectedReqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelsForPairs("__name__", "metric1", "label1", "value1", "target", "prefix_value1"),
+				labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1", "target", "prefix_value1"),
 			)},
 			expectErrs: []bool{false},
 		}, {
@@ -3053,16 +3035,16 @@ func TestRelabelMiddleware(t *testing.T) {
 			ctx:        ctxWithUser,
 			dropLabels: []string{"__name__", "label2", "label3"},
 			reqs: []*mimirpb.WriteRequest{
-				makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric1", "label1", "value1")),
-				makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric2", "label2", "value2")),
-				makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric3", "label3", "value3")),
-				makeWriteRequestForLabelSetGen(5, labelsForPairs("__name__", "metric4", "label4", "value4")),
+				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1")),
+				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric2", "label2", "value2")),
+				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric3", "label3", "value3")),
+				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric4", "label4", "value4")),
 			},
 			expectedReqs: []*mimirpb.WriteRequest{
-				makeWriteRequestForLabelSetGen(5, labelsForPairs("label1", "value1")),
+				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "label1", "value1")),
 				{Timeseries: []mimirpb.PreallocTimeseries{}},
 				{Timeseries: []mimirpb.PreallocTimeseries{}},
-				makeWriteRequestForLabelSetGen(5, labelsForPairs("label4", "value4")),
+				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "label4", "value4")),
 			},
 			expectErrs: []bool{false, false, false, false},
 		},
@@ -3107,14 +3089,31 @@ func TestRelabelMiddleware(t *testing.T) {
 	}
 }
 
-func TestHaDedupeBeforeForwarding(t *testing.T) {
+func TestHaDedupeAndRelabelBeforeForwarding(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
 	const replica1 = "replicaA"
 	const replica2 = "replicaB"
 	const cluster1 = "clusterA"
-	writeReqReplica1 := makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))
-	writeReqReplica2 := makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica2, cluster1))
-	expectedWriteReq := makeWriteRequestForLabelSetGen(5, labelSetGenWithCluster(cluster1))
+	writeReqReplica1 := makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t,
+		"__name__", "foo",
+		"__replica__", replica1, // Will be dropped by ha-dedupe.
+		"bar", "baz", // Will be dropped by drop_label rule.
+		"cluster", cluster1,
+		"sample", "value", // Will be targeted by relabel rule.
+	))
+	writeReqReplica2 := makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t,
+		"__name__", "foo",
+		"__replica__", replica2, // Will be dropped by ha-dedupe.
+		"bar", "baz", // Will be dropped by drop_label rule.
+		"cluster", cluster1,
+		"sample", "value", // Will be targeted by relabel rule.
+	))
+	expectedWriteReq := makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t,
+		"__name__", "foo",
+		"cluster", cluster1,
+		"sample", "value",
+		"target", "prefix_value", // Result of relabel rule.
+	))
 
 	// Capture the submitted write requests which the middlewares pass into the mock push function.
 	var submittedWriteReqs []*mimirpb.WriteRequest
@@ -3140,6 +3139,16 @@ func TestHaDedupeBeforeForwarding(t *testing.T) {
 	limits.ForwardingRules = validation.ForwardingRules{
 		"foo": validation.ForwardingRule{},
 	}
+	limits.MetricRelabelConfigs = []*relabel.Config{
+		{
+			SourceLabels: []model.LabelName{"sample"},
+			Action:       relabel.DefaultRelabelConfig.Action,
+			Regex:        relabel.DefaultRelabelConfig.Regex,
+			TargetLabel:  "target",
+			Replacement:  "prefix_$1",
+		},
+	}
+	limits.DropLabels = []string{"bar"}
 
 	// Prepare distributor and wrap the mock push function with its middlewares.
 	ds, _, _ := prepare(t, prepConfig{
@@ -3153,8 +3162,10 @@ func TestHaDedupeBeforeForwarding(t *testing.T) {
 
 	// Submit the two write requests into the wrapped mock push function, it should:
 	// 1) Perform HA-deduplication
-	// 2) Forward the result of the deduplication via the mock forwarder
-	// 3) Submit the result of the deduplication to the mock push function
+	// 2) Apply relabel rules
+	// 3) Apply drop_label rules
+	// 4) Forward the result via the mock forwarder
+	// 5) Submit the result to the mock push function
 	_, err := wrappedMockPush(ctx, writeReqReplica1, func() {})
 	assert.NoError(t, err)
 	_, err = wrappedMockPush(ctx, writeReqReplica2, func() {})
@@ -3163,11 +3174,11 @@ func TestHaDedupeBeforeForwarding(t *testing.T) {
 	assert.Equal(t, int32(202), resp.Code) // 202 due to HA-dedupe.
 
 	// Check that the write requests which have been submitted to the push function look as expected,
-	// there should only be one and it shouldn't have the replica label.
+	// there should only be one and it should have all of the expected modifications.
 	assert.Equal(t, []*mimirpb.WriteRequest{expectedWriteReq}, submittedWriteReqs)
 
-	// Check that the time series which have been forwarded via the mock forwarded look as expected,
-	// there should only be one slice of timeseries and they shouldn't have the replica label.
+	// Check that the time series which have been forwarded via the mock forwarder look as expected,
+	// there should only be one slice of timeseries and it should have all of the expected modifications.
 	assert.Equal(t, [][]mimirpb.PreallocTimeseries{expectedWriteReq.Timeseries}, forwardedTs)
 }
 
@@ -3468,6 +3479,26 @@ func labelSetGenWithCluster(cluster string) func(int) []mimirpb.LabelAdapter {
 			{Name: "cluster", Value: cluster},
 			{Name: "sample", Value: fmt.Sprintf("%d", id)},
 		}
+	}
+}
+
+// labelSetGenForStringPairs takes a slice of strings which are interpreted as pairs of label names and values,
+// it then returns a label set generator which generates labelsets of the given label names and values.
+func labelSetGenForStringPairs(tb testing.TB, namesValues ...string) func(id int) []mimirpb.LabelAdapter {
+	return func(id int) []mimirpb.LabelAdapter {
+		if len(namesValues)%2 != 0 {
+			tb.Fatalf("number of names and values must be even: %q", namesValues)
+		}
+
+		labels := make([]mimirpb.LabelAdapter, 0, len(namesValues)/2)
+		for idx := 0; idx < len(namesValues)/2; idx++ {
+			labels = append(labels, mimirpb.LabelAdapter{
+				Name:  namesValues[2*idx],
+				Value: namesValues[2*idx+1] + strconv.Itoa(id),
+			})
+		}
+
+		return labels
 	}
 }
 

--- a/pkg/util/slice_operations.go
+++ b/pkg/util/slice_operations.go
@@ -7,11 +7,13 @@ package util
 // that are required to do so by grouping consecutive indexes into ranges and removing the ranges in single operations.
 // The given number of indexes must be sorted in ascending order.
 // Indexes which are duplicate or out of the range of the given slice are ignored.
-// The returned values are:
-// - The resulting slice of elements after the elements at the given indexes have been removed.
-// - The number of elements that have been removed.
-// - The number of ranges of consecutive elements that have been removed.
-func RemoveSliceIndexes[T any](data []T, indexes []int) ([]T, int, int) {
+// It returns the updated slice.
+func RemoveSliceIndexes[T any](data []T, indexes []int) []T {
+	data, _, _ = removeSliceIndexes(data, indexes)
+	return data
+}
+
+func removeSliceIndexes[T any](data []T, indexes []int) ([]T, int, int) {
 	rangeStart := -1
 	rangeEnd := -1
 	rangeCount := 0

--- a/pkg/util/slice_operations.go
+++ b/pkg/util/slice_operations.go
@@ -2,21 +2,6 @@
 
 package util
 
-import (
-	"sync"
-)
-
-type idxRange struct {
-	from int
-	to   int
-}
-
-var idxRangesPool = sync.Pool{
-	New: func() interface{} {
-		return &[]idxRange{}
-	},
-}
-
 // RemoveSliceIndexes takes a slice of elements of any type and a sorted slice of indexes of elements in the former slice.
 // It removes the elements at the given indexes from the given slice, while minimizing the number of copy operations
 // that are required to do so by grouping consecutive indexes into ranges and removing the ranges in single operations.
@@ -27,62 +12,54 @@ var idxRangesPool = sync.Pool{
 // - The number of elements that have been removed.
 // - The number of ranges of consecutive elements that have been removed.
 func RemoveSliceIndexes[T any](data []T, indexes []int) ([]T, int, int) {
-	ranges := idxRangesPool.Get().(*[]idxRange)
-	none := idxRange{-1, -1}
-	currentRange := none
+	rangeStart := -1
+	rangeEnd := -1
+	rangeCount := 0
+	removed := 0
 
 	// Keep track of the last index to filter duplicates.
-	lastIndex := -1
 	for _, index := range indexes {
-		if index < 0 || index >= len(data) {
+		if index < 0 || index >= len(data)+removed {
 			// Invalid indexes given, ignore them.
 			continue
 		}
 
-		// Skip duplicates.
-		if index == lastIndex {
+		// Skip duplicates or unsorted indexes.
+		if rangeEnd >= 0 && index <= rangeEnd {
 			continue
 		}
-		lastIndex = index
 
-		// Initialize the current range variable.
-		if currentRange == none {
-			currentRange.from = index
-			currentRange.to = index
+		// Initialize the current range.
+		if rangeStart < 0 {
+			rangeStart = index
+			rangeEnd = index
 			continue
 		}
 
 		// Extend the current range by one, because this index connected to it.
-		if currentRange.to+1 == index {
-			currentRange.to = index
+		if rangeEnd+1 == index {
+			rangeEnd = index
 			continue
 		}
 
-		// The current range is finished, add it to the ranges list.
-		*ranges = append(*ranges, currentRange)
-
-		// Initialize the next range.
-		currentRange.from = index
-		currentRange.to = index
-	}
-
-	if currentRange != none {
-		// Add the last range.
-		*ranges = append(*ranges, currentRange)
-	}
-
-	removed := 0
-	for _, r := range *ranges {
-		// Remove range while offsetting by the number of already removed elements.
-		data = append(data[:r.from-removed], data[r.to+1-removed:]...)
+		// Otherwise we can remove the previous range
+		rangeCount++
+		data = append(data[:rangeStart-removed], data[rangeEnd+1-removed:]...)
 
 		// Update the number of removed elements.
-		removed += r.to - r.from + 1
+		removed += rangeEnd - rangeStart + 1
+
+		// Initialize the next range.
+		rangeStart = index
+		rangeEnd = index
 	}
 
-	rangeCount := len(*ranges)
-	*ranges = (*ranges)[:0]
-	idxRangesPool.Put(ranges)
+	// Remove last range.
+	if rangeStart >= 0 {
+		rangeCount++
+		data = append(data[:rangeStart-removed], data[rangeEnd+1-removed:]...)
+		removed += rangeEnd - rangeStart + 1
+	}
 
 	return data, removed, rangeCount
 }

--- a/pkg/util/slice_operations.go
+++ b/pkg/util/slice_operations.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import "sort"
+
+type idxRange struct {
+	from int
+	to   int
+}
+
+// RemoveSliceIndexes takes a slice of elements of any type and a slice of indexes referring to elements in the former slice.
+// It removes the elements at the given indexes from the given slice, while minimizing the number of copy operations
+// that are required to do so by grouping consecutive indexes into ranges and removing them in single operations.
+// The returned values are:
+// - The resulting slice of elements after the elements at the given indexes have been removed.
+// - The number of elements that have been removed.
+// - The number of ranges of consecutive elements that have been removed.
+func RemoveSliceIndexes[T any](data []T, indexes []int) ([]T, int, int) {
+	sort.Ints(indexes)
+	ranges := make([]idxRange, 0, len(data))
+	none := idxRange{-1, -1}
+	currentRange := none
+
+	// Keep track of the last index to filter duplicates.
+	lastIndex := -1
+	for _, index := range indexes {
+		if index < 0 || index >= len(data) {
+			// Invalid indexes given, ignore them.
+			continue
+		}
+
+		// Skip duplicates.
+		if index == lastIndex {
+			continue
+		}
+		lastIndex = index
+
+		// Initialize the current range variable.
+		if currentRange == none {
+			currentRange.from = index
+			currentRange.to = index
+			continue
+		}
+
+		// Extend the current range by one, because this index connected to it.
+		if currentRange.to+1 == index {
+			currentRange.to = index
+			continue
+		}
+
+		// The current range is finished, add it to the ranges list.
+		ranges = append(ranges, currentRange)
+
+		// Initialize the next range.
+		currentRange.from = index
+		currentRange.to = index
+	}
+
+	if currentRange != none {
+		// Add the last range.
+		ranges = append(ranges, currentRange)
+	}
+
+	removed := 0
+	for _, r := range ranges {
+		// Remove range while offsetting by the number of already removed elements.
+		data = append(data[:r.from-removed], data[r.to+1-removed:]...)
+
+		// Update the number of removed elements.
+		removed += r.to - r.from + 1
+	}
+
+	return data, removed, len(ranges)
+}

--- a/pkg/util/slice_operations_test.go
+++ b/pkg/util/slice_operations_test.go
@@ -8,103 +8,120 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type removeSliceIndexesTestCase struct {
+	name                    string
+	input                   []int
+	removeIndexes           []int
+	expectedOutput          []int
+	expectedRemovedElements int
+	expectedRemovedRanges   int
+}
+
+var removeSliceIndexesTestCases = []removeSliceIndexesTestCase{
+	{
+		name:                    "no change",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{},
+		expectedOutput:          []int{0, 1, 2, 3, 4},
+		expectedRemovedElements: 0,
+		expectedRemovedRanges:   0,
+	}, {
+		name:                    "remove first",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{0},
+		expectedOutput:          []int{1, 2, 3, 4},
+		expectedRemovedElements: 1,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "remove middle",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{2},
+		expectedOutput:          []int{0, 1, 3, 4},
+		expectedRemovedElements: 1,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "remove last",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{4},
+		expectedOutput:          []int{0, 1, 2, 3},
+		expectedRemovedElements: 1,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "remove all",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{0, 1, 2, 3, 4},
+		expectedOutput:          []int{},
+		expectedRemovedElements: 5,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "remove two ranges",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{0, 1, 3, 4},
+		expectedOutput:          []int{2},
+		expectedRemovedElements: 4,
+		expectedRemovedRanges:   2,
+	}, {
+		name:                    "index overrun",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{4, 5},
+		expectedOutput:          []int{0, 1, 2, 3},
+		expectedRemovedElements: 1,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "duplicate indexes",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{4, 4, 4, 4},
+		expectedOutput:          []int{0, 1, 2, 3},
+		expectedRemovedElements: 1,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "negative indexes",
+		input:                   []int{0, 1, 2, 3, 4},
+		removeIndexes:           []int{-1, 0, 1},
+		expectedOutput:          []int{2, 3, 4},
+		expectedRemovedElements: 2,
+		expectedRemovedRanges:   1,
+	}, {
+		name:                    "all cases combined",
+		input:                   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		removeIndexes:           []int{-1, -1, 0, 3, 5, 6, 8, 9, 9, 10, 11},
+		expectedOutput:          []int{1, 2, 4, 7},
+		expectedRemovedElements: 6,
+		expectedRemovedRanges:   4,
+	},
+}
+
+func runTestCase(tb testing.TB, input, removeIndexes, expectedOutput []int, expectedRemovedElements, expectedRemovedRanges int) {
+	output, removedElements, removedRanges := RemoveSliceIndexes(input, removeIndexes)
+	assert.Equal(tb, expectedOutput, output)
+	assert.Equal(tb, expectedRemovedElements, removedElements)
+	assert.Equal(tb, expectedRemovedRanges, removedRanges)
+}
+
 func TestRemoveSliceIndexes(t *testing.T) {
-	type testCase struct {
-		name                    string
-		input                   []int
-		removeIndexes           []int
-		expectedOutuput         []int
-		expectedRemovedElements int
-		expectedRemovedRanges   int
-	}
-
-	testCases := []testCase{
-		{
-			name:                    "no change",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{},
-			expectedOutuput:         []int{0, 1, 2, 3, 4},
-			expectedRemovedElements: 0,
-			expectedRemovedRanges:   0,
-		}, {
-			name:                    "remove first",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{0},
-			expectedOutuput:         []int{1, 2, 3, 4},
-			expectedRemovedElements: 1,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "remove middle",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{2},
-			expectedOutuput:         []int{0, 1, 3, 4},
-			expectedRemovedElements: 1,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "remove last",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{4},
-			expectedOutuput:         []int{0, 1, 2, 3},
-			expectedRemovedElements: 1,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "remove all",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{0, 1, 2, 3, 4},
-			expectedOutuput:         []int{},
-			expectedRemovedElements: 5,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "remove two ranges",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{0, 1, 3, 4},
-			expectedOutuput:         []int{2},
-			expectedRemovedElements: 4,
-			expectedRemovedRanges:   2,
-		}, {
-			name:                    "index overrun",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{4, 5},
-			expectedOutuput:         []int{0, 1, 2, 3},
-			expectedRemovedElements: 1,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "duplicate indexes",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{4, 4, 4, 4},
-			expectedOutuput:         []int{0, 1, 2, 3},
-			expectedRemovedElements: 1,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "out of order indexes",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{4, 3, 1, 0},
-			expectedOutuput:         []int{2},
-			expectedRemovedElements: 4,
-			expectedRemovedRanges:   2,
-		}, {
-			name:                    "negative indexes",
-			input:                   []int{0, 1, 2, 3, 4},
-			removeIndexes:           []int{-1, 0, 1},
-			expectedOutuput:         []int{2, 3, 4},
-			expectedRemovedElements: 2,
-			expectedRemovedRanges:   1,
-		}, {
-			name:                    "all cases combined",
-			input:                   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-			removeIndexes:           []int{9, 8, 9, 10, 11, -1, -1, 0, 3, 5, 6},
-			expectedOutuput:         []int{1, 2, 4, 7},
-			expectedRemovedElements: 6,
-			expectedRemovedRanges:   4,
-		},
-	}
-
-	for _, tc := range testCases {
+	for _, tc := range removeSliceIndexesTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, removedElements, removedRanges := RemoveSliceIndexes(tc.input, tc.removeIndexes)
-			assert.Equal(t, tc.expectedOutuput, output)
-			assert.Equal(t, tc.expectedRemovedElements, removedElements)
-			assert.Equal(t, tc.expectedRemovedRanges, removedRanges)
+			runTestCase(t, tc.input, tc.removeIndexes, tc.expectedOutput, tc.expectedRemovedElements, tc.expectedRemovedRanges)
+		})
+	}
+}
+
+func BenchmarkRemoveSliceIndexes(b *testing.B) {
+	for _, tc := range removeSliceIndexesTestCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			// Allocate "input" with enough space for the input of the test case.
+			input := make([]int, 0, len(tc.input))
+
+			for i := 0; i < b.N; i++ {
+				// Copy values of "tc.input" to "input" because "RemoveSliceIndexes" is going to modify the input.
+				input = input[:len(tc.input)]
+				copy(input, tc.input)
+
+				runTestCase(b, input, tc.removeIndexes, tc.expectedOutput, tc.expectedRemovedElements, tc.expectedRemovedRanges)
+			}
 		})
 	}
 }

--- a/pkg/util/slice_operations_test.go
+++ b/pkg/util/slice_operations_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveSliceIndexes(t *testing.T) {
+	type testCase struct {
+		name                    string
+		input                   []int
+		removeIndexes           []int
+		expectedOutuput         []int
+		expectedRemovedElements int
+		expectedRemovedRanges   int
+	}
+
+	testCases := []testCase{
+		{
+			name:                    "no change",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{},
+			expectedOutuput:         []int{0, 1, 2, 3, 4},
+			expectedRemovedElements: 0,
+			expectedRemovedRanges:   0,
+		}, {
+			name:                    "remove first",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{0},
+			expectedOutuput:         []int{1, 2, 3, 4},
+			expectedRemovedElements: 1,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "remove middle",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{2},
+			expectedOutuput:         []int{0, 1, 3, 4},
+			expectedRemovedElements: 1,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "remove last",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{4},
+			expectedOutuput:         []int{0, 1, 2, 3},
+			expectedRemovedElements: 1,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "remove all",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{0, 1, 2, 3, 4},
+			expectedOutuput:         []int{},
+			expectedRemovedElements: 5,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "remove two ranges",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{0, 1, 3, 4},
+			expectedOutuput:         []int{2},
+			expectedRemovedElements: 4,
+			expectedRemovedRanges:   2,
+		}, {
+			name:                    "index overrun",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{4, 5},
+			expectedOutuput:         []int{0, 1, 2, 3},
+			expectedRemovedElements: 1,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "duplicate indexes",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{4, 4, 4, 4},
+			expectedOutuput:         []int{0, 1, 2, 3},
+			expectedRemovedElements: 1,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "out of order indexes",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{4, 3, 1, 0},
+			expectedOutuput:         []int{2},
+			expectedRemovedElements: 4,
+			expectedRemovedRanges:   2,
+		}, {
+			name:                    "negative indexes",
+			input:                   []int{0, 1, 2, 3, 4},
+			removeIndexes:           []int{-1, 0, 1},
+			expectedOutuput:         []int{2, 3, 4},
+			expectedRemovedElements: 2,
+			expectedRemovedRanges:   1,
+		}, {
+			name:                    "all cases combined",
+			input:                   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			removeIndexes:           []int{9, 8, 9, 10, 11, -1, -1, 0, 3, 5, 6},
+			expectedOutuput:         []int{1, 2, 4, 7},
+			expectedRemovedElements: 6,
+			expectedRemovedRanges:   4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, removedElements, removedRanges := RemoveSliceIndexes(tc.input, tc.removeIndexes)
+			assert.Equal(t, tc.expectedOutuput, output)
+			assert.Equal(t, tc.expectedRemovedElements, removedElements)
+			assert.Equal(t, tc.expectedRemovedRanges, removedRanges)
+		})
+	}
+}

--- a/pkg/util/slice_operations_test.go
+++ b/pkg/util/slice_operations_test.go
@@ -92,7 +92,7 @@ var removeSliceIndexesTestCases = []removeSliceIndexesTestCase{
 }
 
 func runTestCase(tb testing.TB, input, removeIndexes, expectedOutput []int, expectedRemovedElements, expectedRemovedRanges int) {
-	output, removedElements, removedRanges := RemoveSliceIndexes(input, removeIndexes)
+	output, removedElements, removedRanges := removeSliceIndexes(input, removeIndexes)
 	assert.Equal(tb, expectedOutput, output)
 	assert.Equal(tb, expectedRemovedElements, removedElements)
 	assert.Equal(tb, expectedRemovedRanges, removedRanges)


### PR DESCRIPTION
Breaks the relabel/drop_label rules out of the `PushWithCleanup()` method and moves them into a middleware which gets applied at an earlier stage in the distributor's request processing.