### PR TITLE
jsonnet: Add support for multiple triggers on autoscalers

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -61,10 +61,10 @@
           type: 'prometheus',
           metadata: {
             serverAddress: $._config.autoscaling_prometheus_url,
-            query: config.query,
+            query: trigger.query,
 
             // The metric name uniquely identify a metric in the KEDA metrics server.
-            metricName: config.metric_name,
+            metricName: trigger.metric_name,
 
             // The threshold value is set to the HPA's targetAverageValue. The number of desired replicas is computed
             // by HPA as:
@@ -76,9 +76,9 @@
             //
             // Read more:
             // https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
-            threshold: config.threshold,
+            threshold: trigger.threshold,
           },
-        },
+        } for trigger in config.triggers
       ],
     },
   },
@@ -86,21 +86,26 @@
   newQuerierScaledObject(name, query_scheduler_container, querier_max_concurrent, min_replicas, max_replicas):: self.newScaledObject(name, $._config.namespace, {
     min_replica_count: min_replicas,
     max_replica_count: max_replicas,
-    metric_name: 'cortex_%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-    // Each query scheduler tracks *at regular intervals* the number of inflight requests
-    // (both enqueued and processing queries) as a summary. With the following query we target
-    // to have enough querier workers to run the max observed inflight requests 75% of time.
-    //
-    // Instead of measuring it as instant query, we look at the max 75th percentile over the last
-    // 5 minutes. This allows us to scale up quickly, but scale down slowly (and not too early
-    // if within the next 5 minutes after a scale up we have further spikes).
-    query: 'sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%s",namespace="%s",quantile="0.75"}[5m]))' % [query_scheduler_container, $._config.namespace],
+    triggers: [
+      {
+        metric_name: 'cortex_%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-    // Target to utilize 75% querier workers on peak traffic (as measured by query above),
-    // so we have 25% room for higher peaks.
-    local targetUtilization = 0.75,
-    threshold: '%d' % (querier_max_concurrent * targetUtilization),
+        // Each query scheduler tracks *at regular intervals* the number of inflight requests
+        // (both enqueued and processing queries) as a summary. With the following query we target
+        // to have enough querier workers to run the max observed inflight requests 75% of time.
+        //
+        // Instead of measuring it as instant query, we look at the max 75th percentile over the last
+        // 5 minutes. This allows us to scale up quickly, but scale down slowly (and not too early
+        // if within the next 5 minutes after a scale up we have further spikes).
+        query: 'sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%s",namespace="%s",quantile="0.75"}[5m]))' % [query_scheduler_container, $._config.namespace],
+
+        // Target to utilize 75% querier workers on peak traffic (as measured by query above),
+        // so we have 25% room for higher peaks.
+        local targetUtilization = 0.75,
+        threshold: '%d' % (querier_max_concurrent * targetUtilization),
+      },
+    ],
   }),
 
   // When querier autoscaling is enabled the querier's "replicas" is missing from the spec
@@ -148,14 +153,19 @@
   newRulerQuerierScaledObject(name, querier_cpu_requests, min_replicas, max_replicas):: self.newScaledObject(name, $._config.namespace, {
     min_replica_count: min_replicas,
     max_replica_count: max_replicas,
-    metric_name: 'cortex_%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-    // Due to the more predicatable nature of the ruler-querier workload we can scale on CPU usage.
-    // To scale out relatively quickly, but scale in slower, we look at the average CPU utilization per ruler-querier over 5m (rolling window)
-    // and then we pick the highest value over the last 15m.
-    query: 'max_over_time(sum(rate(container_cpu_usage_seconds_total{container="%s",namespace="%s"}[5m]))[15m:])' % [name, $._config.namespace],
+    triggers: [
+      {
+        metric_name: 'cortex_%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-    threshold: querier_cpu_requests,
+        // Due to the more predicatable nature of the ruler-querier workload we can scale on CPU usage.
+        // To scale out relatively quickly, but scale in slower, we look at the average CPU utilization per ruler-querier over 5m (rolling window)
+        // and then we pick the highest value over the last 15m.
+        query: 'max_over_time(sum(rate(container_cpu_usage_seconds_total{container="%s",namespace="%s"}[5m]))[15m:])' % [name, $._config.namespace],
+
+        threshold: querier_cpu_requests,
+      },
+    ],
   }),
 
   ruler_querier_scaled_object: if !$._config.autoscaling_ruler_querier_enabled || !$._config.ruler_remote_evaluation_enabled then null else

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -78,7 +78,8 @@
             // https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
             threshold: trigger.threshold,
           },
-        } for trigger in config.triggers
+        }
+        for trigger in config.triggers
       ],
     },
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This allows an autoscaler object to have multiple triggers. This is a precursor to being able to autoscale on both CPU and Memory.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
