### PR TITLE
Distributor push wrapper should only receive unforwarded samples.

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -61,7 +61,8 @@ type Config struct {
 	// This allows downstream projects to wrap the distributor push function
 	// and access the deserialized write requests before/after they are pushed.
 	// This function will only receive samples that don't get forwarded to an
-	// alternative remote_write endpoint by the distributor's forwarding feature.
+	// alternative remote_write endpoint by the distributor's forwarding feature,
+	// or dropped by HA deduplication.
 	DistributorPushWrapper DistributorPushWrapper `yaml:"-"`
 
 	// The CustomConfigHandler allows for providing a different handler for the
@@ -240,9 +241,12 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc) {
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	wrappedPush := a.cfg.wrapDistributorPush(d.PushWithMiddlewares)
-	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, wrappedPush), true, false, "POST")
-	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, wrappedPush), true, false, "POST")
+	pushFn := d.PushWithCleanup
+	pushFn = a.cfg.wrapDistributorPush(pushFn)
+	pushFn = d.WrapPushWithMiddlewares(pushFn)
+
+	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, pushFn), true, false, "POST")
+	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, pushFn), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2988,7 +2988,7 @@ func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
 		enableTracker:       true,
 		maxInflightRequests: 1,
 	})
-	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)
+	wrappedMockPush := ds[0].WrapPushWithMiddlewares(mockPush)
 
 	// Make sure first request hits the limit.
 	ds[0].inflightPushRequests.Inc()
@@ -3192,7 +3192,7 @@ func TestHaDedupeAndRelabelBeforeForwarding(t *testing.T) {
 		forwarding:      true,
 		getForwarder:    getForwarder,
 	})
-	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)
+	wrappedMockPush := ds[0].WrapPushWithMiddlewares(mockPush)
 
 	// Submit the two write requests into the wrapped mock push function, it should:
 	// 1) Perform HA-deduplication


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

According to documentation `DistributorPushWrapper` should only receive samples that were not forwarded by distributor. PR #2603 changed this and `DistributorPushWrapper` received all samples before any Distributor's middleware could do anything with it. This PR changes the behaviour back so that `DistributorPushWrapper` receives only non-forwarded samples, and changes behaviour such that HA-deduplicated samples or samples outside of limits are also not sent to `DistributorPushWrapper`.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] (Not user-visible change) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
