### PR TITLE
Add tracing to store-gateway bucket index reader methods

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -2429,7 +2429,7 @@ type symbolizedLabel struct {
 //
 // Error is returned on decoding error or if the reference does not resolve to a known series.
 func (r *bucketIndexReader) LoadSeriesForTime(ctx context.Context, ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64) (ok bool, err error) {
-	span, ctx := tracing.StartSpan(ctx, "LoadSeriesForTime()")
+	span, _ := tracing.StartSpan(ctx, "LoadSeriesForTime()")
 	defer span.Finish()
 
 	b, ok := r.loadedSeries[ref]
@@ -2450,7 +2450,7 @@ func (r *bucketIndexReader) Close() error {
 
 // LookupLabelsSymbols populates label set strings from symbolized label set.
 func (r *bucketIndexReader) LookupLabelsSymbols(ctx context.Context, symbolized []symbolizedLabel) (labels.Labels, error) {
-	span, ctx := tracing.StartSpan(ctx, "LookupLabelsSymbols()")
+	span, _ := tracing.StartSpan(ctx, "LookupLabelsSymbols()")
 	defer span.Finish()
 
 	lbls := make(labels.Labels, len(symbolized))

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -627,7 +627,7 @@ func blockSeries(
 			chks           []chunks.Meta
 		)
 		for _, id := range ps {
-			ok, err := indexr.LoadSeriesForTime(id, &symbolizedLset, &chks, skipChunks, minTime, maxTime)
+			ok, err := indexr.LoadSeriesForTime(ctx, id, &symbolizedLset, &chks, skipChunks, minTime, maxTime)
 			if err != nil {
 				lookupErr = errors.Wrap(err, "read series")
 				return
@@ -637,7 +637,7 @@ func blockSeries(
 				continue
 			}
 
-			lset, err := indexr.LookupLabelsSymbols(symbolizedLset)
+			lset, err := indexr.LookupLabelsSymbols(ctx, symbolizedLset)
 			if err != nil {
 				lookupErr = errors.Wrap(err, "lookup labels symbols")
 				return
@@ -2428,7 +2428,10 @@ type symbolizedLabel struct {
 // LoadSeriesForTime returns false, when there are no series data for given time range.
 //
 // Error is returned on decoding error or if the reference does not resolve to a known series.
-func (r *bucketIndexReader) LoadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64) (ok bool, err error) {
+func (r *bucketIndexReader) LoadSeriesForTime(ctx context.Context, ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64) (ok bool, err error) {
+	span, ctx := tracing.StartSpan(ctx, "LoadSeriesForTime()")
+	defer span.Finish()
+
 	b, ok := r.loadedSeries[ref]
 	if !ok {
 		return false, errors.Errorf("series %d not found", ref)
@@ -2446,7 +2449,10 @@ func (r *bucketIndexReader) Close() error {
 }
 
 // LookupLabelsSymbols populates label set strings from symbolized label set.
-func (r *bucketIndexReader) LookupLabelsSymbols(symbolized []symbolizedLabel) (labels.Labels, error) {
+func (r *bucketIndexReader) LookupLabelsSymbols(ctx context.Context, symbolized []symbolizedLabel) (labels.Labels, error) {
+	span, ctx := tracing.StartSpan(ctx, "LookupLabelsSymbols()")
+	defer span.Finish()
+
 	lbls := make(labels.Labels, len(symbolized))
 	for ix, s := range symbolized {
 		ln, err := r.dec.LookupSymbol(s.name)


### PR DESCRIPTION
#### What this PR does

I've seen some extremely slow requests go into this code and our tracing
ends at the previous level: "blockSeries() lookup series". This will help
figure out where the time is being spent.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
