### PR TITLE
Add max query-scheduler instances support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Anonymous usage statistics tracking: added the minimum and maximum value of `-ingester.out-of-order-time-window`. #2940
 * [FEATURE] Query-scheduler: added an experimental ring-based service discovery support for the query-scheduler. Refer to [query-scheduler configuration](https://grafana.com/docs/mimir/next/operators-guide/architecture/components/query-scheduler/#configuration) for more information. #2957
 * [FEATURE] Introduced `/api/v1/user_limits` endpoint exposed by all components that load runtime configuration. This endpoint exposes realtime limits for the authenticated tenant, in JSON format. #2864
+* [FEATURE] Query-scheduler: added the experimental configuration option `-query-scheduler.max-used-instances` to restrict the number of query-schedulers effectively used regardless how many replicas are running. This feature can be useful when using the experimental read-write deployment mode. #3005
 * [ENHANCEMENT] Distributor: Add `cortex_distributor_query_ingester_chunks_deduped_total` and `cortex_distributor_query_ingester_chunks_total` metrics for determining how effective ingester chunk deduplication at query time is. #2713
 * [ENHANCEMENT] Go: updated to go 1.19.1. #2637
 * [ENHANCEMENT] Runtime config: don't unmarshal runtime configuration files if they haven't changed. This can save a bit of CPU and memory on every component using runtime config. #2954

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [ENHANCEMENT] Distributor: added support forwarding push requests via gRPC, using `httpgrpc` messages from weaveworks/common library. #2996
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
+* [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005
 
 ### Mixin
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -10797,6 +10797,17 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "max_used_instances",
+          "required": false,
+          "desc": "The maximum number of query-scheduler instances to use, regardless how many replicas are running. This option can be set only when -query-scheduler.service-discovery-mode is set to 'ring'. 0 to use all available query-scheduler instances.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "query-scheduler.max-used-instances",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1388,6 +1388,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -query-scheduler.max-outstanding-requests-per-tenant int
     	Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429. (default 100)
+  -query-scheduler.max-used-instances int
+    	[experimental] The maximum number of query-scheduler instances to use, regardless how many replicas are running. This option can be set only when -query-scheduler.service-discovery-mode is set to 'ring'. 0 to use all available query-scheduler instances.
   -query-scheduler.querier-forget-delay duration
     	[experimental] If a querier disconnects without sending notification about graceful shutdown, the query-scheduler will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
   -query-scheduler.ring.consul.acl-token string

--- a/docs/sources/operators-guide/configure/about-versioning.md
+++ b/docs/sources/operators-guide/configure/about-versioning.md
@@ -89,6 +89,7 @@ The following features are currently experimental:
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
   - Ring-based service discovery (`-query-scheduler.service-discovery-mode` and `-query-scheduler.ring.*`)
+  - Max number of used instances (`-query-scheduler.max-used-instances`)
 - Store-gateway
   - `-blocks-storage.bucket-store.index-header-thread-pool-size`
 - Blocks Storage, Alertmanager, and Ruler support for partitioning access to the same storage bucket

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -1336,6 +1336,13 @@ ring:
   # (advanced) IP address to advertise in the ring. Default is auto-detected.
   # CLI flag: -query-scheduler.ring.instance-addr
   [instance_addr: <string> | default = ""]
+
+# (experimental) The maximum number of query-scheduler instances to use,
+# regardless how many replicas are running. This option can be set only when
+# -query-scheduler.service-discovery-mode is set to 'ring'. 0 to use all
+# available query-scheduler instances.
+# CLI flag: -query-scheduler.max-used-instances
+[max_used_instances: <int> | default = 0]
 ```
 
 ### ruler

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -92,6 +92,8 @@ func TestQuerySchedulerWithMaxUsedInstances(t *testing.T) {
 	series, expectedVector := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
 	res, err := c.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//go:build requires_docker
+// +build requires_docker
+
+package integration
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/grafana/e2e"
+	e2edb "github.com/grafana/e2e/db"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/integration/e2emimir"
+)
+
+func TestQuerySchedulerWithMaxUsedInstances(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	flags := mergeFlags(
+		BlocksStorageFlags(),
+		BlocksStorageS3Flags(),
+		map[string]string{
+			"-query-scheduler.service-discovery-mode": "ring",
+			"-query-scheduler.ring.store":             "consul",
+			"-query-scheduler.max-used-instances":     "1",
+			"-querier.max-concurrent":                 "4",
+		},
+	)
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	flags["-query-scheduler.ring.consul.hostname"] = consul.NetworkHTTPEndpoint()
+
+	// Start 2 query-scheduler. We override the address registered in the ring so that we can easily predict it
+	// when computing the expected in-use query-scheduler instance.
+	queryScheduler1 := e2emimir.NewQueryScheduler("query-scheduler-1", mergeFlags(flags, map[string]string{"-query-scheduler.ring.instance-addr": e2e.NetworkContainerHost(s.NetworkName(), "query-scheduler-1")}))
+	queryScheduler2 := e2emimir.NewQueryScheduler("query-scheduler-2", mergeFlags(flags, map[string]string{"-query-scheduler.ring.instance-addr": e2e.NetworkContainerHost(s.NetworkName(), "query-scheduler-2")}))
+	require.NoError(t, s.StartAndWaitReady(queryScheduler1, queryScheduler2))
+
+	// Start all other Mimir services.
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(queryFrontend, querier, ingester, distributor))
+
+	// Wait until distributor and querier have updated the ingesters ring.
+	for _, service := range []*e2emimir.MimirService{distributor, querier} {
+		require.NoError(t, service.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
+			"Service: %s", service.Name())
+	}
+
+	// Wait until query-frontend and querier have updated the query-schedulers ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "query-frontend-query-scheduler-client"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier-query-scheduler-client"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	// Compute which is the expected in-use query-scheduler.
+	schedulers := []*e2emimir.MimirService{queryScheduler1, queryScheduler2}
+	sort.Slice(schedulers, func(i, j int) bool { return schedulers[i].NetworkGRPCEndpoint() < schedulers[j].NetworkGRPCEndpoint() })
+	inUseScheduler := schedulers[0]
+	notInUseScheduler := schedulers[1]
+
+	// We expect the querier to open 4 connections to the in-use scheduler, and 1 connection to the not-in-use one.
+	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_query_scheduler_connected_querier_clients"}))
+
+	// We expect the query-frontend to only open connections to the in-use scheduler.
+	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))
+
+	// Push some series to Mimir.
+	now := time.Now()
+	series, expectedVector := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+
+	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+	res, err := c.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	// Query the series.
+	result, err := c.Query("series_1", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+	assert.Equal(t, expectedVector, result.(model.Vector))
+
+	// Terminate the in-use query-scheduler.
+	require.NoError(t, s.Stop(inUseScheduler))
+
+	// We expect the querier to open 4 connections to the previously not-in-use scheduler.
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
+
+	// We expect the query-frontend to open connections to the previously not-in-use scheduler.
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))
+
+	// Query the series.
+	result, err = c.Query("series_1", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+	assert.Equal(t, expectedVector, result.(model.Vector))
+}

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerdiscovery"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
+	"github.com/grafana/mimir/pkg/util/servicediscovery"
 )
 
 const testFrontendWorkerConcurrency = 5
@@ -165,7 +166,7 @@ func TestFrontendRequestsPerWorkerMetric(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_query_frontend_workers_enqueued_requests_total"))
 
 	// Manually remove the address, check that label is removed.
-	f.schedulerWorkers.AddressRemoved(f.cfg.SchedulerAddress)
+	f.schedulerWorkers.InstanceRemoved(servicediscovery.Instance{Address: f.cfg.SchedulerAddress, InUse: true})
 	expectedMetrics = ``
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_query_frontend_workers_enqueued_requests_total"))
 }
@@ -308,7 +309,7 @@ func TestFrontendFailedCancellation(t *testing.T) {
 		}
 		f.schedulerWorkers.mu.Unlock()
 
-		f.schedulerWorkers.AddressRemoved(addr)
+		f.schedulerWorkers.InstanceRemoved(servicediscovery.Instance{Address: addr, InUse: true})
 
 		// Wait for worker goroutines to stop.
 		time.Sleep(100 * time.Millisecond)

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -256,6 +256,11 @@ func (w *querierWorker) InstanceRemoved(instance servicediscovery.Instance) {
 	if p != nil {
 		p.stop()
 	}
+
+	// Re-balance the connections between the available query-frontends / query-schedulers.
+	w.mu.Lock()
+	w.resetConcurrency()
+	w.mu.Unlock()
 }
 
 func (w *querierWorker) InstanceChanged(instance servicediscovery.Instance) {

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -264,6 +264,12 @@ func (w *querierWorker) InstanceRemoved(instance servicediscovery.Instance) {
 }
 
 func (w *querierWorker) InstanceChanged(instance servicediscovery.Instance) {
+	// Ensure the querier worker hasn't been stopped (or is stopping).
+	ctx := w.ServiceContext()
+	if ctx == nil || ctx.Err() != nil {
+		return
+	}
+
 	level.Info(w.log).Log("msg", "updating connection", "addr", instance.Address, "in-use", instance.InUse)
 
 	w.mu.Lock()

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -98,8 +98,9 @@ type querierWorker struct {
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
 
-	mu       sync.Mutex
-	managers map[string]*processorManager
+	mu        sync.Mutex
+	managers  map[string]*processorManager
+	instances map[string]servicediscovery.Instance
 }
 
 func NewQuerierWorker(cfg Config, handler RequestHandler, log log.Logger, reg prometheus.Registerer) (services.Service, error) {
@@ -120,7 +121,7 @@ func NewQuerierWorker(cfg Config, handler RequestHandler, log log.Logger, reg pr
 		level.Info(log).Log("msg", "Starting querier worker connected to query-scheduler", "scheduler", cfg.SchedulerAddress)
 
 		factory = func(receiver servicediscovery.Notifications) (services.Service, error) {
-			return schedulerdiscovery.NewServiceDiscovery(cfg.QuerySchedulerDiscovery, cfg.SchedulerAddress, cfg.DNSLookupPeriod, "querier", receiver, log, reg)
+			return schedulerdiscovery.New(cfg.QuerySchedulerDiscovery, cfg.SchedulerAddress, cfg.DNSLookupPeriod, "querier", receiver, log, reg)
 		}
 
 		processor, servs = newSchedulerProcessor(cfg, handler, log, reg)
@@ -146,6 +147,7 @@ func newQuerierWorkerWithProcessor(cfg Config, log log.Logger, processor process
 		cfg:       cfg,
 		log:       log,
 		managers:  map[string]*processorManager{},
+		instances: map[string]servicediscovery.Instance{},
 		processor: processor,
 	}
 
@@ -193,10 +195,13 @@ func (w *querierWorker) running(ctx context.Context) error {
 
 func (w *querierWorker) stopping(_ error) error {
 	// Stop all goroutines fetching queries. Note that in Stopping state,
-	// worker no longer creates new managers in AddressAdded method.
+	// worker no longer creates new managers in InstanceAdded method.
 	w.mu.Lock()
-	for _, m := range w.managers {
+	for address, m := range w.managers {
 		m.stop()
+
+		delete(w.managers, address)
+		delete(w.instances, address)
 	}
 	w.mu.Unlock()
 
@@ -208,7 +213,8 @@ func (w *querierWorker) stopping(_ error) error {
 	return services.StopManagerAndAwaitStopped(context.Background(), w.subservices)
 }
 
-func (w *querierWorker) AddressAdded(address string) {
+func (w *querierWorker) InstanceAdded(instance servicediscovery.Instance) {
+	// Ensure the querier worker hasn't been stopped (or is stopping).
 	ctx := w.ServiceContext()
 	if ctx == nil || ctx.Err() != nil {
 		return
@@ -217,11 +223,12 @@ func (w *querierWorker) AddressAdded(address string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	address := instance.Address
 	if m := w.managers[address]; m != nil {
 		return
 	}
 
-	level.Info(w.log).Log("msg", "adding connection", "addr", address)
+	level.Info(w.log).Log("msg", "adding connection", "addr", address, "in-use", instance.InUse)
 	conn, err := w.connect(context.Background(), address)
 	if err != nil {
 		level.Error(w.log).Log("msg", "error connecting", "addr", address, "err", err)
@@ -229,16 +236,21 @@ func (w *querierWorker) AddressAdded(address string) {
 	}
 
 	w.managers[address] = newProcessorManager(ctx, w.processor, conn, address)
+	w.instances[address] = instance
+
 	// Called with lock.
 	w.resetConcurrency()
 }
 
-func (w *querierWorker) AddressRemoved(address string) {
-	level.Info(w.log).Log("msg", "removing connection", "addr", address)
+func (w *querierWorker) InstanceRemoved(instance servicediscovery.Instance) {
+	address := instance.Address
+
+	level.Info(w.log).Log("msg", "removing connection", "addr", address, "in-use", instance.InUse)
 
 	w.mu.Lock()
 	p := w.managers[address]
 	delete(w.managers, address)
+	delete(w.instances, address)
 	w.mu.Unlock()
 
 	if p != nil {
@@ -246,32 +258,90 @@ func (w *querierWorker) AddressRemoved(address string) {
 	}
 }
 
+func (w *querierWorker) InstanceChanged(instance servicediscovery.Instance) {
+	level.Info(w.log).Log("msg", "updating connection", "addr", instance.Address, "in-use", instance.InUse)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Skip if there's no manager for it.
+	if m := w.managers[instance.Address]; m == nil {
+		return
+	}
+
+	// Update instance and adjust concurrency.
+	w.instances[instance.Address] = instance
+
+	// Called with lock.
+	w.resetConcurrency()
+}
+
 // Must be called with lock.
 func (w *querierWorker) resetConcurrency() {
-	index := 0
+	desiredConcurrency := w.getDesiredConcurrency()
 
 	for _, m := range w.managers {
-		concurrency := w.cfg.MaxConcurrentRequests / len(w.managers)
+		concurrency, ok := desiredConcurrency[m.address]
+		if !ok {
+			// This error should never happen. If it does, it means there's a bug in the code.
+			level.Error(w.log).Log("msg", "a querier worker is connected to an unknown remote endpoint", "addr", m.address)
 
-		// If max concurrency does not evenly divide into our frontends a subset will be chosen
-		// to receive an extra connection.  Frontend addresses were shuffled above so this will be a
-		// random selection of frontends.
-		if index < w.cfg.MaxConcurrentRequests%len(w.managers) {
-			level.Warn(w.log).Log("msg", "max concurrency is not evenly divisible across targets, adding an extra connection", "addr", m.address)
+			// Consider it as not in-use.
+			concurrency = 1
+		}
+
+		m.concurrency(concurrency)
+	}
+}
+
+// getDesiredConcurrency returns the number of desired connections for each discovered query-frontend / query-scheduler instance.
+// Must be called with lock.
+func (w *querierWorker) getDesiredConcurrency() map[string]int {
+	// Count the number of in-use instances.
+	numInUse := 0
+	for _, instance := range w.instances {
+		if instance.InUse {
+			numInUse++
+		}
+	}
+
+	var (
+		desired    = make(map[string]int, len(w.instances))
+		inUseIndex = 0
+	)
+
+	// Compute the number of desired connections for each discovered instance.
+	for address, instance := range w.instances {
+		// Run only 1 worker for each instance not in-use, to allow for the queues
+		// to be drained when the in-use instances change or if, for any reason,
+		// queries are enqueued on the ones not in-use.
+		if !instance.InUse {
+			desired[address] = 1
+			continue
+		}
+
+		concurrency := w.cfg.MaxConcurrentRequests / numInUse
+
+		// If max concurrency does not evenly divide into in-use instances, then a subset will be chosen
+		// to receive an extra connection. Since we're iterating a map (whose iteration order is not guaranteed),
+		// then this should pratically select a random address for the extra connection.
+		if inUseIndex < w.cfg.MaxConcurrentRequests%numInUse {
+			level.Warn(w.log).Log("msg", "max concurrency is not evenly divisible across targets, adding an extra connection", "addr", address)
 			concurrency++
 		}
 
 		// If concurrency is 0 then MaxConcurrentRequests is less than the total number of
 		// frontends/schedulers. In order to prevent accidentally starving a frontend or scheduler we are just going to
-		// always connect once to every target.  This is dangerous b/c we may start exceeding PromQL
-		// max concurrency.
+		// always connect once to every target.
 		if concurrency == 0 {
 			concurrency = 1
 		}
 
-		m.concurrency(concurrency)
-		index++
+		desired[address] = concurrency
+		inUseIndex++
 	}
+
+	return desired
 }
 
 func (w *querierWorker) connect(ctx context.Context, address string) (*grpc.ClientConn, error) {

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -238,6 +238,21 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 				"4.4.4.4": 1,
 			},
 		},
+		"should create 1 connection for each instance if max concurrency is > 0 but less than the number of in-use instances": {
+			instances: []servicediscovery.Instance{
+				{Address: "1.1.1.1", InUse: true},
+				{Address: "2.2.2.2", InUse: false},
+				{Address: "3.3.3.3", InUse: true},
+				{Address: "4.4.4.4", InUse: false},
+			},
+			maxConcurrent: 1,
+			expected: map[string]int{
+				"1.1.1.1": 1,
+				"2.2.2.2": 1,
+				"3.3.3.3": 1,
+				"4.4.4.4": 1,
+			},
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grafana/mimir/pkg/scheduler/schedulerdiscovery"
+	"github.com/grafana/mimir/pkg/util/servicediscovery"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -120,25 +121,50 @@ func TestResetConcurrency(t *testing.T) {
 		name                string
 		maxConcurrent       int
 		numTargets          int
+		numInUseTargets     int
 		expectedConcurrency int
 	}{
 		{
-			name:                "Test create at least one processor per target if max concurrent = 0",
+			name:                "Create at least one processor per target if max concurrent = 0, with all targets in use",
 			maxConcurrent:       0,
 			numTargets:          2,
+			numInUseTargets:     2,
 			expectedConcurrency: 2,
 		},
 		{
-			name:                "Test max concurrent dividing with a remainder",
+			name:                "Create at least one processor per target if max concurrent = 0, with some targets in use",
+			maxConcurrent:       0,
+			numTargets:          2,
+			numInUseTargets:     1,
+			expectedConcurrency: 2,
+		},
+		{
+			name:                "Max concurrent dividing with a remainder, with all targets in use",
 			maxConcurrent:       7,
 			numTargets:          4,
+			numInUseTargets:     4,
 			expectedConcurrency: 7,
 		},
 		{
-			name:                "Test max concurrent dividing evenly",
+			name:            "Max concurrent dividing with a remainder, with some targets in use",
+			maxConcurrent:   7,
+			numTargets:      4,
+			numInUseTargets: 2,
+			expectedConcurrency:/* in use:  */ 7 + /* not in use : */ 2,
+		},
+		{
+			name:                "Max concurrent dividing evenly, with all targets in use",
 			maxConcurrent:       6,
 			numTargets:          2,
+			numInUseTargets:     2,
 			expectedConcurrency: 6,
+		},
+		{
+			name:            "Max concurrent dividing evenly, with some targets in use",
+			maxConcurrent:   6,
+			numTargets:      4,
+			numInUseTargets: 2,
+			expectedConcurrency:/* in use:  */ 6 + /* not in use : */ 2,
 		},
 	}
 
@@ -155,7 +181,10 @@ func TestResetConcurrency(t *testing.T) {
 			for i := 0; i < tt.numTargets; i++ {
 				// gRPC connections are virtual... they don't actually try to connect until they are needed.
 				// This allows us to use dummy ports, and not get any errors.
-				w.AddressAdded(fmt.Sprintf("127.0.0.1:%d", i))
+				w.InstanceAdded(servicediscovery.Instance{
+					Address: fmt.Sprintf("127.0.0.1:%d", i),
+					InUse:   i < tt.numInUseTargets,
+				})
 			}
 
 			test.Poll(t, 250*time.Millisecond, tt.expectedConcurrency, func() interface{} {
@@ -164,6 +193,67 @@ func TestResetConcurrency(t *testing.T) {
 
 			require.NoError(t, services.StopAndAwaitTerminated(context.Background(), w))
 			assert.Equal(t, 0, getConcurrentProcessors(w))
+		})
+	}
+}
+
+func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
+	tests := map[string]struct {
+		instances     []servicediscovery.Instance
+		maxConcurrent int
+		expected      map[string]int
+	}{
+		"should return empty map on no instances": {
+			instances:     nil,
+			maxConcurrent: 4,
+			expected:      map[string]int{},
+		},
+		"should divide the max concurrency between in-use instances, and create 1 connection for each instance not in-use": {
+			instances: []servicediscovery.Instance{
+				{Address: "1.1.1.1", InUse: true},
+				{Address: "2.2.2.2", InUse: false},
+				{Address: "3.3.3.3", InUse: true},
+				{Address: "4.4.4.4", InUse: false},
+			},
+			maxConcurrent: 4,
+			expected: map[string]int{
+				"1.1.1.1": 2,
+				"2.2.2.2": 1,
+				"3.3.3.3": 2,
+				"4.4.4.4": 1,
+			},
+		},
+		"should create 1 connection for each instance if max concurrency is set to 0": {
+			instances: []servicediscovery.Instance{
+				{Address: "1.1.1.1", InUse: true},
+				{Address: "2.2.2.2", InUse: false},
+				{Address: "3.3.3.3", InUse: true},
+				{Address: "4.4.4.4", InUse: false},
+			},
+			maxConcurrent: 0,
+			expected: map[string]int{
+				"1.1.1.1": 1,
+				"2.2.2.2": 1,
+				"3.3.3.3": 1,
+				"4.4.4.4": 1,
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := Config{
+				MaxConcurrentRequests: testData.maxConcurrent,
+			}
+
+			w, err := newQuerierWorkerWithProcessor(cfg, log.NewNopLogger(), &mockProcessor{}, nil, nil)
+			require.NoError(t, err)
+
+			for _, instance := range testData.instances {
+				w.instances[instance.Address] = instance
+			}
+
+			assert.Equal(t, testData.expected, w.getDesiredConcurrency())
 		})
 	}
 }

--- a/pkg/scheduler/schedulerdiscovery/config.go
+++ b/pkg/scheduler/schedulerdiscovery/config.go
@@ -3,6 +3,7 @@
 package schedulerdiscovery
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -24,18 +25,26 @@ var (
 )
 
 type Config struct {
-	Mode          string     `yaml:"service_discovery_mode" category:"experimental"`
-	SchedulerRing RingConfig `yaml:"ring" doc:"description=The hash ring configuration. The query-schedulers hash ring is used for service discovery."`
+	Mode             string     `yaml:"service_discovery_mode" category:"experimental"`
+	SchedulerRing    RingConfig `yaml:"ring" doc:"description=The hash ring configuration. The query-schedulers hash ring is used for service discovery."`
+	MaxUsedInstances int        `yaml:"max_used_instances" category:"experimental"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.Mode, ModeFlagName, ModeDNS, fmt.Sprintf("Service discovery mode that query-frontends and queriers use to find query-scheduler instances.%s Supported values are: %s.", sharedOptionWithRingClient, strings.Join(modes, ", ")))
+	f.IntVar(&cfg.MaxUsedInstances, "query-scheduler.max-used-instances", 0, fmt.Sprintf("The maximum number of query-scheduler instances to use, regardless how many replicas are running. This option can be set only when -%s is set to '%s'. 0 to use all available query-scheduler instances.", ModeFlagName, ModeRing))
 	cfg.SchedulerRing.RegisterFlags(f, logger)
 }
 
 func (cfg *Config) Validate() error {
 	if !util.StringsContain(modes, cfg.Mode) {
 		return fmt.Errorf("unsupported query-scheduler service discovery mode (supported values are: %s)", strings.Join(modes, ", "))
+	}
+	if cfg.MaxUsedInstances > 0 && cfg.Mode != ModeRing {
+		return fmt.Errorf("the query-scheduler max used instances can be set only when -%s is set to '%s'", ModeFlagName, ModeRing)
+	}
+	if cfg.MaxUsedInstances < 0 {
+		return errors.New("the query-scheduler max used instances can't be negative")
 	}
 
 	return nil

--- a/pkg/scheduler/schedulerdiscovery/config_test.go
+++ b/pkg/scheduler/schedulerdiscovery/config_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package schedulerdiscovery
+
+import (
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := map[string]struct {
+		setup       func(cfg *Config)
+		expectedErr string
+	}{
+		"should pass with default config": {
+			setup: func(cfg *Config) {},
+		},
+		"should fail if service discovery mode is invalid": {
+			setup: func(cfg *Config) {
+				cfg.Mode = "xxx"
+			},
+			expectedErr: "unsupported query-scheduler service discovery mode",
+		},
+		"should fail if service discovery mode is set to DNS and max used instances has been configured": {
+			setup: func(cfg *Config) {
+				cfg.Mode = ModeDNS
+				cfg.MaxUsedInstances = 1
+			},
+			expectedErr: "the query-scheduler max used instances can be set only when -query-scheduler.service-discovery-mode is set to 'ring'",
+		},
+		"should pass if service discovery mode is set to ring and max used instances has been configured": {
+			setup: func(cfg *Config) {
+				cfg.Mode = ModeRing
+				cfg.MaxUsedInstances = 1
+			},
+		},
+		"should fail if service discovery mode is set to ring but max used instances is negative": {
+			setup: func(cfg *Config) {
+				cfg.Mode = ModeRing
+				cfg.MaxUsedInstances = -1
+			},
+			expectedErr: "the query-scheduler max used instances can't be negative",
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := Config{}
+			flagext.DefaultValues(&cfg)
+			testData.setup(&cfg)
+
+			actualErr := cfg.Validate()
+			if testData.expectedErr == "" {
+				require.NoError(t, actualErr)
+			} else {
+				require.Error(t, actualErr)
+				assert.ErrorContains(t, actualErr, testData.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/schedulerdiscovery/discovery.go
+++ b/pkg/scheduler/schedulerdiscovery/discovery.go
@@ -6,38 +6,29 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/mimir/pkg/util/servicediscovery"
 )
 
-func NewServiceDiscovery(cfg Config, schedulerAddress string, lookupPeriod time.Duration, component string, receiver servicediscovery.Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
+func New(cfg Config, schedulerAddress string, lookupPeriod time.Duration, component string, receiver servicediscovery.Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
 	// Since this is a client for the query-schedulers ring, we append "query-scheduler-client" to the component to clearly differentiate it.
 	component = component + "-query-scheduler-client"
 
 	switch cfg.Mode {
 	case ModeRing:
-		return NewRingServiceDiscovery(cfg, component, receiver, logger, reg)
+		return newRing(cfg, component, receiver, logger, reg)
 	default:
-		return NewDNSServiceDiscovery(schedulerAddress, lookupPeriod, receiver)
+		return servicediscovery.NewDNS(schedulerAddress, lookupPeriod, receiver)
 	}
 }
 
-func NewDNSServiceDiscovery(schedulerAddress string, lookupPeriod time.Duration, receiver servicediscovery.Notifications) (services.Service, error) {
-	return servicediscovery.NewDNS(schedulerAddress, lookupPeriod, receiver)
-}
-
-var (
-	activeSchedulersOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
-)
-
-func NewRingServiceDiscovery(cfg Config, component string, receiver servicediscovery.Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
+func newRing(cfg Config, component string, receiver servicediscovery.Notifications, logger log.Logger, reg prometheus.Registerer) (services.Service, error) {
 	client, err := NewRingClient(cfg.SchedulerRing, component, logger, reg)
 	if err != nil {
 		return nil, err
 	}
 
-	return servicediscovery.NewRing(client, activeSchedulersOp, cfg.SchedulerRing.RingCheckPeriod, receiver), nil
+	return servicediscovery.NewRing(client, cfg.SchedulerRing.RingCheckPeriod, cfg.MaxUsedInstances, receiver), nil
 }

--- a/pkg/scheduler/schedulerdiscovery/discovery.go
+++ b/pkg/scheduler/schedulerdiscovery/discovery.go
@@ -30,5 +30,6 @@ func newRing(cfg Config, component string, receiver servicediscovery.Notificatio
 		return nil, err
 	}
 
-	return servicediscovery.NewRing(client, cfg.SchedulerRing.RingCheckPeriod, cfg.MaxUsedInstances, receiver), nil
+	const ringCheckPeriod = 5 * time.Second
+	return servicediscovery.NewRing(client, ringCheckPeriod, cfg.MaxUsedInstances, receiver), nil
 }

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -53,8 +53,7 @@ type RingConfig struct {
 	InstanceAddr           string   `yaml:"instance_addr" category:"advanced"`
 
 	// Injected internally
-	ListenPort      int           `yaml:"-"`
-	RingCheckPeriod time.Duration `yaml:"-"`
+	ListenPort int `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given flag.FlagSet.
@@ -77,9 +76,6 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.InstanceAddr, "query-scheduler.ring.instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
 	f.IntVar(&cfg.InstancePort, "query-scheduler.ring.instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
 	f.StringVar(&cfg.InstanceID, "query-scheduler.ring.instance-id", hostname, "Instance ID to register in the ring.")
-
-	// Defaults for internal settings.
-	cfg.RingCheckPeriod = 5 * time.Second
 }
 
 // ToBasicLifecyclerConfig returns a ring.BasicLifecyclerConfig based on the query-scheduler ring config.

--- a/pkg/util/servicediscovery/dns.go
+++ b/pkg/util/servicediscovery/dns.go
@@ -41,7 +41,7 @@ type Notifications interface {
 	InstanceRemoved(instance Instance)
 
 	// InstanceChanged is called each time an instance that was previously notified by AddressAdded()
-	// has changed one of its properties.
+	// has changed its InUse value.
 	InstanceChanged(instance Instance)
 }
 

--- a/pkg/util/servicediscovery/dns.go
+++ b/pkg/util/servicediscovery/dns.go
@@ -17,14 +17,32 @@ import (
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
+// Instance notified by the service discovery.
+type Instance struct {
+	Address string
+
+	// InUse is true if this instance should be actively used. For example, if a service discovery
+	// implementation enforced a max number of instances to be used, this flag will be set to true
+	// only on a number of instances up to the configured max.
+	InUse bool
+}
+
+func (i Instance) Equal(other Instance) bool {
+	return i.Address == other.Address && i.InUse == other.InUse
+}
+
 // Notifications about address resolution. All notifications are sent on the same goroutine.
 type Notifications interface {
-	// AddressAdded is called each time a new address has been discovered.
-	AddressAdded(address string)
+	// InstanceAdded is called each time a new instance has been discovered.
+	InstanceAdded(instance Instance)
 
-	// AddressRemoved is called each time an address that was previously notified by AddressAdded()
+	// InstanceRemoved is called each time an instance that was previously notified by AddressAdded()
 	// is no longer available.
-	AddressRemoved(address string)
+	InstanceRemoved(instance Instance)
+
+	// InstanceChanged is called each time an instance that was previously notified by AddressAdded()
+	// has changed one of its properties.
+	InstanceChanged(instance Instance)
 }
 
 type dnsServiceDiscovery struct {
@@ -77,10 +95,10 @@ func (w *dnsServiceDiscovery) watchDNSLoop(servCtx context.Context) error {
 		for _, update := range updates {
 			switch update.Op {
 			case grpcutil.Add:
-				w.receiver.AddressAdded(update.Addr)
+				w.receiver.InstanceAdded(Instance{Address: update.Addr, InUse: true})
 
 			case grpcutil.Delete:
-				w.receiver.AddressRemoved(update.Addr)
+				w.receiver.InstanceRemoved(Instance{Address: update.Addr, InUse: true})
 
 			default:
 				return fmt.Errorf("unknown op: %v", update.Op)

--- a/pkg/util/servicediscovery/ring.go
+++ b/pkg/util/servicediscovery/ring.go
@@ -12,11 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	// The token looked up in the ring to find the instances to use.
-	inUseRingToken = uint32(0)
-)
-
 var (
 	// Ring operation used to get healthy active instances in the ring.
 	activeRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)

--- a/pkg/util/servicediscovery/ring.go
+++ b/pkg/util/servicediscovery/ring.go
@@ -4,6 +4,7 @@ package servicediscovery
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/grafana/dskit/ring"
@@ -11,26 +12,36 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// The token looked up in the ring to find the instances to use.
+	inUseRingToken = uint32(0)
+)
+
+var (
+	// Ring operation used to get healthy active instances in the ring.
+	activeRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+)
+
 type ringServiceDiscovery struct {
 	services.Service
 
 	ringClient         *ring.Ring
-	ringOp             ring.Operation
-	subservicesWatcher *services.FailureWatcher
 	ringCheckPeriod    time.Duration
+	maxUsedInstances   int
+	subservicesWatcher *services.FailureWatcher
 	receiver           Notifications
 
-	// Keep track of the addresses that have been discovered and notified so far.
-	notifiedAddresses map[string]struct{}
+	// Keep track of the instances that have been discovered and notified so far.
+	notified map[string]Instance
 }
 
-func NewRing(ringClient *ring.Ring, ringOp ring.Operation, ringCheckPeriod time.Duration, receiver Notifications) services.Service {
+func NewRing(ringClient *ring.Ring, ringCheckPeriod time.Duration, maxUsedInstances int, receiver Notifications) services.Service {
 	r := &ringServiceDiscovery{
 		ringClient:         ringClient,
-		ringOp:             ringOp,
-		subservicesWatcher: services.NewFailureWatcher(),
 		ringCheckPeriod:    ringCheckPeriod,
-		notifiedAddresses:  make(map[string]struct{}),
+		maxUsedInstances:   maxUsedInstances,
+		subservicesWatcher: services.NewFailureWatcher(),
+		notified:           make(map[string]Instance),
 		receiver:           receiver,
 	}
 
@@ -53,43 +64,65 @@ func (r *ringServiceDiscovery) running(ctx context.Context) error {
 	defer ringTicker.Stop()
 
 	// Notifies the initial state.
-	ringState, _ := r.ringClient.GetAllHealthy(r.ringOp) // nolint:errcheck
-	r.notifyChanges(ringState)
+	all, _ := r.ringClient.GetAllHealthy(activeRingOp) // nolint:errcheck
+	r.notifyChanges(all)
 
 	for {
 		select {
 		case <-ringTicker.C:
-			ringState, _ := r.ringClient.GetAllHealthy(r.ringOp) // nolint:errcheck
-			r.notifyChanges(ringState)
+			all, _ := r.ringClient.GetAllHealthy(activeRingOp) // nolint:errcheck
+			r.notifyChanges(all)
 		case <-ctx.Done():
 			return nil
 		case err := <-r.subservicesWatcher.Chan():
-			return errors.Wrap(err, "a subservice of ring-based service discovery has failed")
+			return errors.Wrap(err, "a subservice of query-schedulers ring-based service discovery has failed")
 		}
 	}
 }
 
-// notifyChanges is not concurrency safe.
-func (r *ringServiceDiscovery) notifyChanges(discovered ring.ReplicationSet) {
-	// Build a map with the discovered addresses.
-	discoveredAddresses := make(map[string]struct{}, len(discovered.Instances))
-	for _, instance := range discovered.Instances {
-		discoveredAddresses[instance.GetAddr()] = struct{}{}
+// notifyChanges is not concurrency safe. The input all and inUse ring.ReplicationSet may be the same object.
+func (r *ringServiceDiscovery) notifyChanges(all ring.ReplicationSet) {
+	// Build a map with the discovered instances.
+	discovered := make(map[string]Instance, len(all.Instances))
+	for _, instance := range selectInUseInstances(all.Instances, r.maxUsedInstances) {
+		discovered[instance.Addr] = Instance{Address: instance.Addr, InUse: true}
 	}
-
-	// Notify new addresses.
-	for addr := range discoveredAddresses {
-		if _, ok := r.notifiedAddresses[addr]; !ok {
-			r.receiver.AddressAdded(addr)
+	for _, instance := range all.Instances {
+		if _, ok := discovered[instance.Addr]; !ok {
+			discovered[instance.Addr] = Instance{Address: instance.Addr, InUse: false}
 		}
 	}
 
-	// Notify removed addresses.
-	for addr := range r.notifiedAddresses {
-		if _, ok := discoveredAddresses[addr]; !ok {
-			r.receiver.AddressRemoved(addr)
+	// Notify new instances.
+	for addr, instance := range discovered {
+		if _, ok := r.notified[addr]; !ok {
+			r.receiver.InstanceAdded(instance)
 		}
 	}
 
-	r.notifiedAddresses = discoveredAddresses
+	// Notify changed instances.
+	for addr, instance := range discovered {
+		if n, ok := r.notified[addr]; ok && !n.Equal(instance) {
+			r.receiver.InstanceChanged(instance)
+		}
+	}
+
+	// Notify removed instances.
+	for addr, instance := range r.notified {
+		if _, ok := discovered[addr]; !ok {
+			r.receiver.InstanceRemoved(instance)
+		}
+	}
+
+	r.notified = discovered
+}
+
+func selectInUseInstances(instances []ring.InstanceDesc, maxInstances int) []ring.InstanceDesc {
+	if maxInstances <= 0 || len(instances) <= maxInstances {
+		return instances
+	}
+
+	// Select the first N instances (sorted by address) to be used.
+	sort.Sort(ring.ByAddr(instances))
+	return instances[:maxInstances]
 }

--- a/pkg/util/servicediscovery/ring_test.go
+++ b/pkg/util/servicediscovery/ring_test.go
@@ -57,26 +57,26 @@ func TestRingServiceDiscovery_WithoutMaxUsedInstances(t *testing.T) {
 	// Register some instances.
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := in.(*ring.Desc)
-		desc.AddIngester("instance-1", "instance-1", "", nil, ring.ACTIVE, time.Now())
-		desc.AddIngester("instance-2", "instance-2", "", nil, ring.PENDING, time.Now())
-		desc.AddIngester("instance-3", "instance-3", "", nil, ring.JOINING, time.Now())
-		desc.AddIngester("instance-4", "instance-4", "", nil, ring.LEAVING, time.Now())
+		desc.AddIngester("instance-1", "127.0.0.1", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-2", "127.0.0.2", "", nil, ring.PENDING, time.Now())
+		desc.AddIngester("instance-3", "127.0.0.3", "", nil, ring.JOINING, time.Now())
+		desc.AddIngester("instance-4", "127.0.0.4", "", nil, ring.LEAVING, time.Now())
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-1", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.1", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
 	// Register more instances.
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := in.(*ring.Desc)
-		desc.AddIngester("instance-5", "instance-5", "", nil, ring.ACTIVE, time.Now())
-		desc.AddIngester("instance-6", "instance-6", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-5", "127.0.0.5", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-6", "127.0.0.6", "", nil, ring.ACTIVE, time.Now())
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-1", true}, {"instance-5", true}, {"instance-6", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.1", true}, {"127.0.0.5", true}, {"127.0.0.6", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
@@ -88,7 +88,7 @@ func TestRingServiceDiscovery_WithoutMaxUsedInstances(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-5", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.5", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
@@ -101,7 +101,7 @@ func TestRingServiceDiscovery_WithoutMaxUsedInstances(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-2", true}, {"instance-5", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.2", true}, {"127.0.0.5", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
@@ -114,7 +114,7 @@ func TestRingServiceDiscovery_WithoutMaxUsedInstances(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-5", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.5", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 }
@@ -159,26 +159,26 @@ func TestRingServiceDiscovery_WithMaxUsedInstances(t *testing.T) {
 	// Register some instances.
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := in.(*ring.Desc)
-		desc.AddIngester("instance-1", "instance-1", "", nil, ring.ACTIVE, time.Now())
-		desc.AddIngester("instance-2", "instance-2", "", nil, ring.PENDING, time.Now())
-		desc.AddIngester("instance-3", "instance-3", "", nil, ring.JOINING, time.Now())
-		desc.AddIngester("instance-4", "instance-4", "", nil, ring.LEAVING, time.Now())
+		desc.AddIngester("instance-1", "127.0.0.1", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-2", "127.0.0.2", "", nil, ring.PENDING, time.Now())
+		desc.AddIngester("instance-3", "127.0.0.3", "", nil, ring.JOINING, time.Now())
+		desc.AddIngester("instance-4", "127.0.0.4", "", nil, ring.LEAVING, time.Now())
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-1", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.1", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
 	// Register more instances.
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := in.(*ring.Desc)
-		desc.AddIngester("instance-5", "instance-5", "", nil, ring.ACTIVE, time.Now())
-		desc.AddIngester("instance-6", "instance-6", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-5", "127.0.0.5", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-6", "127.0.0.6", "", nil, ring.ACTIVE, time.Now())
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-1", true}, {"instance-5", true}, {"instance-6", false}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.1", true}, {"127.0.0.5", true}, {"127.0.0.6", false}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
@@ -190,7 +190,7 @@ func TestRingServiceDiscovery_WithMaxUsedInstances(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-5", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.5", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
@@ -208,7 +208,7 @@ func TestRingServiceDiscovery_WithMaxUsedInstances(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-2", true}, {"instance-3", true}, {"instance-5", false}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.2", true}, {"127.0.0.3", true}, {"127.0.0.5", false}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 
@@ -221,7 +221,7 @@ func TestRingServiceDiscovery_WithMaxUsedInstances(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []Instance{{"instance-3", true}, {"instance-5", true}}, func() interface{} {
+	test.Poll(t, time.Second, []Instance{{"127.0.0.3", true}, {"127.0.0.5", true}}, func() interface{} {
 		return receiver.getDiscoveredInstances()
 	})
 }

--- a/pkg/util/servicediscovery/ring_test.go
+++ b/pkg/util/servicediscovery/ring_test.go
@@ -14,18 +14,14 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRingServiceDiscovery(t *testing.T) {
+func TestRingServiceDiscovery_WithoutMaxUsedInstances(t *testing.T) {
 	const (
 		ringKey         = "test"
 		ringCheckPeriod = 100 * time.Millisecond // Check very frequently to speed up the test.
-	)
-
-	var (
-		ctx    = context.Background()
-		ringOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 	)
 
 	// Use an in-memory KV store.
@@ -33,15 +29,12 @@ func TestRingServiceDiscovery(t *testing.T) {
 	t.Cleanup(func() { _ = closer.Close() })
 
 	// Create a ring client.
-	ringCfg := ring.Config{
-		HeartbeatTimeout:  time.Minute,
-		ReplicationFactor: 1,
-	}
-
+	ringCfg := ring.Config{HeartbeatTimeout: time.Minute, ReplicationFactor: 1}
 	ringClient, err := ring.NewWithStoreClientAndStrategy(ringCfg, "test", ringKey, inmem, ring.NewDefaultReplicationStrategy(), nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	// Create an empty ring.
+	ctx := context.Background()
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		return ring.NewDesc(), true, nil
 	}))
@@ -49,7 +42,7 @@ func TestRingServiceDiscovery(t *testing.T) {
 	// Mock a receiver to keep track of all notified addresses.
 	receiver := newNotificationsReceiverMock()
 
-	sd := NewRing(ringClient, ringOp, ringCheckPeriod, receiver)
+	sd := NewRing(ringClient, ringCheckPeriod, 0, receiver)
 
 	// Start the service discovery.
 	require.NoError(t, services.StartAndAwaitRunning(ctx, sd))
@@ -59,7 +52,7 @@ func TestRingServiceDiscovery(t *testing.T) {
 
 	// Wait some time, we expect no address notified because the ring is empty.
 	time.Sleep(time.Second)
-	require.Empty(t, receiver.getDiscoveredAddresses())
+	require.Empty(t, receiver.getDiscoveredInstances())
 
 	// Register some instances.
 	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
@@ -71,8 +64,8 @@ func TestRingServiceDiscovery(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []string{"instance-1"}, func() interface{} {
-		return receiver.getDiscoveredAddresses()
+	test.Poll(t, time.Second, []Instance{{"instance-1", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
 	})
 
 	// Register more instances.
@@ -83,8 +76,8 @@ func TestRingServiceDiscovery(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []string{"instance-1", "instance-5", "instance-6"}, func() interface{} {
-		return receiver.getDiscoveredAddresses()
+	test.Poll(t, time.Second, []Instance{{"instance-1", true}, {"instance-5", true}, {"instance-6", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
 	})
 
 	// Unregister some instances.
@@ -95,8 +88,8 @@ func TestRingServiceDiscovery(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []string{"instance-5"}, func() interface{} {
-		return receiver.getDiscoveredAddresses()
+	test.Poll(t, time.Second, []Instance{{"instance-5", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
 	})
 
 	// A non-active instance switches to active.
@@ -108,8 +101,8 @@ func TestRingServiceDiscovery(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []string{"instance-2", "instance-5"}, func() interface{} {
-		return receiver.getDiscoveredAddresses()
+	test.Poll(t, time.Second, []Instance{{"instance-2", true}, {"instance-5", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
 	})
 
 	// An active becomes unhealthy.
@@ -121,45 +114,202 @@ func TestRingServiceDiscovery(t *testing.T) {
 		return desc, true, nil
 	}))
 
-	test.Poll(t, time.Second, []string{"instance-5"}, func() interface{} {
-		return receiver.getDiscoveredAddresses()
+	test.Poll(t, time.Second, []Instance{{"instance-5", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
 	})
 }
 
+func TestRingServiceDiscovery_WithMaxUsedInstances(t *testing.T) {
+	const (
+		ringKey          = "test"
+		ringCheckPeriod  = 100 * time.Millisecond // Check very frequently to speed up the test.
+		maxUsedInstances = 2
+	)
+
+	// Use an in-memory KV store.
+	inmem, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	// Create a ring client.
+	ringCfg := ring.Config{HeartbeatTimeout: time.Minute, ReplicationFactor: 1}
+	ringClient, err := ring.NewWithStoreClientAndStrategy(ringCfg, "test", ringKey, inmem, ring.NewDefaultReplicationStrategy(), nil, log.NewNopLogger())
+	require.NoError(t, err)
+
+	// Create an empty ring.
+	ctx := context.Background()
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		return ring.NewDesc(), true, nil
+	}))
+
+	// Mock a receiver to keep track of all notified addresses.
+	receiver := newNotificationsReceiverMock()
+
+	sd := NewRing(ringClient, ringCheckPeriod, maxUsedInstances, receiver)
+
+	// Start the service discovery.
+	require.NoError(t, services.StartAndAwaitRunning(ctx, sd))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, sd))
+	})
+
+	// Wait some time, we expect no address notified because the ring is empty.
+	time.Sleep(time.Second)
+	require.Empty(t, receiver.getDiscoveredInstances())
+
+	// Register some instances.
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := in.(*ring.Desc)
+		desc.AddIngester("instance-1", "instance-1", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-2", "instance-2", "", nil, ring.PENDING, time.Now())
+		desc.AddIngester("instance-3", "instance-3", "", nil, ring.JOINING, time.Now())
+		desc.AddIngester("instance-4", "instance-4", "", nil, ring.LEAVING, time.Now())
+		return desc, true, nil
+	}))
+
+	test.Poll(t, time.Second, []Instance{{"instance-1", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
+	})
+
+	// Register more instances.
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := in.(*ring.Desc)
+		desc.AddIngester("instance-5", "instance-5", "", nil, ring.ACTIVE, time.Now())
+		desc.AddIngester("instance-6", "instance-6", "", nil, ring.ACTIVE, time.Now())
+		return desc, true, nil
+	}))
+
+	test.Poll(t, time.Second, []Instance{{"instance-1", true}, {"instance-5", true}, {"instance-6", false}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
+	})
+
+	// Unregister some instances.
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := in.(*ring.Desc)
+		desc.RemoveIngester("instance-1")
+		desc.RemoveIngester("instance-6")
+		return desc, true, nil
+	}))
+
+	test.Poll(t, time.Second, []Instance{{"instance-5", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
+	})
+
+	// Some non-active instances switch to active.
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := in.(*ring.Desc)
+		instance := desc.Ingesters["instance-2"]
+		instance.State = ring.ACTIVE
+		desc.Ingesters["instance-2"] = instance
+
+		instance = desc.Ingesters["instance-3"]
+		instance.State = ring.ACTIVE
+		desc.Ingesters["instance-3"] = instance
+
+		return desc, true, nil
+	}))
+
+	test.Poll(t, time.Second, []Instance{{"instance-2", true}, {"instance-3", true}, {"instance-5", false}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
+	})
+
+	// An active becomes unhealthy.
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := in.(*ring.Desc)
+		instance := desc.Ingesters["instance-2"]
+		instance.Timestamp = time.Now().Add(-2 * ringCfg.HeartbeatTimeout).Unix()
+		desc.Ingesters["instance-2"] = instance
+		return desc, true, nil
+	}))
+
+	test.Poll(t, time.Second, []Instance{{"instance-3", true}, {"instance-5", true}}, func() interface{} {
+		return receiver.getDiscoveredInstances()
+	})
+}
+
+func TestSelectInUseInstances(t *testing.T) {
+	tests := map[string]struct {
+		input        []ring.InstanceDesc
+		maxInstances int
+		expected     []ring.InstanceDesc
+	}{
+		"should return the input on empty list of instances": {
+			input:        nil,
+			maxInstances: 3,
+			expected:     nil,
+		},
+		"should return the input on a number of instances < max instances": {
+			input:        []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}},
+			maxInstances: 3,
+			expected:     []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}},
+		},
+		"should return the input on a number of instances = max instances": {
+			input:        []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}, {Addr: "2.2.2.2"}},
+			maxInstances: 3,
+			expected:     []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}, {Addr: "2.2.2.2"}},
+		},
+		"should return a subset of the input on a number of instances > max instances": {
+			input:        []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}, {Addr: "2.2.2.2"}, {Addr: "4.4.4.4"}, {Addr: "5.5.5.5"}},
+			maxInstances: 3,
+			expected:     []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "2.2.2.2"}, {Addr: "3.3.3.3"}},
+		},
+		"should return the input if max instances is 0": {
+			input:        []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}, {Addr: "2.2.2.2"}},
+			maxInstances: 0,
+			expected:     []ring.InstanceDesc{{Addr: "1.1.1.1"}, {Addr: "3.3.3.3"}, {Addr: "2.2.2.2"}},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expected, selectInUseInstances(testData.input, testData.maxInstances))
+		})
+	}
+}
+
 type notificationsReceiverMock struct {
-	discoveredAddressesMx sync.Mutex
-	discoveredAddresses   map[string]struct{}
+	discoveredInstancesMx sync.Mutex
+	discoveredInstances   map[string]Instance
 }
 
 func newNotificationsReceiverMock() *notificationsReceiverMock {
 	return &notificationsReceiverMock{
-		discoveredAddresses: map[string]struct{}{},
+		discoveredInstances: map[string]Instance{},
 	}
 }
 
-func (r *notificationsReceiverMock) AddressAdded(address string) {
-	r.discoveredAddressesMx.Lock()
-	defer r.discoveredAddressesMx.Unlock()
+func (r *notificationsReceiverMock) InstanceAdded(instance Instance) {
+	r.discoveredInstancesMx.Lock()
+	defer r.discoveredInstancesMx.Unlock()
 
-	r.discoveredAddresses[address] = struct{}{}
+	r.discoveredInstances[instance.Address] = instance
 }
 
-func (r *notificationsReceiverMock) AddressRemoved(address string) {
-	r.discoveredAddressesMx.Lock()
-	defer r.discoveredAddressesMx.Unlock()
+func (r *notificationsReceiverMock) InstanceRemoved(instance Instance) {
+	r.discoveredInstancesMx.Lock()
+	defer r.discoveredInstancesMx.Unlock()
 
-	delete(r.discoveredAddresses, address)
+	delete(r.discoveredInstances, instance.Address)
 }
 
-func (r *notificationsReceiverMock) getDiscoveredAddresses() []string {
-	r.discoveredAddressesMx.Lock()
-	defer r.discoveredAddressesMx.Unlock()
+func (r *notificationsReceiverMock) InstanceChanged(instance Instance) {
+	r.discoveredInstancesMx.Lock()
+	defer r.discoveredInstancesMx.Unlock()
 
-	out := make([]string, 0, len(r.discoveredAddresses))
-	for addr := range r.discoveredAddresses {
-		out = append(out, addr)
+	r.discoveredInstances[instance.Address] = instance
+}
+
+func (r *notificationsReceiverMock) getDiscoveredInstances() []Instance {
+	r.discoveredInstancesMx.Lock()
+	defer r.discoveredInstancesMx.Unlock()
+
+	out := make([]Instance, 0, len(r.discoveredInstances))
+	for _, instance := range r.discoveredInstances {
+		out = append(out, instance)
 	}
-	sort.Strings(out)
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Address < out[j].Address
+	})
 
 	return out
 }


### PR DESCRIPTION
#### What this PR does
This PR is a follow up https://github.com/grafana/mimir/pull/2957. In https://github.com/grafana/mimir/pull/2957 I introduced the ring for query-scheduler. In this PR I'm adding support to configure a max number of query-scheduler instances effectively used. This setting is 0 by default, which means all available query-schedulers are used. However, in the read-write deployment we'll set this to 2, in order to use only 2 query-schedulers regardless how many backend replicas you're running.

**How it works**:
- Added `-query-scheduler.max-used-instances` config option (experimental). When > 0, the queries are enqueued on the configured max number of query-scheduler instances. It's only supported by query-scheduler ring discovery for now (there's a config validation check).
- The query-frontend only connects to the in-use query-schedulers. The querier workers connect both to in-use and not-in-use query-schedulers. The querier max concurrency is used to determine the number of connections towards in-use query-schedulers. Then, the querier also open 1 connection to each not-in-use query-schedulers, to make sure their queues are always drained (e.g. queries going to not-in-use query-schedulers when the set of in-use query-schedulers change).
- To determine the set of in-use query-schedulers I've not used the ring's replication factor (e.g. looking for an hardcoded token, like Loki is doing) but I'm sorting the scheduler addresses and taking the first N. The reason is that using the replication factor has some drawbacks due to how it's implemented in the ring (e.g. when there are multiple unhealthy instances, you may fail lookup the ring).

_I manually tested this PR in microservices, read-write and monolithic mode._

#### Which issue(s) this PR fixes or relates to

Part of #2749

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
