### PR TITLE
Helm: add podAntiAffinity to the size plans

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [FEATURE] Add support for `topologySpreadConstraints` to all components; add `topologySpreadConstraints` to GEM gateway, admin-api, and alertmanager, which did not have `podAntiAffinity` previously. #2722
 * [ENHANCEMENT] Document `kubeVersionOverride`. If you rely on `helm template`, use this in your values to set the Kubernetes version. If unset helm will use the kubectl client version as the Kubernetes version with `helm template`, which may cause the chart to render incompatible manifests for the actual server version. #2872
 * [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling. This is used when deploying on Kubernetes >= 1.25. #2848
+* [ENHANCEMENT] Add podAntiAffinity to sizing plans (small.yaml, large.yaml, capped-small.yaml, capped-large.yaml). #2906
 
 ## 3.1.0
 

--- a/operations/helm/charts/mimir-distributed/capped-large.yaml
+++ b/operations/helm/charts/mimir-distributed/capped-large.yaml
@@ -60,12 +60,21 @@ ingester:
     limits:
       cpu: 4
       memory: 15Gi
+  topologySpreadConstraints: {}
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: target
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - ingester
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
                 operator: In
                 values:
                   - ingester
@@ -140,6 +149,25 @@ store_gateway:
     limits:
       cpu: 1
       memory: 6Gi
+  topologySpreadConstraints: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
 
 # Grafana Enterprise Metrics feature related
 admin_api:

--- a/operations/helm/charts/mimir-distributed/capped-small.yaml
+++ b/operations/helm/charts/mimir-distributed/capped-small.yaml
@@ -60,12 +60,21 @@ ingester:
     limits:
       cpu: 4
       memory: 15Gi
+  topologySpreadConstraints: {}
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: target
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - ingester
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
                 operator: In
                 values:
                   - ingester
@@ -139,6 +148,26 @@ store_gateway:
     limits:
       cpu: 1
       memory: 6Gi
+  topologySpreadConstraints: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
+
 
 # Grafana Enterprise Metrics feature related
 admin_api:

--- a/operations/helm/charts/mimir-distributed/large.yaml
+++ b/operations/helm/charts/mimir-distributed/large.yaml
@@ -57,12 +57,21 @@ ingester:
     requests:
       cpu: 4
       memory: 15Gi
+  topologySpreadConstraints: { }
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: target
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - ingester
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
                 operator: In
                 values:
                   - ingester
@@ -131,6 +140,26 @@ store_gateway:
     requests:
       cpu: 1
       memory: 6Gi
+  topologySpreadConstraints: { }
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
+
 
 # Grafana Enterprise Metrics feature related
 admin_api:

--- a/operations/helm/charts/mimir-distributed/small.yaml
+++ b/operations/helm/charts/mimir-distributed/small.yaml
@@ -57,12 +57,21 @@ ingester:
     requests:
       cpu: 4
       memory: 15Gi
+  topologySpreadConstraints: {}
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: target
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - ingester
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
                 operator: In
                 values:
                   - ingester
@@ -130,6 +139,25 @@ store_gateway:
     requests:
       cpu: 1
       memory: 6Gi
+  topologySpreadConstraints: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: target # support for enterprise.legacyLabels
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
+
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: 'kubernetes.io/hostname'
 
 # Grafana Enterprise Metrics feature related
 admin_api:


### PR DESCRIPTION
#### What this PR does

#2722 replaced some podAntiAffinities with topologySpreadConstraints,
aiming to provide a quick getting-started experience. It is recommended
to run with podAntiAffinity in production though. So this PR updates the
sizing plans to reflect this recommendation.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>


#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/2681

#### Checklist

- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
