### PR TITLE
Add sanity check at startup to ensure the configured filesystem directories don't overlap for different components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Distributor: Add `cortex_distributor_received_requests_total` and `cortex_distributor_requests_in_total` metrics to provide visiblity into appropriate per-tenant request limits. #2770
 * [ENHANCEMENT] Distributor: Add single forwarding remote-write endpoint for a tenant (`forwarding_endpoint`), instead of using per-rule endpoints. This takes precendence over per-rule endpoints. #2801
 * [ENHANCEMENT] Added `err-mimir-distributor-max-write-message-size` to the errors catalog. #2470
+* [ENHANCEMENT] Add sanity check at startup to ensure the configured filesystem directories don't overlap for different components. #2828
 * [BUGFIX] Ruler: fix not restoring alerts' state at startup. #2648
 * [BUGFIX] Ingester: Fix disk filling up after restarting ingesters with out-of-order support disabled while it was enabled before. #2799
 * [BUGFIX] Memberlist: retry joining memberlist cluster on startup when no nodes are resolved. #2837

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -180,7 +180,9 @@ overrides:
 				"-runtime-config.reload-period":                     "100ms",
 				"-blocks-storage.backend":                           "filesystem",
 				"-blocks-storage.filesystem.dir":                    "/tmp",
+				"-blocks-storage.storage-prefix":                    "blocks",
 				"-blocks-storage.bucket-store.bucket-index.enabled": "false",
+				"-ruler-storage.backend":                            "filesystem",
 				"-ruler-storage.local.directory":                    "/tmp", // Avoid warning "unable to list rules".
 				"-runtime-config.file":                              filepath.Join(e2e.ContainerSharedDir, overridesFile),
 			}

--- a/integration/single_binary_test.go
+++ b/integration/single_binary_test.go
@@ -87,6 +87,7 @@ func TestMimirCanParseIntZeroAsZeroDuration(t *testing.T) {
 	flags := map[string]string{
 		"-common.storage.backend":        "filesystem",
 		"-common.storage.filesystem.dir": "./bucket",
+		"-blocks-storage.storage-prefix": "blocks",
 	}
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -24,15 +24,15 @@ import (
 )
 
 const (
-	// The bucket prefix under which all tenants alertmanager configs are stored.
+	// AlertsPrefix is the bucket prefix under which all tenants alertmanager configs are stored.
 	// Note that objects stored under this prefix follow the pattern:
 	//     alerts/<user-id>
-	alertsPrefix = "alerts"
+	AlertsPrefix = "alerts"
 
-	// The bucket prefix under which other alertmanager state is stored.
+	// AlertmanagerPrefix is the bucket prefix under which other alertmanager state is stored.
 	// Note that objects stored under this prefix follow the pattern:
 	//     alertmanager/<user-id>/<object>
-	alertmanagerPrefix = "alertmanager"
+	AlertmanagerPrefix = "alertmanager"
 
 	// The name of alertmanager full state objects (notification log + silences).
 	fullStateName = "fullstate"
@@ -52,8 +52,8 @@ type BucketAlertStore struct {
 
 func NewBucketAlertStore(bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *BucketAlertStore {
 	return &BucketAlertStore{
-		alertsBucket: bucket.NewPrefixedBucketClient(bkt, alertsPrefix),
-		amBucket:     bucket.NewPrefixedBucketClient(bkt, alertmanagerPrefix),
+		alertsBucket: bucket.NewPrefixedBucketClient(bkt, AlertsPrefix),
+		amBucket:     bucket.NewPrefixedBucketClient(bkt, AlertmanagerPrefix),
 		cfgProvider:  cfgProvider,
 		logger:       logger,
 	}

--- a/pkg/mimir/sanity_check.go
+++ b/pkg/mimir/sanity_check.go
@@ -269,7 +269,7 @@ func checkFilesystemPathsOvelapping(cfg Config, logger log.Logger) error {
 				cfgValue = cfg.AlertmanagerStorage.Filesystem.Directory
 			)
 
-			// All ruler configuration is stored under an hardcoded prefix that we're taking in account here.
+			// All ruler configuration is stored under an hardcoded prefix that we're taking into account here.
 			paths = append(paths, pathConfig{name: name, cfgValue: cfgValue, checkValue: filepath.Join(cfg.AlertmanagerStorage.Filesystem.Directory, alertbucketclient.AlertsPrefix)})
 			paths = append(paths, pathConfig{name: name, cfgValue: cfgValue, checkValue: filepath.Join(cfg.AlertmanagerStorage.Filesystem.Directory, alertbucketclient.AlertmanagerPrefix)})
 		}

--- a/pkg/mimir/sanity_check.go
+++ b/pkg/mimir/sanity_check.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -16,9 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/thanos-io/thanos/pkg/runutil"
 
-	alertbucketclient "github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient"
 	alertstorelocal "github.com/grafana/mimir/pkg/alertmanager/alertstore/local"
-	rulebucketclient "github.com/grafana/mimir/pkg/ruler/rulestore/bucketclient"
 	rulestorelocal "github.com/grafana/mimir/pkg/ruler/rulestore/local"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/util/fs"
@@ -32,13 +29,6 @@ type dirExistsFunc func(string) (bool, error)
 type isDirReadWritableFunc func(dir string) error
 
 func runSanityCheck(ctx context.Context, cfg Config, logger log.Logger) error {
-	level.Info(logger).Log("msg", "Checking configured filesystem paths")
-	if err := checkFilesystemPathsOvelapping(cfg, logger); err != nil {
-		level.Error(logger).Log("msg", err.Error())
-		return err
-	}
-	level.Info(logger).Log("msg", "Configured filesystem paths successfully checked")
-
 	level.Info(logger).Log("msg", "Checking directories read/write access")
 	if err := checkDirectoriesReadWriteAccess(cfg, fs.DirExists, fs.IsDirReadWritable); err != nil {
 		level.Error(logger).Log("msg", "Unable to access directory", "err", err)
@@ -181,155 +171,4 @@ func checkObjectStoreConfig(ctx context.Context, cfg bucket.Config, logger log.L
 
 	runutil.ExhaustCloseWithErrCapture(&err, reader, "error while reading from object store")
 	return err
-}
-
-// checkFilesystemPathsOvelapping checks all configured filesystem paths and return error if it finds two of them
-// overlapping (Mimir expects all filesystem paths to not overlap).
-func checkFilesystemPathsOvelapping(cfg Config, logger log.Logger) error {
-	type pathConfig struct {
-		name       string
-		cfgValue   string
-		checkValue string
-	}
-
-	var paths []pathConfig
-
-	if cfg.BlocksStorage.Bucket.Backend == bucket.Filesystem {
-		// Add the optional prefix to the path, because that's the actual location where blocks will be stored.
-		paths = append(paths, pathConfig{
-			name:       "blocks storage filesystem directory",
-			cfgValue:   cfg.BlocksStorage.Bucket.Filesystem.Directory,
-			checkValue: filepath.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, cfg.BlocksStorage.Bucket.StoragePrefix),
-		})
-	}
-
-	// Ingester.
-	if cfg.isAnyModuleEnabled(All, Ingester, Write) {
-		paths = append(paths, pathConfig{
-			name:       "tsdb directory",
-			cfgValue:   cfg.BlocksStorage.TSDB.Dir,
-			checkValue: cfg.BlocksStorage.TSDB.Dir,
-		})
-	}
-
-	// Store-gateway.
-	if cfg.isAnyModuleEnabled(All, StoreGateway, Backend) {
-		paths = append(paths, pathConfig{
-			name:       "bucket store sync directory",
-			cfgValue:   cfg.BlocksStorage.BucketStore.SyncDir,
-			checkValue: cfg.BlocksStorage.BucketStore.SyncDir,
-		})
-	}
-
-	// Compactor.
-	if cfg.isAnyModuleEnabled(All, Compactor, Backend) {
-		paths = append(paths, pathConfig{
-			name:       "compactor data directory",
-			cfgValue:   cfg.Compactor.DataDir,
-			checkValue: cfg.Compactor.DataDir,
-		})
-	}
-
-	// Ruler.
-	if cfg.isAnyModuleEnabled(All, Ruler, Backend) {
-		paths = append(paths, pathConfig{
-			name:       "ruler data directory",
-			cfgValue:   cfg.Ruler.RulePath,
-			checkValue: cfg.Ruler.RulePath,
-		})
-
-		if cfg.RulerStorage.Backend == bucket.Filesystem {
-			// All ruler configuration is stored under an hardcoded prefix that we're taking in account here.
-			paths = append(paths, pathConfig{
-				name:       "ruler storage filesystem directory",
-				cfgValue:   cfg.RulerStorage.Filesystem.Directory,
-				checkValue: filepath.Join(cfg.RulerStorage.Filesystem.Directory, rulebucketclient.RulesPrefix),
-			})
-		}
-		if cfg.RulerStorage.Backend == rulestorelocal.Name {
-			paths = append(paths, pathConfig{
-				name:       "ruler storage local directory",
-				cfgValue:   cfg.RulerStorage.Local.Directory,
-				checkValue: cfg.RulerStorage.Local.Directory,
-			})
-		}
-	}
-
-	// Alertmanager.
-	if cfg.isAnyModuleEnabled(AlertManager) {
-		paths = append(paths, pathConfig{
-			name:       "alertmanager data directory",
-			cfgValue:   cfg.Alertmanager.DataDir,
-			checkValue: cfg.Alertmanager.DataDir,
-		})
-
-		if cfg.AlertmanagerStorage.Backend == bucket.Filesystem {
-			var (
-				name     = "alertmanager storage filesystem directory"
-				cfgValue = cfg.AlertmanagerStorage.Filesystem.Directory
-			)
-
-			// All ruler configuration is stored under an hardcoded prefix that we're taking into account here.
-			paths = append(paths, pathConfig{name: name, cfgValue: cfgValue, checkValue: filepath.Join(cfg.AlertmanagerStorage.Filesystem.Directory, alertbucketclient.AlertsPrefix)})
-			paths = append(paths, pathConfig{name: name, cfgValue: cfgValue, checkValue: filepath.Join(cfg.AlertmanagerStorage.Filesystem.Directory, alertbucketclient.AlertmanagerPrefix)})
-		}
-
-		if cfg.AlertmanagerStorage.Backend == alertstorelocal.Name {
-			paths = append(paths, pathConfig{
-				name:       "alertmanager storage local directory",
-				cfgValue:   cfg.AlertmanagerStorage.Local.Path,
-				checkValue: cfg.AlertmanagerStorage.Local.Path,
-			})
-		}
-	}
-
-	// Convert all check paths to absolute clean paths.
-	for idx, path := range paths {
-		abs, err := filepath.Abs(path.checkValue)
-		if err != nil {
-			// We prefer to log a warning instead of returning an error to ensure that if we're unable to
-			// run the sanity check Mimir could start anyway.
-			level.Warn(logger).Log("msg", "the configuration sanity check for the filesystem directory has been skipped because can't get the absolute path", "path", path, "err", err)
-			paths[idx].checkValue = ""
-			continue
-		}
-
-		paths[idx].checkValue = abs
-	}
-
-	for _, firstPath := range paths {
-		for _, secondPath := range paths {
-			// Skip the same config field.
-			if firstPath.name == secondPath.name {
-				continue
-			}
-
-			// Skip if we've been unable to get the absolute path of one of the two paths.
-			if firstPath.checkValue == "" || secondPath.checkValue == "" {
-				continue
-			}
-
-			if isAbsPathOverlapping(firstPath.checkValue, secondPath.checkValue) {
-				// Report the configured path in the error message, otherwise it's harder for the user to spot it.
-				return fmt.Errorf("the configured %s %q cannot overlap with the configured %s %q; please set different paths, also ensuring one is not a subdirectory of the other one", firstPath.name, firstPath.cfgValue, secondPath.name, secondPath.cfgValue)
-			}
-		}
-	}
-
-	return nil
-}
-
-// isAbsPathOverlapping returns whether the two input absolute paths overlap.
-func isAbsPathOverlapping(firstAbsPath, secondAbsPath string) bool {
-	firstBase, firstName := filepath.Split(firstAbsPath)
-	secondBase, secondName := filepath.Split(secondAbsPath)
-
-	if firstBase == secondBase {
-		// The base directories are the same, so they overlap if the last segment of the path (name)
-		// is the same or it's missing (happens when the input path is the root "/").
-		return firstName == secondName || firstName == "" || secondName == ""
-	}
-
-	// The base directories are different, but they could still overlap if one is the child of the other one.
-	return strings.HasPrefix(firstAbsPath, secondAbsPath) || strings.HasPrefix(secondAbsPath, firstAbsPath)
 }

--- a/pkg/mimir/sanity_check_test.go
+++ b/pkg/mimir/sanity_check_test.go
@@ -6,13 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
@@ -41,6 +38,8 @@ func TestCheckObjectStoresConfig(t *testing.T) {
 					bucketCfg.Backend = bucket.Filesystem
 					bucketCfg.Filesystem.Directory = "/does/not/exists"
 				}
+
+				cfg.BlocksStorage.Bucket.StoragePrefix = "blocks"
 			},
 			expected: "",
 		},
@@ -277,213 +276,6 @@ func TestCheckDirectoryReadWriteAccess(t *testing.T) {
 					}
 				})
 			}
-		})
-	}
-}
-
-func TestCheckFilesystemPathsOvelapping(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
-	tests := map[string]struct {
-		setup       func(cfg *Config)
-		expectedErr string
-	}{
-		"should succeed with the default configuration": {
-			setup: func(cfg *Config) {},
-		},
-		"should fail if alertmanager filesystem backend directory is equal to alertmanager data directory": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{AlertManager}
-				cfg.Alertmanager.DataDir = "/path/to/alertmanager"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager/"
-			},
-			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager/"`,
-		},
-		"should fail if alertmanager filesystem backend directory is a subdirectory of alertmanager data directory": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{AlertManager}
-				cfg.Alertmanager.DataDir = "/path/to/alertmanager"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager/subdir"
-			},
-			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager/subdir"`,
-		},
-		"should fail if alertmanager data directory is a subdirectory of alertmanager filesystem backend directory, and matches with the prefix used to store alerts": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{AlertManager}
-				cfg.Alertmanager.DataDir = "/path/to/alertmanager/alerts"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager"
-			},
-			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager/alerts" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager"`,
-		},
-		"should succeed if alertmanager data directory is a subdirectory of alertmanager filesystem backend directory, but doesn't match with the prefix used to store alerts": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{AlertManager}
-				cfg.Alertmanager.DataDir = "/path/to/alertmanager/data"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager"
-			},
-		},
-		"should fail if alertmanager data directory (relative) is a subdirectory of alertmanager filesystem backend directory (absolute), and matches with the prefix used to store alertmanager config": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{AlertManager}
-				cfg.Alertmanager.DataDir = "./data/alertmanager"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = filepath.Join(cwd, "data")
-			},
-			expectedErr: fmt.Sprintf(`the configured alertmanager data directory "./data/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "%s"`, filepath.Join(cwd, "data")),
-		},
-		"should fail if ruler filesystem backend directory is equal to ruler data directory": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ruler}
-				cfg.Ruler.RulePath = "/path/to/ruler"
-				cfg.RulerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.RulerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/ruler/"
-			},
-			expectedErr: `the configured ruler data directory "/path/to/ruler" cannot overlap with the configured ruler storage filesystem directory "/path/to/ruler/"`,
-		},
-		"should fail if store-gateway and compactor data directory overlap": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{StoreGateway, Compactor}
-				cfg.BlocksStorage.BucketStore.SyncDir = "/path/to/data"
-				cfg.Compactor.DataDir = "/path/to/data/compactor"
-			},
-			expectedErr: `the configured bucket store sync directory "/path/to/data" cannot overlap with the configured compactor data directory "/path/to/data/compactor"`,
-		},
-		"should succeed if store-gateway and compactor data directory overlap, but it's running only the store-gateway": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{StoreGateway}
-				cfg.BlocksStorage.BucketStore.SyncDir = "/path/to/data"
-				cfg.Compactor.DataDir = "/path/to/data/compactor"
-			},
-		},
-		"should fail if tsdb directory and blocks storage filesystem directory overlap": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ingester}
-				cfg.BlocksStorage.TSDB.Dir = "/path/to/data"
-				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
-				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data/blocks"
-			},
-			expectedErr: `the configured blocks storage filesystem directory "/path/to/data/blocks" cannot overlap with the configured tsdb directory "/path/to/data"`,
-		},
-		"should succeed if tsdb directory and blocks storage filesystem directory overlap, but blocks storage has prefix configured": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ingester}
-				cfg.BlocksStorage.TSDB.Dir = "/path/to/data/tsdb"
-				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
-
-				// The storage directory itself overlaps with TSDB data directory,
-				// but it doesn't if you also apply the prefix.
-				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data"
-				cfg.BlocksStorage.Bucket.StoragePrefix = "blocks"
-			},
-		},
-		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ingester}
-				cfg.BlocksStorage.TSDB.Dir = "/path/to/data/tsdb"
-				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
-				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data/blocks"
-			},
-		},
-		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap and one has the same prefix of the other one": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ingester}
-				cfg.BlocksStorage.TSDB.Dir = "/path/to/data"
-				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
-				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data-blocks"
-			},
-		},
-		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap and they're both root directories": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ingester}
-				cfg.BlocksStorage.TSDB.Dir = "/data"
-				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
-				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/data-blocks"
-			},
-		},
-		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap and they're both child of the same directory": {
-			setup: func(cfg *Config) {
-				cfg.Target = flagext.StringSliceCSV{Ingester}
-				cfg.BlocksStorage.TSDB.Dir = "./data"
-				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
-				cfg.BlocksStorage.Bucket.Filesystem.Directory = "./data-blocks"
-			},
-		},
-	}
-
-	for testName, testData := range tests {
-		t.Run(testName, func(t *testing.T) {
-			cfg := Config{}
-			flagext.DefaultValues(&cfg)
-			testData.setup(&cfg)
-
-			actualErr := checkFilesystemPathsOvelapping(cfg, log.NewNopLogger())
-
-			if testData.expectedErr != "" {
-				require.Error(t, actualErr)
-				require.Contains(t, actualErr.Error(), testData.expectedErr)
-			} else {
-				require.NoError(t, actualErr)
-			}
-		})
-	}
-}
-
-func TestIsAbsPathOverlapping(t *testing.T) {
-	tests := []struct {
-		first    string
-		second   string
-		expected bool
-	}{
-		{
-			first:    "/",
-			second:   "/",
-			expected: true,
-		},
-		{
-			first:    "/data",
-			second:   "/",
-			expected: true,
-		},
-		{
-			first:    "/",
-			second:   "/data",
-			expected: true,
-		},
-		{
-			first:    "/data",
-			second:   "/data-more",
-			expected: false,
-		},
-		{
-			first:    "/path/to/data",
-			second:   "/path/to/data",
-			expected: true,
-		},
-		{
-			first:    "/path/to/data",
-			second:   "/path/to/data/more",
-			expected: true,
-		},
-		{
-			first:    "/path/to/data",
-			second:   "/path/to/data-more",
-			expected: false,
-		},
-		{
-			first:    "/path/to/data",
-			second:   "/path/to/more/data",
-			expected: false,
-		},
-	}
-
-	for _, testData := range tests {
-		t.Run(fmt.Sprintf("check if %q overlaps %q", testData.first, testData.second), func(t *testing.T) {
-			assert.Equal(t, testData.expected, isAbsPathOverlapping(testData.first, testData.second))
 		})
 	}
 }

--- a/pkg/mimir/sanity_check_test.go
+++ b/pkg/mimir/sanity_check_test.go
@@ -6,10 +6,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
@@ -274,6 +277,193 @@ func TestCheckDirectoryReadWriteAccess(t *testing.T) {
 					}
 				})
 			}
+		})
+	}
+}
+
+func TestCheckFilesystemPathsOvelapping(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		setup       func(cfg *Config)
+		expectedErr string
+	}{
+		"should succeed with the default configuration": {
+			setup: func(cfg *Config) {},
+		},
+		"should fail if alertmanager filesystem backend directory is equal to alertmanager data directory": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{AlertManager}
+				cfg.Alertmanager.DataDir = "/path/to/alertmanager"
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager/"
+			},
+			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager/"`,
+		},
+		"should fail if alertmanager filesystem backend directory is a subdirectory of alertmanager data directory": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{AlertManager}
+				cfg.Alertmanager.DataDir = "/path/to/alertmanager"
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager/subdir"
+			},
+			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager/subdir"`,
+		},
+		"should fail if alertmanager data directory is a subdirectory of alertmanager filesystem backend directory": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{AlertManager}
+				cfg.Alertmanager.DataDir = "/path/to/alertmanager/subdir"
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager"
+			},
+			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager/subdir" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager"`,
+		},
+		"should fail if alertmanager data directory (relative) is a subdirectory of alertmanager filesystem backend directory (absolute)": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{AlertManager}
+				cfg.Alertmanager.DataDir = "./data/subdir"
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = filepath.Join(cwd, "data")
+			},
+			expectedErr: fmt.Sprintf(`the configured alertmanager data directory "./data/subdir" cannot overlap with the configured alertmanager storage filesystem directory "%s"`, filepath.Join(cwd, "data")),
+		},
+		"should fail if ruler filesystem backend directory is equal to ruler data directory": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Ruler}
+				cfg.Ruler.RulePath = "/path/to/ruler"
+				cfg.RulerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
+				cfg.RulerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/ruler/"
+			},
+			expectedErr: `the configured ruler data directory "/path/to/ruler" cannot overlap with the configured ruler storage filesystem directory "/path/to/ruler/"`,
+		},
+		"should fail if store-gateway and compactor data directory overlap": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{StoreGateway, Compactor}
+				cfg.BlocksStorage.BucketStore.SyncDir = "/path/to/data"
+				cfg.Compactor.DataDir = "/path/to/data/compactor"
+			},
+			expectedErr: `the configured bucket store sync directory "/path/to/data" cannot overlap with the configured compactor data directory "/path/to/data/compactor"`,
+		},
+		"should succeed if store-gateway and compactor data directory overlap, but it's running only the store-gateway": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{StoreGateway}
+				cfg.BlocksStorage.BucketStore.SyncDir = "/path/to/data"
+				cfg.Compactor.DataDir = "/path/to/data/compactor"
+			},
+		},
+		"should fail if tsdb directory and blocks storage filesystem directory overlap": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Ingester}
+				cfg.BlocksStorage.TSDB.Dir = "/path/to/data"
+				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
+				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data/blocks"
+			},
+			expectedErr: `the configured blocks storage filesystem directory "/path/to/data/blocks" cannot overlap with the configured tsdb directory "/path/to/data"`,
+		},
+		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Ingester}
+				cfg.BlocksStorage.TSDB.Dir = "/path/to/data/tsdb"
+				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
+				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data/blocks"
+			},
+		},
+		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap and one has the same prefix of the other one": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Ingester}
+				cfg.BlocksStorage.TSDB.Dir = "/path/to/data"
+				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
+				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/path/to/data-blocks"
+			},
+		},
+		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap and they're both root directories": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Ingester}
+				cfg.BlocksStorage.TSDB.Dir = "/data"
+				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
+				cfg.BlocksStorage.Bucket.Filesystem.Directory = "/data-blocks"
+			},
+		},
+		"should succeed if tsdb directory and blocks storage filesystem directory don't overlap and they're both child of the same directory": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Ingester}
+				cfg.BlocksStorage.TSDB.Dir = "./data"
+				cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
+				cfg.BlocksStorage.Bucket.Filesystem.Directory = "./data-blocks"
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := Config{}
+			flagext.DefaultValues(&cfg)
+			testData.setup(&cfg)
+
+			actualErr := checkFilesystemPathsOvelapping(cfg, log.NewNopLogger())
+
+			if testData.expectedErr != "" {
+				require.Error(t, actualErr)
+				require.Contains(t, actualErr.Error(), testData.expectedErr)
+			} else {
+				require.NoError(t, actualErr)
+			}
+		})
+	}
+}
+
+func TestIsAbsPathOverlapping(t *testing.T) {
+	tests := []struct {
+		first    string
+		second   string
+		expected bool
+	}{
+		{
+			first:    "/",
+			second:   "/",
+			expected: true,
+		},
+		{
+			first:    "/data",
+			second:   "/",
+			expected: true,
+		},
+		{
+			first:    "/",
+			second:   "/data",
+			expected: true,
+		},
+		{
+			first:    "/data",
+			second:   "/data-more",
+			expected: false,
+		},
+		{
+			first:    "/path/to/data",
+			second:   "/path/to/data",
+			expected: true,
+		},
+		{
+			first:    "/path/to/data",
+			second:   "/path/to/data/more",
+			expected: true,
+		},
+		{
+			first:    "/path/to/data",
+			second:   "/path/to/data-more",
+			expected: false,
+		},
+		{
+			first:    "/path/to/data",
+			second:   "/path/to/more/data",
+			expected: false,
+		},
+	}
+
+	for _, testData := range tests {
+		t.Run(fmt.Sprintf("check if %q overlaps %q", testData.first, testData.second), func(t *testing.T) {
+			assert.Equal(t, testData.expected, isAbsPathOverlapping(testData.first, testData.second))
 		})
 	}
 }

--- a/pkg/ruler/rulestore/bucketclient/bucket_client.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	// The bucket prefix under which all tenants rule groups are stored.
-	rulesPrefix = "rules"
+	// RulesPrefix is the bucket prefix under which all tenants rule groups are stored.
+	RulesPrefix = "rules"
 
 	loadConcurrency = 10
 )
@@ -49,7 +49,7 @@ type BucketRuleStore struct {
 
 func NewBucketRuleStore(bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *BucketRuleStore {
 	return &BucketRuleStore{
-		bucket:      bucket.NewPrefixedBucketClient(bkt, rulesPrefix),
+		bucket:      bucket.NewPrefixedBucketClient(bkt, RulesPrefix),
 		cfgProvider: cfgProvider,
 		logger:      logger,
 	}


### PR DESCRIPTION
#### What this PR does
While answering the question https://github.com/grafana/mimir/discussions/2698#discussioncomment-3464676 I've realized that if you set overlapping local directories for different purposes you could end up with weird behaviour (e.g. alertmanager deleting the alerts store content). These errors are quite difficult to detect, so in this PR I'm proposing to introduce a sanity check to ensure the configured filesystem directories don't overlap for different components (checking only the running components).

Thought: the logic encoded in this new check is non trivial, but that's one more reason why we should encode it instead of letting our users figuring out through a try-and-error process.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
