### PR TITLE
Dont forward samples beyond a certain age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
   * `-store-gateway.sharding-ring.etcd.tls-min-version`
 * [ENHANCEMENT] Store-gateway: Add `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` option to allow requests that exceed the max number of inflight object storage requests to be rejected. #2999
 * [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3048
+* [ENHANCEMENT] Add age filter to Distributor's forwarding functionality, to not forward samples which are older than defined duration. #3049
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,8 @@
   * `-store-gateway.sharding-ring.etcd.tls-cipher-suites`
   * `-store-gateway.sharding-ring.etcd.tls-min-version`
 * [ENHANCEMENT] Store-gateway: Add `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` option to allow requests that exceed the max number of inflight object storage requests to be rejected. #2999
-* [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3048
 * [ENHANCEMENT] Query-frontend: allow setting a separate limit on the total (before splitting/sharding) query length of range queries with the new experimental `-query-frontend.max-total-query-length` flag, which defaults to `-store.max-query-length` if unset or set to 0. #3058
-* [ENHANCEMENT] Add age filter to Distributor's forwarding functionality, to not forward samples which are older than defined duration. #3049
+* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. #3049
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3432,6 +3432,15 @@
         },
         {
           "kind": "field",
+          "name": "forwarding_drop_before",
+          "required": false,
+          "desc": "If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldType": "int"
+        },
+        {
+          "kind": "field",
           "name": "forwarding_rules",
           "required": false,
           "desc": "Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3432,7 +3432,7 @@
         },
         {
           "kind": "field",
-          "name": "forwarding_drop_before",
+          "name": "forwarding_drop_older_than",
           "required": false,
           "desc": "If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped.",
           "fieldValue": null,

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2682,6 +2682,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # rules.
 [forwarding_endpoint: <string> | default = ""]
 
+# If set, forwarding drops samples that are older than this duration. If unset
+# or 0, no samples get dropped.
+[forwarding_drop_before: <int> | default = ]
+
 # Rules based on which the Distributor decides whether a metric should be
 # forwarded to an alternative remote_write API endpoint.
 [forwarding_rules: <map of string to validation.ForwardingRule> | default = ]

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2684,7 +2684,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 
 # If set, forwarding drops samples that are older than this duration. If unset
 # or 0, no samples get dropped.
-[forwarding_drop_before: <int> | default = ]
+[forwarding_drop_older_than: <int> | default = ]
 
 # Rules based on which the Distributor decides whether a metric should be
 # forwarded to an alternative remote_write API endpoint.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -892,10 +892,11 @@ func (d *Distributor) forwardSamples(ctx context.Context, userID string, ts []mi
 	}
 
 	endpoint := d.limits.ForwardingEndpoint(userID)
+	forwardingDropBefore := d.limits.ForwardingDropBefore(userID)
 
 	// Reassign req.Timeseries because the forwarder creates a new slice which has been filtered down.
 	// The cleanup func will cleanup the new slice, it's the forwarders responsibility to return the old one to the pool.
-	ts, forwardingErrCh = d.forwarder.Forward(ctx, endpoint, forwardingRules, ts)
+	ts, forwardingErrCh = d.forwarder.Forward(ctx, endpoint, forwardingDropBefore, forwardingRules, ts)
 
 	return ts, forwardingErrCh
 }

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -892,7 +892,12 @@ func (d *Distributor) forwardSamples(ctx context.Context, userID string, ts []mi
 	}
 
 	endpoint := d.limits.ForwardingEndpoint(userID)
-	forwardingDropBefore := d.limits.ForwardingDropBefore(userID)
+	forwardingDropOlderThan := d.limits.ForwardingDropOlderThan(userID)
+
+	var forwardingDropBefore int64
+	if forwardingDropOlderThan > 0 {
+		forwardingDropBefore = time.Now().Add(-forwardingDropOlderThan).UnixMilli()
+	}
 
 	// Reassign req.Timeseries because the forwarder creates a new slice which has been filtered down.
 	// The cleanup func will cleanup the new slice, it's the forwarders responsibility to return the old one to the pool.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4091,7 +4091,7 @@ func newMockForwarder(timeseriesMutator func([]mimirpb.PreallocTimeseries) []mim
 	}
 }
 
-func (m *mockForwarder) Forward(ctx context.Context, endpoint string, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
+func (m *mockForwarder) Forward(ctx context.Context, endpoint string, dontForwardOlderThan time.Duration, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
 	errCh := make(chan error)
 
 	go func() {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4091,7 +4091,7 @@ func newMockForwarder(timeseriesMutator func([]mimirpb.PreallocTimeseries) []mim
 	}
 }
 
-func (m *mockForwarder) Forward(ctx context.Context, endpoint string, dontForwardOlderThan time.Duration, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
+func (m *mockForwarder) Forward(ctx context.Context, endpoint string, dontForwardBefore int64, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
 	errCh := make(chan error)
 
 	go func() {

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -262,7 +262,7 @@ type tsByTargets map[string]tsWithSampleCount
 
 // copyToTarget copies the given time series into the given target and does the necessary accounting.
 // The time series is deep-copied, so the passed in time series can be returned to the pool without affecting the copy.
-func (t tsByTargets) copyToTarget(target string, ts mimirpb.PreallocTimeseries, dontForwardBeforeTs int64, pool *pools) bool {
+func (t tsByTargets) copyToTarget(target string, dontForwardBeforeTs int64, ts mimirpb.PreallocTimeseries, pool *pools) bool {
 	samplesTooOld := false
 
 	if dontForwardBeforeTs > 0 && samplesNeedFiltering(ts.TimeSeries.Samples, dontForwardBeforeTs) {
@@ -334,7 +334,7 @@ func (f *forwarder) splitByTargets(targetEndpoint string, dontForwardOlderThan i
 	for _, ts := range tsSliceIn {
 		forwardingTarget, ingest := findTargetForLabels(targetEndpoint, ts.Labels, rules)
 		if forwardingTarget != "" {
-			if tsByTargets.copyToTarget(forwardingTarget, ts, dontForwardBeforeTs, f.pools) {
+			if tsByTargets.copyToTarget(forwardingTarget, dontForwardBeforeTs, ts, f.pools) {
 				err = errSamplesTooOld
 			}
 		}

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -365,7 +365,7 @@ func dropSamplesBefore(samples []mimirpb.Sample, dontForwardBefore int64) []mimi
 		}
 	}
 
-	return samples[:0]
+	return nil
 }
 
 func findTargetForLabels(targetEndpoint string, labels []mimirpb.LabelAdapter, rules validation.ForwardingRules) (string, bool) {

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -259,7 +259,7 @@ type tsByTargets map[string]tsWithSampleCount
 // copyToTarget copies the given time series into the given target and does the necessary accounting.
 // The time series is deep-copied, so the passed in time series can be returned to the pool without affecting the copy.
 func (t tsByTargets) copyToTarget(target string, dontForwardBefore int64, ts mimirpb.PreallocTimeseries, pool *pools) (err error) {
-	if dontForwardBefore > 0 && samplesNeedFiltering(ts.TimeSeries.Samples, dontForwardBefore) {
+	if dontForwardBefore > 0 {
 		samplesUnfiltered := ts.TimeSeries.Samples
 		defer func() {
 			// After this function returns we need to restore the original sample slice because
@@ -343,17 +343,6 @@ func (f *forwarder) splitByTargets(targetEndpoint string, dontForwardBefore int6
 	}
 
 	return tsToIngest, tsByTargets, err
-}
-
-// samplesNeedFiltering takes a slice of samples and a timestamp before which samples should be filtered out,
-// it returns true if some samples are older than the given timestamp or false otherwise.
-// It assumes that the samples are sorted by timestamp.
-func samplesNeedFiltering(samples []mimirpb.Sample, dontForwardBefore int64) bool {
-	if len(samples) == 0 {
-		return false
-	}
-
-	return samples[0].TimestampMs < dontForwardBefore
 }
 
 // dropSamplesBefore filters a given slice of samples to only contain samples that have timestamps newer or equal to

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -358,10 +358,6 @@ func samplesNeedFiltering(samples []mimirpb.Sample, dontForwardBefore int64) boo
 // the given timestamp. It relies on the samples being sorted by timestamp.
 // If some samples have been filtered the second return value is true, otherwise it is false.
 func dropSamplesBefore(samples []mimirpb.Sample, dontForwardBefore int64) []mimirpb.Sample {
-	if dontForwardBefore == 0 {
-		return samples
-	}
-
 	for sampleIdx, sample := range samples {
 		if sample.TimestampMs >= dontForwardBefore {
 			// In most cases the first sample should already meet this condition and we can return quickly.

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -358,14 +358,13 @@ func samplesNeedFiltering(samples []mimirpb.Sample, dontForwardBefore int64) boo
 // the given timestamp. It relies on the samples being sorted by timestamp.
 // If some samples have been filtered the second return value is true, otherwise it is false.
 func dropSamplesBefore(samples []mimirpb.Sample, dontForwardBefore int64) []mimirpb.Sample {
-	for sampleIdx, sample := range samples {
-		if sample.TimestampMs >= dontForwardBefore {
-			// In most cases the first sample should already meet this condition and we can return quickly.
-			return samples[sampleIdx:]
+	for sampleIdx := len(samples) - 1; sampleIdx >= 0; sampleIdx-- {
+		if samples[sampleIdx].TimestampMs < dontForwardBefore {
+			return samples[sampleIdx+1:]
 		}
 	}
 
-	return nil
+	return samples
 }
 
 func findTargetForLabels(targetEndpoint string, labels []mimirpb.LabelAdapter, rules validation.ForwardingRules) (string, bool) {

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -64,8 +64,6 @@ type forwarder struct {
 	exemplarsTotal          prometheus.Counter
 	requestLatencyHistogram prometheus.Histogram
 	grpcClientsGauge        prometheus.Gauge
-
-	timeNow func() time.Time
 }
 
 // NewForwarder returns a new forwarder, if forwarding is disabled it returns nil.
@@ -119,8 +117,6 @@ func NewForwarder(cfg Config, reg prometheus.Registerer, log log.Logger) Forward
 			Name: "cortex_distributor_forward_grpc_clients",
 			Help: "Number of gRPC clients used by Distributor forwarder.",
 		}),
-
-		timeNow: time.Now,
 	}
 
 	f.httpGrpcClientPool = f.newHTTPGrpcClientsPool()

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -258,14 +258,14 @@ type tsByTargets map[string]tsWithSampleCount
 
 // copyToTarget copies the given time series into the given target and does the necessary accounting.
 // The time series is deep-copied, so the passed in time series can be returned to the pool without affecting the copy.
-func (t tsByTargets) copyToTarget(target string, dontForwardBeforeTs int64, ts mimirpb.PreallocTimeseries, pool *pools) (err error) {
-	if dontForwardBeforeTs > 0 && samplesNeedFiltering(ts.TimeSeries.Samples, dontForwardBeforeTs) {
+func (t tsByTargets) copyToTarget(target string, dontForwardBefore int64, ts mimirpb.PreallocTimeseries, pool *pools) (err error) {
+	if dontForwardBefore > 0 && samplesNeedFiltering(ts.TimeSeries.Samples, dontForwardBefore) {
 		samplesUnfiltered := ts.TimeSeries.Samples
 		defer func() {
 			ts.TimeSeries.Samples = samplesUnfiltered
 		}()
 
-		samplesFiltered := dropSamplesBefore(samplesUnfiltered, dontForwardBeforeTs)
+		samplesFiltered := dropSamplesBefore(samplesUnfiltered, dontForwardBefore)
 		if len(samplesFiltered) < len(samplesUnfiltered) {
 			err = errSamplesTooOld
 		}

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -265,7 +265,7 @@ func (t tsByTargets) copyToTarget(target string, dontForwardBeforeTs int64, ts m
 			ts.TimeSeries.Samples = samplesUnfiltered
 		}()
 
-		samplesFiltered := filterSamplesBefore(samplesUnfiltered, dontForwardBeforeTs)
+		samplesFiltered := dropSamplesBefore(samplesUnfiltered, dontForwardBeforeTs)
 		if len(samplesFiltered) < len(samplesUnfiltered) {
 			err = errSamplesTooOld
 		}
@@ -354,10 +354,10 @@ func samplesNeedFiltering(samples []mimirpb.Sample, dontForwardBefore int64) boo
 	return samples[0].TimestampMs < dontForwardBefore
 }
 
-// filterSamplesBefore filters a given slice of samples to only contain samples that have timestamps newer or equal to
+// dropSamplesBefore filters a given slice of samples to only contain samples that have timestamps newer or equal to
 // the given timestamp. It relies on the samples being sorted by timestamp.
 // If some samples have been filtered the second return value is true, otherwise it is false.
-func filterSamplesBefore(samples []mimirpb.Sample, dontForwardBefore int64) []mimirpb.Sample {
+func dropSamplesBefore(samples []mimirpb.Sample, dontForwardBefore int64) []mimirpb.Sample {
 	if dontForwardBefore == 0 {
 		return samples
 	}

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -262,6 +262,8 @@ func (t tsByTargets) copyToTarget(target string, dontForwardBefore int64, ts mim
 	if dontForwardBefore > 0 && samplesNeedFiltering(ts.TimeSeries.Samples, dontForwardBefore) {
 		samplesUnfiltered := ts.TimeSeries.Samples
 		defer func() {
+			// After this function returns we need to restore the original sample slice because
+			// we might still want to ingest it into the ingesters.
 			ts.TimeSeries.Samples = samplesUnfiltered
 		}()
 

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -206,9 +206,6 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now()
-	mockTime := func() time.Time {
-		return now
-	}
 	dontForwardOlderThan := 10 * time.Minute
 	cutOffTs := now.UnixMilli() - dontForwardOlderThan.Milliseconds()
 
@@ -317,7 +314,6 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f, _ := newForwarder(t, testConfig, true)
-			f.(*forwarder).timeNow = mockTime
 
 			url, _, bodiesFn, closeFn := newTestServer(t, 200, true)
 			defer closeFn()
@@ -340,7 +336,7 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 				})
 			}
 
-			toIngest, errCh := f.Forward(ctx, url, dontForwardOlderThan, rules, inputTs)
+			toIngest, errCh := f.Forward(ctx, url, cutOffTs, rules, inputTs)
 
 			// All samples should be ingested, including the ones that were dropped by the forwarding.
 			require.Equal(t, len(tc.inputSamples), len(toIngest))

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -160,8 +160,9 @@ type Limits struct {
 	AlertmanagerMaxAlertsCount                 int `yaml:"alertmanager_max_alerts_count" json:"alertmanager_max_alerts_count"`
 	AlertmanagerMaxAlertsSizeBytes             int `yaml:"alertmanager_max_alerts_size_bytes" json:"alertmanager_max_alerts_size_bytes"`
 
-	ForwardingEndpoint string          `yaml:"forwarding_endpoint" json:"forwarding_endpoint" doc:"nocli|description=Remote-write endpoint where metrics specified in forwarding_rules are forwarded to. If set, takes precedence over endpoints specified in forwarding rules."`
-	ForwardingRules    ForwardingRules `yaml:"forwarding_rules" json:"forwarding_rules" doc:"nocli|description=Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint."`
+	ForwardingEndpoint   string          `yaml:"forwarding_endpoint" json:"forwarding_endpoint" doc:"nocli|description=Remote-write endpoint where metrics specified in forwarding_rules are forwarded to. If set, takes precedence over endpoints specified in forwarding rules."`
+	ForwardingDropBefore time.Duration   `yaml:"forwarding_drop_before" json:"forwarding_drop_before" doc:"nocli|description=If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped."`
+	ForwardingRules      ForwardingRules `yaml:"forwarding_rules" json:"forwarding_rules" doc:"nocli|description=Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint."`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -711,6 +712,10 @@ func (o *Overrides) ForwardingRules(user string) ForwardingRules {
 
 func (o *Overrides) ForwardingEndpoint(user string) string {
 	return o.getOverridesForUser(user).ForwardingEndpoint
+}
+
+func (o *Overrides) ForwardingDropBefore(user string) time.Duration {
+	return o.getOverridesForUser(user).ForwardingDropBefore
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -161,7 +161,7 @@ type Limits struct {
 	AlertmanagerMaxAlertsSizeBytes             int `yaml:"alertmanager_max_alerts_size_bytes" json:"alertmanager_max_alerts_size_bytes"`
 
 	ForwardingEndpoint   string          `yaml:"forwarding_endpoint" json:"forwarding_endpoint" doc:"nocli|description=Remote-write endpoint where metrics specified in forwarding_rules are forwarded to. If set, takes precedence over endpoints specified in forwarding rules."`
-	ForwardingDropBefore time.Duration   `yaml:"forwarding_drop_before" json:"forwarding_drop_before" doc:"nocli|description=If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped."`
+	ForwardingDropBefore model.Duration  `yaml:"forwarding_drop_before" json:"forwarding_drop_before" doc:"nocli|description=If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped."`
 	ForwardingRules      ForwardingRules `yaml:"forwarding_rules" json:"forwarding_rules" doc:"nocli|description=Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint."`
 }
 
@@ -715,7 +715,7 @@ func (o *Overrides) ForwardingEndpoint(user string) string {
 }
 
 func (o *Overrides) ForwardingDropBefore(user string) time.Duration {
-	return o.getOverridesForUser(user).ForwardingDropBefore
+	return time.Duration(o.getOverridesForUser(user).ForwardingDropBefore)
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -160,9 +160,9 @@ type Limits struct {
 	AlertmanagerMaxAlertsCount                 int `yaml:"alertmanager_max_alerts_count" json:"alertmanager_max_alerts_count"`
 	AlertmanagerMaxAlertsSizeBytes             int `yaml:"alertmanager_max_alerts_size_bytes" json:"alertmanager_max_alerts_size_bytes"`
 
-	ForwardingEndpoint   string          `yaml:"forwarding_endpoint" json:"forwarding_endpoint" doc:"nocli|description=Remote-write endpoint where metrics specified in forwarding_rules are forwarded to. If set, takes precedence over endpoints specified in forwarding rules."`
-	ForwardingDropBefore model.Duration  `yaml:"forwarding_drop_before" json:"forwarding_drop_before" doc:"nocli|description=If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped."`
-	ForwardingRules      ForwardingRules `yaml:"forwarding_rules" json:"forwarding_rules" doc:"nocli|description=Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint."`
+	ForwardingEndpoint      string          `yaml:"forwarding_endpoint" json:"forwarding_endpoint" doc:"nocli|description=Remote-write endpoint where metrics specified in forwarding_rules are forwarded to. If set, takes precedence over endpoints specified in forwarding rules."`
+	ForwardingDropOlderThan model.Duration  `yaml:"forwarding_drop_older_than" json:"forwarding_drop_older_than" doc:"nocli|description=If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped."`
+	ForwardingRules         ForwardingRules `yaml:"forwarding_rules" json:"forwarding_rules" doc:"nocli|description=Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint."`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -714,8 +714,8 @@ func (o *Overrides) ForwardingEndpoint(user string) string {
 	return o.getOverridesForUser(user).ForwardingEndpoint
 }
 
-func (o *Overrides) ForwardingDropBefore(user string) time.Duration {
-	return time.Duration(o.getOverridesForUser(user).ForwardingDropBefore)
+func (o *Overrides) ForwardingDropOlderThan(user string) time.Duration {
+	return time.Duration(o.getOverridesForUser(user).ForwardingDropOlderThan)
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -496,7 +496,7 @@ func getFieldExample(fieldKey string, fieldType reflect.Type) *FieldExample {
 func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue reflect.Value, flags map[uintptr]*flag.Flag) (*ConfigEntry, error) {
 	if field.Type == reflect.TypeOf(logging.Level{}) || field.Type == reflect.TypeOf(logging.Format{}) {
 		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
-		if err != nil {
+		if err != nil || fieldFlag == nil {
 			return nil, err
 		}
 
@@ -513,7 +513,7 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 	}
 	if field.Type == reflect.TypeOf(flagext.URLValue{}) {
 		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
-		if err != nil {
+		if err != nil || fieldFlag == nil {
 			return nil, err
 		}
 
@@ -530,7 +530,7 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 	}
 	if field.Type == reflect.TypeOf(flagext.Secret{}) {
 		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
-		if err != nil {
+		if err != nil || fieldFlag == nil {
 			return nil, err
 		}
 
@@ -547,7 +547,7 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 	}
 	if field.Type == reflect.TypeOf(model.Duration(0)) {
 		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
-		if err != nil {
+		if err != nil || fieldFlag == nil {
 			return nil, err
 		}
 
@@ -564,7 +564,7 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 	}
 	if field.Type == reflect.TypeOf(flagext.Time{}) {
 		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
-		if err != nil {
+		if err != nil || fieldFlag == nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
#### What this PR does

It adds age filtering to the Distributor's forwarding functionality. The age filter can be configured so that samples which are older than a defined duration (for example `10min`) do not get forwarded.
