### PR TITLE
Backport Fix exponential query sharding time of binops (#3027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Grafana Mimir
 
-
 ### Mixin
 
 ### Jsonnet
@@ -16,6 +15,11 @@
 ### Mimir Continuous Test
 
 ### Documentation
+
+## 2.3.1
+
+### Grafana Mimir
+* [BUGFIX] Query-frontend: query sharding took exponential time to map binary expressions. #3027
 
 ## 2.3.0
 

--- a/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
@@ -8,7 +8,9 @@ package astmapper
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -112,4 +114,35 @@ func mustLabelMatcher(mt labels.MatchType, name, val string) *labels.Matcher {
 		panic(err)
 	}
 	return m
+}
+
+func TestSharding_BinaryExpressionsDontTakeExponentialTime(t *testing.T) {
+	const expressions = 30
+	const timeout = 10 * time.Second
+	query := `vector(1)`
+	// On 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz:
+	// This was taking 3s for 20 expressions, and doubled the time for each extra one.
+	// So checking for 30 expressions would take an hour if processing time is exponential.
+	for i := 2; i <= expressions; i++ {
+		query += fmt.Sprintf("or vector(%d)", i)
+	}
+	expr, err := parser.ParseExpr(query)
+	require.NoError(t, err)
+
+	mapper, err := NewSharding(2, log.NewNopLogger(), NewMapperStats())
+	require.NoError(t, err)
+
+	res := make(chan error)
+	go func() {
+		_, err := mapper.Map(expr)
+		res <- err
+		close(res)
+	}()
+
+	select {
+	case <-time.After(timeout):
+		t.Fatalf("Query sharding process is taking too long, a timeout of %d was exceeded", timeout)
+	case err := <-res:
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
* Fix exponential query sharding time of binops

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Backport of #3027:

When sharding operations like `expr1 or expr2 or ... or expr_n`, the last expression has to be cloned 2^n times by the `canShardAllVectorSelectors` check.

We can avoid that by caching the results of that function for each expr, making the execution time linear again.

(cherry picked from commit 0e45c39fa33ddefe0ceea402a6d15a21b46f4752)
