### PR TITLE
Remove global discarded metrics and use of DefaultRegisterer.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2075,8 +2075,6 @@ func (i *Ingester) closeAndDeleteUserTSDBIfIdle(userID string) tsdbCloseCheckRes
 	i.metrics.deletePerUserMetrics(userID)
 	i.metrics.deletePerUserCustomTrackerMetrics(userID, userDB.activeSeries.CurrentMatcherNames())
 
-	validation.DeletePerUserValidationMetrics(userID, i.logger)
-
 	// And delete local data.
 	if err := os.RemoveAll(dir); err != nil {
 		level.Error(i.logger).Log("msg", "failed to delete local TSDB", "user", userID, "err", err)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -712,9 +712,6 @@ func TestIngester_Push(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			registry := prometheus.NewRegistry()
 
-			registry.MustRegister(validation.DiscardedMetadata)
-			validation.DiscardedMetadata.Reset()
-
 			// Create a mocked ingester
 			cfg := defaultIngesterTestConfig(t)
 			cfg.IngesterRing.ReplicationFactor = 1

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -58,6 +58,10 @@ type ingesterMetrics struct {
 	discardedSamplesNewValueForTimestamp *prometheus.CounterVec
 	discardedSamplesPerUserSeriesLimit   *prometheus.CounterVec
 	discardedSamplesPerMetricSeriesLimit *prometheus.CounterVec
+
+	// Discarded metadata
+	discardedMetadataPerUserMetadataLimit   *prometheus.CounterVec
+	discardedMetadataPerMetricMetadataLimit *prometheus.CounterVec
 }
 
 func newIngesterMetrics(
@@ -274,6 +278,9 @@ func newIngesterMetrics(
 		discardedSamplesNewValueForTimestamp: validation.DiscardedSamplesCounter(r, newValueForTimestamp),
 		discardedSamplesPerUserSeriesLimit:   validation.DiscardedSamplesCounter(r, perUserSeriesLimit),
 		discardedSamplesPerMetricSeriesLimit: validation.DiscardedSamplesCounter(r, perMetricSeriesLimit),
+
+		discardedMetadataPerUserMetadataLimit:   validation.DiscardedMetadataCounter(r, perUserMetadataLimit),
+		discardedMetadataPerMetricMetadataLimit: validation.DiscardedMetadataCounter(r, perMetricMetadataLimit),
 	}
 
 	return m
@@ -291,6 +298,9 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.discardedSamplesNewValueForTimestamp.DeleteLabelValues(userID)
 	m.discardedSamplesPerUserSeriesLimit.DeleteLabelValues(userID)
 	m.discardedSamplesPerMetricSeriesLimit.DeleteLabelValues(userID)
+
+	m.discardedMetadataPerUserMetadataLimit.DeleteLabelValues(userID)
+	m.discardedMetadataPerMetricMetadataLimit.DeleteLabelValues(userID)
 }
 
 func (m *ingesterMetrics) deletePerUserCustomTrackerMetrics(userID string, customTrackerMetrics []string) {

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -114,66 +114,67 @@ type SampleValidationConfig interface {
 
 // SampleValidationMetrics is a collection of metrics used during sample validation.
 type SampleValidationMetrics struct {
-	MissingMetricName      *prometheus.CounterVec
-	InvalidMetricName      *prometheus.CounterVec
-	MaxLabelNamesPerSeries *prometheus.CounterVec
-	InvalidLabel           *prometheus.CounterVec
-	LabelNameTooLong       *prometheus.CounterVec
-	LabelValueTooLong      *prometheus.CounterVec
-	DuplicateLabelNames    *prometheus.CounterVec
-	LabelsNotSorted        *prometheus.CounterVec
-	TooFarInFuture         *prometheus.CounterVec
+	missingMetricName      *prometheus.CounterVec
+	invalidMetricName      *prometheus.CounterVec
+	maxLabelNamesPerSeries *prometheus.CounterVec
+	invalidLabel           *prometheus.CounterVec
+	labelNameTooLong       *prometheus.CounterVec
+	labelValueTooLong      *prometheus.CounterVec
+	duplicateLabelNames    *prometheus.CounterVec
+	labelsNotSorted        *prometheus.CounterVec
+	tooFarInFuture         *prometheus.CounterVec
 }
 
 func (m *SampleValidationMetrics) DeleteUserMetrics(userID string) {
-	m.MissingMetricName.DeleteLabelValues(userID)
-	m.InvalidMetricName.DeleteLabelValues(userID)
-	m.MaxLabelNamesPerSeries.DeleteLabelValues(userID)
-	m.InvalidLabel.DeleteLabelValues(userID)
-	m.LabelNameTooLong.DeleteLabelValues(userID)
-	m.LabelValueTooLong.DeleteLabelValues(userID)
-	m.DuplicateLabelNames.DeleteLabelValues(userID)
-	m.LabelsNotSorted.DeleteLabelValues(userID)
-	m.TooFarInFuture.DeleteLabelValues(userID)
+	m.missingMetricName.DeleteLabelValues(userID)
+	m.invalidMetricName.DeleteLabelValues(userID)
+	m.maxLabelNamesPerSeries.DeleteLabelValues(userID)
+	m.invalidLabel.DeleteLabelValues(userID)
+	m.labelNameTooLong.DeleteLabelValues(userID)
+	m.labelValueTooLong.DeleteLabelValues(userID)
+	m.duplicateLabelNames.DeleteLabelValues(userID)
+	m.labelsNotSorted.DeleteLabelValues(userID)
+	m.tooFarInFuture.DeleteLabelValues(userID)
 }
 
 func NewSampleValidationMetrics(r prometheus.Registerer) *SampleValidationMetrics {
 	return &SampleValidationMetrics{
-		MissingMetricName:      DiscardedSamplesCounter(r, reasonMissingMetricName),
-		InvalidMetricName:      DiscardedSamplesCounter(r, reasonInvalidMetricName),
-		MaxLabelNamesPerSeries: DiscardedSamplesCounter(r, reasonMaxLabelNamesPerSeries),
-		InvalidLabel:           DiscardedSamplesCounter(r, reasonInvalidLabel),
-		LabelNameTooLong:       DiscardedSamplesCounter(r, reasonLabelNameTooLong),
-		LabelValueTooLong:      DiscardedSamplesCounter(r, reasonLabelValueTooLong),
-		DuplicateLabelNames:    DiscardedSamplesCounter(r, reasonDuplicateLabelNames),
-		LabelsNotSorted:        DiscardedSamplesCounter(r, reasonLabelsNotSorted),
-		TooFarInFuture:         DiscardedSamplesCounter(r, reasonTooFarInFuture),
+		missingMetricName:      DiscardedSamplesCounter(r, reasonMissingMetricName),
+		invalidMetricName:      DiscardedSamplesCounter(r, reasonInvalidMetricName),
+		maxLabelNamesPerSeries: DiscardedSamplesCounter(r, reasonMaxLabelNamesPerSeries),
+		invalidLabel:           DiscardedSamplesCounter(r, reasonInvalidLabel),
+		labelNameTooLong:       DiscardedSamplesCounter(r, reasonLabelNameTooLong),
+		labelValueTooLong:      DiscardedSamplesCounter(r, reasonLabelValueTooLong),
+		duplicateLabelNames:    DiscardedSamplesCounter(r, reasonDuplicateLabelNames),
+		labelsNotSorted:        DiscardedSamplesCounter(r, reasonLabelsNotSorted),
+		tooFarInFuture:         DiscardedSamplesCounter(r, reasonTooFarInFuture),
 	}
 }
 
+// ExemplarValidationMetrics is a collection of metrics used by exemplar validation.
 type ExemplarValidationMetrics struct {
-	LabelsMissing    *prometheus.CounterVec
-	TimestampInvalid *prometheus.CounterVec
-	LabelsTooLong    *prometheus.CounterVec
-	LabelsBlank      *prometheus.CounterVec
-	TooOld           *prometheus.CounterVec
+	labelsMissing    *prometheus.CounterVec
+	timestampInvalid *prometheus.CounterVec
+	labelsTooLong    *prometheus.CounterVec
+	labelsBlank      *prometheus.CounterVec
+	tooOld           *prometheus.CounterVec
 }
 
 func (m *ExemplarValidationMetrics) DeleteUserMetrics(userID string) {
-	m.LabelsMissing.DeleteLabelValues(userID)
-	m.TimestampInvalid.DeleteLabelValues(userID)
-	m.LabelsTooLong.DeleteLabelValues(userID)
-	m.LabelsBlank.DeleteLabelValues(userID)
-	m.TooOld.DeleteLabelValues(userID)
+	m.labelsMissing.DeleteLabelValues(userID)
+	m.timestampInvalid.DeleteLabelValues(userID)
+	m.labelsTooLong.DeleteLabelValues(userID)
+	m.labelsBlank.DeleteLabelValues(userID)
+	m.tooOld.DeleteLabelValues(userID)
 }
 
 func NewExemplarValidationMetrics(r prometheus.Registerer) *ExemplarValidationMetrics {
 	return &ExemplarValidationMetrics{
-		LabelsMissing:    DiscardedExemplarsCounter(r, reasonExemplarLabelsMissing),
-		TimestampInvalid: DiscardedExemplarsCounter(r, reasonExemplarTimestampInvalid),
-		LabelsTooLong:    DiscardedExemplarsCounter(r, reasonExemplarLabelsTooLong),
-		LabelsBlank:      DiscardedExemplarsCounter(r, reasonExemplarLabelsBlank),
-		TooOld:           DiscardedExemplarsCounter(r, reasonExemplarTooOld),
+		labelsMissing:    DiscardedExemplarsCounter(r, reasonExemplarLabelsMissing),
+		timestampInvalid: DiscardedExemplarsCounter(r, reasonExemplarTimestampInvalid),
+		labelsTooLong:    DiscardedExemplarsCounter(r, reasonExemplarLabelsTooLong),
+		labelsBlank:      DiscardedExemplarsCounter(r, reasonExemplarLabelsBlank),
+		tooOld:           DiscardedExemplarsCounter(r, reasonExemplarTooOld),
 	}
 }
 
@@ -184,7 +185,7 @@ func ValidateSample(m *SampleValidationMetrics, now model.Time, cfg SampleValida
 	unsafeMetricName, _ := extract.UnsafeMetricNameFromLabelAdapters(ls)
 
 	if model.Time(s.TimestampMs) > now.Add(cfg.CreationGracePeriod(userID)) {
-		m.TooFarInFuture.WithLabelValues(userID).Inc()
+		m.tooFarInFuture.WithLabelValues(userID).Inc()
 		return newSampleTimestampTooNewError(unsafeMetricName, s.TimestampMs)
 	}
 
@@ -195,12 +196,12 @@ func ValidateSample(m *SampleValidationMetrics, now model.Time, cfg SampleValida
 // The returned error may retain the provided series labels.
 func ValidateExemplar(m *ExemplarValidationMetrics, userID string, ls []mimirpb.LabelAdapter, e mimirpb.Exemplar) ValidationError {
 	if len(e.Labels) <= 0 {
-		m.LabelsMissing.WithLabelValues(userID).Inc()
+		m.labelsMissing.WithLabelValues(userID).Inc()
 		return newExemplarEmptyLabelsError(ls, []mimirpb.LabelAdapter{}, e.TimestampMs)
 	}
 
 	if e.TimestampMs == 0 {
-		m.TimestampInvalid.WithLabelValues(userID).Inc()
+		m.timestampInvalid.WithLabelValues(userID).Inc()
 		return newExemplarMissingTimestampError(
 			ls,
 			e.Labels,
@@ -226,7 +227,7 @@ func ValidateExemplar(m *ExemplarValidationMetrics, userID string, ls []mimirpb.
 	}
 
 	if labelSetLen > ExemplarMaxLabelSetLength {
-		m.LabelsTooLong.WithLabelValues(userID).Inc()
+		m.labelsTooLong.WithLabelValues(userID).Inc()
 		return newExemplarMaxLabelLengthError(
 			ls,
 			e.Labels,
@@ -235,7 +236,7 @@ func ValidateExemplar(m *ExemplarValidationMetrics, userID string, ls []mimirpb.
 	}
 
 	if !foundValidLabel {
-		m.LabelsBlank.WithLabelValues(userID).Inc()
+		m.labelsBlank.WithLabelValues(userID).Inc()
 		return newExemplarEmptyLabelsError(ls, e.Labels, e.TimestampMs)
 	}
 
@@ -246,7 +247,7 @@ func ValidateExemplar(m *ExemplarValidationMetrics, userID string, ls []mimirpb.
 // This is separate from ValidateExemplar() so we can silently drop old ones, not log an error.
 func ExemplarTimestampOK(m *ExemplarValidationMetrics, userID string, minTS int64, e mimirpb.Exemplar) bool {
 	if e.TimestampMs < minTS {
-		m.TooOld.WithLabelValues(userID).Inc()
+		m.tooOld.WithLabelValues(userID).Inc()
 		return false
 	}
 	return true
@@ -264,18 +265,18 @@ type LabelValidationConfig interface {
 func ValidateLabels(m *SampleValidationMetrics, cfg LabelValidationConfig, userID string, ls []mimirpb.LabelAdapter, skipLabelNameValidation bool) ValidationError {
 	unsafeMetricName, err := extract.UnsafeMetricNameFromLabelAdapters(ls)
 	if err != nil {
-		m.MissingMetricName.WithLabelValues(userID).Inc()
+		m.missingMetricName.WithLabelValues(userID).Inc()
 		return newNoMetricNameError()
 	}
 
 	if !model.IsValidMetricName(model.LabelValue(unsafeMetricName)) {
-		m.InvalidMetricName.WithLabelValues(userID).Inc()
+		m.invalidMetricName.WithLabelValues(userID).Inc()
 		return newInvalidMetricNameError(unsafeMetricName)
 	}
 
 	numLabelNames := len(ls)
 	if numLabelNames > cfg.MaxLabelNamesPerSeries(userID) {
-		m.MaxLabelNamesPerSeries.WithLabelValues(userID).Inc()
+		m.maxLabelNamesPerSeries.WithLabelValues(userID).Inc()
 		return newTooManyLabelsError(ls, cfg.MaxLabelNamesPerSeries(userID))
 	}
 
@@ -284,19 +285,19 @@ func ValidateLabels(m *SampleValidationMetrics, cfg LabelValidationConfig, userI
 	lastLabelName := ""
 	for _, l := range ls {
 		if !skipLabelNameValidation && !model.LabelName(l.Name).IsValid() {
-			m.InvalidLabel.WithLabelValues(userID).Inc()
+			m.invalidLabel.WithLabelValues(userID).Inc()
 			return newInvalidLabelError(ls, l.Name)
 		} else if len(l.Name) > maxLabelNameLength {
-			m.LabelNameTooLong.WithLabelValues(userID).Inc()
+			m.labelNameTooLong.WithLabelValues(userID).Inc()
 			return newLabelNameTooLongError(ls, l.Name)
 		} else if len(l.Value) > maxLabelValueLength {
-			m.LabelValueTooLong.WithLabelValues(userID).Inc()
+			m.labelValueTooLong.WithLabelValues(userID).Inc()
 			return newLabelValueTooLongError(ls, l.Value)
 		} else if lastLabelName == l.Name {
-			m.DuplicateLabelNames.WithLabelValues(userID).Inc()
+			m.duplicateLabelNames.WithLabelValues(userID).Inc()
 			return newDuplicatedLabelError(ls, l.Name)
 		} else if lastLabelName > l.Name {
-			m.LabelsNotSorted.WithLabelValues(userID).Inc()
+			m.labelsNotSorted.WithLabelValues(userID).Inc()
 			return newLabelsNotSortedError(ls, l.Name)
 		}
 
@@ -307,22 +308,22 @@ func ValidateLabels(m *SampleValidationMetrics, cfg LabelValidationConfig, userI
 
 // MetadataValidationMetrics is a collection of metrics used by metadata validation.
 type MetadataValidationMetrics struct {
-	MissingMetricName *prometheus.CounterVec
-	MetricNameTooLong *prometheus.CounterVec
-	UnitTooLong       *prometheus.CounterVec
+	missingMetricName *prometheus.CounterVec
+	metricNameTooLong *prometheus.CounterVec
+	unitTooLong       *prometheus.CounterVec
 }
 
 func (m *MetadataValidationMetrics) DeleteUserMetrics(userID string) {
-	m.MissingMetricName.DeleteLabelValues(userID)
-	m.MetricNameTooLong.DeleteLabelValues(userID)
-	m.UnitTooLong.DeleteLabelValues(userID)
+	m.missingMetricName.DeleteLabelValues(userID)
+	m.metricNameTooLong.DeleteLabelValues(userID)
+	m.unitTooLong.DeleteLabelValues(userID)
 }
 
 func NewMetadataValidationMetrics(r prometheus.Registerer) *MetadataValidationMetrics {
 	return &MetadataValidationMetrics{
-		MissingMetricName: DiscardedMetadataCounter(r, reasonMissingMetricName),
-		MetricNameTooLong: DiscardedMetadataCounter(r, reasonMetadataMetricNameTooLong),
-		UnitTooLong:       DiscardedMetadataCounter(r, reasonMetadataUnitTooLong),
+		missingMetricName: DiscardedMetadataCounter(r, reasonMissingMetricName),
+		metricNameTooLong: DiscardedMetadataCounter(r, reasonMetadataMetricNameTooLong),
+		unitTooLong:       DiscardedMetadataCounter(r, reasonMetadataUnitTooLong),
 	}
 }
 
@@ -335,7 +336,7 @@ type MetadataValidationConfig interface {
 // CleanAndValidateMetadata returns an err if a metric metadata is invalid.
 func CleanAndValidateMetadata(m *MetadataValidationMetrics, cfg MetadataValidationConfig, userID string, metadata *mimirpb.MetricMetadata) error {
 	if cfg.EnforceMetadataMetricName(userID) && metadata.GetMetricFamilyName() == "" {
-		m.MissingMetricName.WithLabelValues(userID).Inc()
+		m.missingMetricName.WithLabelValues(userID).Inc()
 		return newMetadataMetricNameMissingError()
 	}
 
@@ -354,10 +355,10 @@ func CleanAndValidateMetadata(m *MetadataValidationMetrics, cfg MetadataValidati
 
 	var err error
 	if len(metadata.GetMetricFamilyName()) > maxMetadataValueLength {
-		m.MetricNameTooLong.WithLabelValues(userID).Inc()
+		m.metricNameTooLong.WithLabelValues(userID).Inc()
 		err = newMetadataMetricNameTooLongError(metadata)
 	} else if len(metadata.Unit) > maxMetadataValueLength {
-		m.UnitTooLong.WithLabelValues(userID).Inc()
+		m.unitTooLong.WithLabelValues(userID).Inc()
 		err = newMetadataUnitTooLongError(metadata)
 	}
 

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -150,6 +150,9 @@ func TestValidateLabels(t *testing.T) {
 }
 
 func TestValidateExemplars(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewExemplarValidationMetrics(reg)
+
 	userID := "testUser"
 
 	invalidExemplars := []mimirpb.Exemplar{
@@ -179,7 +182,7 @@ func TestValidateExemplars(t *testing.T) {
 	}
 
 	for _, ie := range invalidExemplars {
-		assert.Error(t, ValidateExemplar(userID, []mimirpb.LabelAdapter{}, ie))
+		assert.Error(t, ValidateExemplar(m, userID, []mimirpb.LabelAdapter{}, ie))
 	}
 
 	validExemplars := []mimirpb.Exemplar{
@@ -196,12 +199,12 @@ func TestValidateExemplars(t *testing.T) {
 	}
 
 	for _, ve := range validExemplars {
-		assert.NoError(t, ValidateExemplar(userID, []mimirpb.LabelAdapter{}, ve))
+		assert.NoError(t, ValidateExemplar(m, userID, []mimirpb.LabelAdapter{}, ve))
 	}
 
-	DiscardedExemplars.WithLabelValues("random reason", "different user").Inc()
+	DiscardedExemplarsCounter(reg, "random reason").WithLabelValues("different user").Inc()
 
-	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
 			cortex_discarded_exemplars_total{reason="exemplar_labels_blank",user="testUser"} 2
@@ -213,8 +216,8 @@ func TestValidateExemplars(t *testing.T) {
 		`), "cortex_discarded_exemplars_total"))
 
 	// Delete test user and verify only different remaining
-	DeletePerUserValidationMetrics(userID, util_log.Logger)
-	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+	m.DeleteUserMetrics(userID)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
 			cortex_discarded_exemplars_total{reason="random reason",user="different user"} 1


### PR DESCRIPTION
#### What this PR does
Continuation of https://github.com/grafana/mimir/pull/3084 and https://github.com/grafana/mimir/pull/2756, this PR finishes removal of global "Discarded" metrics, and use of `prometheus.DefaultRegisterer`.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
