### PR TITLE
Fix subservices watcher in query-frontend, query-scheduler and querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Ruler: fix panic when `ruler.external_url` is explicitly set to an empty string (`""`) in YAML. #2915
 * [BUGFIX] Fix sanity check done on configured filesystem directories when running Alertmanager in microservices mode. #2947
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
+* [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 
 ### Mixin
 

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -88,9 +88,10 @@ type request struct {
 // New creates a new frontend. Frontend implements service, and must be started and stopped.
 func New(cfg Config, limits Limits, log log.Logger, registerer prometheus.Registerer) (*Frontend, error) {
 	f := &Frontend{
-		cfg:    cfg,
-		log:    log,
-		limits: limits,
+		cfg:                cfg,
+		log:                log,
+		limits:             limits,
+		subservicesWatcher: services.NewFailureWatcher(),
 		queueLength: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_query_frontend_queue_length",
 			Help: "Number of queries in the queue.",

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -54,10 +54,11 @@ func newBlocksStoreReplicationSet(
 	reg prometheus.Registerer,
 ) (*blocksStoreReplicationSet, error) {
 	s := &blocksStoreReplicationSet{
-		storesRing:        storesRing,
-		clientsPool:       newStoreGatewayClientPool(client.NewRingServiceDiscovery(storesRing), clientConfig, logger, reg),
-		balancingStrategy: balancingStrategy,
-		limits:            limits,
+		storesRing:         storesRing,
+		clientsPool:        newStoreGatewayClientPool(client.NewRingServiceDiscovery(storesRing), clientConfig, logger, reg),
+		balancingStrategy:  balancingStrategy,
+		limits:             limits,
+		subservicesWatcher: services.NewFailureWatcher(),
 	}
 
 	var err error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -121,6 +121,7 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 
 		pendingRequests:    map[requestKey]*schedulerRequest{},
 		connectedFrontends: map[string]*connectedFrontend{},
+		subservicesWatcher: services.NewFailureWatcher(),
 	}
 
 	s.queueLength = promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
#### What this PR does
While working on https://github.com/grafana/mimir/pull/2957, I've found 3 places where we use `*services.FailureWatcher` but it's not initialized. Since `services.FailureWatcher` functions handle the case the receiver is `nil`, we never noticed it, but it also means it's not practically used.

This PR fixes it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
