### PR TITLE
Fix sanity check done on configured filesystem directories when running Alertmanager in microservices mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [BUGFIX] Memberlist: retry joining memberlist cluster on startup when no nodes are resolved. #2837
 * [BUGFIX] Query-frontend: fix incorrect mapping of http status codes 413 to 500 when request is too large. #2819
 * [BUGFIX] Ruler: fix panic when `ruler.external_url` is explicitly set to an empty string (`""`) in YAML. #2915
+* [BUGFIX] Fix sanity check done on configured filesystem directories when running Alertmanager in microservices mode. #2947
 
 ### Mixin
 

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -325,7 +325,8 @@ func (c *Config) validateFilesystemPaths(logger log.Logger) error {
 
 	var paths []pathConfig
 
-	if c.BlocksStorage.Bucket.Backend == bucket.Filesystem {
+	// Blocks storage (check only for components using it).
+	if c.isAnyModuleEnabled(All, Write, Read, Backend, Ingester, Querier, StoreGateway, Compactor, Ruler) && c.BlocksStorage.Bucket.Backend == bucket.Filesystem {
 		// Add the optional prefix to the path, because that's the actual location where blocks will be stored.
 		paths = append(paths, pathConfig{
 			name:       "blocks storage filesystem directory",


### PR DESCRIPTION
#### What this PR does
See: https://github.com/grafana/mimir/issues/2867#issuecomment-1246449845

#### Which issue(s) this PR fixes or relates to

Fixes #2867

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
