### PR TITLE
Chore: Replace deprecated io/ioutil package

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -10,7 +10,7 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"runtime"
@@ -219,7 +219,7 @@ func main() {
 func parseConfigFileParameter(args []string) (configFile string, expandEnv bool) {
 	// ignore errors and any output here. Any flag errors will be reported by main flag.Parse() call.
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 
 	// usage not used in these functions.
 	fs.StringVar(&configFile, configFileOption, "", "")
@@ -238,7 +238,7 @@ func parseConfigFileParameter(args []string) (configFile string, expandEnv bool)
 
 // LoadConfig read YAML-formatted config from filename into cfg.
 func LoadConfig(filename string, expandEnv bool, cfg *mimir.Config) error {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return errors.Wrap(err, "Error reading config file")
 	}

--- a/integration/api_endpoints_test.go
+++ b/integration/api_endpoints_test.go
@@ -9,7 +9,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -74,7 +74,7 @@ func TestConfigAPIEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	defer runutil.ExhaustCloseWithErrCapture(&err, res.Body, "config API response")
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -315,7 +314,7 @@ func (c *Client) GetPrometheusRules() ([]*promv1.RuleGroup, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +360,7 @@ func (c *Client) GetRuleGroups() (map[string][]rulefmt.RuleGroup, error) {
 	defer res.Body.Close()
 	rgs := map[string][]rulefmt.RuleGroup{}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +494,7 @@ func (c *Client) getRawPage(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1011,7 +1010,7 @@ func (c *Client) DoGetBody(url string) (*http.Response, []byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"testing"
@@ -111,7 +110,7 @@ func TestQuerierRemoteRead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, httpResp.StatusCode)
 
-	compressed, err = ioutil.ReadAll(httpResp.Body)
+	compressed, err = io.ReadAll(httpResp.Body)
 	require.NoError(t, err)
 
 	uncompressed, err := snappy.Decode(nil, compressed)

--- a/integration/single_binary_test.go
+++ b/integration/single_binary_test.go
@@ -5,7 +5,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -73,7 +73,7 @@ func TestMimirCanParseIntZeroAsZeroDuration(t *testing.T) {
 	const singleProcessConfigFile = "docs/configurations/single-process-config-blocks.yaml"
 
 	// Use an example single process config file.
-	config, err := ioutil.ReadFile(filepath.Join(getMimirProjectDir(), singleProcessConfigFile))
+	config, err := os.ReadFile(filepath.Join(getMimirProjectDir(), singleProcessConfigFile))
 	require.NoError(t, err, "unable to read config file")
 
 	// Ensure that there's `server:` to replace in the config, otherwise we're testing nothing.

--- a/integration/util.go
+++ b/integration/util.go
@@ -9,7 +9,6 @@ package integration
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,14 +48,14 @@ func writeFileToSharedDir(s *e2e.Scenario, dst string, content []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		dst,
 		content,
 		os.ModePerm)
 }
 
 func copyFileToSharedDir(s *e2e.Scenario, src, dst string) error {
-	content, err := ioutil.ReadFile(filepath.Join(getMimirProjectDir(), src))
+	content, err := os.ReadFile(filepath.Join(getMimirProjectDir(), src))
 	if err != nil {
 		return errors.Wrapf(err, "unable to read local file %s", src)
 	}

--- a/pkg/alertmanager/alertmanager_http_test.go
+++ b/pkg/alertmanager/alertmanager_http_test.go
@@ -6,7 +6,7 @@
 package alertmanager
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -27,7 +27,7 @@ func TestMultitenantAlertmanager_GetStatusHandler(t *testing.T) {
 
 	resp := w.Result()
 	require.Equal(t, 200, w.Code)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	content := string(body)
 	require.Contains(t, content, "Alertmanager Status: Running")
 }

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -8,7 +8,7 @@ package bucketclient
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 	"sync"
 
@@ -191,7 +191,7 @@ func (s *BucketAlertStore) get(ctx context.Context, bkt objstore.Bucket, name st
 
 	defer runutil.CloseWithLogOnErr(s.logger, readCloser, "close bucket reader")
 
-	buf, err := ioutil.ReadAll(readCloser)
+	buf, err := io.ReadAll(readCloser)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read alertmanager config for user %s", name)
 	}

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -8,7 +8,6 @@ package local
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,7 +145,7 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 		}
 
 		// Load the file to be returned by the store.
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read alertmanager config %s", path)
 		}

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -8,7 +8,6 @@ package local
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,11 +33,11 @@ func TestStore_ListAllUsers(t *testing.T) {
 	{
 		user1Cfg := prepareAlertmanagerConfig("user-1")
 		user2Cfg := prepareAlertmanagerConfig("user-2")
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
 		// The following file is expected to be skipped.
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-3.unsupported-extension"), []byte{}, os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-3.unsupported-extension"), []byte{}, os.ModePerm))
 
 		users, err := store.ListAllUsers(ctx)
 		require.NoError(t, err)
@@ -60,8 +59,8 @@ func TestStore_GetAlertConfig(t *testing.T) {
 	{
 		user1Cfg := prepareAlertmanagerConfig("user-1")
 		user2Cfg := prepareAlertmanagerConfig("user-2")
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
 		config, err := store.GetAlertConfig(ctx, "user-1")
 		require.NoError(t, err)
@@ -87,7 +86,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 	// The storage contains some configs.
 	{
 		user1Cfg := prepareAlertmanagerConfig("user-1")
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
 
 		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
@@ -97,7 +96,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 		// Add another user config.
 		user2Cfg := prepareAlertmanagerConfig("user-2")
-		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
 		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -119,7 +118,7 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 		input = r.Body
 	}
 
-	payload, err := ioutil.ReadAll(input)
+	payload, err := io.ReadAll(input)
 	if err != nil {
 		level.Error(logger).Log("msg", errReadingConfiguration, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errReadingConfiguration, err.Error()), http.StatusBadRequest)
@@ -231,7 +230,7 @@ func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc, limits 
 	// not to configured data dir, and on the flipside, it'll fail if we can't write
 	// to tmpDir. Ignoring both cases for now as they're ultra rare but will revisit if
 	// we see this in the wild.
-	userTempDir, err := ioutil.TempDir("", "validate-config-"+cfg.User)
+	userTempDir, err := os.MkdirTemp("", "validate-config-"+cfg.User)
 	if err != nil {
 		return err
 	}

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -645,7 +645,7 @@ template_files:
 			am.SetUserConfig(w, req.WithContext(ctx))
 			resp := w.Result()
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			if tc.err == nil {
@@ -777,7 +777,7 @@ receivers:
 	resp := w.Result()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, "application/yaml", resp.Header.Get("Content-Type"))
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	expectedYaml := `user1:

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -8,7 +8,7 @@ package alertmanager
 import (
 	"context"
 	"hash/fnv"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"path"
@@ -157,7 +157,7 @@ func (d *Distributor) doQuorum(userID string, w http.ResponseWriter, r *http.Req
 	var body []byte
 	var err error
 	if r.Body != nil {
-		body, err = ioutil.ReadAll(http.MaxBytesReader(w, r.Body, d.maxRecvMsgSize))
+		body, err = io.ReadAll(http.MaxBytesReader(w, r.Body, d.maxRecvMsgSize))
 		if err != nil {
 			if util.IsRequestBodyTooLarge(err) {
 				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
@@ -226,7 +226,7 @@ func (d *Distributor) doUnary(userID string, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	body, err := ioutil.ReadAll(http.MaxBytesReader(w, r.Body, d.maxRecvMsgSize))
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, d.maxRecvMsgSize))
 	if err != nil {
 		if util.IsRequestBodyTooLarge(err) {
 			http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -286,7 +285,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, store alerts
 
 	var fallbackConfig []byte
 	if cfg.FallbackConfigFile != "" {
-		fallbackConfig, err = ioutil.ReadFile(cfg.FallbackConfigFile)
+		fallbackConfig, err = os.ReadFile(cfg.FallbackConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read fallback config %q: %s", cfg.FallbackConfigFile, err)
 		}
@@ -634,7 +633,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 	var pathsToRemove = make(map[string]struct{})
 
 	// List existing files to keep track the ones to be removed
-	if oldTemplateFiles, err := ioutil.ReadDir(userTemplateDir); err == nil {
+	if oldTemplateFiles, err := os.ReadDir(userTemplateDir); err == nil {
 		for _, file := range oldTemplateFiles {
 			pathsToRemove[filepath.Join(userTemplateDir, file.Name())] = struct{}{}
 		}
@@ -1066,7 +1065,7 @@ func (am *MultitenantAlertmanager) deleteUnusedLocalUserState() {
 // getPerUserDirectories returns map of users to their directories (full path). Only users with local
 // directory are returned.
 func (am *MultitenantAlertmanager) getPerUserDirectories() map[string]string {
-	files, err := ioutil.ReadDir(am.cfg.DataDir)
+	files, err := os.ReadDir(am.cfg.DataDir)
 	if err != nil {
 		level.Warn(am.logger).Log("msg", "failed to list local dir", "dir", am.cfg.DataDir, "err", err)
 		return nil
@@ -1183,13 +1182,13 @@ func storeTemplateFile(templateFilepath, content string) (bool, error) {
 	}
 
 	// Check if the template file already exists and if it has changed
-	if tmpl, err := ioutil.ReadFile(templateFilepath); err == nil && string(tmpl) == content {
+	if tmpl, err := os.ReadFile(templateFilepath); err == nil && string(tmpl) == content {
 		return false, nil
 	} else if err != nil && !os.IsNotExist(err) {
 		return false, err
 	}
 
-	if err := ioutil.WriteFile(templateFilepath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(templateFilepath, []byte(content), 0644); err != nil {
 		return false, fmt.Errorf("unable to create Alertmanager template file %q: %s", templateFilepath, err)
 	}
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -582,7 +582,7 @@ receivers:
 					am.ServeHTTP(w, req.WithContext(reqCtx))
 
 					resp := w.Result()
-					_, err := ioutil.ReadAll(resp.Body)
+					_, err := io.ReadAll(resp.Body)
 					require.NoError(t, err)
 					assert.Equal(t, http.StatusOK, w.Code)
 				}
@@ -867,7 +867,7 @@ func TestMultitenantAlertmanager_ServeHTTP(t *testing.T) {
 		am.ServeHTTP(w, req.WithContext(ctx))
 
 		resp := w.Result()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		require.Equal(t, 412, w.Code)
 		require.Equal(t, "the Alertmanager is not configured\n", string(body))
 	}
@@ -926,7 +926,7 @@ func TestMultitenantAlertmanager_ServeHTTP(t *testing.T) {
 		am.ServeHTTP(w, req.WithContext(ctx))
 
 		resp := w.Result()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		require.Equal(t, 412, w.Code)
 		require.Equal(t, "the Alertmanager is not configured\n", string(body))
 	}
@@ -1716,7 +1716,7 @@ func TestAlertmanager_StateReplication(t *testing.T) {
 				multitenantAM.serveRequest(w, req.WithContext(reqCtx))
 
 				resp := w.Result()
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				assert.Equal(t, http.StatusOK, w.Code)
 				require.Regexp(t, regexp.MustCompile(`{"silenceID":".+"}`), string(body))
 			}
@@ -1866,7 +1866,7 @@ func TestAlertmanager_StateReplication_InitialSyncFromPeers(t *testing.T) {
 					i.serveRequest(w, req.WithContext(reqCtx))
 
 					resp := w.Result()
-					body, _ := ioutil.ReadAll(resp.Body)
+					body, _ := io.ReadAll(resp.Body)
 					assert.Equal(t, http.StatusOK, w.Code)
 					require.Regexp(t, regexp.MustCompile(`{"silenceID":".+"}`), string(body))
 				}
@@ -1881,7 +1881,7 @@ func TestAlertmanager_StateReplication_InitialSyncFromPeers(t *testing.T) {
 					i.serveRequest(w, req.WithContext(reqCtx))
 
 					resp := w.Result()
-					body, _ := ioutil.ReadAll(resp.Body)
+					body, _ := io.ReadAll(resp.Body)
 					assert.Equal(t, http.StatusOK, w.Code)
 					require.Regexp(t, regexp.MustCompile(`"comment":"Created for a test case."`), string(body))
 				}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -6,7 +6,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -165,7 +165,7 @@ func TestConfigDiffHandler(t *testing.T) {
 			resp := w.Result()
 			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedBody, string(body))
 		})
@@ -194,7 +194,7 @@ func TestConfigOverrideHandler(t *testing.T) {
 	resp := w.Result()
 	assert.Equal(t, 200, resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("config"), body)
 }

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -8,7 +8,6 @@ package compactor
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -530,7 +529,7 @@ func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket,
 
 	level.Info(logger).Log("msg", "Repairing block broken by https://github.com/prometheus/tsdb/issues/347", "id", ie.id, "err", issue347Err)
 
-	tmpdir, err := ioutil.TempDir("", fmt.Sprintf("repair-issue-347-id-%s-", ie.id))
+	tmpdir, err := os.MkdirTemp("", fmt.Sprintf("repair-issue-347-id-%s-", ie.id))
 	if err != nil {
 		return err
 	}

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -197,7 +196,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		// in which case error is logger and test is failed. (We cannot use Fatal or FailNow from a goroutine).
 		go func() {
 			for ctx.Err() == nil {
-				fs, err := ioutil.ReadDir(dir)
+				fs, err := os.ReadDir(dir)
 				if err != nil && !os.IsNotExist(err) {
 					t.Log("error while listing directory", dir)
 					t.Fail()
@@ -645,7 +644,7 @@ func createEmptyBlock(dir string, mint, maxt int64, extLset labels.Labels, resol
 		return ulid.ULID{}, err
 	}
 
-	if err := ioutil.WriteFile(path.Join(dir, uid.String(), "meta.json"), b, os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(dir, uid.String(), "meta.json"), b, os.ModePerm); err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "saving meta.json")
 	}
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -825,7 +824,7 @@ func (c *MultitenantCompactor) metaSyncDirForUser(userID string) string {
 func (c *MultitenantCompactor) listTenantsWithMetaSyncDirectories() map[string]struct{} {
 	result := map[string]struct{}{}
 
-	files, err := ioutil.ReadDir(c.compactorCfg.DataDir)
+	files, err := os.ReadDir(c.compactorCfg.DataDir)
 	if err != nil {
 		return nil
 	}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -1345,7 +1344,7 @@ func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, max
 	require.NoError(t, db.Snapshot(snapshotDir, true))
 
 	// Look for the created block (we expect one).
-	entries, err := ioutil.ReadDir(snapshotDir)
+	entries, err := os.ReadDir(snapshotDir)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	require.True(t, entries[0].IsDir())
@@ -1372,7 +1371,7 @@ func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, max
 		}
 
 		// Read the file content in memory.
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/pkg/continuoustest/client_test.go
+++ b/pkg/continuoustest/client_test.go
@@ -4,7 +4,7 @@ package continuoustest
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,7 +29,7 @@ func TestClient_WriteSeries(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		// Read the entire body.
-		body, err := ioutil.ReadAll(request.Body)
+		body, err := io.ReadAll(request.Body)
 		require.NoError(t, err)
 		require.NoError(t, request.Body.Close())
 

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
@@ -359,7 +358,7 @@ func (r *request) do() {
 		return
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, httpResp.Body)
+		io.Copy(io.Discard, httpResp.Body)
 		httpResp.Body.Close()
 	}()
 

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -5,7 +5,7 @@ package forwarding
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -662,7 +662,7 @@ func newTestServer(tb testing.TB, status int, record bool) (string, func() []*ht
 	srv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if record {
-				reqBody, err := ioutil.ReadAll(req.Body)
+				reqBody, err := io.ReadAll(req.Body)
 				require.NoError(tb, err)
 
 				mtx.Lock()

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -8,7 +8,7 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -84,7 +84,7 @@ func TestFrontend_RequestHostHeaderWhenDownstreamURLIsConfigured(t *testing.T) {
 		require.Equal(t, 200, resp.StatusCode)
 
 		defer resp.Body.Close()
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		// We expect the Host received by the downstream is the downstream host itself
@@ -142,7 +142,7 @@ func TestFrontend_LogsSlowQueriesFormValues(t *testing.T) {
 
 		resp, err := client.Do(req)
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 
 		assert.NoError(t, err)
@@ -200,7 +200,7 @@ func TestFrontend_ReturnsRequestBodyTooLargeError(t *testing.T) {
 
 		resp, err := client.Do(req)
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		assert.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -337,7 +337,7 @@ func (prometheusCodec) EncodeResponse(ctx context.Context, res Response) (*http.
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},
-		Body:          ioutil.NopCloser(bytes.NewBuffer(b)),
+		Body:          io.NopCloser(bytes.NewBuffer(b)),
 		StatusCode:    http.StatusOK,
 		ContentLength: int64(len(b)),
 	}

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -9,7 +9,7 @@ package querymiddleware
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -121,7 +121,7 @@ func TestDecodeFailedResponse(t *testing.T) {
 	t.Run("internal error", func(t *testing.T) {
 		_, err := PrometheusCodec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(strings.NewReader("something failed")),
+			Body:       io.NopCloser(strings.NewReader("something failed")),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 
@@ -133,7 +133,7 @@ func TestDecodeFailedResponse(t *testing.T) {
 	t.Run("too many requests", func(t *testing.T) {
 		_, err := PrometheusCodec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusTooManyRequests,
-			Body:       ioutil.NopCloser(strings.NewReader("something failed")),
+			Body:       io.NopCloser(strings.NewReader("something failed")),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 
@@ -146,7 +146,7 @@ func TestDecodeFailedResponse(t *testing.T) {
 	t.Run("too large entry", func(t *testing.T) {
 		_, err := PrometheusCodec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusRequestEntityTooLarge,
-			Body:       ioutil.NopCloser(strings.NewReader("something failed")),
+			Body:       io.NopCloser(strings.NewReader("something failed")),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 
@@ -300,7 +300,7 @@ func TestResponseRoundtrip(t *testing.T) {
 			httpResponse := &http.Response{
 				StatusCode:    200,
 				Header:        headers,
-				Body:          ioutil.NopCloser(bytes.NewBuffer(body)),
+				Body:          io.NopCloser(bytes.NewBuffer(body)),
 				ContentLength: int64(len(body)),
 			}
 			decoded, err := PrometheusCodec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
@@ -316,7 +316,7 @@ func TestResponseRoundtrip(t *testing.T) {
 			httpResponse = &http.Response{
 				StatusCode:    200,
 				Header:        headers,
-				Body:          ioutil.NopCloser(bytes.NewBuffer(body)),
+				Body:          io.NopCloser(bytes.NewBuffer(body)),
 				ContentLength: int64(len(body)),
 			}
 			encoded, err := PrometheusCodec.EncodeResponse(context.Background(), decoded)
@@ -624,7 +624,7 @@ func BenchmarkPrometheusCodec_DecodeResponse(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_, err := PrometheusCodec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode:    200,
-			Body:          ioutil.NopCloser(bytes.NewReader(encodedRes)),
+			Body:          io.NopCloser(bytes.NewReader(encodedRes)),
 			ContentLength: int64(len(encodedRes)),
 		}, nil, log.NewNopLogger())
 		require.NoError(b, err)

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -8,7 +8,7 @@ package querymiddleware
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -98,7 +98,7 @@ func TestRangeTripperware(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 
-			bs, err := ioutil.ReadAll(resp.Body)
+			bs, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedBody, string(bs))
 		})
@@ -244,7 +244,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, `{"status":""}`, string(body))
 

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -5,7 +5,7 @@ package querymiddleware
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -120,7 +120,7 @@ func TestSplitAndCacheMiddleware_SplitByInterval(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
-	actualBody, err := ioutil.ReadAll(resp.Body)
+	actualBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, string(actualBody))
 	require.Equal(t, int32(2), actualCount.Load())

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -137,7 +136,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Buffer the body for later use to track slow queries.
 	var buf bytes.Buffer
 	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize)
-	r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &buf))
+	r.Body = io.NopCloser(io.TeeReader(r.Body, &buf))
 
 	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
@@ -227,7 +226,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 
 func (f *Handler) parseRequestQueryString(r *http.Request, bodyBuf bytes.Buffer) url.Values {
 	// Use previously buffered body.
-	r.Body = ioutil.NopCloser(&bodyBuf)
+	r.Body = io.NopCloser(&bodyBuf)
 
 	// Ensure the form has been parsed so all the parameters are present
 	err := r.ParseForm()

--- a/pkg/frontend/transport/roundtripper.go
+++ b/pkg/frontend/transport/roundtripper.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/weaveworks/common/httpgrpc"
@@ -55,7 +54,7 @@ func (a *grpcRoundTripperAdapter) RoundTrip(r *http.Request) (*http.Response, er
 
 	httpResp := &http.Response{
 		StatusCode:    int(resp.Code),
-		Body:          &buffer{buff: resp.Body, ReadCloser: ioutil.NopCloser(bytes.NewReader(resp.Body))},
+		Body:          &buffer{buff: resp.Body, ReadCloser: io.NopCloser(bytes.NewReader(resp.Body))},
 		Header:        http.Header{},
 		ContentLength: int64(len(resp.Body)),
 	}

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -8,7 +8,7 @@ package v1
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -61,7 +61,7 @@ func TestFrontend(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		assert.Equal(t, "Hello World", string(body))
@@ -110,7 +110,7 @@ func TestFrontendPropagateTrace(t *testing.T) {
 		require.Equal(t, 200, resp.StatusCode)
 
 		defer resp.Body.Close()
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		// Query should do one call.
@@ -202,7 +202,7 @@ func TestFrontendMetricsCleanup(t *testing.T) {
 		require.Equal(t, 200, resp.StatusCode)
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		assert.Equal(t, "Hello World", string(body))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"net/http"
@@ -3069,8 +3068,8 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 				// it's the last one and opening TSDB should fail).
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user0", "wal", ""), 0700))
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user0", "chunks_head", ""), 0700))
-				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "user0", "chunks_head", "00000001"), nil, 0700))
-				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "user0", "chunks_head", "00000002"), nil, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "user0", "chunks_head", "00000001"), nil, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "user0", "chunks_head", "00000002"), nil, 0700))
 
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user1", "dummy"), 0700))
 			},
@@ -3093,8 +3092,8 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 				// it's the last one and opening TSDB should fail).
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user2", "wal", ""), 0700))
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user2", "chunks_head", ""), 0700))
-				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "user2", "chunks_head", "00000001"), nil, 0700))
-				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "user2", "chunks_head", "00000002"), nil, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "user2", "chunks_head", "00000001"), nil, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "user2", "chunks_head", "00000002"), nil, 0700))
 			},
 			check: func(t *testing.T, i *Ingester) {
 				require.Equal(t, 0, len(i.tsdbs))

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -7,7 +7,6 @@ package ingester
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -197,7 +196,7 @@ func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 // blockMetasFromOldest returns the block meta of each block found in dir
 // sorted by minTime asc.
 func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, _ error) {
-	fis, err := ioutil.ReadDir(s.dir)
+	fis, err := os.ReadDir(s.dir)
 	if err != nil {
 		return nil, errors.Wrap(err, "read dir")
 	}

--- a/pkg/querier/cardinality_analysis_handler_test.go
+++ b/pkg/querier/cardinality_analysis_handler_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -45,7 +45,7 @@ func TestLabelNamesCardinalityHandler(t *testing.T) {
 	body := recorder.Result().Body
 	defer body.Close()
 	responseBody := LabelNamesCardinalityResponse{}
-	bodyContent, err := ioutil.ReadAll(body)
+	bodyContent, err := io.ReadAll(body)
 	require.NoError(t, err)
 	err = json.Unmarshal(bodyContent, &responseBody)
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestLabelNamesCardinalityHandler_MatchersTest(t *testing.T) {
 			handler.ServeHTTP(recorder, request)
 			body := recorder.Result().Body
 			defer body.Close()
-			bodyContent, err := ioutil.ReadAll(body)
+			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, recorder.Result().StatusCode, "unexpected error %v", string(bodyContent))
 			distributor.AssertCalled(t, "LabelNamesAndValues", mock.Anything, data.expectedMatchers)
@@ -167,7 +167,7 @@ func TestLabelNamesCardinalityHandler_LimitTest(t *testing.T) {
 			body := recorder.Result().Body
 			defer body.Close()
 			responseBody := LabelNamesCardinalityResponse{}
-			bodyContent, err := ioutil.ReadAll(body)
+			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 			err = json.Unmarshal(bodyContent, &responseBody)
 			require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestLabelNamesCardinalityHandler_DistributorError(t *testing.T) {
 			body := recorder.Result().Body
 			defer func() { _ = body.Close() }()
 
-			bodyContent, err := ioutil.ReadAll(body)
+			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 			bodyErrMessage := string(bodyContent)
 
@@ -283,7 +283,7 @@ func TestLabelNamesCardinalityHandler_NegativeTests(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode)
 			body := recorder.Result().Body
 			defer body.Close()
-			bytes, err := ioutil.ReadAll(body)
+			bytes, err := io.ReadAll(body)
 			require.NoError(t, err)
 			require.Contains(t, string(bytes), data.expectedErrorMessage)
 		})
@@ -567,7 +567,7 @@ func TestLabelValuesCardinalityHandler_Success(t *testing.T) {
 			defer func() { _ = body.Close() }()
 
 			responseBody := labelValuesCardinalityResponse{}
-			bodyContent, err := ioutil.ReadAll(body)
+			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 			err = json.Unmarshal(bodyContent, &responseBody)
 			require.NoError(t, err)
@@ -587,7 +587,7 @@ func TestLabelValuesCardinalityHandler_Success(t *testing.T) {
 			defer func() { _ = body.Close() }()
 
 			responseBody := labelValuesCardinalityResponse{}
-			bodyContent, err := ioutil.ReadAll(body)
+			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 			err = json.Unmarshal(bodyContent, &responseBody)
 			require.NoError(t, err)
@@ -642,7 +642,7 @@ func TestLabelValuesCardinalityHandler_FeatureFlag(t *testing.T) {
 				body := recorder.Result().Body
 				defer func() { _ = body.Close() }()
 
-				bodyContent, err := ioutil.ReadAll(body)
+				bodyContent, err := io.ReadAll(body)
 				require.NoError(t, err)
 				require.Equal(t, string(bodyContent), testData.expectedErrorMessage)
 			}
@@ -710,7 +710,7 @@ func TestLabelValuesCardinalityHandler_ParseError(t *testing.T) {
 				body := recorder.Result().Body
 				defer func() { _ = body.Close() }()
 
-				bytes, err := ioutil.ReadAll(body)
+				bytes, err := io.ReadAll(body)
 				require.NoError(t, err)
 				require.Contains(t, string(bytes), testData.expectedErrorMessage)
 			})
@@ -763,7 +763,7 @@ func TestLabelValuesCardinalityHandler_DistributorError(t *testing.T) {
 			body := recorder.Result().Body
 			defer func() { _ = body.Close() }()
 
-			bodyContent, err := ioutil.ReadAll(body)
+			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 			bodyErrMessage := string(bodyContent)
 

--- a/pkg/querier/metadata_handler_test.go
+++ b/pkg/querier/metadata_handler_test.go
@@ -7,7 +7,7 @@ package querier
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,7 +34,7 @@ func TestMetadataHandler_Success(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 
 	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
-	responseBody, err := ioutil.ReadAll(recorder.Result().Body)
+	responseBody, err := io.ReadAll(recorder.Result().Body)
 	require.NoError(t, err)
 
 	expectedJSON := `
@@ -68,7 +68,7 @@ func TestMetadataHandler_Error(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 
 	require.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode)
-	responseBody, err := ioutil.ReadAll(recorder.Result().Body)
+	responseBody, err := io.ReadAll(recorder.Result().Body)
 	require.NoError(t, err)
 
 	expectedJSON := `

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -102,7 +101,7 @@ func TestSampledRemoteRead(t *testing.T) {
 
 	require.Equal(t, 200, recorder.Result().StatusCode)
 	require.Equal(t, []string([]string{"application/x-protobuf"}), recorder.Result().Header["Content-Type"])
-	responseBody, err := ioutil.ReadAll(recorder.Result().Body)
+	responseBody, err := io.ReadAll(recorder.Result().Body)
 	require.NoError(t, err)
 	responseBody, err = snappy.Decode(nil, responseBody)
 	require.NoError(t, err)

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -7,7 +7,7 @@ package ruler
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -456,7 +456,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	payload, err := ioutil.ReadAll(req.Body)
+	payload, err := io.ReadAll(req.Body)
 	if err != nil {
 		level.Error(logger).Log("msg", "unable to read rule group payload", "err", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -175,7 +174,7 @@ func TestRuler(t *testing.T) {
 			a.PrometheusRules(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 
 			// Check status code and status response
 			responseJSON := response{}
@@ -215,7 +214,7 @@ func TestRuler_alerts(t *testing.T) {
 	a.PrometheusAlerts(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	// Check status code and status response
 	responseJSON := response{}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -8,7 +8,7 @@ package ruler
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -1014,7 +1014,7 @@ func TestRuler_ListAllRules(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	// Check status code and header
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/pkg/ruler/rulestore/bucketclient/bucket_client.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -71,7 +71,7 @@ func (b *BucketRuleStore) getRuleGroup(ctx context.Context, userID, namespace, g
 	}
 	defer func() { _ = reader.Close() }()
 
-	buf, err := ioutil.ReadAll(reader)
+	buf, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read rule group %s", objectKey)
 	}

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -8,7 +8,6 @@ package local
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -51,7 +50,7 @@ func NewLocalRulesClient(cfg Config, loader promRules.GroupLoader) (*Client, err
 
 func (l *Client) ListAllUsers(ctx context.Context) ([]string, error) {
 	root := l.cfg.Directory
-	infos, err := ioutil.ReadDir(root)
+	infos, err := os.ReadDir(root)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read dir %s", root)
 	}
@@ -60,16 +59,19 @@ func (l *Client) ListAllUsers(ctx context.Context) ([]string, error) {
 	for _, info := range infos {
 		// After resolving link, info.Name() may be different than user, so keep original name.
 		user := info.Name()
+		isDir := info.IsDir()
 
-		if info.Mode()&os.ModeSymlink != 0 {
-			// ioutil.ReadDir only returns result of LStat. Calling Stat resolves symlink.
-			info, err = os.Stat(filepath.Join(root, info.Name()))
+		if info.Type()&os.ModeSymlink != 0 {
+			// os.ReadDir only returns result of LStat. Calling Stat resolves symlink.
+			finfo, err := os.Stat(filepath.Join(root, info.Name()))
 			if err != nil {
 				return nil, err
 			}
+
+			isDir = finfo.IsDir()
 		}
 
-		if info.IsDir() {
+		if isDir {
 			result = append(result, user)
 		}
 	}
@@ -115,7 +117,7 @@ func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (
 	var allLists rulespb.RuleGroupList
 
 	root := filepath.Join(l.cfg.Directory, userID)
-	infos, err := ioutil.ReadDir(root)
+	infos, err := os.ReadDir(root)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read rule dir %s", root)
 	}
@@ -123,17 +125,20 @@ func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (
 	for _, info := range infos {
 		// After resolving link, info.Name() may be different than namespace, so keep original name.
 		namespace := info.Name()
+		isDir := info.IsDir()
 
-		if info.Mode()&os.ModeSymlink != 0 {
-			// ioutil.ReadDir only returns result of LStat. Calling Stat resolves symlink.
+		if info.Type()&os.ModeSymlink != 0 {
+			// os.ReadDir only returns result of LStat. Calling Stat resolves symlink.
 			path := filepath.Join(root, info.Name())
-			info, err = os.Stat(path)
+			finfo, err := os.Stat(path)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to stat rule file %s", path)
 			}
+
+			isDir = finfo.IsDir()
 		}
 
-		if info.IsDir() {
+		if isDir {
 			continue
 		}
 

--- a/pkg/ruler/rulestore/local/local_test.go
+++ b/pkg/ruler/rulestore/local/local_test.go
@@ -7,7 +7,6 @@ package local
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -27,7 +26,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	user2 := "second-user"
 
 	namespace1 := "ns"
-	namespace2 := "z-another" // This test relies on the fact that ioutil.ReadDir() returns files sorted by name.
+	namespace2 := "z-another" // This test relies on the fact that os.ReadDir() returns files sorted by name.
 
 	dir := t.TempDir()
 
@@ -56,7 +55,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	err = os.Symlink(user1, path.Join(dir, user2))
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(path.Join(dir, user1, namespace1), b, 0777)
+	err = os.WriteFile(path.Join(dir, user1, namespace1), b, 0777)
 	require.NoError(t, err)
 
 	const ignoredDir = "ignored-dir"

--- a/pkg/storage/bucket/client_mock.go
+++ b/pkg/storage/bucket/client_mock.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -104,7 +103,7 @@ func (m *ClientMock) MockGet(name, content string, err error) {
 		// each time the mocked Get() is called we do create a new one, so
 		// that getting the same mocked object twice works as expected.
 		m.On("Get", mock.Anything, name).Return(func(_ context.Context, _ string) (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader([]byte(content))), err
+			return io.NopCloser(bytes.NewReader([]byte(content))), err
 		})
 	} else {
 		m.On("Exists", mock.Anything, name).Return(false, err)

--- a/pkg/storage/bucket/prefixed_bucket_client_test.go
+++ b/pkg/storage/bucket/prefixed_bucket_client_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func TestPrefixedBucketClient(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		mockBucket.On("Get", mock.Anything, prefix+"/file").Return(ioutil.NopCloser(bytes.NewReader([]byte(("1")))), nil)
+		mockBucket.On("Get", mock.Anything, prefix+"/file").Return(io.NopCloser(bytes.NewReader([]byte(("1")))), nil)
 
 		reader, err := client.Get(context.Background(), "file")
 		assert.NoError(t, err)
@@ -55,7 +54,7 @@ func TestPrefixedBucketClient(t *testing.T) {
 	})
 
 	t.Run("GetRange", func(t *testing.T) {
-		mockBucket.On("GetRange", mock.Anything, prefix+"/file", mock.Anything, mock.Anything).Return(ioutil.NopCloser(bytes.NewReader([]byte(("1")))), nil)
+		mockBucket.On("GetRange", mock.Anything, prefix+"/file", mock.Anything, mock.Anything).Return(io.NopCloser(bytes.NewReader([]byte(("1")))), nil)
 
 		reader, err := client.GetRange(context.Background(), "file", 0, 10)
 		assert.NoError(t, err)

--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"sync"
 	"time"
@@ -385,7 +384,7 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset
 		}
 	}
 
-	return ioutil.NopCloser(newSubrangesReader(cfg.subrangeSize, offsetKeys, hits, offset, length)), nil
+	return io.NopCloser(newSubrangesReader(cfg.subrangeSize, offsetKeys, hits, offset, length)), nil
 }
 
 type rng struct {

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
@@ -245,7 +244,7 @@ func verifyGetRange(t *testing.T, cachingBucket *CachingBucket, name string, off
 	r, err := cachingBucket.GetRange(context.Background(), name, offset, length)
 	assert.NoError(t, err)
 
-	read, err := ioutil.ReadAll(r)
+	read, err := io.ReadAll(r)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLength, int64(len(read)))
 
@@ -558,7 +557,7 @@ func verifyGet(t *testing.T, cb *CachingBucket, file string, expectedData []byte
 	} else {
 		assert.NoError(t, err)
 		defer runutil.CloseWithLogOnErr(log.NewNopLogger(), r, "verifyGet")
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedData, data)
 

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"path"
 
 	"github.com/grafana/dskit/multierror"
@@ -41,7 +40,7 @@ func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Read
 	}
 
 	// Read the marker.
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -8,7 +8,7 @@ package bucketindex
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path"
 	"time"
 
@@ -137,7 +137,7 @@ func (w *Updater) updateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Blo
 	}
 	defer runutil.CloseWithLogOnErr(w.logger, r, "close get block meta file")
 
-	metaContent, err := ioutil.ReadAll(r)
+	metaContent, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "read block meta file: %v", metaFile)
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -13,7 +13,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -348,7 +347,7 @@ func (s *BucketStore) InitialSync(ctx context.Context) error {
 		return errors.Wrap(err, "sync block")
 	}
 
-	fis, err := ioutil.ReadDir(s.dir)
+	fis, err := os.ReadDir(s.dir)
 	if err != nil {
 		return errors.Wrap(err, "read dir")
 	}
@@ -2643,7 +2642,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 	for i, pIdx := range pIdxs {
 		// Fast forward range reader to the next chunk start in case of sparse (for our purposes) byte range.
 		for readOffset < int(pIdx.offset) {
-			written, err = io.CopyN(ioutil.Discard, bufReader, int64(pIdx.offset)-int64(readOffset))
+			written, err = io.CopyN(io.Discard, bufReader, int64(pIdx.offset)-int64(readOffset))
 			if err != nil {
 				return errors.Wrap(err, "fast forward range reader")
 			}

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -8,7 +8,6 @@ package storegateway
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -499,7 +498,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 // closeBucketStoreAndDeleteLocalFilesForExcludedTenants closes bucket store and removes local "sync" directories
 // for tenants that are not included in the current shard.
 func (u *BucketStores) closeBucketStoreAndDeleteLocalFilesForExcludedTenants(includeUserIDs map[string]struct{}) {
-	files, err := ioutil.ReadDir(u.cfg.BucketStore.SyncDir)
+	files, err := os.ReadDir(u.cfg.BucketStore.SyncDir)
 	if err != nil {
 		return
 	}

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -679,7 +678,7 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 }
 
 func getUsersInDir(t *testing.T, dir string) []string {
-	fs, err := ioutil.ReadDir(dir)
+	fs, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
 	var result []string

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -8,7 +8,6 @@ package storegateway
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -564,7 +563,7 @@ func TestStoreGateway_ShouldSupportLoadRingTokensFromFile(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+			tokensFile, err := os.CreateTemp(os.TempDir(), "tokens-*")
 			require.NoError(t, err)
 			t.Cleanup(func() { assert.NoError(t, os.Remove(tokensFile.Name())) })
 

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -13,7 +13,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -148,7 +147,7 @@ func newChunkedIndexReader(ctx context.Context, bkt objstore.BucketReader, id ul
 		return nil, 0, errors.Wrapf(err, "get TOC from object storage of %s", indexFilepath)
 	}
 
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	if err != nil {
 		runutil.CloseWithErrCapture(&err, rc, "close reader")
 		return nil, 0, errors.Wrapf(err, "get header from object storage of %s", indexFilepath)
@@ -190,7 +189,7 @@ func (r *chunkedIndexReader) readTOC() (*index.TOC, error) {
 		return nil, errors.Wrapf(err, "get TOC from object storage of %s", r.path)
 	}
 
-	tocBytes, err := ioutil.ReadAll(rc)
+	tocBytes, err := io.ReadAll(rc)
 	if err != nil {
 		runutil.CloseWithErrCapture(&err, rc, "close toc reader")
 		return nil, errors.Wrapf(err, "get TOC from object storage of %s", r.path)

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -8,7 +8,6 @@ package indexheader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -36,7 +35,7 @@ import (
 func TestReaders(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -345,7 +344,7 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *meta
 func BenchmarkBinaryWrite(t *testing.B) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "bench-indexheader")
+	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -364,7 +363,7 @@ func BenchmarkBinaryWrite(t *testing.B) {
 
 func BenchmarkBinaryReader(t *testing.B) {
 	ctx := context.Background()
-	tmpDir, err := ioutil.TempDir("", "bench-indexheader")
+	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -397,7 +396,7 @@ func benchmarkBinaryReaderLookupSymbol(b *testing.B, numSeries int) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 
-	tmpDir, err := ioutil.TempDir("", "benchmark-lookupsymbol")
+	tmpDir, err := os.MkdirTemp("", "benchmark-lookupsymbol")
 	require.NoError(b, err)
 	defer func() { require.NoError(b, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -7,7 +7,6 @@ package indexheader
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -30,7 +29,7 @@ import (
 func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -45,7 +44,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -86,7 +85,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -104,7 +103,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 
 	// Write a corrupted index-header for the block.
 	headerFilename := filepath.Join(tmpDir, blockID.String(), block.IndexHeaderFilename)
-	require.NoError(t, ioutil.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
+	require.NoError(t, os.WriteFile(headerFilename, []byte("xxx"), os.ModePerm))
 
 	m := NewLazyBinaryReaderMetrics(nil)
 	r, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, BinaryReaderConfig{}, m, nil)
@@ -126,7 +125,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -178,7 +177,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -229,7 +228,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -7,7 +7,6 @@ package indexheader
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +44,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 
@@ -83,7 +82,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "test-indexheader")
+	tmpDir, err := os.MkdirTemp("", "test-indexheader")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
 

--- a/pkg/util/gziphandler/gzip_test.go
+++ b/pkg/util/gziphandler/gzip_test.go
@@ -9,11 +9,11 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"testing"
 
@@ -237,7 +237,7 @@ func TestGzipHandlerNoBody(t *testing.T) {
 		req.Header.Set("Accept-Encoding", "gzip")
 		handler.ServeHTTP(rec, req)
 
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if err != nil {
 			t.Fatalf("Unexpected error reading response body: %v", err)
 		}
@@ -305,7 +305,7 @@ func TestGzipHandlerContentLength(t *testing.T) {
 		}
 		defer res.Body.Close()
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("Unexpected error reading response body in test iteration %d: %v", num, err)
 		}
@@ -433,7 +433,7 @@ func TestGzipHandlerDoubleWriteHeader(t *testing.T) {
 	}
 	req.Header.Set("Accept-Encoding", "gzip")
 	wrapper.ServeHTTP(rec, req)
-	body, err := ioutil.ReadAll(rec.Body)
+	body, err := io.ReadAll(rec.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error reading response body: %v", err)
 	}
@@ -634,7 +634,7 @@ func gzipStrLevel(s string, lvl int) []byte {
 }
 
 func benchmark(b *testing.B, parallel bool, size int) {
-	bin, err := ioutil.ReadFile("testdata/benchmark.json")
+	bin, err := os.ReadFile("testdata/benchmark.json")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -221,7 +221,7 @@ func (b bytesBuffered) BytesBuffer() *bytes.Buffer {
 }
 
 func TestIsRequestBodyTooLargeRegression(t *testing.T) {
-	_, err := ioutil.ReadAll(http.MaxBytesReader(httptest.NewRecorder(), ioutil.NopCloser(bytes.NewReader([]byte{1, 2, 3, 4})), 1))
+	_, err := io.ReadAll(http.MaxBytesReader(httptest.NewRecorder(), io.NopCloser(bytes.NewReader([]byte{1, 2, 3, 4})), 1))
 	assert.True(t, util.IsRequestBodyTooLarge(err))
 }
 

--- a/pkg/util/process/collector.go
+++ b/pkg/util/process/collector.go
@@ -9,7 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -105,7 +105,7 @@ func (c *processCollector) getMapsCountLimit() (float64, error) {
 	}
 	defer file.Close()
 
-	content, err := ioutil.ReadAll(file)
+	content, err := io.ReadAll(file)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/util/process/collector_test.go
+++ b/pkg/util/process/collector_test.go
@@ -7,7 +7,6 @@ package process
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,8 +29,8 @@ func TestProcessCollector(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(mapsPath), os.ModePerm))
 	require.NoError(t, os.MkdirAll(filepath.Dir(mapsLimitPath), os.ModePerm))
 
-	require.NoError(t, ioutil.WriteFile(mapsPath, []byte("1\n2\n3\n4\n5\n"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(mapsLimitPath, []byte("262144\n"), os.ModePerm))
+	require.NoError(t, os.WriteFile(mapsPath, []byte("1\n2\n3\n4\n5\n"), os.ModePerm))
+	require.NoError(t, os.WriteFile(mapsLimitPath, []byte("262144\n"), os.ModePerm))
 
 	// Create a new collector and test metrics.
 	c, err := newProcessCollector(pid, procDir)

--- a/pkg/util/push/push_test.go
+++ b/pkg/util/push/push_test.go
@@ -10,7 +10,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -82,7 +82,7 @@ func TestHandler_otlpWriteRequestTooBigWithCompression(t *testing.T) {
 	handler := OTLPHandler(140, nil, false, verifyWriteRequestHandler(t, mimirpb.API))
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.Code)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Contains(t, string(body), "the incoming push request has been rejected because its message size is larger than the allowed limit of 140 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator.")
 }

--- a/tools/add-license/main.go
+++ b/tools/add-license/main.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func addLicense(dir string) error {
 			return nil
 		}
 
-		b, err := ioutil.ReadFile(filepath.Clean(path))
+		b, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return err
 		}
@@ -111,7 +110,7 @@ func addLicense(dir string) error {
 		// Add the rest of the file.
 		_, _ = bb.Write(b)
 
-		return ioutil.WriteFile(path, bb.Bytes(), 0600)
+		return os.WriteFile(path, bb.Bytes(), 0600)
 	})
 }
 

--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -8,7 +8,6 @@ package querytee
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -116,7 +115,7 @@ func (b *ProxyBackend) doBackendRequest(req *http.Request) (int, []byte, error) 
 
 	// Read the entire response body.
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "reading backend response")
 	}

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
@@ -88,7 +87,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 	)
 
 	if r.Body != nil {
-		body, err = ioutil.ReadAll(r.Body)
+		body, err = io.ReadAll(r.Body)
 		if err != nil {
 			level.Warn(p.logger).Log("msg", "Unable to read request body", "err", err)
 			return
@@ -97,7 +96,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 			level.Warn(p.logger).Log("msg", "Unable to close request body", "err", err)
 		}
 
-		r.Body = ioutil.NopCloser(bytes.NewReader(body))
+		r.Body = io.NopCloser(bytes.NewReader(body))
 		if err := r.ParseForm(); err != nil {
 			level.Warn(p.logger).Log("msg", "Unable to parse form", "err", err)
 		}
@@ -117,7 +116,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 				start      = time.Now()
 			)
 			if len(body) > 0 {
-				bodyReader = ioutil.NopCloser(bytes.NewReader(body))
+				bodyReader = io.NopCloser(bytes.NewReader(body))
 			}
 
 			status, body, err := b.ForwardRequest(r, bodyReader)

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -8,7 +8,7 @@ package querytee
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -189,7 +189,7 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 			require.NoError(t, err)
 
 			defer res.Body.Close()
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
 
 			assert.Equal(t, testData.expectedStatus, res.StatusCode)
@@ -342,7 +342,7 @@ func TestProxy_Passthrough(t *testing.T) {
 				require.NoError(t, err)
 
 				defer res.Body.Close()
-				body, err := ioutil.ReadAll(res.Body)
+				body, err := io.ReadAll(res.Body)
 				require.NoError(t, err)
 
 				assert.Equal(t, query.expectedStatusCode, res.StatusCode)
@@ -412,7 +412,7 @@ func TestProxyHTTPGRPC(t *testing.T) {
 		require.NoError(t, err)
 
 		defer res.Body.Close()
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 
 		assert.Equal(t, 200, res.StatusCode)

--- a/tools/trafficdump/parser.go
+++ b/tools/trafficdump/parser.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"mime"
 	"net/http"
@@ -238,7 +238,7 @@ func (rp *parser) processHTTPResponse(resp *http.Response, body []byte) *respons
 		r, err = gzip.NewReader(bytes.NewReader(body))
 		if err == nil {
 			var newBody []byte
-			newBody, err = ioutil.ReadAll(r)
+			newBody, err = io.ReadAll(r)
 			if err == nil {
 				body = newBody
 			}

--- a/tools/trafficdump/streams.go
+++ b/tools/trafficdump/streams.go
@@ -5,7 +5,6 @@ package main
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -44,7 +43,7 @@ func (rs *requestStream) parseRequests() {
 		if err != nil {
 			r = &request{Error: err.Error()}
 		} else {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			_ = req.Body.Close()
 
 			if err != nil {
@@ -95,7 +94,7 @@ func (rs *responseStream) parseResponses() {
 		if err != nil {
 			r = &response{Error: err.Error()}
 		} else {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			_ = req.Body.Close()
 
 			if err != nil {


### PR DESCRIPTION
#### What this PR does
Replace [io/ioutil](https://pkg.go.dev/io/ioutil) package, that's been deprecated since Go 1.16.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
