### PR TITLE
Fix deprecation warning for minio root-credentials

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -206,7 +206,7 @@ std.manifestYamlDoc({
     minio: {
       image: 'minio/minio',
       command: ['server', '/data'],
-      environment: ['MINIO_ACCESS_KEY=mimir', 'MINIO_SECRET_KEY=supersecret'],
+      environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: ['9000:9000'],
       volumes: ['.data-minio:/data:delegated'],
     },

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -204,8 +204,8 @@
       - "server"
       - "/data"
     "environment":
-      - "MINIO_ACCESS_KEY=mimir"
-      - "MINIO_SECRET_KEY=supersecret"
+      - "MINIO_ROOT_USER=mimir"
+      - "MINIO_ROOT_PASSWORD=supersecret"
     "image": "minio/minio"
     "ports":
       - "9000:9000"

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     image: minio/minio
     command: [ "server", "/data" ]
     environment:
-      - MINIO_ACCESS_KEY=mimir
-      - MINIO_SECRET_KEY=supersecret
+      - MINIO_ROOT_USER=mimir
+      - MINIO_ROOT_PASSWORD=supersecret
     ports:
       - 9000:9000
     volumes:

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -60,7 +60,7 @@ std.manifestYamlDoc({
     minio: {
       image: 'minio/minio',
       command: ['server', '/data'],
-      environment: ['MINIO_ACCESS_KEY=mimir', 'MINIO_SECRET_KEY=supersecret'],
+      environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: ['9000:9000'],
       volumes: ['.data-minio:/data:delegated'],
     },

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -151,8 +151,8 @@
       - "server"
       - "/data"
     "environment":
-      - "MINIO_ACCESS_KEY=mimir"
-      - "MINIO_SECRET_KEY=supersecret"
+      - "MINIO_ROOT_USER=mimir"
+      - "MINIO_ROOT_PASSWORD=supersecret"
     "image": "minio/minio"
     "ports":
       - "9000:9000"

--- a/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
+++ b/docs/sources/tutorials/play-with-grafana-mimir/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     entrypoint: [""]
     command: ["sh", "-c", "mkdir -p /data/mimir-blocks /data/mimir-ruler /data/mimir-alertmanager && minio server --quiet /data"]
     environment:
-      - MINIO_ACCESS_KEY=mimir
-      - MINIO_SECRET_KEY=supersecret
+      - MINIO_ROOT_USER=mimir
+      - MINIO_ROOT_PASSWORD=supersecret
     volumes:
       - minio-data:/data
 


### PR DESCRIPTION
The environment variables for the root credentials of `minio` are no longer named `MINIO_ACCESS_KEY` and `MINIO_ACCESS_SECRET`, but are named `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` since the release on 2021-04-22.

This change introduces the new environment variable names and removes the deprecation notices.

Source:
https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#root-credentials

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
