### PR TITLE
Chore: refactor successFailurePanel() utility function in dashboards

### DIFF
--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -290,8 +290,8 @@ local fixTargetsForTransformations(panel, refIds) = panel {
         { yaxes: $.yaxes('ops') },
       )
       .addPanel(
+        $.panel('Blocks deletions / sec') +
         $.successFailurePanel(
-          'Blocks deletions / sec',
           // The cortex_compactor_blocks_cleaned_total tracks the number of successfully
           // deleted blocks.
           |||
@@ -304,14 +304,16 @@ local fixTargetsForTransformations(panel, refIds) = panel {
           ||| % {
             job: $.jobMatcher($._config.job_names.compactor),
           },
-        ) + { yaxes: $.yaxes('ops') }
+        ) +
+        $.stack +
+        { yaxes: $.yaxes('ops') }
       )
     )
     .addRow(
       $.row('Metadata sync')
       .addPanel(
+        $.panel('Metadata syncs / sec') +
         $.successFailurePanel(
-          'Metadata syncs / sec',
           // The cortex_compactor_meta_syncs_total metric is incremented each time a per-tenant
           // metadata sync is triggered.
           |||
@@ -326,7 +328,9 @@ local fixTargetsForTransformations(panel, refIds) = panel {
           ||| % {
             job: $.jobMatcher($._config.job_names.compactor),
           },
-        ) + { yaxes: $.yaxes('ops') }
+        ) +
+        $.stack +
+        { yaxes: $.yaxes('ops') }
       )
       .addPanel(
         $.panel('Metadata sync duration') +

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -200,10 +200,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
     },
 
-  successFailurePanel(title, successMetric, failureMetric)::
-    $.panel(title) +
+  successFailurePanel(successMetric, failureMetric)::
     $.queryPanel([successMetric, failureMetric], ['successful', 'failed']) +
-    $.stack + {
+    {
       aliasColors: {
         successful: successColor,
         failed: errorColor,

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -204,7 +204,9 @@ local filename = 'mimir-overview.json';
         { yaxes: $.yaxes('s') },
       )
       .addPanel(
-        $.successFailurePanel('Alerting notifications sent to Alertmanager / sec', $.queries.ruler.notifications.successPerSecond, $.queries.ruler.notifications.failurePerSecond)
+        $.panel('Alerting notifications sent to Alertmanager / sec') +
+        $.successFailurePanel($.queries.ruler.notifications.successPerSecond, $.queries.ruler.notifications.failurePerSecond) +
+        $.stack
       )
     )
 
@@ -220,7 +222,9 @@ local filename = 'mimir-overview.json';
         ||| % helpers),
       )
       .addPanel(
-        $.successFailurePanel('Requests / sec', $.queries.storage.successPerSecond, $.queries.storage.failurePerSecond) +
+        $.panel('Requests / sec') +
+        $.successFailurePanel($.queries.storage.successPerSecond, $.queries.storage.failurePerSecond) +
+        $.stack +
         { yaxes: $.yaxes('reqps') },
       )
       .addPanel(

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -213,11 +213,12 @@ local filename = 'mimir-queries.json';
         { yaxes: $.yaxes('short') },
       )
       .addPanel(
+        $.panel('Bucket indexes load / sec') +
         $.successFailurePanel(
-          'Bucket indexes load / sec',
           'sum(rate(cortex_bucket_index_loads_total{%s}[$__rate_interval])) - sum(rate(cortex_bucket_index_load_failures_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.querier), $.jobMatcher($._config.job_names.querier)],
           'sum(rate(cortex_bucket_index_load_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.querier),
-        )
+        ) +
+        $.stack
       )
       .addPanel(
         $.panel('Bucket indexes load latency') +
@@ -267,18 +268,20 @@ local filename = 'mimir-queries.json';
         { fill: 0 }
       )
       .addPanel(
+        $.panel('Blocks loaded / sec') +
         $.successFailurePanel(
-          'Blocks loaded / sec',
           'sum(rate(cortex_bucket_store_block_loads_total{component="store-gateway",%s}[$__rate_interval])) - sum(rate(cortex_bucket_store_block_load_failures_total{component="store-gateway",%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
           'sum(rate(cortex_bucket_store_block_load_failures_total{component="store-gateway",%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.store_gateway),
-        )
+        ) +
+        $.stack
       )
       .addPanel(
+        $.panel('Blocks dropped / sec') +
         $.successFailurePanel(
-          'Blocks dropped / sec',
           'sum(rate(cortex_bucket_store_block_drops_total{component="store-gateway",%s}[$__rate_interval])) - sum(rate(cortex_bucket_store_block_drop_failures_total{component="store-gateway",%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
           'sum(rate(cortex_bucket_store_block_drop_failures_total{component="store-gateway",%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.store_gateway),
-        )
+        ) +
+        $.stack
       )
     )
     .addRow(

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -166,8 +166,8 @@ local filename = 'mimir-writes.json';
     .addRow(
       $.row('Ingester - shipper')
       .addPanel(
+        $.panel('Uploaded blocks / sec') +
         $.successFailurePanel(
-          'Uploaded blocks / sec',
           'sum(rate(cortex_ingester_shipper_uploads_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -177,7 +177,8 @@ local filename = 'mimir-writes.json';
             The rate of blocks being uploaded from the ingesters
             to object storage.
           |||
-        ),
+        ) +
+        $.stack,
       )
       .addPanel(
         $.panel('Upload latency') +
@@ -194,8 +195,8 @@ local filename = 'mimir-writes.json';
     .addRow(
       $.row('Ingester - TSDB head')
       .addPanel(
+        $.panel('Compactions / sec') +
         $.successFailurePanel(
-          'Compactions / sec',
           'sum(rate(cortex_ingester_tsdb_compactions_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_compactions_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -206,7 +207,8 @@ local filename = 'mimir-writes.json';
             active time series; these blocks get periodically compacted (by default, every 2h).
             This panel shows the rate of compaction operations across all TSDBs on all ingesters.
           |||
-        ),
+        ) +
+        $.stack,
       )
       .addPanel(
         $.panel('Compactions latency') +
@@ -223,8 +225,8 @@ local filename = 'mimir-writes.json';
     .addRow(
       $.row('Ingester - TSDB write ahead log (WAL)')
       .addPanel(
+        $.panel('WAL truncations / sec') +
         $.successFailurePanel(
-          'WAL truncations / sec',
           'sum(rate(cortex_ingester_tsdb_wal_truncations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -234,11 +236,12 @@ local filename = 'mimir-writes.json';
             The WAL is truncated each time a new TSDB block is written. This panel measures the rate of
             truncations.
           |||
-        ),
+        ) +
+        $.stack,
       )
       .addPanel(
+        $.panel('Checkpoints created / sec') +
         $.successFailurePanel(
-          'Checkpoints created / sec',
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -248,7 +251,8 @@ local filename = 'mimir-writes.json';
             Checkpoints are created as part of the WAL truncation process.
             This metric measures the rate of checkpoint creation.
           |||
-        ),
+        ) +
+        $.stack,
       )
       .addPanel(
         $.panel('WAL truncations latency (includes checkpointing)') +


### PR DESCRIPTION
#### What this PR does
I would like to extend the usage of `successFailurePanel()` utility, but the hardcoded `$.stack` inside it makes it harder. I propose to make `successFailurePanel()` to work like `queryPanel()`, so moving `$.panel()` and `$.stack` outside and thus making it more flexible.

This PR is expected to be a no-op.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
