### PR TITLE
Do not log "error processing requests from scheduler" when the query-scheduler is shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Distributor: failure to send request to forwarding target now also increments `cortex_distributor_forward_errors_total`, with `status_code="failed"`. #2968
 * [ENHANCEMENT] Distributor: added support forwarding push requests via gRPC, using `httpgrpc` messages from weaveworks/common library. #2996
 * [ENHANCEMENT] Query-frontend / Querier: increase internal backoff period used to retry connections to query-frontend / query-scheduler. #3011
+* [ENHANCEMENT] Querier: do not log "error processing requests from scheduler" when the query-scheduler is shutting down. #3012
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -118,7 +119,7 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 
 		if err := sp.querierLoop(c, address, inflightQuery); err != nil {
 			// Do not log an error is the query-scheduler is shutting down.
-			if s, ok := status.FromError(err); !ok || s.Message() != schedulerpb.ErrSchedulerIsNotRunning.Error() {
+			if s, ok := status.FromError(err); !ok || !strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) {
 				level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
 			}
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/ring/client"
@@ -110,13 +111,17 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 		}
 
 		if err != nil {
-			level.Error(sp.log).Log("msg", "error contacting scheduler", "err", err, "addr", address)
+			level.Warn(sp.log).Log("msg", "error contacting scheduler", "err", err, "addr", address)
 			backoff.Wait()
 			continue
 		}
 
 		if err := sp.querierLoop(c, address, inflightQuery); err != nil {
-			level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
+			// Do not log an error is the query-scheduler is shutting down.
+			if s, ok := status.FromError(err); !ok || s.Message() != schedulerpb.ErrSchedulerIsNotRunning.Error() {
+				level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
+			}
+
 			backoff.Wait()
 			continue
 		}

--- a/pkg/scheduler/schedulerpb/custom.go
+++ b/pkg/scheduler/schedulerpb/custom.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package schedulerpb
+
+import "github.com/pkg/errors"
+
+var (
+	ErrSchedulerIsNotRunning = errors.New("scheduler is not running")
+)


### PR DESCRIPTION
#### What this PR does
While testing https://github.com/grafana/mimir/pull/3005 I've noticed the querier logs a stream of "error processing requests from scheduler" when the query-scheduler terminates. I propose to detect such error and avoid logging it, given it's a normal condition.

I also suggest to reduce the "error contacting scheduler" level from error to warn, because it could happen while the query-scheduler is shutting down but before the service discovery detected it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
