### PR TITLE
Fix typo on tenant spelling

### DIFF
--- a/docs/sources/operators-guide/configure/configuring-high-availability-deduplication.md
+++ b/docs/sources/operators-guide/configure/configuring-high-availability-deduplication.md
@@ -120,7 +120,7 @@ Configure the default cluster and replica label names using the following CLI fl
 
 #### Example configuration
 
-The following configuration example snippet enables the HA tracker for all tentants via a YAML configuration file:
+The following configuration example snippet enables the HA tracker for all tenants via a YAML configuration file:
 
 ```yaml
 limits:

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -125,7 +125,7 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 		Command("check", "Run various best practice checks against rules.").
 		Action(r.checkRecordingRuleNames)
 
-	// Require Mimir cluster address and tentant ID on all these commands
+	// Require Mimir cluster address and tenant ID on all these commands
 	for _, c := range []*kingpin.CmdClause{listCmd, printRulesCmd, getRuleGroupCmd, deleteRuleGroupCmd, loadRulesCmd, diffRulesCmd, syncRulesCmd} {
 		c.Flag("address", "Address of the Grafana Mimir cluster; alternatively, set "+envVars.Address+".").
 			Envar(envVars.Address).


### PR DESCRIPTION
#### What this PR does

Fix spelling typo in "tenant" across codebase

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [N/A] Tests updated
- [ X ] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
