### PR TITLE
fix: add Overrides to Flusher dependencies to prevent panic on startup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
+
 ### Mixin
 
 ### Jsonnet

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -831,7 +831,7 @@ func (t *Mimir) setupModuleManager() error {
 		DistributorService:       {Ring, Overrides},
 		Ingester:                 {IngesterService, API},
 		IngesterService:          {Overrides, RuntimeConfig, MemberlistKV},
-		Flusher:                  {API},
+		Flusher:                  {Overrides, API},
 		Queryable:                {Overrides, DistributorService, Ring, API, StoreQueryable, MemberlistKV},
 		Querier:                  {TenantFederation},
 		StoreQueryable:           {Overrides, MemberlistKV},


### PR DESCRIPTION
Signed-off-by: Rohan Kumar <rohankmr414@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds `Overrides` module as a dependency `Flusher` to prevent panics on startup. Before removing chunks storage in #755, Flusher depended on `Store` which depended on `Overrides` module, this might be the reason behind panics

#### Which issue(s) this PR fixes or relates to

Fixes #2866

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
