### PR TITLE
ingester: parallelize label values cardinality computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
   * `-ruler.recording-rules-evaluation-enabled`
   * `-ruler.alerting-rules-evaluation-enabled`
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. #3049
+* [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3044
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/ingester/label_names_and_values.go
+++ b/pkg/ingester/label_names_and_values.go
@@ -4,15 +4,25 @@ package ingester
 
 import (
 	"context"
+	"sync"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 )
 
-const checkContextErrorSeriesCount = 1000 // series count interval in which context cancellation must be checked.
+const (
+	checkContextErrorSeriesCount = 1000 // series count interval in which context cancellation must be checked.
+)
+
+type labelValueCountResult struct {
+	val   string
+	count uint64
+	err   error
+}
 
 // labelNamesAndValues streams the messages with the labels and values of the labels matching the `matchers` param.
 // Messages are immediately sent as soon they reach message size threshold defined in `messageSizeThreshold` param.
@@ -104,44 +114,38 @@ func labelValuesCardinality(
 	resp := client.LabelValuesCardinalityResponse{}
 	respSize := 0
 
-	// We will use original matchers + one extra matcher for label value.
-	lblValMatchers := make([]*labels.Matcher, len(matchers)+1)
-	copy(lblValMatchers, matchers)
-
-	for _, lbName := range lbNames {
+	for _, lblName := range lbNames {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		// Obtain all values for current label name.
-		lbValues, err := idxReader.LabelValues(lbName, matchers...)
+		lblValues, err := idxReader.LabelValues(lblName, matchers...)
 		if err != nil {
 			return err
 		}
 		// For each value count total number of series storing the result into cardinality response item.
 		var respItem *client.LabelValueSeriesCount
 
-		for _, lbValue := range lbValues {
-			if err := ctx.Err(); err != nil {
-				return err
+		resultCh := computeLabelValuesSeriesCount(ctx, lblName, lblValues, matchers, idxReader, postingsForMatchersFn)
+
+		for countRes := range resultCh {
+			if countRes.err != nil {
+				return countRes.err
 			}
-			// Create label name response item entry.
+			if countRes.count == 0 {
+				continue
+			}
 			if respItem == nil {
 				respItem = &client.LabelValueSeriesCount{
-					LabelName:        lbName,
+					LabelName:        lblName,
 					LabelValueSeries: make(map[string]uint64),
 				}
 				resp.Items = append(resp.Items, respItem)
 			}
-			// Get total series count applying label matchers.
-			lblValMatchers[len(lblValMatchers)-1] = labels.MustNewMatcher(labels.MatchEqual, lbName, lbValue)
 
-			seriesCount, err := countLabelValueSeries(ctx, idxReader, postingsForMatchersFn, lblValMatchers)
-			if err != nil {
-				return err
-			}
-			respItem.LabelValueSeries[lbValue] = seriesCount
+			respItem.LabelValueSeries[countRes.val] = countRes.count
 
-			respSize += len(lbValue)
+			respSize += len(countRes.val)
 			if respSize < msgSizeThreshold {
 				continue
 			}
@@ -161,13 +165,65 @@ func labelValuesCardinality(
 	return nil
 }
 
-func countLabelValueSeries(
+func computeLabelValuesSeriesCount(
 	ctx context.Context,
+	lblName string,
+	lblValues []string,
+	matchers []*labels.Matcher,
 	idxReader tsdb.IndexReader,
 	postingsForMatchersFn func(tsdb.IndexPostingsReader, ...*labels.Matcher) (index.Postings, error),
-	lblValMatchers []*labels.Matcher,
+) <-chan labelValueCountResult {
+	const maxConcurrency = 16
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(lblValues))
+
+	countCh := make(chan labelValueCountResult, len(lblValues))
+
+	indexes := atomic.NewInt64(-1)
+	for ix := 0; ix < maxConcurrency; ix++ {
+		go func() {
+			for {
+				idx := int(indexes.Inc())
+				if idx >= len(lblValues) {
+					return
+				}
+				seriesCount, err := countLabelValueSeries(ctx, lblName, lblValues[idx], matchers, idxReader, postingsForMatchersFn)
+				countCh <- labelValueCountResult{
+					val:   lblValues[idx],
+					count: seriesCount,
+					err:   err,
+				}
+				wg.Done()
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(countCh)
+	}()
+
+	return countCh
+}
+
+func countLabelValueSeries(
+	ctx context.Context,
+	lblName string,
+	lblValue string,
+	matchers []*labels.Matcher,
+	idxReader tsdb.IndexReader,
+	postingsForMatchersFn func(tsdb.IndexPostingsReader, ...*labels.Matcher) (index.Postings, error),
 ) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	var count uint64
+
+	// We will use original matchers + one extra matcher for label value.
+	lblValMatchers := make([]*labels.Matcher, len(matchers)+1)
+	copy(lblValMatchers, matchers)
+
+	lblValMatchers[len(lblValMatchers)-1] = labels.MustNewMatcher(labels.MatchEqual, lblName, lblValue)
 
 	p, err := postingsForMatchersFn(idxReader, lblValMatchers...)
 	if err != nil {

--- a/pkg/ingester/label_names_and_values.go
+++ b/pkg/ingester/label_names_and_values.go
@@ -173,7 +173,10 @@ func computeLabelValuesSeriesCount(
 	idxReader tsdb.IndexReader,
 	postingsForMatchersFn func(tsdb.IndexPostingsReader, ...*labels.Matcher) (index.Postings, error),
 ) <-chan labelValueCountResult {
-	const maxConcurrency = 16
+	maxConcurrency := 16
+	if len(lblValues) < maxConcurrency {
+		maxConcurrency = len(lblValues)
+	}
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(lblValues))

--- a/pkg/ingester/label_names_and_values_test.go
+++ b/pkg/ingester/label_names_and_values_test.go
@@ -293,9 +293,9 @@ func TestCountLabelValueSeries_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := countLabelValueSeries(ctx, nil, func(reader tsdb.IndexPostingsReader, matcher ...*labels.Matcher) (index.Postings, error) {
+	_, err := countLabelValueSeries(ctx, "lblName", "lblVal", nil, nil, func(reader tsdb.IndexPostingsReader, matcher ...*labels.Matcher) (index.Postings, error) {
 		return infinitePostings{}, nil
-	}, nil)
+	})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adapts `labelValuesCardinality` to iterate postings in parallel to obtain label values total series count.

~~Additionally, an extra benchmark has been included to compare performance with the old implementation.~~  To do performance comparison the [recently refactored](https://github.com/grafana/mimir/pull/3080) `BenchmarkIngester_LabelValuesCardinality` has been used. 

The new implementation is about `2x-3x` faster in my testing.

Run the following command to verify the results:

```
go test -run=X -bench=BenchmarkIngester_LabelValuesCardinality -benchmem -count=5 -cpu=4 ./pkg/ingester/
```

Comparison:

```
name                                                                                             old time/op    new time/op    delta
Ingester_LabelValuesCardinality/no_matchers,___name___label_with_1_value_all_series-4              8.06ms ± 4%    7.95ms ± 0%      ~     (p=1.000 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_10_label,_1M_series_each-4                        7.95ms ± 0%    2.54ms ± 1%   -68.07%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_77_label,_130K_series_each-4                      8.03ms ± 0%    2.25ms ± 1%   -71.97%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_4199,_2400_series_each-4                          11.8ms ± 0%     5.3ms ± 1%   -54.69%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_10_label,_1M_series_each-4                    274ms ± 0%      77ms ± 1%   -71.85%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_77_label,_130K_series_each-4                  831ms ± 0%     197ms ± 1%   -76.26%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_4199_label,_2400_series_each-4                835ms ± 3%     200ms ± 7%   -76.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___and_mod_10_matchers,_mod_4199_label,_240_series_each-4    49.8ms ± 0%    50.7ms ± 1%    +1.96%  (p=0.008 n=5+5)

name                                                                                             old alloc/op   new alloc/op   delta
Ingester_LabelValuesCardinality/no_matchers,___name___label_with_1_value_all_series-4              2.30kB ± 0%    4.80kB ± 0%  +108.46%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_10_label,_1M_series_each-4                        5.70kB ± 0%    8.63kB ± 0%   +51.41%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_77_label,_130K_series_each-4                      40.8kB ± 0%    47.0kB ± 0%   +15.31%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_4199,_2400_series_each-4                          2.27MB ± 0%    2.48MB ± 0%    +9.12%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_10_label,_1M_series_each-4                   8.64kB ± 2%   11.53kB ± 0%   +33.51%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_77_label,_130K_series_each-4                 62.1kB ± 2%    68.9kB ± 1%   +10.94%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_4199_label,_2400_series_each-4               61.7kB ± 2%    68.2kB ± 1%   +10.59%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___and_mod_10_matchers,_mod_4199_label,_240_series_each-4    3.21kB ± 0%    8.20kB ± 0%  +155.48%  (p=0.008 n=5+5)

name                                                                                             old allocs/op  new allocs/op  delta
Ingester_LabelValuesCardinality/no_matchers,___name___label_with_1_value_all_series-4                43.0 ± 0%      64.0 ± 0%   +48.84%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_10_label,_1M_series_each-4                           127 ± 0%       157 ± 0%   +23.62%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_77_label,_130K_series_each-4                         811 ± 0%       907 ± 0%   +11.94%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_4199,_2400_series_each-4                           42.3k ± 0%     46.5k ± 0%    +9.97%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_10_label,_1M_series_each-4                      203 ± 0%       232 ± 0%   +14.29%  (p=0.016 n=4+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_77_label,_130K_series_each-4                  1.30k ± 1%     1.39k ± 1%    +7.24%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_4199_label,_2400_series_each-4                1.30k ± 0%     1.39k ± 0%    +7.27%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___and_mod_10_matchers,_mod_4199_label,_240_series_each-4      75.0 ± 0%     116.0 ± 0%   +54.67%  (p=0.008 n=5+5)
```

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
