### PR TITLE
mimir-continuous-test tool: Add basic authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Mimir Continuous Test
 
+* [ENHANCEMENT] Added basic authentication and bearer token support for when Mimir is behind a gateway authenticating the calls. #2717
+
 ### Documentation
 
 

--- a/docs/sources/operators-guide/tools/mimir-continuous-test.md
+++ b/docs/sources/operators-guide/tools/mimir-continuous-test.md
@@ -35,11 +35,14 @@ chmod +x mimir-continuous-test
 
 ## Configure mimir-continuous-test
 
-Mimir-continuous-test requires the endpoints of the backend Grafana Mimir clusters and the tenant ID for writing and querying testing metrics:
+Mimir-continuous-test requires the endpoints of the backend Grafana Mimir clusters and the authentication for writing and querying testing metrics:
 
 - Set `-tests.write-endpoint` to the base endpoint on the write path. Remove any trailing slash from the URL. The tool appends the specific API path to the URL, for example `/api/v1/push` for the remote-write API.
 - Set `-tests.read-endpoint` to the base endpoint on the read path. Remove any trailing slash from the URL. The tool appends the specific API path to the URL, for example `/api/v1/query_range` for the range-query API.
-- Set `-tests.tenant-id` to the tenant ID to use to write and read metrics in tests.
+- Set the authentication means to use to write and read metrics in tests. By priority order:
+  - `-tests.bearer-token` for bearer token authentication.
+  - `-tests.basic-auth-user` and `-tests.basic-auth-password` for a basic authentication.
+  - `-tests.tenant-id` to the tenant ID, default to `anonymous`.
 - Set `-tests.smoke-test` to run the test once and immediately exit. In this mode, the process exit code is non-zero when the test fails.
 
 > **Note:** You can run `mimir-continuous-test -help` to list all available configuration options.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Added basic authentication support to mimir-continuous-testing for when Mimir is behind a gateway authenticating the calls.

#### Which issue(s) this PR fixes or relates to

Fixes #2105

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`