### PR TITLE
Fix docs requirement in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @grafana/mimir-maintainers
 
 # Documentation.
-/docs/ @osg-grafana
+/docs/ @osg-grafana @grafana/mimir-maintainers


### PR DESCRIPTION
#### What this PR does
Yesterday I fixed CODEOWNERS in https://github.com/grafana/mimir/pull/2960, but now we can't merge any PR touching `/docs/` without Ursula approval, even if we just change a single letter or changes to the internal doc. I propose to use our best judgement and wait for docs squad review when we real changes to the doc.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
