### PR TITLE
Fix ruler flaky tests

### DIFF
--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -98,6 +98,8 @@ func NewDefaultMultiTenantManager(cfg Config, managerFactory ManagerFactory, reg
 	}, nil
 }
 
+// SyncRuleGroups sync the input rulesGroups.
+// It's not safe to call this function concurrently.
 func (r *DefaultMultiTenantManager) SyncRuleGroups(ctx context.Context, ruleGroups map[string]rulespb.RuleGroupList) {
 	if !r.cfg.TenantFederation.Enabled {
 		RemoveFederatedRuleGroups(ruleGroups)

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -459,6 +459,7 @@ func (r *Ruler) run(ctx context.Context) error {
 }
 
 // It's not safe to call this function concurrently.
+// We expect this function is only called from Ruler.run().
 func (r *Ruler) syncRules(ctx context.Context, reason string) {
 	level.Debug(r.logger).Log("msg", "syncing rules", "reason", reason)
 	r.metrics.rulerSync.WithLabelValues(reason).Inc()

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -458,6 +458,7 @@ func (r *Ruler) run(ctx context.Context) error {
 	}
 }
 
+// It's not safe to call this function concurrently.
 func (r *Ruler) syncRules(ctx context.Context, reason string) {
 	level.Debug(r.logger).Log("msg", "syncing rules", "reason", reason)
 	r.metrics.rulerSync.WithLabelValues(reason).Inc()


### PR DESCRIPTION
#### What this PR does
`TestRuler_Rules` is flaky. The problem is that some ruler tests both start the ruler service **and** call `ruler.syncRules()`. The `ruler.syncRules()` is not concurrency safe, because of the rules config file mapper (it's not safe). The ruler logic is OK, but tests are not and they suffer some race conditions.

In this PR I'm removing any call to `ruler.syncRules()` from tests, just relying on the sync done by the ruler service itself and introducing a polling to wait until the desired condition is met.

#### Which issue(s) this PR fixes or relates to

Fixes #2803

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
