### PR TITLE
Helm: move ingester deployment validation to validate.yaml

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-dep.yaml
@@ -1,3 +1,0 @@
-{{- if not .Values.ingester.statefulSet.enabled -}}
-{{- fail "Ingesters are stateful, kubernetes Deployment workloads are no longer supported. Please refer to the documentation for more details." }}
-{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingester.statefulSet.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -151,4 +150,3 @@ spec:
             {{- with .Values.ingester.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/validate.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/validate.yaml
@@ -143,3 +143,7 @@
     {{- fail "memcached-results.enabled has been renamed to results-cache.enabled" }}
   {{- end }}
 {{- end }}
+
+{{- if not .Values.ingester.statefulSet.enabled -}}
+{{- fail "Ingesters are stateful, kubernetes Deployment workloads are no longer supported. Please refer to the documentation for more details." }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/validate.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/validate.yaml
@@ -145,5 +145,5 @@
 {{- end }}
 
 {{- if not .Values.ingester.statefulSet.enabled -}}
-{{- fail "Ingesters are stateful, kubernetes Deployment workloads are no longer supported. Please refer to the documentation for more details." }}
+{{- fail "You have set ingester.statefulSet.enabled: false. Ingesters are stateful, kubernetes Deployment workloads are no longer supported. Please refer to the documentation for more details." }}
 {{- end -}}


### PR DESCRIPTION
It's in the wrong place, preparing for multizone.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
