### PR TITLE
Helm: Remove PSP if kubernetes doesn't support it

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -23,6 +23,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Do not use undocumented `mulf` function in templates. #2752
 * [BUGFIX] Open port 80 for the Enterprise `gateway` service so that the read and write address reported by NOTES.txt is correct. Also deprecate the current default of 8080. #2860
 * [BUGFIX] Periodically rebalance gRPC connection between GEM gateway and distributors after scale out of the distributors. #2862
+* [BUGFIX] Remove PodSecurityPolicy when running against Kubernetes >= 1.25. #2870
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -388,13 +388,13 @@ Get the no_auth_tenant from the configuration
 {{/*
 Return if we should create a PodSecurityPoliPodSecurityPolicycy. Takes into account user values and supported kubernetes versions.
 */}}
-{{- define "mimir.ingress.usePodSecurityPolicy" -}}
+{{- define "mimir.rbac.usePodSecurityPolicy" -}}
 {{- and (semverCompare "< 1.25-0" (include "mimir.kubeVersion" .)) (and .Values.rbac.create (eq .Values.rbac.type "psp")) -}}
 {{- end -}}
 
 {{/*
 Return if we should create a SecurityContextConstraints. Takes into account user values and supported openshift versions.
 */}}
-{{- define "mimir.ingress.useSecurityContextConstraints" -}}
+{{- define "mimir.rbac.useSecurityContextConstraints" -}}
 {{- and .Values.rbac.create (eq .Values.rbac.type "scc") -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -384,3 +384,17 @@ Get the no_auth_tenant from the configuration
 {{- define "mimir.noAuthTenant" -}}
 {{- (include "mimir.calculatedConfig" . | fromYaml).no_auth_tenant | default "anonymous" -}}
 {{- end -}}
+
+{{/*
+Return if we should create a PodSecurityPoliPodSecurityPolicycy. Takes into account user values and supported kubernetes versions.
+*/}}
+{{- define "mimir.ingress.usePodSecurityPolicy" -}}
+{{- and (semverCompare "< 1.25-0" (include "mimir.kubeVersion" .)) (and .Values.rbac.create (eq .Values.rbac.type "psp")) -}}
+{{- end -}}
+
+{{/*
+Return if we should create a SecurityContextConstraints. Takes into account user values and supported openshift versions.
+*/}}
+{{- define "mimir.ingress.useSecurityContextConstraints" -}}
+{{- and .Values.rbac.create (eq .Values.rbac.type "scc") -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "mimir.ingress.usePodSecurityPolicy" .) "true" }}
+{{- if eq (include "mimir.rbac.usePodSecurityPolicy" .) "true" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (eq .Values.rbac.type "psp") }}
+{{- if eq (include "mimir.ingress.usePodSecurityPolicy" .) "true" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/operations/helm/charts/mimir-distributed/templates/role.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/role.yaml
@@ -1,5 +1,5 @@
-{{- $usePSP := (eq (include "mimir.ingress.usePodSecurityPolicy" .) "true") }}
-{{- $useSCC := (eq (include "mimir.ingress.useSecurityContextConstraints" .) "true") }}
+{{- $usePSP := (eq (include "mimir.rbac.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "mimir.rbac.useSecurityContextConstraints" .) "true") }}
 {{- if or $usePSP $useSCC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/operations/helm/charts/mimir-distributed/templates/role.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/role.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.rbac.create (or (eq .Values.rbac.type "psp") (eq .Values.rbac.type "scc")) }}
+{{- $usePSP := (eq (include "mimir.ingress.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "mimir.ingress.useSecurityContextConstraints" .) "true") }}
+{{- if or $usePSP $useSCC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -7,13 +9,13 @@ metadata:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
-{{- if eq .Values.rbac.type "psp" }}
+{{- if $usePSP }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ include "mimir.resourceName" (dict "ctx" .) }}]
 {{- end }}
-{{- if eq .Values.rbac.type "scc" }}
+{{- if $useSCC }}
 - apiGroups:
     - security.openshift.io
   resources:

--- a/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.rbac.create (or (eq .Values.rbac.type "psp") (eq .Values.rbac.type "scc")) }}
+{{- $usePSP := (eq (include "mimir.ingress.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "mimir.ingress.useSecurityContextConstraints" .) "true") }}
+{{- if or $usePSP $useSCC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
-{{- $usePSP := (eq (include "mimir.ingress.usePodSecurityPolicy" .) "true") }}
-{{- $useSCC := (eq (include "mimir.ingress.useSecurityContextConstraints" .) "true") }}
+{{- $usePSP := (eq (include "mimir.rbac.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "mimir.rbac.useSecurityContextConstraints" .) "true") }}
 {{- if or $usePSP $useSCC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/helm/charts/mimir-distributed/templates/securitycontextconstraints.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/securitycontextconstraints.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (eq .Values.rbac.type "scc") }}
+{{- if eq (include "mimir.ingress.useSecurityContextConstraints" .) "true" }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/operations/helm/charts/mimir-distributed/templates/securitycontextconstraints.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/securitycontextconstraints.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "mimir.ingress.useSecurityContextConstraints" .) "true" }}
+{{- if eq (include "mimir.rbac.useSecurityContextConstraints" .) "true" }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -11,6 +11,12 @@
 # Note: Grafana provided dashboards rely on the default naming and will need changes.
 nameOverride: null
 
+# -- Overrides the version used to determine compatibility of resources with the target Kubernetes cluster.
+# This is useful when using `helm template`, because then helm will use the client version of kubectl as the Kubernetes version,
+# which may or may not match your cluster's server version. Example: 'v1.24.4'. Set to null to use the version that helm
+# devises.
+kubeVersionOverride: null
+
 # -- Overrides the chart's computed fullname. Used to change the full prefix of resource names. E.g. myRelease-mimir-ingester-1 to fullnameOverride-ingester-1.
 # Note: Grafana provided dashboards rely on the default naming and will need changes.
 fullnameOverride: null

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -11,12 +11,6 @@
 # Note: Grafana provided dashboards rely on the default naming and will need changes.
 nameOverride: null
 
-# -- Overrides the version used to determine compatibility of resources with the target Kubernetes cluster.
-# This is useful when using `helm template`, because then helm will use the client version of kubectl as the Kubernetes version,
-# which may or may not match your cluster's server version. Example: 'v1.24.4'. Set to null to use the version that helm
-# devises.
-kubeVersionOverride: null
-
 # -- Overrides the chart's computed fullname. Used to change the full prefix of resource names. E.g. myRelease-mimir-ingester-1 to fullnameOverride-ingester-1.
 # Note: Grafana provided dashboards rely on the default naming and will need changes.
 fullnameOverride: null


### PR DESCRIPTION
#### What this PR does

PodSecurityPolicy (PSP) was deprecated as part of kubernetes 1.25
This PR removed the PSP for versions higher than or equal to 1.25

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/2201
closes https://github.com/grafana/mimir/pull/2428

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
