### PR TITLE
Added support to forcefully disable recording and/or alerting rules evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@
   * `-store-gateway.sharding-ring.etcd.tls-min-version`
 * [ENHANCEMENT] Store-gateway: Add `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` option to allow requests that exceed the max number of inflight object storage requests to be rejected. #2999
 * [ENHANCEMENT] Query-frontend: allow setting a separate limit on the total (before splitting/sharding) query length of range queries with the new experimental `-query-frontend.max-total-query-length` flag, which defaults to `-store.max-query-length` if unset or set to 0. #3058
+* [ENHANCEMENT] Ruler: added support to forcefully disable recording and/or alerting rules evaluation. The following new configuration options have been introduced, which can be overridden on a per-tenant basis in the runtime configuration: #3088
+  * `-ruler.recording-rules-evaluation-enabled`
+  * `-ruler.alerting-rules-evaluation-enabled`
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3237,6 +3237,28 @@
         },
         {
           "kind": "field",
+          "name": "ruler_recording_rules_evaluation_enabled",
+          "required": false,
+          "desc": "Controls whether recording rules evaluation is enabled. This configuration option can be used to forcefully disable recording rules evaluation on a per-tenant basis.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "ruler.recording-rules-evaluation-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "ruler_alerting_rules_evaluation_enabled",
+          "required": false,
+          "desc": "Controls whether alerting rules evaluation is enabled. This configuration option can be used to forcefully disable alerting rules evaluation on a per-tenant basis.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "ruler.alerting-rules-evaluation-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "store_gateway_tenant_shard_size",
           "required": false,
           "desc": "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1603,6 +1603,8 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift user ID.
   -ruler-storage.swift.username string
     	OpenStack Swift username.
+  -ruler.alerting-rules-evaluation-enabled
+    	[experimental] Controls whether alerting rules evaluation is enabled. This configuration option can be used to forcefully disable alerting rules evaluation on a per-tenant basis. (default true)
   -ruler.alertmanager-client.basic-auth-password string
     	HTTP Basic authentication password. It overrides the password set in the URL (if any).
   -ruler.alertmanager-client.basic-auth-username string
@@ -1723,6 +1725,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -ruler.query-stats-enabled
     	Report the wall time for ruler queries to complete as a per-tenant metric and as an info level log message.
+  -ruler.recording-rules-evaluation-enabled
+    	[experimental] Controls whether recording rules evaluation is enabled. This configuration option can be used to forcefully disable recording rules evaluation on a per-tenant basis. (default true)
   -ruler.resend-delay duration
     	Minimum amount of time to wait before resending an alert to Alertmanager. (default 1m0s)
   -ruler.ring.consul.acl-token string

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -164,6 +164,7 @@ limits:
   max_global_exemplars_per_user: 5000
   query_sharding_total_shards: 16
   query_sharding_max_sharded_queries: 32
+  ingestion_rate: 50000
 
 runtime_config:
   file: ./config/runtime.yaml

--- a/docs/sources/operators-guide/configure/about-versioning.md
+++ b/docs/sources/operators-guide/configure/about-versioning.md
@@ -49,6 +49,9 @@ The following features are currently experimental:
 - Ruler
   - Tenant federation
   - Use query-frontend for rule evaluation
+  - Disable alerting and recording rules evaluation on a per-tenant basis
+    - `-ruler.recording-rules-evaluation-enabled`
+    - `-ruler.alerting-rules-evaluation-enabled`
 - Distributor
   - Metrics relabeling
   - Request rate limit

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2571,6 +2571,18 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -ruler.max-rule-groups-per-tenant
 [ruler_max_rule_groups_per_tenant: <int> | default = 70]
 
+# (experimental) Controls whether recording rules evaluation is enabled. This
+# configuration option can be used to forcefully disable recording rules
+# evaluation on a per-tenant basis.
+# CLI flag: -ruler.recording-rules-evaluation-enabled
+[ruler_recording_rules_evaluation_enabled: <boolean> | default = true]
+
+# (experimental) Controls whether alerting rules evaluation is enabled. This
+# configuration option can be used to forcefully disable alerting rules
+# evaluation on a per-tenant basis.
+# CLI flag: -ruler.alerting-rules-evaluation-enabled
+[ruler_alerting_rules_evaluation_enabled: <boolean> | default = true]
+
 # The tenant's shard size, used when store-gateway sharding is enabled. Value of
 # 0 disables shuffle sharding for the tenant, that is all tenant blocks are
 # sharded across all store-gateway replicas.

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -36,7 +36,7 @@ func TestRuler(t *testing.T) {
 
 	testCases := map[string]struct {
 		configuredRules rulespb.RuleGroupList
-		limits          *validation.Overrides
+		limits          RulesLimits
 		expectedRules   []*RuleGroup
 	}{
 		"should load and evaluate the configured rules": {

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
@@ -28,125 +29,201 @@ import (
 )
 
 func TestRuler(t *testing.T) {
+	const (
+		userID   = "user1"
+		interval = time.Minute
+	)
+
 	testCases := map[string]struct {
-		mockRules        map[string]rulespb.RuleGroupList
-		userID           string
-		expectedResponse response
+		configuredRules rulespb.RuleGroupList
+		limits          *validation.Overrides
+		expectedRules   []*RuleGroup
 	}{
-		"rules": {
-			mockRules: mockRules,
-			userID:    "user1",
-			expectedResponse: response{
-				Status: "success",
-				Data: &RuleDiscovery{
-					RuleGroups: []*RuleGroup{
-						{
-							Name: "group1",
-							File: "namespace1",
-							Rules: []rule{
-								&recordingRule{
-									Name:   "UP_RULE",
-									Query:  "up",
-									Health: "unknown",
-									Type:   "recording",
-								},
-								&alertingRule{
-									Name:   "UP_ALERT",
-									Query:  "up < 1",
-									State:  "inactive",
-									Health: "unknown",
-									Type:   "alerting",
-									Alerts: []*Alert{},
-								},
-							},
-							Interval: 60,
+		"should load and evaluate the configured rules": {
+			configuredRules: rulespb.RuleGroupList{
+				&rulespb.RuleGroupDesc{
+					Name:      "group1",
+					Namespace: "namespace1",
+					User:      userID,
+					Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+					Interval:  interval,
+				},
+			},
+			limits: validation.MockDefaultOverrides(),
+			expectedRules: []*RuleGroup{
+				{
+					Name: "group1",
+					File: "namespace1",
+					Rules: []rule{
+						&recordingRule{
+							Name:   "UP_RULE",
+							Query:  "up",
+							Health: "unknown",
+							Type:   "recording",
+						},
+						&alertingRule{
+							Name:   "UP_ALERT",
+							Query:  "up < 1",
+							State:  "inactive",
+							Health: "unknown",
+							Type:   "alerting",
+							Alerts: []*Alert{},
 						},
 					},
+					Interval: 60,
 				},
 			},
 		},
-		"rules special characters": {
-			mockRules: mockSpecialCharRules,
-			userID:    "user1",
-			expectedResponse: response{
-				Status: "success",
-				Data: &RuleDiscovery{
-					RuleGroups: []*RuleGroup{
-						{
-							Name: ")(_+?/|group1+/?",
-							File: ")(_+?/|namespace1+/?",
-							Rules: []rule{
-								&recordingRule{
-									Name:   "UP_RULE",
-									Query:  "up",
-									Health: "unknown",
-									Type:   "recording",
-								},
-								&alertingRule{
-									Name:   "UP_ALERT",
-									Query:  "up < 1",
-									State:  "inactive",
-									Health: "unknown",
-									Type:   "alerting",
-									Alerts: []*Alert{},
-								},
-							},
-							Interval: 60,
+		"should load and evaluate only recording rules if alerting rules evaluation is disabled for the tenant": {
+			configuredRules: rulespb.RuleGroupList{
+				&rulespb.RuleGroupDesc{
+					Name:      "group1",
+					Namespace: "namespace1",
+					User:      userID,
+					Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+					Interval:  interval,
+				},
+			},
+			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits[userID] = validation.MockDefaultLimits()
+				tenantLimits[userID].RulerRecordingRulesEvaluationEnabled = true
+				tenantLimits[userID].RulerAlertingRulesEvaluationEnabled = false
+			}),
+			expectedRules: []*RuleGroup{
+				{
+					Name: "group1",
+					File: "namespace1",
+					Rules: []rule{
+						&recordingRule{
+							Name:   "UP_RULE",
+							Query:  "up",
+							Health: "unknown",
+							Type:   "recording",
 						},
 					},
+					Interval: 60,
 				},
 			},
 		},
-		"federated rules": {
-			userID: "user1",
-			mockRules: map[string]rulespb.RuleGroupList{
-				"user1": {
-					&rulespb.RuleGroupDesc{
-						Name:          "group1",
-						Namespace:     "namespace1",
-						User:          "user1",
-						SourceTenants: []string{"tenant-1"},
-						Rules: []*rulespb.RuleDesc{
-							{
-								Record: "UP_RULE",
-								Expr:   "up",
-							},
-							{
-								Alert: "UP_ALERT",
-								Expr:  "up < 1",
-							},
-						},
-						Interval: interval,
-					},
+		"should load and evaluate only alerting rules if recording rules evaluation is disabled for the tenant": {
+			configuredRules: rulespb.RuleGroupList{
+				&rulespb.RuleGroupDesc{
+					Name:      "group1",
+					Namespace: "namespace1",
+					User:      userID,
+					Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+					Interval:  interval,
 				},
 			},
-			expectedResponse: response{
-				Status: "success",
-				Data: &RuleDiscovery{
-					RuleGroups: []*RuleGroup{
-						{
-							Name:          "group1",
-							File:          "namespace1",
-							SourceTenants: []string{"tenant-1"},
-							Rules: []rule{
-								&recordingRule{
-									Name:   "UP_RULE",
-									Query:  "up",
-									Health: "unknown",
-									Type:   "recording",
-								},
-								&alertingRule{
-									Name:   "UP_ALERT",
-									Query:  "up < 1",
-									State:  "inactive",
-									Health: "unknown",
-									Type:   "alerting",
-									Alerts: []*Alert{},
-								},
-							},
-							Interval: 60,
+			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits[userID] = validation.MockDefaultLimits()
+				tenantLimits[userID].RulerRecordingRulesEvaluationEnabled = false
+				tenantLimits[userID].RulerAlertingRulesEvaluationEnabled = true
+			}),
+			expectedRules: []*RuleGroup{
+				{
+					Name: "group1",
+					File: "namespace1",
+					Rules: []rule{
+						&alertingRule{
+							Name:   "UP_ALERT",
+							Query:  "up < 1",
+							State:  "inactive",
+							Health: "unknown",
+							Type:   "alerting",
+							Alerts: []*Alert{},
 						},
 					},
+					Interval: 60,
+				},
+			},
+		},
+		"should load and evaluate no rules if rules evaluation is disabled for the tenant": {
+			configuredRules: rulespb.RuleGroupList{
+				&rulespb.RuleGroupDesc{
+					Name:      "group1",
+					Namespace: "namespace1",
+					User:      userID,
+					Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+					Interval:  interval,
+				},
+			},
+			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits[userID] = validation.MockDefaultLimits()
+				tenantLimits[userID].RulerRecordingRulesEvaluationEnabled = false
+				tenantLimits[userID].RulerAlertingRulesEvaluationEnabled = false
+			}),
+			expectedRules: []*RuleGroup{},
+		},
+		"should load and evaluate the configured rules with special characters": {
+			configuredRules: rulespb.RuleGroupList{
+				&rulespb.RuleGroupDesc{
+					Name:      ")(_+?/|group1+/?",
+					Namespace: ")(_+?/|namespace1+/?",
+					User:      userID,
+					Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+					Interval:  interval,
+				},
+			},
+			limits: validation.MockDefaultOverrides(),
+			expectedRules: []*RuleGroup{
+				{
+					Name: ")(_+?/|group1+/?",
+					File: ")(_+?/|namespace1+/?",
+					Rules: []rule{
+						&recordingRule{
+							Name:   "UP_RULE",
+							Query:  "up",
+							Health: "unknown",
+							Type:   "recording",
+						},
+						&alertingRule{
+							Name:   "UP_ALERT",
+							Query:  "up < 1",
+							State:  "inactive",
+							Health: "unknown",
+							Type:   "alerting",
+							Alerts: []*Alert{},
+						},
+					},
+					Interval: 60,
+				},
+			},
+		},
+		"should support federated rules": {
+			configuredRules: rulespb.RuleGroupList{
+				&rulespb.RuleGroupDesc{
+					Name:          "group1",
+					Namespace:     "namespace1",
+					User:          userID,
+					SourceTenants: []string{"tenant-1"},
+					Rules:         []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+					Interval:      interval,
+				},
+			},
+			limits: validation.MockDefaultOverrides(),
+			expectedRules: []*RuleGroup{
+				{
+					Name:          "group1",
+					File:          "namespace1",
+					SourceTenants: []string{"tenant-1"},
+					Rules: []rule{
+						&recordingRule{
+							Name:   "UP_RULE",
+							Query:  "up",
+							Health: "unknown",
+							Type:   "recording",
+						},
+						&alertingRule{
+							Name:   "UP_ALERT",
+							Query:  "up < 1",
+							State:  "inactive",
+							Health: "unknown",
+							Type:   "alerting",
+							Alerts: []*Alert{},
+						},
+					},
+					Interval: 60,
 				},
 			},
 		},
@@ -154,31 +231,36 @@ func TestRuler(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			// Pre-condition check: ensure all rules have the user set.
+			for _, rule := range tc.configuredRules {
+				assert.Equal(t, userID, rule.User)
+			}
+
 			cfg := defaultRulerConfig(t)
 			cfg.TenantFederation.Enabled = true
 
 			rulerAddrMap := map[string]*Ruler{}
 
-			r := prepareRuler(t, cfg, newMockRuleStore(tc.mockRules), withRulerAddrMap(rulerAddrMap))
-			require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-			t.Cleanup(func() {
-				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), r))
-			})
+			storageRules := map[string]rulespb.RuleGroupList{
+				userID: tc.configuredRules,
+			}
+
+			r := prepareRuler(t, cfg, newMockRuleStore(storageRules), withRulerAddrMap(rulerAddrMap), withLimits(tc.limits), withStart())
 
 			// Make sure mock grpc client can find this instance, based on instance address registered in the ring.
 			rulerAddrMap[r.lifecycler.GetInstanceAddr()] = r
 
 			// Rules will be synchronized asynchronously, so we wait until the expected number of rule groups
 			// has been synched.
-			test.Poll(t, 5*time.Second, len(tc.mockRules[tc.userID]), func() interface{} {
-				ctx := user.InjectOrgID(context.Background(), tc.userID)
+			test.Poll(t, 5*time.Second, len(tc.expectedRules), func() interface{} {
+				ctx := user.InjectOrgID(context.Background(), userID)
 				rls, _ := r.Rules(ctx, &RulesRequest{})
 				return len(rls.Groups)
 			})
 
 			a := NewAPI(r, r.store, log.NewNopLogger())
 
-			req := requestFor(t, http.MethodGet, "https://localhost:8080/prometheus/api/v1/rules", nil, tc.userID)
+			req := requestFor(t, http.MethodGet, "https://localhost:8080/prometheus/api/v1/rules", nil, userID)
 			w := httptest.NewRecorder()
 			a.PrometheusRules(w, req)
 
@@ -193,7 +275,13 @@ func TestRuler(t *testing.T) {
 			require.Equal(t, responseJSON.Status, "success")
 
 			// Testing the running rules
-			expectedResponse, err := json.Marshal(tc.expectedResponse)
+			expectedResponse, err := json.Marshal(response{
+				Status: "success",
+				Data: &RuleDiscovery{
+					RuleGroups: tc.expectedRules,
+				},
+			})
+
 			require.NoError(t, err)
 			require.Equal(t, string(expectedResponse), string(body))
 		})
@@ -349,33 +437,15 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 				Name:      "group1",
 				Namespace: "namespace1",
 				User:      "user1",
-				Rules: []*rulespb.RuleDesc{
-					{
-						Record: "UP_RULE",
-						Expr:   "up",
-					},
-					{
-						Alert: "UP_ALERT",
-						Expr:  "up < 1",
-					},
-				},
-				Interval: interval,
+				Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+				Interval:  interval,
 			},
 			&rulespb.RuleGroupDesc{
 				Name:      "fail",
 				Namespace: "namespace2",
 				User:      "user1",
-				Rules: []*rulespb.RuleDesc{
-					{
-						Record: "UP2_RULE",
-						Expr:   "up",
-					},
-					{
-						Alert: "UP2_ALERT",
-						Expr:  "up < 1",
-					},
-				},
-				Interval: interval,
+				Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP2_RULE", "up"), mockAlertingRuleDesc("UP2_ALERT", "up < 1")},
+				Interval:  interval,
 			},
 		},
 	}
@@ -415,7 +485,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 func TestRuler_LimitsPerGroup(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits) {
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
 	})))
@@ -468,7 +538,7 @@ rules:
 func TestRuler_RulerGroupLimits(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits) {
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
 	})))

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -120,6 +120,8 @@ type RulesLimits interface {
 	RulerTenantShardSize(userID string) int
 	RulerMaxRuleGroupsPerTenant(userID string) int
 	RulerMaxRulesPerRuleGroup(userID string) int
+	RulerRecordingRulesEvaluationEnabled(userID string) bool
+	RulerAlertingRulesEvaluationEnabled(userID string) bool
 }
 
 func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Counter) rules.QueryFunc {

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -134,8 +134,7 @@ func TestPusherErrors(t *testing.T) {
 
 			writes := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 			failures := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-
-			limits := validation.MockOverrides(func(defaults *validation.Limits) {
+			limits := validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 				defaults.RulerEvaluationDelay = 0
 			})
 
@@ -261,10 +260,7 @@ func TestRecordAndReportRuleQueryMetrics(t *testing.T) {
 func TestManagerFactory_CorrectQueryableUsed(t *testing.T) {
 	const userID = "tenant-1"
 
-	dummyRules := []*rulespb.RuleDesc{{
-		Expr:   "sum(up)",
-		Record: "sum:up",
-	}}
+	dummyRules := []*rulespb.RuleDesc{mockRecordingRuleDesc("sum:up", "sum(up)")}
 
 	testCases := map[string]struct {
 		ruleGroup rulespb.RuleGroupDesc

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -642,6 +642,13 @@ func filterRuleGroupsByEnabled(configs map[string]rulespb.RuleGroupList, limits 
 
 		// Quick case: remove the user at all if all rules are disabled.
 		if !recordingEnabled && !alertingEnabled {
+			// We don't expect rules evaluation to be disabled for the normal use case. For this reason,
+			// when it's disabled we prefer to log it with "info" instead of "debug" to make it more visible.
+			level.Info(logger).Log(
+				"msg", "filtered out all rules because evaluation is disabled for the tenant",
+				"user", userID,
+				"recording_rules_enabled", recordingEnabled,
+				"alerting_rules_enabled", alertingEnabled)
 			continue
 		}
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1147,14 +1147,14 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 		"should remove alerting rules if disabled for a given tenant": {
 			configs: map[string]rulespb.RuleGroupList{
 				"user-1": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-1", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-1", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-1", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
@@ -1164,27 +1164,27 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 			}),
 			expected: map[string]rulespb.RuleGroupList{
 				"user-1": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
+					mockRuleGroup("group-1", "user-1", mockRecordingRuleDesc("record:1", "1"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-1", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
 				},
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 		},
 		"should remove recording rules if disabled for a given tenant": {
 			configs: map[string]rulespb.RuleGroupList{
 				"user-1": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-1", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-1", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-1", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
@@ -1194,27 +1194,27 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 			}),
 			expected: map[string]rulespb.RuleGroupList{
 				"user-1": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-2", "2")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-1", mockAlertingRuleDesc("alert-2", "2")),
+					mockRuleGroup("group-3", "user-1", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 		},
 		"should remove all config for a user if both recording and alerting rules are disabled": {
 			configs: map[string]rulespb.RuleGroupList{
 				"user-1": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-1", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-1", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-1", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
@@ -1224,23 +1224,23 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 			}),
 			expected: map[string]rulespb.RuleGroupList{
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 		},
 		"should remove configs for all users if both recording and alerting rules are disabled for every user": {
 			configs: map[string]rulespb.RuleGroupList{
 				"user-1": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-1", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-1", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-1", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 				"user-2": {
-					{Name: "group-1", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")}},
-					{Name: "group-2", Rules: []*rulespb.RuleDesc{mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")}},
-					{Name: "group-3", Rules: []*rulespb.RuleDesc{mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")}},
+					mockRuleGroup("group-1", "user-2", mockRecordingRuleDesc("record:1", "1"), mockAlertingRuleDesc("alert-2", "2"), mockRecordingRuleDesc("record:3", "3")),
+					mockRuleGroup("group-2", "user-2", mockRecordingRuleDesc("record:4", "4"), mockRecordingRuleDesc("record:5", "5")),
+					mockRuleGroup("group-3", "user-2", mockAlertingRuleDesc("alert-6", "6"), mockAlertingRuleDesc("alert-7", "7")),
 				},
 			},
 			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
@@ -1255,12 +1255,89 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			logger := log.NewNopLogger()
 
-			allocs := testing.AllocsPerRun(1, func() {
-				filterRuleGroupsByEnabled(testData.configs, testData.limits, logger)
-			})
+			actual := filterRuleGroupsByEnabled(testData.configs, testData.limits, logger)
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}
 
-			assert.Equal(t, testData.expected, testData.configs)
-			assert.Equal(t, 0., allocs)
+func BenchmarkFilterRuleGroupsByEnabled(b *testing.B) {
+	const (
+		numTenants                    = 1000
+		numRuleGroupsPerTenant        = 10
+		numRecordingRulesPerRuleGroup = 10
+		numAlertingRulesPerRuleGroup  = 10
+	)
+
+	var (
+		logger = log.NewNopLogger()
+	)
+
+	b.Logf("total number of rules: %d", numTenants*numRuleGroupsPerTenant*(numRecordingRulesPerRuleGroup+numAlertingRulesPerRuleGroup))
+
+	// Utility used to create the ruler configs.
+	buildConfigs := func() map[string]rulespb.RuleGroupList {
+		configs := make(map[string]rulespb.RuleGroupList, numTenants)
+
+		for t := 0; t < numTenants; t++ {
+			tenantID := fmt.Sprintf("tenant-%d", t)
+			configs[tenantID] = make(rulespb.RuleGroupList, 0, numRuleGroupsPerTenant)
+
+			for g := 0; g < numRuleGroupsPerTenant; g++ {
+				group := &rulespb.RuleGroupDesc{
+					User:  tenantID,
+					Name:  fmt.Sprintf("group-%d", g),
+					Rules: make([]*rulespb.RuleDesc, 0, numRecordingRulesPerRuleGroup+numAlertingRulesPerRuleGroup),
+				}
+
+				for r := 0; r < numRecordingRulesPerRuleGroup; r++ {
+					group.Rules = append(group.Rules, mockRecordingRuleDesc(fmt.Sprintf("record:%d", r), "count(up)"))
+				}
+
+				for r := 0; r < numAlertingRulesPerRuleGroup; r++ {
+					group.Rules = append(group.Rules, mockAlertingRuleDesc(fmt.Sprintf("alert-%d", r), "count(up)"))
+				}
+
+				configs[tenantID] = append(configs[tenantID], group)
+			}
+		}
+
+		return configs
+	}
+
+	tests := map[string]struct {
+		limits RulesLimits
+	}{
+		"all rules enabled": {
+			limits: validation.MockDefaultOverrides(),
+		},
+		"recording rules disabled": {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				defaults.RulerRecordingRulesEvaluationEnabled = false
+			}),
+		},
+		"alerting rules disabled": {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				defaults.RulerAlertingRulesEvaluationEnabled = false
+			}),
+		},
+		"all rules disabled": {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				defaults.RulerRecordingRulesEvaluationEnabled = false
+				defaults.RulerAlertingRulesEvaluationEnabled = false
+			}),
+		},
+	}
+
+	for testName, testData := range tests {
+		b.Run(testName, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				// The CPU/mem required to build the initial config is taken in account too.
+				// Unfortunately if build it upfront and then reset the timer after building it,
+				// the filterRuleGroupsByEnabled() (in-place replacement version) is so fast that
+				// the benchmark will run a very high b.N  which will in turn exhaust the memory.
+				filterRuleGroupsByEnabled(buildConfigs(), testData.limits, logger)
+			}
 		})
 	}
 }
@@ -1276,5 +1353,18 @@ func mockAlertingRuleDesc(alert, expr string) *rulespb.RuleDesc {
 	return &rulespb.RuleDesc{
 		Alert: alert,
 		Expr:  expr,
+	}
+}
+
+// mockRuleGroup creates a rule group filling in all fields, so that we can use it in tests to check if all fields
+// are copied when a rule group is cloned.
+func mockRuleGroup(name, user string, rules ...*rulespb.RuleDesc) *rulespb.RuleGroupDesc {
+	return &rulespb.RuleGroupDesc{
+		Name:          name,
+		Namespace:     "test",
+		Interval:      time.Minute,
+		Rules:         rules,
+		User:          user,
+		SourceTenants: []string{user},
 	}
 }

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -30,17 +30,8 @@ var (
 				Name:      "group1",
 				Namespace: "namespace1",
 				User:      "user1",
-				Rules: []*rulespb.RuleDesc{
-					{
-						Record: "UP_RULE",
-						Expr:   "up",
-					},
-					{
-						Alert: "UP_ALERT",
-						Expr:  "up < 1",
-					},
-				},
-				Interval: interval,
+				Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up"), mockAlertingRuleDesc("UP_ALERT", "up < 1")},
+				Interval:  interval,
 			},
 		},
 		"user2": {
@@ -48,34 +39,8 @@ var (
 				Name:      "group1",
 				Namespace: "namespace1",
 				User:      "user2",
-				Rules: []*rulespb.RuleDesc{
-					{
-						Record: "UP_RULE",
-						Expr:   "up",
-					},
-				},
-				Interval: interval,
-			},
-		},
-	}
-
-	mockSpecialCharRules = map[string]rulespb.RuleGroupList{
-		"user1": {
-			&rulespb.RuleGroupDesc{
-				Name:      ")(_+?/|group1+/?",
-				Namespace: ")(_+?/|namespace1+/?",
-				User:      "user1",
-				Rules: []*rulespb.RuleDesc{
-					{
-						Record: "UP_RULE",
-						Expr:   "up",
-					},
-					{
-						Alert: "UP_ALERT",
-						Expr:  "up < 1",
-					},
-				},
-				Interval: interval,
+				Rules:     []*rulespb.RuleDesc{mockRecordingRuleDesc("UP_RULE", "up")},
+				Interval:  interval,
 			},
 		},
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -129,10 +129,12 @@ type Limits struct {
 	LabelValuesMaxCardinalityLabelNamesPerRequest int  `yaml:"label_values_max_cardinality_label_names_per_request" json:"label_values_max_cardinality_label_names_per_request"`
 
 	// Ruler defaults and limits.
-	RulerEvaluationDelay        model.Duration `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
-	RulerTenantShardSize        int            `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
-	RulerMaxRulesPerRuleGroup   int            `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
-	RulerMaxRuleGroupsPerTenant int            `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
+	RulerEvaluationDelay                 model.Duration `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
+	RulerTenantShardSize                 int            `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroup            int            `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
+	RulerMaxRuleGroupsPerTenant          int            `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
+	RulerRecordingRulesEvaluationEnabled bool           `yaml:"ruler_recording_rules_evaluation_enabled" json:"ruler_recording_rules_evaluation_enabled" category:"experimental"`
+	RulerAlertingRulesEvaluationEnabled  bool           `yaml:"ruler_alerting_rules_evaluation_enabled" json:"ruler_alerting_rules_evaluation_enabled" category:"experimental"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
@@ -219,6 +221,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.")
 	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 20, "Maximum number of rules per rule group per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 70, "Maximum number of rule groups per-tenant. 0 to disable.")
+	f.BoolVar(&l.RulerRecordingRulesEvaluationEnabled, "ruler.recording-rules-evaluation-enabled", true, "Controls whether recording rules evaluation is enabled. This configuration option can be used to forcefully disable recording rules evaluation on a per-tenant basis.")
+	f.BoolVar(&l.RulerAlertingRulesEvaluationEnabled, "ruler.alerting-rules-evaluation-enabled", true, "Controls whether alerting rules evaluation is enabled. This configuration option can be used to forcefully disable alerting rules evaluation on a per-tenant basis.")
 
 	f.Var(&l.CompactorBlocksRetentionPeriod, "compactor.blocks-retention-period", "Delete blocks containing samples older than the specified retention period. 0 to disable.")
 	f.IntVar(&l.CompactorSplitAndMergeShards, "compactor.split-and-merge-shards", 0, "The number of shards to use when splitting blocks. 0 to disable splitting.")
@@ -611,6 +615,16 @@ func (o *Overrides) RulerMaxRulesPerRuleGroup(userID string) int {
 // RulerMaxRuleGroupsPerTenant returns the maximum number of rule groups for a given user.
 func (o *Overrides) RulerMaxRuleGroupsPerTenant(userID string) int {
 	return o.getOverridesForUser(userID).RulerMaxRuleGroupsPerTenant
+}
+
+// RulerRecordingRulesEvaluationEnabled returns whether the recording rules evaluation is enabled for a given user.
+func (o *Overrides) RulerRecordingRulesEvaluationEnabled(userID string) bool {
+	return o.getOverridesForUser(userID).RulerRecordingRulesEvaluationEnabled
+}
+
+// RulerAlertingRulesEvaluationEnabled returns whether the alerting rules evaluation is enabled for a given user.
+func (o *Overrides) RulerAlertingRulesEvaluationEnabled(userID string) bool {
+	return o.getOverridesForUser(userID).RulerAlertingRulesEvaluationEnabled
 }
 
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -28,12 +28,29 @@ func (l *mockTenantLimits) AllByUserID() map[string]*Limits {
 	return l.limits
 }
 
-func MockOverrides(customize func(defaults *Limits)) *Overrides {
+func MockOverrides(customize func(defaults *Limits, tenantLimits map[string]*Limits)) *Overrides {
+	defaults := MockDefaultLimits()
+	tenantLimits := map[string]*Limits{}
+	customize(defaults, tenantLimits)
+
+	overrides, err := NewOverrides(*defaults, NewMockTenantLimits(tenantLimits))
+	if err != nil {
+		// This function is expected to be used only in tests, so we're not afraid of panicking.
+		panic(err)
+	}
+
+	return overrides
+}
+
+func MockDefaultLimits() *Limits {
 	defaults := Limits{}
 	flagext.DefaultValues(&defaults)
-	customize(&defaults)
+	return &defaults
+}
 
-	overrides, err := NewOverrides(defaults, nil)
+func MockDefaultOverrides() *Overrides {
+	defaults := MockDefaultLimits()
+	overrides, err := NewOverrides(*defaults, nil)
 	if err != nil {
 		// This function is expected to be used only in tests, so we're not afraid of panicking.
 		panic(err)


### PR DESCRIPTION
#### What this PR does
I'm working on a tenants migration between two Mimir cluster and, as part of this migration, I need to selectively disable alerting rules for specific tenants. Instead of doing an hack in the ruler, I thought it could be generally useful having some advanced settings to forcefully disable recording and/or alerting rules evaluation on a per-tenant basis.

Note to reviewers:
- I think the only risky change in this PR is that the new function `filterRuleGroupsByEnabled()` manipulates the rules configuration in place. I've done it in place to avoid memory allocations at all. I checked both the bucket and local storage implementations and I don't think it will introduce issues, because both of them return a fresh map/slice each time. However, GEM also uses a custom rules manager and, even if I think it's not an issue today, this in-place manipulation could potentially introduce subtle bugs in the future. If you don't have concerns about introducing some memory allocations when rules evaluation is disabled, then I would suggest make some copies just to be safe.
- I did some refactoring in `TestRuler` to avoid using global variables and clean it up a bit

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
