### PR TITLE
Add explicit component section mapping in Helm helper

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -322,28 +322,44 @@ Cluster name that shows up in dashboard metrics
 
 {{/*
 mimir.componentSectionFromName returns the sections from the user .Values in YAML
-that corresponds to the requested component. mimir.componentSectionFromName takes three arguments
+that corresponds to the requested component. mimir.componentSectionFromName takes two arguments
   .ctx = the root context of the chart
-  .component = the name of the component. If provided, dashes (-) are replaced with underscores (_)
-                and the section with that name is returned from .ctxValues
-  .componentSection = when provided instead of using .component to infer the component section name in the
-                      user values, mimir.componentSectionFromName uses .componentSection as the YAML path
-                      to the component section. Nested sections should be split by dots (.)
+  .component = the name of the component. mimir.componentSectionFromName uses an internal mapping to know
+                which component lives where in the values.yaml
 Examples:
   $componentSection := include "mimir.componentSectionFromName" (dict "ctx" . "component" "store-gateway") | fromYaml
-  $componentSection := include "mimir.componentSectionFromName" (dict "ctx" . "componentSection" "graphite.querier") | fromYaml
+  $componentSection.podLabels ...
 */}}
 {{- define "mimir.componentSectionFromName" -}}
-{{ if .componentSection }}
-  {{ $section := .ctx.Values }}
-  {{- range regexSplit "\\." .componentSection -1 }}
-    {{ $section = index $section . }}
-    {{- if not $section }}{{- printf "Component %s not found in values; values: %s" $.componentSection ($.ctx.Values | toJson | abbrev 100) | fail }}{{ end }}
-  {{- end }}
-  {{- $section | toYaml }}
-{{- else }}
-  {{- index .ctx.Values (.component | replace "-" "_") | toYaml }}
-{{- end }}
+{{- $componentsMap := dict
+  "admin-api" "admin_api"
+  "alertmanager" "alertmanager"
+  "chunks-cache" "chunks-cache"
+  "compactor" "compactor"
+  "distributor" "distributor"
+  "gateway" "gateway"
+  "index-cache" "index-cache"
+  "ingester" "ingester"
+  "metadata-cache" "metadata-cache"
+  "nginx" "nginx"
+  "overrides-exporter" "overrides_exporter"
+  "querier" "querier"
+  "query-frontend" "query_frontend"
+  "query-scheduler" "query_scheduler"
+  "results-cache" "results-cache"
+  "ruler" "ruler"
+  "smoke-test" "smoke_test"
+  "store-gateway" "store_gateway"
+  "tokengen" "tokengenJob"
+-}}
+{{- $componentSection := index $componentsMap .component -}}
+{{- if not $componentSection -}}{{- printf "No component section mapping for %s not found in values; submit a bug report if you are a user, edit mimir.componentSectionFromName if you are a contributor" .component | fail -}}{{- end -}}
+{{- $section := .ctx.Values -}}
+{{- range regexSplit "\\." $componentSection -1 -}}
+  {{- $section = index $section . -}}
+  {{- if not $section -}}{{- printf "Component section %s not found in values; values: %s" . ($.ctx.Values | toJson | abbrev 100) | fail -}}{{- end -}}
+{{- end -}}
+{{- $section | toYaml -}}
 {{- end -}}
 
 {{/*

--- a/operations/helm/charts/mimir-distributed/templates/lib/pdb.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/lib/pdb.tpl
@@ -5,9 +5,8 @@ Params:
   component = name of the component
 */}}
 {{- define "mimir.lib.podDisruptionBudget" -}}
-{{- $componentSection := include "mimir.componentSectionFromName" . }}
-{{ with (index $.ctx.Values $componentSection) }}
-{{- if .podDisruptionBudget -}}
+{{- $componentSection := include "mimir.componentSectionFromName" . | fromYaml }}
+{{ with ($componentSection).podDisruptionBudget }}
 apiVersion: {{ include "mimir.podDisruptionBudget.apiVersion" $.ctx }}
 kind: PodDisruptionBudget
 metadata:
@@ -19,7 +18,6 @@ spec:
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" $.ctx "component" $.component) | nindent 6 }}
-{{ toYaml .podDisruptionBudget | indent 2 }}
-{{- end -}}
+{{ toYaml . | indent 2 }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
For #2711 we want to nest the graphite components under `graphite` in the values.yaml.

A problem we have is that some of named templates within the chart need to grab the raw values from the values.yaml in order to automatically set things like pod labels and annotations. And those named templates do not know how to work with nested values. There is already a helper `mimir.componentSectionFromName` which infers the _name_ of the section in the values from the component name. 


This PR changes `mimir.componentSectionFromName` to have a hardcoded YAML section for each component. 

The PR also introduces a change in how `mimir.componentSectionFromName` is used. It now returns the values as YAML instead of just the name of the section. So its result should be parsed with `fromYaml`