### PR TITLE
Docs: improve gRPC clients config documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### Documentation
 
 * [ENHANCEMENT] Added documentation on how to configure storage retention. #2970
+* [ENHANCEMENT] Improved gRPC clients config documentation. #3020
 
 ## 2.3.0
 

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -1166,8 +1166,7 @@ The `ruler` block configures the ruler.
 # CLI flag: -ruler.external.url
 [external_url: <url> | default = ]
 
-# The grpc_client block configures the gRPC client used to communicate between
-# two Mimir components.
+# Configures the gRPC client used to communicate between ruler instances.
 # The CLI flags prefix for this block configuration is: ruler.client
 [ruler_client: <grpc_client>]
 

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -634,8 +634,9 @@ forwarding:
   # CLI flag: -distributor.forwarding.propagate-errors
   [propagate_errors: <boolean> | default = true]
 
-  # The grpc_client block configures the gRPC client used to communicate between
-  # two Mimir components.
+  # Configures the gRPC client used to communicate between the distributors and
+  # the configured remote write endpoints used by the metrics forwarding
+  # feature.
   # The CLI flags prefix for this block configuration is:
   # distributor.forwarding.grpc-client
   [grpc_client: <grpc_client>]
@@ -978,8 +979,8 @@ The `frontend` block configures the query-frontend.
 # CLI flag: -query-frontend.scheduler-worker-concurrency
 [scheduler_worker_concurrency: <int> | default = 5]
 
-# The grpc_client block configures the gRPC client used to communicate between
-# two Mimir components.
+# Configures the gRPC client used to communicate between the query-frontends and
+# the query-schedulers.
 # The CLI flags prefix for this block configuration is:
 # query-frontend.grpc-client-config
 [grpc_client_config: <grpc_client>]
@@ -1065,8 +1066,8 @@ The `query_scheduler` block configures the query-scheduler.
 # CLI flag: -query-scheduler.querier-forget-delay
 [querier_forget_delay: <duration> | default = 0s]
 
-# The grpc_client block configures the gRPC client used to communicate between
-# two Mimir components.
+# This configures the gRPC client used to report errors back to the
+# query-frontend.
 # The CLI flags prefix for this block configuration is:
 # query-scheduler.grpc-client-config
 [grpc_client_config: <grpc_client>]
@@ -1348,8 +1349,8 @@ query_frontend:
   # CLI flag: -ruler.query-frontend.address
   [address: <string> | default = ""]
 
-  # The grpc_client block configures the gRPC client used to communicate between
-  # two Mimir components.
+  # Configures the gRPC client used to communicate between the rulers and
+  # query-frontends.
   # The CLI flags prefix for this block configuration is:
   # ruler.query-frontend.grpc-client-config
   [grpc_client_config: <grpc_client>]
@@ -1687,8 +1688,8 @@ The `flusher` block configures the WAL flusher target, used to manually run one-
 The `ingester_client` block configures how the distributors connect to the ingesters.
 
 ```yaml
-# The grpc_client block configures the gRPC client used to communicate between
-# two Mimir components.
+# Configures the gRPC client used to communicate between distributors and
+# ingesters.
 # The CLI flags prefix for this block configuration is: ingester.client
 [grpc_client_config: <grpc_client>]
 ```
@@ -1805,8 +1806,8 @@ The `frontend_worker` block configures the worker running within the querier, pi
 # CLI flag: -querier.id
 [id: <string> | default = ""]
 
-# The grpc_client block configures the gRPC client used to communicate between
-# two Mimir components.
+# Configures the gRPC client used to communicate between the queriers and the
+# query-frontends / query-schedulers.
 # The CLI flags prefix for this block configuration is: querier.frontend-client
 [grpc_client_config: <grpc_client>]
 ```

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -634,74 +634,11 @@ forwarding:
   # CLI flag: -distributor.forwarding.propagate-errors
   [propagate_errors: <boolean> | default = true]
 
-  grpc_client:
-    # (advanced) gRPC client max receive message size (bytes).
-    # CLI flag: -distributor.forwarding.grpc-client.grpc-max-recv-msg-size
-    [max_recv_msg_size: <int> | default = 104857600]
-
-    # (advanced) gRPC client max send message size (bytes).
-    # CLI flag: -distributor.forwarding.grpc-client.grpc-max-send-msg-size
-    [max_send_msg_size: <int> | default = 104857600]
-
-    # (advanced) Use compression when sending messages. Supported values are:
-    # 'gzip', 'snappy' and '' (disable compression)
-    # CLI flag: -distributor.forwarding.grpc-client.grpc-compression
-    [grpc_compression: <string> | default = ""]
-
-    # (advanced) Rate limit for gRPC client; 0 means disabled.
-    # CLI flag: -distributor.forwarding.grpc-client.grpc-client-rate-limit
-    [rate_limit: <float> | default = 0]
-
-    # (advanced) Rate limit burst for gRPC client.
-    # CLI flag: -distributor.forwarding.grpc-client.grpc-client-rate-limit-burst
-    [rate_limit_burst: <int> | default = 0]
-
-    # (advanced) Enable backoff and retry when we hit ratelimits.
-    # CLI flag: -distributor.forwarding.grpc-client.backoff-on-ratelimits
-    [backoff_on_ratelimits: <boolean> | default = false]
-
-    backoff_config:
-      # (advanced) Minimum delay when backing off.
-      # CLI flag: -distributor.forwarding.grpc-client.backoff-min-period
-      [min_period: <duration> | default = 100ms]
-
-      # (advanced) Maximum delay when backing off.
-      # CLI flag: -distributor.forwarding.grpc-client.backoff-max-period
-      [max_period: <duration> | default = 10s]
-
-      # (advanced) Number of times to backoff and retry before failing.
-      # CLI flag: -distributor.forwarding.grpc-client.backoff-retries
-      [max_retries: <int> | default = 10]
-
-    # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled
-    # when any other TLS flag is set. If set to false, insecure connection to
-    # gRPC server will be used.
-    # CLI flag: -distributor.forwarding.grpc-client.tls-enabled
-    [tls_enabled: <boolean> | default = false]
-
-    # (advanced) Path to the client certificate file, which will be used for
-    # authenticating with the server. Also requires the key path to be
-    # configured.
-    # CLI flag: -distributor.forwarding.grpc-client.tls-cert-path
-    [tls_cert_path: <string> | default = ""]
-
-    # (advanced) Path to the key file for the client certificate. Also requires
-    # the client certificate to be configured.
-    # CLI flag: -distributor.forwarding.grpc-client.tls-key-path
-    [tls_key_path: <string> | default = ""]
-
-    # (advanced) Path to the CA certificates file to validate server certificate
-    # against. If not set, the host's root CA certificates are used.
-    # CLI flag: -distributor.forwarding.grpc-client.tls-ca-path
-    [tls_ca_path: <string> | default = ""]
-
-    # (advanced) Override the expected name on the server certificate.
-    # CLI flag: -distributor.forwarding.grpc-client.tls-server-name
-    [tls_server_name: <string> | default = ""]
-
-    # (advanced) Skip validating server certificate.
-    # CLI flag: -distributor.forwarding.grpc-client.tls-insecure-skip-verify
-    [tls_insecure_skip_verify: <boolean> | default = false]
+  # The grpc_client block configures the gRPC client used to communicate between
+  # two Mimir components.
+  # The CLI flags prefix for this block configuration is:
+  # distributor.forwarding.grpc-client
+  [grpc_client: <grpc_client>]
 ```
 
 ### ingester
@@ -1041,73 +978,11 @@ The `frontend` block configures the query-frontend.
 # CLI flag: -query-frontend.scheduler-worker-concurrency
 [scheduler_worker_concurrency: <int> | default = 5]
 
-grpc_client_config:
-  # (advanced) gRPC client max receive message size (bytes).
-  # CLI flag: -query-frontend.grpc-client-config.grpc-max-recv-msg-size
-  [max_recv_msg_size: <int> | default = 104857600]
-
-  # (advanced) gRPC client max send message size (bytes).
-  # CLI flag: -query-frontend.grpc-client-config.grpc-max-send-msg-size
-  [max_send_msg_size: <int> | default = 104857600]
-
-  # (advanced) Use compression when sending messages. Supported values are:
-  # 'gzip', 'snappy' and '' (disable compression)
-  # CLI flag: -query-frontend.grpc-client-config.grpc-compression
-  [grpc_compression: <string> | default = ""]
-
-  # (advanced) Rate limit for gRPC client; 0 means disabled.
-  # CLI flag: -query-frontend.grpc-client-config.grpc-client-rate-limit
-  [rate_limit: <float> | default = 0]
-
-  # (advanced) Rate limit burst for gRPC client.
-  # CLI flag: -query-frontend.grpc-client-config.grpc-client-rate-limit-burst
-  [rate_limit_burst: <int> | default = 0]
-
-  # (advanced) Enable backoff and retry when we hit ratelimits.
-  # CLI flag: -query-frontend.grpc-client-config.backoff-on-ratelimits
-  [backoff_on_ratelimits: <boolean> | default = false]
-
-  backoff_config:
-    # (advanced) Minimum delay when backing off.
-    # CLI flag: -query-frontend.grpc-client-config.backoff-min-period
-    [min_period: <duration> | default = 100ms]
-
-    # (advanced) Maximum delay when backing off.
-    # CLI flag: -query-frontend.grpc-client-config.backoff-max-period
-    [max_period: <duration> | default = 10s]
-
-    # (advanced) Number of times to backoff and retry before failing.
-    # CLI flag: -query-frontend.grpc-client-config.backoff-retries
-    [max_retries: <int> | default = 10]
-
-  # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
-  # any other TLS flag is set. If set to false, insecure connection to gRPC
-  # server will be used.
-  # CLI flag: -query-frontend.grpc-client-config.tls-enabled
-  [tls_enabled: <boolean> | default = false]
-
-  # (advanced) Path to the client certificate file, which will be used for
-  # authenticating with the server. Also requires the key path to be configured.
-  # CLI flag: -query-frontend.grpc-client-config.tls-cert-path
-  [tls_cert_path: <string> | default = ""]
-
-  # (advanced) Path to the key file for the client certificate. Also requires
-  # the client certificate to be configured.
-  # CLI flag: -query-frontend.grpc-client-config.tls-key-path
-  [tls_key_path: <string> | default = ""]
-
-  # (advanced) Path to the CA certificates file to validate server certificate
-  # against. If not set, the host's root CA certificates are used.
-  # CLI flag: -query-frontend.grpc-client-config.tls-ca-path
-  [tls_ca_path: <string> | default = ""]
-
-  # (advanced) Override the expected name on the server certificate.
-  # CLI flag: -query-frontend.grpc-client-config.tls-server-name
-  [tls_server_name: <string> | default = ""]
-
-  # (advanced) Skip validating server certificate.
-  # CLI flag: -query-frontend.grpc-client-config.tls-insecure-skip-verify
-  [tls_insecure_skip_verify: <boolean> | default = false]
+# The grpc_client block configures the gRPC client used to communicate between
+# two Mimir components.
+# The CLI flags prefix for this block configuration is:
+# query-frontend.grpc-client-config
+[grpc_client_config: <grpc_client>]
 
 # (advanced) List of network interface names to look up when finding the
 # instance IP address. This address is sent to query-scheduler and querier,
@@ -1190,75 +1065,11 @@ The `query_scheduler` block configures the query-scheduler.
 # CLI flag: -query-scheduler.querier-forget-delay
 [querier_forget_delay: <duration> | default = 0s]
 
-# This configures the gRPC client used to report errors back to the
-# query-frontend.
-grpc_client_config:
-  # (advanced) gRPC client max receive message size (bytes).
-  # CLI flag: -query-scheduler.grpc-client-config.grpc-max-recv-msg-size
-  [max_recv_msg_size: <int> | default = 104857600]
-
-  # (advanced) gRPC client max send message size (bytes).
-  # CLI flag: -query-scheduler.grpc-client-config.grpc-max-send-msg-size
-  [max_send_msg_size: <int> | default = 104857600]
-
-  # (advanced) Use compression when sending messages. Supported values are:
-  # 'gzip', 'snappy' and '' (disable compression)
-  # CLI flag: -query-scheduler.grpc-client-config.grpc-compression
-  [grpc_compression: <string> | default = ""]
-
-  # (advanced) Rate limit for gRPC client; 0 means disabled.
-  # CLI flag: -query-scheduler.grpc-client-config.grpc-client-rate-limit
-  [rate_limit: <float> | default = 0]
-
-  # (advanced) Rate limit burst for gRPC client.
-  # CLI flag: -query-scheduler.grpc-client-config.grpc-client-rate-limit-burst
-  [rate_limit_burst: <int> | default = 0]
-
-  # (advanced) Enable backoff and retry when we hit ratelimits.
-  # CLI flag: -query-scheduler.grpc-client-config.backoff-on-ratelimits
-  [backoff_on_ratelimits: <boolean> | default = false]
-
-  backoff_config:
-    # (advanced) Minimum delay when backing off.
-    # CLI flag: -query-scheduler.grpc-client-config.backoff-min-period
-    [min_period: <duration> | default = 100ms]
-
-    # (advanced) Maximum delay when backing off.
-    # CLI flag: -query-scheduler.grpc-client-config.backoff-max-period
-    [max_period: <duration> | default = 10s]
-
-    # (advanced) Number of times to backoff and retry before failing.
-    # CLI flag: -query-scheduler.grpc-client-config.backoff-retries
-    [max_retries: <int> | default = 10]
-
-  # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
-  # any other TLS flag is set. If set to false, insecure connection to gRPC
-  # server will be used.
-  # CLI flag: -query-scheduler.grpc-client-config.tls-enabled
-  [tls_enabled: <boolean> | default = false]
-
-  # (advanced) Path to the client certificate file, which will be used for
-  # authenticating with the server. Also requires the key path to be configured.
-  # CLI flag: -query-scheduler.grpc-client-config.tls-cert-path
-  [tls_cert_path: <string> | default = ""]
-
-  # (advanced) Path to the key file for the client certificate. Also requires
-  # the client certificate to be configured.
-  # CLI flag: -query-scheduler.grpc-client-config.tls-key-path
-  [tls_key_path: <string> | default = ""]
-
-  # (advanced) Path to the CA certificates file to validate server certificate
-  # against. If not set, the host's root CA certificates are used.
-  # CLI flag: -query-scheduler.grpc-client-config.tls-ca-path
-  [tls_ca_path: <string> | default = ""]
-
-  # (advanced) Override the expected name on the server certificate.
-  # CLI flag: -query-scheduler.grpc-client-config.tls-server-name
-  [tls_server_name: <string> | default = ""]
-
-  # (advanced) Skip validating server certificate.
-  # CLI flag: -query-scheduler.grpc-client-config.tls-insecure-skip-verify
-  [tls_insecure_skip_verify: <boolean> | default = false]
+# The grpc_client block configures the gRPC client used to communicate between
+# two Mimir components.
+# The CLI flags prefix for this block configuration is:
+# query-scheduler.grpc-client-config
+[grpc_client_config: <grpc_client>]
 
 # (experimental) Service discovery mode that query-frontends and queriers use to
 # find query-scheduler instances. When query-scheduler ring-based service
@@ -1354,73 +1165,10 @@ The `ruler` block configures the ruler.
 # CLI flag: -ruler.external.url
 [external_url: <url> | default = ]
 
-ruler_client:
-  # (advanced) gRPC client max receive message size (bytes).
-  # CLI flag: -ruler.client.grpc-max-recv-msg-size
-  [max_recv_msg_size: <int> | default = 104857600]
-
-  # (advanced) gRPC client max send message size (bytes).
-  # CLI flag: -ruler.client.grpc-max-send-msg-size
-  [max_send_msg_size: <int> | default = 104857600]
-
-  # (advanced) Use compression when sending messages. Supported values are:
-  # 'gzip', 'snappy' and '' (disable compression)
-  # CLI flag: -ruler.client.grpc-compression
-  [grpc_compression: <string> | default = ""]
-
-  # (advanced) Rate limit for gRPC client; 0 means disabled.
-  # CLI flag: -ruler.client.grpc-client-rate-limit
-  [rate_limit: <float> | default = 0]
-
-  # (advanced) Rate limit burst for gRPC client.
-  # CLI flag: -ruler.client.grpc-client-rate-limit-burst
-  [rate_limit_burst: <int> | default = 0]
-
-  # (advanced) Enable backoff and retry when we hit ratelimits.
-  # CLI flag: -ruler.client.backoff-on-ratelimits
-  [backoff_on_ratelimits: <boolean> | default = false]
-
-  backoff_config:
-    # (advanced) Minimum delay when backing off.
-    # CLI flag: -ruler.client.backoff-min-period
-    [min_period: <duration> | default = 100ms]
-
-    # (advanced) Maximum delay when backing off.
-    # CLI flag: -ruler.client.backoff-max-period
-    [max_period: <duration> | default = 10s]
-
-    # (advanced) Number of times to backoff and retry before failing.
-    # CLI flag: -ruler.client.backoff-retries
-    [max_retries: <int> | default = 10]
-
-  # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
-  # any other TLS flag is set. If set to false, insecure connection to gRPC
-  # server will be used.
-  # CLI flag: -ruler.client.tls-enabled
-  [tls_enabled: <boolean> | default = false]
-
-  # (advanced) Path to the client certificate file, which will be used for
-  # authenticating with the server. Also requires the key path to be configured.
-  # CLI flag: -ruler.client.tls-cert-path
-  [tls_cert_path: <string> | default = ""]
-
-  # (advanced) Path to the key file for the client certificate. Also requires
-  # the client certificate to be configured.
-  # CLI flag: -ruler.client.tls-key-path
-  [tls_key_path: <string> | default = ""]
-
-  # (advanced) Path to the CA certificates file to validate server certificate
-  # against. If not set, the host's root CA certificates are used.
-  # CLI flag: -ruler.client.tls-ca-path
-  [tls_ca_path: <string> | default = ""]
-
-  # (advanced) Override the expected name on the server certificate.
-  # CLI flag: -ruler.client.tls-server-name
-  [tls_server_name: <string> | default = ""]
-
-  # (advanced) Skip validating server certificate.
-  # CLI flag: -ruler.client.tls-insecure-skip-verify
-  [tls_insecure_skip_verify: <boolean> | default = false]
+# The grpc_client block configures the gRPC client used to communicate between
+# two Mimir components.
+# The CLI flags prefix for this block configuration is: ruler.client
+[ruler_client: <grpc_client>]
 
 # (advanced) How frequently to evaluate rules
 # CLI flag: -ruler.evaluation-interval
@@ -1600,74 +1348,11 @@ query_frontend:
   # CLI flag: -ruler.query-frontend.address
   [address: <string> | default = ""]
 
-  grpc_client_config:
-    # (advanced) gRPC client max receive message size (bytes).
-    # CLI flag: -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size
-    [max_recv_msg_size: <int> | default = 104857600]
-
-    # (advanced) gRPC client max send message size (bytes).
-    # CLI flag: -ruler.query-frontend.grpc-client-config.grpc-max-send-msg-size
-    [max_send_msg_size: <int> | default = 104857600]
-
-    # (advanced) Use compression when sending messages. Supported values are:
-    # 'gzip', 'snappy' and '' (disable compression)
-    # CLI flag: -ruler.query-frontend.grpc-client-config.grpc-compression
-    [grpc_compression: <string> | default = ""]
-
-    # (advanced) Rate limit for gRPC client; 0 means disabled.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.grpc-client-rate-limit
-    [rate_limit: <float> | default = 0]
-
-    # (advanced) Rate limit burst for gRPC client.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.grpc-client-rate-limit-burst
-    [rate_limit_burst: <int> | default = 0]
-
-    # (advanced) Enable backoff and retry when we hit ratelimits.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.backoff-on-ratelimits
-    [backoff_on_ratelimits: <boolean> | default = false]
-
-    backoff_config:
-      # (advanced) Minimum delay when backing off.
-      # CLI flag: -ruler.query-frontend.grpc-client-config.backoff-min-period
-      [min_period: <duration> | default = 100ms]
-
-      # (advanced) Maximum delay when backing off.
-      # CLI flag: -ruler.query-frontend.grpc-client-config.backoff-max-period
-      [max_period: <duration> | default = 10s]
-
-      # (advanced) Number of times to backoff and retry before failing.
-      # CLI flag: -ruler.query-frontend.grpc-client-config.backoff-retries
-      [max_retries: <int> | default = 10]
-
-    # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled
-    # when any other TLS flag is set. If set to false, insecure connection to
-    # gRPC server will be used.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.tls-enabled
-    [tls_enabled: <boolean> | default = false]
-
-    # (advanced) Path to the client certificate file, which will be used for
-    # authenticating with the server. Also requires the key path to be
-    # configured.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.tls-cert-path
-    [tls_cert_path: <string> | default = ""]
-
-    # (advanced) Path to the key file for the client certificate. Also requires
-    # the client certificate to be configured.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.tls-key-path
-    [tls_key_path: <string> | default = ""]
-
-    # (advanced) Path to the CA certificates file to validate server certificate
-    # against. If not set, the host's root CA certificates are used.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.tls-ca-path
-    [tls_ca_path: <string> | default = ""]
-
-    # (advanced) Override the expected name on the server certificate.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.tls-server-name
-    [tls_server_name: <string> | default = ""]
-
-    # (advanced) Skip validating server certificate.
-    # CLI flag: -ruler.query-frontend.grpc-client-config.tls-insecure-skip-verify
-    [tls_insecure_skip_verify: <boolean> | default = false]
+  # The grpc_client block configures the gRPC client used to communicate between
+  # two Mimir components.
+  # The CLI flags prefix for this block configuration is:
+  # ruler.query-frontend.grpc-client-config
+  [grpc_client_config: <grpc_client>]
 
 tenant_federation:
   # Enable running rule groups against multiple tenants. The tenant IDs involved
@@ -2002,73 +1687,93 @@ The `flusher` block configures the WAL flusher target, used to manually run one-
 The `ingester_client` block configures how the distributors connect to the ingesters.
 
 ```yaml
-grpc_client_config:
-  # (advanced) gRPC client max receive message size (bytes).
-  # CLI flag: -ingester.client.grpc-max-recv-msg-size
-  [max_recv_msg_size: <int> | default = 104857600]
+# The grpc_client block configures the gRPC client used to communicate between
+# two Mimir components.
+# The CLI flags prefix for this block configuration is: ingester.client
+[grpc_client_config: <grpc_client>]
+```
 
-  # (advanced) gRPC client max send message size (bytes).
-  # CLI flag: -ingester.client.grpc-max-send-msg-size
-  [max_send_msg_size: <int> | default = 104857600]
+### grpc_client
 
-  # (advanced) Use compression when sending messages. Supported values are:
-  # 'gzip', 'snappy' and '' (disable compression)
-  # CLI flag: -ingester.client.grpc-compression
-  [grpc_compression: <string> | default = ""]
+The `grpc_client` block configures the gRPC client used to communicate between two Mimir components. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
-  # (advanced) Rate limit for gRPC client; 0 means disabled.
-  # CLI flag: -ingester.client.grpc-client-rate-limit
-  [rate_limit: <float> | default = 0]
+- `distributor.forwarding.grpc-client`
+- `ingester.client`
+- `querier.frontend-client`
+- `query-frontend.grpc-client-config`
+- `query-scheduler.grpc-client-config`
+- `ruler.client`
+- `ruler.query-frontend.grpc-client-config`
 
-  # (advanced) Rate limit burst for gRPC client.
-  # CLI flag: -ingester.client.grpc-client-rate-limit-burst
-  [rate_limit_burst: <int> | default = 0]
+&nbsp;
 
-  # (advanced) Enable backoff and retry when we hit ratelimits.
-  # CLI flag: -ingester.client.backoff-on-ratelimits
-  [backoff_on_ratelimits: <boolean> | default = false]
+```yaml
+# (advanced) gRPC client max receive message size (bytes).
+# CLI flag: -<prefix>.grpc-max-recv-msg-size
+[max_recv_msg_size: <int> | default = 104857600]
 
-  backoff_config:
-    # (advanced) Minimum delay when backing off.
-    # CLI flag: -ingester.client.backoff-min-period
-    [min_period: <duration> | default = 100ms]
+# (advanced) gRPC client max send message size (bytes).
+# CLI flag: -<prefix>.grpc-max-send-msg-size
+[max_send_msg_size: <int> | default = 104857600]
 
-    # (advanced) Maximum delay when backing off.
-    # CLI flag: -ingester.client.backoff-max-period
-    [max_period: <duration> | default = 10s]
+# (advanced) Use compression when sending messages. Supported values are:
+# 'gzip', 'snappy' and '' (disable compression)
+# CLI flag: -<prefix>.grpc-compression
+[grpc_compression: <string> | default = ""]
 
-    # (advanced) Number of times to backoff and retry before failing.
-    # CLI flag: -ingester.client.backoff-retries
-    [max_retries: <int> | default = 10]
+# (advanced) Rate limit for gRPC client; 0 means disabled.
+# CLI flag: -<prefix>.grpc-client-rate-limit
+[rate_limit: <float> | default = 0]
 
-  # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
-  # any other TLS flag is set. If set to false, insecure connection to gRPC
-  # server will be used.
-  # CLI flag: -ingester.client.tls-enabled
-  [tls_enabled: <boolean> | default = false]
+# (advanced) Rate limit burst for gRPC client.
+# CLI flag: -<prefix>.grpc-client-rate-limit-burst
+[rate_limit_burst: <int> | default = 0]
 
-  # (advanced) Path to the client certificate file, which will be used for
-  # authenticating with the server. Also requires the key path to be configured.
-  # CLI flag: -ingester.client.tls-cert-path
-  [tls_cert_path: <string> | default = ""]
+# (advanced) Enable backoff and retry when we hit ratelimits.
+# CLI flag: -<prefix>.backoff-on-ratelimits
+[backoff_on_ratelimits: <boolean> | default = false]
 
-  # (advanced) Path to the key file for the client certificate. Also requires
-  # the client certificate to be configured.
-  # CLI flag: -ingester.client.tls-key-path
-  [tls_key_path: <string> | default = ""]
+backoff_config:
+  # (advanced) Minimum delay when backing off.
+  # CLI flag: -<prefix>.backoff-min-period
+  [min_period: <duration> | default = 100ms]
 
-  # (advanced) Path to the CA certificates file to validate server certificate
-  # against. If not set, the host's root CA certificates are used.
-  # CLI flag: -ingester.client.tls-ca-path
-  [tls_ca_path: <string> | default = ""]
+  # (advanced) Maximum delay when backing off.
+  # CLI flag: -<prefix>.backoff-max-period
+  [max_period: <duration> | default = 10s]
 
-  # (advanced) Override the expected name on the server certificate.
-  # CLI flag: -ingester.client.tls-server-name
-  [tls_server_name: <string> | default = ""]
+  # (advanced) Number of times to backoff and retry before failing.
+  # CLI flag: -<prefix>.backoff-retries
+  [max_retries: <int> | default = 10]
 
-  # (advanced) Skip validating server certificate.
-  # CLI flag: -ingester.client.tls-insecure-skip-verify
-  [tls_insecure_skip_verify: <boolean> | default = false]
+# (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
+# any other TLS flag is set. If set to false, insecure connection to gRPC server
+# will be used.
+# CLI flag: -<prefix>.tls-enabled
+[tls_enabled: <boolean> | default = false]
+
+# (advanced) Path to the client certificate file, which will be used for
+# authenticating with the server. Also requires the key path to be configured.
+# CLI flag: -<prefix>.tls-cert-path
+[tls_cert_path: <string> | default = ""]
+
+# (advanced) Path to the key file for the client certificate. Also requires the
+# client certificate to be configured.
+# CLI flag: -<prefix>.tls-key-path
+[tls_key_path: <string> | default = ""]
+
+# (advanced) Path to the CA certificates file to validate server certificate
+# against. If not set, the host's root CA certificates are used.
+# CLI flag: -<prefix>.tls-ca-path
+[tls_ca_path: <string> | default = ""]
+
+# (advanced) Override the expected name on the server certificate.
+# CLI flag: -<prefix>.tls-server-name
+[tls_server_name: <string> | default = ""]
+
+# (advanced) Skip validating server certificate.
+# CLI flag: -<prefix>.tls-insecure-skip-verify
+[tls_insecure_skip_verify: <boolean> | default = false]
 ```
 
 ### frontend_worker
@@ -2100,73 +1805,10 @@ The `frontend_worker` block configures the worker running within the querier, pi
 # CLI flag: -querier.id
 [id: <string> | default = ""]
 
-grpc_client_config:
-  # (advanced) gRPC client max receive message size (bytes).
-  # CLI flag: -querier.frontend-client.grpc-max-recv-msg-size
-  [max_recv_msg_size: <int> | default = 104857600]
-
-  # (advanced) gRPC client max send message size (bytes).
-  # CLI flag: -querier.frontend-client.grpc-max-send-msg-size
-  [max_send_msg_size: <int> | default = 104857600]
-
-  # (advanced) Use compression when sending messages. Supported values are:
-  # 'gzip', 'snappy' and '' (disable compression)
-  # CLI flag: -querier.frontend-client.grpc-compression
-  [grpc_compression: <string> | default = ""]
-
-  # (advanced) Rate limit for gRPC client; 0 means disabled.
-  # CLI flag: -querier.frontend-client.grpc-client-rate-limit
-  [rate_limit: <float> | default = 0]
-
-  # (advanced) Rate limit burst for gRPC client.
-  # CLI flag: -querier.frontend-client.grpc-client-rate-limit-burst
-  [rate_limit_burst: <int> | default = 0]
-
-  # (advanced) Enable backoff and retry when we hit ratelimits.
-  # CLI flag: -querier.frontend-client.backoff-on-ratelimits
-  [backoff_on_ratelimits: <boolean> | default = false]
-
-  backoff_config:
-    # (advanced) Minimum delay when backing off.
-    # CLI flag: -querier.frontend-client.backoff-min-period
-    [min_period: <duration> | default = 100ms]
-
-    # (advanced) Maximum delay when backing off.
-    # CLI flag: -querier.frontend-client.backoff-max-period
-    [max_period: <duration> | default = 10s]
-
-    # (advanced) Number of times to backoff and retry before failing.
-    # CLI flag: -querier.frontend-client.backoff-retries
-    [max_retries: <int> | default = 10]
-
-  # (advanced) Enable TLS in the GRPC client. This flag needs to be enabled when
-  # any other TLS flag is set. If set to false, insecure connection to gRPC
-  # server will be used.
-  # CLI flag: -querier.frontend-client.tls-enabled
-  [tls_enabled: <boolean> | default = false]
-
-  # (advanced) Path to the client certificate file, which will be used for
-  # authenticating with the server. Also requires the key path to be configured.
-  # CLI flag: -querier.frontend-client.tls-cert-path
-  [tls_cert_path: <string> | default = ""]
-
-  # (advanced) Path to the key file for the client certificate. Also requires
-  # the client certificate to be configured.
-  # CLI flag: -querier.frontend-client.tls-key-path
-  [tls_key_path: <string> | default = ""]
-
-  # (advanced) Path to the CA certificates file to validate server certificate
-  # against. If not set, the host's root CA certificates are used.
-  # CLI flag: -querier.frontend-client.tls-ca-path
-  [tls_ca_path: <string> | default = ""]
-
-  # (advanced) Override the expected name on the server certificate.
-  # CLI flag: -querier.frontend-client.tls-server-name
-  [tls_server_name: <string> | default = ""]
-
-  # (advanced) Skip validating server certificate.
-  # CLI flag: -querier.frontend-client.tls-insecure-skip-verify
-  [tls_insecure_skip_verify: <boolean> | default = false]
+# The grpc_client block configures the gRPC client used to communicate between
+# two Mimir components.
+# The CLI flags prefix for this block configuration is: querier.frontend-client
+[grpc_client_config: <grpc_client>]
 ```
 
 ### etcd

--- a/pkg/distributor/forwarding/config.go
+++ b/pkg/distributor/forwarding/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	RequestTimeout     time.Duration `yaml:"request_timeout" category:"experimental"`
 	PropagateErrors    bool          `yaml:"propagate_errors" category:"experimental"`
 
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client" doc:"description=Configures the gRPC client used to communicate between the distributors and the configured remote write endpoints used by the metrics forwarding feature."`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -40,7 +40,7 @@ type Config struct {
 	SchedulerAddress  string            `yaml:"scheduler_address"`
 	DNSLookupPeriod   time.Duration     `yaml:"scheduler_dns_lookup_period" category:"advanced"`
 	WorkerConcurrency int               `yaml:"scheduler_worker_concurrency" category:"advanced"`
-	GRPCClientConfig  grpcclient.Config `yaml:"grpc_client_config"`
+	GRPCClientConfig  grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the query-frontends and the query-schedulers."`
 
 	// Used to find local IP address, that is sent to scheduler and querier-worker.
 	InfNames []string `yaml:"instance_interface_names" category:"advanced" doc:"default=[<private network interfaces>]"`

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -59,7 +59,7 @@ func (c *closableHealthAndIngesterClient) Close() error {
 
 // Config is the configuration struct for the ingester client
 type Config struct {
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between distributors and ingesters."`
 }
 
 // RegisterFlags registers configuration settings used by the ingester client config.

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -31,7 +31,7 @@ type Config struct {
 	SchedulerAddress string            `yaml:"scheduler_address"`
 	DNSLookupPeriod  time.Duration     `yaml:"dns_lookup_duration" category:"advanced"`
 	QuerierID        string            `yaml:"id" category:"advanced"`
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the queriers and the query-frontends / query-schedulers."`
 
 	// This configuration is injected internally.
 	MaxConcurrentRequests   int                       `yaml:"-"` // Must be same as passed to PromQL Engine.

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -55,7 +55,7 @@ type QueryFrontendConfig struct {
 	Address string `yaml:"address"`
 
 	// GRPCClientConfig contains gRPC specific config options.
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the rulers and query-frontends."`
 }
 
 func (c *QueryFrontendConfig) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -75,7 +75,7 @@ type Config struct {
 	// This is used for template expansion in alerts; must be a valid URL.
 	ExternalURL flagext.URLValue `yaml:"external_url"`
 	// GRPC Client configuration.
-	ClientTLSConfig grpcclient.Config `yaml:"ruler_client" doc="description=Configures the gRPC client used to communicate between ruler instances."`
+	ClientTLSConfig grpcclient.Config `yaml:"ruler_client" doc:"description=Configures the gRPC client used to communicate between ruler instances."`
 	// How frequently to evaluate rules by default.
 	EvaluationInterval time.Duration `yaml:"evaluation_interval" category:"advanced"`
 	// How frequently to poll for updated rules.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -75,7 +75,7 @@ type Config struct {
 	// This is used for template expansion in alerts; must be a valid URL.
 	ExternalURL flagext.URLValue `yaml:"external_url"`
 	// GRPC Client configuration.
-	ClientTLSConfig grpcclient.Config `yaml:"ruler_client"`
+	ClientTLSConfig grpcclient.Config `yaml:"ruler_client" doc="description=Configures the gRPC client used to communicate between ruler instances."`
 	// How frequently to evaluate rules by default.
 	EvaluationInterval time.Duration `yaml:"evaluation_interval" category:"advanced"`
 	// How frequently to poll for updated rules.

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -202,7 +202,9 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 
 				if isRoot {
 					blockName = rootName
-					blockDesc = rootDesc
+
+					// Honor the custom description if available.
+					blockDesc = getFieldDescription(field, rootDesc)
 				} else {
 					blockName = fieldName
 					blockDesc = getFieldDescription(field, "")

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -5,6 +5,7 @@ package parse
 import (
 	"reflect"
 
+	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/kv/etcd"
 	"github.com/grafana/dskit/kv/memberlist"
@@ -103,6 +104,11 @@ var (
 			Name:       "ingester_client",
 			StructType: reflect.TypeOf(client.Config{}),
 			Desc:       "The ingester_client block configures how the distributors connect to the ingesters.",
+		},
+		{
+			Name:       "grpc_client",
+			StructType: reflect.TypeOf(grpcclient.Config{}),
+			Desc:       "The grpc_client block configures the gRPC client used to communicate between two Mimir components.",
 		},
 		{
 			Name:       "frontend_worker",

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -148,7 +148,11 @@ func (w *markdownWriter) writeConfigDoc(blocks []*parse.ConfigBlock) {
 
 	for _, rootBlock := range parse.RootBlocks {
 		if block, ok := uniqueBlocks[rootBlock.Name]; ok {
-			w.writeConfigBlock(block)
+			// Keep the root block description.
+			blockToWrite := *block
+			blockToWrite.Desc = rootBlock.Desc
+
+			w.writeConfigBlock(&blockToWrite)
 		}
 	}
 }


### PR DESCRIPTION
#### What this PR does
Looking at #2996 made me realise the gRPC client config is duplicated a lot across the auto-generated config. In this PR I'm proposing to add a dedicated section for it.

As separate commits:
- [Define a block for the grpc client config documentation](https://github.com/grafana/mimir/commit/2f1f499b2d4a55d788d4bd7f26febeea931d62cd)
- [Improve gRPC clients config documentation](https://github.com/grafana/mimir/commit/6140c6b46d3e7f2a15ce7e0241de22ae0fcdf626)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
