### PR TITLE
Helm: open port 80 on enterprise gateway

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -21,6 +21,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Upgrade nginx image tag to `nginxinc/nginx-unprivileged:1.22-alpine`. #2742
 * [ENHANCEMENT] Upgrade minio subchart to `4.0.12`. #2759
 * [BUGFIX] Do not use undocumented `mulf` function in templates. #2752
+* [BUGFIX] Open port 80 for the Enterprise `gateway` so that the read and write address reported by NOTEX.txt is correct. Also deprecate the current default of 8080.
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -21,7 +21,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Upgrade nginx image tag to `nginxinc/nginx-unprivileged:1.22-alpine`. #2742
 * [ENHANCEMENT] Upgrade minio subchart to `4.0.12`. #2759
 * [BUGFIX] Do not use undocumented `mulf` function in templates. #2752
-* [BUGFIX] Open port 80 for the Enterprise `gateway` so that the read and write address reported by NOTEX.txt is correct. Also deprecate the current default of 8080.
+* [BUGFIX] Open port 80 for the Enterprise `gateway` so that the read and write address reported by NOTEX.txt is correct. Also deprecate the current default of 8080. #2860
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -21,7 +21,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Upgrade nginx image tag to `nginxinc/nginx-unprivileged:1.22-alpine`. #2742
 * [ENHANCEMENT] Upgrade minio subchart to `4.0.12`. #2759
 * [BUGFIX] Do not use undocumented `mulf` function in templates. #2752
-* [BUGFIX] Open port 80 for the Enterprise `gateway` so that the read and write address reported by NOTEX.txt is correct. Also deprecate the current default of 8080. #2860
+* [BUGFIX] Open port 80 for the Enterprise `gateway` service so that the read and write address reported by NOTES.txt is correct. Also deprecate the current default of 8080. #2860
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/templates/NOTES.txt
+++ b/operations/helm/charts/mimir-distributed/templates/NOTES.txt
@@ -17,7 +17,7 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port | default "80" }}/api/v1/push
+  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port }}/api/v1/push
 
 Read address, Grafana data source (Prometheus) URL:
 {{ with $gateway.ingress -}}
@@ -30,4 +30,4 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port | default "80" }}{{ template "mimir.prometheusHttpPrefix" $ }}
+  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port }}{{ template "mimir.prometheusHttpPrefix" $ }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -14,10 +14,16 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.gateway.service.port | default (include "mimir.serverHttpListenPort" . ) }}
+    - port: {{ .Values.gateway.service.port }}
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
+    {{- with .Values.gateway.service.legacyPort }}
+    - port: {{ . }}
+      protocol: TCP
+      name: legacy-http-metrics
+      targetPort: http-metrics
+    {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "gateway") | nindent 4 }}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2011,8 +2011,10 @@ gateway:
   service:
     annotations: {}
     labels: {}
-    # -- If the port is left undefined, the service will listen on the same port as the pod
-    port: null
+    # -- Port the gateway service listens on
+    port: 80
+    # -- DEPRECATED Legacy compatibility port the gateway service listens on, set to 'null' to disable
+    legacyPort: 8080
 
   strategy:
     type: RollingUpdate

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -15,9 +15,13 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8080
+    - port: 80
       protocol: TCP
       name: http-metrics
+      targetPort: http-metrics
+    - port: 8080
+      protocol: TCP
+      name: legacy-http-metrics
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: mimir

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -15,9 +15,13 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8080
+    - port: 80
       protocol: TCP
       name: http-metrics
+      targetPort: http-metrics
+    - port: 8080
+      protocol: TCP
+      name: legacy-http-metrics
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: mimir


### PR DESCRIPTION
#### What this PR does

We opened 8080 by default default and this is kept as legacy.
NOTEX.txt assumed we open port 80 by default, this is fixed by encoding
80 in the values file.

Updated docstring.

#### Which issue(s) this PR fixes or relates to

Relates to: #2203 

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
