### PR TITLE
Add counter for chunks from ingesters entirely deduplicated (#2713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] Distributor: if forwarding rules are used to forward samples, exemplars are now removed from the request. #2710
 * [CHANGE] Limits: change the default value of `max_global_series_per_metric` limit to `0` (disabled). Setting this limit by default does not provide much benefit because series are sharded by all labels. #2714
+* [ENHANCEMENT] Distributor: Add `cortex_distributor_query_ingester_chunks_deduped_total` and `cortex_distributor_query_ingester_chunks_total` metrics for determining how effective ingester chunk deduplication at query time is. #2713
 * [BUGFIX] Fix reporting of tracing spans from PromQL engine. #2707
 * [BUGFIX] Distributor: Apply distributor instance limits before running HA deduplication. #2709
 * [BUGFIX] Apply relabel and drop_label rules before forwarding rules in the distributor. #2703

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -117,6 +117,8 @@ type Distributor struct {
 
 	// Metrics
 	queryDuration                    *instrument.HistogramCollector
+	ingesterChunksDeduplicated       prometheus.Counter
+	ingesterChunksTotal              prometheus.Counter
 	receivedSamples                  *prometheus.CounterVec
 	receivedExemplars                *prometheus.CounterVec
 	receivedMetadata                 *prometheus.CounterVec
@@ -237,6 +239,16 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			Help:      "Time spent executing expression and exemplar queries.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30},
 		}, []string{"method", "status_code"})),
+		ingesterChunksDeduplicated: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Name:      "distributor_query_ingester_chunks_deduped_total",
+			Help:      "Number of chunks deduplicated at query time from ingesters.",
+		}),
+		ingesterChunksTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Name:      "distributor_query_ingester_chunks_total",
+			Help:      "Number of chunks transferred at query time from ingesters.",
+		}),
 		receivedSamples: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex",
 			Name:      "distributor_received_samples_total",


### PR DESCRIPTION
Add a counter for tracking the number of chunks that could be entirely discarded
as duplicates of an existing chunk when querying ingesters. This is a requirement
of testing distributor <-> ingester timeout changes.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

cherry-pick of 8a13ad4995ef84eab7cb4340ce36610dee9cb15f