### PR TITLE
Use postings to calculate label values cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [ENHANCEMENT] Query-frontend / Querier: increase internal backoff period used to retry connections to query-frontend / query-scheduler. #3011
 * [ENHANCEMENT] Querier: do not log "error processing requests from scheduler" when the query-scheduler is shutting down. #3012
 * [ENHANCEMENT] Query-frontend: query sharding process is now time-bounded and it is cancelled if the request is aborted. #3028
+* [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3048
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1223,7 +1223,6 @@ func (i *Ingester) LabelValuesCardinality(req *client.LabelValuesCardinalityRequ
 		req.GetLabelNames(),
 		matchers,
 		idx,
-		tsdb.PostingsForMatchers,
 		labelValuesCardinalityTargetSizeBytes,
 		srv,
 	)

--- a/pkg/ingester/label_names_and_values.go
+++ b/pkg/ingester/label_names_and_values.go
@@ -95,7 +95,6 @@ func labelValuesCardinality(
 	lbNames []string,
 	matchers []*labels.Matcher,
 	idxReader tsdb.IndexReader,
-	postingsForMatchersFn func(tsdb.IndexPostingsReader, ...*labels.Matcher) (index.Postings, error),
 	msgSizeThreshold int,
 	srv client.Ingester_LabelValuesCardinalityServer,
 ) error {
@@ -106,7 +105,7 @@ func labelValuesCardinality(
 
 	var mpc *index.PostingsCloner
 	if len(matchers) > 0 {
-		matchedPostings, err := postingsForMatchersFn(idxReader, matchers...)
+		matchedPostings, err := idxReader.PostingsForMatchers(false, matchers...)
 		if err != nil {
 			return err
 		}

--- a/pkg/ingester/label_names_and_values_test.go
+++ b/pkg/ingester/label_names_and_values_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
@@ -289,13 +288,11 @@ func (ip infinitePostings) Seek(v storage.SeriesRef) bool { return true }
 func (ip infinitePostings) At() storage.SeriesRef         { return 0 }
 func (ip infinitePostings) Err() error                    { return nil }
 
-func TestCountLabelValueSeries_ContextCancellation(t *testing.T) {
+func TestPostingsLength_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := countLabelValueSeries(ctx, nil, func(reader tsdb.IndexPostingsReader, matcher ...*labels.Matcher) (index.Postings, error) {
-		return infinitePostings{}, nil
-	}, nil)
+	_, err := postingsLength(ctx, infinitePostings{})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
#### What this PR does

While reviewing https://github.com/grafana/mimir/pull/3044 I realized that there's a lot of work duplicated in that method:

When label values cardinality endpoint is being called with at least one matcher, we were passing that matcher to each `countLabelValueSeries` call.

This, in turn called `PostingsForMatchers` with the provided matchers plus an extra matcher fixing the label value.

This operation calculates the intersection of the postings for the provided matchers with the label value postings. As you can see, the "postings for the provided matchers" would be calculated for every label value found, which is quite inefficient, and gets worse as more matchers are provided.

This approach calculates those postings for the provided matchers in the first place, and then intersects them with the postings of each one of the labels, reducing drastically the amount of work performed.

I also wrote a different benchmark, based on a real TSDB rather than a mock that does nothing and sleeps, as that doesn't give us real numbers.

```
name                                                                                                            old time/op    new time/op    delta
Ingester_LabelValuesCardinality/no_matchers,___name___label_with_1_value_all_series-4                              370ns ± 1%     348ns ± 1%   -5.88%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_l_label_with_10k_values,_1_series_each-4                              377ns ± 1%     358ns ± 2%   -5.09%  (p=0.016 n=4+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_10_label_with_1k_values,_10_series_each-4                         377ns ± 3%     367ns ± 3%     ~     (p=0.056 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_100_label_with_100_values,_100_series_each-4                      374ns ± 1%     363ns ± 3%   -3.09%  (p=0.032 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_l_label_with_10k_values,_1_series_each-4                         632ns ± 7%     554ns ± 2%  -12.47%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_10_label_with_1k_values,_10_series_each-4                    614ns ± 1%     554ns ± 1%   -9.80%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_100_label_with_100_values,_100_series_each-4                 614ns ± 1%     548ns ± 1%  -10.81%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___and_mod_10_matchers,_mod_100_label_with_100_values,_100_series_each-4    1.18µs ± 7%    0.79µs ± 4%  -33.57%  (p=0.008 n=5+5)

name                                                                                                            old alloc/op   new alloc/op   delta
Ingester_LabelValuesCardinality/no_matchers,___name___label_with_1_value_all_series-4                               120B ± 0%      112B ± 0%   -6.67%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_l_label_with_10k_values,_1_series_each-4                               120B ± 0%      112B ± 0%   -6.67%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_10_label_with_1k_values,_10_series_each-4                          120B ± 0%      112B ± 0%   -6.67%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_100_label_with_100_values,_100_series_each-4                       120B ± 0%      112B ± 0%   -6.67%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_l_label_with_10k_values,_1_series_each-4                          256B ± 0%      216B ± 0%  -15.62%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_10_label_with_1k_values,_10_series_each-4                     256B ± 0%      216B ± 0%  -15.62%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_100_label_with_100_values,_100_series_each-4                  256B ± 0%      216B ± 0%  -15.62%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___and_mod_10_matchers,_mod_100_label_with_100_values,_100_series_each-4      552B ± 0%      352B ± 0%  -36.23%  (p=0.008 n=5+5)

name                                                                                                            old allocs/op  new allocs/op  delta
Ingester_LabelValuesCardinality/no_matchers,___name___label_with_1_value_all_series-4                               4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_l_label_with_10k_values,_1_series_each-4                               4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_10_label_with_1k_values,_10_series_each-4                          4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/no_matchers,_mod_100_label_with_100_values,_100_series_each-4                       4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_l_label_with_10k_values,_1_series_each-4                          10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_10_label_with_1k_values,_10_series_each-4                     10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___matcher,_mod_100_label_with_100_values,_100_series_each-4                  10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
Ingester_LabelValuesCardinality/__name___and_mod_10_matchers,_mod_100_label_with_100_values,_100_series_each-4      23.0 ± 0%      13.0 ± 0%  -43.48%  (p=0.008 n=5+5)

```

#### Which issue(s) this PR fixes or relates to

None, related to PR https://github.com/grafana/mimir/pull/3044

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
