### PR TITLE
Made some tweaks to the documentation for the block upload functionality

### DIFF
--- a/docs/sources/operators-guide/configure/configure-tsdb-block-upload.md
+++ b/docs/sources/operators-guide/configure/configure-tsdb-block-upload.md
@@ -10,7 +10,7 @@ weight: 120
 Grafana Mimir supports uploading of historic TSDB blocks, sourced from Prometheus, Cortex, or even other
 Grafana Mimir installations. Upload from Thanos is currently not supported; for more information, see [Known limitations of TSDB block upload]({{< relref "#known-limitations-of-tsdb-block-upload" >}}).
 
-To make performing block upload simple, we've built support for it into Mimir's CLI tool, [mimirtool]({{< relref "../tools/mimirtool.md" >}})). See the [mimirtool backfill]({{< relref "../tools/mimirtool.md#backfill" >}}) documentation to learn more. 
+To make performing block upload simple, we've built support for it into Mimir's CLI tool, [mimirtool]({{< relref "../tools/mimirtool.md" >}})). See the [mimirtool backfill]({{< relref "../tools/mimirtool.md#backfill" >}}) documentation to learn more.
 
 Block upload is still considered experimental and is therefore disabled by default. You can enable it via the `-compactor.block-upload-enabled`
 CLI flag, or via the corresponding `limits.compactor_block_upload_enabled` configuration parameter:
@@ -47,9 +47,9 @@ For information about limitations that relate to importing blocks from Thanos as
 
 ### No validation on imported blocks
 
-Grafana Mimir does not validate that the uploaded blocks are well-formed. This means that users could upload malformed blocks to Grafana Mimir. These malformed blocks could potentially cause problems on the Mimir query path or for the operation of Mimir's compactor component.  
+Grafana Mimir does not validate that the uploaded blocks are well-formed. This means that users could upload malformed blocks to Grafana Mimir. These malformed blocks could potentially cause problems on the Mimir query path or for the operation of Mimir's compactor component.
 
-We intend to add validation of uploaded blocks in a future release, which would allow us to identify and reject malformed blocks at upload time and prevent any downstream impact to Grafana Mimir. 
+We intend to add validation of uploaded blocks in a future release, which would allow us to identify and reject malformed blocks at upload time and prevent any downstream impact to Grafana Mimir.
 
 ### The results-cache needs flushing
 

--- a/docs/sources/operators-guide/configure/configure-tsdb-block-upload.md
+++ b/docs/sources/operators-guide/configure/configure-tsdb-block-upload.md
@@ -8,7 +8,7 @@ weight: 120
 # Configure TSDB block upload
 
 Grafana Mimir supports uploading of historic TSDB blocks, sourced from Prometheus, Cortex, or even other
-Grafana Mimir installations. Upload from Thanos is currently not supported; for more information, see [Known limitations of TSDB block upload]({{< relref "#known-limitations-of-TSDB-block-upload" >}}).
+Grafana Mimir installations. Upload from Thanos is currently not supported; for more information, see [Known limitations of TSDB block upload]({{< relref "#known-limitations-of-tsdb-block-upload" >}}).
 
 To make performing block upload simple, we've built support for it into Mimir's CLI tool, [mimirtool]({{< relref "../tools/mimirtool.md" >}})). See the [mimirtool backfill]({{< relref "../tools/mimirtool.md#backfill" >}}) documentation to learn more. 
 

--- a/docs/sources/operators-guide/configure/configure-tsdb-block-upload.md
+++ b/docs/sources/operators-guide/configure/configure-tsdb-block-upload.md
@@ -7,15 +7,12 @@ weight: 120
 
 # Configure TSDB block upload
 
-Grafana Mimir supports uploading of historic TSDB blocks, sourced from f.ex. Prometheus or
-Grafana Mimir itself.
+Grafana Mimir supports uploading of historic TSDB blocks, sourced from Prometheus, Cortex, or even other
+Grafana Mimir installations. Upload from Thanos is currently not supported; for more information, see [Known limitations of TSDB block upload]({{< relref "#known-limitations-of-TSDB-block-upload" >}}).
 
-For information about limitations that relate to importing blocks from Thanos, see
-[Migrating from Thanos or Prometheus to Grafana Mimir]({{< relref "../../migration-guide/migrating-from-thanos-or-prometheus.md" >}}).
+To make performing block upload simple, we've built support for it into Mimir's CLI tool, [mimirtool]({{< relref "../tools/mimirtool.md" >}})). See the [mimirtool backfill]({{< relref "../tools/mimirtool.md#backfill" >}}) documentation to learn more. 
 
-To upload blocks, refer to the [mimirtool backfill]({{< relref "../tools/mimirtool.md#backfill" >}}) command.
-
-The functionality is disabled by default, but you can enable it via the `-compactor.block-upload-enabled`
+Block upload is still considered experimental and is therefore disabled by default. You can enable it via the `-compactor.block-upload-enabled`
 CLI flag, or via the corresponding `limits.compactor_block_upload_enabled` configuration parameter:
 
 ```yaml
@@ -41,6 +38,19 @@ overrides:
 
 ## Known limitations of TSDB block upload
 
+### Thanos blocks cannot be uploaded
+
+Because Thanos blocks contain unsupported labels among their metadata, they cannot be uploaded.
+
+For information about limitations that relate to importing blocks from Thanos as well as existing workarounds, see
+[Migrating from Thanos or Prometheus to Grafana Mimir]({{< relref "../../migration-guide/migrating-from-thanos-or-prometheus.md" >}}).
+
+### No validation on imported blocks
+
+Grafana Mimir does not validate that the uploaded blocks are well-formed. This means that users could upload malformed blocks to Grafana Mimir. These malformed blocks could potentially cause problems on the Mimir query path or for the operation of Mimir's compactor component.  
+
+We intend to add validation of uploaded blocks in a future release, which would allow us to identify and reject malformed blocks at upload time and prevent any downstream impact to Grafana Mimir. 
+
 ### The results-cache needs flushing
 
 After uploading one or more blocks, the results-cache needs flushing. The reason is that Grafana Mimir caches query results
@@ -54,7 +64,3 @@ When queriers receive a query for a given [start, end] period, they consult this
 data from storage, ingesters, or both. Say `-querier.query-store-after` is set to `12h`. It means that a query
 `[now-13h, now]` will read data from storage. But a query `[now-5h, now]` will _not_. If a user uploads blocks that are
 “too new”, the querier may not query them, because it is configured to only query ingesters for “fresh” time ranges.
-
-### Thanos blocks cannot be uploaded
-
-Because Thanos blocks contain unsupported labels among their metadata, they cannot be uploaded.

--- a/docs/sources/operators-guide/tools/mimirtool.md
+++ b/docs/sources/operators-guide/tools/mimirtool.md
@@ -878,7 +878,7 @@ The only parameter of the script is a file containing the flags, with each flag 
 
 ### Backfill
 
-The `backfill` command uploads Prometheus TSDB blocks into Grafana Mimir, by using the block-upload API that is exposed by the compactor component.
+The `backfill` command uploads Prometheus TSDB blocks into Grafana Mimir, by using the [block-upload API that is exposed by the compactor component]({{< relref "../reference-http-api/index.md#compactor" >}}).
 
 If the command is interrupted, you can restart it. Mimirtool detects which blocks are already uploaded, and will only upload unfinished or new blocks.
 


### PR DESCRIPTION
In particular, called out the fact that we today don't validate blocks at upload time, though we do eventually intend to do this. 