### PR TITLE
Add tsdb.IntersectTwoPostings

### DIFF
--- a/pkg/ingester/label_names_and_values.go
+++ b/pkg/ingester/label_names_and_values.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/index"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 )
 
 const checkContextErrorSeriesCount = 1000 // series count interval in which context cancellation must be checked.
@@ -174,7 +175,7 @@ func countLabelValueSeries(ctx context.Context, lbName string, lbValue string, i
 	}
 
 	if matchedPostingsCloner != nil {
-		lbPostings = index.Intersect(lbPostings, matchedPostingsCloner.Clone())
+		lbPostings = mimir_tsdb.IntersectTwoPostings(lbPostings, matchedPostingsCloner.Clone())
 	}
 
 	seriesCount, err := postingsLength(ctx, lbPostings)

--- a/pkg/storage/tsdb/postings.go
+++ b/pkg/storage/tsdb/postings.go
@@ -1,0 +1,63 @@
+package tsdb
+
+import (
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+// IntersectTwoPostings returns a new index.Postings resulting from the intersection of the two provided.
+// It's more efficient than calling a generic index.Intersect when there are only two postings available.
+func IntersectTwoPostings(a, b index.Postings) index.Postings {
+	if a == index.EmptyPostings() || b == index.EmptyPostings() {
+		return index.EmptyPostings()
+	}
+
+	return &intersectTwoPostings{a: a, b: b}
+}
+
+type intersectTwoPostings struct {
+	a, b index.Postings
+	cur  storage.SeriesRef
+}
+
+func (itp *intersectTwoPostings) Err() error {
+	if itp.a.Err() != nil {
+		return itp.a.Err()
+	}
+	return itp.b.Err()
+}
+
+func (itp *intersectTwoPostings) At() storage.SeriesRef {
+	return itp.cur
+}
+
+func (itp *intersectTwoPostings) Next() bool {
+	if !itp.a.Next() {
+		return false
+	}
+	if !itp.b.Next() {
+		return false
+	}
+	return itp.seekSame()
+}
+
+func (itp *intersectTwoPostings) Seek(id storage.SeriesRef) bool {
+	return itp.a.Seek(id) && itp.b.Seek(id) && itp.seekSame()
+}
+
+func (itp *intersectTwoPostings) seekSame() bool {
+	for {
+		if ca, cb := itp.a.At(), itp.b.At(); ca == cb {
+			itp.cur = ca
+			return true
+		} else if ca < cb {
+			if !itp.a.Seek(cb) {
+				return false
+			}
+		} else if ca > cb {
+			if !itp.b.Seek(ca) {
+				return false
+			}
+		}
+	}
+}

--- a/pkg/storage/tsdb/postings_test.go
+++ b/pkg/storage/tsdb/postings_test.go
@@ -1,0 +1,206 @@
+package tsdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntersectTwoPostings(t *testing.T) {
+	a := newListPostings(1, 2, 3)
+	b := newListPostings(2, 3, 4)
+
+	cases := []struct {
+		a, b index.Postings
+
+		res index.Postings
+	}{
+		{
+			a:   a,
+			b:   b,
+			res: newListPostings(2, 3),
+		},
+		{
+			a:   a,
+			b:   index.EmptyPostings(),
+			res: index.EmptyPostings(),
+		},
+		{
+			a:   index.EmptyPostings(),
+			b:   b,
+			res: index.EmptyPostings(),
+		},
+		{
+			a:   index.EmptyPostings(),
+			b:   index.EmptyPostings(),
+			res: index.EmptyPostings(),
+		},
+		{
+			a:   newListPostings(1, 2, 3, 4, 5),
+			b:   newListPostings(6, 7, 8, 9, 10),
+			res: newListPostings(),
+		},
+		{
+			a:   newListPostings(1, 2, 3, 4, 5),
+			b:   newListPostings(4, 5, 6, 7, 8),
+			res: newListPostings(4, 5),
+		},
+		{
+			a:   newListPostings(1, 2, 3, 4, 9, 10),
+			b:   newListPostings(1, 4, 5, 6, 7, 8, 10, 11),
+			res: newListPostings(1, 4, 10),
+		},
+		{
+			a:   newListPostings(1),
+			b:   newListPostings(0, 1),
+			res: newListPostings(1),
+		},
+		{
+			a:   newListPostings(1),
+			b:   newListPostings(),
+			res: newListPostings(),
+		},
+		{
+			a:   newListPostings(),
+			b:   newListPostings(),
+			res: newListPostings(),
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			if c.res == nil {
+				t.Fatal("intersect result expectancy cannot be nil")
+			}
+
+			expected, err := index.ExpandPostings(c.res)
+			require.NoError(t, err)
+
+			i := index.Intersect(c.a, c.b)
+
+			if c.res == index.EmptyPostings() {
+				require.Equal(t, index.EmptyPostings(), i)
+				return
+			}
+
+			if i == index.EmptyPostings() {
+				t.Fatal("intersect unexpected result: EmptyPostings sentinel")
+			}
+
+			res, err := index.ExpandPostings(i)
+			require.NoError(t, err)
+			require.Equal(t, expected, res)
+		})
+	}
+}
+
+func BenchmarkIntersectTwoPostings(t *testing.B) {
+	// intersect extracts the benchmarked function to easily replace it by index.Intersect
+	intersect := func(a, b index.Postings) index.Postings {
+		return IntersectTwoPostings(a, b)
+	}
+
+	t.Run("Few common postings", func(bench *testing.B) {
+		var a, b []storage.SeriesRef
+
+		for i := 0; i < 12500000; i++ {
+			if i%2 == 0 || i%100 == 0 {
+				a = append(a, storage.SeriesRef(i))
+			}
+			if i%2 == 1 || i%100 == 0 {
+				b = append(b, storage.SeriesRef(i))
+			}
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := drainPostings(intersect(i1, i2)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("All common postings", func(bench *testing.B) {
+		var a []storage.SeriesRef
+		for i := 0; i < 12500000; i++ {
+			a = append(a, storage.SeriesRef(i))
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(a...)
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := drainPostings(intersect(i1, i2)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("LongPostings1", func(bench *testing.B) {
+		var a, b []storage.SeriesRef
+
+		for i := 0; i < 10000000; i += 2 {
+			a = append(a, storage.SeriesRef(i))
+		}
+		for i := 5000000; i < 5000100; i += 4 {
+			b = append(b, storage.SeriesRef(i))
+		}
+		for i := 5090000; i < 5090600; i += 4 {
+			b = append(b, storage.SeriesRef(i))
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := drainPostings(intersect(i1, i2)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("LongPostings2", func(bench *testing.B) {
+		var a, b []storage.SeriesRef
+
+		for i := 0; i < 12500000; i++ {
+			a = append(a, storage.SeriesRef(i))
+		}
+		for i := 7500000; i < 12500000; i++ {
+			b = append(b, storage.SeriesRef(i))
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := drainPostings(intersect(i1, i2)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+}
+
+func newListPostings(list ...storage.SeriesRef) index.Postings {
+	return index.NewListPostings(list)
+}
+
+// ExpandPostings returns the postings expanded as a slice.
+func drainPostings(p index.Postings) (s storage.SeriesRef, err error) {
+	for p.Next() {
+		s += p.At()
+	}
+	return s, p.Err()
+}


### PR DESCRIPTION
#### What this PR does

The implementation of `index.Intersect` can be seen as too complex for when only two postings iterators are provided.

This is a simpler implementation, which is shown to be faster by the provided benchmark.

```
name                              old time/op    new time/op    delta
Intersect/Few_common_postings-16    87.9ns ± 7%    51.6ns ±14%  -41.31%  (p=0.008 n=5+5)
Intersect/All_common_postings-16    62.6ns ± 3%    31.8ns ± 2%  -49.20%  (p=0.008 n=5+5)
Intersect/LongPostings1-16          51.6ns ± 2%    29.4ns ± 1%  -43.01%  (p=0.008 n=5+5)
Intersect/LongPostings2-16          54.0ns ± 5%    29.8ns ± 2%  -44.68%  (p=0.008 n=5+5)

name                              old alloc/op   new alloc/op   delta
Intersect/Few_common_postings-16     64.0B ± 0%     48.0B ± 0%  -25.00%  (p=0.008 n=5+5)
Intersect/All_common_postings-16     64.0B ± 0%     48.0B ± 0%  -25.00%  (p=0.008 n=5+5)
Intersect/LongPostings1-16           64.0B ± 0%     48.0B ± 0%  -25.00%  (p=0.008 n=5+5)
Intersect/LongPostings2-16           64.0B ± 0%     48.0B ± 0%  -25.00%  (p=0.008 n=5+5)

name                              old allocs/op  new allocs/op  delta
Intersect/Few_common_postings-16      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
Intersect/All_common_postings-16      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
Intersect/LongPostings1-16            2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
Intersect/LongPostings2-16            2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
```

#### Which issue(s) this PR fixes or relates to

Some followup on https://github.com/grafana/mimir/pull/3048

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
