### PR TITLE
Docs: Fixed Alertmanager capacity planning documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 * [BUGFIX] Fixed configuration option names in "Enabling zone-awareness via the Grafana Mimir Jsonnet". #3018
 * [BUGFIX] Fixed `mimirtool analyze` parameters documentation. #3094
 * [BUGFIX] Fixed YAML configuraton in the "Manage the configuration of Grafana Mimir with Helm" guide. #3042
+* [BUGFIX] Fixed Alertmanager capacity planning documentation. #3132
 
 ### Tools
 

--- a/docs/sources/operators-guide/run-production-environment/planning-capacity.md
+++ b/docs/sources/operators-guide/run-production-environment/planning-capacity.md
@@ -160,5 +160,17 @@ The [Alertmanager]({{< relref "../architecture/components/alertmanager.md" >}}) 
 
 Estimated required CPU and memory:
 
-- CPU: 1 CPU core for every 100 firing alerts
-- Memory: 1GB for every 100 firing alerts
+- CPU: 1 CPU core for every 100 firing alert notifications per second
+- Memory: 1GB for every 5,000 firing alerts
+
+To estimate the peak of firing alert notifications per second in the last 24 hours, run the following query across all Prometheus servers:
+
+```
+sum(max_over_time(rate(alertmanager_alerts_received_total[5m])[24h:5m]))
+```
+
+To estimate the maximum number of firing alerts in the last 24 hours, run the following query across all Prometheus servers:
+
+```
+sum(max_over_time(alertmanager_alerts[24h]))
+```


### PR DESCRIPTION
#### What this PR does
Starting from [this comment](https://github.com/grafana/mimir/issues/1469#issuecomment-1267294868), I looked again at the Mimir Alertmanager resources utilization in a single tenant cluster with many firing alerts. I updated the capacity planning doc accordingly.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
