### PR TITLE
Add CHANGELOG entry about anonymous usage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710 #2725
 * [CHANGE] Limits: change the default value of `max_global_series_per_metric` limit to `0` (disabled). Setting this limit by default does not provide much benefit because series are sharded by all labels. #2714
+* [FEATURE] Introduced an experimental anonymous usage statistics tracking (disabled by default), to help Mimir maintainers driving better decisions to support the opensource community. The tracking system anonymously collects non-sensitive and non-personal identifiable information about the running Mimir cluster, and is disabled by default. #2643 #2662 #2685 #2732
 * [ENHANCEMENT] Distributor: Add `cortex_distributor_query_ingester_chunks_deduped_total` and `cortex_distributor_query_ingester_chunks_total` metrics for determining how effective ingester chunk deduplication at query time is. #2713
 * [ENHANCEMENT] Upgrade Docker base images to `alpine:3.16.2`. #2729
 * [BUGFIX] Fix reporting of tracing spans from PromQL engine. #2707

--- a/docs/sources/operators-guide/configure/about-versioning.md
+++ b/docs/sources/operators-guide/configure/about-versioning.md
@@ -96,6 +96,7 @@ The following features are currently experimental:
 - Compactor
   - HTTP API for uploading TSDB blocks
   - Tenant deletion API
+- Anonymous usage statistics tracking
 
 ## Deprecated features
 


### PR DESCRIPTION
#### What this PR does
In this PR I'm adding the CHANGELOG entry about anonymous usage stats work (currently disabled by default). I will work on the documentation changes in a follow up PR.

#### Which issue(s) this PR fixes or relates to

Part of #1815

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
