### PR TITLE
Add a timeout to query sharding process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Distributor: added support forwarding push requests via gRPC, using `httpgrpc` messages from weaveworks/common library. #2996
 * [ENHANCEMENT] Query-frontend / Querier: increase internal backoff period used to retry connections to query-frontend / query-scheduler. #3011
 * [ENHANCEMENT] Querier: do not log "error processing requests from scheduler" when the query-scheduler is shutting down. #3012
+* [ENHANCEMENT] Query-frontend: query sharding process is now time-bounded and it is cancelled if the request is aborted. #3028 
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * [ENHANCEMENT] Distributor: added support forwarding push requests via gRPC, using `httpgrpc` messages from weaveworks/common library. #2996
 * [ENHANCEMENT] Query-frontend / Querier: increase internal backoff period used to retry connections to query-frontend / query-scheduler. #3011
 * [ENHANCEMENT] Querier: do not log "error processing requests from scheduler" when the query-scheduler is shutting down. #3012
-* [ENHANCEMENT] Query-frontend: query sharding process is now time-bounded and it is cancelled if the request is aborted. #3028 
+* [ENHANCEMENT] Query-frontend: query sharding process is now time-bounded and it is cancelled if the request is aborted. #3028
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -3,6 +3,7 @@
 package astmapper
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -373,7 +374,7 @@ func TestInstantSplitter(t *testing.T) {
 
 		t.Run(tt.in, func(t *testing.T) {
 			stats := NewInstantSplitterStats()
-			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
+			mapper := NewInstantQuerySplitter(context.Background(), splitInterval, log.NewNopLogger(), stats)
 
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
@@ -424,7 +425,7 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 
 		t.Run(tt.in, func(t *testing.T) {
 			stats := NewInstantSplitterStats()
-			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
+			mapper := NewInstantQuerySplitter(context.Background(), splitInterval, log.NewNopLogger(), stats)
 
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
@@ -609,7 +610,7 @@ func TestInstantSplitterSkippedQueryReason(t *testing.T) {
 
 		t.Run(tt.query, func(t *testing.T) {
 			stats := NewInstantSplitterStats()
-			mapper := NewInstantQuerySplitter(splitInterval, log.NewNopLogger(), stats)
+			mapper := NewInstantQuerySplitter(context.Background(), splitInterval, log.NewNopLogger(), stats)
 
 			expr, err := parser.ParseExpr(tt.query)
 			require.NoError(t, err)

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -6,6 +6,7 @@
 package astmapper
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -507,7 +508,7 @@ func TestShardSummer(t *testing.T) {
 
 		t.Run(tt.in, func(t *testing.T) {
 			stats := NewMapperStats()
-			mapper, err := NewSharding(3, log.NewNopLogger(), stats)
+			mapper, err := NewSharding(context.Background(), 3, log.NewNopLogger(), stats)
 			require.NoError(t, err)
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
@@ -561,7 +562,7 @@ func TestShardSummerWithEncoding(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			stats := NewMapperStats()
-			summer, err := newShardSummer(c.shards, vectorSquasher, log.NewNopLogger(), stats)
+			summer, err := newShardSummer(context.Background(), c.shards, vectorSquasher, log.NewNopLogger(), stats)
 			require.Nil(t, err)
 			expr, err := parser.ParseExpr(c.input)
 			require.Nil(t, err)


### PR DESCRIPTION
#### What this PR does

Adds a context check to expression mapping when running query sharding or instant query splitting.

Also a timeout of 10s is set on the context passed to the mapping. We don't expect this operation to last more than few milliseconds, so anything reaching 10s can be considered a bug or poor implementation.

I have manually checked that this works by commenting out the fix in #3027
Can't see how can I write a test for this, since this protects us from something we don't expect to happen.

#### Which issue(s) this PR fixes or relates to

Relates to #3027

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
