### PR TITLE
Disable resource requests in Helm CI runs

### DIFF
--- a/operations/helm/charts/mimir-distributed/ci/test-enterprise-configmap-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-enterprise-configmap-values.yaml
@@ -1,6 +1,12 @@
 # Test values to limit the load during CI
 kubeVersionOverride: "1.20"
 
+
+# Remove resource requests and limits because in CI we only have limited memory and CPU
+ci_resources: &ci_resources
+  requests:
+  limits:
+
 global:
   extraEnvFrom:
     - secretRef:
@@ -32,23 +38,40 @@ enterprise:
   enabled: true
 
 alertmanager:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
 
 compactor:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
 
 ingester:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
-  resources:
-    requests:
-      cpu: 10m
 
 store_gateway:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
+
+querier:
+  resources:
+    <<: *ci_resources
+
+query_frontend:
+  resources:
+    <<: *ci_resources
+
+query_scheduler:
+  resources:
+    <<: *ci_resources
 
 # For testing only
 testing:

--- a/operations/helm/charts/mimir-distributed/ci/test-enterprise-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-enterprise-values.yaml
@@ -1,26 +1,48 @@
 # Test values to limit the load during CI
 kubeVersionOverride: "1.20"
 
+# Remove resource requests and limits because in CI we only have limited memory and CPU
+ci_resources: &ci_resources
+  requests:
+  limits:
+
 configStorageType: Secret
 
 enterprise:
   enabled: true
 
 alertmanager:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
 
 compactor:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
 
 ingester:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
-  resources:
-    requests:
-      cpu: 10m
 
 store_gateway:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
+
+querier:
+  resources:
+    <<: *ci_resources
+
+query_frontend:
+  resources:
+    <<: *ci_resources
+
+query_scheduler:
+  resources:
+    <<: *ci_resources

--- a/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/test-oss-values.yaml
@@ -1,6 +1,11 @@
 # Test values to limit the load during CI
 kubeVersionOverride: "1.20"
 
+# Remove resource requests and limits because in CI we only have limited memory and CPU
+ci_resources: &ci_resources
+  requests:
+  limits:
+
 global:
   extraEnvFrom:
     - secretRef:
@@ -32,13 +37,14 @@ compactor:
     enabled: false
 
 ingester:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
-  resources:
-    requests:
-      cpu: 10m
 
 store_gateway:
+  resources:
+    <<: *ci_resources
   persistentVolume:
     enabled: false
 
@@ -51,26 +57,34 @@ chunks-cache:
   enabled: true
   allocatedMemory: 10
   resources:
-    requests:
-      cpu: 10m
+    <<: *ci_resources
 
 index-cache:
   enabled: true
   allocatedMemory: 30
   resources:
-    requests:
-      cpu: 10m
+    <<: *ci_resources
 
 metadata-cache:
   enabled: true
   allocatedMemory: 10
   resources:
-    requests:
-      cpu: 10m
+    <<: *ci_resources
 
 results-cache:
   enabled: true
   allocatedMemory: 10
   resources:
-    requests:
-      cpu: 10m
+    <<: *ci_resources
+
+querier:
+  resources:
+    <<: *ci_resources
+
+query_frontend:
+  resources:
+    <<: *ci_resources
+
+query_scheduler:
+  resources:
+    <<: *ci_resources

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -100,9 +100,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -106,9 +106,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 100m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -98,9 +98,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 10m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -76,9 +76,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -71,9 +71,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -104,9 +104,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 100m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -96,9 +96,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -102,9 +102,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 100m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -94,9 +94,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 10m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -75,9 +75,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -70,9 +70,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -100,9 +100,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 100m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,8 +55,8 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            requests:
-              cpu: 10m
+            limits: null
+            requests: null
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,8 +55,8 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            requests:
-              cpu: 10m
+            limits: null
+            requests: null
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -93,9 +93,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 10m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,8 +55,8 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            requests:
-              cpu: 10m
+            limits: null
+            requests: null
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -74,9 +74,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -69,9 +69,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,8 +55,8 @@ spec:
           image: memcached:1.6.9-alpine
           imagePullPolicy: IfNotPresent
           resources:
-            requests:
-              cpu: 10m
+            limits: null
+            requests: null
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -99,9 +99,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            requests:
-              cpu: 100m
-              memory: 512Mi
+            limits: null
           securityContext:
             readOnlyRootFilesystem: true
           env:


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

During the development of https://github.com/grafana/mimir/pull/2087 helm CI runs (call-lint-test / lint-test) started failing because pods could not be scheduled ([example](https://github.com/grafana/mimir/runs/7856053868?check_suite_focus=true)). The info at the end of the run which describes all pods showed the following for two pods:

```
Events:
  Type     Reason            Age                 From               Message
  ----     ------            ----                ----               -------
  Warning  FailedScheduling  11s (x13 over 10m)  default-scheduler  0/1 nodes are available: 1 Insufficient cpu.
```

GitHub hosted runners only have 2 CPUs and 7GB of memory ([docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)). 

This PR removes resource limits and requirements for some pods in the CI values files for Helm. This way Kubernetes won't have to calculate resource quotas. The caveat is that now CI runs may become less stable because of resource contention.

The changes here were cherry-picked onto the work in #2087 to demonstrate that they unblock the CI runs - [example run](https://github.com/grafana/mimir/runs/7858441654?check_suite_focus=true)

An alternative approach is to install self-hosted runners with more available CPU and memory. A second alternative is to migrate the CI runs to drone, for which we have bigger agents.
