### PR TITLE
Fix usage stats report resend logic to not generate a new report each time we retry sending it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710 #2725
 * [CHANGE] Limits: change the default value of `max_global_series_per_metric` limit to `0` (disabled). Setting this limit by default does not provide much benefit because series are sharded by all labels. #2714
-* [FEATURE] Introduced an experimental anonymous usage statistics tracking (disabled by default), to help Mimir maintainers driving better decisions to support the opensource community. The tracking system anonymously collects non-sensitive and non-personal identifiable information about the running Mimir cluster, and is disabled by default. #2643 #2662 #2685 #2732
+* [FEATURE] Introduced an experimental anonymous usage statistics tracking (disabled by default), to help Mimir maintainers driving better decisions to support the opensource community. The tracking system anonymously collects non-sensitive and non-personal identifiable information about the running Mimir cluster, and is disabled by default. #2643 #2662 #2685 #2732 #2735
 * [ENHANCEMENT] Distributor: Add `cortex_distributor_query_ingester_chunks_deduped_total` and `cortex_distributor_query_ingester_chunks_total` metrics for determining how effective ingester chunk deduplication at query time is. #2713
 * [ENHANCEMENT] Upgrade Docker base images to `alpine:3.16.2`. #2729
 * [ENHANCEMENT] Ruler: Add `<prometheus-http-prefix>/api/v1/status/buildinfo` endpoint. #2724

--- a/pkg/usagestats/report.go
+++ b/pkg/usagestats/report.go
@@ -47,7 +47,7 @@ type Report struct {
 }
 
 // buildReport builds the report to be sent to the stats server.
-func buildReport(seed ClusterSeed, reportAt time.Time, reportInterval time.Duration) Report {
+func buildReport(seed ClusterSeed, reportAt time.Time, reportInterval time.Duration) *Report {
 	var (
 		targetName  string
 		editionName string
@@ -63,7 +63,7 @@ func buildReport(seed ClusterSeed, reportAt time.Time, reportInterval time.Durat
 		}
 	}
 
-	return Report{
+	return &Report{
 		ClusterID:      seed.UID,
 		CreatedAt:      seed.CreatedAt,
 		Version:        buildVersion(),

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -109,8 +109,20 @@ func (r *Reporter) running(ctx context.Context) error {
 
 	level.Info(r.logger).Log("msg", "usage stats reporter initialized", "cluster_id", seed.UID)
 
-	// Find when to send the next report. We want all instances of the same Mimir cluster computing the same value.
-	nextReportAt := nextReport(r.reportSendInterval, seed.CreatedAt, time.Now())
+	// Keep track of the next report to send, so that we reuse the same on retries after send failures.
+	var nextReport *Report
+	var nextReportAt time.Time
+
+	// We define a function to update the timestamp of the next report to make sure
+	// we also reset the next report when doing it.
+	updateNextReportAt := func() {
+		// We want all instances of the same Mimir cluster computing the same value.
+		nextReportAt = getNextReportAt(r.reportSendInterval, seed.CreatedAt, time.Now())
+		nextReport = nil
+	}
+
+	// Find when to send the next report.
+	updateNextReportAt()
 
 	ticker := time.NewTicker(r.reportCheckInterval)
 	defer ticker.Stop()
@@ -125,20 +137,26 @@ func (r *Reporter) running(ctx context.Context) error {
 			// If the send is failing since a long time and the report is falling behind,
 			// we'll skip this one and try to send the next one.
 			if time.Since(nextReportAt) >= r.reportSendInterval {
-				nextReportAt = nextReport(r.reportSendInterval, seed.CreatedAt, time.Now())
+				updateNextReportAt()
 				level.Info(r.logger).Log("msg", "failed to send anonymous usage stats report for too long, skipping to next report", "next_report_at", nextReportAt.String())
 				continue
 			}
 
+			// We're going to send the report. If we already have it, then it means it's a retry after a failure,
+			// otherwise we have to generate a new one.
+			if nextReport == nil {
+				nextReport = buildReport(seed, nextReportAt, r.reportSendInterval)
+			}
+
 			level.Debug(r.logger).Log("msg", "sending anonymous usage stats report")
-			if err := r.sendReport(ctx, buildReport(seed, nextReportAt, r.reportSendInterval)); err != nil {
+			if err := r.sendReport(ctx, nextReport); err != nil {
 				level.Info(r.logger).Log("msg", "failed to send anonymous usage stats report", "err", err)
 
 				// We'll try at the next check interval.
 				continue
 			}
 
-			nextReportAt = nextReport(r.reportSendInterval, seed.CreatedAt, time.Now())
+			updateNextReportAt()
 		case <-ctx.Done():
 			if err := ctx.Err(); !errors.Is(err, context.Canceled) {
 				return err
@@ -149,7 +167,11 @@ func (r *Reporter) running(ctx context.Context) error {
 }
 
 // sendReport sends the report to the stats server.
-func (r *Reporter) sendReport(ctx context.Context, report Report) (returnErr error) {
+func (r *Reporter) sendReport(ctx context.Context, report *Report) (returnErr error) {
+	if report == nil {
+		return errors.New("no report provided")
+	}
+
 	startTime := time.Now()
 	r.requestsTotal.Inc()
 
@@ -196,9 +218,9 @@ func (r *Reporter) sendReport(ctx context.Context, report Report) (returnErr err
 	return nil
 }
 
-// nextReport compute the next report time based on the interval.
+// getNextReportAt compute the next report time based on the interval.
 // The interval is based off the creation of the cluster seed to avoid all cluster reporting at the same time.
-func nextReport(interval time.Duration, createdAt, now time.Time) time.Time {
+func getNextReportAt(interval time.Duration, createdAt, now time.Time) time.Time {
 	// createdAt * (x * interval ) >= now
 	return createdAt.Add(time.Duration(math.Ceil(float64(now.Sub(createdAt))/float64(interval))) * interval)
 }


### PR DESCRIPTION
#### What this PR does
While working on https://github.com/grafana/mimir/pull/2685 I realized it's not very good we regenerate a new report when we retry sending it after a failure. The main reason is that counter metrics are reset each time we generate a new report.

In this PR I'm proposing to resend the previously generated report when we resend it.

#### Which issue(s) this PR fixes or relates to

Part of #1815

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
