### PR TITLE
Update grafana/regexp branch used by Mimir to speedup-golang-1.19.2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.3.0
 	github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9
-	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2
+	github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.54.0
 	go.opentelemetry.io/collector/pdata v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/mimir-prometheus v0.0.0-20220822125643-4aa6d561a134 h1:dS8d6jRiMci9dIXENCktYdPcRXee8VRBqK+omnquQf8=
 github.com/grafana/mimir-prometheus v0.0.0-20220822125643-4aa6d561a134/go.mod h1:y+uCk/SdO73g9bMtjCZbejjmcjY4X+xLuKN7cBor5UE=
-github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
-github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
+github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafana/thanos v0.19.1-0.20220713162227-7bde03e4afa9 h1:K8dScpAih2+GKowaVQ8RIqPRetesNenu2TK71iLDiXM=
 github.com/grafana/thanos v0.19.1-0.20220713162227-7bde03e4afa9/go.mod h1:sklyj/ttQrL8iY3g/pQEAdIhayKW4HvOpbA7TEYK0Xs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/vendor/github.com/grafana/regexp/README.md
+++ b/vendor/github.com/grafana/regexp/README.md
@@ -10,3 +10,10 @@ The `main` branch is non-optimised: switch over to [`speedup`](https://github.co
 ## Benchmarks:
 
 ![image](https://user-images.githubusercontent.com/8125524/152182951-856549ed-6044-4285-b799-69b31f598e32.png)
+
+## Links to upstream changes:
+* [regexp: allow patterns with no alternates to be one-pass](https://go-review.googlesource.com/c/go/+/353711)
+* [regexp: speed up onepass prefix check](https://go-review.googlesource.com/c/go/+/354909)
+* [regexp: handle prefix string with fold-case](https://go-review.googlesource.com/c/go/+/358756)
+* [regexp: avoid copying each instruction executed](https://go-review.googlesource.com/c/go/+/355789)
+* [regexp: allow prefix string anchored at beginning](https://go-review.googlesource.com/c/go/+/377294)

--- a/vendor/github.com/grafana/regexp/exec.go
+++ b/vendor/github.com/grafana/regexp/exec.go
@@ -6,8 +6,9 @@ package regexp
 
 import (
 	"io"
-	"regexp/syntax"
 	"sync"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // A queue is a 'sparse array' holding pending threads of execution.
@@ -204,6 +205,8 @@ func (m *machine) match(i input, pos int) bool {
 				// Have match; finished exploring alternatives.
 				break
 			}
+			// Note we don't check foldCase here, because Unicode folding is complicated;
+			// just let it fall through to EqualFold on the whole string.
 			if len(m.re.prefix) > 0 && r1 != m.re.prefixRune && i.canCheckPrefix() {
 				// Match requires literal prefix; fast search for it.
 				advance := i.index(m.re, pos)
@@ -401,48 +404,49 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 	}
 
 	m := newOnePassMachine()
+	matched := false
+	i, _ := m.inputs.init(ir, ib, is)
+
+	r, r1 := endOfText, endOfText
+	width, width1 := 0, 0
+	var flag lazyFlag
+	var pc int
+	var inst *onePassInst
+
+	// If there is a simple literal prefix, skip over it.
+	if pos == 0 && len(re.prefix) > 0 && i.canCheckPrefix() {
+		// Match requires literal prefix; fast search for it.
+		if !i.hasPrefix(re) {
+			goto Return
+		}
+		pos += len(re.prefix)
+		pc = int(re.prefixEnd)
+	} else {
+		pc = re.onepass.Start
+	}
+
 	if cap(m.matchcap) < ncap {
 		m.matchcap = make([]int, ncap)
 	} else {
 		m.matchcap = m.matchcap[:ncap]
 	}
 
-	matched := false
 	for i := range m.matchcap {
 		m.matchcap[i] = -1
 	}
 
-	i, _ := m.inputs.init(ir, ib, is)
-
-	r, r1 := endOfText, endOfText
-	width, width1 := 0, 0
 	r, width = i.step(pos)
-	if r != endOfText {
-		r1, width1 = i.step(pos + width)
-	}
-	var flag lazyFlag
 	if pos == 0 {
 		flag = newLazyFlag(-1, r)
 	} else {
 		flag = i.context(pos)
 	}
-	pc := re.onepass.Start
-	inst := re.onepass.Inst[pc]
 	// If there is a simple literal prefix, skip over it.
-	if pos == 0 && flag.match(syntax.EmptyOp(inst.Arg)) &&
-		len(re.prefix) > 0 && i.canCheckPrefix() {
-		// Match requires literal prefix; fast search for it.
-		if !i.hasPrefix(re) {
-			goto Return
-		}
-		pos += len(re.prefix)
-		r, width = i.step(pos)
+	if r != endOfText {
 		r1, width1 = i.step(pos + width)
-		flag = i.context(pos)
-		pc = int(re.prefixEnd)
 	}
 	for {
-		inst = re.onepass.Inst[pc]
+		inst = &re.onepass.Inst[pc]
 		pc = int(inst.Out)
 		switch inst.Op {
 		default:
@@ -470,7 +474,7 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 			}
 		// peek at the input rune to see which branch of the Alt to take
 		case syntax.InstAlt, syntax.InstAltMatch:
-			pc = int(onePassNext(&inst, r))
+			pc = int(onePassNext(inst, r))
 			continue
 		case syntax.InstFail:
 			goto Return
@@ -526,6 +530,29 @@ func (re *Regexp) doExecute(r io.RuneReader, b []byte, s string, pos int, ncap i
 
 	if r == nil && len(b)+len(s) < re.minInputLen {
 		return nil
+	}
+
+	// Check prefix match before allocating data structures
+	if len(re.prefix) > 0 && r == nil {
+		if re.cond&syntax.EmptyBeginText != 0 { // anchored
+			if b != nil && !(&inputBytes{str: b[pos:]}).hasPrefix(re) {
+				return nil
+			}
+			if s != "" && !(&inputString{str: s[pos:]}).hasPrefix(re) {
+				return nil
+			}
+		} else { // non-anchored
+			var advance int
+			if b != nil {
+				advance = (&inputBytes{str: b}).index(re, pos)
+			} else {
+				advance = (&inputString{str: s}).index(re, pos)
+			}
+			if advance < 0 {
+				return nil
+			}
+			pos += advance
+		}
 	}
 
 	if re.onepass != nil {

--- a/vendor/github.com/grafana/regexp/onepass.go
+++ b/vendor/github.com/grafana/regexp/onepass.go
@@ -5,10 +5,12 @@
 package regexp
 
 import (
-	"regexp/syntax"
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // "One-pass" regexp execution.
@@ -37,10 +39,10 @@ type onePassInst struct {
 // is the entire match. Pc is the index of the last rune instruction
 // in the string. The OnePassPrefix skips over the mandatory
 // EmptyBeginText
-func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
+func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, foldCase bool, pc uint32) {
 	i := &p.Inst[p.Start]
 	if i.Op != syntax.InstEmptyWidth || (syntax.EmptyOp(i.Arg))&syntax.EmptyBeginText == 0 {
-		return "", i.Op == syntax.InstMatch, uint32(p.Start)
+		return "", i.Op == syntax.InstMatch, false, uint32(p.Start)
 	}
 	pc = i.Out
 	i = &p.Inst[pc]
@@ -50,12 +52,13 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 	}
 	// Avoid allocation of buffer if prefix is empty.
 	if iop(i) != syntax.InstRune || len(i.Rune) != 1 {
-		return "", i.Op == syntax.InstMatch, uint32(p.Start)
+		return "", i.Op == syntax.InstMatch, false, uint32(p.Start)
 	}
 
+	foldCase = (syntax.Flags(i.Arg)&syntax.FoldCase != 0)
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && syntax.Flags(i.Arg)&syntax.FoldCase == 0 {
+	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && (syntax.Flags(i.Arg)&syntax.FoldCase != 0) == foldCase && i.Rune[0] != utf8.RuneError {
 		buf.WriteRune(i.Rune[0])
 		pc, i = i.Out, &p.Inst[i.Out]
 	}
@@ -64,7 +67,7 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 		p.Inst[i.Out].Op == syntax.InstMatch {
 		complete = true
 	}
-	return buf.String(), complete, pc
+	return buf.String(), complete, foldCase, pc
 }
 
 // OnePassNext selects the next actionable state of the prog, based on the input character.
@@ -471,12 +474,20 @@ func compileOnePass(prog *syntax.Prog) (p *onePassProg) {
 		syntax.EmptyOp(prog.Inst[prog.Start].Arg)&syntax.EmptyBeginText != syntax.EmptyBeginText {
 		return nil
 	}
-	// every instruction leading to InstMatch must be EmptyEndText
+	hasAlt := false
+	for _, inst := range prog.Inst {
+		if inst.Op == syntax.InstAlt || inst.Op == syntax.InstAltMatch {
+			hasAlt = true
+			break
+		}
+	}
+	// If we have alternates, every instruction leading to InstMatch must be EmptyEndText.
+	// Also, any match on empty text must be $.
 	for _, inst := range prog.Inst {
 		opOut := prog.Inst[inst.Out].Op
 		switch inst.Op {
 		default:
-			if opOut == syntax.InstMatch {
+			if opOut == syntax.InstMatch && hasAlt {
 				return nil
 			}
 		case syntax.InstAlt, syntax.InstAltMatch:

--- a/vendor/github.com/grafana/regexp/syntax/doc.go
+++ b/vendor/github.com/grafana/regexp/syntax/doc.go
@@ -9,123 +9,132 @@ Package syntax parses regular expressions into parse trees and compiles
 parse trees into programs. Most clients of regular expressions will use the
 facilities of package regexp (such as Compile and Match) instead of this package.
 
-Syntax
+# Syntax
 
 The regular expression syntax understood by this package when parsing with the Perl flag is as follows.
 Parts of the syntax can be disabled by passing alternate flags to Parse.
 
-
 Single characters:
-  .              any character, possibly including newline (flag s=true)
-  [xyz]          character class
-  [^xyz]         negated character class
-  \d             Perl character class
-  \D             negated Perl character class
-  [[:alpha:]]    ASCII character class
-  [[:^alpha:]]   negated ASCII character class
-  \pN            Unicode character class (one-letter name)
-  \p{Greek}      Unicode character class
-  \PN            negated Unicode character class (one-letter name)
-  \P{Greek}      negated Unicode character class
+
+	.              any character, possibly including newline (flag s=true)
+	[xyz]          character class
+	[^xyz]         negated character class
+	\d             Perl character class
+	\D             negated Perl character class
+	[[:alpha:]]    ASCII character class
+	[[:^alpha:]]   negated ASCII character class
+	\pN            Unicode character class (one-letter name)
+	\p{Greek}      Unicode character class
+	\PN            negated Unicode character class (one-letter name)
+	\P{Greek}      negated Unicode character class
 
 Composites:
-  xy             x followed by y
-  x|y            x or y (prefer x)
+
+	xy             x followed by y
+	x|y            x or y (prefer x)
 
 Repetitions:
-  x*             zero or more x, prefer more
-  x+             one or more x, prefer more
-  x?             zero or one x, prefer one
-  x{n,m}         n or n+1 or ... or m x, prefer more
-  x{n,}          n or more x, prefer more
-  x{n}           exactly n x
-  x*?            zero or more x, prefer fewer
-  x+?            one or more x, prefer fewer
-  x??            zero or one x, prefer zero
-  x{n,m}?        n or n+1 or ... or m x, prefer fewer
-  x{n,}?         n or more x, prefer fewer
-  x{n}?          exactly n x
+
+	x*             zero or more x, prefer more
+	x+             one or more x, prefer more
+	x?             zero or one x, prefer one
+	x{n,m}         n or n+1 or ... or m x, prefer more
+	x{n,}          n or more x, prefer more
+	x{n}           exactly n x
+	x*?            zero or more x, prefer fewer
+	x+?            one or more x, prefer fewer
+	x??            zero or one x, prefer zero
+	x{n,m}?        n or n+1 or ... or m x, prefer fewer
+	x{n,}?         n or more x, prefer fewer
+	x{n}?          exactly n x
 
 Implementation restriction: The counting forms x{n,m}, x{n,}, and x{n}
 reject forms that create a minimum or maximum repetition count above 1000.
 Unlimited repetitions are not subject to this restriction.
 
 Grouping:
-  (re)           numbered capturing group (submatch)
-  (?P<name>re)   named & numbered capturing group (submatch)
-  (?:re)         non-capturing group
-  (?flags)       set flags within current group; non-capturing
-  (?flags:re)    set flags during re; non-capturing
 
-  Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z). The flags are:
+	(re)           numbered capturing group (submatch)
+	(?P<name>re)   named & numbered capturing group (submatch)
+	(?:re)         non-capturing group
+	(?flags)       set flags within current group; non-capturing
+	(?flags:re)    set flags during re; non-capturing
 
-  i              case-insensitive (default false)
-  m              multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false)
-  s              let . match \n (default false)
-  U              ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false)
+	Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z). The flags are:
+
+	i              case-insensitive (default false)
+	m              multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false)
+	s              let . match \n (default false)
+	U              ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false)
 
 Empty strings:
-  ^              at beginning of text or line (flag m=true)
-  $              at end of text (like \z not \Z) or line (flag m=true)
-  \A             at beginning of text
-  \b             at ASCII word boundary (\w on one side and \W, \A, or \z on the other)
-  \B             not at ASCII word boundary
-  \z             at end of text
+
+	^              at beginning of text or line (flag m=true)
+	$              at end of text (like \z not \Z) or line (flag m=true)
+	\A             at beginning of text
+	\b             at ASCII word boundary (\w on one side and \W, \A, or \z on the other)
+	\B             not at ASCII word boundary
+	\z             at end of text
 
 Escape sequences:
-  \a             bell (== \007)
-  \f             form feed (== \014)
-  \t             horizontal tab (== \011)
-  \n             newline (== \012)
-  \r             carriage return (== \015)
-  \v             vertical tab character (== \013)
-  \*             literal *, for any punctuation character *
-  \123           octal character code (up to three digits)
-  \x7F           hex character code (exactly two digits)
-  \x{10FFFF}     hex character code
-  \Q...\E        literal text ... even if ... has punctuation
+
+	\a             bell (== \007)
+	\f             form feed (== \014)
+	\t             horizontal tab (== \011)
+	\n             newline (== \012)
+	\r             carriage return (== \015)
+	\v             vertical tab character (== \013)
+	\*             literal *, for any punctuation character *
+	\123           octal character code (up to three digits)
+	\x7F           hex character code (exactly two digits)
+	\x{10FFFF}     hex character code
+	\Q...\E        literal text ... even if ... has punctuation
 
 Character class elements:
-  x              single character
-  A-Z            character range (inclusive)
-  \d             Perl character class
-  [:foo:]        ASCII character class foo
-  \p{Foo}        Unicode character class Foo
-  \pF            Unicode character class F (one-letter name)
+
+	x              single character
+	A-Z            character range (inclusive)
+	\d             Perl character class
+	[:foo:]        ASCII character class foo
+	\p{Foo}        Unicode character class Foo
+	\pF            Unicode character class F (one-letter name)
 
 Named character classes as character class elements:
-  [\d]           digits (== \d)
-  [^\d]          not digits (== \D)
-  [\D]           not digits (== \D)
-  [^\D]          not not digits (== \d)
-  [[:name:]]     named ASCII class inside character class (== [:name:])
-  [^[:name:]]    named ASCII class inside negated character class (== [:^name:])
-  [\p{Name}]     named Unicode property inside character class (== \p{Name})
-  [^\p{Name}]    named Unicode property inside negated character class (== \P{Name})
+
+	[\d]           digits (== \d)
+	[^\d]          not digits (== \D)
+	[\D]           not digits (== \D)
+	[^\D]          not not digits (== \d)
+	[[:name:]]     named ASCII class inside character class (== [:name:])
+	[^[:name:]]    named ASCII class inside negated character class (== [:^name:])
+	[\p{Name}]     named Unicode property inside character class (== \p{Name})
+	[^\p{Name}]    named Unicode property inside negated character class (== \P{Name})
 
 Perl character classes (all ASCII-only):
-  \d             digits (== [0-9])
-  \D             not digits (== [^0-9])
-  \s             whitespace (== [\t\n\f\r ])
-  \S             not whitespace (== [^\t\n\f\r ])
-  \w             word characters (== [0-9A-Za-z_])
-  \W             not word characters (== [^0-9A-Za-z_])
+
+	\d             digits (== [0-9])
+	\D             not digits (== [^0-9])
+	\s             whitespace (== [\t\n\f\r ])
+	\S             not whitespace (== [^\t\n\f\r ])
+	\w             word characters (== [0-9A-Za-z_])
+	\W             not word characters (== [^0-9A-Za-z_])
 
 ASCII character classes:
-  [[:alnum:]]    alphanumeric (== [0-9A-Za-z])
-  [[:alpha:]]    alphabetic (== [A-Za-z])
-  [[:ascii:]]    ASCII (== [\x00-\x7F])
-  [[:blank:]]    blank (== [\t ])
-  [[:cntrl:]]    control (== [\x00-\x1F\x7F])
-  [[:digit:]]    digits (== [0-9])
-  [[:graph:]]    graphical (== [!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])
-  [[:lower:]]    lower case (== [a-z])
-  [[:print:]]    printable (== [ -~] == [ [:graph:]])
-  [[:punct:]]    punctuation (== [!-/:-@[-`{-~])
-  [[:space:]]    whitespace (== [\t\n\v\f\r ])
-  [[:upper:]]    upper case (== [A-Z])
-  [[:word:]]     word characters (== [0-9A-Za-z_])
-  [[:xdigit:]]   hex digit (== [0-9A-Fa-f])
+
+	[[:alnum:]]    alphanumeric (== [0-9A-Za-z])
+	[[:alpha:]]    alphabetic (== [A-Za-z])
+	[[:ascii:]]    ASCII (== [\x00-\x7F])
+	[[:blank:]]    blank (== [\t ])
+	[[:cntrl:]]    control (== [\x00-\x1F\x7F])
+	[[:digit:]]    digits (== [0-9])
+	[[:graph:]]    graphical (== [!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])
+	[[:lower:]]    lower case (== [a-z])
+	[[:print:]]    printable (== [ -~] == [ [:graph:]])
+	[[:punct:]]    punctuation (== [!-/:-@[-`{-~])
+	[[:space:]]    whitespace (== [\t\n\v\f\r ])
+	[[:upper:]]    upper case (== [A-Z])
+	[[:word:]]     word characters (== [0-9A-Za-z_])
+	[[:xdigit:]]   hex digit (== [0-9A-Fa-f])
 
 Unicode character classes are those in unicode.Categories and unicode.Scripts.
 */

--- a/vendor/github.com/grafana/regexp/syntax/parse.go
+++ b/vendor/github.com/grafana/regexp/syntax/parse.go
@@ -43,6 +43,7 @@ const (
 	ErrMissingRepeatArgument ErrorCode = "missing argument to repetition operator"
 	ErrTrailingBackslash     ErrorCode = "trailing backslash at end of expression"
 	ErrUnexpectedParen       ErrorCode = "unexpected )"
+	ErrNestingDepth          ErrorCode = "expression nests too deeply"
 )
 
 func (e ErrorCode) String() string {
@@ -90,15 +91,49 @@ const (
 // until we've allocated at least maxHeight Regexp structures.
 const maxHeight = 1000
 
+// maxSize is the maximum size of a compiled regexp in Insts.
+// It too is somewhat arbitrarily chosen, but the idea is to be large enough
+// to allow significant regexps while at the same time small enough that
+// the compiled form will not take up too much memory.
+// 128 MB is enough for a 3.3 million Inst structures, which roughly
+// corresponds to a 3.3 MB regexp.
+const (
+	maxSize  = 128 << 20 / instSize
+	instSize = 5 * 8 // byte, 2 uint32, slice is 5 64-bit words
+)
+
+// maxRunes is the maximum number of runes allowed in a regexp tree
+// counting the runes in all the nodes.
+// Ignoring character classes p.numRunes is always less than the length of the regexp.
+// Character classes can make it much larger: each \pL adds 1292 runes.
+// 128 MB is enough for 32M runes, which is over 26k \pL instances.
+// Note that repetitions do not make copies of the rune slices,
+// so \pL{1000} is only one rune slice, not 1000.
+// We could keep a cache of character classes we've seen,
+// so that all the \pL we see use the same rune list,
+// but that doesn't remove the problem entirely:
+// consider something like [\pL01234][\pL01235][\pL01236]...[\pL^&*()].
+// And because the Rune slice is exposed directly in the Regexp,
+// there is not an opportunity to change the representation to allow
+// partial sharing between different character classes.
+// So the limit is the best we can do.
+const (
+	maxRunes = 128 << 20 / runeSize
+	runeSize = 4 // rune is int32
+)
+
 type parser struct {
 	flags       Flags     // parse mode flags
 	stack       []*Regexp // stack of parsed expressions
 	free        *Regexp
 	numCap      int // number of capturing groups seen
 	wholeRegexp string
-	tmpClass    []rune          // temporary char class work space
-	numRegexp   int             // number of regexps allocated
-	height      map[*Regexp]int // regexp height for height limit check
+	tmpClass    []rune            // temporary char class work space
+	numRegexp   int               // number of regexps allocated
+	numRunes    int               // number of runes in char classes
+	repeats     int64             // product of all repetitions seen
+	height      map[*Regexp]int   // regexp height, for height limit check
+	size        map[*Regexp]int64 // regexp compiled size, for size limit check
 }
 
 func (p *parser) newRegexp(op Op) *Regexp {
@@ -122,6 +157,104 @@ func (p *parser) reuse(re *Regexp) {
 	p.free = re
 }
 
+func (p *parser) checkLimits(re *Regexp) {
+	if p.numRunes > maxRunes {
+		panic(ErrInternalError)
+	}
+	p.checkSize(re)
+	p.checkHeight(re)
+}
+
+func (p *parser) checkSize(re *Regexp) {
+	if p.size == nil {
+		// We haven't started tracking size yet.
+		// Do a relatively cheap check to see if we need to start.
+		// Maintain the product of all the repeats we've seen
+		// and don't track if the total number of regexp nodes
+		// we've seen times the repeat product is in budget.
+		if p.repeats == 0 {
+			p.repeats = 1
+		}
+		if re.Op == OpRepeat {
+			n := re.Max
+			if n == -1 {
+				n = re.Min
+			}
+			if n <= 0 {
+				n = 1
+			}
+			if int64(n) > maxSize/p.repeats {
+				p.repeats = maxSize
+			} else {
+				p.repeats *= int64(n)
+			}
+		}
+		if int64(p.numRegexp) < maxSize/p.repeats {
+			return
+		}
+
+		// We need to start tracking size.
+		// Make the map and belatedly populate it
+		// with info about everything we've constructed so far.
+		p.size = make(map[*Regexp]int64)
+		for _, re := range p.stack {
+			p.checkSize(re)
+		}
+	}
+
+	if p.calcSize(re, true) > maxSize {
+		panic(ErrInternalError)
+	}
+}
+
+func (p *parser) calcSize(re *Regexp, force bool) int64 {
+	if !force {
+		if size, ok := p.size[re]; ok {
+			return size
+		}
+	}
+
+	var size int64
+	switch re.Op {
+	case OpLiteral:
+		size = int64(len(re.Rune))
+	case OpCapture, OpStar:
+		// star can be 1+ or 2+; assume 2 pessimistically
+		size = 2 + p.calcSize(re.Sub[0], false)
+	case OpPlus, OpQuest:
+		size = 1 + p.calcSize(re.Sub[0], false)
+	case OpConcat:
+		for _, sub := range re.Sub {
+			size += p.calcSize(sub, false)
+		}
+	case OpAlternate:
+		for _, sub := range re.Sub {
+			size += p.calcSize(sub, false)
+		}
+		if len(re.Sub) > 1 {
+			size += int64(len(re.Sub)) - 1
+		}
+	case OpRepeat:
+		sub := p.calcSize(re.Sub[0], false)
+		if re.Max == -1 {
+			if re.Min == 0 {
+				size = 2 + sub // x*
+			} else {
+				size = 1 + int64(re.Min)*sub // xxx+
+			}
+			break
+		}
+		// x{2,5} = xx(x(x(x)?)?)?
+		size = int64(re.Max)*sub + int64(re.Max-re.Min)
+	}
+
+	if size < 1 {
+		size = 1
+	}
+	p.size[re] = size
+	return size
+}
+
 func (p *parser) checkHeight(re *Regexp) {
 	if p.numRegexp < maxHeight {
 		return
@@ -133,7 +266,7 @@ func (p *parser) checkHeight(re *Regexp) {
 		}
 	}
 	if p.calcHeight(re, true) > maxHeight {
-		panic(ErrInternalError)
+		panic(ErrNestingDepth)
 	}
 }
 
@@ -158,6 +291,7 @@ func (p *parser) calcHeight(re *Regexp, force bool) int {
 
 // push pushes the regexp re onto the parse stack and returns the regexp.
 func (p *parser) push(re *Regexp) *Regexp {
+	p.numRunes += len(re.Rune)
 	if re.Op == OpCharClass && len(re.Rune) == 2 && re.Rune[0] == re.Rune[1] {
 		// Single rune.
 		if p.maybeConcat(re.Rune[0], p.flags&^FoldCase) {
@@ -189,7 +323,7 @@ func (p *parser) push(re *Regexp) *Regexp {
 	}
 
 	p.stack = append(p.stack, re)
-	p.checkHeight(re)
+	p.checkLimits(re)
 	return re
 }
 
@@ -299,7 +433,7 @@ func (p *parser) repeat(op Op, min, max int, before, after, lastRepeat string) (
 	re.Sub = re.Sub0[:1]
 	re.Sub[0] = sub
 	p.stack[n-1] = re
-	p.checkHeight(re)
+	p.checkLimits(re)
 
 	if op == OpRepeat && (min >= 2 || max >= 2) && !repeatIsValid(re, 1000) {
 		return "", &Error{ErrInvalidRepeatSize, before[:len(before)-len(after)]}
@@ -444,12 +578,16 @@ func (p *parser) collapse(subs []*Regexp, op Op) *Regexp {
 // frees (passes to p.reuse) any removed *Regexps.
 //
 // For example,
-//     ABC|ABD|AEF|BCX|BCY
-// simplifies by literal prefix extraction to
-//     A(B(C|D)|EF)|BC(X|Y)
-// which simplifies by character class introduction to
-//     A(B[CD]|EF)|BC[XY]
 //
+//	ABC|ABD|AEF|BCX|BCY
+//
+// simplifies by literal prefix extraction to
+//
+//	A(B(C|D)|EF)|BC(X|Y)
+//
+// which simplifies by character class introduction to
+//
+//	A(B[CD]|EF)|BC[XY]
 func (p *parser) factor(sub []*Regexp) []*Regexp {
 	if len(sub) < 2 {
 		return sub
@@ -503,6 +641,7 @@ func (p *parser) factor(sub []*Regexp) []*Regexp {
 
 			for j := start; j < i; j++ {
 				sub[j] = p.removeLeadingString(sub[j], len(str))
+				p.checkLimits(sub[j])
 			}
 			suffix := p.collapse(sub[start:i], OpAlternate) // recurse
 
@@ -560,6 +699,7 @@ func (p *parser) factor(sub []*Regexp) []*Regexp {
 			for j := start; j < i; j++ {
 				reuse := j != start // prefix came from sub[start]
 				sub[j] = p.removeLeadingRegexp(sub[j], reuse)
+				p.checkLimits(sub[j])
 			}
 			suffix := p.collapse(sub[start:i], OpAlternate) // recurse
 
@@ -757,8 +897,10 @@ func parse(s string, flags Flags) (_ *Regexp, err error) {
 			panic(r)
 		case nil:
 			// ok
-		case ErrInternalError:
+		case ErrInternalError: // too big
 			err = &Error{Code: ErrInternalError, Expr: s}
+		case ErrNestingDepth:
+			err = &Error{Code: ErrNestingDepth, Expr: s}
 		}
 	}()
 
@@ -892,13 +1034,7 @@ func parse(s string, flags Flags) (_ *Regexp, err error) {
 				case 'Q':
 					// \Q ... \E: the ... is always literals
 					var lit string
-					if i := strings.Index(t, `\E`); i < 0 {
-						lit = t[2:]
-						t = ""
-					} else {
-						lit = t[2:i]
-						t = t[i+2:]
-					}
+					lit, t, _ = strings.Cut(t[2:], `\E`)
 					for lit != "" {
 						c, rest, err := nextRune(lit)
 						if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -478,7 +478,7 @@ github.com/grafana/e2e
 github.com/grafana/e2e/cache
 github.com/grafana/e2e/db
 github.com/grafana/e2e/images
-# github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2
+# github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 ## explicit; go 1.17
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax


### PR DESCRIPTION
#### What this PR does

This PR updates branch of https://github.com/grafana/regexp package to use https://github.com/grafana/regexp/tree/speedup-golang-1.19.2, with latest changes from Go 1.19.2.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
