### PR TITLE
Extract instance limits check into middleware, that runs before any other distributor middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709
+
 ### Mixin
 
 ### Jsonnet

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -613,13 +613,15 @@ func (d *Distributor) validateSeries(nowt time.Time, ts mimirpb.PreallocTimeseri
 func (d *Distributor) wrapPushWithMiddlewares(next push.Func) push.Func {
 	var middlewares []func(push.Func) push.Func
 
-	// The middlewares will be applied in the order of the slice "middlewares",
-	// requests will traverse them in the reverse order and the first middleware will wrap the second one, etc.
-	middlewares = append(middlewares, d.prePushForwardingMiddleware)
+	// The middlewares will be applied to the request (!) in the specified order, from first to last.
+	// To guarantee that, middleware functions will be called in reversed order, wrapping the
+	// result from previous call.
+	middlewares = append(middlewares, d.instanceLimitsMiddleware) // should run first
 	middlewares = append(middlewares, d.prePushHaDedupeMiddleware)
+	middlewares = append(middlewares, d.prePushForwardingMiddleware)
 
-	for _, middleware := range middlewares {
-		next = middleware(next)
+	for ix := len(middlewares) - 1; ix >= 0; ix-- {
+		next = middlewares[ix](next)
 	}
 
 	return next
@@ -732,6 +734,56 @@ func (d *Distributor) prePushForwardingMiddleware(next push.Func) push.Func {
 	}
 }
 
+// instanceLimitsMiddleware checks for instance limits and rejects request if this instance cannot process it at the moment.
+func (d *Distributor) instanceLimitsMiddleware(next push.Func) push.Func {
+	return func(ctx context.Context, req *mimirpb.WriteRequest, callerCleanup func()) (*mimirpb.WriteResponse, error) {
+		// We will report *this* request in the error too.
+		inflight := d.inflightPushRequests.Inc()
+		reqSize := int64(req.Size())
+		inflightBytes := d.inflightPushRequestsBytes.Add(reqSize)
+
+		// Decrement counter after all ingester calls have finished or been cancelled.
+		cleanup := func() {
+			callerCleanup()
+			d.inflightPushRequests.Dec()
+			d.inflightPushRequestsBytes.Sub(reqSize)
+		}
+		cleanupInDefer := true
+		defer func() {
+			if cleanupInDefer {
+				cleanup()
+			}
+		}()
+
+		userID, err := tenant.TenantID(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		span := opentracing.SpanFromContext(ctx)
+		if span != nil {
+			span.SetTag("organization", userID)
+		}
+
+		if d.cfg.InstanceLimits.MaxInflightPushRequests > 0 && inflight > int64(d.cfg.InstanceLimits.MaxInflightPushRequests) {
+			return nil, errMaxInflightRequestsReached
+		}
+
+		if d.cfg.InstanceLimits.MaxIngestionRate > 0 {
+			if rate := d.ingestionRate.Rate(); rate >= d.cfg.InstanceLimits.MaxIngestionRate {
+				return nil, errMaxIngestionRateReached
+			}
+		}
+
+		if d.cfg.InstanceLimits.MaxInflightPushRequestsBytes > 0 && inflightBytes > int64(d.cfg.InstanceLimits.MaxInflightPushRequestsBytes) {
+			return nil, errMaxInflightRequestsBytesReached
+		}
+
+		cleanupInDefer = false
+		return next(ctx, req, cleanup)
+	}
+}
+
 func (d *Distributor) forwardSamples(ctx context.Context, userID string, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, <-chan error) {
 	forwardingErrCh := make(chan error)
 	forwardingRules := d.limits.ForwardingRules(userID)
@@ -760,18 +812,7 @@ func (d *Distributor) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mim
 
 // PushWithCleanup takes a WriteRequest and distributes it to ingesters using the ring.
 // Strings in `req` may be pointers into the gRPC buffer which will be reused, so must be copied if retained.
-func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteRequest, callerCleanup func()) (*mimirpb.WriteResponse, error) {
-	// We will report *this* request in the error too.
-	inflight := d.inflightPushRequests.Inc()
-	reqSize := int64(req.Size())
-	inflightBytes := d.inflightPushRequestsBytes.Add(reqSize)
-
-	// Decrement counter after all ingester calls have finished or been cancelled.
-	cleanup := func() {
-		callerCleanup()
-		d.inflightPushRequests.Dec()
-		d.inflightPushRequestsBytes.Sub(reqSize)
-	}
+func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error) {
 	cleanupInDefer := true
 	defer func() {
 		if cleanupInDefer {
@@ -782,25 +823,6 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	span := opentracing.SpanFromContext(ctx)
-	if span != nil {
-		span.SetTag("organization", userID)
-	}
-
-	if d.cfg.InstanceLimits.MaxInflightPushRequests > 0 && inflight > int64(d.cfg.InstanceLimits.MaxInflightPushRequests) {
-		return nil, errMaxInflightRequestsReached
-	}
-
-	if d.cfg.InstanceLimits.MaxIngestionRate > 0 {
-		if rate := d.ingestionRate.Rate(); rate >= d.cfg.InstanceLimits.MaxIngestionRate {
-			return nil, errMaxIngestionRateReached
-		}
-	}
-
-	if d.cfg.InstanceLimits.MaxInflightPushRequestsBytes > 0 && inflightBytes > int64(d.cfg.InstanceLimits.MaxInflightPushRequestsBytes) {
-		return nil, errMaxInflightRequestsBytesReached
 	}
 
 	now := mtime.Now()
@@ -1191,8 +1213,8 @@ func (m *labelNamesAndValuesResponseMerger) putItemsToMap(message *ingester_clie
 }
 
 // LabelValuesCardinality performs the following two operations in parallel:
-//  * queries ingesters for label values cardinality of a set of labelNames
-//  * queries ingesters for user stats to get the ingester's series head count
+//   - queries ingesters for label values cardinality of a set of labelNames
+//   - queries ingesters for user stats to get the ingester's series head count
 func (d *Distributor) LabelValuesCardinality(ctx context.Context, labelNames []model.LabelName, matchers []*labels.Matcher) (uint64, *ingester_client.LabelValuesCardinalityResponse, error) {
 	var totalSeries uint64
 	var labelValuesCardinalityResponse *ingester_client.LabelValuesCardinalityResponse

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2944,7 +2944,6 @@ func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
 		numDistributors:     1,
 		limits:              &limits,
 		enableTracker:       true,
-		forwarding:          false,
 		maxInflightRequests: 1,
 	})
 	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2914,6 +2914,62 @@ func TestHaDedupeMiddleware(t *testing.T) {
 	}
 }
 
+func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "user")
+
+	const replica1 = "replicaA"
+	const replica2 = "replicaB"
+	const cluster1 = "clusterA"
+
+	writeReqReplica1 := makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))
+	writeReqReplica2 := makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica2, cluster1))
+	expectedWriteReq := makeWriteRequestForLabelSetGen(5, labelSetGenWithCluster(cluster1))
+
+	// Capture the submitted write requests which the middlewares pass into the mock push function.
+	var submittedWriteReqs []*mimirpb.WriteRequest
+	mockPush := func(_ context.Context, writeReq *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error) {
+		defer cleanup()
+		submittedWriteReqs = append(submittedWriteReqs, writeReq)
+		return nil, nil
+	}
+
+	// Setup limits with HA enabled and forwarding rules for the metric "foo".
+	var limits validation.Limits
+	flagext.DefaultValues(&limits)
+	limits.AcceptHASamples = true
+	limits.MaxLabelValueLength = 15
+
+	// Prepare distributor and wrap the mock push function with its middlewares.
+	ds, _, _ := prepare(t, prepConfig{
+		numDistributors:     1,
+		limits:              &limits,
+		enableTracker:       true,
+		forwarding:          false,
+		maxInflightRequests: 1,
+	})
+	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)
+
+	// Send first request. This will set HA tracker to track first replica.
+	_, err := wrappedMockPush(ctx, writeReqReplica1, func() {})
+	require.NoError(t, err)
+
+	// Simulate one inflight request. Sending a request should hit instance limit.
+	ds[0].inflightPushRequests.Inc()
+	_, err = wrappedMockPush(ctx, writeReqReplica1, func() {})
+	require.Equal(t, errMaxInflightRequestsReached, err)
+
+	// Simulate no other inflight request. Sending request should now work, but will be deduplicated.
+	ds[0].inflightPushRequests.Dec()
+	_, err = wrappedMockPush(ctx, writeReqReplica2, func() {})
+	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(202), resp.Code) // 202 due to HA-dedupe.
+
+	// Check that the write requests which have been submitted to the push function look as expected,
+	// there should only be one, and it shouldn't have the replica label.
+	assert.Equal(t, []*mimirpb.WriteRequest{expectedWriteReq}, submittedWriteReqs)
+}
+
 func TestHaDedupeBeforeForwarding(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
 	const replica1 = "replicaA"


### PR DESCRIPTION
#### What this PR does

After merging #2603, instance limits checks are done only after running HA deduplication. That's not correct. This PR moves instance limits checks into its own middleware, and makes it the first middleware to run.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
