### PR TITLE
Add gossip label to ruler queriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 
 * [FEATURE] Added support for query-scheduler ring-based service discovery. #3128
 * [ENHANCEMENT] Querier autoscaling is now slower on scale downs: scale down 10% every 1m instead of 100%. #2962
+* [BUGFIX] Memberlist: `gossip_member_label` is now set for ruler-queriers. #3141
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -867,6 +867,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: ruler-querier
     spec:
       containers:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -869,6 +869,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: ruler-querier
     spec:
       containers:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -868,6 +868,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: ruler-querier
     spec:
       containers:

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -116,6 +116,8 @@
 
   querier_deployment+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
 
+  ruler_querier_deployment+: if !$._config.memberlist_ring_enabled || !$._config.ruler_remote_evaluation_enabled then {} else gossipLabel,
+
   ruler_deployment+: if !$._config.memberlist_ring_enabled || !$._config.ruler_enabled then {} else gossipLabel,
 
   query_scheduler_deployment+: if !querySchedulerMemberlistEnabled then {} else gossipLabel,

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -24,9 +24,9 @@
 (import 'shuffle-sharding.libsonnet') +
 (import 'query-sharding.libsonnet') +
 (import 'multi-zone.libsonnet') +
+(import 'ruler-remote-evaluation.libsonnet') +
 (import 'memberlist.libsonnet') +
 (import 'continuous-test.libsonnet') +
-(import 'ruler-remote-evaluation.libsonnet') +
 
 // Import autoscaling at the end because it overrides deployments.
 (import 'autoscaling.libsonnet')


### PR DESCRIPTION
#### What this PR does

Sets `gossip_ring_member=true` for ruler queriers. This was a little tricky because the import ordering mattered.

#### Which issue(s) this PR fixes or relates to

Fixes #2849

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
