### PR TITLE
Add prometheus-prefixed buildinfo endpoint to ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] Introduced an experimental anonymous usage statistics tracking (disabled by default), to help Mimir maintainers driving better decisions to support the opensource community. The tracking system anonymously collects non-sensitive and non-personal identifiable information about the running Mimir cluster, and is disabled by default. #2643 #2662 #2685 #2732
 * [ENHANCEMENT] Distributor: Add `cortex_distributor_query_ingester_chunks_deduped_total` and `cortex_distributor_query_ingester_chunks_total` metrics for determining how effective ingester chunk deduplication at query time is. #2713
 * [ENHANCEMENT] Upgrade Docker base images to `alpine:3.16.2`. #2729
+* [ENHANCEMENT] Ruler: Add `<prometheus-http-prefix>/api/v1/status/buildinfo` endpoint. #2724
 * [BUGFIX] Fix reporting of tracing spans from PromQL engine. #2707
 * [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709
 * [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703

--- a/docs/sources/operators-guide/reference-http-api/index.md
+++ b/docs/sources/operators-guide/reference-http-api/index.md
@@ -21,67 +21,67 @@ This document groups API endpoints by service. Note that the API endpoints are e
 
 ## Endpoints
 
-| API                                                                                   | Service                 | Endpoint                                                                  |
-| ------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------- |
-| [Index page](#index-page)                                                             | _All services_          | `GET /`                                                                   |
-| [Configuration](#configuration)                                                       | _All services_          | `GET /config`                                                             |
-| [Runtime Configuration](#runtime-configuration)                                       | _All services_          | `GET /runtime_config`                                                     |
-| [Services' status](#services-status)                                                  | _All services_          | `GET /services`                                                           |
-| [Readiness probe](#readiness-probe)                                                   | _All services_          | `GET /ready`                                                              |
-| [Metrics](#metrics)                                                                   | _All services_          | `GET /metrics`                                                            |
-| [Pprof](#pprof)                                                                       | _All services_          | `GET /debug/pprof`                                                        |
-| [Fgprof](#fgprof)                                                                     | _All services_          | `GET /debug/fgprof`                                                       |
-| [Build information](#build-information)                                               | _All services_          | `GET /api/v1/status/buildinfo`                                            |
-| [Memberlist cluster](#memberlist-cluster)                                             | _All services_          | `GET /memberlist`                                                         |
-| [Remote write](#remote-write)                                                         | Distributor             | `POST /api/v1/push`                                                       |
-| [OTLP](#otlp)                                                                         | Distributor             | `POST /otlp/v1/metrics`                                                   |
-| [Tenants stats](#tenants-stats)                                                       | Distributor             | `GET /distributor/all_user_stats`                                         |
-| [HA tracker status](#ha-tracker-status)                                               | Distributor             | `GET /distributor/ha_tracker`                                             |
-| [Flush chunks / blocks](#flush-chunks--blocks)                                        | Ingester                | `GET,POST /ingester/flush`                                                |
-| [Shutdown](#shutdown)                                                                 | Ingester                | `GET,POST /ingester/shutdown`                                             |
-| [Ingesters ring status](#ingesters-ring-status)                                       | Distributor,Ingester    | `GET /ingester/ring`                                                      |
-| [Instant query](#instant-query)                                                       | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/query`                          |
-| [Range query](#range-query)                                                           | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/query_range`                    |
-| [Exemplar query](#exemplar-query)                                                     | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/query_exemplars`                |
-| [Get series by label matchers](#get-series-by-label-matchers)                         | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/series`                         |
-| [Get label names](#get-label-names)                                                   | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/labels`                         |
-| [Get label values](#get-label-values)                                                 | Querier, Query-frontend | `GET <prometheus-http-prefix>/api/v1/label/{name}/values`                 |
-| [Get metric metadata](#get-metric-metadata)                                           | Querier, Query-frontend | `GET <prometheus-http-prefix>/api/v1/metadata`                            |
-| [Remote read](#remote-read)                                                           | Querier, Query-frontend | `POST <prometheus-http-prefix>/api/v1/read`                               |
-| [Label names cardinality](#label-names-cardinality)                                   | Querier, Query-frontend | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_names`       |
-| [Label values cardinality](#label-values-cardinality)                                 | Querier, Query-frontend | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_values`      |
-| [Build information](#build-information)                                               | Querier, Query-frontend | `GET <prometheus-http-prefix>/api/v1/status/buildinfo`                    |
-| [Get tenant ingestion stats](#get-tenant-ingestion-stats)                             | Querier                 | `GET /api/v1/user_stats`                                                  |
-| [Ruler ring status](#ruler-ring-status)                                               | Ruler                   | `GET /ruler/ring`                                                         |
-| [Ruler rules ](#ruler-rules)                                                          | Ruler                   | `GET /ruler/rule_groups`                                                  |
-| [List Prometheus rules](#list-prometheus-rules)                                       | Ruler                   | `GET <prometheus-http-prefix>/api/v1/rules`                               |
-| [List Prometheus alerts](#list-prometheus-alerts)                                     | Ruler                   | `GET <prometheus-http-prefix>/api/v1/alerts`                              |
-| [List rule groups](#list-rule-groups)                                                 | Ruler                   | `GET <prometheus-http-prefix>/config/v1/rules`                            |
-| [Get rule groups by namespace](#get-rule-groups-by-namespace)                         | Ruler                   | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}`                |
-| [Get rule group](#get-rule-group)                                                     | Ruler                   | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}`    |
-| [Set rule group](#set-rule-group)                                                     | Ruler                   | `POST <prometheus-http-prefix>/config/v1/rules/{namespace}`               |
-| [Delete rule group](#delete-rule-group)                                               | Ruler                   | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}` |
-| [Delete namespace](#delete-namespace)                                                 | Ruler                   | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}`             |
-| [Delete tenant configuration](#delete-tenant-configuration)                           | Ruler                   | `POST /ruler/delete_tenant_config`                                        |
-| [Alertmanager status](#alertmanager-status)                                           | Alertmanager            | `GET /multitenant_alertmanager/status`                                    |
-| [Alertmanager configs](#alertmanager-configs)                                         | Alertmanager            | `GET /multitenant_alertmanager/configs`                                   |
-| [Alertmanager ring status](#alertmanager-ring-status)                                 | Alertmanager            | `GET /multitenant_alertmanager/ring`                                      |
-| [Alertmanager UI](#alertmanager-ui)                                                   | Alertmanager            | `GET <alertmanager-http-prefix>`                                          |
-| [Build Information](#build-information)                                               | Alertmanager            | `GET <alertmanager-http-prefix>/api/v1/status/buildinfo`                  |
-| [Alertmanager Delete Tenant Configuration](#alertmanager-delete-tenant-configuration) | Alertmanager            | `POST /multitenant_alertmanager/delete_tenant_config`                     |
-| [Get Alertmanager configuration](#get-alertmanager-configuration)                     | Alertmanager            | `GET /api/v1/alerts`                                                      |
-| [Set Alertmanager configuration](#set-alertmanager-configuration)                     | Alertmanager            | `POST /api/v1/alerts`                                                     |
-| [Delete Alertmanager configuration](#delete-alertmanager-configuration)               | Alertmanager            | `DELETE /api/v1/alerts`                                                   |
-| [Store-gateway ring status](#store-gateway-ring-status)                               | Store-gateway           | `GET /store-gateway/ring`                                                 |
-| [Store-gateway tenants](#store-gateway-tenants)                                       | Store-gateway           | `GET /store-gateway/tenants`                                              |
-| [Store-gateway tenant blocks](#store-gateway-tenant-blocks)                           | Store-gateway           | `GET /store-gateway/tenant/{tenant}/blocks`                               |
-| [Compactor ring status](#compactor-ring-status)                                       | Compactor               | `GET /compactor/ring`                                                     |
-| [Start block upload](#start-block-upload)                                             | Compactor               | `POST /api/v1/upload/block/{block}/start`                                 |
-| [Upload block file](#upload-block-file)                                               | Compactor               | `POST /api/v1/upload/block/{block}/files?path={path}`                     |
-| [Complete block upload](#complete-block-upload)                                       | Compactor               | `POST /api/v1/upload/block/{block}/finish`                                |
-| [Check block upload](#check-block-upload)                                             | Compactor               | `GET /api/v1/upload/block/{block}/check`                                  |
-| [Tenant delete request](#tenant-delete-request)                                       | Compactor               | `POST /compactor/delete_tenant`                                           |
-| [Tenant delete status](#tenant-delete-status)                                         | Compactor               | `GET /compactor/delete_tenant_status`                                     |
+| API                                                                                   | Service                        | Endpoint                                                                  |
+| ------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| [Index page](#index-page)                                                             | _All services_                 | `GET /`                                                                   |
+| [Configuration](#configuration)                                                       | _All services_                 | `GET /config`                                                             |
+| [Runtime Configuration](#runtime-configuration)                                       | _All services_                 | `GET /runtime_config`                                                     |
+| [Services' status](#services-status)                                                  | _All services_                 | `GET /services`                                                           |
+| [Readiness probe](#readiness-probe)                                                   | _All services_                 | `GET /ready`                                                              |
+| [Metrics](#metrics)                                                                   | _All services_                 | `GET /metrics`                                                            |
+| [Pprof](#pprof)                                                                       | _All services_                 | `GET /debug/pprof`                                                        |
+| [Fgprof](#fgprof)                                                                     | _All services_                 | `GET /debug/fgprof`                                                       |
+| [Build information](#build-information)                                               | _All services_                 | `GET /api/v1/status/buildinfo`                                            |
+| [Memberlist cluster](#memberlist-cluster)                                             | _All services_                 | `GET /memberlist`                                                         |
+| [Remote write](#remote-write)                                                         | Distributor                    | `POST /api/v1/push`                                                       |
+| [OTLP](#otlp)                                                                         | Distributor                    | `POST /otlp/v1/metrics`                                                   |
+| [Tenants stats](#tenants-stats)                                                       | Distributor                    | `GET /distributor/all_user_stats`                                         |
+| [HA tracker status](#ha-tracker-status)                                               | Distributor                    | `GET /distributor/ha_tracker`                                             |
+| [Flush chunks / blocks](#flush-chunks--blocks)                                        | Ingester                       | `GET,POST /ingester/flush`                                                |
+| [Shutdown](#shutdown)                                                                 | Ingester                       | `GET,POST /ingester/shutdown`                                             |
+| [Ingesters ring status](#ingesters-ring-status)                                       | Distributor,Ingester           | `GET /ingester/ring`                                                      |
+| [Instant query](#instant-query)                                                       | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/query`                          |
+| [Range query](#range-query)                                                           | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/query_range`                    |
+| [Exemplar query](#exemplar-query)                                                     | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/query_exemplars`                |
+| [Get series by label matchers](#get-series-by-label-matchers)                         | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/series`                         |
+| [Get label names](#get-label-names)                                                   | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/labels`                         |
+| [Get label values](#get-label-values)                                                 | Querier, Query-frontend        | `GET <prometheus-http-prefix>/api/v1/label/{name}/values`                 |
+| [Get metric metadata](#get-metric-metadata)                                           | Querier, Query-frontend        | `GET <prometheus-http-prefix>/api/v1/metadata`                            |
+| [Remote read](#remote-read)                                                           | Querier, Query-frontend        | `POST <prometheus-http-prefix>/api/v1/read`                               |
+| [Label names cardinality](#label-names-cardinality)                                   | Querier, Query-frontend        | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_names`       |
+| [Label values cardinality](#label-values-cardinality)                                 | Querier, Query-frontend        | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_values`      |
+| [Build information](#build-information)                                               | Querier, Query-frontend, Ruler | `GET <prometheus-http-prefix>/api/v1/status/buildinfo`                    |
+| [Get tenant ingestion stats](#get-tenant-ingestion-stats)                             | Querier                        | `GET /api/v1/user_stats`                                                  |
+| [Ruler ring status](#ruler-ring-status)                                               | Ruler                          | `GET /ruler/ring`                                                         |
+| [Ruler rules ](#ruler-rules)                                                          | Ruler                          | `GET /ruler/rule_groups`                                                  |
+| [List Prometheus rules](#list-prometheus-rules)                                       | Ruler                          | `GET <prometheus-http-prefix>/api/v1/rules`                               |
+| [List Prometheus alerts](#list-prometheus-alerts)                                     | Ruler                          | `GET <prometheus-http-prefix>/api/v1/alerts`                              |
+| [List rule groups](#list-rule-groups)                                                 | Ruler                          | `GET <prometheus-http-prefix>/config/v1/rules`                            |
+| [Get rule groups by namespace](#get-rule-groups-by-namespace)                         | Ruler                          | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}`                |
+| [Get rule group](#get-rule-group)                                                     | Ruler                          | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}`    |
+| [Set rule group](#set-rule-group)                                                     | Ruler                          | `POST <prometheus-http-prefix>/config/v1/rules/{namespace}`               |
+| [Delete rule group](#delete-rule-group)                                               | Ruler                          | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}` |
+| [Delete namespace](#delete-namespace)                                                 | Ruler                          | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}`             |
+| [Delete tenant configuration](#delete-tenant-configuration)                           | Ruler                          | `POST /ruler/delete_tenant_config`                                        |
+| [Alertmanager status](#alertmanager-status)                                           | Alertmanager                   | `GET /multitenant_alertmanager/status`                                    |
+| [Alertmanager configs](#alertmanager-configs)                                         | Alertmanager                   | `GET /multitenant_alertmanager/configs`                                   |
+| [Alertmanager ring status](#alertmanager-ring-status)                                 | Alertmanager                   | `GET /multitenant_alertmanager/ring`                                      |
+| [Alertmanager UI](#alertmanager-ui)                                                   | Alertmanager                   | `GET <alertmanager-http-prefix>`                                          |
+| [Build Information](#build-information)                                               | Alertmanager                   | `GET <alertmanager-http-prefix>/api/v1/status/buildinfo`                  |
+| [Alertmanager Delete Tenant Configuration](#alertmanager-delete-tenant-configuration) | Alertmanager                   | `POST /multitenant_alertmanager/delete_tenant_config`                     |
+| [Get Alertmanager configuration](#get-alertmanager-configuration)                     | Alertmanager                   | `GET /api/v1/alerts`                                                      |
+| [Set Alertmanager configuration](#set-alertmanager-configuration)                     | Alertmanager                   | `POST /api/v1/alerts`                                                     |
+| [Delete Alertmanager configuration](#delete-alertmanager-configuration)               | Alertmanager                   | `DELETE /api/v1/alerts`                                                   |
+| [Store-gateway ring status](#store-gateway-ring-status)                               | Store-gateway                  | `GET /store-gateway/ring`                                                 |
+| [Store-gateway tenants](#store-gateway-tenants)                                       | Store-gateway                  | `GET /store-gateway/tenants`                                              |
+| [Store-gateway tenant blocks](#store-gateway-tenant-blocks)                           | Store-gateway                  | `GET /store-gateway/tenant/{tenant}/blocks`                               |
+| [Compactor ring status](#compactor-ring-status)                                       | Compactor                      | `GET /compactor/ring`                                                     |
+| [Start block upload](#start-block-upload)                                             | Compactor                      | `POST /api/v1/upload/block/{block}/start`                                 |
+| [Upload block file](#upload-block-file)                                               | Compactor                      | `POST /api/v1/upload/block/{block}/files?path={path}`                     |
+| [Complete block upload](#complete-block-upload)                                       | Compactor                      | `POST /api/v1/upload/block/{block}/finish`                                |
+| [Check block upload](#check-block-upload)                                             | Compactor                      | `GET /api/v1/upload/block/{block}/check`                                  |
+| [Tenant delete request](#tenant-delete-request)                                       | Compactor                      | `POST /compactor/delete_tenant`                                           |
+| [Tenant delete status](#tenant-delete-status)                                         | Compactor                      | `GET /compactor/delete_tenant_status`                                     |
 
 ### Path prefixes
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -279,7 +279,7 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 }
 
 // RegisterRuler registers routes associated with the Ruler service.
-func (a *API) RegisterRuler(r *ruler.Ruler) {
+func (a *API) RegisterRuler(r *ruler.Ruler, buildInfoHandler http.Handler) {
 	a.indexPage.AddLinks(defaultWeight, "Ruler", []IndexPageLink{
 		{Desc: "Ring status", Path: "/ruler/ring"},
 	})
@@ -290,6 +290,7 @@ func (a *API) RegisterRuler(r *ruler.Ruler) {
 
 	// List all user rule groups
 	a.RegisterRoute("/ruler/rule_groups", http.HandlerFunc(r.ListAllRules), false, true, "GET")
+	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/status/buildinfo"), buildInfoHandler, false, true, "GET")
 
 	ruler.RegisterRulerServer(a.server.GRPC, r)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -279,7 +279,7 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 }
 
 // RegisterRuler registers routes associated with the Ruler service.
-func (a *API) RegisterRuler(r *ruler.Ruler, buildInfoHandler http.Handler) {
+func (a *API) RegisterRuler(r *ruler.Ruler) {
 	a.indexPage.AddLinks(defaultWeight, "Ruler", []IndexPageLink{
 		{Desc: "Ring status", Path: "/ruler/ring"},
 	})
@@ -290,18 +290,18 @@ func (a *API) RegisterRuler(r *ruler.Ruler, buildInfoHandler http.Handler) {
 
 	// List all user rule groups
 	a.RegisterRoute("/ruler/rule_groups", http.HandlerFunc(r.ListAllRules), false, true, "GET")
-	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/status/buildinfo"), buildInfoHandler, false, true, "GET")
 
 	ruler.RegisterRulerServer(a.server.GRPC, r)
 }
 
 // RegisterRulerAPI registers routes associated with the Ruler API
-func (a *API) RegisterRulerAPI(r *ruler.API, configAPIEnabled bool) {
+func (a *API) RegisterRulerAPI(r *ruler.API, configAPIEnabled bool, buildInfoHandler http.Handler) {
 	// Prometheus Rule API Routes
 	// We want to always enable these. They are read-only. Also if using local storage as rule storage,
 	// you would like the API to be disabled and still be able to understand in what state rule evaluations are.
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/rules"), http.HandlerFunc(r.PrometheusRules), true, true, "GET")
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/alerts"), http.HandlerFunc(r.PrometheusAlerts), true, true, "GET")
+	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/status/buildinfo"), buildInfoHandler, false, true, "GET")
 
 	if configAPIEnabled {
 		// Long-term maintained configuration API routes

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -653,7 +653,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 	}
 
 	// Expose HTTP/GRPC admin endpoints for the Ruler service
-	t.API.RegisterRuler(t.Ruler)
+	t.API.RegisterRuler(t.Ruler, t.BuildInfoHandler)
 
 	// Expose HTTP configuration and prometheus-compatible Ruler APIs
 	t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, util_log.Logger), t.Cfg.Ruler.EnableAPI)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -653,10 +653,10 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 	}
 
 	// Expose HTTP/GRPC admin endpoints for the Ruler service
-	t.API.RegisterRuler(t.Ruler, t.BuildInfoHandler)
+	t.API.RegisterRuler(t.Ruler)
 
 	// Expose HTTP configuration and prometheus-compatible Ruler APIs
-	t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, util_log.Logger), t.Cfg.Ruler.EnableAPI)
+	t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, util_log.Logger), t.Cfg.Ruler.EnableAPI, t.BuildInfoHandler)
 
 	return t.Ruler, nil
 }


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds the `/prometheus`-prefixed `buildinfo` endpoint to the ruler. This endpoint is exposed by all other components (querier, query-frontend) that use the `<prometheus-http-prefix>`, except the ruler.

#### Which issue(s) this PR fixes or relates to

Fixes #2678 

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
