### PR TITLE
Include multiple tenant IDs in loggers with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 * [ENHANCEMENT] Improved tracing spans tracked by distributors, ingesters and store-gateways. #2879 #3099 #3089
 * [ENHANCEMENT] Ingester: improved the performance of label value cardinality endpoint. #3044
 * [ENHANCEMENT] Ruler: use backoff retry on remote evaluation #3098
+* [ENHANCEMENT] Query-frontend: Include multiple tenant IDs in query logs when present instead of dropping them. #3125
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -21,6 +21,12 @@ func WithUserID(userID string, l log.Logger) log.Logger {
 	return log.With(l, "user", userID)
 }
 
+// WithUserIDs returns a Logger that has information about the current user or
+// users (separated by "|") in its details.
+func WithUserIDs(userIDs []string, l log.Logger) log.Logger {
+	return log.With(l, "user", tenant.JoinTenantIDs(userIDs))
+}
+
 // WithTraceID returns a Logger that has information about the traceID in
 // its details.
 func WithTraceID(traceID string, l log.Logger) log.Logger {
@@ -28,19 +34,20 @@ func WithTraceID(traceID string, l log.Logger) log.Logger {
 	return log.With(l, "traceID", traceID)
 }
 
-// WithContext returns a Logger that has information about the current user in
-// its details.
+// WithContext returns a Logger that has information about the current user or users
+// and trace in its details.
 //
 // e.g.
 //
-//	log := util.WithContext(ctx)
-//	log.Errorf("Could not chunk chunks: %v", err)
+//	log = util.WithContext(ctx, log)
+//	# level=error user=user-1|user-2 traceID=123abc msg="Could not chunk chunks" err="an error"
+//	level.Error(log).Log("msg", "Could not chunk chunks", "err", err)
 func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
-	userID, err := tenant.TenantID(ctx)
+	userIDs, err := tenant.TenantIDs(ctx)
 	if err == nil {
-		l = WithUserID(userID, l)
+		l = WithUserIDs(userIDs, l)
 	}
 
 	traceID, ok := tracing.ExtractSampledTraceID(ctx)


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Previously, if there were multiple tenant IDs present in a request the `user` key value pair was dropped from the logger. Now it is included along with the multiple tenant IDs separated by a `|`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
