### PR TITLE
fix(remote-read): return err instead of nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 
 ### Mimirtool
 
+* [BUGFIX] mimir-tool remote-read: fix returns where some conditions [return nil error even if there is error](https://github.com/grafana/cortex-tools/issues/260). #3053
+
 ### Query-tee
 
 ### Mimir Continuous Test

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -276,7 +276,7 @@ func (c *RemoteReadCommand) dump(k *kingpin.ParseContext) error {
 
 	timeseries, err := query(context.Background())
 	if err != nil {
-		return nil
+		return err
 	}
 
 	iterator := newTimeSeriesIterator(timeseries)
@@ -309,7 +309,7 @@ func (c *RemoteReadCommand) stats(k *kingpin.ParseContext) error {
 
 	timeseries, err := query(context.Background())
 	if err != nil {
-		return nil
+		return err
 	}
 
 	num := struct {


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

For example, an invalid URL `http://10.11.12.13:30090/prometheus/api/v1/read` returns `404`.

I'd expect an exit 1 and fatal log here, but it returns success instead.

```
$ go run cmd/mimirtool/main.go remote-read stats --address http://10.11.12.13:30090 --selector '{__name__!=""}'

INFO[0000] Created remote read client using endpoint 'http://10.11.12.13:30090/prometheus/api/v1/read'
INFO[0000] Querying time from=2022-09-27T08:48:54+03:00 to=2022-09-27T09:48:54+03:00 with selector={__name__!=""}
main: error: remote server http://10.11.12.13:30090/prometheus/api/v1/read returned HTTP status 404 Not Found: 404 page not found, try --help
exit status 1
```

![Screen Shot 2022-01-18 at 17 40 19](https://user-images.githubusercontent.com/16493751/149958397-2bd5b99d-a3ba-4928-8014-bd4cc7ff3069.png)

**Actual Behavior**
```
$ go run cmd/mimirtool/main.go remote-read stats --address http://10.10.10.10:30090 --selector '{__name__=~"istio.*"}' --remote-read-path /api/v1/read --log.level debug --read-timeout 60s

INFO[0000] log level set to debug
INFO[0000] Created remote read client using endpoint 'http://10.10.10.10:30090/api/v1/read'
INFO[0000] Querying time from=2022-01-18T16:01:52+03:00 to=2022-01-18T17:01:52+03:00 with selector={__name__=~"istio.*"}

$ echo $?
0
```

**Expected Behavior**

```
INFO[0000] log level set to debug                       
INFO[0000] Created remote read client using endpoint 'http://10.10.10.10:30090/api/v1/read' 
INFO[0000] Querying time from=2022-01-18T16:39:20+03:00 to=2022-01-18T17:39:20+03:00 with selector={__name__=~"istio.*"} 
___2remote_read_stats: error: remote server http://10.10.10.10:30090/api/v1/read returned HTTP status 400 Bad Request: exceeded sample limit (50000000), try --help

Process finished with the exit code 1
```

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/cortex-tools/issues/260

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`