### PR TITLE
Chore: remove inaccurate log from querier

### DIFF
--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -104,8 +104,7 @@ type querierWorker struct {
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
 
-	mu sync.Mutex
-	// Set to nil when stop is called... no more managers are created afterwards.
+	mu       sync.Mutex
 	managers map[string]*processorManager
 }
 
@@ -255,7 +254,6 @@ func (w *querierWorker) AddressRemoved(address string) {
 
 // Must be called with lock.
 func (w *querierWorker) resetConcurrency() {
-	totalConcurrency := 0
 	index := 0
 
 	for _, m := range w.managers {
@@ -277,13 +275,8 @@ func (w *querierWorker) resetConcurrency() {
 			concurrency = 1
 		}
 
-		totalConcurrency += concurrency
 		m.concurrency(concurrency)
 		index++
-	}
-
-	if totalConcurrency > w.cfg.MaxConcurrentRequests {
-		level.Warn(w.log).Log("msg", "total worker concurrency is greater than promql max concurrency. Queries may be queued in the querier which reduces QOS")
 	}
 }
 


### PR DESCRIPTION
#### What this PR does
In #2598 we removed the PromQL concurrency (leveraging only on the actual number of querier workers) in order to reduce a source of confusion where queries could be enqueued inside the querier too in certain scenarios. However, we forgot to remove a log in the querier, which I'm fixing in this PR.

I'm also removing a comment about `querierWorker.managers` which is **not** set to `nil` when stopping.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
