### PR TITLE
Discard exemplars when forwarding them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710
+
 ### Mixin
 
 ### Jsonnet

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -128,11 +128,11 @@ func (f *forwarder) worker() {
 // returned slice of time series must be returned to the pool by the caller once it is done using it.
 //
 // The return values are:
-// - A TimeSeriesCounts object containing the sample / exemplar counts that were removed from the
-//   given time series slice relative to the returned slice.
-// - A slice of time series which should be sent to the ingesters, based on the given rule set.
-//   The Forward() method does not send the time series to the ingesters itself, it expects the caller to do that.
-// - A chan of errors which resulted from forwarding the time series, the chan gets closed when all forwarding requests have completed.
+//   - A TimeSeriesCounts object containing the sample / exemplar counts that were removed from the
+//     given time series slice relative to the returned slice.
+//   - A slice of time series which should be sent to the ingesters, based on the given rule set.
+//     The Forward() method does not send the time series to the ingesters itself, it expects the caller to do that.
+//   - A chan of errors which resulted from forwarding the time series, the chan gets closed when all forwarding requests have completed.
 func (f *forwarder) Forward(ctx context.Context, rules validation.ForwardingRules, in []mimirpb.PreallocTimeseries) (TimeseriesCounts, []mimirpb.PreallocTimeseries, chan error) {
 	if !f.cfg.Enabled {
 		errCh := make(chan error)
@@ -179,7 +179,8 @@ func (t tsByTargets) copyToTarget(target string, ts mimirpb.PreallocTimeseries, 
 	tsIdx := len(tsByTarget.ts)
 	tsByTarget.ts = append(tsByTarget.ts, mimirpb.PreallocTimeseries{TimeSeries: pool.getTs()})
 
-	tsByTarget.ts[tsIdx] = mimirpb.DeepCopyTimeseries(tsByTarget.ts[tsIdx], ts)
+	// We don't keep exemplars when forwarding.
+	tsByTarget.ts[tsIdx] = mimirpb.DeepCopyTimeseries(tsByTarget.ts[tsIdx], ts, false)
 	tsByTarget.counts.count(tsByTarget.ts[tsIdx])
 
 	t[target] = tsByTarget

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -123,7 +123,7 @@ func TestDeepCopyTimeseries(t *testing.T) {
 		},
 	}
 	dst := PreallocTimeseries{}
-	dst = DeepCopyTimeseries(dst, src)
+	dst = DeepCopyTimeseries(dst, src, true)
 
 	// Check that the values in src and dst are the same.
 	assert.Equal(t, src.TimeSeries, dst.TimeSeries)
@@ -151,4 +151,8 @@ func TestDeepCopyTimeseries(t *testing.T) {
 			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Exemplars[exemplarIdx].Labels)).Data,
 		)
 	}
+
+	dst = PreallocTimeseries{}
+	dst = DeepCopyTimeseries(dst, src, false)
+	assert.Nil(t, dst.Exemplars)
 }


### PR DESCRIPTION
#### What this PR does

This PR modifies forwarder to discard exemplars. In general we should perhaps introduce new option to allow/disable forwarding of exemplars, but for now this works.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
