### PR TITLE
Chore: refactor service discovery implementation

### DIFF
--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grafana/mimir/pkg/scheduler/schedulerdiscovery"
-	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/servicediscovery"
 )
 
 type Config struct {
@@ -136,7 +136,7 @@ func NewQuerierWorker(cfg Config, handler RequestHandler, log log.Logger, reg pr
 		level.Info(log).Log("msg", "Starting querier worker connected to query-frontend", "frontend", cfg.FrontendAddress)
 
 		factory = func(receiver serviceDiscoveryNotifications) (services.Service, error) {
-			return util.NewDNSWatcher(cfg.FrontendAddress, cfg.DNSLookupPeriod, receiver)
+			return servicediscovery.NewDNSWatcher(cfg.FrontendAddress, cfg.DNSLookupPeriod, receiver)
 		}
 
 		processor = newFrontendProcessor(cfg, handler, log)

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -130,7 +130,7 @@ func NewQuerierWorker(cfg Config, handler RequestHandler, log log.Logger, reg pr
 		level.Info(log).Log("msg", "Starting querier worker connected to query-frontend", "frontend", cfg.FrontendAddress)
 
 		factory = func(receiver servicediscovery.Notifications) (services.Service, error) {
-			return servicediscovery.NewDNSServiceDiscovery(cfg.FrontendAddress, cfg.DNSLookupPeriod, receiver)
+			return servicediscovery.NewDNS(cfg.FrontendAddress, cfg.DNSLookupPeriod, receiver)
 		}
 
 		processor = newFrontendProcessor(cfg, handler, log)

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -136,7 +136,7 @@ func NewQuerierWorker(cfg Config, handler RequestHandler, log log.Logger, reg pr
 		level.Info(log).Log("msg", "Starting querier worker connected to query-frontend", "frontend", cfg.FrontendAddress)
 
 		factory = func(receiver serviceDiscoveryNotifications) (services.Service, error) {
-			return servicediscovery.NewDNSWatcher(cfg.FrontendAddress, cfg.DNSLookupPeriod, receiver)
+			return servicediscovery.NewDNSServiceDiscovery(cfg.FrontendAddress, cfg.DNSLookupPeriod, receiver)
 		}
 
 		processor = newFrontendProcessor(cfg, handler, log)

--- a/pkg/scheduler/schedulerdiscovery/discovery.go
+++ b/pkg/scheduler/schedulerdiscovery/discovery.go
@@ -26,7 +26,7 @@ func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.
 }
 
 func NewDNSServiceDiscovery(schedulerAddress string, lookupPeriod time.Duration, receiver servicediscovery.Notifications) (services.Service, error) {
-	return servicediscovery.NewDNSServiceDiscovery(schedulerAddress, lookupPeriod, receiver)
+	return servicediscovery.NewDNS(schedulerAddress, lookupPeriod, receiver)
 }
 
 var (
@@ -39,5 +39,5 @@ func NewRingServiceDiscovery(cfg Config, component string, receiver servicedisco
 		return nil, err
 	}
 
-	return servicediscovery.NewRingServiceDiscovery(client, activeSchedulersOp, cfg.SchedulerRing.RingCheckPeriod, receiver), nil
+	return servicediscovery.NewRing(client, activeSchedulersOp, cfg.SchedulerRing.RingCheckPeriod, receiver), nil
 }

--- a/pkg/scheduler/schedulerdiscovery/discovery.go
+++ b/pkg/scheduler/schedulerdiscovery/discovery.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/servicediscovery"
 )
 
 // Notifications about address resolution. All notifications are sent on the same goroutine.
@@ -38,7 +38,7 @@ func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.
 }
 
 func NewDNSServiceDiscovery(schedulerAddress string, lookupPeriod time.Duration, receiver Notifications) (services.Service, error) {
-	return util.NewDNSWatcher(schedulerAddress, lookupPeriod, receiver)
+	return servicediscovery.NewDNSWatcher(schedulerAddress, lookupPeriod, receiver)
 }
 
 var (

--- a/pkg/scheduler/schedulerdiscovery/discovery.go
+++ b/pkg/scheduler/schedulerdiscovery/discovery.go
@@ -38,7 +38,7 @@ func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.
 }
 
 func NewDNSServiceDiscovery(schedulerAddress string, lookupPeriod time.Duration, receiver Notifications) (services.Service, error) {
-	return servicediscovery.NewDNSWatcher(schedulerAddress, lookupPeriod, receiver)
+	return servicediscovery.NewDNSServiceDiscovery(schedulerAddress, lookupPeriod, receiver)
 }
 
 var (

--- a/pkg/scheduler/schedulerdiscovery/discovery.go
+++ b/pkg/scheduler/schedulerdiscovery/discovery.go
@@ -3,29 +3,17 @@
 package schedulerdiscovery
 
 import (
-	"context"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/mimir/pkg/util/servicediscovery"
 )
 
-// Notifications about address resolution. All notifications are sent on the same goroutine.
-type Notifications interface {
-	// AddressAdded is called each time a new query-scheduler address has been discovered by service discovery.
-	AddressAdded(address string)
-
-	// AddressRemoved is called each time query-scheduler address that was previously notified by AddressAdded()
-	// is no longer available.
-	AddressRemoved(address string)
-}
-
-func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.Duration, component string, receiver Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
+func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.Duration, component string, receiver servicediscovery.Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
 	// Since this is a client for the query-schedulers ring, we append "query-scheduler-client" to the component to clearly differentiate it.
 	component = component + "-query-scheduler-client"
 
@@ -37,7 +25,7 @@ func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.
 	}
 }
 
-func NewDNSServiceDiscovery(schedulerAddress string, lookupPeriod time.Duration, receiver Notifications) (services.Service, error) {
+func NewDNSServiceDiscovery(schedulerAddress string, lookupPeriod time.Duration, receiver servicediscovery.Notifications) (services.Service, error) {
 	return servicediscovery.NewDNSServiceDiscovery(schedulerAddress, lookupPeriod, receiver)
 }
 
@@ -45,89 +33,11 @@ var (
 	activeSchedulersOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 )
 
-type ringServiceDiscovery struct {
-	services.Service
-
-	ring               *ring.Ring
-	subservicesWatcher *services.FailureWatcher
-	checkPeriod        time.Duration
-	receiver           Notifications
-
-	// Keep track of the addresses that have been discovered and notified so far.
-	notifiedAddresses map[string]struct{}
-}
-
-func NewRingServiceDiscovery(cfg Config, component string, receiver Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
+func NewRingServiceDiscovery(cfg Config, component string, receiver servicediscovery.Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
 	client, err := NewRingClient(cfg.SchedulerRing, component, logger, reg)
 	if err != nil {
 		return nil, err
 	}
 
-	r := &ringServiceDiscovery{
-		ring:               client,
-		subservicesWatcher: services.NewFailureWatcher(),
-		checkPeriod:        cfg.SchedulerRing.RingCheckPeriod,
-		notifiedAddresses:  make(map[string]struct{}),
-		receiver:           receiver,
-	}
-
-	r.Service = services.NewBasicService(r.starting, r.running, r.stopping)
-
-	return r, nil
-}
-
-func (r *ringServiceDiscovery) starting(ctx context.Context) error {
-	r.subservicesWatcher.WatchService(r.ring)
-
-	return errors.Wrap(services.StartAndAwaitRunning(ctx, r.ring), "failed to start query-schedulers ring client")
-}
-
-func (r *ringServiceDiscovery) stopping(_ error) error {
-	return errors.Wrap(services.StopAndAwaitTerminated(context.Background(), r.ring), "failed to stop query-schedulers ring client")
-}
-
-func (r *ringServiceDiscovery) running(ctx context.Context) error {
-	ringTicker := time.NewTicker(r.checkPeriod)
-	defer ringTicker.Stop()
-
-	// Notifies the initial state.
-	ringState, _ := r.ring.GetAllHealthy(activeSchedulersOp) // nolint:errcheck
-	r.notifyChanges(ringState)
-
-	for {
-		select {
-		case <-ringTicker.C:
-			ringState, _ := r.ring.GetAllHealthy(activeSchedulersOp) // nolint:errcheck
-			r.notifyChanges(ringState)
-		case <-ctx.Done():
-			return nil
-		case err := <-r.subservicesWatcher.Chan():
-			return errors.Wrap(err, "a subservice of query-schedulers ring-based service discovery has failed")
-		}
-	}
-}
-
-// notifyChanges is not concurrency safe.
-func (r *ringServiceDiscovery) notifyChanges(discovered ring.ReplicationSet) {
-	// Build a map with the discovered addresses.
-	discoveredAddresses := make(map[string]struct{}, len(discovered.Instances))
-	for _, instance := range discovered.Instances {
-		discoveredAddresses[instance.GetAddr()] = struct{}{}
-	}
-
-	// Notify new addresses.
-	for addr := range discoveredAddresses {
-		if _, ok := r.notifiedAddresses[addr]; !ok {
-			r.receiver.AddressAdded(addr)
-		}
-	}
-
-	// Notify removed addresses.
-	for addr := range r.notifiedAddresses {
-		if _, ok := discoveredAddresses[addr]; !ok {
-			r.receiver.AddressRemoved(addr)
-		}
-	}
-
-	r.notifiedAddresses = discoveredAddresses
+	return servicediscovery.NewRingServiceDiscovery(client, activeSchedulersOp, cfg.SchedulerRing.RingCheckPeriod, receiver), nil
 }

--- a/pkg/util/servicediscovery/dns.go
+++ b/pkg/util/servicediscovery/dns.go
@@ -18,21 +18,22 @@ import (
 )
 
 // Notifications about address resolution. All notifications are sent on the same goroutine.
-type DNSNotifications interface {
-	// New address has been discovered by DNS watcher for supplied hostname.
+type Notifications interface {
+	// AddressAdded is called each time a new address has been discovered.
 	AddressAdded(address string)
 
-	// Previously-discovered address is no longer resolved for the hostname.
+	// AddressRemoved is called each time an address that was previously notified by AddressAdded()
+	// is no longer available.
 	AddressRemoved(address string)
 }
 
-type dnsWatcher struct {
-	watcher       grpcutil.Watcher
-	notifications DNSNotifications
+type dnsServiceDiscovery struct {
+	watcher  grpcutil.Watcher
+	receiver Notifications
 }
 
-// NewDNSWatcher creates a new DNS watcher and returns a service that is wrapping it.
-func NewDNSWatcher(address string, dnsLookupPeriod time.Duration, notifications DNSNotifications) (services.Service, error) {
+// NewDNSServiceDiscovery creates a new DNS-based service discovery.
+func NewDNSServiceDiscovery(address string, dnsLookupPeriod time.Duration, notifications Notifications) (services.Service, error) {
 	resolver, err := grpcutil.NewDNSResolverWithFreq(dnsLookupPeriod, util_log.Logger)
 	if err != nil {
 		return nil, err
@@ -44,15 +45,15 @@ func NewDNSWatcher(address string, dnsLookupPeriod time.Duration, notifications 
 		return nil, err
 	}
 
-	w := &dnsWatcher{
-		watcher:       watcher,
-		notifications: notifications,
+	w := &dnsServiceDiscovery{
+		watcher:  watcher,
+		receiver: notifications,
 	}
 	return services.NewBasicService(nil, w.watchDNSLoop, nil), nil
 }
 
-// watchDNSLoop watches for changes in DNS and sends notifications.
-func (w *dnsWatcher) watchDNSLoop(servCtx context.Context) error {
+// watchDNSLoop watches for changes in DNS and sends receiver.
+func (w *dnsServiceDiscovery) watchDNSLoop(servCtx context.Context) error {
 	go func() {
 		// Close the watcher, when this service is asked to stop.
 		// Closing the watcher makes watchDNSLoop exit, since it only iterates on watcher updates, and has no other
@@ -70,16 +71,16 @@ func (w *dnsWatcher) watchDNSLoop(servCtx context.Context) error {
 			if servCtx.Err() != nil {
 				return nil
 			}
-			return errors.Wrapf(err, "error from DNS watcher")
+			return errors.Wrapf(err, "error from DNS service discovery")
 		}
 
 		for _, update := range updates {
 			switch update.Op {
 			case grpcutil.Add:
-				w.notifications.AddressAdded(update.Addr)
+				w.receiver.AddressAdded(update.Addr)
 
 			case grpcutil.Delete:
-				w.notifications.AddressRemoved(update.Addr)
+				w.receiver.AddressRemoved(update.Addr)
 
 			default:
 				return fmt.Errorf("unknown op: %v", update.Op)

--- a/pkg/util/servicediscovery/dns.go
+++ b/pkg/util/servicediscovery/dns.go
@@ -52,7 +52,7 @@ func NewDNS(address string, dnsLookupPeriod time.Duration, notifications Notific
 	return services.NewBasicService(nil, w.watchDNSLoop, nil), nil
 }
 
-// watchDNSLoop watches for changes in DNS and sends receiver.
+// watchDNSLoop watches for changes in DNS and sends notifications.
 func (w *dnsServiceDiscovery) watchDNSLoop(servCtx context.Context) error {
 	go func() {
 		// Close the watcher, when this service is asked to stop.

--- a/pkg/util/servicediscovery/dns.go
+++ b/pkg/util/servicediscovery/dns.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package util
+package servicediscovery
 
 import (
 	"context"

--- a/pkg/util/servicediscovery/dns.go
+++ b/pkg/util/servicediscovery/dns.go
@@ -32,8 +32,8 @@ type dnsServiceDiscovery struct {
 	receiver Notifications
 }
 
-// NewDNSServiceDiscovery creates a new DNS-based service discovery.
-func NewDNSServiceDiscovery(address string, dnsLookupPeriod time.Duration, notifications Notifications) (services.Service, error) {
+// NewDNS creates a new DNS-based service discovery.
+func NewDNS(address string, dnsLookupPeriod time.Duration, notifications Notifications) (services.Service, error) {
 	resolver, err := grpcutil.NewDNSResolverWithFreq(dnsLookupPeriod, util_log.Logger)
 	if err != nil {
 		return nil, err

--- a/pkg/util/servicediscovery/ring.go
+++ b/pkg/util/servicediscovery/ring.go
@@ -24,7 +24,7 @@ type ringServiceDiscovery struct {
 	notifiedAddresses map[string]struct{}
 }
 
-func NewRingServiceDiscovery(ringClient *ring.Ring, ringOp ring.Operation, ringCheckPeriod time.Duration, receiver Notifications) services.Service {
+func NewRing(ringClient *ring.Ring, ringOp ring.Operation, ringCheckPeriod time.Duration, receiver Notifications) services.Service {
 	r := &ringServiceDiscovery{
 		ringClient:         ringClient,
 		ringOp:             ringOp,

--- a/pkg/util/servicediscovery/ring.go
+++ b/pkg/util/servicediscovery/ring.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package servicediscovery
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+)
+
+type ringServiceDiscovery struct {
+	services.Service
+
+	ringClient         *ring.Ring
+	ringOp             ring.Operation
+	subservicesWatcher *services.FailureWatcher
+	ringCheckPeriod    time.Duration
+	receiver           Notifications
+
+	// Keep track of the addresses that have been discovered and notified so far.
+	notifiedAddresses map[string]struct{}
+}
+
+func NewRingServiceDiscovery(ringClient *ring.Ring, ringOp ring.Operation, ringCheckPeriod time.Duration, receiver Notifications) services.Service {
+	r := &ringServiceDiscovery{
+		ringClient:         ringClient,
+		ringOp:             ringOp,
+		subservicesWatcher: services.NewFailureWatcher(),
+		ringCheckPeriod:    ringCheckPeriod,
+		notifiedAddresses:  make(map[string]struct{}),
+		receiver:           receiver,
+	}
+
+	r.Service = services.NewBasicService(r.starting, r.running, r.stopping)
+	return r
+}
+
+func (r *ringServiceDiscovery) starting(ctx context.Context) error {
+	r.subservicesWatcher.WatchService(r.ringClient)
+
+	return errors.Wrap(services.StartAndAwaitRunning(ctx, r.ringClient), "failed to start ring client")
+}
+
+func (r *ringServiceDiscovery) stopping(_ error) error {
+	return errors.Wrap(services.StopAndAwaitTerminated(context.Background(), r.ringClient), "failed to stop ring client")
+}
+
+func (r *ringServiceDiscovery) running(ctx context.Context) error {
+	ringTicker := time.NewTicker(r.ringCheckPeriod)
+	defer ringTicker.Stop()
+
+	// Notifies the initial state.
+	ringState, _ := r.ringClient.GetAllHealthy(r.ringOp) // nolint:errcheck
+	r.notifyChanges(ringState)
+
+	for {
+		select {
+		case <-ringTicker.C:
+			ringState, _ := r.ringClient.GetAllHealthy(r.ringOp) // nolint:errcheck
+			r.notifyChanges(ringState)
+		case <-ctx.Done():
+			return nil
+		case err := <-r.subservicesWatcher.Chan():
+			return errors.Wrap(err, "a subservice of ring-based service discovery has failed")
+		}
+	}
+}
+
+// notifyChanges is not concurrency safe.
+func (r *ringServiceDiscovery) notifyChanges(discovered ring.ReplicationSet) {
+	// Build a map with the discovered addresses.
+	discoveredAddresses := make(map[string]struct{}, len(discovered.Instances))
+	for _, instance := range discovered.Instances {
+		discoveredAddresses[instance.GetAddr()] = struct{}{}
+	}
+
+	// Notify new addresses.
+	for addr := range discoveredAddresses {
+		if _, ok := r.notifiedAddresses[addr]; !ok {
+			r.receiver.AddressAdded(addr)
+		}
+	}
+
+	// Notify removed addresses.
+	for addr := range r.notifiedAddresses {
+		if _, ok := discoveredAddresses[addr]; !ok {
+			r.receiver.AddressRemoved(addr)
+		}
+	}
+
+	r.notifiedAddresses = discoveredAddresses
+}

--- a/pkg/util/servicediscovery/ring_test.go
+++ b/pkg/util/servicediscovery/ring_test.go
@@ -49,7 +49,7 @@ func TestRingServiceDiscovery(t *testing.T) {
 	// Mock a receiver to keep track of all notified addresses.
 	receiver := newNotificationsReceiverMock()
 
-	sd := NewRingServiceDiscovery(ringClient, ringOp, ringCheckPeriod, receiver)
+	sd := NewRing(ringClient, ringOp, ringCheckPeriod, receiver)
 
 	// Start the service discovery.
 	require.NoError(t, services.StartAndAwaitRunning(ctx, sd))

--- a/pkg/util/servicediscovery/ring_test.go
+++ b/pkg/util/servicediscovery/ring_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package schedulerdiscovery
+package servicediscovery
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
@@ -19,17 +18,28 @@ import (
 )
 
 func TestRingServiceDiscovery(t *testing.T) {
-	ctx := context.Background()
-	cfg := Config{}
-	flagext.DefaultValues(&cfg)
+	const (
+		ringKey         = "test"
+		ringCheckPeriod = 100 * time.Millisecond // Check very frequently to speed up the test.
+	)
 
-	// Check very frequently to speed up the test.
-	cfg.SchedulerRing.RingCheckPeriod = 100 * time.Millisecond
+	var (
+		ctx    = context.Background()
+		ringOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+	)
 
-	// Inject in-memory KV store.
+	// Use an in-memory KV store.
 	inmem, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { _ = closer.Close() })
-	cfg.SchedulerRing.KVStore.Mock = inmem
+
+	// Create a ring client.
+	ringCfg := ring.Config{
+		HeartbeatTimeout:  time.Minute,
+		ReplicationFactor: 1,
+	}
+
+	ringClient, err := ring.NewWithStoreClientAndStrategy(ringCfg, "test", ringKey, inmem, ring.NewDefaultReplicationStrategy(), nil, log.NewNopLogger())
+	require.NoError(t, err)
 
 	// Create an empty ring.
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
@@ -39,8 +49,7 @@ func TestRingServiceDiscovery(t *testing.T) {
 	// Mock a receiver to keep track of all notified addresses.
 	receiver := newNotificationsReceiverMock()
 
-	sd, err := NewRingServiceDiscovery(cfg, "test", receiver, log.NewNopLogger(), nil)
-	require.NoError(t, err)
+	sd := NewRingServiceDiscovery(ringClient, ringOp, ringCheckPeriod, receiver)
 
 	// Start the service discovery.
 	require.NoError(t, services.StartAndAwaitRunning(ctx, sd))
@@ -107,7 +116,7 @@ func TestRingServiceDiscovery(t *testing.T) {
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := in.(*ring.Desc)
 		instance := desc.Ingesters["instance-2"]
-		instance.Timestamp = time.Now().Add(-2 * cfg.SchedulerRing.HeartbeatTimeout).Unix()
+		instance.Timestamp = time.Now().Add(-2 * ringCfg.HeartbeatTimeout).Unix()
 		desc.Ingesters["instance-2"] = instance
 		return desc, true, nil
 	}))


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/2957 I've introduced an (optional) ring for the query-scheduler. The next step will be introducing support for "max query-scheduler active replicas" as part of the [read-write deployment mode support](https://github.com/grafana/mimir/issues/2749), but before that I would like to do a refactoring to simplify the diff of the next PR.

In this PR, as separate commits:
- [Move DNS watcher to pkg/util/servicediscovery/](https://github.com/grafana/mimir/commit/68cd173d2ae7841af5e5d4f9e0a7181c3295ca2a)
- [Renamed dnsWatcher to dnsServiceDiscovery](https://github.com/grafana/mimir/commit/18bbe069d39960d04039b98b76b6a1cc4fadc5a6)
- [Moved ring-based service discovery to pkg/util/servicediscovery/ and removed redundant notifications interfaces](https://github.com/grafana/mimir/commit/e1b94b842e495b8991eb3a1730382a04e0ea75d5) 

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
