### PR TITLE
Increase MimirQuerierAutoscalerNotActive 'for' and make critical

### DIFF
--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -722,15 +722,15 @@ groups:
   rules:
   - alert: MimirQuerierAutoscalerNotActive
     annotations:
-      message: The Horizontal Pod Autoscaler (HPA) in {{ $labels.namespace }} is not
-        active.
+      message: The Horizontal Pod Autoscaler (HPA) {{ $labels.horizontalpodautoscaler
+        }} in {{ $labels.namespace }} is not active.
     expr: |
-      kube_horizontalpodautoscaler_status_condition{horizontalpodautoscaler="keda-hpa-querier",condition="ScalingActive",status="false"}
+      kube_horizontalpodautoscaler_status_condition{horizontalpodautoscaler=~"(keda-hpa-querier)|(keda-hpa-ruler-querier)",condition="ScalingActive",status="false"}
       * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
       > 0
-    for: 15m
+    for: 1h
     labels:
-      severity: warning
+      severity: critical
 - name: mimir_continuous_test
   rules:
   - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -1,24 +1,25 @@
 (import 'alerts-utils.libsonnet') {
   groups+: if !$._config.autoscaling.querier_enabled then [] else [
+    local regexMatching = function(strings=[]) std.join('|', std.map(function(s) '(%s)' % s, strings));
     {
       name: 'mimir_autoscaling_querier',
       rules: [
         {
           alert: $.alertName('QuerierAutoscalerNotActive'),
-          'for': '15m',
+          'for': '1h',
           expr: |||
-            kube_horizontalpodautoscaler_status_condition{horizontalpodautoscaler="%(hpa_name)s",condition="ScalingActive",status="false"}
+            kube_horizontalpodautoscaler_status_condition{horizontalpodautoscaler=~"%(hpa_name)s",condition="ScalingActive",status="false"}
             * on(%(aggregation_labels)s) group_left max by(%(aggregation_labels)s) (cortex_build_info)
             > 0
           ||| % {
             aggregation_labels: $._config.alert_aggregation_labels,
-            hpa_name: $._config.autoscaling.querier_hpa_name,
+            hpa_name: regexMatching([$._config.autoscaling.querier_hpa_name, $._config.autoscaling.ruler_querier_hpa_name]),
           },
           labels: {
-            severity: 'warning',
+            severity: 'critical',
           },
           annotations: {
-            message: 'The Horizontal Pod Autoscaler (HPA) in {{ $labels.namespace }} is not active.' % $._config,
+            message: 'The Horizontal Pod Autoscaler (HPA) {{ $labels.horizontalpodautoscaler }} in {{ $labels.namespace }} is not active.' % $._config,
           },
         },
       ],


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Keeping this as a warning can cause it to slip sometimes. Also increases
the 'for' period to 1h to make the alert less sensitive to flaky HPAs.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- NA Tests updated
- NA Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
