### PR TITLE
Add useful helm chart scripts

### DIFF
--- a/operations/helm/charts/mimir-distributed/scripts/bootstrap_kind_cluster.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/bootstrap_kind_cluster.sh
@@ -25,6 +25,11 @@ helm upgrade --install mimir-demo \
   --kube-context kind-mimir-demo
 
 # Enterprise and graphite enabled
+# if ! test -f "license.jwt"; then
+#     echo "Please place a license.jwt file in this directory"
+#     exit 1
+# fi
+#
 # helm upgrade --install mimir-demo \
 #   "${chart_path}" \
 #   --values "${chart_path}/values.yaml" \

--- a/operations/helm/charts/mimir-distributed/scripts/bootstrap_kind_cluster.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/bootstrap_kind_cluster.sh
@@ -4,8 +4,47 @@
 # This script will bootstrap a new kubernetes cluster using kind and install the
 # mimir-distributed chart
 
+set -eufo pipefail
+
 command -v helm >/dev/null 2>&1 || { echo "helm is not installed"; exit 1; }
 command -v kind >/dev/null 2>&1 || { echo "kind is not installed"; exit 1; }
+
+function usage {
+  cat <<EOF
+Bootstrap kind cluster to test mimir-distributed helm chart
+
+Usage:
+  $0 [options]
+
+Options:
+  -ne opensource only feature
+  -e  enterprise feature
+
+Examples:
+  $0 -ne
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+enterprise=false
+non_enterprise=false
+
+while [[ $# -gt 0 ]] ; do
+case "$1" in
+  -e)
+    enterprise=true
+    ;;
+  -ne)
+    non_enterprise=true
+    ;;
+  -h) usage && exit 0 ;;
+esac
+shift
+done
 
 chart_path="../."
 
@@ -18,22 +57,25 @@ kind delete cluster --name="mimir-demo"
 echo "# Creating new kind cluster"
 kind create cluster --name mimir-demo
 
-# OSS Mimir
-helm upgrade --install mimir-demo \
-  "${chart_path}" \
-  --values "${chart_path}/values.yaml" \
-  --kube-context kind-mimir-demo
+if [ "${non_enterprise}" = "true" ] ; then
+  helm upgrade --install mimir-demo \
+    "${chart_path}" \
+    --values "${chart_path}/values.yaml" \
+    --kube-context kind-mimir-demo
+fi
 
-# Enterprise and graphite enabled
-# if ! test -f "license.jwt"; then
-#     echo "Please place a license.jwt file in this directory"
-#     exit 1
-# fi
-#
-# helm upgrade --install mimir-demo \
-#   "${chart_path}" \
-#   --values "${chart_path}/values.yaml" \
-#   --set 'enterprise.enabled=true' \
-#   --set 'graphite.enabled=true' \
-#   --set-file 'license.contents=./license.jwt' \
-#   --kube-context kind-mimir-demo
+if [ "${enterprise}" = "true" ] ; then
+  if ! test -f "license.jwt"; then
+      echo
+      echo "ERROR: Please place a license.jwt file in this directory"
+      exit 1
+  fi
+
+  helm upgrade --install mimir-demo \
+    "${chart_path}" \
+    --values "${chart_path}/values.yaml" \
+    --set 'enterprise.enabled=true' \
+    --set 'graphite.enabled=true' \
+    --set-file 'license.contents=./license.jwt' \
+    --kube-context kind-mimir-demo
+fi

--- a/operations/helm/charts/mimir-distributed/scripts/bootstrap_kind_cluster.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/bootstrap_kind_cluster.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# vim: ai:ts=8:sw=8:noet
+# This script will bootstrap a new kubernetes cluster using kind and install the
+# mimir-distributed chart
+
+command -v helm >/dev/null 2>&1 || { echo "helm is not installed"; exit 1; }
+command -v kind >/dev/null 2>&1 || { echo "kind is not installed"; exit 1; }
+
+chart_path="../."
+
+# Run this once to get the dependencies
+echo "# Fetching helm dependencies"
+helm dependency update "${chart_path}"
+
+echo "# Deleting pre-existing mimir-demo cluster if any"
+kind delete cluster --name="mimir-demo"
+echo "# Creating new kind cluster"
+kind create cluster --name mimir-demo
+
+# OSS Mimir
+helm upgrade --install mimir-demo \
+  "${chart_path}" \
+  --values "${chart_path}/values.yaml" \
+  --kube-context kind-mimir-demo
+
+# Enterprise and graphite enabled
+# helm upgrade --install mimir-demo \
+#   "${chart_path}" \
+#   --values "${chart_path}/values.yaml" \
+#   --set 'enterprise.enabled=true' \
+#   --set 'graphite.enabled=true' \
+#   --set-file 'license.contents=./license.jwt' \
+#   --kube-context kind-mimir-demo

--- a/operations/helm/charts/mimir-distributed/scripts/generate_enterprise_tenant_token.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/generate_enterprise_tenant_token.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# vim: ai:ts=8:sw=8:noet
+# This script will talk to the admin API and generate an authorization header
+# to use in future Mimir API calls.
+# It requires:
+# - Select the appropiate kubectl context before run
+# - The helm chart has already been installed and has enterprise mode enabled
+# - Specify the helm installation name in the HELM_INSTALL_NAME variable
+# - Port-forward the metric-api service to port 8080 and specify the hostname in
+# ADMIN_API_HOST
+
+set -eufo pipefail
+export SHELLOPTS
+IFS=$'\t\n'
+umask 0077
+
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed"; exit 1; }
+command -v awk >/dev/null 2>&1 || { echo "awk is not installed"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is not installed"; exit 1; }
+
+HELM_INSTALL_NAME="mimir-demo"
+ADMIN_API_HOST="localhost"
+TENANT="test-tenant"
+
+echo "# Getting API TOKEN from tokengen job"
+API_TOKEN=$(kubectl logs -f "job/${HELM_INSTALL_NAME}-mimir-tokengen" | grep Token | awk '{print $2}')
+echo "Succesfully found token: ${API_TOKEN}"
+
+echo "# Creating Test Tenant"
+data=$(cat <<END
+{
+  "name": "${TENANT}",
+  "display_name": "Test Tenant",
+  "cluster": "${HELM_INSTALL_NAME}"
+}
+END
+);
+
+curl \
+  -X POST \
+  -u ":${API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${ADMIN_API_HOST}:8080/admin/api/v2/tenants" -d  "${data}"
+
+echo
+echo "# Creating Access policy for reads and writes"
+data=$(cat <<END
+{
+  "name": "metrics-reader-and-writer",
+  "display_name": "Metrics Reader and Writer",
+  "realms": [
+    {
+      "tenant": "${TENANT}",
+      "cluster": "${HELM_INSTALL_NAME}"
+    }
+  ],
+  "scopes": [
+    "metrics:read",
+    "metrics:write"
+  ]
+}
+END
+);
+
+curl \
+  -X POST \
+  -u ":${API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${ADMIN_API_HOST}:8080/admin/api/v2/accesspolicies" -d "${data}"
+
+echo
+echo "# Creating access token"
+data=$(cat <<END
+{
+  "name": "${TENANT}-token-7",
+  "display_name": "Test Tenant Token",
+  "access_policy": "metrics-reader-and-writer"
+}
+END
+);
+
+token_response=$(curl -s \
+  -X POST \
+  -u ":${API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${ADMIN_API_HOST}:8080/admin/api/v2/tokens" -d "${data}")
+
+token=$(jq -r '.token' <(echo "${token_response}"))
+echo "# Generated API token '${token}'"
+
+# The authorization header is the base64 string of $TENANT:$TOKEN
+encoded_token=$(echo -n "${TENANT}:${token}" | base64 -w0)
+
+echo "# Use the following Authorization header in your calls"
+echo "Authorization: Basic ${encoded_token}"

--- a/operations/helm/charts/mimir-distributed/scripts/generate_enterprise_tenant_token.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/generate_enterprise_tenant_token.sh
@@ -94,3 +94,6 @@ encoded_token=$(echo -n "${TENANT}:${token}" | base64 -w0)
 
 echo "# Use the following Authorization header in your calls"
 echo "Authorization: Basic ${encoded_token}"
+echo "# Exporting environment variable MIMIR_BASIC_AUTH with the token contents"
+export MIMIR_BASIC_AUTH="${encoded_token}"
+echo "Done"

--- a/operations/helm/charts/mimir-distributed/scripts/test_graphite_read_path.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/test_graphite_read_path.sh
@@ -23,4 +23,5 @@ curl \
   -X GET \
   -H "Authorization: Basic ${MIMIR_BASIC_AUTH}" \
   -H "Content-Type: application/json" \
+  --fail-with-body \
   "${MIMIR_GATEWAY_HOST}:8080/graphite/tags"

--- a/operations/helm/charts/mimir-distributed/scripts/test_graphite_read_path.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/test_graphite_read_path.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# vim: ai:ts=8:sw=8:noet
+# This script will perform a curl to the graphite tags endpoint to make sure
+# that the graphite read path works.
+# It requires:
+# - Mimir gateway to be port forwarded to port 8080
+# - Basic auth header to be previously exported at MIMIR_BASIC_AUTH
+
+export SHELLOPTS        # propagate set to children by default
+IFS=$'\t\n'
+umask 0077
+
+MIMIR_GATEWAY_HOST="localhost"
+
+if [[ -z "${MIMIR_BASIC_AUTH}" ]]; then
+  echo "Environment variable MIMIR_BASIC_AUTH is not set. Exiting..."
+  exit 1
+fi
+
+echo "# Getting tags"
+curl \
+  -X GET \
+  -H "Authorization: Basic ${MIMIR_BASIC_AUTH}" \
+  -H "Content-Type: application/json" \
+  "${MIMIR_GATEWAY_HOST}:8080/graphite/tags"

--- a/operations/helm/charts/mimir-distributed/scripts/test_graphite_write_path.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/test_graphite_write_path.sh
@@ -47,4 +47,5 @@ curl \
   -X POST \
   -H "Authorization: Basic ${MIMIR_BASIC_AUTH}" \
   -H "Content-Type: application/json" \
+  --fail-with-body \
   "${MIMIR_GATEWAY_HOST}:8080/graphite/metrics" -d  "${data}"

--- a/operations/helm/charts/mimir-distributed/scripts/test_graphite_write_path.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/test_graphite_write_path.sh
@@ -26,19 +26,19 @@ data='[{
 "name": "uplink.speed_test.ping_ms",
 "interval": 3600,
 "value": 58080231,
-"tags": ["sponsor=Deutsche_Telekom", "server=Hamburg", "test=foo"]
+"tags": ["service=foo", "server=bar", "test=foo"]
 }, {
 "time": REPLACE_DATE,
 "name": "uplink.speed_test.down_bits",
 "interval": 3600,
 "value": 23,
-"tags": ["sponsor=Deutsche_Telekom", "server=Hamburg"]
+"tags": ["service=foo", "server=bar"]
 }, {
 "time": REPLACE_DATE,
 "name": "uplink.speed_test.up_bits",
 "interval": 3600,
 "value": 52058673,
-"tags": ["sponsor=Deutsche_Telekom", "server=Hamburg"]
+"tags": ["service=foo", "server=bar"]
 }]'
 
 data=${data//REPLACE_DATE/${timestamp}}

--- a/operations/helm/charts/mimir-distributed/scripts/test_graphite_write_path.sh
+++ b/operations/helm/charts/mimir-distributed/scripts/test_graphite_write_path.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# vim: ai:ts=8:sw=8:noet
+# This script will perform a curl to the graphite metrics endpoint to make sure
+# that the graphite write path works.
+# It requires:
+# - Mimir gateway to be port forwarded to port 8080
+# - Basic auth header to be previously exported at MIMIR_BASIC_AUTH
+
+export SHELLOPTS        # propagate set to children by default
+IFS=$'\t\n'
+umask 0077
+
+MIMIR_GATEWAY_HOST="localhost"
+
+if [[ -z "${MIMIR_BASIC_AUTH}" ]]; then
+  echo "Environment variable MIMIR_BASIC_AUTH is not set. Exiting..."
+  exit 1
+fi
+
+echo "# Pushing metrics "
+timestamp=$(date '+%s')
+
+data='[{
+"time": REPLACE_DATE,
+"name": "uplink.speed_test.ping_ms",
+"interval": 3600,
+"value": 58080231,
+"tags": ["sponsor=Deutsche_Telekom", "server=Hamburg", "test=foo"]
+}, {
+"time": REPLACE_DATE,
+"name": "uplink.speed_test.down_bits",
+"interval": 3600,
+"value": 23,
+"tags": ["sponsor=Deutsche_Telekom", "server=Hamburg"]
+}, {
+"time": REPLACE_DATE,
+"name": "uplink.speed_test.up_bits",
+"interval": 3600,
+"value": 52058673,
+"tags": ["sponsor=Deutsche_Telekom", "server=Hamburg"]
+}]'
+
+data=${data//REPLACE_DATE/${timestamp}}
+
+curl \
+  -X POST \
+  -H "Authorization: Basic ${MIMIR_BASIC_AUTH}" \
+  -H "Content-Type: application/json" \
+  "${MIMIR_GATEWAY_HOST}:8080/graphite/metrics" -d  "${data}"


### PR DESCRIPTION
This commit is adding two new scripts to:
- Bootstrap a new kind cluster with mimir-distributed installed.
- Generate an enterprise tenant token given a mimir-distributed
  installation with enterprise enabled.
