### PR TITLE
Remove the "Cache - Latency (old)" panel from the "Mimir / Queries" dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Mixin
 
+* [CHANGE] Dashboards: remove the "Cache - Latency (old)" panel from the "Mimir / Queries" dashboard. #2796
 * [FEATURE] Dashboards: added support to experimental read-write deployment mode. #2780
 * [ENHANCEMENT] Dashboards: added support to query-tee in front of ruler-query-frontend in the "Remote ruler reads" dashboard. #2761
 

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -711,7 +711,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 6,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -788,99 +788,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
-                  "targets": [
-                     {
-                        "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_method:cortex_cache_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read))\", method=~\"frontend.+\"})) * 1e3",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "99th Percentile",
-                        "refId": "A",
-                        "step": 10
-                     },
-                     {
-                        "expr": "histogram_quantile(0.50, sum by (le) (cluster_job_method:cortex_cache_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read))\", method=~\"frontend.+\"})) * 1e3",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "50th Percentile",
-                        "refId": "B",
-                        "step": 10
-                     },
-                     {
-                        "expr": "1e3 * sum(cluster_job_method:cortex_cache_request_duration_seconds_sum:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read))\", method=~\"frontend.+\"}) / sum(cluster_job_method:cortex_cache_request_duration_seconds_count:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read))\", method=~\"frontend.+\"})",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Average",
-                        "refId": "C",
-                        "step": 10
-                     }
-                  ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
-                  "title": "Latency (old)",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
-                  "yaxes": [
-                     {
-                        "format": "ms",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": 0,
-                        "show": true
-                     },
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": false
-                     }
-                  ]
-               },
-               {
-                  "aliasColors": { },
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
-                  "datasource": "$datasource",
-                  "fill": 1,
-                  "id": 12,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [ ],
-                  "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
-                  "span": 4,
+                  "span": 6,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -915,7 +823,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Latency (new)",
+                  "title": "Latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -975,7 +883,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 13,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1052,7 +960,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 14,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1144,7 +1052,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 15,
+                  "id": 14,
                   "legend": {
                      "show": false
                   },
@@ -1226,7 +1134,7 @@
                   "datasource": "$datasource",
                   "description": "### Replicas\nThe minimum, maximum, and current number of querier replicas.\n\n",
                   "fill": 1,
-                  "id": 16,
+                  "id": 15,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1322,7 +1230,7 @@
                   "datasource": "$datasource",
                   "description": "### Scaling metric\nThis panel shows the result of the query used as scaling metric and target/threshold used.\nThe desired number of replicas is computed by HPA as: <scaling metric> / <target per replica>.\n\n",
                   "fill": 1,
-                  "id": 17,
+                  "id": 16,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1414,7 +1322,7 @@
                   "datasource": "$datasource",
                   "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
                   "fill": 1,
-                  "id": 18,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1511,7 +1419,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 19,
+                  "id": 18,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1588,7 +1496,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 20,
+                  "id": 19,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1680,7 +1588,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 21,
+                  "id": 20,
                   "legend": {
                      "show": false
                   },
@@ -1769,7 +1677,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 22,
+                  "id": 21,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1846,7 +1754,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 23,
+                  "id": 22,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1938,7 +1846,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 24,
+                  "id": 23,
                   "legend": {
                      "show": false
                   },
@@ -2027,7 +1935,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 25,
+                  "id": 24,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2104,7 +2012,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 26,
+                  "id": 25,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2211,7 +2119,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 27,
+                  "id": 26,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2288,7 +2196,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 28,
+                  "id": 27,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2384,7 +2292,7 @@
                   "datasource": "$datasource",
                   "description": "### Hit ratio\nEven if you do not set up memcached for the blocks index cache, you will still see data in this panel because the store-gateway by default has an\nin-memory blocks index cache.\n\n",
                   "fill": 1,
-                  "id": 29,
+                  "id": 28,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2473,7 +2381,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 30,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2550,7 +2458,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 31,
+                  "id": 30,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2645,7 +2553,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 32,
+                  "id": 31,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2734,7 +2642,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 33,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2811,7 +2719,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 34,
+                  "id": 33,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2906,7 +2814,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 35,
+                  "id": 34,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2995,7 +2903,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 36,
+                  "id": 35,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3072,7 +2980,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 37,
+                  "id": 36,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3167,7 +3075,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 38,
+                  "id": 37,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3256,7 +3164,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 39,
+                  "id": 38,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3333,7 +3241,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 40,
+                  "id": 39,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3410,7 +3318,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 41,
+                  "id": 40,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3505,7 +3413,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 42,
+                  "id": 41,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3612,7 +3520,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 43,
+                  "id": 42,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3707,7 +3615,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 44,
+                  "id": 43,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3802,7 +3710,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 45,
+                  "id": 44,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3897,7 +3805,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 46,
+                  "id": 45,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4004,7 +3912,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 47,
+                  "id": 46,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4081,7 +3989,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 48,
+                  "id": 47,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4158,7 +4066,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 49,
+                  "id": 48,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4253,7 +4161,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 50,
+                  "id": 49,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4360,7 +4268,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 51,
+                  "id": 50,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4455,7 +4363,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 52,
+                  "id": 51,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4550,7 +4458,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 53,
+                  "id": 52,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -4645,7 +4553,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 54,
+                  "id": 53,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -171,11 +171,7 @@ local filename = 'mimir-reads.json';
         { yaxes: $.yaxes('ops') },
       )
       .addPanel(
-        $.panel('Latency (old)') +
-        utils.latencyRecordingRulePanel('cortex_cache_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('method', 'frontend.+')])
-      )
-      .addPanel(
-        $.panel('Latency (new)') +
+        $.panel('Latency') +
         $.latencyPanel(
           'thanos_memcached_operation_duration_seconds',
           '{%s, name="frontend-cache"}' % $.jobMatcher($._config.job_names.query_frontend)


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/821 I migrated query-frontend to use the same memcached client as blocks storage, and this changed the metrics exposed by it too. This change was included in Mimir 2.0.0, but I kept querying the old metric in the panel called "Latency (old)" to offer a smoother transition for people migrating from Cortex. Given we're now releasing Mimir 2.3.0 (and so this proposed change will be included in 2.4.0), I think it's time to remove "Latency (old)" panel and just keep the Mimir metric.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
