### PR TITLE
Increase discarded samples metric if forwarded series receives too old samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin
@@ -94,7 +95,6 @@
 * [ENHANCEMENT] Ruler: added support to forcefully disable recording and/or alerting rules evaluation. The following new configuration options have been introduced, which can be overridden on a per-tenant basis in the runtime configuration: #3088
   * `-ruler.recording-rules-evaluation-enabled`
   * `-ruler.alerting-rules-evaluation-enabled`
-* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
 * [ENHANCEMENT] Distributor: Improved error messages reported when the distributor fails to remote write to ingesters. #3055
 * [ENHANCEMENT] Improved tracing spans tracked by distributors, ingesters and store-gateways. #2879 #3099 #3089
 * [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3044

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 * [ENHANCEMENT] Ruler: added support to forcefully disable recording and/or alerting rules evaluation. The following new configuration options have been introduced, which can be overridden on a per-tenant basis in the runtime configuration: #3088
   * `-ruler.recording-rules-evaluation-enabled`
   * `-ruler.alerting-rules-evaluation-enabled`
-* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. #3049
+* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarding-sample-too-old"}` is increased. #3049 #3133
 * [ENHANCEMENT] Distributor: Improved error messages reported when the distributor fails to remote write to ingesters. #3055
 * [ENHANCEMENT] Improved tracing spans tracked by distributors, ingesters and store-gateways. #2879 #3099 #3089
 * [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3044

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 * [ENHANCEMENT] Ruler: added support to forcefully disable recording and/or alerting rules evaluation. The following new configuration options have been introduced, which can be overridden on a per-tenant basis in the runtime configuration: #3088
   * `-ruler.recording-rules-evaluation-enabled`
   * `-ruler.alerting-rules-evaluation-enabled`
-* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarding-sample-too-old"}` is increased. #3049 #3133
+* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
 * [ENHANCEMENT] Distributor: Improved error messages reported when the distributor fails to remote write to ingesters. #3055
 * [ENHANCEMENT] Improved tracing spans tracked by distributors, ingesters and store-gateways. #2879 #3099 #3089
 * [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3044

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -536,7 +536,9 @@ func (d *Distributor) cleanupInactiveUser(userID string) {
 	d.exemplarValidationMetrics.DeleteUserMetrics(userID)
 	d.metadataValidationMetrics.DeleteUserMetrics(userID)
 
-	d.forwarder.DeleteMetricsForUser(userID)
+	if d.forwarder != nil {
+		d.forwarder.DeleteMetricsForUser(userID)
+	}
 }
 
 // Called after distributor is asked to stop via StopAsync.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -535,6 +535,8 @@ func (d *Distributor) cleanupInactiveUser(userID string) {
 	d.sampleValidationMetrics.DeleteUserMetrics(userID)
 	d.exemplarValidationMetrics.DeleteUserMetrics(userID)
 	d.metadataValidationMetrics.DeleteUserMetrics(userID)
+
+	d.forwarder.DeleteMetricsForUser(userID)
 }
 
 // Called after distributor is asked to stop via StopAsync.
@@ -929,7 +931,7 @@ func (d *Distributor) forwardSamples(ctx context.Context, userID string, ts []mi
 
 	// Reassign req.Timeseries because the forwarder creates a new slice which has been filtered down.
 	// The cleanup func will cleanup the new slice, it's the forwarders responsibility to return the old one to the pool.
-	ts, forwardingErrCh = d.forwarder.Forward(ctx, endpoint, dropSamplesBeforeTimestamp, forwardingRules, ts)
+	ts, forwardingErrCh = d.forwarder.Forward(ctx, endpoint, dropSamplesBeforeTimestamp, forwardingRules, ts, userID)
 
 	return ts, forwardingErrCh
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4100,7 +4100,7 @@ func newMockForwarder(timeseriesMutator func([]mimirpb.PreallocTimeseries) []mim
 	}
 }
 
-func (m *mockForwarder) Forward(ctx context.Context, endpoint string, dontForwardBefore int64, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
+func (m *mockForwarder) Forward(ctx context.Context, endpoint string, dontForwardBefore int64, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries, user string) ([]mimirpb.PreallocTimeseries, chan error) {
 	errCh := make(chan error)
 
 	go func() {
@@ -4117,6 +4117,8 @@ func (m *mockForwarder) Forward(ctx context.Context, endpoint string, dontForwar
 
 	return nil, errCh
 }
+
+func (m *mockForwarder) DeleteMetricsForUser(user string) {}
 
 func ingestAllTimeseriesMutator(ts []mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries {
 	return ts

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -304,7 +304,6 @@ func (f *forwarder) filterAndCopyTimeseries(ts mimirpb.PreallocTimeseries, dontF
 type TimeseriesCounts struct {
 	SampleCount   int
 	ExemplarCount int
-	SamplesTooOld int
 }
 
 func (t *TimeseriesCounts) count(ts mimirpb.PreallocTimeseries) {

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -122,7 +122,7 @@ func NewForwarder(cfg Config, reg prometheus.Registerer, log log.Logger) Forward
 			Help: "Number of gRPC clients used by Distributor forwarder.",
 		}),
 
-		discardedSamplesTooOld: validation.DiscardedSamplesCounter(reg, "forwarding-sample-too-old"),
+		discardedSamplesTooOld: validation.DiscardedSamplesCounter(reg, "forwarded-sample-too-old"),
 	}
 
 	f.httpGrpcClientPool = f.newHTTPGrpcClientsPool()

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -37,7 +37,8 @@ import (
 
 type Forwarder interface {
 	services.Service
-	Forward(ctx context.Context, targetEndpoint string, dontForwardBefore int64, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error)
+	Forward(ctx context.Context, targetEndpoint string, dontForwardBefore int64, forwardingRules validation.ForwardingRules, ts []mimirpb.PreallocTimeseries, user string) ([]mimirpb.PreallocTimeseries, chan error)
+	DeleteMetricsForUser(user string)
 }
 
 // httpGrpcPrefix is URL prefix used by forwarder to check if it should use httpgrpc for sending request over to the target.
@@ -65,6 +66,8 @@ type forwarder struct {
 	exemplarsTotal          prometheus.Counter
 	requestLatencyHistogram prometheus.Histogram
 	grpcClientsGauge        prometheus.Gauge
+
+	discardedSamplesTooOld *prometheus.CounterVec
 }
 
 // NewForwarder returns a new forwarder, if forwarding is disabled it returns nil.
@@ -118,12 +121,18 @@ func NewForwarder(cfg Config, reg prometheus.Registerer, log log.Logger) Forward
 			Name: "cortex_distributor_forward_grpc_clients",
 			Help: "Number of gRPC clients used by Distributor forwarder.",
 		}),
+
+		discardedSamplesTooOld: validation.DiscardedSamplesCounter(reg, "forwarding-sample-too-old"),
 	}
 
 	f.httpGrpcClientPool = f.newHTTPGrpcClientsPool()
 	f.Service = services.NewIdleService(f.start, f.stop)
 
 	return f
+}
+
+func (f *forwarder) DeleteMetricsForUser(user string) {
+	f.discardedSamplesTooOld.DeleteLabelValues(user)
 }
 
 func (f *forwarder) newHTTPGrpcClientsPool() *client.Pool {
@@ -219,7 +228,7 @@ func (f *forwarder) worker() {
 //   - A slice of time series which should be sent to the ingesters, based on the given rule set.
 //     The Forward() method does not send the time series to the ingesters itself, it expects the caller to do that.
 //   - A chan of errors which resulted from forwarding the time series, the chan gets closed when all forwarding requests have completed.
-func (f *forwarder) Forward(ctx context.Context, endpoint string, dontForwardBefore int64, rules validation.ForwardingRules, in []mimirpb.PreallocTimeseries) ([]mimirpb.PreallocTimeseries, chan error) {
+func (f *forwarder) Forward(ctx context.Context, endpoint string, dontForwardBefore int64, rules validation.ForwardingRules, in []mimirpb.PreallocTimeseries, user string) ([]mimirpb.PreallocTimeseries, chan error) {
 	if !f.cfg.Enabled || endpoint == "" {
 		errCh := make(chan error)
 		close(errCh)
@@ -234,7 +243,7 @@ func (f *forwarder) Forward(ctx context.Context, endpoint string, dontForwardBef
 		}
 	}()
 
-	toIngest, toForward, counts, err := f.splitToIngestedAndForwardedTimeseries(in, rules, dontForwardBefore)
+	toIngest, toForward, counts, err := f.splitToIngestedAndForwardedTimeseries(in, rules, dontForwardBefore, user)
 	errCh := make(chan error, 2) // 1 for result of forwarding, 1 for possible error
 	if err != nil {
 		errCh <- err
@@ -266,8 +275,7 @@ func (f *forwarder) Forward(ctx context.Context, endpoint string, dontForwardBef
 
 // filterAndCopyTimeseries makes a copy of the timeseries with old samples filtered out. Original timeseries is unchanged.
 // The time series is deep-copied, so the passed in time series can be returned to the pool without affecting the copy.
-func (f *forwarder) filterAndCopyTimeseries(ts mimirpb.PreallocTimeseries, dontForwardBeforeTimestamp int64) (mimirpb.PreallocTimeseries, error) {
-	var err error
+func (f *forwarder) filterAndCopyTimeseries(ts mimirpb.PreallocTimeseries, dontForwardBeforeTimestamp int64) (_ mimirpb.PreallocTimeseries, filteredSamplesCount int) {
 	if dontForwardBeforeTimestamp > 0 {
 		samplesUnfiltered := ts.TimeSeries.Samples
 		defer func() {
@@ -278,7 +286,7 @@ func (f *forwarder) filterAndCopyTimeseries(ts mimirpb.PreallocTimeseries, dontF
 
 		samplesFiltered := dropSamplesBefore(samplesUnfiltered, dontForwardBeforeTimestamp)
 		if len(samplesFiltered) < len(samplesUnfiltered) {
-			err = errSamplesTooOld
+			filteredSamplesCount = len(samplesUnfiltered) - len(samplesFiltered)
 		}
 
 		// Prepare ts for deep copy. Original samples will be set back via defer function.
@@ -290,12 +298,13 @@ func (f *forwarder) filterAndCopyTimeseries(ts mimirpb.PreallocTimeseries, dontF
 		// We don't keep exemplars when forwarding.
 		result = mimirpb.DeepCopyTimeseries(result, ts, false)
 	}
-	return result, err
+	return result, filteredSamplesCount
 }
 
 type TimeseriesCounts struct {
 	SampleCount   int
 	ExemplarCount int
+	SamplesTooOld int
 }
 
 func (t *TimeseriesCounts) count(ts mimirpb.PreallocTimeseries) {
@@ -311,7 +320,7 @@ func (t *TimeseriesCounts) count(ts mimirpb.PreallocTimeseries) {
 //   - A slice of time series to forward
 //   - TimeseriesCounts
 //   - An error if any occurred.
-func (f *forwarder) splitToIngestedAndForwardedTimeseries(tsSliceIn []mimirpb.PreallocTimeseries, rules validation.ForwardingRules, dontForwardBefore int64) (tsToIngest, tsToForward []mimirpb.PreallocTimeseries, _ TimeseriesCounts, _ error) {
+func (f *forwarder) splitToIngestedAndForwardedTimeseries(tsSliceIn []mimirpb.PreallocTimeseries, rules validation.ForwardingRules, dontForwardBefore int64, user string) (tsToIngest, tsToForward []mimirpb.PreallocTimeseries, _ TimeseriesCounts, _ error) {
 	// This functions copies all the entries of tsSliceIn into new slices so tsSliceIn can be recycled,
 	// we adjust the length of the slice to 0 to prevent that the contained *mimirpb.TimeSeries objects that have been
 	// reassigned (not deep copied) get returned while they are still referred to by another slice.
@@ -325,9 +334,12 @@ func (f *forwarder) splitToIngestedAndForwardedTimeseries(tsSliceIn []mimirpb.Pr
 	for _, ts := range tsSliceIn {
 		forward, ingest := shouldForwardAndIngest(ts.Labels, rules)
 		if forward {
-			tsCopy, filterErr := f.filterAndCopyTimeseries(ts, dontForwardBefore)
-			if filterErr != nil {
-				err = filterErr
+			tsCopy, filteredSamples := f.filterAndCopyTimeseries(ts, dontForwardBefore)
+			if filteredSamples > 0 {
+				err = errSamplesTooOld
+				if !ingest {
+					f.discardedSamplesTooOld.WithLabelValues(user).Add(float64(filteredSamples))
+				}
 			}
 
 			if len(tsCopy.TimeSeries.Samples) > 0 {

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -290,7 +290,7 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 
 			toIngest, errCh := f.Forward(ctx, url, cutOffTs, rules, inputTs, "user")
 
-			// All samples should be ingested, including the ones that were dropped by the forwarding.
+			// If ingestion is enabled, all samples should be ingested, including the ones that were dropped by the forwarding.
 			if !tc.disableIngest {
 				require.Equal(t, len(tc.inputSamples), len(toIngest))
 				for tsIdx := range tc.inputSamples {

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -219,7 +219,7 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 			expectedMetrics: `
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{reason="forwarding-sample-too-old",user="user"} 3
+			cortex_discarded_samples_total{reason="forwarded-sample-too-old",user="user"} 3
 `,
 		}, {
 			name: "split one sample slice in the middle",

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -56,7 +56,7 @@ func TestForwardingSamplesSuccessfullyToSingleTarget(t *testing.T) {
 		newSample(t, now, 3, 300, "__name__", "metric2", "some_label", "foo"),
 		newSample(t, now, 4, 400, "__name__", "metric2", "some_label", "bar"),
 	}
-	tsToIngest, errCh := forwarder.Forward(ctx, url, 0, rules, ts)
+	tsToIngest, errCh := forwarder.Forward(ctx, url, 0, rules, ts, "user")
 
 	// The metric2 should be returned by the forwarding because the matching rule has ingest set to "true".
 	require.Len(t, tsToIngest, 2)
@@ -126,8 +126,12 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 	type testCase struct {
 		name            string
 		inputSamples    [][]mimirpb.Sample
+		disableIngest   bool // default = false, ie. ingestion is enabled
 		expectedSamples [][]mimirpb.Sample
 		expectError     error
+
+		checkMetricNames []string
+		expectedMetrics  string
 	}
 
 	testCases := []testCase{
@@ -159,7 +163,7 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 			},
 			expectError: nil, // Expecting no error because nothing was dropped.
 		}, {
-			name: "drop some of the samples",
+			name: "drop some of the samples, ingest true",
 			inputSamples: [][]mimirpb.Sample{
 				{
 					{TimestampMs: cutOffTs - 100, Value: 1}, // too old
@@ -168,6 +172,7 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 					{TimestampMs: cutOffTs, Value: 1},      // ok
 					{TimestampMs: cutOffTs + 50, Value: 1}, // ok
 				}, {
+					{TimestampMs: cutOffTs - 100, Value: 1}, // too old
 					{TimestampMs: cutOffTs + 100, Value: 1}, // ok
 					{TimestampMs: cutOffTs + 150, Value: 1}, // ok
 				},
@@ -181,7 +186,41 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 					{TimestampMs: cutOffTs + 150, Value: 1},
 				},
 			},
-			expectError: errSamplesTooOld,
+			expectError:      errSamplesTooOld,
+			checkMetricNames: []string{"cortex_discarded_samples_total"},
+			expectedMetrics:  ``, // nothing is reported
+		}, {
+			name: "drop some of the samples, ingest false",
+			inputSamples: [][]mimirpb.Sample{
+				{
+					{TimestampMs: cutOffTs - 100, Value: 1}, // too old
+					{TimestampMs: cutOffTs - 50, Value: 1},  // too old
+				}, {
+					{TimestampMs: cutOffTs, Value: 1},      // ok
+					{TimestampMs: cutOffTs + 50, Value: 1}, // ok
+				}, {
+					{TimestampMs: cutOffTs - 100, Value: 1}, // too old
+					{TimestampMs: cutOffTs + 100, Value: 1}, // ok
+					{TimestampMs: cutOffTs + 150, Value: 1}, // ok
+				},
+			},
+			disableIngest: true,
+			expectedSamples: [][]mimirpb.Sample{
+				{
+					{TimestampMs: cutOffTs, Value: 1},
+					{TimestampMs: cutOffTs + 50, Value: 1},
+				}, {
+					{TimestampMs: cutOffTs + 100, Value: 1},
+					{TimestampMs: cutOffTs + 150, Value: 1},
+				},
+			},
+			expectError:      errSamplesTooOld,
+			checkMetricNames: []string{"cortex_discarded_samples_total"},
+			expectedMetrics: `
+			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+			# TYPE cortex_discarded_samples_total counter
+			cortex_discarded_samples_total{reason="forwarding-sample-too-old",user="user"} 3
+`,
 		}, {
 			name: "split one sample slice in the middle",
 			inputSamples: [][]mimirpb.Sample{
@@ -227,13 +266,13 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			f, _ := newForwarder(t, testConfig, true)
+			f, reg := newForwarder(t, testConfig, true)
 
 			url, _, bodiesFn := newTestServer(t, 200, true)
 
 			testMetric := "metric1"
 			rules := validation.ForwardingRules{
-				testMetric: validation.ForwardingRule{Ingest: true},
+				testMetric: validation.ForwardingRule{Ingest: !tc.disableIngest},
 			}
 
 			inputTs := make([]mimirpb.PreallocTimeseries, 0, len(tc.inputSamples))
@@ -249,12 +288,14 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 				})
 			}
 
-			toIngest, errCh := f.Forward(ctx, url, cutOffTs, rules, inputTs)
+			toIngest, errCh := f.Forward(ctx, url, cutOffTs, rules, inputTs, "user")
 
 			// All samples should be ingested, including the ones that were dropped by the forwarding.
-			require.Equal(t, len(tc.inputSamples), len(toIngest))
-			for tsIdx := range tc.inputSamples {
-				require.Equal(t, tc.inputSamples[tsIdx], toIngest[tsIdx].Samples)
+			if !tc.disableIngest {
+				require.Equal(t, len(tc.inputSamples), len(toIngest))
+				for tsIdx := range tc.inputSamples {
+					require.Equal(t, tc.inputSamples[tsIdx], toIngest[tsIdx].Samples)
+				}
 			}
 
 			if tc.expectError == nil {
@@ -283,6 +324,10 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 			} else {
 				// Expecting no requests if there were no samples to forward.
 				require.Len(t, bodies, 0)
+			}
+
+			if len(tc.checkMetricNames) > 0 {
+				require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(tc.expectedMetrics), tc.checkMetricNames...))
 			}
 		})
 	}
@@ -438,7 +483,7 @@ func TestForwardingEnsureThatPooledObjectsGetReturned(t *testing.T) {
 			}
 
 			// Perform the forwarding operation.
-			toIngest, errCh := forwarder.Forward(context.Background(), url, 0, tc.rules, ts)
+			toIngest, errCh := forwarder.Forward(context.Background(), url, 0, tc.rules, ts, "user")
 			require.NoError(t, <-errCh)
 
 			// receivedSamples counts the number of samples that each forwarding target has received.
@@ -777,7 +822,7 @@ func BenchmarkRemoteWriteForwarding(b *testing.B) {
 					require.NoError(b, <-errChs[errChIdx])
 				}
 
-				samples, errChs[errChIdx] = f.Forward(ctx, "http://localhost/", 0, tc.rules, samples)
+				samples, errChs[errChIdx] = f.Forward(ctx, "http://localhost/", 0, tc.rules, samples, "user")
 				errChIdx = (errChIdx + 1) % len(errChs)
 
 				mimirpb.ReuseSlice(samples)
@@ -809,7 +854,7 @@ func TestForwardingToHTTPGrpcTarget(t *testing.T) {
 		newSample(t, now, 4, 400, "__name__", "metric2", "some_label", "bar"),
 	}
 
-	tsToIngest, errCh := forwarder.Forward(ctx, httpGrpcPrefix+url, 0, rules, ts)
+	tsToIngest, errCh := forwarder.Forward(ctx, httpGrpcPrefix+url, 0, rules, ts, "user")
 
 	// The metric2 should be returned by the forwarding because the matching rule has ingest set to "true".
 	require.Len(t, tsToIngest, 2)


### PR DESCRIPTION
#### What this PR does

This PR increased discarded samples metric for forwarded series that receive too old samples, and are otherwise not ingested. 

#### Which issue(s) this PR fixes or relates to

Fixes comment https://github.com/grafana/mimir/pull/3049#discussion_r984555654

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
