### PR TITLE
Fix version checking in mimirtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Mimirtool
 
+* [BUGFIX] Version checking no longer prompts for updating when already on latest version.  
+
 ### Mimir Continuous Test
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Mimirtool
 
-* [BUGFIX] Version checking no longer prompts for updating when already on latest version.  
+* [BUGFIX] Version checking no longer prompts for updating when already on latest version. #2723
 
 ### Mimir Continuous Test
 


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fixes a bug where version checking was broken

```
$ mimirtool version
Mimirtool, version 2.2.0 (branch: HEAD, revision: 65344e2ed)
  go version:       go1.17.8
  platform:         darwin/arm64
checking latest version... A newer version of mimirtool is available, please update to mimir-2.2.0
```

Also adds a link to the release

```
$ cmd/mimirtool/mimirtool version
Mimirtool, version 2.3.0 (branch: dimitar/fix-mimirtool-version-check, revision: 64c5aefa8)
  go version:       go1.18.4
  platform:         darwin/arm64
checking latest version... A newer version of mimirtool is available, please update to 2.2.0 https://github.com/grafana/mimir/releases/tag/mimir-2.2.0
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
