### PR TITLE
Allow to adjust mount options in Makefile

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -37,7 +37,8 @@ make
 You can use `make help` to see the available targets.
 (By default, the build runs in a Docker container, using an image built
 with all the tools required. The source code is mounted from where you
-run `make` into the build container as a Docker volume.)
+run `make` into the build container as a Docker volume.
+The mount options can be adjusted with `CONTAINER_MOUNT_OPTIONS`.)
 
 To run the unit tests suite:
 
@@ -48,6 +49,15 @@ go test ./...
 To run the integration tests suite please see "[How integration tests work](./how-integration-tests-work.md)".
 
 If using macOS, make sure you have `gnu-sed` installed; otherwise, some make targets will not work properly.
+
+Depending on how docker is installed, configured but also the hardening applied to your workstation using the docker mount options might not work properly.
+This is also true if you are using an alternative to docker like for example podman. In such case, you can use `CONTAINER_MOUNT_OPTIONS` to adjust the mount option.
+
+Example:
+
+```
+make CONTAINER_MOUNT_OPTIONS=delegated
+```
 
 ### Dependency management
 


### PR DESCRIPTION
#### What this PR does

Depending on how docker is installed and configured but also the hardening applied to the workstation, docker might not be able to mount the code base properly in the container. As such, the user could end up with a error similar to the following:

```
❯ make lint
--8<--
>>>> Entering build container: lint-packaging-scripts
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v /workspace/github.com/grafana/mimir/.cache:/go/cache:delegated,z -v /workspace/github.com/grafana/mimir/.pkg:/go/pkg:delegated,z -v /workspace/github.com/grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=amd64 BINARY_SUFFIX="" lint-packaging-scripts;
Error: error preparing container 9c7c78b35ac936b65510dec180a81f6f38ea98e027d7049012f73f7ac31f885d for attach: lsetxattr /workspace/github.com/grafana/mimir/.cache: operation not supported

real    0m0,719s
user    0m0,046s
sys     0m0,021s
```

This error could also be trigger when using [podman](https://podman.io/) as an alternative for docker.

See: https://github.com/containers/podman/issues/13631

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`


I'm not sure where to add this information in `CHANGELOG.md`, I will update the PR to follow your instruction.