### PR TITLE
Added `mimirtool rules delete-namespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Jsonnet
 
 ### Mimirtool
+* [ENHANCEMENT] Added `mimirtool rules delete-namespace` command to delete all of the rule groups in a namespace including the namespace itself. #3136
 
 ### Documentation
 

--- a/docs/sources/operators-guide/tools/mimirtool.md
+++ b/docs/sources/operators-guide/tools/mimirtool.md
@@ -196,6 +196,14 @@ groups:
         expr: sum by (job) (http_inprogress_requests)
 ```
 
+#### Delete a namespace
+
+The following command deletes all of the rule groups in a namespace, including the namespace itself:
+
+```bash
+mimirtool rules delete-namespace <namespace>
+```
+
 #### Lint
 
 The `lint` command provides YAML and PromQL expression formatting within the rule file.

--- a/pkg/mimirtool/client/rules.go
+++ b/pkg/mimirtool/client/rules.go
@@ -114,3 +114,18 @@ func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[stri
 
 	return ruleSet, nil
 }
+
+// DeleteNamespace delete all the rule groups in a namespace including the namespace itself
+func (r *MimirClient) DeleteNamespace(ctx context.Context, namespace string) error {
+	escapedNamespace := url.PathEscape(namespace)
+	path := r.apiPath + "/" + escapedNamespace
+
+	res, err := r.doRequest(path, "DELETE", nil, -1)
+	if err != nil {
+		return err
+	}
+
+	res.Body.Close()
+
+	return nil
+}


### PR DESCRIPTION
#### What this PR does
The following changes allow user delete all the rule groups in a namespace (including the namespace itself).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
