### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @mimir-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
+# Default owners for everything in the repo, unless a later match takes precedence.
+* @grafana/mimir-maintainers
+
+# Documentation.
 /docs/ @osg-grafana


### PR DESCRIPTION
#### What this PR does
There are a couple of issues with our CODEOWNERS:
- We have 2 of them
- `@mimir-maintainers` is invalid, it should actually be `@grafana/mimir-maintainers`

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
