### PR TITLE
Fix panic when ruler.external_url is set to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [BUGFIX] Ingester: Fix disk filling up after restarting ingesters with out-of-order support disabled while it was enabled before. #2799
 * [BUGFIX] Memberlist: retry joining memberlist cluster on startup when no nodes are resolved. #2837
 * [BUGFIX] Query-frontend: fix incorrect mapping of http status codes 413 to 500 when request is too large. #2819
+* [BUGFIX] Ruler: fix panic when `ruler.external_url` is explicitly set to an empty string (`""`) in YAML. #2915
 
 ### Mixin
 

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -8,7 +8,6 @@ package ruler
 import (
 	"context"
 	"errors"
-	"net/url"
 	"time"
 
 	"github.com/go-kit/log"
@@ -264,20 +263,14 @@ func DefaultTenantManagerFactory(
 		wrappedQueryFunc = MetricsQueryFunc(queryFunc, totalQueries, failedQueries)
 		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, logger)
 
-		externalURL := cfg.ExternalURL.URL
-		if externalURL == nil {
-			// We need a non-nil URL. dskit sets a nil URL when the yaml is `url: ""`.
-			// If we were to url.Parse(""), that will give a pointer to a zero-valued url.Url.
-			externalURL = &url.URL{}
-		}
 		return rules.NewManager(&rules.ManagerOptions{
 			Appendable:                 NewPusherAppendable(p, userID, overrides, totalWrites, failedWrites),
 			Queryable:                  embeddedQueryable,
 			QueryFunc:                  wrappedQueryFunc,
 			Context:                    user.InjectOrgID(ctx, userID),
 			GroupEvaluationContextFunc: FederatedGroupContextFunc,
-			ExternalURL:                externalURL,
-			NotifyFunc:                 SendAlerts(notifier, externalURL.String()),
+			ExternalURL:                cfg.ExternalURL.URL,
+			NotifyFunc:                 SendAlerts(notifier, cfg.ExternalURL.String()),
 			Logger:                     log.With(logger, "user", userID),
 			Registerer:                 reg,
 			OutageTolerance:            cfg.OutageTolerance,


### PR DESCRIPTION
Panic is on 2.3.0-rc0
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7126c0]
goroutine 108 [running]:
net/url.(*URL).String(0x0)
	/usr/local/go/src/net/url/url.go:800 +0x40
github.com/grafana/mimir/pkg/ruler.DefaultTenantManagerFactory.func1({0x257e040, 0xc000139b80}, {0xc000945973, 0x9}, 0x0?, {0x25641e0, 0xc000607720}, {0x2577428?, 0xc0004f0050})
	/__w/mimir/mimir/pkg/ruler/compat.go:273 +0x345
github.com/grafana/mimir/pkg/ruler.(*DefaultMultiTenantManager).newManager(0xc00083f900, {0x257e040, 0xc000139b80}, {0xc000945973, 0x9})
	/__w/mimir/mimir/pkg/ruler/manager.go:219 +0x163
```

This happens because the parsing in dskit places a nil in the URL when
the value in YAML is an empty string. By contrast, when the value is set
 as a CLI flag, it invokes `url.Parse("")`, which returns a non-nil
 `*url.Url`.

In the ruler we need a non-nil URL, otherwise prometheus code panics.

I didn't change this in dskit because that behaviour there has a unit
test to ensure that marshaling to YAML and then unmarshalling is
effectively a noop. This is the [code](https://github.com/grafana/mimir/blob/ecefbb673367c7047b0f9a04c8f614d229dfd656/vendor/github.com/grafana/dskit/flagext/url.go#L35-L39) in dskit,
this is the [test](https://github.com/grafana/dskit/blob/bbabef49ebf558538749d5b339bf81d96edfe512/flagext/url_test.go#L55-L73).

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

- ? Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
