### PR TITLE
Alerting squad CODEOWNERS for Alertmanager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @mimir-maintainers
+/pkg/alertmanager/ @grafana/alerting-squad-backend


### PR DESCRIPTION
#### What this PR does

With the Alerting squad owning the Cloud Alertmanager I think it makes sense for us to be the codeowners and, subsequent reviewers, for pull requests that make changes or update the vendored Alertmanager. The motivation for this change is a bug that made it into r201 (please see https://github.com/prometheus/alertmanager/issues/3064 and https://github.com/golang/go/issues/55032) where we had to work back through each commit from r200 and r201 to find the cause.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
