### PR TITLE
Dashboards: Use the "req/s" unit on panels showing the requests rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 * [ENHANCEMENT] Dashboards: Make queries used to find job, cluster and namespace for dropdown menus configurable. #2893
 * [ENHANCEMENT] Dashboards: Include rate of label and series queries in "Reads" dashboard. #3065 #3074
 * [ENHANCEMENT] Dashboards: Fix legend showing on per-pod panels. #2944
+* [ENHANCEMENT] Dashboards: Use the "req/s" unit on panels showing the requests rate. #3118
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -341,7 +341,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -889,7 +889,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -1440,7 +1440,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2264,7 +2264,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -93,7 +93,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -257,7 +257,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -444,7 +444,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -694,7 +694,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1062,7 +1062,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1573,7 +1573,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1812,7 +1812,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2051,7 +2051,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -3256,7 +3256,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -4072,7 +4072,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -213,7 +213,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -452,7 +452,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -640,7 +640,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -597,7 +597,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -785,7 +785,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -973,7 +973,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1993,7 +1993,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "rps",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -519,7 +519,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -758,7 +758,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -997,7 +997,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1185,7 +1185,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1373,7 +1373,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "reqps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -146,6 +146,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
     },
 
+  qpsPanel(selector, statusLabelName='status_code')::
+    super.qpsPanel(selector, statusLabelName) +
+    { yaxes: $.yaxes('reqps') },
+
   // hiddenLegendQueryPanel adds on to 'timeseriesPanel', not the deprecated 'panel'.
   // It is a standard query panel designed to handle a large number of series.  it hides the legend, doesn't fill the series and
   // shows all values on tooltip, descending. Also turns on exemplars, unless 4th parameter is false.
@@ -478,7 +482,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.panel('Operations / sec') +
       $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s,component="%s"}[$__rate_interval]))' % [$.namespaceMatcher(), component], '{{operation}}') +
       $.stack +
-      { yaxes: $.yaxes('rps') },
+      { yaxes: $.yaxes('reqps') },
     )
     .addPanel(
       $.panel('Error rate') +

--- a/operations/mimir-mixin/dashboards/object-store.libsonnet
+++ b/operations/mimir-mixin/dashboards/object-store.libsonnet
@@ -11,7 +11,7 @@ local filename = 'mimir-object-store.json';
         $.panel('RPS / component') +
         $.queryPanel('sum by(component) (rate(thanos_objstore_bucket_operations_total{%s}[$__rate_interval]))' % $.namespaceMatcher(), '{{component}}') +
         $.stack +
-        { yaxes: $.yaxes('rps') },
+        { yaxes: $.yaxes('reqps') },
       )
       .addPanel(
         $.panel('Error rate / component') +
@@ -25,7 +25,7 @@ local filename = 'mimir-object-store.json';
         $.panel('RPS / operation') +
         $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s}[$__rate_interval]))' % $.namespaceMatcher(), '{{operation}}') +
         $.stack +
-        { yaxes: $.yaxes('rps') },
+        { yaxes: $.yaxes('reqps') },
       )
       .addPanel(
         $.panel('Error rate / operation') +


### PR DESCRIPTION
#### What this PR does
In Grafana "rps" means "read / sec", while "reqps" means "req / sec". We have few panels incorrectly using "rps" instead of "reqps", which I'm fixing in this PR. Moreover, I'm adding "reqps" to the `qpsPanel()` too.

#### Which issue(s) this PR fixes or relates to

Pre-requisite of #3079

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
