### PR TITLE
Update 2.5.0 tenative release cut date

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ A new Grafana Mimir release is cut approximately every 6 weeks. The following ta
 | 2.2.0   | 2022-06-27 | Oleg Zaytsev      |
 | 2.3.0   | 2022-08-08 | Tyler Reid        |
 | 2.4.0   | 2022-10-10 | Marco Pracucci    |
-| 2.5.0   | 2022-11-21 | _To be announced_ |
+| 2.5.0   | 2022-11-28 | _To be announced_ |
 
 ## Release shepherd responsibilities
 


### PR DESCRIPTION
#### What this PR does

As Grafana Labs will test production workloads on the week of November 21st for the release 2.5.0, it may make sense to just postpone it a week.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
