### PR TITLE
Chore: do not run query-scheduler in monolithic local dev env

### DIFF
--- a/development/mimir-monolithic-mode/config/mimir.yaml
+++ b/development/mimir-monolithic-mode/config/mimir.yaml
@@ -71,14 +71,5 @@ ruler_storage:
     secret_access_key: supersecret
     insecure: true
 
-query_scheduler:
-  # Comment to not use the query-scheduler and enqueue queries directly in the query-frontend.
-  service_discovery_mode: "ring"
-  ring:
-    kvstore:
-      store: consul
-      consul:
-        host: consul:8500
-
 runtime_config:
   file: ./config/runtime.yaml

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: mimir
-    command: ["sh", "-c", "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=all,query-scheduler -server.http-listen-port=8001 -server.grpc-listen-port=9001"]
+    command: ["sh", "-c", "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=all -server.http-listen-port=8001 -server.grpc-listen-port=9001"]
     depends_on:
       - consul
       - minio
@@ -68,7 +68,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: mimir
-    command: ["sh", "-c", "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=all,query-scheduler -server.http-listen-port=8002 -server.grpc-listen-port=9002"]
+    command: ["sh", "-c", "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=all -server.http-listen-port=8002 -server.grpc-listen-port=9002"]
     depends_on:
       - consul
       - minio


### PR DESCRIPTION
#### What this PR does
In #2957 I've enabled query-scheduler in the monolithic local dev env, but we don't expect people running the monolithic version to run the query-scheduler (given it's not part of `-target=all`), so in this PR I'm reverting the change to the local dev env.

This PR addresses the [feedback received here](https://github.com/grafana/mimir/pull/2957#discussion_r974338322).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
