### PR TITLE
Helm: update agent-operator subchart to 0.2.5

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Document `kubeVersionOverride`. If you rely on `helm template`, use this in your values to set the Kubernetes version. If unset helm will use the kubectl client version as the Kubernetes version with `helm template`, which may cause the chart to render incompatible manifests for the actual server version. #2872
 * [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling. This is used when deploying on Kubernetes >= 1.25. #2848
 * [ENHANCEMENT] Add podAntiAffinity to sizing plans (small.yaml, large.yaml, capped-small.yaml, capped-large.yaml). #2906
+* [ENHANCEMENT] Update agent-operator subchart to `0.2.5`. #3009
 
 
 ## 3.1.0

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 4.0.12
 - name: grafana-agent-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.1.12
-digest: sha256:f57498f4a2d3db706e0739d38c877aac74a619a848be29b5b0ca7317ba339be2
-generated: "2022-08-17T11:05:13.740767-04:00"
+  version: 0.2.5
+digest: sha256:5f2b221e2a10dcc2c29840cdec1d6fdf7d5ce4ac2ecf92dec8567a2fa94a4e36
+generated: "2022-09-21T17:15:09.970414-04:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -14,6 +14,6 @@ dependencies:
     condition: minio.enabled
   - name: grafana-agent-operator
     alias: grafana-agent-operator
-    version: 0.1.12
+    version: 0.2.5
     repository: https://grafana.github.io/helm-charts
     condition: metaMonitoring.grafanaAgent.installOperator

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -23,7 +23,7 @@ Kubernetes: `^1.20.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 4.0.12 |
-| https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.1.12 |
+| https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.2.5 |
 
 ## Dependencies
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-clusterrole.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-clusterrole.yaml
@@ -5,12 +5,12 @@ kind: ClusterRole
 metadata:
   name: metamonitoring-values-grafana-agent-operator
   labels:
-    app.kubernetes.io/component: operator
     app.kubernetes.io/name: grafana-agent-operator
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: grafana-agent-operator-0.1.12
-    app.kubernetes.io/version: "0.24.2"
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.5
+    app.kubernetes.io/version: "0.27.1"
 rules:
 - apiGroups: [monitoring.grafana.com]
   resources:
@@ -18,6 +18,7 @@ rules:
   - metricsinstances
   - logsinstances
   - podlogs
+  - integrations
   verbs: [get, list, watch]
 - apiGroups: [monitoring.grafana.com]
   resources:
@@ -25,6 +26,7 @@ rules:
   - metricsinstances/finalizers
   - logsinstances/finalizers
   - podlogs/finalizers
+  - integrations/finalizers
   verbs: [get, list, watch, update]
 - apiGroups: [monitoring.coreos.com]
   resources:
@@ -54,4 +56,5 @@ rules:
   resources:
   - statefulsets
   - daemonsets
+  - deployments
   verbs: [get, list, watch, create, update, patch, delete]

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-clusterrolebinding.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-clusterrolebinding.yaml
@@ -5,12 +5,12 @@ kind: ClusterRoleBinding
 metadata:
   name: metamonitoring-values-grafana-agent-operator
   labels:
-    app.kubernetes.io/component: operator
     app.kubernetes.io/name: grafana-agent-operator
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: grafana-agent-operator-0.1.12
-    app.kubernetes.io/version: "0.24.2"
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.5
+    app.kubernetes.io/version: "0.27.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-deployment.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-deployment.yaml
@@ -5,12 +5,12 @@ kind: Deployment
 metadata:
   name: metamonitoring-values-grafana-agent-operator
   labels:
-    app.kubernetes.io/component: operator
     app.kubernetes.io/name: grafana-agent-operator
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: grafana-agent-operator-0.1.12
-    app.kubernetes.io/version: "0.24.2"
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.5
+    app.kubernetes.io/version: "0.27.1"
 spec:
   replicas: 1
   selector:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: metamonitoring-values-grafana-agent-operator
       containers:
       - name: grafana-agent-operator
-        image: "docker.io/grafana/agent-operator:v0.24.2"
+        image: "docker.io/grafana/agent-operator:v0.27.1"
         imagePullPolicy: IfNotPresent
         args:
           - --kubelet-service=default/kubelet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-serviceaccount.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/operator-serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: metamonitoring-values-grafana-agent-operator
   labels:
-    app.kubernetes.io/component: operator
     app.kubernetes.io/name: grafana-agent-operator
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: grafana-agent-operator-0.1.12
-    app.kubernetes.io/version: "0.24.2"
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.5
+    app.kubernetes.io/version: "0.27.1"

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
@@ -94,10 +94,22 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
-  image: "docker.io/grafana/agent:v0.24.2"
+  image: "docker.io/grafana/agent:v0.27.1"
   logLevel: info
   serviceAccountName: grafana-agent-test-sa
   metrics:
     instanceSelector:
       matchLabels:
         agent: grafana-agent-test
+---
+# Source: mimir-distributed/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: MetricsInstance
+metadata:
+  name: primary-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+  labels:
+    agent: grafana-agent-test
+spec: {}


### PR DESCRIPTION
#### What this PR does

Updates the agent-operator subchart to 0.2.5.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/828

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
