### PR TITLE
Backport: Helm: update agent-operator chart to 0.2.5 (#3009)

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Upgrade memcached image tag to `memcached:1.6.16-alpine`. #2740
 * [ENHANCEMENT] Upgrade nginx image tag to `nginxinc/nginx-unprivileged:1.22-alpine`. #2742
 * [ENHANCEMENT] Upgrade minio subchart to `4.0.12`. #2759
+* [ENHANCEMENT] Update agent-operator subchart to `0.2.5`. #3009
 * [BUGFIX] `nginx.extraArgs` are now actually passed to the nginx container. #2336
 * [BUGFIX] Add missing `containerSecurityContext` to alertmanager and tokengen job. #2416
 * [BUGFIX] Add missing `containerSecutiryContext` to memcached exporter containers. #2666

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 4.0.12
 - name: grafana-agent-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.1.12
-digest: sha256:f57498f4a2d3db706e0739d38c877aac74a619a848be29b5b0ca7317ba339be2
-generated: "2022-08-17T11:05:13.740767-04:00"
+  version: 0.2.5
+digest: sha256:5f2b221e2a10dcc2c29840cdec1d6fdf7d5ce4ac2ecf92dec8567a2fa94a4e36
+generated: "2022-09-21T17:15:09.970414-04:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -14,6 +14,6 @@ dependencies:
     condition: minio.enabled
   - name: grafana-agent-operator
     alias: grafana-agent-operator
-    version: 0.1.12
+    version: 0.2.5
     repository: https://grafana.github.io/helm-charts
     condition: metaMonitoring.grafanaAgent.installOperator

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -21,7 +21,7 @@ Kubernetes: `^1.20.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 4.0.12 |
-| https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.1.12 |
+| https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.2.5 |
 
 ## Dependencies
 


### PR DESCRIPTION
#### What this PR does
Backport: Helm: update agent-operator chart to 0.2.5 (#3009)

