### PR TITLE
Chore: refactor ruler tests initialization

### DIFF
--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -159,7 +159,7 @@ func TestRuler(t *testing.T) {
 
 			rulerAddrMap := map[string]*Ruler{}
 
-			r := buildRuler(t, cfg, newMockRuleStore(tc.mockRules), rulerAddrMap)
+			r := prepareRuler(t, cfg, newMockRuleStore(tc.mockRules), rulerAddrMap)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 			t.Cleanup(func() {
 				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), r))
@@ -206,7 +206,7 @@ func TestRuler_alerts(t *testing.T) {
 
 	rulerAddrMap := map[string]*Ruler{}
 
-	r := buildRuler(t, cfg, newMockRuleStore(mockRules), rulerAddrMap)
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRules), rulerAddrMap)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 	t.Cleanup(func() {
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), r))
@@ -254,7 +254,7 @@ func TestRuler_alerts(t *testing.T) {
 func TestRuler_Create(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	tc := []struct {
@@ -380,7 +380,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 		},
 	}
 
-	r := buildRuler(t, cfg, newMockRuleStore(mockRulesNamespaces), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRulesNamespaces), nil, withStart())
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	router := mux.NewRouter()
@@ -415,7 +415,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 func TestRuler_LimitsPerGroup(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
 	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
@@ -469,7 +469,7 @@ rules:
 func TestRuler_RulerGroupLimits(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
 	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -415,11 +415,10 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 func TestRuler_LimitsPerGroup(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart())
-	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
-	})
+	})))
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
@@ -469,11 +468,10 @@ rules:
 func TestRuler_RulerGroupLimits(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart())
-	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
-	})
+	})))
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -254,7 +254,7 @@ func TestRuler_alerts(t *testing.T) {
 func TestRuler_Create(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildAndStartRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+	r := buildRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	tc := []struct {
@@ -380,7 +380,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 		},
 	}
 
-	r := buildAndStartRuler(t, cfg, newMockRuleStore(mockRulesNamespaces))
+	r := buildRuler(t, cfg, newMockRuleStore(mockRulesNamespaces), nil, withStart())
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	router := mux.NewRouter()
@@ -415,7 +415,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 func TestRuler_LimitsPerGroup(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildAndStartRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+	r := buildRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
 	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
@@ -469,7 +469,7 @@ rules:
 func TestRuler_RulerGroupLimits(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildAndStartRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
+	r := buildRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
 	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaveworks/common/user"
 
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 func TestRuler(t *testing.T) {
@@ -415,7 +416,10 @@ func TestRuler_LimitsPerGroup(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
 	r := buildAndStartRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
+	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
+		defaults.RulerMaxRuleGroupsPerTenant = 1
+		defaults.RulerMaxRulesPerRuleGroup = 1
+	})
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
@@ -466,7 +470,10 @@ func TestRuler_RulerGroupLimits(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
 	r := buildAndStartRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
+	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
+		defaults.RulerMaxRuleGroupsPerTenant = 1
+		defaults.RulerMaxRulesPerRuleGroup = 1
+	})
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -159,7 +159,7 @@ func TestRuler(t *testing.T) {
 
 			rulerAddrMap := map[string]*Ruler{}
 
-			r := prepareRuler(t, cfg, newMockRuleStore(tc.mockRules), rulerAddrMap)
+			r := prepareRuler(t, cfg, newMockRuleStore(tc.mockRules), withRulerAddrMap(rulerAddrMap))
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 			t.Cleanup(func() {
 				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), r))
@@ -206,7 +206,7 @@ func TestRuler_alerts(t *testing.T) {
 
 	rulerAddrMap := map[string]*Ruler{}
 
-	r := prepareRuler(t, cfg, newMockRuleStore(mockRules), rulerAddrMap)
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRules), withRulerAddrMap(rulerAddrMap))
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 	t.Cleanup(func() {
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), r))
@@ -254,7 +254,7 @@ func TestRuler_alerts(t *testing.T) {
 func TestRuler_Create(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart())
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	tc := []struct {
@@ -380,7 +380,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 		},
 	}
 
-	r := prepareRuler(t, cfg, newMockRuleStore(mockRulesNamespaces), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRulesNamespaces), withStart())
 	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	router := mux.NewRouter()
@@ -415,7 +415,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 func TestRuler_LimitsPerGroup(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart())
 	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
@@ -469,7 +469,7 @@ rules:
 func TestRuler_RulerGroupLimits(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart())
 	r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -310,7 +310,8 @@ func TestManagerFactory_CorrectQueryableUsed(t *testing.T) {
 
 			// setup
 			cfg := defaultRulerConfig(t)
-			_, _, pusher, logger, overrides := testSetup()
+			_, _, pusher, logger := testSetup()
+			options := applyPrepareOptions()
 			notifierManager := notifier.NewManager(&notifier.Options{Do: func(_ context.Context, _ *http.Client, _ *http.Request) (*http.Response, error) { return nil, nil }}, logger)
 			ruleFiles := writeRuleGroupToFiles(t, cfg.RulePath, logger, userID, tc.ruleGroup)
 			regularQueryable, federatedQueryable := newMockQueryable(), newMockQueryable()
@@ -327,7 +328,7 @@ func TestManagerFactory_CorrectQueryableUsed(t *testing.T) {
 			queryFunc := TenantFederationQueryFunc(regularQueryFunc, federatedQueryFunc)
 
 			// create and use manager factory
-			managerFactory := DefaultTenantManagerFactory(cfg, pusher, federatedQueryable, queryFunc, overrides, nil)
+			managerFactory := DefaultTenantManagerFactory(cfg, pusher, federatedQueryable, queryFunc, options.limits, nil)
 
 			manager := managerFactory(context.Background(), userID, notifierManager, logger, nil)
 

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type fakePusher struct {
@@ -134,7 +135,11 @@ func TestPusherErrors(t *testing.T) {
 			writes := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 			failures := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 
-			pa := NewPusherAppendable(pusher, "user-1", ruleLimits{evalDelay: 10 * time.Second}, writes, failures)
+			limits := validation.MockOverrides(func(defaults *validation.Limits) {
+				defaults.RulerEvaluationDelay = 0
+			})
+
+			pa := NewPusherAppendable(pusher, "user-1", limits, writes, failures)
 
 			lbls, err := parser.ParseMetric("foo_bar")
 			require.NoError(t, err)

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -23,7 +23,7 @@ func TestRulerShutdown(t *testing.T) {
 	ctx := context.Background()
 
 	config := defaultRulerConfig(t)
-	r := prepareRuler(t, config, newMockRuleStore(mockRules), nil)
+	r := prepareRuler(t, config, newMockRuleStore(mockRules))
 
 	kvStore := config.Ring.KVStore.Mock
 
@@ -54,7 +54,7 @@ func TestRuler_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 	cfg.Ring.HeartbeatPeriod = 100 * time.Millisecond
 	cfg.Ring.HeartbeatTimeout = heartbeatTimeout
 
-	r := prepareRuler(t, cfg, newMockRuleStore(mockRules), nil)
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRules))
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
 	defer services.StopAndAwaitTerminated(ctx, r) //nolint:errcheck

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -23,7 +23,7 @@ func TestRulerShutdown(t *testing.T) {
 	ctx := context.Background()
 
 	config := defaultRulerConfig(t)
-	r := buildRuler(t, config, newMockRuleStore(mockRules), nil)
+	r := prepareRuler(t, config, newMockRuleStore(mockRules), nil)
 
 	kvStore := config.Ring.KVStore.Mock
 
@@ -54,7 +54,7 @@ func TestRuler_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 	cfg.Ring.HeartbeatPeriod = 100 * time.Millisecond
 	cfg.Ring.HeartbeatTimeout = heartbeatTimeout
 
-	r := buildRuler(t, cfg, newMockRuleStore(mockRules), nil)
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRules), nil)
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
 	defer services.StopAndAwaitTerminated(ctx, r) //nolint:errcheck

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -154,6 +154,13 @@ func withStart() prepareOption {
 	}
 }
 
+// withLimits is a prepareOption that overrides the limits used in the test.
+func withLimits(limits RulesLimits) prepareOption {
+	return func(opts *prepareOptions) {
+		opts.limits = limits
+	}
+}
+
 // withRulerAddrMap is a prepareOption that configures the mapping between rulers and their network addresses.
 func withRulerAddrMap(addrs map[string]*Ruler) prepareOption {
 	return func(opts *prepareOptions) {
@@ -390,11 +397,10 @@ func TestGetRules(t *testing.T) {
 					},
 				}
 
-				r := prepareRuler(t, cfg, storage, withRulerAddrMap(rulerAddrMap))
-				r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
+				r := prepareRuler(t, cfg, storage, withRulerAddrMap(rulerAddrMap), withLimits(validation.MockOverrides(func(defaults *validation.Limits) {
 					defaults.RulerEvaluationDelay = 0
 					defaults.RulerTenantShardSize = tc.shuffleShardSize
-				})
+				})))
 
 				rulerAddrMap[id] = r
 				if r.ring != nil {
@@ -834,11 +840,10 @@ func TestSharding(t *testing.T) {
 					DisabledTenants: tc.disabledUsers,
 				}
 
-				r := prepareRuler(t, cfg, newMockRuleStore(allRules))
-				r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
+				r := prepareRuler(t, cfg, newMockRuleStore(allRules), withLimits(validation.MockOverrides(func(defaults *validation.Limits) {
 					defaults.RulerEvaluationDelay = 0
 					defaults.RulerTenantShardSize = tc.shuffleShardSize
-				})
+				})))
 
 				if forceRing != nil {
 					r.ring = forceRing

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -172,7 +172,7 @@ func withStart() prepareOption {
 	}
 }
 
-func buildRuler(t *testing.T, cfg Config, storage rulestore.RuleStore, rulerAddrMap map[string]*Ruler, opts ...prepareOption) *Ruler {
+func prepareRuler(t *testing.T, cfg Config, storage rulestore.RuleStore, rulerAddrMap map[string]*Ruler, opts ...prepareOption) *Ruler {
 	options := applyPrepareOptions(opts...)
 
 	noopQueryable, noopQueryFunc, pusher, logger, overrides := testSetup()
@@ -285,7 +285,7 @@ func TestRuler_Rules(t *testing.T) {
 			cfg := defaultRulerConfig(t)
 			cfg.TenantFederation.Enabled = true
 
-			r := buildRuler(t, cfg, newMockRuleStore(tc.mockRules), nil, withStart())
+			r := prepareRuler(t, cfg, newMockRuleStore(tc.mockRules), nil, withStart())
 
 			// Rules will be synchronized asynchronously, so we wait until the expected number of rule groups
 			// has been synched.
@@ -386,7 +386,7 @@ func TestGetRules(t *testing.T) {
 					},
 				}
 
-				r := buildRuler(t, cfg, storage, rulerAddrMap)
+				r := prepareRuler(t, cfg, storage, rulerAddrMap)
 				r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 					defaults.RulerEvaluationDelay = 0
 					defaults.RulerTenantShardSize = tc.shuffleShardSize
@@ -830,7 +830,7 @@ func TestSharding(t *testing.T) {
 					DisabledTenants: tc.disabledUsers,
 				}
 
-				r := buildRuler(t, cfg, newMockRuleStore(allRules), nil)
+				r := prepareRuler(t, cfg, newMockRuleStore(allRules), nil)
 				r.limits = validation.MockOverrides(func(defaults *validation.Limits) {
 					defaults.RulerEvaluationDelay = 0
 					defaults.RulerTenantShardSize = tc.shuffleShardSize
@@ -1027,7 +1027,7 @@ type ruleGroupKey struct {
 func TestRuler_ListAllRules(t *testing.T) {
 	cfg := defaultRulerConfig(t)
 
-	r := buildRuler(t, cfg, newMockRuleStore(mockRules), nil, withStart())
+	r := prepareRuler(t, cfg, newMockRuleStore(mockRules), nil, withStart())
 
 	router := mux.NewRouter()
 	router.Path("/ruler/rule_groups").Methods(http.MethodGet).HandlerFunc(r.ListAllRules)

--- a/pkg/ruler/tenant_federation_test.go
+++ b/pkg/ruler/tenant_federation_test.go
@@ -76,7 +76,7 @@ func TestRuler_TenantFederationFlag(t *testing.T) {
 			cfg.TenantFederation.Enabled = tc.tenantFederationEnabled
 			existingRules := map[string]rulespb.RuleGroupList{userID: tc.existingRules}
 
-			r := newManager(t, cfg)
+			r := prepareRulerManager(t, cfg)
 			t.Cleanup(r.Stop)
 
 			r.SyncRuleGroups(context.Background(), existingRules)

--- a/pkg/util/validation/exporter_test.go
+++ b/pkg/util/validation/exporter_test.go
@@ -26,7 +26,7 @@ func TestOverridesExporter_noConfig(t *testing.T) {
 }
 
 func TestOverridesExporter_emptyConfig(t *testing.T) {
-	exporter := NewOverridesExporter(&Limits{}, newMockTenantLimits(nil))
+	exporter := NewOverridesExporter(&Limits{}, NewMockTenantLimits(nil))
 
 	// With no updated override configurations, there should be no override metrics
 	count := testutil.CollectAndCount(exporter, "cortex_limits_overrides")
@@ -64,7 +64,7 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 		MaxFetchedChunkBytesPerQuery: 29,
 		RulerMaxRulesPerRuleGroup:    31,
 		RulerMaxRuleGroupsPerTenant:  32,
-	}, newMockTenantLimits(tenantLimits))
+	}, NewMockTenantLimits(tenantLimits))
 	limitsMetrics := `
 # HELP cortex_limits_overrides Resource limit overrides applied to tenants
 # TYPE cortex_limits_overrides gauge

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/util/validation/limits_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package validation
+
+import "github.com/grafana/dskit/flagext"
+
+// mockTenantLimits exposes per-tenant limits based on a provided map
+type mockTenantLimits struct {
+	limits map[string]*Limits
+}
+
+// NewMockTenantLimits creates a new mockTenantLimits that returns per-tenant limits based on
+// the given map
+func NewMockTenantLimits(limits map[string]*Limits) *mockTenantLimits {
+	return &mockTenantLimits{
+		limits: limits,
+	}
+}
+
+func (l *mockTenantLimits) ByUserID(userID string) *Limits {
+	return l.limits[userID]
+}
+
+func (l *mockTenantLimits) AllByUserID() map[string]*Limits {
+	return l.limits
+}
+
+func MockOverrides(customize func(defaults *Limits)) *Overrides {
+	defaults := Limits{}
+	flagext.DefaultValues(&defaults)
+	customize(&defaults)
+
+	overrides, err := NewOverrides(defaults, nil)
+	if err != nil {
+		// This function is expected to be used only in tests, so we're not afraid of panicking.
+		panic(err)
+	}
+
+	return overrides
+}

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -14,7 +14,7 @@ type mockTenantLimits struct {
 
 // NewMockTenantLimits creates a new mockTenantLimits that returns per-tenant limits based on
 // the given map
-func NewMockTenantLimits(limits map[string]*Limits) *mockTenantLimits {
+func NewMockTenantLimits(limits map[string]*Limits) TenantLimits {
 	return &mockTenantLimits{
 		limits: limits,
 	}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -22,34 +22,13 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 )
 
-// mockTenantLimits exposes per-tenant limits based on a provided map
-type mockTenantLimits struct {
-	limits map[string]*Limits
-}
-
-// newMockTenantLimits creates a new mockTenantLimits that returns per-tenant limits based on
-// the given map
-func newMockTenantLimits(limits map[string]*Limits) *mockTenantLimits {
-	return &mockTenantLimits{
-		limits: limits,
-	}
-}
-
-func (l *mockTenantLimits) ByUserID(userID string) *Limits {
-	return l.limits[userID]
-}
-
-func (l *mockTenantLimits) AllByUserID() map[string]*Limits {
-	return l.limits
-}
-
 func TestOverridesManager_GetOverrides(t *testing.T) {
 	tenantLimits := map[string]*Limits{}
 
 	defaults := Limits{
 		MaxLabelNamesPerSeries: 100,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user1"))
@@ -203,7 +182,7 @@ func TestSmallestPositiveIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryParallelism: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -235,7 +214,7 @@ func TestSmallestPositiveNonZeroIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueriersPerTenant: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -267,7 +246,7 @@ func TestSmallestPositiveNonZeroDurationPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryLength: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -300,7 +279,7 @@ func TestMaxTotalQueryLengthWithoutDefault(t *testing.T) {
 		MaxQueryLength: model.Duration(2 * time.Hour),
 	}
 
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -331,7 +310,7 @@ func TestMaxTotalQueryLengthWithDefault(t *testing.T) {
 		MaxTotalQueryLength: model.Duration(3 * time.Hour),
 	}
 
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -543,7 +522,7 @@ testuser:
 			err = yaml.Unmarshal([]byte(tc.overrides), &overrides)
 			require.NoError(t, err, "parsing overrides")
 
-			tl := newMockTenantLimits(overrides)
+			tl := NewMockTenantLimits(overrides)
 
 			ov, err := NewOverrides(limitsYAML, tl)
 			require.NoError(t, err)

--- a/pkg/util/validation/user_limits_handler_test.go
+++ b/pkg/util/validation/user_limits_handler_test.go
@@ -64,7 +64,7 @@ func TestUserLimitsHandler(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 
-			handler := UserLimitsHandler(defaults, newMockTenantLimits(tenantLimits))
+			handler := UserLimitsHandler(defaults, NewMockTenantLimits(tenantLimits))
 			request := httptest.NewRequest("GET", "/api/v1/user_limits", nil)
 			if tc.orgID != "" {
 				ctx := user.InjectOrgID(context.Background(), tc.orgID)


### PR DESCRIPTION
#### What this PR does
This PR does a refactoring in ruler tests, follow up a feedback received [here](https://github.com/grafana/mimir/pull/3088#discussion_r983560600) and [here](https://github.com/grafana/mimir/pull/3088#discussion_r983569287).

The diff is quite difficult to read, so suggest to review it commit-by-commit which should be way easier:
- [Removed ruleLimits from pkg/ruler and use the mock from pkg/util/validation instead](https://github.com/grafana/mimir/commit/21080f83f8116926f52205d2f0d90311bd522762) 
- [Removed buildAndStartRuler() in favour of buildRuler(..., withStart())](https://github.com/grafana/mimir/commit/26a2444d06ab1e2cc022046d1b178ef5be3bc039)
- [Renamed buildRuler() to prepareRuler()](https://github.com/grafana/mimir/commit/a6881c6f70cbd0c1852dcd5606ab55ce43c98294)
- [Moved default limits initialization out of testSetup()](https://github.com/grafana/mimir/commit/2ed24dd3e7751dfe295d03584ee0e065328b76e7)
- [Renamed newManager() to prepareRulerManager(), removed testSetup() and moved testSetup() logic partially to prepareRulerManager() and partially to prepareOptions](https://github.com/grafana/mimir/commit/a3b8c2146d9bd21e9dd054499ec82ac8d36608b9) 
- [Added withRulerAddrMap() option](https://github.com/grafana/mimir/pull/3090/commits/0cb36c5250a2df6318b3c24f5fcb8fb6fa4053c3)
- [Added withLimits() prepare option](https://github.com/grafana/mimir/pull/3090/commits/9d624803cd860fec2325c9e52a617de879ea402d)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
