### PR TITLE
TestQueryShardingCorrectness: __name__!=""

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -511,6 +511,18 @@ func TestQueryShardingCorrectness(t *testing.T) {
 			query:                  `scalar(sum(metric_counter)) < bool 1`,
 			expectedShardedQueries: 1,
 		},
+		`sum({__name__!=""})`: {
+			query:                  `sum({__name__!=""})`,
+			expectedShardedQueries: 1,
+		},
+		`sum by (group_1) ({__name__!=""})`: {
+			query:                  `sum by (group_1) ({__name__!=""})`,
+			expectedShardedQueries: 1,
+		},
+		`sum by (group_1) (count_over_time({__name__!=""}[1m]))`: {
+			query:                  `sum by (group_1) (count_over_time({__name__!=""}[1m]))`,
+			expectedShardedQueries: 1,
+		},
 	}
 
 	series := make([]*promql.StorageSeries, 0, numSeries+(numHistograms*len(histogramBuckets)))


### PR DESCRIPTION
#### What this PR does

Test that querysharding works correctly with aggregations on top of queries that don't select a metric name.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
