### PR TITLE
Don't include empty Endpoint when marshalling ForwardingRule.

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -61,7 +61,7 @@ type ForwardingRule struct {
 
 	// Endpoint is the URL of the remote_write endpoint to which a metric should be forwarded.
 	// Deprecated in favor of ForwardingEndpoint.
-	Endpoint string `yaml:"endpoint" json:"endpoint"`
+	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 
 // ForwardingRules are keyed by metric names, excluding labels.


### PR DESCRIPTION
#### What this PR does

This PR modifies `validation.ForwardingRule` to not include empty endpoint in the serialization output.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
