### PR TITLE
Add scale down policies for autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 * [ENHANCEMENT] Upgrade memcached image tag to `memcached:1.6.16-alpine`. #2740
 * [ENHANCEMENT] Added `$._config.configmaps` and `$._config.runtime_config_files` to make it easy to add new configmaps or runtime config file to all components. #2748
+* [ENHANCEMENT] Querier autoscaling is now slower on scale downs: scale down 10% every 1m instead of 100%. #2962
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1725,6 +1725,14 @@ metadata:
   name: querier
   namespace: default
 spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
   maxReplicaCount: 30
   minReplicaCount: 3
   pollingInterval: 10
@@ -1744,6 +1752,14 @@ metadata:
   name: ruler-querier
   namespace: default
 spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
   maxReplicaCount: 30
   minReplicaCount: 3
   pollingInterval: 10

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -40,6 +40,22 @@
       // by KEDA, while scaling from 1+->N is managed by HPA (and this setting doesn't apply to HPA).
       pollingInterval: 10,
 
+      advanced: {
+        horizontalPodAutoscalerConfig: {
+          behavior: {
+            scaleDown: {
+              policies: [{
+                // Allow to scale down up to 10% of pods every 1m. This prevents from suddenly scaling to minRepliacs
+                // when Prometheus comes back up after a long outage (longer than stabilizationWindowSeconds=300s)
+                type: 'Percent',
+                value: 10,
+                periodSeconds: 60,
+              }],
+            },
+          },
+        },
+      },
+
       triggers: [
         {
           type: 'prometheus',


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
[By default](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#default-behavior), autoscaling allows to scale down to minReplicas in one go. This is
problematic in cases where the external metric source for autoscaling is
 unavailable for longer than the stabilization window for scaling down.
That window is 5m by default.

If the scaling metric needs some time to start increasing (if for
example it's using sum(rate()) over longer periods), this scale down
will take longer to recover from. This PR allows to scale down only 10%
of replicas every 1m. This will give more time for the metric source to
scrape metrics and for the scaling metric to stabilize before we reach
minReplicas.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
