### PR TITLE
Make api prefix configurable in mimirtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * [ENHANCEMENT] Refactor `mimirtool analyze prometheus`: add concurrency and resiliency #3349
   * Add `--concurrency` flag. Default: number of logical CPUs
 * [BUGFIX] `--log.level=debug` now correctly prints the response from the remote endpoint when a request fails. #3180
+* [BUGFIX] Make `/prometheus` endpoint prefix configurable in `mimirtool rules` and `mimirtool alerts`. #2918
 
 ### Documentation
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Makes prometheus api prefix configurable in mimir tool to match mimir API and helm chart


#### Which issue(s) this PR fixes or relates to

Fixes #2917

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
