### PR TITLE
helm: make metamonitoring scrape interval configurable

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to
   Mimir under the `metamonitoring` tenant; this enhancement does not apply to GEM. #3176
 * [ENHANCEMENT] Improve default rollout strategies. Now distributor, overrides_exporter, querier, query_frontend, admin_api, gateway, and graphite components can be upgraded more quickly and also can be rolled out with a single replica without downtime. #3029
+* [ENHANCEMENT] Metamonitoring: make scrape interval configurable. #2945
 * [BUGFIX] Fix an issue that caused metamonitoring secrets to be created incorrectly #3170
 
 ## 3.2.0

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "meta-monitoring") | nindent 8 }}
     # cluster label for logs is added in the LogsInstance
   metrics:
+    scrapeInterval: {{ .metrics.scrapeInterval }}
     instanceSelector:
       matchLabels:
         {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "meta-monitoring") | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1965,6 +1965,9 @@ metaMonitoring:
           labelSelectors:
             app.kubernetes.io/name: kube-state-metrics
 
+      # -- The scrape interval for all ServiceMonitors.
+      scrapeInterval: 30s
+
     # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
     namespace: ''
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1966,7 +1966,7 @@ metaMonitoring:
             app.kubernetes.io/name: kube-state-metrics
 
       # -- The scrape interval for all ServiceMonitors.
-      scrapeInterval: 30s
+      scrapeInterval: 60s
 
     # -- Sets the namespace of the resources. Leave empty or unset to use the same namespace as the Helm release.
     namespace: ''

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/component: meta-monitoring
     # cluster label for logs is added in the LogsInstance
   metrics:
+    scrapeInterval: 60s
     instanceSelector:
       matchLabels:
         app.kubernetes.io/name: mimir


### PR DESCRIPTION
This PR makes it possible to configure the scrape interval for metamonitoring metrics. The default is 60s.