### PR TITLE
Helm: Clean up default rollout strategies

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -27,7 +27,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to
   Mimir under the `metamonitoring` tenant; this enhancement does not apply to GEM. #3176
-* [ENHANCEMENT] Clean up default rollout strategies. Now distributor, overrides_exporter, querier, query_frontend, admin_api, gateway, and graphite components rollout with a single replica when without downtime. #3029
+* [ENHANCEMENT] Improve default rollout strategies. Now distributor, overrides_exporter, querier, query_frontend, admin_api, gateway, and graphite components can be upgraded more quickly and also can be rolled out with a single replica without downtime. #3029
 * [BUGFIX] Fix an issue that caused metamonitoring secrets to be created incorrectly #3170
 
 ## 3.2.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -27,6 +27,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to
   Mimir under the `metamonitoring` tenant; this enhancement does not apply to GEM. #3176
+* [ENHANCEMENT] Clean up default rollout strategies. Now distributor, overrides_exporter, querier, query_frontend, admin_api, gateway, and graphite components rollout with a single replica when without downtime. #3029
 * [BUGFIX] Fix an issue that caused metamonitoring secrets to be created incorrectly #3170
 
 ## 3.2.0

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -529,9 +529,6 @@ distributor:
 
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
 
   terminationGracePeriodSeconds: 60
 
@@ -635,11 +632,6 @@ ingester:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
   statefulStrategy:
     type: RollingUpdate
 
@@ -667,9 +659,6 @@ overrides_exporter:
 
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
 
   podLabels: {}
   podAnnotations: {}
@@ -848,9 +837,6 @@ querier:
 
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
 
   terminationGracePeriodSeconds: 180
 
@@ -917,9 +903,6 @@ query_frontend:
 
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
 
   terminationGracePeriodSeconds: 180
 
@@ -2050,9 +2033,6 @@ admin_api:
 
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
 
   podLabels: {}
   podAnnotations: {}
@@ -2122,9 +2102,6 @@ gateway:
 
   strategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
 
   podLabels: {}
   podAnnotations: {}
@@ -2271,9 +2248,6 @@ graphite:
 
     strategy:
       type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
 
     terminationGracePeriodSeconds: 180
 
@@ -2340,9 +2314,7 @@ graphite:
     securityContext: {}
     strategy:
       type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
+
     # -- Grace period to allow the graphite-write-proxy to shutdown before it is killed
     terminationGracePeriodSeconds: 180
     env: []

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: admin-api
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: distributor
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: gateway
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: graphite-querier
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: graphite-write-proxy
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: overrides-exporter
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: querier
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: graphite-enabled-values
       app.kubernetes.io/component: query-frontend
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: metamonitoring-values
       app.kubernetes.io/component: distributor
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: metamonitoring-values
       app.kubernetes.io/component: overrides-exporter
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: metamonitoring-values
       app.kubernetes.io/component: querier
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: metamonitoring-values
       app.kubernetes.io/component: query-frontend
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-configmap-values
       app.kubernetes.io/component: admin-api
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-configmap-values
       app.kubernetes.io/component: distributor
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-configmap-values
       app.kubernetes.io/component: gateway
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-configmap-values
       app.kubernetes.io/component: overrides-exporter
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-configmap-values
       app.kubernetes.io/component: querier
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-configmap-values
       app.kubernetes.io/component: query-frontend
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -18,9 +18,6 @@ spec:
       app: enterprise-metrics-admin-api
       release: test-enterprise-legacy-label-values
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -18,9 +18,6 @@ spec:
       app: enterprise-metrics-distributor
       release: test-enterprise-legacy-label-values
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -18,9 +18,6 @@ spec:
       app: enterprise-metrics-gateway
       release: test-enterprise-legacy-label-values
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -18,9 +18,6 @@ spec:
       app: enterprise-metrics-overrides-exporter
       release: test-enterprise-legacy-label-values
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -18,9 +18,6 @@ spec:
       app: enterprise-metrics-querier
       release: test-enterprise-legacy-label-values
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -18,9 +18,6 @@ spec:
       app: enterprise-metrics-query-frontend
       release: test-enterprise-legacy-label-values
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: admin-api
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: distributor
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: gateway
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: overrides-exporter
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: querier
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: query-frontend
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-oss-values
       app.kubernetes.io/component: distributor
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-oss-values
       app.kubernetes.io/component: overrides-exporter
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -21,9 +21,6 @@ spec:
       app.kubernetes.io/instance: test-oss-values
       app.kubernetes.io/component: querier
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -20,9 +20,6 @@ spec:
       app.kubernetes.io/instance: test-oss-values
       app.kubernetes.io/component: query-frontend
   strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Remove `{maxSurge:0, maxUnavailable:1}` for distributor,
overrides_exporter, querier, query_frontend, admin_api, gateway,
graphite_{querier,write_proxy,web}. This uses the default values of
`{maxSurge:25% (rounded up), maxUnavailable:25% (rounded down)}`.

This change allows to do zero-downtime rollouts for these components
when replicas==1. This was affecting the distributor, query_frontend,
admin_api, gateway.

Related to #2890 

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
