### PR TITLE
Add query-scheduler exceptions for jsonnet<>helm diff

### DIFF
--- a/operations/compare-helm-with-jsonnet/components/config/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/components/config/kustomization.yaml
@@ -34,7 +34,7 @@ patches:
 
   - target:
       kind: MimirConfig
-      name: 'alertmanager|compactor|distributor|ingester|overrides-exporter|querier|ruler|query-frontend'
+      name: 'alertmanager|compactor|distributor|ingester|overrides-exporter|querier|ruler|query-frontend|query-scheduler'
     patch: |-
       - op: remove
         path: /config/blocks_storage/bucket_store/index_cache
@@ -43,14 +43,14 @@ patches:
 
   - target:
       kind: MimirConfig
-      name: 'alertmanager|compactor|distributor|ingester|overrides-exporter|query-frontend'
+      name: 'alertmanager|compactor|distributor|ingester|overrides-exporter|query-frontend|query-scheduler'
     patch: |-
       - op: remove
         path: /config/blocks_storage/bucket_store/metadata_cache
 
   - target:
       kind: MimirConfig
-      name: 'alertmanager|compactor|distributor|ingester|overrides-exporter|querier|ruler|store-gateway'
+      name: 'alertmanager|compactor|distributor|ingester|overrides-exporter|querier|ruler|store-gateway|query-scheduler'
     patch: |-
       - op: remove
         path: /config/frontend

--- a/operations/compare-helm-with-jsonnet/helm/03-labels/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/helm/03-labels/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
 
   - target:
       kind: 'Deployment|StatefulSet'
-      name: 'mimir-(distributor|alertmanager|ingester|store-gateway|query-frontend|overrides-exporter|ruler|compactor|querier)'
+      name: 'mimir-(distributor|alertmanager|ingester|store-gateway|query-frontend|query-scheduler|overrides-exporter|ruler|compactor|querier)'
     patch: |-
       - op: remove
         path: /spec/template/metadata/annotations

--- a/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
 
   # TODO(logiraptor): Helm adds an emptyDir volume to several components. This is due to the fact that readOnlyRootFilesystem=true and some ephemeral data is written
   - target:
-      name: mimir-(distributor|query-frontend|querier|ruler|querier|overrides-exporter|alertmanager)
+      name: mimir-(distributor|query-frontend|query-scheduler|querier|ruler|querier|overrides-exporter|alertmanager)
       kind: Deployment|StatefulSet
     patch: |-
       - op: remove
@@ -49,7 +49,7 @@ patches:
 
   # Minor Difference: Helm names the overrides volume slightly differently
   - target:
-      name: mimir-(distributor|query-frontend|overrides-exporter|ruler|querier|alertmanager|ingester|store-gateway|compactor)
+      name: mimir-(distributor|query-frontend|query-scheduler|overrides-exporter|ruler|querier|alertmanager|ingester|store-gateway|compactor)
       kind: Deployment|StatefulSet
     patch: |-
       - op: replace

--- a/operations/compare-helm-with-jsonnet/jsonnet/01-ignore/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/01-ignore/kustomization.yaml
@@ -19,12 +19,6 @@ patches:
       kind: ConfigMap
     patch: *deletePatch
 
-  # TODO: Helm does not create a query scheduler
-  - target:
-      name: 'mimir-query-scheduler(-discovery)?'
-      kind: (Service|Deployment)
-    patch: *deletePatch
-
   # TODO: Helm does not create an alertmanager pdb
   - target:
       name: 'mimir-alertmanager-pdb'

--- a/operations/compare-helm-with-jsonnet/jsonnet/03-rename/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/03-rename/kustomization.yaml
@@ -42,6 +42,14 @@ patches:
         value: 'mimir-query-frontend-headless'
 
   - target:
+      kind: 'Service'
+      name: 'mimir-query-scheduler-discovery'
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: 'mimir-query-scheduler-headless'  
+
+  - target:
       kind: 'Service|StatefulSet'
       name: 'mimir-memcached-frontend'
     patch: |-

--- a/operations/compare-helm-with-jsonnet/jsonnet/04-labels/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/04-labels/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
 
   - target:
       kind: 'Service'
-      name: 'mimir-(alertmanager-headless|ruler|query-frontend(-headless)?|distributor(-headless)?|querier|(chunks|results|index|metadata)-cache)'
+      name: 'mimir-(alertmanager-headless|ruler|query-frontend(-headless)?|query-scheduler(-headless)?|distributor(-headless)?|querier|(chunks|results|index|metadata)-cache)'
     patch: |-
       - op: remove
         path: /metadata/labels

--- a/operations/compare-helm-with-jsonnet/jsonnet/06-services/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/06-services/kustomization.yaml
@@ -4,7 +4,7 @@ patches:
   # Minor difference: Jsonnet names service ports differently and uses numbers instead of names for targetPort
   - target:
       kind: Service
-      name: 'mimir-(overrides-exporter|store-gateway|query-frontend(-headless)?|querier|ingester|ruler|distributor-headless|compactor|alertmanager-headless)'
+      name: 'mimir-(overrides-exporter|store-gateway|query-frontend(-headless)?|query-scheduler(-headless)?|querier|ingester|ruler|distributor-headless|compactor|alertmanager-headless)'
     patch: |-
       - op: replace
         path: /spec/ports/0/name
@@ -16,7 +16,7 @@ patches:
   # Minor difference: Jsonnet names service ports differently and uses numbers instead of names for targetPort
   - target:
       kind: Service
-      name: 'mimir-(store-gateway|query-frontend(-headless)?|querier|ingester|ruler|distributor-headless|compactor|alertmanager-headless)'
+      name: 'mimir-(store-gateway|query-frontend(-headless)?|query-scheduler(-headless)?|querier|ingester|ruler|distributor-headless|compactor|alertmanager-headless)'
     patch: |-
       - op: replace
         path: /spec/ports/1/name


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

After merging #2087 the differences between helm and jsonnet reduced slightly. In turn I had to add the query-scheduler to many exceptions like labels, annotations, irrelevant config and service names.