### PR TITLE
Helm: add autoscaling/v2 horizontalPodAutoscaler for nginx

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Ingresses for the GEM gateway and nginx will no longer render on Kubernetes versions <1.19. #2872
 * [FEATURE] Add support for `topologySpreadConstraints` to all components; add `topologySpreadConstraints` to GEM gateway, admin-api, and alertmanager, which did not have `podAntiAffinity` previously. #2722
 * [ENHANCEMENT] Document `kubeVersionOverride`. If you rely on `helm template`, use this in your values to set the Kubernetes version. If unset helm will use the kubectl client version as the Kubernetes version with `helm template`, which may cause the chart to render incompatible manifests for the actual server version. #2872
+* [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling. This is enabled by default on Kubernetes >= 1.25. #2848
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -18,7 +18,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Ingresses for the GEM gateway and nginx will no longer render on Kubernetes versions <1.19. #2872
 * [FEATURE] Add support for `topologySpreadConstraints` to all components; add `topologySpreadConstraints` to GEM gateway, admin-api, and alertmanager, which did not have `podAntiAffinity` previously. #2722
 * [ENHANCEMENT] Document `kubeVersionOverride`. If you rely on `helm template`, use this in your values to set the Kubernetes version. If unset helm will use the kubectl client version as the Kubernetes version with `helm template`, which may cause the chart to render incompatible manifests for the actual server version. #2872
-* [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling. This is enabled by default on Kubernetes >= 1.25. #2848
+* [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling. This is used when deploying on Kubernetes >= 1.25. #2848
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/templates/nginx/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/_helpers.tpl
@@ -4,3 +4,14 @@ nginx auth secret name
 {{- define "mimir.nginxAuthSecret" -}}
 {{ .Values.nginx.basicAuth.existingSecret | default (include "mimir.resourceName" (dict "ctx" . "component" "nginx") ) }}
 {{- end }}
+
+{{/*
+Returns the HorizontalPodAutoscaler API version for this verison of kubernetes.
+*/}}
+{{- define "mimir.hpa.version" -}}
+{{- if semverCompare ">= 1.25-0" .Capabilities.KubeVersion.Version -}}
+autoscaling/v2
+{{- else -}}
+autoscaling/v2beta1
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
@@ -1,0 +1,37 @@
+{{- if not .Values.enterprise.enabled -}}
+{{- if .Values.nginx.autoscaling.enabled }}
+{{- if eq (include "mimir.hpa.version" .) "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "nginx") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "nginx") }}
+  minReplicas: {{ .Values.nginx.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.nginx.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.nginx.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.nginx.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageValue
+          averageUtilization: {{ . }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-v2beta1-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-v2beta1-hpa.yaml
@@ -1,5 +1,6 @@
 {{- if not .Values.enterprise.enabled -}}
 {{- if .Values.nginx.autoscaling.enabled }}
+{{- if eq (include "mimir.hpa.version" .) "autoscaling/v2beta1" }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -27,5 +28,6 @@ spec:
         name: cpu
         targetAverageUtilization: {{ . }}
   {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/validate.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/validate.yaml
@@ -147,3 +147,12 @@
 {{- if not .Values.ingester.statefulSet.enabled -}}
 {{- fail "You have set ingester.statefulSet.enabled: false. Ingesters are stateful, kubernetes Deployment workloads are no longer supported. Please refer to the documentation for more details." }}
 {{- end -}}
+
+{{- with .Values.nginx -}}
+{{- if and .autoscaling.enabled .autoscaling.targetCPUUtilizationPercentage (not ((.resources).requests).cpu) -}}
+{{- fail "You have enabled nginx.autoscaling.targetCPUUtilizationPercentage, you must also set nginx.resources.requests.cpu." -}}
+{{- end -}}
+{{- if and .autoscaling.enabled .autoscaling.targetMemoryUtilizationPercentage (not ((.resources).requests).memory) -}}
+{{- fail "You have enabled nginx.autoscaling.targetMemoryUtilizationPercentage, you must also set nginx.resources.requests.memory." -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
#### What this PR does

The autoscaling/v2beta1 HorizontalPodAutoscaler is [removed in Kubernetes 1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125) in favour of autoscaling/v2. This creates a different resource for the HPA if the kubernetes version is >=1.25.

I still haven't tested that the below works on 1.25, but the manifests seem to comply with the [API spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec).

Keeping in draft until I can verify this works with 1.25

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/2201

#### Checklist

- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
