### PR TITLE
Distributor: Support for forwarding request via httpgrpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Query-frontend: Add `cortex_frontend_query_result_cache_skipped_total` and `cortex_frontend_query_result_cache_attempted_total` metrics to track the reason why query results are not cached. #2855
 * [ENHANCEMENT] Distributor: pool more connections per host when forwarding request. Mark requests as idempotent so they can be retried under some conditions. #2968
 * [ENHANCEMENT] Distributor: failure to send request to forwarding target now also increments `cortex_distributor_forward_errors_total`, with `status_code="failed"`. #2968
+* [ENHANCEMENT] Distributor: added support forwarding push requests via gRPC, using `httpgrpc` messages from weaveworks/common library. #2996
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1398,6 +1398,191 @@
               "fieldFlag": "distributor.forwarding.propagate-errors",
               "fieldType": "boolean",
               "fieldCategory": "experimental"
+            },
+            {
+              "kind": "block",
+              "name": "grpc_client",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "max_recv_msg_size",
+                  "required": false,
+                  "desc": "gRPC client max receive message size (bytes).",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 104857600,
+                  "fieldFlag": "distributor.forwarding.grpc-client.grpc-max-recv-msg-size",
+                  "fieldType": "int",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_send_msg_size",
+                  "required": false,
+                  "desc": "gRPC client max send message size (bytes).",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 104857600,
+                  "fieldFlag": "distributor.forwarding.grpc-client.grpc-max-send-msg-size",
+                  "fieldType": "int",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "grpc_compression",
+                  "required": false,
+                  "desc": "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "distributor.forwarding.grpc-client.grpc-compression",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "rate_limit",
+                  "required": false,
+                  "desc": "Rate limit for gRPC client; 0 means disabled.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "distributor.forwarding.grpc-client.grpc-client-rate-limit",
+                  "fieldType": "float",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "rate_limit_burst",
+                  "required": false,
+                  "desc": "Rate limit burst for gRPC client.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "distributor.forwarding.grpc-client.grpc-client-rate-limit-burst",
+                  "fieldType": "int",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "backoff_on_ratelimits",
+                  "required": false,
+                  "desc": "Enable backoff and retry when we hit ratelimits.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "distributor.forwarding.grpc-client.backoff-on-ratelimits",
+                  "fieldType": "boolean",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "backoff_config",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "min_period",
+                      "required": false,
+                      "desc": "Minimum delay when backing off.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100000000,
+                      "fieldFlag": "distributor.forwarding.grpc-client.backoff-min-period",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_period",
+                      "required": false,
+                      "desc": "Maximum delay when backing off.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10000000000,
+                      "fieldFlag": "distributor.forwarding.grpc-client.backoff-max-period",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_retries",
+                      "required": false,
+                      "desc": "Number of times to backoff and retry before failing.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10,
+                      "fieldFlag": "distributor.forwarding.grpc-client.backoff-retries",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "field",
+                  "name": "tls_enabled",
+                  "required": false,
+                  "desc": "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "distributor.forwarding.grpc-client.tls-enabled",
+                  "fieldType": "boolean",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "tls_cert_path",
+                  "required": false,
+                  "desc": "Path to the client certificate file, which will be used for authenticating with the server. Also requires the key path to be configured.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "distributor.forwarding.grpc-client.tls-cert-path",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "tls_key_path",
+                  "required": false,
+                  "desc": "Path to the key file for the client certificate. Also requires the client certificate to be configured.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "distributor.forwarding.grpc-client.tls-key-path",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "tls_ca_path",
+                  "required": false,
+                  "desc": "Path to the CA certificates file to validate server certificate against. If not set, the host's root CA certificates are used.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "distributor.forwarding.grpc-client.tls-ca-path",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "tls_server_name",
+                  "required": false,
+                  "desc": "Override the expected name on the server certificate.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "distributor.forwarding.grpc-client.tls-server-name",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "tls_insecure_skip_verify",
+                  "required": false,
+                  "desc": "Skip validating server certificate.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "distributor.forwarding.grpc-client.tls-insecure-skip-verify",
+                  "fieldType": "boolean",
+                  "fieldCategory": "advanced"
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -748,6 +748,36 @@ Usage of ./cmd/mimir/mimir:
     	This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.
   -distributor.forwarding.enabled
     	[experimental] Enables the feature to forward certain metrics in remote_write requests, depending on defined rules.
+  -distributor.forwarding.grpc-client.backoff-max-period duration
+    	Maximum delay when backing off. (default 10s)
+  -distributor.forwarding.grpc-client.backoff-min-period duration
+    	Minimum delay when backing off. (default 100ms)
+  -distributor.forwarding.grpc-client.backoff-on-ratelimits
+    	Enable backoff and retry when we hit ratelimits.
+  -distributor.forwarding.grpc-client.backoff-retries int
+    	Number of times to backoff and retry before failing. (default 10)
+  -distributor.forwarding.grpc-client.grpc-client-rate-limit float
+    	Rate limit for gRPC client; 0 means disabled.
+  -distributor.forwarding.grpc-client.grpc-client-rate-limit-burst int
+    	Rate limit burst for gRPC client.
+  -distributor.forwarding.grpc-client.grpc-compression string
+    	Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)
+  -distributor.forwarding.grpc-client.grpc-max-recv-msg-size int
+    	gRPC client max receive message size (bytes). (default 104857600)
+  -distributor.forwarding.grpc-client.grpc-max-send-msg-size int
+    	gRPC client max send message size (bytes). (default 104857600)
+  -distributor.forwarding.grpc-client.tls-ca-path string
+    	Path to the CA certificates file to validate server certificate against. If not set, the host's root CA certificates are used.
+  -distributor.forwarding.grpc-client.tls-cert-path string
+    	Path to the client certificate file, which will be used for authenticating with the server. Also requires the key path to be configured.
+  -distributor.forwarding.grpc-client.tls-enabled
+    	Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.
+  -distributor.forwarding.grpc-client.tls-insecure-skip-verify
+    	Skip validating server certificate.
+  -distributor.forwarding.grpc-client.tls-key-path string
+    	Path to the key file for the client certificate. Also requires the client certificate to be configured.
+  -distributor.forwarding.grpc-client.tls-server-name string
+    	Override the expected name on the server certificate.
   -distributor.forwarding.propagate-errors
     	[experimental] If disabled then forwarding requests are always considered to be successful, errors are ignored. (default true)
   -distributor.forwarding.request-concurrency int

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -633,6 +633,75 @@ forwarding:
   # be successful, errors are ignored.
   # CLI flag: -distributor.forwarding.propagate-errors
   [propagate_errors: <boolean> | default = true]
+
+  grpc_client:
+    # (advanced) gRPC client max receive message size (bytes).
+    # CLI flag: -distributor.forwarding.grpc-client.grpc-max-recv-msg-size
+    [max_recv_msg_size: <int> | default = 104857600]
+
+    # (advanced) gRPC client max send message size (bytes).
+    # CLI flag: -distributor.forwarding.grpc-client.grpc-max-send-msg-size
+    [max_send_msg_size: <int> | default = 104857600]
+
+    # (advanced) Use compression when sending messages. Supported values are:
+    # 'gzip', 'snappy' and '' (disable compression)
+    # CLI flag: -distributor.forwarding.grpc-client.grpc-compression
+    [grpc_compression: <string> | default = ""]
+
+    # (advanced) Rate limit for gRPC client; 0 means disabled.
+    # CLI flag: -distributor.forwarding.grpc-client.grpc-client-rate-limit
+    [rate_limit: <float> | default = 0]
+
+    # (advanced) Rate limit burst for gRPC client.
+    # CLI flag: -distributor.forwarding.grpc-client.grpc-client-rate-limit-burst
+    [rate_limit_burst: <int> | default = 0]
+
+    # (advanced) Enable backoff and retry when we hit ratelimits.
+    # CLI flag: -distributor.forwarding.grpc-client.backoff-on-ratelimits
+    [backoff_on_ratelimits: <boolean> | default = false]
+
+    backoff_config:
+      # (advanced) Minimum delay when backing off.
+      # CLI flag: -distributor.forwarding.grpc-client.backoff-min-period
+      [min_period: <duration> | default = 100ms]
+
+      # (advanced) Maximum delay when backing off.
+      # CLI flag: -distributor.forwarding.grpc-client.backoff-max-period
+      [max_period: <duration> | default = 10s]
+
+      # (advanced) Number of times to backoff and retry before failing.
+      # CLI flag: -distributor.forwarding.grpc-client.backoff-retries
+      [max_retries: <int> | default = 10]
+
+    # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled
+    # when any other TLS flag is set. If set to false, insecure connection to
+    # gRPC server will be used.
+    # CLI flag: -distributor.forwarding.grpc-client.tls-enabled
+    [tls_enabled: <boolean> | default = false]
+
+    # (advanced) Path to the client certificate file, which will be used for
+    # authenticating with the server. Also requires the key path to be
+    # configured.
+    # CLI flag: -distributor.forwarding.grpc-client.tls-cert-path
+    [tls_cert_path: <string> | default = ""]
+
+    # (advanced) Path to the key file for the client certificate. Also requires
+    # the client certificate to be configured.
+    # CLI flag: -distributor.forwarding.grpc-client.tls-key-path
+    [tls_key_path: <string> | default = ""]
+
+    # (advanced) Path to the CA certificates file to validate server certificate
+    # against. If not set, the host's root CA certificates are used.
+    # CLI flag: -distributor.forwarding.grpc-client.tls-ca-path
+    [tls_ca_path: <string> | default = ""]
+
+    # (advanced) Override the expected name on the server certificate.
+    # CLI flag: -distributor.forwarding.grpc-client.tls-server-name
+    [tls_server_name: <string> | default = ""]
+
+    # (advanced) Skip validating server certificate.
+    # CLI flag: -distributor.forwarding.grpc-client.tls-insecure-skip-verify
+    [tls_insecure_skip_verify: <boolean> | default = false]
 ```
 
 ### ingester

--- a/pkg/distributor/forwarding/config.go
+++ b/pkg/distributor/forwarding/config.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"flag"
 	"time"
+
+	"github.com/grafana/dskit/grpcclient"
 )
 
 type Config struct {
@@ -13,6 +15,8 @@ type Config struct {
 	RequestConcurrency int           `yaml:"request_concurrency" category:"experimental"`
 	RequestTimeout     time.Duration `yaml:"request_timeout" category:"experimental"`
 	PropagateErrors    bool          `yaml:"propagate_errors" category:"experimental"`
+
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
@@ -20,6 +24,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&c.RequestConcurrency, "distributor.forwarding.request-concurrency", 10, "Maximum concurrency at which forwarding requests get performed.")
 	f.DurationVar(&c.RequestTimeout, "distributor.forwarding.request-timeout", 2*time.Second, "Timeout for requests to ingestion endpoints to which we forward metrics.")
 	f.BoolVar(&c.PropagateErrors, "distributor.forwarding.propagate-errors", true, "If disabled then forwarding requests are always considered to be successful, errors are ignored.")
+	c.GRPCClientConfig.RegisterFlagsWithPrefix("distributor.forwarding.grpc-client", f)
 }
 
 func (c *Config) Validate() error {

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -4,10 +4,13 @@ package forwarding
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,11 +18,15 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/middleware"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/extract"
@@ -31,21 +38,29 @@ type Forwarder interface {
 	Forward(ctx context.Context, targetEndpoint string, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error)
 }
 
+// httpGrpcPrefix is URL prefix used by forwarder to check if it should use httpgrpc for sending request over to the target.
+// Full URL is in the form: httpgrpc://hostname:port/some/path, where "hostname:port" will be used to establish gRPC connection,
+// and "/some/path" will be included in the "url" part of the message for "httpgrpc.HTTP/Handle" method.
+const httpGrpcPrefix = "httpgrpc://"
+
 type forwarder struct {
 	services.Service
 
-	cfg      Config
-	pools    *pools
-	client   http.Client
-	log      log.Logger
-	workerWg sync.WaitGroup
-	reqCh    chan *request
+	cfg                Config
+	pools              *pools
+	client             http.Client
+	log                log.Logger
+	workerWg           sync.WaitGroup
+	reqCh              chan *request
+	httpGrpcClientPool *client.Pool
 
-	requestsTotal           prometheus.Counter
-	errorsTotal             *prometheus.CounterVec
-	samplesTotal            prometheus.Counter
-	exemplarsTotal          prometheus.Counter
-	requestLatencyHistogram prometheus.Histogram
+	requestsTotal             prometheus.Counter
+	errorsTotal               *prometheus.CounterVec
+	samplesTotal              prometheus.Counter
+	exemplarsTotal            prometheus.Counter
+	requestLatencyHistogram   prometheus.Histogram
+	grpcClientsGauge          prometheus.Gauge
+	grpcClientRequestDuration *prometheus.HistogramVec
 }
 
 // NewForwarder returns a new forwarder, if forwarding is disabled it returns nil.
@@ -94,11 +109,62 @@ func NewForwarder(cfg Config, reg prometheus.Registerer, log log.Logger) Forward
 			Help:      "The client-side latency of requests to forward metrics made by the Distributor.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30},
 		}),
+
+		grpcClientsGauge: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_distributor_forward_grpc_clients",
+			Help: "Number of gRPC clients used by Distributor forwarder.",
+		}),
+		grpcClientRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "cortex_distributor_forward_grpc_client_request_duration_seconds",
+			Help:    "Time spend doing requests to forwarding target via gRPC.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+		}, []string{"operation", "status_code"}),
 	}
 
+	f.httpGrpcClientPool = f.newHttpGrpcClientsPool()
 	f.Service = services.NewIdleService(f.start, f.stop)
 
 	return f
+}
+
+func (f *forwarder) newHttpGrpcClientsPool() *client.Pool {
+	poolConfig := client.PoolConfig{
+		CheckInterval:      5 * time.Second,
+		HealthCheckEnabled: true,
+		HealthCheckTimeout: 1 * time.Second,
+	}
+
+	return client.NewPool("frontend", poolConfig, nil, f.createHttpGrpcClient, f.grpcClientsGauge, f.log)
+}
+
+func (f *forwarder) createHttpGrpcClient(addr string) (client.PoolClient, error) {
+	opts, err := f.cfg.GRPCClientConfig.DialOption(
+		[]grpc.UnaryClientInterceptor{
+			middleware.UnaryClientInstrumentInterceptor(f.grpcClientRequestDuration),
+		},
+		nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	const grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
+
+	opts = append(opts,
+		grpc.WithBlock(),
+		grpc.WithDefaultServiceConfig(grpcServiceConfig),
+	)
+
+	conn, err := grpc.Dial(addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &grpcHttpClient{
+		HTTPClient:   httpgrpc.NewHTTPClient(conn),
+		HealthClient: grpc_health_v1.NewHealthClient(conn),
+		conn:         conn,
+	}, nil
 }
 
 func (f *forwarder) start(ctx context.Context) error {
@@ -261,9 +327,10 @@ func findTargetForLabels(targetEndpoint string, labels []mimirpb.LabelAdapter, r
 }
 
 type request struct {
-	pools  *pools
-	client *http.Client
-	log    log.Logger
+	pools              *pools
+	client             *http.Client
+	httpGrpcClientPool *client.Pool
+	log                log.Logger
 
 	ctx             context.Context
 	timeout         time.Duration
@@ -288,6 +355,7 @@ func (f *forwarder) submitForwardingRequest(ctx context.Context, endpoint string
 
 	req.pools = f.pools
 	req.client = &f.client // http client should be re-used so open connections get re-used.
+	req.httpGrpcClientPool = f.httpGrpcClientPool
 	req.log = f.log
 	req.ctx = ctx
 	req.timeout = f.cfg.RequestTimeout
@@ -339,15 +407,25 @@ func (r *request) do() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	bytesReader := r.pools.getBytesReader()
-	defer r.pools.putBytesReader(bytesReader)
+	if strings.HasPrefix(r.endpoint, httpGrpcPrefix) {
+		err = r.doHttpGrpc(ctx, snappyBuf)
+	} else {
+		err = r.doHttp(ctx, snappyBuf)
+	}
 
-	bytesReader.Reset(snappyBuf)
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", r.endpoint, bytesReader)
+	if err != nil {
+		r.errors.WithLabelValues("failed").Inc()
+
+		r.handleError(http.StatusInternalServerError, err)
+		return
+	}
+}
+
+func (r *request) doHttp(ctx context.Context, body []byte) error {
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", r.endpoint, bytes.NewReader(body))
 	if err != nil {
 		// Errors from NewRequest are from unparsable URLs being configured, so this is an internal server error.
-		r.handleError(http.StatusInternalServerError, errors.Wrap(err, "failed to create HTTP request for forwarding"))
-		return
+		return errors.Wrap(err, "failed to create HTTP request for forwarding")
 	}
 
 	httpReq.Header.Add("Content-Encoding", "snappy")
@@ -363,11 +441,8 @@ func (r *request) do() {
 	httpResp, err := r.client.Do(httpReq)
 	r.latency.Observe(time.Since(beforeTs).Seconds())
 	if err != nil {
-		r.errors.WithLabelValues("failed").Inc()
-
 		// Errors from Client.Do are from (for example) network errors, so we want the client to retry.
-		r.handleError(http.StatusInternalServerError, errors.Wrap(err, "failed to send HTTP request for forwarding"))
-		return
+		return errors.Wrap(err, "failed to send HTTP request for forwarding")
 	}
 	defer func() {
 		io.Copy(io.Discard, httpResp.Body)
@@ -380,15 +455,81 @@ func (r *request) do() {
 		if scanner.Scan() {
 			line = scanner.Text()
 		}
-		r.errors.WithLabelValues(strconv.Itoa(httpResp.StatusCode)).Inc()
-		err := errors.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
-		if httpResp.StatusCode/100 == 5 || httpResp.StatusCode == http.StatusTooManyRequests {
-			// The forwarding endpoint has returned a retriable error, so we want the client to retry.
-			r.handleError(http.StatusInternalServerError, err)
-			return
-		}
-		r.handleError(http.StatusBadRequest, err)
+
+		r.processHttpResponse(httpResp.StatusCode, line)
 	}
+	return nil
+}
+
+func (r *request) processHttpResponse(code int, message string) {
+	r.errors.WithLabelValues(strconv.Itoa(code)).Inc()
+
+	err := errors.Errorf("server returned HTTP status %s: %s", code, message)
+	if code/100 == 5 || code == http.StatusTooManyRequests {
+		// The forwarding endpoint has returned a retriable error, so we want the client to retry.
+		r.handleError(http.StatusInternalServerError, err)
+		return
+	}
+	r.handleError(http.StatusBadRequest, err)
+}
+
+var headers = []*httpgrpc.Header{
+	{
+		Key:    "Content-Encoding",
+		Values: []string{"snappy"},
+	},
+	{
+		Key:    "Content-Type",
+		Values: []string{"application/x-protobuf"},
+	},
+}
+
+func (r *request) doHttpGrpc(ctx context.Context, body []byte) error {
+	u, err := url.Parse(r.endpoint)
+	if err != nil {
+		return errors.Wrap(err, "failed to send HTTP request for forwarding")
+	}
+
+	req := &httpgrpc.HTTPRequest{
+		Method:  "POST",
+		Url:     u.Path,
+		Body:    body,
+		Headers: headers,
+	}
+
+	c, err := r.httpGrpcClientPool.GetClientFor(u.Host)
+	if err != nil {
+		return errors.Wrap(err, "failed to send HTTP request for forwarding")
+	}
+
+	h := c.(httpgrpc.HTTPClient)
+
+	r.requests.Inc()
+	r.samples.Add(float64(r.ts.counts.SampleCount))
+	r.exemplars.Add(float64(r.ts.counts.ExemplarCount))
+
+	beforeTs := time.Now()
+	resp, err := h.Handle(ctx, req)
+	r.latency.Observe(time.Since(beforeTs).Seconds())
+
+	if err != nil {
+		if r, ok := httpgrpc.HTTPResponseFromError(err); ok {
+			resp = r
+		} else {
+			return errors.Wrap(err, "failed to send HTTP request for forwarding")
+		}
+	}
+
+	if resp.Code/100 != 2 {
+		scanner := bufio.NewScanner(io.LimitReader(bytes.NewReader(resp.Body), 1024))
+		line := ""
+		if scanner.Scan() {
+			line = scanner.Text()
+		}
+
+		r.processHttpResponse(int(resp.Code), line)
+	}
+	return nil
 }
 
 func (r *request) handleError(status int, err error) {
@@ -412,4 +553,14 @@ func (r *request) cleanup() {
 	r.pools.putReq(r)
 
 	wg.Done()
+}
+
+type grpcHttpClient struct {
+	httpgrpc.HTTPClient
+	grpc_health_v1.HealthClient
+	conn *grpc.ClientConn
+}
+
+func (fc *grpcHttpClient) Close() error {
+	return fc.conn.Close()
 }

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -170,7 +170,7 @@ func (f *forwarder) createHTTPGrpcClient(addr string) (client.PoolClient, error)
 
 func (f *forwarder) start(ctx context.Context) error {
 	if err := services.StartAndAwaitRunning(ctx, f.httpGrpcClientPool); err != nil {
-		return errors.Wrap(err, "failed to start client pool")
+		return errors.Wrap(err, "failed to start grpc client pool")
 	}
 
 	f.workerWg.Add(f.cfg.RequestConcurrency)

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -775,12 +775,12 @@ func BenchmarkRemoteWriteForwarding(b *testing.B) {
 	}
 }
 
-func TestForwardingToHttpgrpcTarget(t *testing.T) {
+func TestForwardingToHTTPGrpcTarget(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UnixMilli()
 
-	cfg := Config{}
-	cfg = testConfig
+	var cfg Config
+	cfg = testConfig // Using "var cfg Config", to make sure we make a copy of testConfig.
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("ignored", flag.NewFlagSet("ignored", flag.ContinueOnError))
 
 	forwarder, reg := newForwarder(t, cfg, true)
@@ -894,6 +894,7 @@ func newTestHttpgrpcServer(tb testing.TB, status int) (string, func() []*httpgrp
 	}()
 	tb.Cleanup(func() {
 		_ = l.Close()
+		server.Stop()
 	})
 
 	return l.Addr().String(), hs.getRequests

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -4,8 +4,10 @@ package forwarding
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -17,13 +19,16 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/golang/snappy"
+	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
-
-	"github.com/grafana/dskit/services"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -768,6 +773,161 @@ func BenchmarkRemoteWriteForwarding(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestForwardingToHttpgrpcTarget(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UnixMilli()
+
+	cfg := Config{}
+	cfg = testConfig
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("ignored", flag.NewFlagSet("ignored", flag.ContinueOnError))
+
+	forwarder, reg := newForwarder(t, cfg, true)
+
+	url1, reqs1 := newTestHttpgrpcServer(t, 200)
+	url2, reqs2 := newTestHttpgrpcServer(t, 200)
+
+	rules := validation.ForwardingRules{
+		"metric1": validation.ForwardingRule{Endpoint: httpGrpcPrefix + url1, Ingest: false},
+		"metric2": validation.ForwardingRule{Endpoint: httpGrpcPrefix + url2, Ingest: true},
+	}
+
+	ts := []mimirpb.PreallocTimeseries{
+		newSample(t, now, 1, 100, "__name__", "metric1", "some_label", "foo"),
+		newSample(t, now, 2, 200, "__name__", "metric1", "some_label", "bar"),
+		newSample(t, now, 3, 300, "__name__", "metric2", "some_label", "foo"),
+		newSample(t, now, 4, 400, "__name__", "metric2", "some_label", "bar"),
+	}
+	tsToIngest, errCh := forwarder.Forward(ctx, "", rules, ts)
+
+	// The metric2 should be returned by the forwarding because the matching rule has ingest set to "true".
+	require.Len(t, tsToIngest, 2)
+	requireLabelsEqual(t, tsToIngest[0].Labels, "__name__", "metric2", "some_label", "foo")
+	requireSamplesEqual(t, tsToIngest[0].Samples, now, 3)
+	requireExemplarsEqual(t, tsToIngest[0].Exemplars, now, 300)
+	requireLabelsEqual(t, tsToIngest[1].Labels, "__name__", "metric2", "some_label", "bar")
+	requireSamplesEqual(t, tsToIngest[1].Samples, now, 4)
+	requireExemplarsEqual(t, tsToIngest[1].Exemplars, now, 400)
+
+	// Loop until errCh gets closed, errCh getting closed indicates that all forwarding requests have completed.
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	for _, req := range append(reqs1(), reqs2()...) {
+		ce := ""
+		ct := ""
+
+		for _, h := range req.Headers {
+			if h.Key == "Content-Encoding" {
+				ce = h.Values[0]
+			}
+			if h.Key == "Content-Type" {
+				ct = h.Values[0]
+			}
+		}
+		require.Equal(t, "snappy", ce)
+		require.Equal(t, "application/x-protobuf", ct)
+	}
+
+	bodies := reqs1()
+	require.Len(t, bodies, 1)
+	receivedReq1 := decodeBody(t, bodies[0].Body)
+	require.Len(t, receivedReq1.Timeseries, 2)
+	requireLabelsEqual(t, receivedReq1.Timeseries[0].Labels, "__name__", "metric1", "some_label", "foo")
+	requireSamplesEqual(t, receivedReq1.Timeseries[0].Samples, now, 1)
+	require.Empty(t, receivedReq1.Timeseries[0].Exemplars)
+	requireLabelsEqual(t, receivedReq1.Timeseries[1].Labels, "__name__", "metric1", "some_label", "bar")
+	requireSamplesEqual(t, receivedReq1.Timeseries[1].Samples, now, 2)
+	require.Empty(t, receivedReq1.Timeseries[1].Exemplars)
+
+	bodies = reqs2()
+	require.Len(t, bodies, 1)
+	receivedReq2 := decodeBody(t, bodies[0].Body)
+	require.Len(t, receivedReq2.Timeseries, 2)
+	requireLabelsEqual(t, receivedReq2.Timeseries[0].Labels, "__name__", "metric2", "some_label", "foo")
+	requireSamplesEqual(t, receivedReq2.Timeseries[0].Samples, now, 3)
+	require.Empty(t, receivedReq2.Timeseries[0].Exemplars)
+	requireLabelsEqual(t, receivedReq2.Timeseries[1].Labels, "__name__", "metric2", "some_label", "bar")
+	requireSamplesEqual(t, receivedReq2.Timeseries[1].Samples, now, 4)
+	require.Empty(t, receivedReq2.Timeseries[1].Exemplars)
+
+	expectedMetrics := `
+	# HELP cortex_distributor_forward_requests_total The total number of requests the Distributor made to forward samples.
+	# TYPE cortex_distributor_forward_requests_total counter
+	cortex_distributor_forward_requests_total{} 2
+	# HELP cortex_distributor_forward_samples_total The total number of samples the Distributor forwarded.
+	# TYPE cortex_distributor_forward_samples_total counter
+	cortex_distributor_forward_samples_total{} 4
+	# TYPE cortex_distributor_forward_grpc_clients gauge
+	# HELP cortex_distributor_forward_grpc_clients Number of gRPC clients used by Distributor forwarder.
+	cortex_distributor_forward_grpc_clients 2
+`
+
+	require.NoError(t, testutil.GatherAndCompare(
+		reg,
+		strings.NewReader(expectedMetrics),
+		"cortex_distributor_forward_requests_total",
+		"cortex_distributor_forward_samples_total",
+		"cortex_distributor_forward_grpc_clients",
+	))
+}
+
+func newTestHttpgrpcServer(tb testing.TB, status int) (string, func() []*httpgrpc.HTTPRequest) {
+	tb.Helper()
+
+	server := grpc.NewServer()
+
+	// Register handler for httpgrpc
+	hs := &httpgrpcServer{status: int32(status)}
+	httpgrpc.RegisterHTTPServer(server, hs)
+
+	// Register health server (pool requires health checks to pass).
+	grpc_health_v1.RegisterHealthServer(server, healthServer{})
+
+	l, err := net.Listen("tcp", "")
+	require.NoError(tb, err)
+
+	go func() {
+		_ = server.Serve(l)
+	}()
+	tb.Cleanup(func() {
+		_ = l.Close()
+	})
+
+	return l.Addr().String(), hs.getRequests
+}
+
+type httpgrpcServer struct {
+	mu       sync.Mutex
+	requests []*httpgrpc.HTTPRequest
+	status   int32
+}
+
+func (h *httpgrpcServer) Handle(_ context.Context, httpRequest *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+	h.mu.Lock()
+	h.requests = append(h.requests, httpRequest)
+	h.mu.Unlock()
+
+	return &httpgrpc.HTTPResponse{
+		Code: h.status,
+	}, nil
+}
+
+func (h *httpgrpcServer) getRequests() []*httpgrpc.HTTPRequest {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]*httpgrpc.HTTPRequest(nil), h.requests...)
+}
+
+type healthServer struct{}
+
+func (healthServer) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+func (healthServer) Watch(*grpc_health_v1.HealthCheckRequest, grpc_health_v1.Health_WatchServer) error {
+	return status.Errorf(codes.Unimplemented, "method Watch not implemented")
 }
 
 type noopRoundTripper struct{}

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -779,8 +779,7 @@ func TestForwardingToHTTPGrpcTarget(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UnixMilli()
 
-	var cfg Config
-	cfg = testConfig // Using "var cfg Config", to make sure we make a copy of testConfig.
+	cfg := testConfig
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("ignored", flag.NewFlagSet("ignored", flag.ContinueOnError))
 
 	forwarder, reg := newForwarder(t, cfg, true)


### PR DESCRIPTION
#### What this PR does

This PR implements forwarding of requests via `httpgrpc.HTTP/Handle` method, instead of plain HTTP. To use this, forwarding URL must be in form of `httpgrpc://<host>:<port>/path`, where `<host>:<port>` will be used as address of gRPC server and path will be put into `url` field of `httpgrpc.HTTPRequest` message.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
