### PR TITLE
Fix sizing of buffer and don't nil exemplars buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710
+* [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710 #2725
 * [CHANGE] Limits: change the default value of `max_global_series_per_metric` limit to `0` (disabled). Setting this limit by default does not provide much benefit because series are sharded by all labels. #2714
 * [BUGFIX] Fix reporting of tracing spans from PromQL engine. #2707
 * [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -154,5 +154,41 @@ func TestDeepCopyTimeseries(t *testing.T) {
 
 	dst = PreallocTimeseries{}
 	dst = DeepCopyTimeseries(dst, src, false)
-	assert.Nil(t, dst.Exemplars)
+	assert.NotNil(t, dst.Exemplars)
+	assert.Len(t, dst.Exemplars, 0)
+}
+
+func TestDeepCopyTimeseriesExemplars(t *testing.T) {
+	src := PreallocTimeseries{
+		TimeSeries: &TimeSeries{
+			Labels: []LabelAdapter{
+				{Name: "sampleLabel1", Value: "sampleValue1"},
+				{Name: "sampleLabel2", Value: "sampleValue2"},
+			},
+			Samples: []Sample{
+				{Value: 1, TimestampMs: 2},
+				{Value: 3, TimestampMs: 4},
+			},
+		},
+	}
+
+	for i := 0; i < 100; i++ {
+		src.Exemplars = append(src.Exemplars, Exemplar{
+			Value:       1,
+			TimestampMs: 2,
+			Labels: []LabelAdapter{
+				{Name: "exemplarLabel1", Value: "exemplarValue1"},
+				{Name: "exemplarLabel2", Value: "exemplarValue2"},
+			},
+		})
+	}
+
+	dst1 := PreallocTimeseries{}
+	dst1 = DeepCopyTimeseries(dst1, src, false)
+
+	dst2 := PreallocTimeseries{}
+	dst2 = DeepCopyTimeseries(dst2, src, true)
+
+	// dst1 should use much smaller buffer than dst2.
+	assert.Less(t, cap(*dst1.yoloSlice), cap(*dst2.yoloSlice))
 }


### PR DESCRIPTION
#### What this PR does

This PR is a follow-up to #2710. When doing deep copy of request without exemplars, computed buffer size used for copying request was bigger than necessary. At the same time, by nil-ing `Exemplars` field we thrown away previously allocated slice for exemplars, which could be reused.


#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
