### PR TITLE
ruler: ignore non-config values when checking defaults

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 
 require (
 	github.com/alecthomas/chroma v0.10.0
+	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.3.0
 	github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9
@@ -136,7 +137,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20220608213341-c488b8fa1db3 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect

--- a/pkg/ruler/rulestore/config_test.go
+++ b/pkg/ruler/rulestore/config_test.go
@@ -34,6 +34,13 @@ func TestIsDefaults(t *testing.T) {
 			},
 			expected: false,
 		},
+		"should return true if only a non-config field has changed": {
+			setup: func(cfg *Config) {
+				flagext.DefaultValues(cfg)
+				cfg.Middlewares = append(cfg.Middlewares, nil)
+			},
+			expected: true,
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
The idea of `rulestore.IsDefaults()` is to check whether the ruler has been configured by the user. However `reflect.DeepEqual()` checks all data within the Config struct, including things which are not actually config.

This change skips any fields within the config marked as `yaml:"-"`, which are not settable from yaml and therefore not config.

Using package `github.com/google/go-cmp/cmp`, which is documented as "not for use in production" since it panics when it cannot compare things. However we should catch that in unit testing, so should be ok.
(Note gRPC also uses this package).

Added a test which (artificially) induces the problem.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-facing
