### PR TITLE
move certain distributor metrics into their own middleware

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -643,6 +643,7 @@ func (d *Distributor) wrapPushWithMiddlewares(next push.Func) push.Func {
 	// To guarantee that, middleware functions will be called in reversed order, wrapping the
 	// result from previous call.
 	middlewares = append(middlewares, d.instanceLimitsMiddleware) // should run first
+	middlewares = append(middlewares, d.metricsMiddleware)
 	middlewares = append(middlewares, d.prePushHaDedupeMiddleware)
 	middlewares = append(middlewares, d.prePushRelabelMiddleware)
 	middlewares = append(middlewares, d.prePushForwardingMiddleware)
@@ -811,6 +812,39 @@ func (d *Distributor) prePushForwardingMiddleware(next push.Func) push.Func {
 	}
 }
 
+// metricsMiddleware updates metrics which are expected to account for all received data,
+// including data that later gets modified or dropped.
+func (d *Distributor) metricsMiddleware(next push.Func) push.Func {
+	return func(ctx context.Context, req *mimirpb.WriteRequest, cleanup func()) (*mimirpb.WriteResponse, error) {
+		cleanupInDefer := true
+		defer func() {
+			if cleanupInDefer {
+				cleanup()
+			}
+		}()
+
+		userID, err := tenant.TenantID(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		numSamples := 0
+		numExemplars := 0
+		for _, ts := range req.Timeseries {
+			numSamples += len(ts.Samples)
+			numExemplars += len(ts.Exemplars)
+		}
+
+		d.incomingRequests.WithLabelValues(userID).Inc()
+		d.incomingSamples.WithLabelValues(userID).Add(float64(numSamples))
+		d.incomingExemplars.WithLabelValues(userID).Add(float64(numExemplars))
+		d.incomingMetadata.WithLabelValues(userID).Add(float64(len(req.Metadata)))
+
+		cleanupInDefer = false
+		return next(ctx, req, cleanup)
+	}
+}
+
 // instanceLimitsMiddleware checks for instance limits and rejects request if this instance cannot process it at the moment.
 func (d *Distributor) instanceLimitsMiddleware(next push.Func) push.Func {
 	return func(ctx context.Context, req *mimirpb.WriteRequest, callerCleanup func()) (*mimirpb.WriteResponse, error) {
@@ -832,11 +866,6 @@ func (d *Distributor) instanceLimitsMiddleware(next push.Func) push.Func {
 			}
 		}()
 
-		userID, err := tenant.TenantID(ctx)
-		if err != nil {
-			return nil, err
-		}
-
 		if d.cfg.InstanceLimits.MaxInflightPushRequests > 0 && inflight > int64(d.cfg.InstanceLimits.MaxInflightPushRequests) {
 			return nil, errMaxInflightRequestsReached
 		}
@@ -851,9 +880,6 @@ func (d *Distributor) instanceLimitsMiddleware(next push.Func) push.Func {
 			}
 		}
 
-		// Increment counter for per-tenant requests here before potentially discarding them due to HA
-		// dedupe or forwarding rules.
-		d.incomingRequests.WithLabelValues(userID).Add(1)
 		cleanupInDefer = false
 		return next(ctx, req, cleanup)
 	}
@@ -867,15 +893,9 @@ func (d *Distributor) forwardSamples(ctx context.Context, userID string, ts []mi
 		return ts, forwardingErrCh
 	}
 
-	var notIngestedCounts forwarding.TimeseriesCounts
-
 	// Reassign req.Timeseries because the forwarder creates a new slice which has been filtered down.
 	// The cleanup func will cleanup the new slice, it's the forwarders responsibility to return the old one to the pool.
-	notIngestedCounts, ts, forwardingErrCh = d.forwarder.Forward(ctx, forwardingRules, ts)
-
-	// Some samples have been forwarded and won't be ingested but we still need to account for them in some of the metrics.
-	d.incomingSamples.WithLabelValues(userID).Add(float64(notIngestedCounts.SampleCount))
-	d.incomingExemplars.WithLabelValues(userID).Add(float64(notIngestedCounts.ExemplarCount))
+	ts, forwardingErrCh = d.forwarder.Forward(ctx, forwardingRules, ts)
 
 	return ts, forwardingErrCh
 }
@@ -921,18 +941,6 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 	source := util.GetSourceIPsFromOutgoingCtx(ctx)
 
 	var firstPartialErr error
-
-	numSamples := 0
-	numExemplars := 0
-	for _, ts := range req.Timeseries {
-		numSamples += len(ts.Samples)
-		numExemplars += len(ts.Exemplars)
-	}
-	// Count the total samples in, prior to validation or deduplication, for comparison with other metrics.
-	d.incomingSamples.WithLabelValues(userID).Add(float64(numSamples))
-	d.incomingExemplars.WithLabelValues(userID).Add(float64(numExemplars))
-	// Count the total number of metadata in.
-	d.incomingMetadata.WithLabelValues(userID).Add(float64(len(req.Metadata)))
 
 	// A WriteRequest can only contain series or metadata but not both. This might change in the future.
 	// For each timeseries or samples, we compute a hash to distribute across ingesters;

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4387,7 +4387,17 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		ds, _, regs := prepare(t, config)
 		return ds[0], regs[0]
 	}
-	getExpectedMetrics := func(requestsIn, samplesIn, exemplarsIn, metadataIn, receivedRequests, receivedSamples, receivedExemplars, receivedMetadata int) (string, []string) {
+	type expectedMetricsCfg struct {
+		requestsIn        int
+		samplesIn         int
+		exemplarsIn       int
+		metadataIn        int
+		receivedRequests  int
+		receivedSamples   int
+		receivedExemplars int
+		receivedMetadata  int
+	}
+	getExpectedMetrics := func(cfg expectedMetricsCfg) (string, []string) {
 		return fmt.Sprintf(`
 				# HELP cortex_distributor_requests_in_total The total number of requests that have come in to the distributor, including rejected, forwarded or deduped requests.
 				# TYPE cortex_distributor_requests_in_total counter
@@ -4413,7 +4423,7 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 				# HELP cortex_distributor_received_metadata_total The total number of received metadata, excluding rejected.
 				# TYPE cortex_distributor_received_metadata_total counter
 				cortex_distributor_received_metadata_total{user="%s"} %d
-	`, tenant, requestsIn, tenant, samplesIn, tenant, exemplarsIn, tenant, metadataIn, tenant, receivedRequests, tenant, receivedSamples, tenant, receivedExemplars, tenant, receivedMetadata), []string{
+	`, tenant, cfg.requestsIn, tenant, cfg.samplesIn, tenant, cfg.exemplarsIn, tenant, cfg.metadataIn, tenant, cfg.receivedRequests, tenant, cfg.receivedSamples, tenant, cfg.receivedExemplars, tenant, cfg.receivedMetadata), []string{
 				"cortex_distributor_requests_in_total",
 				"cortex_distributor_samples_in_total",
 				"cortex_distributor_exemplars_in_total",
@@ -4446,7 +4456,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		_, err := dist.Push(getCtx(), req)
 		require.NoError(t, err)
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 10, 10, 10)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   10,
+			receivedExemplars: 10,
+			receivedMetadata:  10})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4468,7 +4486,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		_, err := dist.Push(getCtx(), req)
 		require.NoError(t, err)
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 5, 5, 10)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   5,
+			receivedExemplars: 5,
+			receivedMetadata:  10})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4485,7 +4511,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 
 		dist.Push(getCtx(), req) //nolint:errcheck
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 0, 0, 10)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   0,
+			receivedExemplars: 0,
+			receivedMetadata:  10})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4520,7 +4554,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		require.NoError(t, err)
 		dist.Push(ctx, makeWriteRequestForGenerators(10, uniqueMetricsGenWithReplica("replica2"), exemplarLabelGen, metaDataGen)) //nolint:errcheck
 
-		expectedMetrics, metricNames := getExpectedMetrics(4, 40, 40, 40, 2, 20, 20, 20)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        4,
+			samplesIn:         40,
+			exemplarsIn:       40,
+			metadataIn:        40,
+			receivedRequests:  2,
+			receivedSamples:   20,
+			receivedExemplars: 20,
+			receivedMetadata:  20})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4547,7 +4589,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		_, err := dist.Push(getCtx(), req)
 		require.NoError(t, err)
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 5, 5, 10)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   5,
+			receivedExemplars: 5,
+			receivedMetadata:  10})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4565,7 +4615,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		_, err := dist.Push(getCtx(), req)
 		require.NoError(t, err)
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 10, 0, 10)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   10,
+			receivedExemplars: 0,
+			receivedMetadata:  10})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4594,7 +4652,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 
 		dist.Push(getCtx(), req) //nolint:errcheck
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 5, 5, 10)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   5,
+			receivedExemplars: 5,
+			receivedMetadata:  10})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,
@@ -4630,7 +4696,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 
 		dist.Push(getCtx(), req) //nolint:errcheck
 
-		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 10, 10, 5)
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         10,
+			exemplarsIn:       10,
+			metadataIn:        10,
+			receivedRequests:  1,
+			receivedSamples:   10,
+			receivedExemplars: 10,
+			receivedMetadata:  5})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -851,7 +851,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 			err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica, time.Now())
 			assert.NoError(t, err)
 
-			request := makeWriteRequestForLabelSetGen(tc.samples, labelSetGenWithReplicaAndCluster(tc.testReplica, tc.cluster))
+			request := makeWriteRequestForGenerators(tc.samples, labelSetGenWithReplicaAndCluster(tc.testReplica, tc.cluster), nil, nil)
 			response, err := d.Push(ctx, request)
 			assert.Equal(t, tc.expectedResponse, response)
 
@@ -2475,7 +2475,11 @@ func TestDistributor_IngestionIsControlledByForwarder(t *testing.T) {
 			var forwardReqCnt atomic.Uint32
 			forwardReqCallback := func(_ []mimirpb.PreallocTimeseries) { forwardReqCnt.Inc() }
 			getForwarder := func() forwarding.Forwarder {
-				return newMockForwarder(tc.ingestSample, forwardReqCallback)
+				var mutator func([]mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries
+				if tc.ingestSample {
+					mutator = ingestAllTimeseriesMutator
+				}
+				return newMockForwarder(mutator, forwardReqCallback)
 			}
 
 			distributors, ingesters, regs := prepare(t, prepConfig{
@@ -2804,8 +2808,8 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			ctx:               ctxWithUser,
 			enableHaTracker:   true,
 			acceptHaSamples:   false,
-			reqs:              []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))},
-			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))},
+			reqs:              []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)},
+			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)},
 			expectedNextCalls: 1,
 			expectErrs:        []int{0},
 		}, {
@@ -2813,8 +2817,8 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			ctx:               ctxWithUser,
 			enableHaTracker:   false,
 			acceptHaSamples:   true,
-			reqs:              []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))},
-			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithCluster(cluster1))},
+			reqs:              []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)},
+			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithCluster(cluster1), nil, nil)},
 			expectedNextCalls: 1,
 			expectErrs:        []int{0},
 		}, {
@@ -2822,7 +2826,7 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			ctx:               context.Background(),
 			enableHaTracker:   true,
 			acceptHaSamples:   true,
-			reqs:              []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))},
+			reqs:              []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)},
 			expectedReqs:      nil,
 			expectedNextCalls: 0,
 			expectErrs:        []int{-1}, // Special value because this is not an httpgrpc error.
@@ -2832,10 +2836,10 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			enableHaTracker: true,
 			acceptHaSamples: true,
 			reqs: []*mimirpb.WriteRequest{
-				makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1)),
-				makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica2, cluster1)),
+				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil),
+				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil),
 			},
-			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithCluster(cluster1))},
+			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithCluster(cluster1), nil, nil)},
 			expectedNextCalls: 1,
 			expectErrs:        []int{0, 202},
 		}, {
@@ -2844,12 +2848,12 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			enableHaTracker: true,
 			acceptHaSamples: true,
 			reqs: []*mimirpb.WriteRequest{
-				makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1)),
-				makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica2, cluster1)),
-				makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster2)), // HaMaxClusters is set to 1.
-				makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica2, cluster2)),
+				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil),
+				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil),
+				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster2), nil, nil), // HaMaxClusters is set to 1.
+				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica2, cluster2), nil, nil),
 			},
-			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenWithCluster(cluster1))},
+			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithCluster(cluster1), nil, nil)},
 			expectedNextCalls: 1,
 			expectErrs:        []int{0, 202, 400, 400},
 		},
@@ -2921,9 +2925,9 @@ func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
 	const replica2 = "replicaB"
 	const cluster1 = "clusterA"
 
-	writeReqReplica1 := makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica1, cluster1))
-	writeReqReplica2 := makeWriteRequestForLabelSetGen(5, labelSetGenWithReplicaAndCluster(replica2, cluster1))
-	expectedWriteReq := makeWriteRequestForLabelSetGen(5, labelSetGenWithCluster(cluster1))
+	writeReqReplica1 := makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
+	writeReqReplica2 := makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil)
+	expectedWriteReq := makeWriteRequestForGenerators(5, labelSetGenWithCluster(cluster1), nil, nil)
 
 	// Capture the submitted write requests which the middlewares pass into the mock push function.
 	var submittedWriteReqs []*mimirpb.WriteRequest
@@ -2988,15 +2992,15 @@ func TestRelabelMiddleware(t *testing.T) {
 			ctx:            ctxWithUser,
 			relabelConfigs: nil,
 			dropLabels:     nil,
-			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"))},
-			expectedReqs:   []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"))},
+			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"), nil, nil)},
+			expectedReqs:   []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"), nil, nil)},
 			expectErrs:     []bool{false},
 		}, {
 			name:           "no user in context",
 			ctx:            context.Background(),
 			relabelConfigs: nil,
 			dropLabels:     nil,
-			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"))},
+			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label", "value_%d"), nil, nil)},
 			expectedReqs:   nil,
 			expectErrs:     []bool{true},
 		}, {
@@ -3004,13 +3008,9 @@ func TestRelabelMiddleware(t *testing.T) {
 			ctx:            ctxWithUser,
 			relabelConfigs: nil,
 			dropLabels:     []string{"label1", "label3"},
-			reqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1", "label2", "value2", "label3", "value3"),
-			)},
-			expectedReqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelSetGenForStringPairs(t, "__name__", "metric1", "label2", "value2"),
-			)},
-			expectErrs: []bool{false},
+			reqs:           []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1", "label2", "value2", "label3", "value3"), nil, nil)},
+			expectedReqs:   []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label2", "value2"), nil, nil)},
+			expectErrs:     []bool{false},
 		}, {
 			name: "drop two out of three labels",
 			ctx:  ctxWithUser,
@@ -3023,28 +3023,24 @@ func TestRelabelMiddleware(t *testing.T) {
 					Replacement:  "prefix_$1",
 				},
 			},
-			reqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1"),
-			)},
-			expectedReqs: []*mimirpb.WriteRequest{makeWriteRequestForLabelSetGen(5,
-				labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1", "target", "prefix_value1"),
-			)},
-			expectErrs: []bool{false},
+			reqs:         []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1"), nil, nil)},
+			expectedReqs: []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1", "target", "prefix_value1"), nil, nil)},
+			expectErrs:   []bool{false},
 		}, {
 			name:       "drop entire series if they have no labels",
 			ctx:        ctxWithUser,
 			dropLabels: []string{"__name__", "label2", "label3"},
 			reqs: []*mimirpb.WriteRequest{
-				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1")),
-				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric2", "label2", "value2")),
-				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric3", "label3", "value3")),
-				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "__name__", "metric4", "label4", "value4")),
+				makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric1", "label1", "value1"), nil, nil),
+				makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric2", "label2", "value2"), nil, nil),
+				makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric3", "label3", "value3"), nil, nil),
+				makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "__name__", "metric4", "label4", "value4"), nil, nil),
 			},
 			expectedReqs: []*mimirpb.WriteRequest{
-				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "label1", "value1")),
+				makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "label1", "value1"), nil, nil),
 				{Timeseries: []mimirpb.PreallocTimeseries{}},
 				{Timeseries: []mimirpb.PreallocTimeseries{}},
-				makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t, "label4", "value4")),
+				makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t, "label4", "value4"), nil, nil),
 			},
 			expectErrs: []bool{false, false, false, false},
 		},
@@ -3094,26 +3090,26 @@ func TestHaDedupeAndRelabelBeforeForwarding(t *testing.T) {
 	const replica1 = "replicaA"
 	const replica2 = "replicaB"
 	const cluster1 = "clusterA"
-	writeReqReplica1 := makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t,
+	writeReqReplica1 := makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t,
 		"__name__", "foo",
 		"__replica__", replica1, // Will be dropped by ha-dedupe.
 		"bar", "baz", // Will be dropped by drop_label rule.
 		"cluster", cluster1,
 		"sample", "value", // Will be targeted by relabel rule.
-	))
-	writeReqReplica2 := makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t,
+	), nil, nil)
+	writeReqReplica2 := makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t,
 		"__name__", "foo",
 		"__replica__", replica2, // Will be dropped by ha-dedupe.
 		"bar", "baz", // Will be dropped by drop_label rule.
 		"cluster", cluster1,
 		"sample", "value", // Will be targeted by relabel rule.
-	))
-	expectedWriteReq := makeWriteRequestForLabelSetGen(5, labelSetGenForStringPairs(t,
+	), nil, nil)
+	expectedWriteReq := makeWriteRequestForGenerators(5, labelSetGenForStringPairs(t,
 		"__name__", "foo",
 		"cluster", cluster1,
 		"sample", "value",
 		"target", "prefix_value", // Result of relabel rule.
-	))
+	), nil, nil)
 
 	// Capture the submitted write requests which the middlewares pass into the mock push function.
 	var submittedWriteReqs []*mimirpb.WriteRequest
@@ -3128,7 +3124,7 @@ func TestHaDedupeAndRelabelBeforeForwarding(t *testing.T) {
 		forwardedTs = append(forwardedTs, ts)
 	}
 	getForwarder := func() forwarding.Forwarder {
-		return newMockForwarder(true, forwardReqCallback)
+		return newMockForwarder(ingestAllTimeseriesMutator, forwardReqCallback)
 	}
 
 	// Setup limits with HA enabled and forwarding rules for the metric "foo".
@@ -3502,22 +3498,55 @@ func labelSetGenForStringPairs(tb testing.TB, namesValues ...string) func(id int
 	}
 }
 
-func makeWriteRequestForLabelSetGen(samples int, labelSetGen func(int) []mimirpb.LabelAdapter) *mimirpb.WriteRequest {
+type labelSetGen func(int) []mimirpb.LabelAdapter
+type metaDataGen func(int, string) *mimirpb.MetricMetadata
+
+// makeWriteRequestForGenerators generates a write request based on the given generator functions.
+// The label set generator gets called once for each sample, the returned label set gets added to the request with the sample.
+// The exemplar label set generator also gets called once for each sample, if it isn't nil.
+// The metadata generator gets called once for each unique metric name that has been returned by the label generator, if it isn't nil.
+func makeWriteRequestForGenerators(samples int, lsg labelSetGen, elsg labelSetGen, mdg metaDataGen) *mimirpb.WriteRequest {
+	metricNames := make(map[string]struct{})
+
 	request := &mimirpb.WriteRequest{}
 	for i := 0; i < samples; i++ {
+		labelSet := lsg(i)
+		metricName := mimirpb.FromLabelAdaptersToLabels(labelSet).Get(model.MetricNameLabel)
+		if metricName != "" {
+			metricNames[metricName] = struct{}{}
+		}
+
 		ts := mimirpb.PreallocTimeseries{
 			TimeSeries: &mimirpb.TimeSeries{
-				Labels: labelSetGen(i),
+				Labels: labelSet,
 			},
 		}
-		ts.Samples = []mimirpb.Sample{
-			{
-				Value:       float64(i),
-				TimestampMs: int64(i),
-			},
+
+		ts.Samples = []mimirpb.Sample{{
+			Value:       float64(100 + i),
+			TimestampMs: int64(100 + i),
+		}}
+
+		if elsg != nil {
+			ts.Exemplars = []mimirpb.Exemplar{{
+				Labels:      elsg(100 + i),
+				Value:       float64(100 + i),
+				TimestampMs: int64(100 + i),
+			}}
 		}
+
 		request.Timeseries = append(request.Timeseries, ts)
+
 	}
+
+	if mdg != nil {
+		metricIdx := 0
+		for metricName := range metricNames {
+			request.Metadata = append(request.Metadata, mdg(metricIdx, metricName))
+			metricIdx++
+		}
+	}
+
 	return request
 }
 
@@ -4009,20 +4038,22 @@ outer:
 type mockForwarder struct {
 	services.Service
 
-	ingest bool
+	// Optional callback which takes the given timeseries and returns a modified version of it,
+	// the modified version gets returned by Forward().
+	timeseriesMutator func([]mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries
 
 	// Optional callback to run in place of the actual forwarding request.
 	forwardReqCallback func([]mimirpb.PreallocTimeseries)
 }
 
-func newMockForwarder(ingest bool, forwardReqCallback func([]mimirpb.PreallocTimeseries)) forwarding.Forwarder {
+func newMockForwarder(timeseriesMutator func([]mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries, forwardReqCallback func([]mimirpb.PreallocTimeseries)) forwarding.Forwarder {
 	return &mockForwarder{
-		ingest:             ingest,
+		timeseriesMutator:  timeseriesMutator,
 		forwardReqCallback: forwardReqCallback,
 	}
 }
 
-func (m *mockForwarder) Forward(ctx context.Context, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) (forwarding.TimeseriesCounts, []mimirpb.PreallocTimeseries, chan error) {
+func (m *mockForwarder) Forward(ctx context.Context, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
 	errCh := make(chan error)
 
 	go func() {
@@ -4033,18 +4064,15 @@ func (m *mockForwarder) Forward(ctx context.Context, forwardingRules validation.
 		}
 	}()
 
-	var notIngestedCounts forwarding.TimeseriesCounts
-
-	if m.ingest {
-		return notIngestedCounts, ts, errCh
+	if m.timeseriesMutator != nil {
+		return m.timeseriesMutator(ts), errCh
 	}
 
-	for _, t := range ts {
-		notIngestedCounts.SampleCount += len(t.Samples)
-		notIngestedCounts.ExemplarCount += len(t.Exemplars)
-	}
+	return nil, errCh
+}
 
-	return notIngestedCounts, nil, errCh
+func ingestAllTimeseriesMutator(ts []mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries {
+	return ts
 }
 
 func TestDistributorValidation(t *testing.T) {
@@ -4333,4 +4361,281 @@ func countMockIngestersCalls(ingesters []mockIngester, name string) int {
 		}
 	}
 	return count
+}
+
+// TestDistributor_MetricsWithRequestModifications tests that the distributor metrics are properly updated when
+// requests get modified by the mechanisms that can modify them: relabel rules, drop labels, ha-dedupe, forwarding, limits.
+func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
+	tenant := "tenant1"
+	getCtx := func() context.Context {
+		return user.InjectOrgID(context.Background(), tenant)
+	}
+	getDefaultConfig := func() prepConfig {
+		var limits validation.Limits
+		flagext.DefaultValues(&limits)
+		limits.MaxGlobalExemplarsPerUser = 1000
+
+		return prepConfig{
+			limits:            &limits,
+			numIngesters:      1,
+			happyIngesters:    1,
+			replicationFactor: 1,
+			numDistributors:   1,
+		}
+	}
+	getDistributor := func(config prepConfig) (*Distributor, *prometheus.Registry) {
+		ds, _, regs := prepare(t, config)
+		return ds[0], regs[0]
+	}
+	getExpectedMetrics := func(requestsIn, samplesIn, exemplarsIn, metadataIn, receivedRequests, receivedSamples, receivedExemplars, receivedMetadata int) (string, []string) {
+		return fmt.Sprintf(`
+				# HELP cortex_distributor_requests_in_total The total number of requests that have come in to the distributor, including rejected, forwarded or deduped requests.
+				# TYPE cortex_distributor_requests_in_total counter
+				cortex_distributor_requests_in_total{user="%s"} %d
+				# HELP cortex_distributor_samples_in_total The total number of samples that have come in to the distributor, including rejected, forwarded or deduped samples.
+				# TYPE cortex_distributor_samples_in_total counter
+				cortex_distributor_samples_in_total{user="%s"} %d
+				# HELP cortex_distributor_exemplars_in_total The total number of exemplars that have come in to the distributor, including rejected, forwarded or deduped exemplars.
+				# TYPE cortex_distributor_exemplars_in_total counter
+				cortex_distributor_exemplars_in_total{user="%s"} %d
+				# HELP cortex_distributor_metadata_in_total The total number of metadata the have come in to the distributor, including rejected.
+				# TYPE cortex_distributor_metadata_in_total counter
+				cortex_distributor_metadata_in_total{user="%s"} %d
+				# HELP cortex_distributor_received_requests_total The total number of received requests, excluding rejected, forwarded and deduped requests.
+				# TYPE cortex_distributor_received_requests_total counter
+				cortex_distributor_received_requests_total{user="%s"} %d
+				# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected, forwarded and deduped samples.
+				# TYPE cortex_distributor_received_samples_total counter
+				cortex_distributor_received_samples_total{user="%s"} %d
+				# HELP cortex_distributor_received_exemplars_total The total number of received exemplars, excluding rejected, forwarded and deduped exemplars.
+				# TYPE cortex_distributor_received_exemplars_total counter
+				cortex_distributor_received_exemplars_total{user="%s"} %d
+				# HELP cortex_distributor_received_metadata_total The total number of received metadata, excluding rejected.
+				# TYPE cortex_distributor_received_metadata_total counter
+				cortex_distributor_received_metadata_total{user="%s"} %d
+	`, tenant, requestsIn, tenant, samplesIn, tenant, exemplarsIn, tenant, metadataIn, tenant, receivedRequests, tenant, receivedSamples, tenant, receivedExemplars, tenant, receivedMetadata), []string{
+				"cortex_distributor_requests_in_total",
+				"cortex_distributor_samples_in_total",
+				"cortex_distributor_exemplars_in_total",
+				"cortex_distributor_metadata_in_total",
+				"cortex_distributor_received_requests_total",
+				"cortex_distributor_received_samples_total",
+				"cortex_distributor_received_exemplars_total",
+				"cortex_distributor_received_metadata_total",
+			}
+	}
+	uniqueMetricsGen := func(sampleIdx int) []mimirpb.LabelAdapter {
+		return []mimirpb.LabelAdapter{{Name: "__name__", Value: fmt.Sprintf("metric_%d", sampleIdx)}}
+	}
+	exemplarLabelGen := func(sampleIdx int) []mimirpb.LabelAdapter {
+		return []mimirpb.LabelAdapter{{Name: "exemplarLabel", Value: fmt.Sprintf("value_%d", sampleIdx)}}
+	}
+	metaDataGen := func(metricIdx int, metricName string) *mimirpb.MetricMetadata {
+		return &mimirpb.MetricMetadata{
+			Type:             mimirpb.COUNTER,
+			MetricFamilyName: metricName,
+			Help:             "test metric",
+			Unit:             "unknown",
+		}
+	}
+
+	t.Run("No modifications", func(t *testing.T) {
+		dist, reg := getDistributor(getDefaultConfig())
+		req := makeWriteRequestForGenerators(10, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+		_, err := dist.Push(getCtx(), req)
+		require.NoError(t, err)
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 10, 10, 10)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop samples via relabel rules", func(t *testing.T) {
+		cfg := getDefaultConfig()
+		cfg.limits.MetricRelabelConfigs = []*relabel.Config{{
+			SourceLabels: []model.LabelName{"__name__"},
+			Regex:        relabel.MustNewRegexp("^metric_[5-9]$"),
+			Action:       relabel.Drop,
+		}}
+		dist, reg := getDistributor(cfg)
+		req := makeWriteRequestForGenerators(10, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+		_, err := dist.Push(getCtx(), req)
+		require.NoError(t, err)
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 5, 5, 10)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop samples via drop_label rule", func(t *testing.T) {
+		cfg := getDefaultConfig()
+		cfg.limits.DropLabels = []string{"__name__"}
+		dist, reg := getDistributor(cfg)
+		req := makeWriteRequestForGenerators(10, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+		dist.Push(getCtx(), req) //nolint:errcheck
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 0, 0, 10)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop requests via ha-dedupe", func(t *testing.T) {
+		cfg := getDefaultConfig()
+		cfg.limits.AcceptHASamples = true
+		cfg.limits.MaxLabelValueLength = 15
+		cfg.limits.HAMaxClusters = 1
+		cfg.enableTracker = true
+		dist, reg := getDistributor(cfg)
+
+		uniqueMetricsGenWithReplica := func(replica string) func(sampleIdx int) []mimirpb.LabelAdapter {
+			return func(sampleIdx int) []mimirpb.LabelAdapter {
+				labels := uniqueMetricsGen(sampleIdx)
+				labels = append(labels, mimirpb.LabelAdapter{Name: "__replica__", Value: replica})
+				labels = append(labels, mimirpb.LabelAdapter{Name: "cluster", Value: "test_cluster"})
+				return labels
+			}
+		}
+
+		ctx := getCtx()
+		_, err := dist.Push(ctx, makeWriteRequestForGenerators(10, uniqueMetricsGenWithReplica("replica1"), exemplarLabelGen, metaDataGen))
+		require.NoError(t, err)
+		dist.Push(ctx, makeWriteRequestForGenerators(10, uniqueMetricsGenWithReplica("replica2"), exemplarLabelGen, metaDataGen)) //nolint:errcheck
+
+		_, err = dist.Push(ctx, makeWriteRequestForGenerators(10, uniqueMetricsGenWithReplica("replica1"), exemplarLabelGen, metaDataGen))
+		require.NoError(t, err)
+		dist.Push(ctx, makeWriteRequestForGenerators(10, uniqueMetricsGenWithReplica("replica2"), exemplarLabelGen, metaDataGen)) //nolint:errcheck
+
+		expectedMetrics, metricNames := getExpectedMetrics(4, 40, 40, 40, 2, 20, 20, 20)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Some samples get forwarded", func(t *testing.T) {
+		cfg := getDefaultConfig()
+		cfg.limits.ForwardingRules = validation.ForwardingRules{"any_metric": {}} // Needs to be len()>0 to enable forwarding.
+		cfg.forwarding = true
+		cfg.getForwarder = func() forwarding.Forwarder {
+			// This mock forwarder will return half of all samples for ingestion.
+			return newMockForwarder(
+				func(ts []mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries {
+					return ts[:len(ts)/2]
+				}, nil,
+			)
+		}
+		dist, reg := getDistributor(cfg)
+		req := makeWriteRequestForGenerators(10, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+		_, err := dist.Push(getCtx(), req)
+		require.NoError(t, err)
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 5, 5, 10)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop examplars via limit", func(t *testing.T) {
+		cfg := getDefaultConfig()
+		cfg.limits.MaxGlobalExemplarsPerUser = 0
+		dist, reg := getDistributor(cfg)
+		req := makeWriteRequestForGenerators(10, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+		_, err := dist.Push(getCtx(), req)
+		require.NoError(t, err)
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 10, 0, 10)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop half of samples via label value length limit", func(t *testing.T) {
+		labelValueLimit := 10
+		cfg := getDefaultConfig()
+		cfg.limits.MaxLabelValueLength = labelValueLimit
+		dist, reg := getDistributor(cfg)
+
+		halfLabelValuesAboveLimit := func(sampleIdx int) []mimirpb.LabelAdapter {
+			labels := uniqueMetricsGen(sampleIdx)
+			if sampleIdx%2 == 0 {
+				labels = append(labels, mimirpb.LabelAdapter{
+					Name: "long_label", Value: strings.Repeat("a", labelValueLimit+1),
+				})
+			}
+			return labels
+		}
+
+		req := makeWriteRequestForGenerators(10, halfLabelValuesAboveLimit, exemplarLabelGen, metaDataGen)
+
+		dist.Push(getCtx(), req) //nolint:errcheck
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 5, 5, 10)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop half of metadata via label value length limit", func(t *testing.T) {
+		metadataLengthLimit := 20
+		cfg := getDefaultConfig()
+		cfg.limits.MaxMetadataLength = metadataLengthLimit
+		dist, reg := getDistributor(cfg)
+
+		metaDataGen := func(metricIdx int, metricName string) *mimirpb.MetricMetadata {
+			if metricIdx%2 == 0 {
+				return &mimirpb.MetricMetadata{
+					Type:             mimirpb.COUNTER,
+					MetricFamilyName: metricName,
+					Help:             strings.Repeat("a", metadataLengthLimit+1),
+					Unit:             "unknown",
+				}
+			}
+			return &mimirpb.MetricMetadata{
+				Type:             mimirpb.COUNTER,
+				MetricFamilyName: metricName,
+				Help:             strings.Repeat("a", metadataLengthLimit-1),
+				Unit:             "unknown",
+			}
+		}
+
+		req := makeWriteRequestForGenerators(10, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+		dist.Push(getCtx(), req) //nolint:errcheck
+
+		expectedMetrics, metricNames := getExpectedMetrics(1, 10, 10, 10, 1, 10, 10, 5)
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
 }

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -29,7 +29,7 @@ import (
 
 type Forwarder interface {
 	services.Service
-	Forward(ctx context.Context, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) (TimeseriesCounts, []mimirpb.PreallocTimeseries, chan error)
+	Forward(ctx context.Context, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error)
 }
 
 type forwarder struct {
@@ -128,19 +128,17 @@ func (f *forwarder) worker() {
 // returned slice of time series must be returned to the pool by the caller once it is done using it.
 //
 // The return values are:
-//   - A TimeSeriesCounts object containing the sample / exemplar counts that were removed from the
-//     given time series slice relative to the returned slice.
 //   - A slice of time series which should be sent to the ingesters, based on the given rule set.
 //     The Forward() method does not send the time series to the ingesters itself, it expects the caller to do that.
 //   - A chan of errors which resulted from forwarding the time series, the chan gets closed when all forwarding requests have completed.
-func (f *forwarder) Forward(ctx context.Context, rules validation.ForwardingRules, in []mimirpb.PreallocTimeseries) (TimeseriesCounts, []mimirpb.PreallocTimeseries, chan error) {
+func (f *forwarder) Forward(ctx context.Context, rules validation.ForwardingRules, in []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
 	if !f.cfg.Enabled {
 		errCh := make(chan error)
 		close(errCh)
-		return TimeseriesCounts{}, in, errCh
+		return in, errCh
 	}
 
-	notIngestedCounts, toIngest, tsByTargets := f.splitByTargets(in, rules)
+	toIngest, tsByTargets := f.splitByTargets(in, rules)
 	defer f.pools.putTsByTargets(tsByTargets)
 
 	var requestWg sync.WaitGroup
@@ -158,7 +156,7 @@ func (f *forwarder) Forward(ctx context.Context, rules validation.ForwardingRule
 		close(errCh)
 	}()
 
-	return notIngestedCounts, toIngest, errCh
+	return toIngest, errCh
 }
 
 type tsWithSampleCount struct {
@@ -200,18 +198,13 @@ func (t *TimeseriesCounts) count(ts mimirpb.PreallocTimeseries) {
 // the target to which each of them should be forwarded according to the forwarding rules.
 // It returns the following values:
 //
-// - The counts of samples and exemplars that will not be ingested by the ingesters.
 // - A slice of time series to ingest into the ingesters.
 // - A map of slices of time series which is keyed by the target to which they should be forwarded.
-func (f *forwarder) splitByTargets(tsSliceIn []mimirpb.PreallocTimeseries, rules validation.ForwardingRules) (TimeseriesCounts, []mimirpb.PreallocTimeseries, tsByTargets) {
+func (f *forwarder) splitByTargets(tsSliceIn []mimirpb.PreallocTimeseries, rules validation.ForwardingRules) ([]mimirpb.PreallocTimeseries, tsByTargets) {
 	// This functions copies all the entries of tsSliceIn into new slices so tsSliceIn can be recycled,
 	// we adjust the length of the slice to 0 to prevent that the contained *mimirpb.TimeSeries objects that have been
 	// reassigned (not deep copied) get returned while they are still referred to by another slice.
 	defer f.pools.putTsSlice(tsSliceIn[:0])
-
-	// notIngestedCounts keeps track of the number of samples and exemplars that we don't send to the ingesters,
-	// we need to count these in order to later update some of the distributor's metrics correctly.
-	var notIngestedCounts TimeseriesCounts
 
 	tsToIngest := f.pools.getTsSlice()
 	tsByTargets := f.pools.getTsByTargets()
@@ -226,7 +219,6 @@ func (f *forwarder) splitByTargets(tsSliceIn []mimirpb.PreallocTimeseries, rules
 			// the distributor will return them to the pool when it is done sending them to the ingesters.
 			tsToIngest = append(tsToIngest, ts)
 		} else {
-			notIngestedCounts.count(ts)
 
 			// This ts won't be returned to the distributor because it should not be ingested according to the rules,
 			// so we have to return it to the pool now to prevent that its reference gets lost.
@@ -234,7 +226,7 @@ func (f *forwarder) splitByTargets(tsSliceIn []mimirpb.PreallocTimeseries, rules
 		}
 	}
 
-	return notIngestedCounts, tsToIngest, tsByTargets
+	return tsToIngest, tsByTargets
 }
 
 func findTargetForLabels(labels []mimirpb.LabelAdapter, rules validation.ForwardingRules) (string, bool) {


### PR DESCRIPTION
This creates a metrics middleware in the distributor which updates the metrics that should include all requests as they arrive, without any modifications.

It also adds tests to check whether the metrics get updated to the correct values in various scenarios where requests get modified by distributor middlewares.

Fix issue #2783


At first I intended to also implement the short-circuit which @56quarters has suggested [here](https://github.com/grafana/mimir/pull/2786#discussion_r950441966), but I figured this PR is already complicated enough as it is. Once it is merged the tests which get added by this PR should help with implementing that suggestion.