### PR TITLE
Add examples for sending Helm metamonitoring to Mimir

### DIFF
--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -107,6 +107,54 @@ metaMonitoring:
             app.kubernetes.io/name: kube-state-metrics
 ```
 
+
+#### Sending metrics back into Mimir/GEM
+
+You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
+The configuration varies slightly for GEM and Mimir.
+
+If you have deployed Mimir, then the Helm chart values should look like the following.
+Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+
+```yaml
+metaMonitoring:
+  serviceMonitor:
+    enabled: true
+  grafanaAgent:
+    enabled: true
+    installOperator: true
+
+  metrics:
+    remote:
+      url: 'http://<HELM_RELEASE_NAME>-mimir-nginx.mimir.svc/api/v1/push'
+      headers:
+        X-Scope-OrgID: metamonitoring
+```
+
+If you have deployed GEM, then the URL will point to the GEM gateway instead of the nginx Deployment.
+If you are using the GEM authentication model, then you also need to provide a Secret with the
+authentication token for a tenant. Refer to [Credentials](#credentials) for setting up the Secret.
+
+Assuming you are using the GEM authentication model, the Helm chart values should look like the following.
+Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+
+```yaml
+metaMonitoring:
+  serviceMonitor:
+    enabled: true
+  grafanaAgent:
+    enabled: true
+    installOperator: true
+
+  metrics:
+    remote:
+      url: 'http://<HELM_RELEASE_NAME>-mimir-gateway.mimir.svc/api/v1/push'
+      auth:
+        username: metamonitoring
+        passwordSecretName: gem-tokens
+        passwordSecretKey: metamonitoring
+```
+
 ### Collect metrics and logs via Grafana Agent
 
 Older versions of the Helm chart need to be manually instrumented. This means that you need to set up a Grafana Agent

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -107,7 +107,6 @@ metaMonitoring:
             app.kubernetes.io/name: kube-state-metrics
 ```
 
-
 #### Sending metrics back into Mimir/GEM
 
 You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
@@ -126,7 +125,7 @@ metaMonitoring:
 
   metrics:
     remote:
-      url: 'http://<HELM_RELEASE_NAME>-mimir-nginx.mimir.svc/api/v1/push'
+      url: "http://<HELM_RELEASE_NAME>-mimir-nginx.mimir.svc/api/v1/push"
       headers:
         X-Scope-OrgID: metamonitoring
 ```
@@ -148,7 +147,7 @@ metaMonitoring:
 
   metrics:
     remote:
-      url: 'http://<HELM_RELEASE_NAME>-mimir-gateway.mimir.svc/api/v1/push'
+      url: "http://<HELM_RELEASE_NAME>-mimir-gateway.mimir.svc/api/v1/push"
       auth:
         username: metamonitoring
         passwordSecretName: gem-tokens

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -112,7 +112,7 @@ metaMonitoring:
 You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
 The configuration varies slightly for GEM and Mimir.
 
-If you have deployed Mimir, then the Helm chart values should look like the following.
+If you have deployed Mimir, then the Helm chart values should look like the following example.
 Replace `HELM_RELEASE_NAME` with the name of your Helm release:
 
 ```yaml
@@ -134,7 +134,7 @@ If you have deployed GEM, then the URL will point to the GEM gateway instead of 
 If you are using the GEM authentication model, then you also need to provide a Secret with the
 authentication token for a tenant. Refer to [Credentials](#credentials) for setting up the Secret.
 
-Assuming you are using the GEM authentication model, the Helm chart values should look like the following.
+Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
 Replace `HELM_RELEASE_NAME` with the name of your Helm release:
 
 ```yaml

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1930,7 +1930,7 @@ metaMonitoring:
       # You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
       # The configuration varies slightly for GEM and Mimir.
       #
-      # If you have deployed Mimir, then the Helm chart values should look like the following.
+      # If you have deployed Mimir, then the Helm chart values should look like the following example.
       # Replace `HELM_RELEASE_NAME` with the name of your Helm release:
       #
       # remote:
@@ -1942,7 +1942,7 @@ metaMonitoring:
       # If you are using the GEM authentication model, then you also need to provide a Secret with the
       # authentication token for a tenant. Refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
       # for setting up the Secret.
-      # Assuming you are using the GEM authentication model, the Helm chart values should look like the following.
+      # Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
       # Replace `HELM_RELEASE_NAME` with the name of your Helm release:
       #
       # remote:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1926,6 +1926,31 @@ metaMonitoring:
       # -- Default destination for metrics. The config here is translated to remote_write
       # configuration to push metrics to this Prometheus-compatible remote. Optional.
       # Note that you need to configure serviceMonitor in order to have some metrics available.
+      #
+      # You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
+      # The configuration varies slightly for GEM and Mimir.
+      #
+      # If you have deployed Mimir, then the Helm chart values should look like the following.
+      # Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+      #
+      # remote:
+      #   url: 'http://<HELM_RELEASE_NAME>-mimir-nginx.mimir.svc/api/v1/push'
+      #   headers:
+      #     X-Scope-OrgID: metamonitoring
+      #
+      # If you have deployed GEM, then the URL will point to the GEM gateway instead of the nginx Deployment.
+      # If you are using the GEM authentication model, then you also need to provide a Secret with the
+      # authentication token for a tenant. Refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
+      # for setting up the Secret.
+      # Assuming you are using the GEM authentication model, the Helm chart values should look like the following.
+      # Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+      #
+      # remote:
+      #   url: 'http://<HELM_RELEASE_NAME>-mimir-gateway.mimir.svc/api/v1/push'
+      #   auth:
+      #     username: metamonitoring
+      #     passwordSecretName: gem-tokens
+      #     passwordSecretKey: metamonitoring
       remote:
         # -- Full URL for Prometheus remote-write. Usually ends in /push
         url: ''


### PR DESCRIPTION
#### What this PR does

A few community members have asked if it's possible to send metamonitoring directly back to mimir. This PR adds examples of how to do this.

I also added an example in the helm values.yaml since this is where some people look for documentation first.


#### Checklist

- NA Tests updated
- [x] Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
