### PR TITLE
Use default HTTP and gRPC ports in the read-write local dev env

### DIFF
--- a/development/mimir-read-write-mode/config/grafana-agent.yaml
+++ b/development/mimir-read-write-mode/config/grafana-agent.yaml
@@ -11,22 +11,22 @@ prometheus:
       scrape_configs:
         - job_name: mimir-read-write-mode/mimir-write
           static_configs:
-            - targets: ['mimir-write-1:8001', 'mimir-write-2:8002', 'mimir-write-3:8003']
+            - targets: ['mimir-write-1:8080', 'mimir-write-2:8080', 'mimir-write-3:8080']
               labels:
                 cluster: 'docker-compose'
                 namespace: 'mimir-read-write-mode'
         - job_name: mimir-read-write-mode/mimir-read
           static_configs:
-            - targets: ['mimir-read-1:8004', 'mimir-read-2:8005']
+            - targets: ['mimir-read-1:8080', 'mimir-read-2:8080']
               labels:
                 cluster: 'docker-compose'
                 namespace: 'mimir-read-write-mode'
         - job_name: mimir-read-write-mode/mimir-backend
           static_configs:
-            - targets: ['mimir-backend-1:8006', 'mimir-backend-2:8007']
+            - targets: ['mimir-backend-1:8080', 'mimir-backend-2:8080']
               labels:
                 cluster: 'docker-compose'
                 namespace: 'mimir-read-write-mode'
 
       remote_write:
-        - url: http://mimir-write-1:8001/api/v1/push
+        - url: http://mimir-write-1:8080/api/v1/push

--- a/development/mimir-read-write-mode/config/mimir.yaml
+++ b/development/mimir-read-write-mode/config/mimir.yaml
@@ -39,7 +39,7 @@ memberlist:
 ruler:
   rule_path: /data/ruler
   # Each ruler is configured to route alerts to the Alertmanager running within the same component.
-  alertmanager_url: http://mimir-backend-1:8006/alertmanager
+  alertmanager_url: http://localhost:8080/alertmanager
 
 ruler_storage:
   s3:
@@ -48,12 +48,12 @@ ruler_storage:
 frontend:
   # Currently we can't specify multiple addresses, so we're just using a single replica for the query-scheduler.
   # See: https://github.com/grafana/mimir/issues/2012
-  scheduler_address: "mimir-backend-1:9006"
+  scheduler_address: "mimir-backend-1:9095"
 
 frontend_worker:
   # Currently we can't specify multiple addresses, so we're just using a single replica for the query-scheduler.
   # See: https://github.com/grafana/mimir/issues/2012
-  scheduler_address: "mimir-backend-1:9006"
+  scheduler_address: "mimir-backend-1:9095"
 
 alertmanager:
   data_dir: /data/alertmanager

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -18,16 +18,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=backend"
-      - "-server.http-listen-port=8006"
-      - "-server.grpc-listen-port=9006"
-      - "-activity-tracker.filepath=/activity/backend-8006"
+      - "-activity-tracker.filepath=/activity/mimir-backend-1"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-backend-1"
     "image": "mimir"
     "ports":
-      - "8006:8006"
+      - "8006:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -39,16 +37,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=backend"
-      - "-server.http-listen-port=8007"
-      - "-server.grpc-listen-port=9007"
-      - "-activity-tracker.filepath=/activity/backend-8007"
+      - "-activity-tracker.filepath=/activity/mimir-backend-2"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-backend-2"
     "image": "mimir"
     "ports":
-      - "8007:8007"
+      - "8007:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -60,16 +56,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=read"
-      - "-server.http-listen-port=8004"
-      - "-server.grpc-listen-port=9004"
-      - "-activity-tracker.filepath=/activity/read-8004"
+      - "-activity-tracker.filepath=/activity/mimir-read-1"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-read-1"
     "image": "mimir"
     "ports":
-      - "8004:8004"
+      - "8004:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -81,16 +75,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=read"
-      - "-server.http-listen-port=8005"
-      - "-server.grpc-listen-port=9005"
-      - "-activity-tracker.filepath=/activity/read-8005"
+      - "-activity-tracker.filepath=/activity/mimir-read-2"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-read-2"
     "image": "mimir"
     "ports":
-      - "8005:8005"
+      - "8005:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -102,16 +94,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=write"
-      - "-server.http-listen-port=8001"
-      - "-server.grpc-listen-port=9001"
-      - "-activity-tracker.filepath=/activity/write-8001"
+      - "-activity-tracker.filepath=/activity/mimir-write-1"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-write-1"
     "image": "mimir"
     "ports":
-      - "8001:8001"
+      - "8001:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -124,16 +114,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=write"
-      - "-server.http-listen-port=8002"
-      - "-server.grpc-listen-port=9002"
-      - "-activity-tracker.filepath=/activity/write-8002"
+      - "-activity-tracker.filepath=/activity/mimir-write-2"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-write-2"
     "image": "mimir"
     "ports":
-      - "8002:8002"
+      - "8002:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -146,16 +134,14 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=write"
-      - "-server.http-listen-port=8003"
-      - "-server.grpc-listen-port=9003"
-      - "-activity-tracker.filepath=/activity/write-8003"
+      - "-activity-tracker.filepath=/activity/mimir-write-3"
     "depends_on":
       - "minio"
     "environment": []
     "hostname": "mimir-write-3"
     "image": "mimir"
     "ports":
-      - "8003:8003"
+      - "8003:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"


### PR DESCRIPTION
#### What this PR does
When working on https://github.com/grafana/mimir/pull/2838 I've found annoying that each replica in the local dev env customize the HTTP and gRPC port. We don't really need it, we just need the published port to be different.

In this PR I'm using the default HTTP (8080) and gRPC (9095) ports, and then using a different port for each replica when publishing them to the host (keeps the previous published port number).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
