### PR TITLE
Reduce usage of global Prometheus registerer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,9 @@ lint: check-makefiles
 		github.com/thanos-io/thanos/pkg/store/cache" \
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
+	# Ensure we never use the default registerer and we allow to use a custom one (improves testability).
+	faillint -paths="github.com/prometheus/client_golang/prometheus.{MustRegister,Register,DefaultRegisterer}" ./pkg/...
+
 format: ## Run gofmt and goimports.
 	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec gofmt -w -s {} \;
 	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec goimports -w -local github.com/grafana/mimir {} \;

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -185,7 +185,7 @@ func main() {
 	// Initialise seed for randomness usage.
 	rand.Seed(time.Now().UnixNano())
 
-	t, err := mimir.New(cfg)
+	t, err := mimir.New(cfg, prometheus.DefaultRegisterer)
 	util_log.CheckFatal("initializing application", err)
 
 	if mainFlags.printModules {

--- a/cmd/mimirtool/main.go
+++ b/cmd/mimirtool/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/mimir/pkg/mimirtool/commands"
@@ -45,7 +46,7 @@ func main() {
 	logConfig.Register(app, envVars)
 	pushGateway.Register(app, envVars)
 	remoteReadCommand.Register(app, envVars)
-	ruleCommand.Register(app, envVars)
+	ruleCommand.Register(app, envVars, prometheus.DefaultRegisterer)
 	backfillCommand.Register(app, envVars)
 
 	app.Command("version", "Get the version of the mimirtool CLI").Action(func(k *kingpin.ParseContext) error {

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -492,10 +492,6 @@ type Mimir struct {
 
 // New makes a new Mimir.
 func New(cfg Config, reg prometheus.Registerer) (*Mimir, error) {
-	if reg == nil {
-		return nil, errors.New("no Prometheus registerer provided")
-	}
-
 	if cfg.PrintConfig {
 		if err := yaml.NewEncoder(os.Stdout).Encode(&cfg); err != nil {
 			fmt.Println("Error encoding config:", err)

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -548,7 +548,9 @@ func (t *Mimir) setupThanosTracing() {
 func (t *Mimir) Run() error {
 	// Register custom process metrics.
 	if c, err := process.NewProcessCollector(); err == nil {
-		t.Registerer.MustRegister(c)
+		if t.Registerer != nil {
+			t.Registerer.MustRegister(c)
+		}
 	} else {
 		level.Warn(util_log.Logger).Log("msg", "skipped registration of custom process metrics collector", "err", err)
 	}

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/server"
@@ -151,7 +150,7 @@ func TestMimir(t *testing.T) {
 		Target: []string{All, AlertManager},
 	}
 
-	c, err := New(cfg, prometheus.NewPedanticRegistry())
+	c, err := New(cfg, nil)
 	require.NoError(t, err)
 
 	serviceMap, err := c.ModuleManager.InitModuleServices(cfg.Target...)
@@ -192,7 +191,7 @@ func TestMimirServerShutdownWithActivityTrackerEnabled(t *testing.T) {
 
 	util_log.InitLogger(&cfg.Server)
 
-	c, err := New(cfg, prometheus.NewPedanticRegistry())
+	c, err := New(cfg, nil)
 	require.NoError(t, err)
 
 	errCh := make(chan error)
@@ -389,7 +388,7 @@ func TestGrpcAuthMiddleware(t *testing.T) {
 
 	// Setup server, using Mimir config. This includes authentication middleware.
 	{
-		c, err := New(cfg, prometheus.NewPedanticRegistry())
+		c, err := New(cfg, nil)
 		require.NoError(t, err)
 
 		serv, err := c.initServer()

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/server"
@@ -150,7 +151,7 @@ func TestMimir(t *testing.T) {
 		Target: []string{All, AlertManager},
 	}
 
-	c, err := New(cfg, nil)
+	c, err := New(cfg, prometheus.NewPedanticRegistry())
 	require.NoError(t, err)
 
 	serviceMap, err := c.ModuleManager.InitModuleServices(cfg.Target...)
@@ -191,7 +192,7 @@ func TestMimirServerShutdownWithActivityTrackerEnabled(t *testing.T) {
 
 	util_log.InitLogger(&cfg.Server)
 
-	c, err := New(cfg, nil)
+	c, err := New(cfg, prometheus.NewPedanticRegistry())
 	require.NoError(t, err)
 
 	errCh := make(chan error)
@@ -388,7 +389,7 @@ func TestGrpcAuthMiddleware(t *testing.T) {
 
 	// Setup server, using Mimir config. This includes authentication middleware.
 	{
-		c, err := New(cfg, nil)
+		c, err := New(cfg, prometheus.NewPedanticRegistry())
 		require.NoError(t, err)
 
 		serv, err := c.initServer()

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -254,7 +254,9 @@ func (t *Mimir) initOverrides() (serv services.Service, err error) {
 
 func (t *Mimir) initOverridesExporter() (services.Service, error) {
 	exporter := validation.NewOverridesExporter(&t.Cfg.LimitsConfig, t.TenantLimits)
-	t.Registerer.MustRegister(exporter)
+	if t.Registerer != nil {
+		t.Registerer.MustRegister(exporter)
+	}
 
 	// the overrides exporter has no state and reads overrides for runtime configuration each time it
 	// is collected so there is no need to return any service

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -138,7 +138,7 @@ func (t *Mimir) initActivityTracker() (services.Service, error) {
 		level.Warn(l).Log("start", e.Timestamp.UTC().Format(time.RFC3339Nano), "activity", e.Activity)
 	}
 
-	at, err := activitytracker.NewActivityTracker(t.Cfg.ActivityTracker, prometheus.DefaultRegisterer)
+	at, err := activitytracker.NewActivityTracker(t.Cfg.ActivityTracker, t.Registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (t *Mimir) initServer() (services.Service, error) {
 }
 
 func (t *Mimir) initRing() (serv services.Service, err error) {
-	t.Ring, err = ring.New(t.Cfg.Ingester.IngesterRing.ToRingConfig(), "ingester", ingester.IngesterRingKey, util_log.Logger, prometheus.WrapRegistererWithPrefix("cortex_", prometheus.DefaultRegisterer))
+	t.Ring, err = ring.New(t.Cfg.Ingester.IngesterRing.ToRingConfig(), "ingester", ingester.IngesterRingKey, util_log.Logger, prometheus.WrapRegistererWithPrefix("cortex_", t.Registerer))
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func (t *Mimir) initRuntimeConfig() (services.Service, error) {
 	// make sure to set default limits before we start loading configuration into memory
 	validation.SetDefaultLimitsForYAMLUnmarshalling(t.Cfg.LimitsConfig)
 
-	serv, err := runtimeconfig.New(t.Cfg.RuntimeConfig, prometheus.WrapRegistererWithPrefix("cortex_", prometheus.DefaultRegisterer), util_log.Logger)
+	serv, err := runtimeconfig.New(t.Cfg.RuntimeConfig, prometheus.WrapRegistererWithPrefix("cortex_", t.Registerer), util_log.Logger)
 	if err == nil {
 		// TenantLimits just delegates to RuntimeConfig and doesn't have any state or need to do
 		// anything in the start/stopping phase. Thus we can create it as part of runtime config
@@ -254,7 +254,7 @@ func (t *Mimir) initOverrides() (serv services.Service, err error) {
 
 func (t *Mimir) initOverridesExporter() (services.Service, error) {
 	exporter := validation.NewOverridesExporter(&t.Cfg.LimitsConfig, t.TenantLimits)
-	prometheus.MustRegister(exporter)
+	t.Registerer.MustRegister(exporter)
 
 	// the overrides exporter has no state and reads overrides for runtime configuration each time it
 	// is collected so there is no need to return any service
@@ -277,7 +277,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 	// ruler's dependency)
 	canJoinDistributorsRing := t.Cfg.isModuleEnabled(Distributor) || t.Cfg.isModuleEnabled(All)
 
-	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.Ring, canJoinDistributorsRing, prometheus.DefaultRegisterer, util_log.Logger)
+	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.Ring, canJoinDistributorsRing, t.Registerer, util_log.Logger)
 	if err != nil {
 		return
 	}
@@ -294,7 +294,7 @@ func (t *Mimir) initDistributor() (serv services.Service, err error) {
 // initQueryable instantiates the queryable and promQL engine used to service queries to
 // Mimir. It also registers the API endpoints associated with those two services.
 func (t *Mimir) initQueryable() (serv services.Service, err error) {
-	querierRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, prometheus.DefaultRegisterer)
+	querierRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, t.Registerer)
 
 	// Create a querier queryable and PromQL engine
 	t.QuerierQueryable, t.ExemplarQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, querierRegisterer, util_log.Logger, t.ActivityTracker)
@@ -382,7 +382,7 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 		t.MetadataSupplier,
 		t.QuerierEngine,
 		t.Distributor,
-		prometheus.DefaultRegisterer,
+		t.Registerer,
 		util_log.Logger,
 		t.Overrides,
 	)
@@ -424,14 +424,14 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 	}
 
 	t.Cfg.Worker.MaxConcurrentRequests = t.Cfg.Querier.EngineConfig.MaxConcurrent
-	return querier_worker.NewQuerierWorker(t.Cfg.Worker, httpgrpc_server.NewServer(internalQuerierRouter), util_log.Logger, prometheus.DefaultRegisterer)
+	return querier_worker.NewQuerierWorker(t.Cfg.Worker, httpgrpc_server.NewServer(internalQuerierRouter), util_log.Logger, t.Registerer)
 }
 
 func (t *Mimir) initStoreQueryables() (services.Service, error) {
 	var servs []services.Service
 
 	//nolint:golint // I prefer this form over removing 'else', because it allows q to have smaller scope.
-	if q, err := querier.NewBlocksStoreQueryableFromConfig(t.Cfg.Querier, t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer); err != nil {
+	if q, err := querier.NewBlocksStoreQueryableFromConfig(t.Cfg.Querier, t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, t.Registerer); err != nil {
 		return nil, fmt.Errorf("failed to initialize querier: %v", err)
 	} else {
 		t.StoreQueryables = append(t.StoreQueryables, querier.UseAlwaysQueryable(q))
@@ -462,7 +462,7 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.InstanceLimitsFn = ingesterInstanceLimits(t.RuntimeConfig)
 	t.tsdbIngesterConfig()
 
-	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Overrides, prometheus.DefaultRegisterer, util_log.Logger)
+	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Overrides, t.Registerer, util_log.Logger)
 	if err != nil {
 		return
 	}
@@ -488,7 +488,7 @@ func (t *Mimir) initFlusher() (serv services.Service, err error) {
 		t.Cfg.Flusher,
 		t.Cfg.Ingester,
 		t.Overrides,
-		prometheus.DefaultRegisterer,
+		t.Registerer,
 		util_log.Logger,
 	)
 	if err != nil {
@@ -501,7 +501,7 @@ func (t *Mimir) initFlusher() (serv services.Service, err error) {
 // initQueryFrontendTripperware instantiates the tripperware used by the query frontend
 // to optimize Prometheus query requests.
 func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error) {
-	promqlEngineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "query-frontend"}, prometheus.DefaultRegisterer)
+	promqlEngineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "query-frontend"}, t.Registerer)
 
 	tripperware, err := querymiddleware.NewTripperware(
 		t.Cfg.Frontend.QueryMiddleware,
@@ -510,7 +510,7 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		querymiddleware.PrometheusCodec,
 		querymiddleware.PrometheusResponseExtractor{},
 		engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer),
-		prometheus.DefaultRegisterer,
+		t.Registerer,
 	)
 	if err != nil {
 		return nil, err
@@ -521,7 +521,7 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 }
 
 func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
-	roundTripper, frontendV1, frontendV2, err := frontend.InitFrontend(t.Cfg.Frontend, t.Overrides, t.Cfg.Server.GRPCListenPort, util_log.Logger, prometheus.DefaultRegisterer)
+	roundTripper, frontendV1, frontendV2, err := frontend.InitFrontend(t.Cfg.Frontend, t.Overrides, t.Cfg.Server.GRPCListenPort, util_log.Logger, t.Registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +529,7 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 	// Wrap roundtripper into Tripperware.
 	roundTripper = t.QueryFrontendTripperware(roundTripper)
 
-	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, prometheus.DefaultRegisterer)
+	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, t.Registerer)
 	t.API.RegisterQueryFrontendHandler(handler, t.BuildInfoHandler)
 
 	if frontendV1 != nil {
@@ -553,7 +553,7 @@ func (t *Mimir) initRulerStorage() (serv services.Service, err error) {
 		return
 	}
 
-	t.RulerStorage, err = ruler.NewRuleStore(context.Background(), t.Cfg.RulerStorage, t.Overrides, rules.FileLoader{}, util_log.Logger, prometheus.DefaultRegisterer)
+	t.RulerStorage, err = ruler.NewRuleStore(context.Background(), t.Cfg.RulerStorage, t.Overrides, rules.FileLoader{}, util_log.Logger, t.Registerer)
 	return
 }
 
@@ -588,7 +588,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		var queryable, federatedQueryable prom_storage.Queryable
 
 		// TODO: Consider wrapping logger to differentiate from querier module logger
-		rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
+		rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, t.Registerer)
 
 		queryable, _, eng := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, rulerRegisterer, util_log.Logger, t.ActivityTracker)
 		queryable = querier.NewErrorTranslateQueryableWithFn(queryable, ruler.WrapQueryableErrors)
@@ -621,7 +621,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		embeddedQueryable,
 		queryFunc,
 		t.Overrides,
-		prometheus.DefaultRegisterer,
+		t.Registerer,
 	)
 
 	// We need to prefix and add a label to the metrics for the DNS resolver because, unlike other mimir components,
@@ -630,12 +630,12 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		"cortex_",
 		prometheus.WrapRegistererWith(
 			prometheus.Labels{"component": "ruler"},
-			prometheus.DefaultRegisterer,
+			t.Registerer,
 		),
 	)
 
 	dnsResolver := dns.NewProvider(util_log.Logger, dnsProviderReg, dns.GolangResolverType)
-	manager, err := ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, managerFactory, prometheus.DefaultRegisterer, util_log.Logger, dnsResolver)
+	manager, err := ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, managerFactory, t.Registerer, util_log.Logger, dnsResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +643,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 	t.Ruler, err = ruler.NewRuler(
 		t.Cfg.Ruler,
 		manager,
-		prometheus.DefaultRegisterer,
+		t.Registerer,
 		util_log.Logger,
 		t.RulerStorage,
 		t.Overrides,
@@ -665,12 +665,12 @@ func (t *Mimir) initAlertManager() (serv services.Service, err error) {
 	t.Cfg.Alertmanager.ShardingRing.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Alertmanager.CheckExternalURL(t.Cfg.API.AlertmanagerHTTPPrefix, util_log.Logger)
 
-	store, err := alertstore.NewAlertStore(context.Background(), t.Cfg.AlertmanagerStorage, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer)
+	store, err := alertstore.NewAlertStore(context.Background(), t.Cfg.AlertmanagerStorage, t.Overrides, util_log.Logger, t.Registerer)
 	if err != nil {
 		return
 	}
 
-	t.Alertmanager, err = alertmanager.NewMultitenantAlertmanager(&t.Cfg.Alertmanager, store, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer)
+	t.Alertmanager, err = alertmanager.NewMultitenantAlertmanager(&t.Cfg.Alertmanager, store, t.Overrides, util_log.Logger, t.Registerer)
 	if err != nil {
 		return
 	}
@@ -682,7 +682,7 @@ func (t *Mimir) initAlertManager() (serv services.Service, err error) {
 func (t *Mimir) initCompactor() (serv services.Service, err error) {
 	t.Cfg.Compactor.ShardingRing.ListenPort = t.Cfg.Server.GRPCListenPort
 
-	t.Compactor, err = compactor.NewMultitenantCompactor(t.Cfg.Compactor, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer)
+	t.Compactor, err = compactor.NewMultitenantCompactor(t.Cfg.Compactor, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, t.Registerer)
 	if err != nil {
 		return
 	}
@@ -695,7 +695,7 @@ func (t *Mimir) initCompactor() (serv services.Service, err error) {
 func (t *Mimir) initStoreGateway() (serv services.Service, err error) {
 	t.Cfg.StoreGateway.ShardingRing.ListenPort = t.Cfg.Server.GRPCListenPort
 
-	t.StoreGateway, err = storegateway.NewStoreGateway(t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, t.Cfg.Server.LogLevel, util_log.Logger, prometheus.DefaultRegisterer, t.ActivityTracker)
+	t.StoreGateway, err = storegateway.NewStoreGateway(t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, t.Cfg.Server.LogLevel, util_log.Logger, t.Registerer, t.ActivityTracker)
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +707,7 @@ func (t *Mimir) initStoreGateway() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initMemberlistKV() (services.Service, error) {
-	reg := prometheus.DefaultRegisterer
+	reg := t.Registerer
 	t.Cfg.MemberlistKV.MetricsRegisterer = reg
 	t.Cfg.MemberlistKV.Codecs = []codec.Codec{
 		ring.GetCodec(),
@@ -735,7 +735,7 @@ func (t *Mimir) initMemberlistKV() (services.Service, error) {
 }
 
 func (t *Mimir) initQueryScheduler() (services.Service, error) {
-	s, err := scheduler.NewScheduler(t.Cfg.QueryScheduler, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer)
+	s, err := scheduler.NewScheduler(t.Cfg.QueryScheduler, t.Overrides, util_log.Logger, t.Registerer)
 	if err != nil {
 		return nil, errors.Wrap(err, "query-scheduler init")
 	}
@@ -755,7 +755,7 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 		return nil, nil
 	}
 
-	bucketClient, err := bucket.NewClient(context.Background(), t.Cfg.BlocksStorage.Bucket, "usage-stats", util_log.Logger, prometheus.DefaultRegisterer)
+	bucketClient, err := bucket.NewClient(context.Background(), t.Cfg.BlocksStorage.Bucket, "usage-stats", util_log.Logger, t.Registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +763,7 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 	// Track anonymous usage statistics.
 	usagestats.GetString("blocks_storage_backend").Set(t.Cfg.BlocksStorage.Bucket.Backend)
 
-	t.UsageStatsReporter = usagestats.NewReporter(bucketClient, util_log.Logger, prometheus.DefaultRegisterer)
+	t.UsageStatsReporter = usagestats.NewReporter(bucketClient, util_log.Logger, t.Registerer)
 	return t.UsageStatsReporter, nil
 }
 

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/server"
@@ -27,8 +26,7 @@ func TestAPIConfig(t *testing.T) {
 	actualCfg := newDefaultConfig()
 
 	mimir := &Mimir{
-		Server:     &server.Server{},
-		Registerer: prometheus.NewPedanticRegistry(),
+		Server: &server.Server{},
 	}
 
 	for _, tc := range []struct {
@@ -147,9 +145,8 @@ func TestMimir_InitRulerStorage(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			mimir := &Mimir{
-				Server:     &server.Server{},
-				Cfg:        *testData.config,
-				Registerer: prometheus.NewPedanticRegistry(),
+				Server: &server.Server{},
+				Cfg:    *testData.config,
 			}
 
 			_, err := mimir.initRulerStorage()
@@ -219,7 +216,7 @@ func TestMultiKVSetup(t *testing.T) {
 			// Must be set, otherwise MultiKV config provider will not be set.
 			cfg.RuntimeConfig.LoadPath = []string{filepath.Join(dir, "config.yaml")}
 
-			c, err := New(cfg, prometheus.NewPedanticRegistry())
+			c, err := New(cfg, nil)
 			require.NoError(t, err)
 
 			_, err = c.ModuleManager.InitModuleServices(cfg.Target...)

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/server"
@@ -26,7 +27,7 @@ func TestAPIConfig(t *testing.T) {
 	actualCfg := newDefaultConfig()
 
 	mimir := &Mimir{
-		Server: &server.Server{},
+		Server: &server.Server{Registerer: prometheus.NewPedanticRegistry()},
 	}
 
 	for _, tc := range []struct {
@@ -145,7 +146,7 @@ func TestMimir_InitRulerStorage(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			mimir := &Mimir{
-				Server: &server.Server{},
+				Server: &server.Server{Registerer: prometheus.NewPedanticRegistry()},
 				Cfg:    *testData.config,
 			}
 
@@ -216,7 +217,7 @@ func TestMultiKVSetup(t *testing.T) {
 			// Must be set, otherwise MultiKV config provider will not be set.
 			cfg.RuntimeConfig.LoadPath = []string{filepath.Join(dir, "config.yaml")}
 
-			c, err := New(cfg, nil)
+			c, err := New(cfg, prometheus.NewPedanticRegistry())
 			require.NoError(t, err)
 
 			_, err = c.ModuleManager.InitModuleServices(cfg.Target...)

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/server"
@@ -26,7 +27,8 @@ func TestAPIConfig(t *testing.T) {
 	actualCfg := newDefaultConfig()
 
 	mimir := &Mimir{
-		Server: &server.Server{},
+		Server:     &server.Server{},
+		Registerer: prometheus.NewPedanticRegistry(),
 	}
 
 	for _, tc := range []struct {
@@ -145,8 +147,9 @@ func TestMimir_InitRulerStorage(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			mimir := &Mimir{
-				Server: &server.Server{},
-				Cfg:    *testData.config,
+				Server:     &server.Server{},
+				Cfg:        *testData.config,
+				Registerer: prometheus.NewPedanticRegistry(),
 			}
 
 			_, err := mimir.initRulerStorage()
@@ -206,8 +209,6 @@ func TestMultiKVSetup(t *testing.T) {
 		},
 	} {
 		t.Run(target, func(t *testing.T) {
-			prepareGlobalMetricsRegistry(t)
-
 			cfg := Config{}
 			flagext.DefaultValues(&cfg)
 			// Set to 0 to find any free port.
@@ -218,7 +219,7 @@ func TestMultiKVSetup(t *testing.T) {
 			// Must be set, otherwise MultiKV config provider will not be set.
 			cfg.RuntimeConfig.LoadPath = []string{filepath.Join(dir, "config.yaml")}
 
-			c, err := New(cfg)
+			c, err := New(cfg, prometheus.NewPedanticRegistry())
 			require.NoError(t, err)
 
 			_, err = c.ModuleManager.InitModuleServices(cfg.Target...)

--- a/pkg/mimir/server_service_test.go
+++ b/pkg/mimir/server_service_test.go
@@ -17,14 +17,7 @@ import (
 )
 
 func TestServerStopViaContext(t *testing.T) {
-	// server registers some metrics to default registry
-	savedRegistry := prometheus.DefaultRegisterer
-	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-	defer func() {
-		prometheus.DefaultRegisterer = savedRegistry
-	}()
-
-	serv, err := server.New(server.Config{})
+	serv, err := server.New(server.Config{Registerer: prometheus.NewPedanticRegistry()})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -38,14 +31,7 @@ func TestServerStopViaContext(t *testing.T) {
 }
 
 func TestServerStopViaShutdown(t *testing.T) {
-	// server registers some metrics to default registry
-	savedRegistry := prometheus.DefaultRegisterer
-	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-	defer func() {
-		prometheus.DefaultRegisterer = savedRegistry
-	}()
-
-	serv, err := server.New(server.Config{})
+	serv, err := server.New(server.Config{Registerer: prometheus.NewPedanticRegistry()})
 	require.NoError(t, err)
 
 	s := NewServerService(serv, func() []services.Service { return nil })
@@ -59,14 +45,7 @@ func TestServerStopViaShutdown(t *testing.T) {
 }
 
 func TestServerStopViaStop(t *testing.T) {
-	// server registers some metrics to default registry
-	savedRegistry := prometheus.DefaultRegisterer
-	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-	defer func() {
-		prometheus.DefaultRegisterer = savedRegistry
-	}()
-
-	serv, err := server.New(server.Config{})
+	serv, err := server.New(server.Config{Registerer: prometheus.NewPedanticRegistry()})
 	require.NoError(t, err)
 
 	s := NewServerService(serv, func() []services.Service { return nil })

--- a/pkg/mimirtool/commands/bucket_validation.go
+++ b/pkg/mimirtool/commands/bucket_validation.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -121,7 +120,7 @@ func (b *BucketValidationCommand) validate(k *kingpin.ParseContext) error {
 	b.logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	ctx := context.Background()
 
-	bucketClient, err := bucket.NewClient(ctx, b.cfg, "testClient", b.logger, prometheus.DefaultRegisterer)
+	bucketClient, err := bucket.NewClient(ctx, b.cfg, "testClient", b.logger, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create the bucket client")
 	}

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -92,8 +92,8 @@ type RuleCommand struct {
 }
 
 // Register rule related commands and flags with the kingpin application
-func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames) {
-	rulesCmd := app.Command("rules", "View and edit rules stored in Grafan Mimir.").PreAction(r.setup)
+func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, reg prometheus.Registerer) {
+	rulesCmd := app.Command("rules", "View and edit rules stored in Grafan Mimir.").PreAction(func(k *kingpin.ParseContext) error { return r.setup(k, reg) })
 	rulesCmd.Flag("user", fmt.Sprintf("API user to use when contacting Grafana Mimir; alternatively, set %s. If empty, %s is used instead.", envVars.APIUser, envVars.TenantID)).Default("").Envar(envVars.APIUser).StringVar(&r.ClientConfig.User)
 	rulesCmd.Flag("key", "API key to use when contacting Grafana Mimir; alternatively, set "+envVars.APIKey+".").Default("").Envar(envVars.APIKey).StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with (deprecated)").Default(rules.MimirBackend).EnumVar(&r.Backend, backends...)
@@ -239,8 +239,8 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames) {
 	listCmd.Flag("disable-color", "disable colored output").BoolVar(&r.DisableColor)
 }
 
-func (r *RuleCommand) setup(k *kingpin.ParseContext) error {
-	prometheus.MustRegister(
+func (r *RuleCommand) setup(_ *kingpin.ParseContext, reg prometheus.Registerer) error {
+	reg.MustRegister(
 		ruleLoadTimestamp,
 		ruleLoadSuccessTimestamp,
 	)

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -66,7 +67,7 @@ func metricReasonFromErrorID(id globalerror.ID) string {
 }
 
 // DiscardedRequests is a metric of the number of discarded requests.
-var DiscardedRequests = prometheus.NewCounterVec(
+var DiscardedRequests = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cortex_discarded_requests_total",
 		Help: "The total number of requests that were discarded due to rate limiting.",
@@ -75,7 +76,7 @@ var DiscardedRequests = prometheus.NewCounterVec(
 )
 
 // DiscardedSamples is a metric of the number of discarded samples, by reason.
-var DiscardedSamples = prometheus.NewCounterVec(
+var DiscardedSamples = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cortex_discarded_samples_total",
 		Help: "The total number of samples that were discarded.",
@@ -84,7 +85,7 @@ var DiscardedSamples = prometheus.NewCounterVec(
 )
 
 // DiscardedExemplars is a metric of the number of discarded exemplars, by reason.
-var DiscardedExemplars = prometheus.NewCounterVec(
+var DiscardedExemplars = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cortex_discarded_exemplars_total",
 		Help: "The total number of exemplars that were discarded.",
@@ -93,20 +94,13 @@ var DiscardedExemplars = prometheus.NewCounterVec(
 )
 
 // DiscardedMetadata is a metric of the number of discarded metadata, by reason.
-var DiscardedMetadata = prometheus.NewCounterVec(
+var DiscardedMetadata = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cortex_discarded_metadata_total",
 		Help: "The total number of metadata that were discarded.",
 	},
 	[]string{discardReasonLabel, "user"},
 )
-
-func init() {
-	prometheus.MustRegister(DiscardedRequests)
-	prometheus.MustRegister(DiscardedSamples)
-	prometheus.MustRegister(DiscardedExemplars)
-	prometheus.MustRegister(DiscardedMetadata)
-}
 
 // SampleValidationConfig helps with getting required config to validate sample.
 type SampleValidationConfig interface {


### PR DESCRIPTION
#### What this PR does
I'm working to add read-write deployment mode support to Mimir and I've found it's annoying to unit test because of the usage of the global Prometheus registerer. Long time ago we started a code cleanup to avoid using it and I think we're very close.

In this PR I'm removing the usage of `prometheus.{MustRegister,Register,DefaultRegisterer}` from `pkg/...`. This unblocks my work on read-write deployment mode.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
