### PR TITLE
TLS: make cipher suite list and min version configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Flag `-azure.msi-resource` is now ignored, and will be removed in Mimir 2.7. This setting is now made automatically by Azure. #2682
+* [ENHANCEMENT] Added `<prefix>.tls-min-version` and `<prefix>.tls-cipher-suites` flags to configure cipher suites and min TLS version supported by servers. #2898
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -169,6 +169,26 @@
           "fieldCategory": "advanced"
         },
         {
+          "kind": "field",
+          "name": "tls_cipher_suites",
+          "required": false,
+          "desc": "Comma-separated list of cipher suites to use. If blank, the default Go cipher suites is used.",
+          "fieldValue": null,
+          "fieldDefaultValue": "",
+          "fieldFlag": "server.tls-cipher-suites",
+          "fieldType": "string"
+        },
+        {
+          "kind": "field",
+          "name": "tls_min_version",
+          "required": false,
+          "desc": "Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.",
+          "fieldValue": null,
+          "fieldDefaultValue": "",
+          "fieldFlag": "server.tls-min-version",
+          "fieldType": "string"
+        },
+        {
           "kind": "block",
           "name": "http_tls_config",
           "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1869,6 +1869,10 @@ Usage of ./cmd/mimir/mimir:
     	Base path to serve all API routes from (e.g. /v1/)
   -server.register-instrumentation
     	Register the intrumentation handlers (/metrics etc). (default true)
+  -server.tls-cipher-suites string
+    	Comma-separated list of cipher suites to use. If blank, the default Go cipher suites is used.
+  -server.tls-min-version string
+    	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
   -store-gateway.sharding-ring.consul.acl-token string
     	ACL Token used to interact with Consul.
   -store-gateway.sharding-ring.consul.cas-retry-delay duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -549,6 +549,10 @@ Usage of ./cmd/mimir/mimir:
     	HTTP server listen address.
   -server.http-listen-port int
     	HTTP server listen port. (default 8080)
+  -server.tls-cipher-suites string
+    	Comma-separated list of cipher suites to use. If blank, the default Go cipher suites is used.
+  -server.tls-min-version string
+    	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
   -store-gateway.sharding-ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -store-gateway.sharding-ring.etcd.endpoints string

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -302,6 +302,16 @@ The `server` block configures the HTTP and gRPC server of the launched service(s
 # CLI flag: -server.grpc-conn-limit
 [grpc_listen_conn_limit: <int> | default = 0]
 
+# Comma-separated list of cipher suites to use. If blank, the default Go cipher
+# suites is used.
+# CLI flag: -server.tls-cipher-suites
+[tls_cipher_suites: <string> | default = ""]
+
+# Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11,
+# VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
+# CLI flag: -server.tls-min-version
+[tls_min_version: <string> | default = ""]
+
 http_tls_config:
   # (advanced) HTTP server cert path.
   # CLI flag: -server.http-tls-cert-path

--- a/docs/sources/operators-guide/secure/securing-communications-with-tls.md
+++ b/docs/sources/operators-guide/secure/securing-communications-with-tls.md
@@ -48,7 +48,36 @@ Every gRPC link between Grafana Mimir components supports TLS configuration as s
 
 #### Server flags
 
-Server flag settings determine if a server requires a client to provide a valid certificate back to the server.
+You can set the cipher suites and minimum TLS version that the server will accept:
+
+- `-server.tls-cipher-suites`: Comma-separated list of cipher suites to use. If blank, the default Go cipher suites is used.
+  Possible values, from https://pkg.go.dev/crypto/tls#pkg-constants:
+  - TLS_RSA_WITH_RC4_128_SHA
+  - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+  - TLS_RSA_WITH_AES_128_CBC_SHA
+  - TLS_RSA_WITH_AES_256_CBC_SHA
+  - TLS_RSA_WITH_AES_128_CBC_SHA256
+  - TLS_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+  - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+- `-server.tls-min-version`: Minimum TLS version to use. Allowed values: "VersionTLS10", "VersionTLS11", "VersionTLS12", "VersionTLS13". If blank, the Go TLS minimum version is used.
+
+The following
+server flag settings determine if a server requires a client to provide a valid certificate back to the server.
 The flags support all the values defined in the [crypto/tls](https://pkg.go.dev/crypto/tls#ClientAuthType) standard library.
 
 For all values except `NoClientCert`, the policy defines that the server requests a client certificate during the handshake. The values determine whether the client must send certificates and if the server must verify them.
@@ -84,6 +113,9 @@ In the following example, both of the server authorization flags, `-server.http-
 
     # Type of Client Auth for the gRPC Server
     -server.grpc-tls-client-auth="RequireAndVerifyClientCert"
+
+    # Path to the Client CA Cert for the gRPC Server
+    -server.grpc-tls-ca-path=/path/to/root.crt
 
     # Path to the Client CA Cert for the gRPC Server
     -server.grpc-tls-ca-path=/path/to/root.crt

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/thanos-io/thanos v0.27.0-rc.0.0.20221013114534-ee07110026f8
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
-	github.com/weaveworks/common v0.0.0-20220915171148-7b5f6f3e74bc
+	github.com/weaveworks/common v0.0.0-20220927162600-d0a1a93a15be
 	go.uber.org/atomic v1.10.0
 	go.uber.org/goleak v1.2.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
@@ -176,7 +176,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
-	github.com/prometheus/exporter-toolkit v0.7.1 // indirect
+	github.com/prometheus/exporter-toolkit v0.7.2-0.20220901134540-2434b08435da // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -759,9 +759,8 @@ github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8
 github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
 github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdDeppTwGX4=
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
-github.com/prometheus/exporter-toolkit v0.7.0/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
-github.com/prometheus/exporter-toolkit v0.7.1 h1:c6RXaK8xBVercEeUQ4tRNL8UGWzDHfvj9dseo1FcK1Y=
-github.com/prometheus/exporter-toolkit v0.7.1/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
+github.com/prometheus/exporter-toolkit v0.7.2-0.20220901134540-2434b08435da h1:HKYw+isMD0yfUIDhokkou+a/5WiLuivBhMAuVtdumNE=
+github.com/prometheus/exporter-toolkit v0.7.2-0.20220901134540-2434b08435da/go.mod h1:FUC6xKjS3i3WhT3hc2msIfFv14kcGkQJd4yQQ6uQ9Bc=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
@@ -858,8 +857,8 @@ github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
-github.com/weaveworks/common v0.0.0-20220915171148-7b5f6f3e74bc h1:Ij4XaA5D8HSUACaxKRzquIMRN9f7E2sF3nOy7UHAI3s=
-github.com/weaveworks/common v0.0.0-20220915171148-7b5f6f3e74bc/go.mod h1:QEa7yMHcG65BuJrUEcZ4LM9TrKPyBdv383tm06X+AL0=
+github.com/weaveworks/common v0.0.0-20220927162600-d0a1a93a15be h1:/Zt20imhU9Fw9UfOI49YsX1DNqFP0JPZqvJH0oAyW8A=
+github.com/weaveworks/common v0.0.0-20220927162600-d0a1a93a15be/go.mod h1:3AQDNAObqldt8KtTn6sk6jvXwgi9J6nNgmTFmzQB9x4=
 github.com/weaveworks/promrus v1.2.0 h1:jOLf6pe6/vss4qGHjXmGz4oDJQA+AOCqEL3FvvZGz7M=
 github.com/weaveworks/promrus v1.2.0/go.mod h1:SaE82+OJ91yqjrE1rsvBWVzNZKcHYFtMUyS1+Ogs/KA=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
@@ -959,7 +958,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/vendor/github.com/weaveworks/common/server/tls_config.go
+++ b/vendor/github.com/weaveworks/common/server/tls_config.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"crypto/tls"
+	fmt "fmt"
+	"strings"
+
+	"github.com/prometheus/exporter-toolkit/web"
+)
+
+// Collect all cipher suite names and IDs recognized by Go, including insecure ones.
+func allCiphers() map[string]web.Cipher {
+	acceptedCiphers := make(map[string]web.Cipher)
+	for _, suite := range tls.CipherSuites() {
+		acceptedCiphers[suite.Name] = web.Cipher(suite.ID)
+	}
+	for _, suite := range tls.InsecureCipherSuites() {
+		acceptedCiphers[suite.Name] = web.Cipher(suite.ID)
+	}
+	return acceptedCiphers
+}
+
+func stringToCipherSuites(s string) ([]web.Cipher, error) {
+	if s == "" {
+		return nil, nil
+	}
+	ciphersSlice := []web.Cipher{}
+	possibleCiphers := allCiphers()
+	for _, cipher := range strings.Split(s, ",") {
+		intValue, ok := possibleCiphers[cipher]
+		if !ok {
+			return nil, fmt.Errorf("cipher suite %q not recognized", cipher)
+		}
+		ciphersSlice = append(ciphersSlice, intValue)
+	}
+	return ciphersSlice, nil
+}
+
+// Using the same names that Kubernetes does
+var tlsVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+func stringToTLSVersion(s string) (web.TLSVersion, error) {
+	if s == "" {
+		return 0, nil
+	}
+	if version, ok := tlsVersions[s]; ok {
+		return web.TLSVersion(version), nil
+	}
+	return 0, fmt.Errorf("TLS version %q not recognized", s)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -742,8 +742,8 @@ github.com/prometheus/common/version
 # github.com/prometheus/common/sigv4 v0.1.0
 ## explicit; go 1.15
 github.com/prometheus/common/sigv4
-# github.com/prometheus/exporter-toolkit v0.7.1
-## explicit; go 1.14
+# github.com/prometheus/exporter-toolkit v0.7.2-0.20220901134540-2434b08435da
+## explicit; go 1.17
 github.com/prometheus/exporter-toolkit/web
 # github.com/prometheus/procfs v0.8.0
 ## explicit; go 1.17
@@ -913,7 +913,7 @@ github.com/vimeo/galaxycache/http
 github.com/vimeo/galaxycache/lru
 github.com/vimeo/galaxycache/promoter
 github.com/vimeo/galaxycache/singleflight
-# github.com/weaveworks/common v0.0.0-20220915171148-7b5f6f3e74bc
+# github.com/weaveworks/common v0.0.0-20220927162600-d0a1a93a15be
 ## explicit; go 1.14
 github.com/weaveworks/common/errors
 github.com/weaveworks/common/grpc


### PR DESCRIPTION
#### What this PR does

Allows the admin to configure the list of ciphers supported by Mimir services, and/or the minimum TLS version.

This is revisiting the change rejected in https://github.com/grafana/mimir/pull/2309#discussion_r913098472 on the basis that the documentation was user-hostile.

In this version, the cipher suite list is configured as a single string, patterned after the similar Kubernetes option.

Cipher names are as used by Go, at https://pkg.go.dev/crypto/tls#pkg-constants.

Updates weaveworks/common and prometheus/exporter-toolkit libraries.  
**NOTE** [the weaveworks/common PR](https://github.com/weaveworks/common/pull/256) is not merged yet; I wanted to get consensus on this change before doing that.

I didn't add a test specifically for these changes in Mimir; weaveworks/common unit tests check the basic name-decoding functionality.

Documentation change here is pretty minimal; in particular we should link to the [list of cipher names](https://pkg.go.dev/crypto/tls#pkg-constants).

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated
