### PR TITLE
ruler: use backoff retry on remote evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
   * `-ruler.alerting-rules-evaluation-enabled`
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. #3049
 * [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3044
+* [ENHANCEMENT] Ruler: use backoff retry on remote evaluation #3098
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -258,7 +258,7 @@ func (q *RemoteQuerier) query(ctx context.Context, query string, ts time.Time, l
 
 func (q *RemoteQuerier) sendRequest(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
 	// Ongoing request may be cancelled during evaluation due to some transient error or server shutdown,
-	// so we'll keep retrying until we get a successful response or context is eventually cancelled.
+	// so we'll keep retrying until we get a successful response or backoff is terminated.
 	retryConfig := backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 2 * time.Second,
@@ -269,7 +269,7 @@ func (q *RemoteQuerier) sendRequest(ctx context.Context, req *httpgrpc.HTTPReque
 	for retry.Ongoing() {
 		resp, err := q.client.Handle(ctx, req)
 		if err != nil {
-			level.Warn(q.logger).Log("msg", "failed to perform remote request", "err", err)
+			level.Warn(q.logger).Log("msg", "failed to remotely evaluate query expression, will retry", "err", err)
 			retry.Wait()
 			continue
 		}

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -46,6 +46,8 @@ const (
 	mimeTypeFormPost = "application/x-www-form-urlencoded"
 
 	statusError = "error"
+
+	maxRequestRetries = 3
 )
 
 var userAgent = fmt.Sprintf("mimir/%s", version.Version)
@@ -260,6 +262,7 @@ func (q *RemoteQuerier) sendRequest(ctx context.Context, req *httpgrpc.HTTPReque
 	retryConfig := backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 2 * time.Second,
+		MaxRetries: maxRequestRetries,
 	}
 	retry := backoff.New(ctx, retryConfig)
 

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -4,6 +4,7 @@ package ruler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -101,25 +102,54 @@ func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
 }
 
 func TestRemoteQuerier_BackoffRetry(t *testing.T) {
-	const failedRequestCount = 2
-
-	retries := 0
-	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
-		retries++
-		if retries <= failedRequestCount {
-			return nil, status.Error(codes.Internal, "something went wrong")
-		}
-		return &httpgrpc.HTTPResponse{Code: http.StatusOK, Body: []byte(`{
+	tcs := map[string]struct {
+		failedRequests  int
+		expectedError   string
+		requestDeadline time.Duration
+	}{
+		"succeed on failed requests <= max retries": {
+			failedRequests: maxRequestRetries,
+		},
+		"fail on failed requests > max retries": {
+			failedRequests: maxRequestRetries + 1,
+			expectedError:  "failed request: 4",
+		},
+		"return last known error on context cancellation": {
+			failedRequests:  1,
+			requestDeadline: 50 * time.Millisecond, // force context cancellation while waiting for retry
+			expectedError:   "context deadline exceeded while retrying request, last err was: failed request: 1",
+		},
+	}
+	for tn, tc := range tcs {
+		t.Run(tn, func(t *testing.T) {
+			retries := 0
+			mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+				retries++
+				if retries <= tc.failedRequests {
+					return nil, fmt.Errorf("failed request: %d", retries)
+				}
+				return &httpgrpc.HTTPResponse{Code: http.StatusOK, Body: []byte(`{
 							"status": "success","data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[1,"773054.5916666666"]}]}
 						}`)}, nil
+			}
+			q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, "/prometheus", log.NewNopLogger())
+
+			ctx := context.Background()
+			if tc.requestDeadline > 0 {
+				var cancelFn context.CancelFunc
+				ctx, cancelFn = context.WithTimeout(ctx, tc.requestDeadline)
+				defer cancelFn()
+			}
+
+			resp, err := q.Query(ctx, "qs", time.Now())
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+			} else {
+				require.NotNil(t, resp)
+				require.Len(t, resp, 1)
+			}
+		})
 	}
-	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, "/prometheus", log.NewNopLogger())
-
-	resp, err := q.Query(context.Background(), "qs", time.Now())
-	require.NoError(t, err)
-
-	require.NotNil(t, resp)
-	require.Len(t, resp, 1)
 }
 
 func TestRemoteQuerier_StatusErrorResponses(t *testing.T) {

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -101,7 +101,7 @@ func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
 }
 
 func TestRemoteQuerier_BackoffRetry(t *testing.T) {
-	const failedRequestCount = 3
+	const failedRequestCount = 2
 
 	retries := 0
 	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

This PR adds backoff retry logic for ruler expression evaluation when running in remote operational mode. 

With this change we aim to mitigate evaluation errors derived from remote server transient conditions, such as those taking place during rollouts. 

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
