### PR TITLE
fix(remote-read): return err instead of nil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gofmt
     - misspell
     - errorlint
+    - errcheck
 
 linters-settings:
   errcheck:

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -356,7 +356,7 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, rawCfg s
 		return notifier
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	muteTimes := make(map[string][]timeinterval.TimeInterval, len(conf.MuteTimeIntervals))

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -276,7 +276,7 @@ func (c *RemoteReadCommand) dump(k *kingpin.ParseContext) error {
 
 	timeseries, err := query(context.Background())
 	if err != nil {
-		return nil
+		return err
 	}
 
 	iterator := newTimeSeriesIterator(timeseries)
@@ -309,7 +309,7 @@ func (c *RemoteReadCommand) stats(k *kingpin.ParseContext) error {
 
 	timeseries, err := query(context.Background())
 	if err != nil {
-		return nil
+		return err
 	}
 
 	num := struct {


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Also adds missing `errcheck` linter since we already have a `errcheckexclude` file in the root.

Previous PR: https://github.com/grafana/cortex-tools/pull/237

```
$ go run cmd/mimirtool/main.go remote-read stats --address http://10.11.12.13:30090 --selector '{__name__!=""}'

INFO[0000] Created remote read client using endpoint 'http://10.11.12.13:30090/prometheus/api/v1/read'
INFO[0000] Querying time from=2022-09-27T08:48:54+03:00 to=2022-09-27T09:48:54+03:00 with selector={__name__!=""}
main: error: remote server http://10.11.12.13:30090/prometheus/api/v1/read returned HTTP status 404 Not Found: 404 page not found, try --help
exit status 1
```

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/cortex-tools/issues/236

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

cc @aknuds1