### PR TITLE
Fix exponential query sharding time of binops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005
 * [BUGFIX] Distributor: Now returns the quorum error from ingesters. For example, with replication_factor=3, two HTTP 400 errors and one HTTP 500 error, now the distributor will always return HTTP 400. Previously the behaviour was to return the error which the distributor first received. #2979
+* [BUGFIX] Query-frontend: query sharding took exponential time to map binary expressions. #3027
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
@@ -117,7 +117,7 @@ func mustLabelMatcher(mt labels.MatchType, name, val string) *labels.Matcher {
 }
 
 func TestSharding_BinaryExpressionsDontTakeExponentialTime(t *testing.T) {
-	const expressions = 25
+	const expressions = 30
 	const timeout = 10 * time.Second
 	query := `vector(1)`
 	// On 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz:

--- a/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
@@ -8,7 +8,9 @@ package astmapper
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -112,4 +114,35 @@ func mustLabelMatcher(mt labels.MatchType, name, val string) *labels.Matcher {
 		panic(err)
 	}
 	return m
+}
+
+func TestSharding_BinaryExpressionsDontTakeExponentialTime(t *testing.T) {
+	const expressions = 25
+	const timeout = 10 * time.Second
+	query := `vector(1)`
+	// On 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz:
+	// This was taking 3s for 20 expressions, and doubled the time for each extra one.
+	// So checking for 30 expressions would take an hour if processing time is exponential.
+	for i := 2; i <= expressions; i++ {
+		query += fmt.Sprintf("or vector(%d)", i)
+	}
+	expr, err := parser.ParseExpr(query)
+	require.NoError(t, err)
+
+	mapper, err := NewSharding(2, log.NewNopLogger(), NewMapperStats())
+	require.NoError(t, err)
+
+	res := make(chan error)
+	go func() {
+		_, err := mapper.Map(expr)
+		res <- err
+		close(res)
+	}()
+
+	select {
+	case <-time.After(timeout):
+		t.Fatalf("Query sharding process is taking too long, a timeout of %d was exceeded", timeout)
+	case err := <-res:
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
#### What this PR does

When sharding operations like `expr1 or expr2 or ... or expr_n`, the last expression has to be cloned `2^n` times by the `canShardAllVectorSelectors` check.

We can avoid that by caching the results of that function for each expr, making the execution time linear again.

#### Which issue(s) this PR fixes or relates to

Fixes an internal issue.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
