### PR TITLE
Revert "Use postings to calculate label values cardinality (#3048)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@
   * `-store-gateway.sharding-ring.etcd.tls-cipher-suites`
   * `-store-gateway.sharding-ring.etcd.tls-min-version`
 * [ENHANCEMENT] Store-gateway: Add `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` option to allow requests that exceed the max number of inflight object storage requests to be rejected. #2999
-* [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3048
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1223,6 +1223,7 @@ func (i *Ingester) LabelValuesCardinality(req *client.LabelValuesCardinalityRequ
 		req.GetLabelNames(),
 		matchers,
 		idx,
+		tsdb.PostingsForMatchers,
 		labelValuesCardinalityTargetSizeBytes,
 		srv,
 	)

--- a/pkg/ingester/label_names_and_values_test.go
+++ b/pkg/ingester/label_names_and_values_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
@@ -288,11 +289,13 @@ func (ip infinitePostings) Seek(v storage.SeriesRef) bool { return true }
 func (ip infinitePostings) At() storage.SeriesRef         { return 0 }
 func (ip infinitePostings) Err() error                    { return nil }
 
-func TestPostingsLength_ContextCancellation(t *testing.T) {
+func TestCountLabelValueSeries_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := postingsLength(ctx, infinitePostings{})
+	_, err := countLabelValueSeries(ctx, nil, func(reader tsdb.IndexPostingsReader, matcher ...*labels.Matcher) (index.Postings, error) {
+		return infinitePostings{}, nil
+	}, nil)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
#### What this PR does

This reverts https://github.com/grafana/mimir/pull/3048

The benchmark fixed in https://github.com/grafana/mimir/pull/3080 shows that this implementation is much worse, see comment in https://github.com/grafana/mimir/pull/3048#issuecomment-1261160041

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
