### PR TITLE
Add continuous testing to helm chart

### DIFF
--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -89,6 +89,7 @@ validate_version_update $new_chart_version $current_chart_version $latest_gem_ta
 update_yaml_node $values_file .image.tag $latest_mimir_tag
 update_yaml_node $values_file .smoke_test.image.tag $latest_mimir_tag
 update_yaml_node $values_file .enterprise.image.tag $latest_gem_tag
+update_yaml_node $values_file .continuous_test.image.tag $latest_mimir_tag
 update_yaml_node $chart_file .appVersion $(extract_r_version $latest_mimir_tag)
 update_yaml_node $chart_file .version $new_chart_version
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -222,6 +222,7 @@ Either:
       - `image.tag` (Mimir)
       - `enterprise.image.tag` (GEM)
       - `smoke_test.image.tag` (Smoke test, usually same as Mimir)
+      - `continuous_test.image.tag` (Continuous test, usually same as Mimir)
    1. For stable versions, update the [Helm changelog](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md)
       - If there are any deprecated features that should be removed in this release, then verify that they have been removed, and move their deprecation notices in the section for this release.
    1. Set the `version` to the desired chart version number in the Helm [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml)

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -34,6 +34,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling. This is used when deploying on Kubernetes >= 1.25. #2848
 * [ENHANCEMENT] Monitoring: Add additional flags to conditionally enable log / metric scraping. #2936
 * [ENHANCEMENT] Add podAntiAffinity to sizing plans (small.yaml, large.yaml, capped-small.yaml, capped-large.yaml). #2906
+* [ENHANCEMENT] Add ability to configure and run mimir-continuous-test. #3117
 
 
 ## 3.1.0

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -347,6 +347,7 @@ Examples:
   "alertmanager" "alertmanager"
   "chunks-cache" "chunks-cache"
   "compactor" "compactor"
+  "continuous-test" "continuous_test"
   "distributor" "distributor"
   "gateway" "gateway"
   "gr-aggr-cache" "gr-aggr-cache"

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
@@ -49,11 +49,11 @@ spec:
             - "-tests.read-endpoint={{ template "mimir.gatewayUrl" . }}/prometheus"
             - "-tests.run-interval={{ .Values.continuous_test.runInterval }}"
             {{- if eq .Values.continuous_test.auth.type "tenantId" }}
-            - "-tests.tenant-id={{ .Values.continuous_test.auth.tenantId }}"
+            - "-tests.tenant-id={{ .Values.continuous_test.auth.tenant }}"
             {{- end }}
             {{- if eq .Values.continuous_test.auth.type "basicAuth" }}
             - "-tests.basic-auth-password={{ .Values.continuous_test.auth.password }}"
-            - "-tests.basic-auth-user={{ .Values.continuous_test.auth.username }}"
+            - "-tests.basic-auth-user={{ .Values.continuous_test.auth.tenant }}"
             {{- end }}
             {{- if eq .Values.continuous_test.auth.type "bearerToken" }}
             - "-tests.bearer-token={{ .Values.continuous_test.auth.bearerToken }}"

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.continuous_test.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- toYaml .Values.continuous_test.annotations | nindent 4 }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "continuous-test") | nindent 4 }}
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "continuous-test") }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.continuous_test.replicas }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "continuous-test") | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.continuous_test.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mimir.podLabels" (dict "ctx" . "component" "continuous-test") | nindent 8 }}
+      annotations:
+        {{- include "mimir.podAnnotations" (dict "ctx" . "component" "continuous-test") | nindent 8 }}
+      namespace: {{ .Release.Namespace | quote }}
+    spec:
+      serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      {{- if .Values.continuous_test.priorityClassName }}
+      priorityClassName: {{ .Values.continuous_test.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.continuous_test.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.continuous_test.initContainers | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: continuous-test
+          image: {{ .Values.continuous_test.image.repository }}:{{ .Values.continuous_test.image.tag }}
+          imagePullPolicy: {{ .Values.continuous_test.image.pullPolicy }}
+          args:
+            - "-server.metrics-port={{ include "mimir.serverHttpListenPort" . }}"
+            - "-tests.write-read-series-test.num-series={{ .Values.continuous_test.numSeries }}"
+            - "-tests.write-read-series-test.max-query-age={{ .Values.continuous_test.maxQueryAge }}"
+            - "-tests.write-endpoint={{ template "mimir.gatewayUrl" . }}"
+            - "-tests.read-endpoint={{ template "mimir.gatewayUrl" . }}/prometheus"
+            - "-tests.run-interval={{ .Values.continuous_test.runInterval }}"
+            {{- if eq .Values.continuous_test.auth.type "tenantId" }}
+            - "-tests.tenant-id={{ .Values.continuous_test.auth.tenantId }}"
+            {{- end }}
+            {{- if eq .Values.continuous_test.auth.type "basicAuth" }}
+            - "-tests.basic-auth-password={{ .Values.continuous_test.auth.password }}"
+            - "-tests.basic-auth-user={{ .Values.continuous_test.auth.username }}"
+            {{- end }}
+            {{- if eq .Values.continuous_test.auth.type "bearerToken" }}
+            - "-tests.bearer-token={{ .Values.continuous_test.auth.bearerToken }}"
+            {{- end }}
+            {{- range $key, $value := .Values.continuous_test.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.continuous_test.extraVolumeMounts }}
+              {{ toYaml .Values.continuous_test.extraVolumeMounts | nindent 12}}
+            {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ include "mimir.serverHttpListenPort" . }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.continuous_test.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.continuous_test.containerSecurityContext | nindent 12 }}
+          env:
+            {{- with .Values.global.extraEnv }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.continuous_test.env }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.global.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.continuous_test.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.continuous_test.extraContainers }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.continuous_test.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.continuous_test.affinity | nindent 8 }}
+      topologySpreadConstraints:
+        {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" . "component" "continuous-test") | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.continuous_test.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.continuous_test.terminationGracePeriodSeconds }}
+      volumes:
+        {{- if .Values.continuous_test.extraVolumes }}
+        {{ toYaml .Values.continuous_test.extraVolumes | nindent 8}}
+        {{- end }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-servmon.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.continuous_test.enabled -}}
+{{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "continuous-test") }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-svc-headless.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.continuous_test.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "continuous-test") }}-headless
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "continuous-test") | nindent 4 }}
+    {{- with .Values.continuous_test.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.continuous_test.service.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ include "mimir.serverHttpListenPort" . }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "continuous-test") | nindent 4 }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2497,7 +2497,10 @@ gr-metricname-cache:
     annotations: {}
     labels: {}
 
-# Settings for the smoke-test job.
+# -- Settings for the smoke-test job. This is meant to run as a Helm test hook
+# (`helm test RELEASE`) after installing the chart. It quickly verifies
+# that writing and reading metrics works. Currently not supported for
+# installations using GEM token-based authentication.
 smoke_test:
   image:
     repository: grafana/mimir-continuous-test
@@ -2512,26 +2515,31 @@ smoke_test:
   # -- The name of the PriorityClass for smoke-test pods
   priorityClassName: null
 
-# Settings for continous testing
+# -- Settings for mimir-continuous-test.
+# This continuously writes and reads metrics from Mimir.
+# https://grafana.com/docs/mimir/latest/operators-guide/tools/mimir-continuous-test/
 continuous_test:
   enabled: false
   # -- Number of replicas to start of continuous test
   replicas: 1
   image:
     repository: grafana/mimir-continuous-test
-    tag: r205-f2ad133
+    tag: r206-310ea58
     pullPolicy: IfNotPresent
+    # Note: optional pullSecrets are set in toplevel 'image' section, not here
+
   # -- Authentication settings of continuous test
   auth:
     # -- Type of authentication to use (tenantId, basicAuth, bearerToken)
     type: tenantId
-    # -- TenantId for tenantId auth
-    tenantId: 'mimir-continuous-test'
-    # -- Username for basicAuth auth
-    username: 'mimir-continuous-test'
-    # -- Password for basicAuth auth (note: can be environment variable from secret, e.g. $(PASSWORD))
+    # -- The tenant to use for tenantId or basicAuth authentication type
+    # In case of tenantId authentication, it is injected as the X-Scope-OrgID header on requests.
+    # In case of basicAuth, it is set as the username.
+    tenant: 'mimir-continuous-test'
+    # -- Password for basicAuth auth (note: can be environment variable from secret attached in extraEnvFrom, e.g. $(PASSWORD))
+    # It should contain an access token created for an access policy that allows metrics reads and writes for the tenant.
     password: null
-    # -- Bearer token for bearerToken auth (note: can be environment variable from secret, e.g. $(TOKEN))
+    # -- Bearer token for bearerToken auth (note: can be environment variable from secret attached in extraEnvFrom, e.g. $(TOKEN))
     bearerToken: null
   # -- The maximum number of series to write in a single request.
   numSeries: 1000
@@ -2540,23 +2548,29 @@ continuous_test:
   # -- Interval between test runs
   runInterval: "5m"
 
-  # -- Annotations for the continuous_test Deployment
+  # -- Pod affinity settings for the continuous test replicas
+  affinity: {}
+  # -- Annotations for the continuous test Deployment
   annotations: {}
   # -- The SecurityContext for continuous test containers
   containerSecurityContext:
     readOnlyRootFilesystem: true
-  # Extra environment variables for continuous test containers
+  # -- Extra environment variables for continuous test containers
   env: []
-  # Extra command line arguments for the continuous test container
+  # -- Extra command line arguments for the continuous test container
   extraArgs: {}
-  # Extra environment from secret/configmap for continuous test containers
+  # -- Extra environment from secret/configmap for continuous test containers
   extraEnvFrom: []
-  # Extra volumes for the continuous test container
+  # -- Extra volumes for the continuous test container
   extraVolumes: []
-  # Extra volume mounts for the continuous test container
+  # -- Extra volume mounts for the continuous test container
   extraVolumeMounts: []
-  # Extra initcontainers for the continuous test Deployment
+  # -- Extra containers for the continuous test Deployment
+  extraContainers: []
+  # -- Extra initContainers for the continuous test Deployment
   initContainers: []
+  # -- Nodeselector of continuous test replicas
+  nodeSelector: {}
   # -- The name of the PriorityClass for continuous test pods
   priorityClassName: null
   # -- Kubernetes resource requests and limits for continuous test
@@ -2566,15 +2580,18 @@ continuous_test:
     requests:
       cpu: "1"
       memory: 512Mi
-  # Security context for the continuous test Deployment
+  # -- Security context for the continuous test Deployment
   securityContext: {}
-  # Service for monitoring continuous test
+  # -- Service for monitoring continuous test
   service:
     annotations: {}
     labels: {}
-  # Upgrade strategy for the continuous test Deployment
+  # -- Upgrade strategy for the continuous test Deployment
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+
+  tolerations: []
+  terminationGracePeriodSeconds: 30

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2537,7 +2537,7 @@ continuous_test:
     # In case of basicAuth, it is set as the username.
     tenant: 'mimir-continuous-test'
     # -- Password for basicAuth auth (note: can be environment variable from secret attached in extraEnvFrom, e.g. $(PASSWORD))
-    # It should contain an access token created for an access policy that allows metrics reads and writes for the tenant.
+    # For GEM, it should contain an access token created for an access policy that allows `metrics:read` and `metrics:write` for the tenant.
     password: null
     # -- Bearer token for bearerToken auth (note: can be environment variable from secret attached in extraEnvFrom, e.g. $(TOKEN))
     bearerToken: null

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2511,3 +2511,70 @@ smoke_test:
   initContainers: []
   # -- The name of the PriorityClass for smoke-test pods
   priorityClassName: null
+
+# Settings for continous testing
+continuous_test:
+  enabled: false
+  # -- Number of replicas to start of continuous test
+  replicas: 1
+  image:
+    repository: grafana/mimir-continuous-test
+    tag: r205-f2ad133
+    pullPolicy: IfNotPresent
+  # -- Authentication settings of continuous test
+  auth:
+    # -- Type of authentication to use (tenantId, basicAuth, bearerToken)
+    type: tenantId
+    # -- TenantId for tenantId auth
+    tenantId: 'mimir-continuous-test'
+    # -- Username for basicAuth auth
+    username: 'mimir-continuous-test'
+    # -- Password for basicAuth auth (note: can be environment variable from secret, e.g. $(PASSWORD))
+    password: null
+    # -- Bearer token for bearerToken auth (note: can be environment variable from secret, e.g. $(TOKEN))
+    bearerToken: null
+  # -- The maximum number of series to write in a single request.
+  numSeries: 1000
+  # -- How far back in the past metrics can be queried at most.
+  maxQueryAge: "48h"
+  # -- Interval between test runs
+  runInterval: "5m"
+
+  # -- Annotations for the continuous_test Deployment
+  annotations: {}
+  # -- The SecurityContext for continuous test containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+  # Extra environment variables for continuous test containers
+  env: []
+  # Extra command line arguments for the continuous test container
+  extraArgs: {}
+  # Extra environment from secret/configmap for continuous test containers
+  extraEnvFrom: []
+  # Extra volumes for the continuous test container
+  extraVolumes: []
+  # Extra volume mounts for the continuous test container
+  extraVolumeMounts: []
+  # Extra initcontainers for the continuous test Deployment
+  initContainers: []
+  # -- The name of the PriorityClass for continuous test pods
+  priorityClassName: null
+  # -- Kubernetes resource requests and limits for continuous test
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      cpu: "1"
+      memory: 512Mi
+  # Security context for the continuous test Deployment
+  securityContext: {}
+  # Service for monitoring continuous test
+  service:
+    annotations: {}
+    labels: {}
+  # Upgrade strategy for the continuous test Deployment
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1


### PR DESCRIPTION
Support different kind of authentication methods.

This is for better testing of #2778 and also parity with jsonnet which already has continuous test support.

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
