### PR TITLE
Helm chore: Move build/check-helm-tests to build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ GOVOLUMES=	-v $(shell pwd)/.cache:/go/cache:delegated,z \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:delegated,z
 
-exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt conftest-test conftest-verify: fetch-build-image
+exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt conftest-test conftest-verify check-helm-tests build-helm-tests: fetch-build-image
 	@mkdir -p $(shell pwd)/.pkg
 	@mkdir -p $(shell pwd)/.cache
 	@echo
@@ -445,6 +445,14 @@ conftest-verify:
 conftest-test:
 	@tools/run-conftest.sh --do-dependency-update --policies-path $(HELM_REGO_POLICIES_PATH)
 
+build-helm-tests: ## Build the helm golden records.
+build-helm-tests: operations/helm/charts/mimir-distributed/charts
+	@./operations/helm/tests/build.sh
+
+check-helm-tests: ## Check the helm golden records.
+check-helm-tests: build-helm-tests
+	@./tools/find-diff-or-untracked.sh operations/helm/tests || (echo "Please rebuild helm tests output 'make build-helm-tests'" && false)
+
 endif
 
 .PHONY: check-makefiles
@@ -551,14 +559,6 @@ operations/helm/charts/mimir-distributed/charts: operations/helm/charts/mimir-di
 check-helm-jsonnet-diff: ## Check the helm jsonnet diff.
 check-helm-jsonnet-diff: operations/helm/charts/mimir-distributed/charts build-jsonnet-tests
 	@./operations/compare-helm-with-jsonnet/compare-helm-with-jsonnet.sh
-
-build-helm-tests: ## Build the helm jsonnet tests.
-build-helm-tests: operations/helm/charts/mimir-distributed/charts
-	@./operations/helm/tests/build.sh
-
-check-helm-tests: ## Check the helm jsonnet tests output.
-check-helm-tests: build-helm-tests
-	@./tools/find-diff-or-untracked.sh operations/helm/tests || (echo "Please rebuild helm tests output 'make build-helm-tests'" && false)
 
 build-jsonnet-tests: ## Build the jsonnet tests.
 	@./operations/mimir-tests/build.sh

--- a/docs/internal/contributing/contributing-to-helm-chart.md
+++ b/docs/internal/contributing/contributing-to-helm-chart.md
@@ -14,8 +14,6 @@ We keep a compiled version of the helm chart for each values file in the `ci` di
 This makes it easy to see how a given PR impacts the final output.
 A PR check will fail if you forget to update the compiled manifests, and you can use `make build-helm-tests` to update them.
 
-If using macOS, make sure you have `gnu-sed` installed; otherwise, some make targets will not work properly.
-
 ## Versioning
 
 Normally contributors need _not_ bump the version. The chart will be released with a beta version weekly by maintainers (unless no changes were made) and also regular stable releases will be released by cherry picking commits from the `main` branch to a release branch (e.g. `release-2.1`).


### PR DESCRIPTION
We already have helm in the build image, so we might as well move the
golden records generation into the build image so that all contributors
get the same outputs regardless of their local helm version.

The tradeoff is the time it takes to run them. On my macOS it takes 3x the time
```
real	0m36.561s
user	0m0.062s
sys  	0m0.044s
```

vs

```
real	0m10.662s
user	0m12.030s
sys 	0m3.078s
```

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
