### PR TITLE
Update default for max_global_series_per_metric limit to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710
+* [CHANGE] Limits: change the default value of `max_global_series_per_metric` limit to `0` (disabled). Setting this limit by default does not provide much benefit because series are sharded by all labels. #2714
 * [BUGFIX] Fix reporting of tracing spans from PromQL engine. #2707
 * [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709
 * [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2658,7 +2658,7 @@
           "required": false,
           "desc": "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.",
           "fieldValue": null,
-          "fieldDefaultValue": 20000,
+          "fieldDefaultValue": 0,
           "fieldFlag": "ingester.max-global-series-per-metric",
           "fieldType": "int"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -971,7 +971,7 @@ Usage of ./cmd/mimir/mimir:
   -ingester.max-global-metadata-per-user int
     	The maximum number of in-memory metrics with metadata per tenant, across the cluster. 0 to disable.
   -ingester.max-global-series-per-metric int
-    	The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable. (default 20000)
+    	The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.
   -ingester.max-global-series-per-user int
     	The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable. (default 150000)
   -ingester.metadata-retain-period duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -343,7 +343,7 @@ Usage of ./cmd/mimir/mimir:
   -ingester.max-global-metadata-per-user int
     	The maximum number of in-memory metrics with metadata per tenant, across the cluster. 0 to disable.
   -ingester.max-global-series-per-metric int
-    	The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable. (default 20000)
+    	The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.
   -ingester.max-global-series-per-user int
     	The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable. (default 150000)
   -ingester.ring.consul.hostname string

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2372,7 +2372,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # The maximum number of in-memory series per metric name, across the cluster
 # before replication. 0 to disable.
 # CLI flag: -ingester.max-global-series-per-metric
-[max_global_series_per_metric: <int> | default = 20000]
+[max_global_series_per_metric: <int> | default = 0]
 
 # The maximum number of in-memory metrics with metadata per tenant, across the
 # cluster. 0 to disable.

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1292,7 +1292,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1349,7 +1349,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1560,7 +1560,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s
@@ -1674,7 +1673,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s
@@ -1788,7 +1786,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1239,7 +1239,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -759,7 +759,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -992,7 +992,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -492,7 +492,6 @@ spec:
         - -distributor.ingestion-rate-limit=10000
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
@@ -1063,7 +1062,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -991,7 +991,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -996,7 +996,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1001,7 +1001,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -996,7 +996,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1349,7 +1349,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1427,7 +1427,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1427,7 +1427,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1427,7 +1427,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1427,7 +1427,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ingester.ring.heartbeat-period=15s

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -994,7 +994,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -991,7 +991,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1214,7 +1214,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m
@@ -1332,7 +1331,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m
@@ -1450,7 +1448,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1271,7 +1271,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m
@@ -1387,7 +1386,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m
@@ -1505,7 +1503,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m
@@ -1623,7 +1620,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -996,7 +996,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1294,7 +1294,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1293,7 +1293,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1000,7 +1000,6 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1001,7 +1001,6 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1003,7 +1003,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -991,7 +991,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -998,7 +998,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -657,7 +657,6 @@ spec:
         - -distributor.health-check-ingesters=true
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
-        - -ingester.max-global-series-per-metric=0
         - -ingester.max-global-series-per-user=150000
         - -ingester.ring.heartbeat-period=15s
         - -ingester.ring.heartbeat-timeout=10m

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -230,7 +230,6 @@
     },
     ingesterLimitsConfig: {
       'ingester.max-global-series-per-user': $._config.limits.max_global_series_per_user,
-      'ingester.max-global-series-per-metric': $._config.limits.max_global_series_per_metric,
       'ingester.max-global-metadata-per-user': $._config.limits.max_global_metadata_per_user,
       'ingester.max-global-metadata-per-metric': $._config.limits.max_global_metadata_per_metric,
     },
@@ -251,8 +250,6 @@
       extra_small_user:: {
         // Our limit should be 100k, but we need some room of about ~50% to take rollouts into account
         max_global_series_per_user: 150000,
-        // Disabled in favor of using max_global_series_per_user only.
-        max_global_series_per_metric: 0,
         max_global_metadata_per_user: std.ceil(self.max_global_series_per_user * 0.2),
         max_global_metadata_per_metric: 10,
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -180,7 +180,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
-	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 20000, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")
+	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")
 
 	f.IntVar(&l.MaxGlobalMetricsWithMetadataPerUser, MaxMetadataPerUserFlag, 0, "The maximum number of in-memory metrics with metadata per tenant, across the cluster. 0 to disable.")
 	f.IntVar(&l.MaxGlobalMetadataPerMetric, MaxMetadataPerMetricFlag, 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")


### PR DESCRIPTION
#### What this PR does

This brings the CLI default and Helm chart in line with the Jsonnet
default value. This default is set because it doesn't provide any
protection for Mimir now that series are sharded by all labels
(previously they were sharded only by metric name). It's still useful
for preventing cardinality explosions in some cases but, more often
it is a source of confusion for users.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
