### PR TITLE
Mention gnu-sed for contributors on macOS

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -47,6 +47,8 @@ go test ./...
 
 To run the integration tests suite please see "[How integration tests work](./how-integration-tests-work.md)".
 
+If using macOS, make sure you have `gnu-sed` installed; otherwise, some make targets may not work properly.
+
 ### Dependency management
 
 We uses [Go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to manage dependencies on external packages.

--- a/docs/internal/contributing/contributing-to-helm-chart.md
+++ b/docs/internal/contributing/contributing-to-helm-chart.md
@@ -14,6 +14,8 @@ We keep a compiled version of the helm chart for each values file in the `ci` di
 This makes it easy to see how a given PR impacts the final output.
 A PR check will fail if you forget to update the compiled manifests, and you can use `make build-helm-tests` to update them.
 
+If using macOS, make sure you have `gnu-sed` installed; otherwise, some make targets may not work properly.
+
 ## Versioning
 
 Normally contributors need _not_ bump the version. The chart will be released with a beta version weekly by maintainers (unless no changes were made) and also regular stable releases will be released by cherry picking commits from the `main` branch to a release branch (e.g. `release-2.1`).


### PR DESCRIPTION
Some make targets require this to be installed otherwise they do the
wrong thing.
