### PR TITLE
Marco will shepherd 2.4 release on 10th Oct 2022

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,8 +12,8 @@ A new Grafana Mimir release is cut approximately every 6 weeks. The following ta
 | 2.1.0   | 2022-05-16 | Johanna Ratliff   |
 | 2.2.0   | 2022-06-27 | Oleg Zaytsev      |
 | 2.3.0   | 2022-08-08 | Tyler Reid        |
-| 2.4.0   | 2022-09-19 | _To be announced_ |
-| 2.5.0   | 2022-10-31 | _To be announced_ |
+| 2.4.0   | 2022-10-10 | Marco Pracucci    |
+| 2.5.0   | 2022-11-21 | _To be announced_ |
 
 ## Release shepherd responsibilities
 


### PR DESCRIPTION
#### What this PR does
Since we're late on 2.3 release, Mimir maintainers agreed to postpone 2.4 release by 3 weeks. I will also shepherd it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
