### PR TITLE
Docs: fixed list of experimental features

### DIFF
--- a/docs/sources/operators-guide/configure/about-versioning.md
+++ b/docs/sources/operators-guide/configure/about-versioning.md
@@ -91,7 +91,7 @@ The following features are currently experimental:
   - Ring-based service discovery (`-query-scheduler.service-discovery-mode` and `-query-scheduler.ring.*`)
   - Max number of used instances (`-query-scheduler.max-used-instances`)
 - Store-gateway
-  - `-blocks-storage.bucket-store.index-header-thread-pool-size`
+  - `-blocks-storage.bucket-store.index-header.map-populate-enabled`
 - Blocks Storage, Alertmanager, and Ruler support for partitioning access to the same storage bucket
   - `-alertmanager-storage.storage-prefix`
   - `-blocks-storage.storage-prefix`


### PR DESCRIPTION
#### What this PR does
In the list of experimental features we still have the old (now removed) `-blocks-storage.bucket-store.index-header-thread-pool-size` config param, instead of `-blocks-storage.bucket-store.index-header.map-populate-enabled`. The latter was already marked as experimental in the CHANGELOG.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
