### PR TITLE
distributor: Wrap errors from pushing to ingesters

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1125,8 +1125,12 @@ func (d *Distributor) send(ctx context.Context, ingester ring.InstanceDesc, time
 		Source:     source,
 	}
 	_, err = c.Push(ctx, &req)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errors.Wrapf(err, "timed out pushing to ingester (configured timeout: %s)",
+			d.cfg.RemoteTimeout.String())
+	}
 
-	return err
+	return errors.Wrap(err, "failed to push to ingester")
 }
 
 // forReplicationSet runs f, in parallel, for all ingesters in the input replication set.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1126,8 +1126,7 @@ func (d *Distributor) send(ctx context.Context, ingester ring.InstanceDesc, time
 	}
 	_, err = c.Push(ctx, &req)
 	if errors.Is(err, context.DeadlineExceeded) {
-		return errors.Wrapf(err, "timed out pushing to ingester (configured timeout: %s)",
-			d.cfg.RemoteTimeout.String())
+		return errors.Wrap(err, "timed out pushing to ingester")
 	}
 
 	return errors.Wrap(err, "failed to push to ingester")

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/test"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
@@ -109,6 +110,8 @@ func TestDistributor_Push(t *testing.T) {
 		mtime.NowReset()
 	})
 
+	expErrFail := errors.Wrap(errFail, "failed to push to ingester")
+
 	type samplesIn struct {
 		num              int
 		startTimestampMs int64
@@ -158,7 +161,7 @@ func TestDistributor_Push(t *testing.T) {
 			numIngesters:   3,
 			happyIngesters: 1,
 			samples:        samplesIn{num: 10, startTimestampMs: 123456789000},
-			expectedError:  errFail,
+			expectedError:  expErrFail,
 			metricNames:    []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
@@ -170,7 +173,7 @@ func TestDistributor_Push(t *testing.T) {
 			numIngesters:   3,
 			happyIngesters: 0,
 			samples:        samplesIn{num: 10, startTimestampMs: 123456789000},
-			expectedError:  errFail,
+			expectedError:  expErrFail,
 			metricNames:    []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
@@ -288,8 +291,12 @@ func TestDistributor_Push(t *testing.T) {
 
 			request := makeWriteRequest(tc.samples.startTimestampMs, tc.samples.num, tc.metadata, false)
 			response, err := ds[0].Push(ctx, request)
-			assert.Equal(t, tc.expectedResponse, response)
-			assert.Equal(t, tc.expectedError, err)
+			require.Equal(t, tc.expectedResponse, response)
+			if tc.expectedError == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, tc.expectedError.Error())
+			}
 
 			// Check tracked Prometheus metrics. Since the Push() response is sent as soon as the quorum
 			// is reached, when we reach this point the 3rd ingester may not have received series/metadata


### PR DESCRIPTION
#### What this PR does
In the distributor component, wrap errors stemming from calling the `push` gRPC method on ingesters. If an errors stems from a timeout, that gets wrapped with a specific message.

I hope this will be useful in diagnosing write requests timing out in the ingester component (e.g. due to CPU starvation).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
