### PR TITLE
Explicitly set request_rate limit to 0 in each user plan

### DIFF
--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -262,6 +262,9 @@
         ingestion_rate: 10000,
         ingestion_burst_size: 200000,
 
+        request_rate: 0,
+        request_burst_size: 0,
+
         // 700 rules
         ruler_max_rules_per_rule_group: 20,
         ruler_max_rule_groups_per_tenant: 35,
@@ -278,6 +281,9 @@
         ingestion_rate: 30000,
         ingestion_burst_size: 300000,
 
+        request_rate: 0,
+        request_burst_size: 0,
+
         // 1000 rules
         ruler_max_rules_per_rule_group: 20,
         ruler_max_rule_groups_per_tenant: 50,
@@ -290,6 +296,9 @@
 
         ingestion_rate: 100000,
         ingestion_burst_size: 1000000,
+
+        request_rate: 0,
+        request_burst_size: 0,
 
         // 1400 rules
         ruler_max_rules_per_rule_group: 20,
@@ -304,6 +313,9 @@
         ingestion_rate: 350000,  // 350K
         ingestion_burst_size: 3500000,  // 3.5M
 
+        request_rate: 0,
+        request_burst_size: 0,
+
         // 1800 rules
         ruler_max_rules_per_rule_group: 20,
         ruler_max_rule_groups_per_tenant: 90,
@@ -317,6 +329,9 @@
         ingestion_rate: 700000,  // 700K
         ingestion_burst_size: 7000000,  // 7M
 
+        request_rate: 0,
+        request_burst_size: 0,
+
         // 2200 rules
         ruler_max_rules_per_rule_group: 20,
         ruler_max_rule_groups_per_tenant: 110,
@@ -329,6 +344,9 @@
 
         ingestion_rate: 1500000,  // 1.5M
         ingestion_burst_size: 15000000,  // 15M
+
+        request_rate: 0,
+        request_burst_size: 0,
 
         // 2600 rules
         ruler_max_rules_per_rule_group: 20,
@@ -347,6 +365,9 @@
 
         ingestion_rate: 2250000,  // 2.25M
         ingestion_burst_size: 22500000,  // 22.5M
+
+        request_rate: 0,
+        request_burst_size: 0,
 
         // 3000 rules
         ruler_max_rules_per_rule_group: 20,


### PR DESCRIPTION
#### What this PR does

This is required due to specifics of how the "free tier" works at
Grafana. In particular, free tier limits are not removed - just
overridden by more specific limits in another runtime config file.
As a consequence of that we need to set the request rate here.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
