### PR TITLE
Fix sanity check done on configured filesystem directories when running Alertmanager in microservices mode (#2947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Fix sanity check done on configured filesystem directories when running Alertmanager in microservices mode. #2947
+
 ### Mixin
 
 ### Jsonnet

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -325,7 +325,8 @@ func (c *Config) validateFilesystemPaths(logger log.Logger) error {
 
 	var paths []pathConfig
 
-	if c.BlocksStorage.Bucket.Backend == bucket.Filesystem {
+	// Blocks storage (check only for components using it).
+	if c.isAnyModuleEnabled(All, Write, Read, Backend, Ingester, Querier, StoreGateway, Compactor, Ruler) && c.BlocksStorage.Bucket.Backend == bucket.Filesystem {
 		// Add the optional prefix to the path, because that's the actual location where blocks will be stored.
 		paths = append(paths, pathConfig{
 			name:       "blocks storage filesystem directory",


### PR DESCRIPTION
#### What this PR does
Cherry-picking the fix done in #2947.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
