### PR TITLE
Remove use of DefaultRegistrer for discarded samples metric.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -134,6 +134,11 @@ type Distributor struct {
 	replicationFactor                prometheus.Gauge
 	latestSeenSampleTimestampPerUser *prometheus.GaugeVec
 
+	discardedSamplesTooManyHaClusters *prometheus.CounterVec
+	discardedSamplesRateLimited       *prometheus.CounterVec
+
+	sampleValidationMetrics *validation.SampleValidationMetrics
+
 	PushWithMiddlewares push.Func
 }
 
@@ -335,6 +340,11 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			Name: "cortex_distributor_latest_seen_sample_timestamp_seconds",
 			Help: "Unix timestamp of latest received sample per user.",
 		}, []string{"user"}),
+
+		discardedSamplesTooManyHaClusters: validation.DiscardedSamplesCounter(reg, validation.ReasonTooManyHAClusters),
+		discardedSamplesRateLimited:       validation.DiscardedSamplesCounter(reg, validation.ReasonRateLimited),
+
+		sampleValidationMetrics: validation.NewSampleValidationMetrics(reg),
 	}
 
 	promauto.With(reg).NewGauge(prometheus.GaugeOpts{
@@ -506,6 +516,10 @@ func (d *Distributor) cleanupInactiveUser(userID string) {
 
 	d.dedupedSamples.DeletePartialMatch(prometheus.Labels{"user": userID})
 
+	d.discardedSamplesTooManyHaClusters.DeleteLabelValues(userID)
+	d.discardedSamplesRateLimited.DeleteLabelValues(userID)
+	d.sampleValidationMetrics.DeleteUserMetrics(userID)
+
 	validation.DeletePerUserValidationMetrics(userID, d.log)
 }
 
@@ -588,7 +602,7 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 // The returned error may retain the series labels.
 // It uses the passed nowt time to observe the delay of sample timestamps.
 func (d *Distributor) validateSeries(nowt time.Time, ts mimirpb.PreallocTimeseries, userID string, skipLabelNameValidation bool, minExemplarTS int64) error {
-	if err := validation.ValidateLabels(d.limits, userID, ts.Labels, skipLabelNameValidation); err != nil {
+	if err := validation.ValidateLabels(d.sampleValidationMetrics, d.limits, userID, ts.Labels, skipLabelNameValidation); err != nil {
 		return err
 	}
 
@@ -601,7 +615,7 @@ func (d *Distributor) validateSeries(nowt time.Time, ts mimirpb.PreallocTimeseri
 			d.sampleDelayHistogram.Observe(float64(delta) / 1000)
 		}
 
-		if err := validation.ValidateSample(now, d.limits, userID, ts.Labels, s); err != nil {
+		if err := validation.ValidateSample(d.sampleValidationMetrics, now, d.limits, userID, ts.Labels, s); err != nil {
 			return err
 		}
 	}
@@ -697,7 +711,7 @@ func (d *Distributor) prePushHaDedupeMiddleware(next push.Func) push.Func {
 			}
 
 			if errors.Is(err, tooManyClustersError{}) {
-				validation.DiscardedSamples.WithLabelValues(validation.ReasonTooManyHAClusters, userID).Add(float64(numSamples))
+				d.discardedSamplesTooManyHaClusters.WithLabelValues(userID).Add(float64(numSamples))
 				return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -1034,7 +1048,7 @@ func (d *Distributor) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReq
 
 	totalN := validatedSamples + validatedExemplars + len(validatedMetadata)
 	if !d.ingestionRateLimiter.AllowN(now, userID, totalN) {
-		validation.DiscardedSamples.WithLabelValues(validation.ReasonRateLimited, userID).Add(float64(validatedSamples))
+		d.discardedSamplesRateLimited.WithLabelValues(userID).Add(float64(validatedSamples))
 		validation.DiscardedExemplars.WithLabelValues(validation.ReasonRateLimited, userID).Add(float64(validatedExemplars))
 		validation.DiscardedMetadata.WithLabelValues(validation.ReasonRateLimited, userID).Add(float64(len(validatedMetadata)))
 		// Return a 429 here to tell the client it is going too fast.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -889,22 +889,22 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 	i.appendedExemplarsStats.Inc(int64(succeededExemplarsCount))
 
 	if sampleOutOfBoundsCount > 0 {
-		validation.DiscardedSamples.WithLabelValues(sampleOutOfBounds, userID).Add(float64(sampleOutOfBoundsCount))
+		i.metrics.discardedSamplesSampleOutOfBounds.WithLabelValues(userID).Add(float64(sampleOutOfBoundsCount))
 	}
 	if sampleOutOfOrderCount > 0 {
-		validation.DiscardedSamples.WithLabelValues(sampleOutOfOrder, userID).Add(float64(sampleOutOfOrderCount))
+		i.metrics.discardedSamplesSampleOutOfOrder.WithLabelValues(userID).Add(float64(sampleOutOfOrderCount))
 	}
 	if sampleTooOldCount > 0 {
-		validation.DiscardedSamples.WithLabelValues(sampleTooOld, userID).Add(float64(sampleTooOldCount))
+		i.metrics.discardedSamplesSampleTooOld.WithLabelValues(userID).Add(float64(sampleTooOldCount))
 	}
 	if newValueForTimestampCount > 0 {
-		validation.DiscardedSamples.WithLabelValues(newValueForTimestamp, userID).Add(float64(newValueForTimestampCount))
+		i.metrics.discardedSamplesNewValueForTimestamp.WithLabelValues(userID).Add(float64(newValueForTimestampCount))
 	}
 	if perUserSeriesLimitCount > 0 {
-		validation.DiscardedSamples.WithLabelValues(perUserSeriesLimit, userID).Add(float64(perUserSeriesLimitCount))
+		i.metrics.discardedSamplesPerUserSeriesLimit.WithLabelValues(userID).Add(float64(perUserSeriesLimitCount))
 	}
 	if perMetricSeriesLimitCount > 0 {
-		validation.DiscardedSamples.WithLabelValues(perMetricSeriesLimit, userID).Add(float64(perMetricSeriesLimitCount))
+		i.metrics.discardedSamplesPerMetricSeriesLimit.WithLabelValues(userID).Add(float64(perMetricSeriesLimitCount))
 	}
 	if succeededSamplesCount > 0 {
 		i.ingestionRate.Add(int64(succeededSamplesCount))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -712,8 +712,6 @@ func TestIngester_Push(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			registry := prometheus.NewRegistry()
 
-			registry.MustRegister(validation.DiscardedSamples)
-			validation.DiscardedSamples.Reset()
 			registry.MustRegister(validation.DiscardedMetadata)
 			validation.DiscardedMetadata.Reset()
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type ingesterMetrics struct {
@@ -49,6 +50,14 @@ type ingesterMetrics struct {
 	appenderAddDuration    prometheus.Histogram
 	appenderCommitDuration prometheus.Histogram
 	idleTsdbChecks         *prometheus.CounterVec
+
+	// Discarded samples
+	discardedSamplesSampleOutOfBounds    *prometheus.CounterVec
+	discardedSamplesSampleOutOfOrder     *prometheus.CounterVec
+	discardedSamplesSampleTooOld         *prometheus.CounterVec
+	discardedSamplesNewValueForTimestamp *prometheus.CounterVec
+	discardedSamplesPerUserSeriesLimit   *prometheus.CounterVec
+	discardedSamplesPerMetricSeriesLimit *prometheus.CounterVec
 }
 
 func newIngesterMetrics(
@@ -258,6 +267,13 @@ func newIngesterMetrics(
 		}),
 
 		idleTsdbChecks: idleTsdbChecks,
+
+		discardedSamplesSampleOutOfBounds:    validation.DiscardedSamplesCounter(r, sampleOutOfBounds),
+		discardedSamplesSampleOutOfOrder:     validation.DiscardedSamplesCounter(r, sampleOutOfOrder),
+		discardedSamplesSampleTooOld:         validation.DiscardedSamplesCounter(r, sampleTooOld),
+		discardedSamplesNewValueForTimestamp: validation.DiscardedSamplesCounter(r, newValueForTimestamp),
+		discardedSamplesPerUserSeriesLimit:   validation.DiscardedSamplesCounter(r, perUserSeriesLimit),
+		discardedSamplesPerMetricSeriesLimit: validation.DiscardedSamplesCounter(r, perMetricSeriesLimit),
 	}
 
 	return m
@@ -268,6 +284,13 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.ingestedSamplesFail.DeleteLabelValues(userID)
 	m.memMetadataCreatedTotal.DeleteLabelValues(userID)
 	m.memMetadataRemovedTotal.DeleteLabelValues(userID)
+
+	m.discardedSamplesSampleOutOfBounds.DeleteLabelValues(userID)
+	m.discardedSamplesSampleOutOfOrder.DeleteLabelValues(userID)
+	m.discardedSamplesSampleTooOld.DeleteLabelValues(userID)
+	m.discardedSamplesNewValueForTimestamp.DeleteLabelValues(userID)
+	m.discardedSamplesPerUserSeriesLimit.DeleteLabelValues(userID)
+	m.discardedSamplesPerMetricSeriesLimit.DeleteLabelValues(userID)
 }
 
 func (m *ingesterMetrics) deletePerUserCustomTrackerMetrics(userID string, customTrackerMetrics []string) {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -294,7 +294,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initDistributor() (serv services.Service, err error) {
-	t.API.RegisterDistributor(t.Distributor, t.Cfg.Distributor)
+	t.API.RegisterDistributor(t.Distributor, t.Cfg.Distributor, t.Registerer)
 
 	return nil, nil
 }


### PR DESCRIPTION
#### What this PR does

This is continuation of #2756, it changes discarded samples metric to avoid using `prometheus.DefaultRegisterer`. Opening as draft for discussion.

This also fixes interesting bug in monolithic mode: when distributor is cleaning metrics due to user being inactive, it currently also clears metrics created by ingester, even though ingester may still have TSDB open.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
