### PR TITLE
Update memcached image to 1.6.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Jsonnet
 
+* [ENHANCEMENT] Upgrade memcached image tag to `memcached:1.6.16-alpine`. #2740
+
 ### Mimirtool
 
 * [BUGFIX] Version checking no longer prompts for updating when already on latest version. #2723

--- a/development/tsdb-blocks-storage-s3/docker-compose.jsonnet
+++ b/development/tsdb-blocks-storage-s3/docker-compose.jsonnet
@@ -214,7 +214,7 @@ std.manifestYamlDoc({
 
   memcached:: {
     memcached: {
-      image: 'memcached:1.6',
+      image: 'memcached:1.6.16-alpine',
     },
   },
 

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -198,7 +198,7 @@
       - "16686:16686"
       - "14268"
   "memcached":
-    "image": "memcached:1.6"
+    "image": "memcached:1.6.16-alpine"
   "minio":
     "command":
       - "server"

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -27,6 +27,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Memberlist now uses DNS service-discovery by default. #2549 #2561
 * [ENHANCEMENT] The Mimir configuration parameters `server.http_listen_port` and `server.grpc_listen_port` are now configurable in `mimir.structuredConfig`. #2561
 * [ENHANCEMENT] Default to injecting the `no_auth_tenant` from the Mimir configuration as the value for `X-Scope-OrgID` in nginx. #2614
+* [ENHANCEMENT] Upgrade memcached image tag to `memcached:1.6.16-alpine`. #2740
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 * [BUGFIX] Add missing `containerSecurityContext` to alertmanager and tokengen job. #2416
 * [BUGFIX] Add missing `containerSecutiryContext` to memcached exporter containers. #2666

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [FEATURE] Add query-scheduler, which is now enabled by default. If you have copied the `mimir.config`, then update it to correctly configure the query-frontend and the querier. #2087
+* [ENHANCEMENT] Upgrade memcached image tag to `memcached:1.6.16-alpine`. #2740
 * [ENHANCEMENT] Upgrade nginx image tag to `nginxinc/nginx-unprivileged:1.22-alpine`. #2742
 
 ## 3.1.0
@@ -27,7 +28,6 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Memberlist now uses DNS service-discovery by default. #2549 #2561
 * [ENHANCEMENT] The Mimir configuration parameters `server.http_listen_port` and `server.grpc_listen_port` are now configurable in `mimir.structuredConfig`. #2561
 * [ENHANCEMENT] Default to injecting the `no_auth_tenant` from the Mimir configuration as the value for `X-Scope-OrgID` in nginx. #2614
-* [ENHANCEMENT] Upgrade memcached image tag to `memcached:1.6.16-alpine`. #2740
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 * [BUGFIX] Add missing `containerSecurityContext` to alertmanager and tokengen job. #2416
 * [BUGFIX] Add missing `containerSecutiryContext` to memcached exporter containers. #2666

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1131,7 +1131,7 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.6.9-alpine
+    tag: 1.6.16-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
 

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.9-alpine
+          image: memcached:1.6.16-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.9-alpine
+          image: memcached:1.6.16-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.9-alpine
+          image: memcached:1.6.16-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.9-alpine
+          image: memcached:1.6.16-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1388,7 +1388,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1441,7 +1441,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1494,7 +1494,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1547,7 +1547,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1442,7 +1442,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1495,7 +1495,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1548,7 +1548,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1601,7 +1601,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1881,7 +1881,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1934,7 +1934,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1987,7 +1987,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2040,7 +2040,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1332,7 +1332,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1385,7 +1385,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1438,7 +1438,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1491,7 +1491,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -855,7 +855,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -908,7 +908,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -961,7 +961,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1014,7 +1014,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -1088,7 +1088,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1141,7 +1141,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1194,7 +1194,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1158,7 +1158,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1211,7 +1211,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1264,7 +1264,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1317,7 +1317,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1087,7 +1087,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1140,7 +1140,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1193,7 +1193,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1246,7 +1246,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1093,7 +1093,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1146,7 +1146,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1199,7 +1199,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1252,7 +1252,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1099,7 +1099,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1152,7 +1152,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1205,7 +1205,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1258,7 +1258,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1093,7 +1093,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1146,7 +1146,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1199,7 +1199,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1252,7 +1252,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1442,7 +1442,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1495,7 +1495,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1548,7 +1548,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1601,7 +1601,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1526,7 +1526,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1579,7 +1579,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1632,7 +1632,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1685,7 +1685,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1526,7 +1526,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1579,7 +1579,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1632,7 +1632,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1685,7 +1685,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1526,7 +1526,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1579,7 +1579,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1632,7 +1632,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1685,7 +1685,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1526,7 +1526,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1579,7 +1579,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1632,7 +1632,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1685,7 +1685,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1090,7 +1090,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1143,7 +1143,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1196,7 +1196,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1249,7 +1249,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1087,7 +1087,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1140,7 +1140,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1193,7 +1193,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1246,7 +1246,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1546,7 +1546,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1599,7 +1599,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1652,7 +1652,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1705,7 +1705,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1718,7 +1718,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1771,7 +1771,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1824,7 +1824,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1877,7 +1877,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1092,7 +1092,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1145,7 +1145,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1198,7 +1198,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1251,7 +1251,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1390,7 +1390,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1443,7 +1443,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1496,7 +1496,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1549,7 +1549,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1389,7 +1389,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1495,7 +1495,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1548,7 +1548,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1096,7 +1096,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1149,7 +1149,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1202,7 +1202,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1255,7 +1255,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1097,7 +1097,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1150,7 +1150,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1203,7 +1203,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1256,7 +1256,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1099,7 +1099,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1152,7 +1152,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1205,7 +1205,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1258,7 +1258,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1087,7 +1087,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1140,7 +1140,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1193,7 +1193,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1246,7 +1246,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1094,7 +1094,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1147,7 +1147,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1200,7 +1200,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1253,7 +1253,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -753,7 +753,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -806,7 +806,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -859,7 +859,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -912,7 +912,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.9-alpine
+        image: memcached:1.6.16-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.9-alpine',
+    memcached: 'memcached:1.6.16-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.


### PR DESCRIPTION
#### What this PR does

Updates the memcached image tag used in jsonnet and helm from `memcached:1.6.9-alpine` to `memcached:1.6.16-alpine`

I read through the memcached changelogs and didn't find anything concerning. Performed a sanity test with a local helm install with metadata cache enabled and all pods started up as normal.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/829

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
