### PR TITLE
Dashboards: Use a consistent color across dashboards for the error rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 * [ENHANCEMENT] Dashboards: Include rate of label and series queries in "Reads" dashboard. #3065 #3074
 * [ENHANCEMENT] Dashboards: Fix legend showing on per-pod panels. #2944
 * [ENHANCEMENT] Dashboards: Use the "req/s" unit on panels showing the requests rate. #3118
+* [ENHANCEMENT] Dashboards: Use a consistent color across dashboards for the error rate. #3154
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -463,7 +463,10 @@
             "height": "250px",
             "panels": [
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -497,7 +500,7 @@
                         "expr": "sum(cluster_job:cortex_alertmanager_alerts_received_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n-\nsum(cluster_job:cortex_alertmanager_alerts_invalid_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },
@@ -559,7 +562,10 @@
             "height": "250px",
             "panels": [
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -593,7 +599,7 @@
                         "expr": "sum(cluster_job_integration:cortex_alertmanager_notifications_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n-\nsum(cluster_job_integration:cortex_alertmanager_notifications_failed_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },
@@ -1887,7 +1893,10 @@
             "height": "250px",
             "panels": [
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -1921,7 +1930,7 @@
                         "expr": "sum(rate(cortex_alertmanager_sync_configs_total{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n-\nsum(rate(cortex_alertmanager_sync_configs_failed_total{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },
@@ -2307,7 +2316,10 @@
                   ]
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -2342,7 +2354,7 @@
                         "format": "time_series",
                         "interval": "1m",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },
@@ -2405,7 +2417,10 @@
             "height": "250px",
             "panels": [
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -2439,7 +2454,7 @@
                         "expr": "sum(cluster_job:cortex_alertmanager_state_replication_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n-\nsum(cluster_job:cortex_alertmanager_state_replication_failed_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },
@@ -2489,7 +2504,10 @@
                   ]
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -2523,7 +2541,7 @@
                         "expr": "sum(cluster_job:cortex_alertmanager_partial_state_merges_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n-\nsum(cluster_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },
@@ -2573,7 +2591,10 @@
                   ]
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "successful": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -2607,7 +2628,7 @@
                         "expr": "sum(rate(cortex_alertmanager_state_persist_total{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n-\nsum(rate(cortex_alertmanager_state_persist_failed_total{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "success",
+                        "legendFormat": "successful",
                         "legendLink": null,
                         "step": 10
                      },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -764,7 +764,10 @@
                   "type": "text"
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "success": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -1699,7 +1699,9 @@
                   ]
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "Failure Rate": "#E24D42"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -1453,7 +1453,7 @@
                         "expr": "sum by(metric) (rate(keda_metrics_adapter_scaler_errors[$__rate_interval])) +\non(metric) group_left\nlabel_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=\"keda-hpa-querier\"}\n    * 0, \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Failures per second",
+                        "legendFormat": "{{metric}} failures",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -1031,7 +1031,7 @@
                         "expr": "sum by(metric) (rate(keda_metrics_adapter_scaler_errors[$__rate_interval])) +\non(metric) group_left\nlabel_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=\"keda-hpa-ruler-querier\"}\n    * 0, \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Failures per second",
+                        "legendFormat": "{{metric}} failures",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -351,7 +351,10 @@
             "height": "250px",
             "panels": [
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "failed": "#E24D42",
+                     "success": "#7EB26D"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -1279,7 +1282,9 @@
                   ]
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "Failures / sec": "#E24D42"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,
@@ -1313,7 +1318,7 @@
                         "expr": "sum(rate(cortex_querier_blocks_consistency_checks_failed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend))\"}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend))\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Failure Rate",
+                        "legendFormat": "Failures / sec",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -2087,7 +2087,9 @@
                   ]
                },
                {
-                  "aliasColors": { },
+                  "aliasColors": {
+                     "rate": "#E24D42"
+                  },
                   "bars": false,
                   "dashLength": 10,
                   "dashes": false,

--- a/operations/mimir-mixin/dashboards/alertmanager.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager.libsonnet
@@ -38,16 +38,13 @@ local filename = 'mimir-alertmanager.json';
       $.row('Alerts received')
       .addPanel(
         $.panel('APS') +
-        $.queryPanel(
-          [
-            |||
-              sum(%s_job:cortex_alertmanager_alerts_received_total:rate5m{%s})
-              -
-              sum(%s_job:cortex_alertmanager_alerts_invalid_total:rate5m{%s})
-            ||| % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager), $._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
-            'sum(%s_job:cortex_alertmanager_alerts_invalid_total:rate5m{%s})' % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          |||
+            sum(%s_job:cortex_alertmanager_alerts_received_total:rate5m{%s})
+            -
+            sum(%s_job:cortex_alertmanager_alerts_invalid_total:rate5m{%s})
+          ||| % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager), $._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
+          'sum(%s_job:cortex_alertmanager_alerts_invalid_total:rate5m{%s})' % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
         )
       )
     )
@@ -55,12 +52,9 @@ local filename = 'mimir-alertmanager.json';
       $.row('Alert notifications')
       .addPanel(
         $.panel('NPS') +
-        $.queryPanel(
-          [
-            $.queries.alertmanager.notifications.successPerSecond,
-            $.queries.alertmanager.notifications.failurePerSecond,
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          $.queries.alertmanager.notifications.successPerSecond,
+          $.queries.alertmanager.notifications.failurePerSecond,
         )
       )
       .addPanel(
@@ -131,16 +125,13 @@ local filename = 'mimir-alertmanager.json';
       $.row('Tenant configuration sync')
       .addPanel(
         $.panel('Syncs/sec') +
-        $.queryPanel(
-          [
-            |||
-              sum(rate(cortex_alertmanager_sync_configs_total{%s}[$__rate_interval]))
-              -
-              sum(rate(cortex_alertmanager_sync_configs_failed_total{%s}[$__rate_interval]))
-            ||| % [$.jobMatcher($._config.job_names.alertmanager), $.jobMatcher($._config.job_names.alertmanager)],
-            'sum(rate(cortex_alertmanager_sync_configs_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.alertmanager),
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          |||
+            sum(rate(cortex_alertmanager_sync_configs_total{%s}[$__rate_interval]))
+            -
+            sum(rate(cortex_alertmanager_sync_configs_failed_total{%s}[$__rate_interval]))
+          ||| % [$.jobMatcher($._config.job_names.alertmanager), $.jobMatcher($._config.job_names.alertmanager)],
+          'sum(rate(cortex_alertmanager_sync_configs_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.alertmanager),
         )
       )
       .addPanel(
@@ -187,16 +178,13 @@ local filename = 'mimir-alertmanager.json';
       )
       .addPanel(
         $.panel('Fetch state from other alertmanagers /sec') +
-        $.queryPanel(
-          [
-            |||
-              sum(rate(cortex_alertmanager_state_fetch_replica_state_total{%s}[$__rate_interval]))
-              -
-              sum(rate(cortex_alertmanager_state_fetch_replica_state_failed_total{%s}[$__rate_interval]))
-            ||| % [$.jobMatcher($._config.job_names.alertmanager), $.jobMatcher($._config.job_names.alertmanager)],
-            'sum(rate(cortex_alertmanager_state_fetch_replica_state_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.alertmanager),
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          |||
+            sum(rate(cortex_alertmanager_state_fetch_replica_state_total{%s}[$__rate_interval]))
+            -
+            sum(rate(cortex_alertmanager_state_fetch_replica_state_failed_total{%s}[$__rate_interval]))
+          ||| % [$.jobMatcher($._config.job_names.alertmanager), $.jobMatcher($._config.job_names.alertmanager)],
+          'sum(rate(cortex_alertmanager_state_fetch_replica_state_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.alertmanager),
         ) + {
           targets: [
             target {
@@ -211,44 +199,35 @@ local filename = 'mimir-alertmanager.json';
       $.row('Sharding runtime state sync')
       .addPanel(
         $.panel('Replicate state to other alertmanagers /sec') +
-        $.queryPanel(
-          [
-            |||
-              sum(%s_job:cortex_alertmanager_state_replication_total:rate5m{%s})
-              -
-              sum(%s_job:cortex_alertmanager_state_replication_failed_total:rate5m{%s})
-            ||| % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager), $._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
-            'sum(%s_job:cortex_alertmanager_state_replication_failed_total:rate5m{%s})' % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          |||
+            sum(%s_job:cortex_alertmanager_state_replication_total:rate5m{%s})
+            -
+            sum(%s_job:cortex_alertmanager_state_replication_failed_total:rate5m{%s})
+          ||| % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager), $._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
+          'sum(%s_job:cortex_alertmanager_state_replication_failed_total:rate5m{%s})' % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
         )
       )
       .addPanel(
         $.panel('Merge state from other alertmanagers /sec') +
-        $.queryPanel(
-          [
-            |||
-              sum(%s_job:cortex_alertmanager_partial_state_merges_total:rate5m{%s})
-              -
-              sum(%s_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m{%s})
-            ||| % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager), $._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
-            'sum(%s_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m{%s})' % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          |||
+            sum(%s_job:cortex_alertmanager_partial_state_merges_total:rate5m{%s})
+            -
+            sum(%s_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m{%s})
+          ||| % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager), $._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
+          'sum(%s_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m{%s})' % [$._config.per_cluster_label, $.jobMatcher($._config.job_names.alertmanager)],
         )
       )
       .addPanel(
         $.panel('Persist state to remote storage /sec') +
-        $.queryPanel(
-          [
-            |||
-              sum(rate(cortex_alertmanager_state_persist_total{%s}[$__rate_interval]))
-              -
-              sum(rate(cortex_alertmanager_state_persist_failed_total{%s}[$__rate_interval]))
-            ||| % [$.jobMatcher($._config.job_names.alertmanager), $.jobMatcher($._config.job_names.alertmanager)],
-            'sum(rate(cortex_alertmanager_state_persist_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.alertmanager),
-          ],
-          ['success', 'failed']
+        $.successFailurePanel(
+          |||
+            sum(rate(cortex_alertmanager_state_persist_total{%s}[$__rate_interval]))
+            -
+            sum(rate(cortex_alertmanager_state_persist_failed_total{%s}[$__rate_interval]))
+          ||| % [$.jobMatcher($._config.job_names.alertmanager), $.jobMatcher($._config.job_names.alertmanager)],
+          'sum(rate(cortex_alertmanager_state_persist_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.alertmanager),
         )
       )
     ),

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -200,12 +200,33 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
     },
 
+  // Creates a panel like queryPanel() but if the legend contains only 1 entry,
+  // than it configures the series alias color to the one used to display failures.
+  failurePanel(queries, legends, legendLink=null)::
+    $.queryPanel(queries, legends, legendLink) + {
+      // Set the failure color only if there's just 1 legend and it doesn't contain any placeholder.
+      aliasColors: if (std.type(legends) == 'string' && std.length(std.findSubstr('{', legends[0])) == 0) then {
+        [legends]: errorColor,
+      } else {},
+    },
+
   successFailurePanel(successMetric, failureMetric)::
     $.queryPanel([successMetric, failureMetric], ['successful', 'failed']) +
     {
       aliasColors: {
         successful: successColor,
         failed: errorColor,
+      },
+    },
+
+  // successFailureCustomPanel is like successFailurePanel() but allows to customize the legends
+  // and have additional queries. The success and failure queries MUST be the first and second
+  // queries respectively.
+  successFailureCustomPanel(queries, legends)::
+    $.queryPanel(queries, legends) + {
+      aliasColors: {
+        [legends[0]]: successColor,
+        [legends[1]]: errorColor,
       },
     },
 

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -186,7 +186,7 @@ local filename = 'mimir-overview.json';
       )
       .addPanel(
         $.panel('Rule evaluations / sec') +
-        $.queryPanel(
+        $.successFailureCustomPanel(
           [
             $.queries.ruler.evaluations.successPerSecond,
             $.queries.ruler.evaluations.failurePerSecond,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -197,7 +197,7 @@ local filename = 'mimir-queries.json';
       )
       .addPanel(
         $.panel('Consistency checks failed') +
-        $.queryPanel('sum(rate(cortex_querier_blocks_consistency_checks_failed_total{%s}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.querier), $.jobMatcher($._config.job_names.querier)], 'Failure Rate') +
+        $.failurePanel('sum(rate(cortex_querier_blocks_consistency_checks_failed_total{%s}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.querier), $.jobMatcher($._config.job_names.querier)], 'Failure Rate') +
         { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
       )
     )

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -255,7 +255,7 @@ local filename = 'mimir-reads.json';
         $.panel(title) +
         $.queryPanel(
           $.filterKedaMetricByHPA('sum by(metric) (rate(keda_metrics_adapter_scaler_errors[$__rate_interval]))', $._config.autoscaling.querier_hpa_name),
-          'Failures per second'
+          '{{metric}} failures'
         ) +
         $.panelDescription(
           title,

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -148,7 +148,7 @@ local filename = 'mimir-remote-ruler-reads.json';
         $.panel(title) +
         $.queryPanel(
           $.filterKedaMetricByHPA('sum by(metric) (rate(keda_metrics_adapter_scaler_errors[$__rate_interval]))', $._config.autoscaling.ruler_querier_hpa_name),
-          'Failures per second'
+          '{{metric}} failures'
         ) +
         $.panelDescription(
           title,

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -39,7 +39,7 @@ local filename = 'mimir-ruler.json';
       $.row('Rule evaluations global')
       .addPanel(
         $.panel('Evaluations per second') +
-        $.queryPanel(
+        $.successFailureCustomPanel(
           [
             $.queries.ruler.evaluations.successPerSecond,
             $.queries.ruler.evaluations.failurePerSecond,
@@ -116,7 +116,7 @@ local filename = 'mimir-ruler.json';
       )
       .addPanel(
         $.panel('Consistency checks failed') +
-        $.queryPanel('sum(rate(cortex_querier_blocks_consistency_checks_failed_total{%s}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], 'Failure Rate') +
+        $.failurePanel('sum(rate(cortex_querier_blocks_consistency_checks_failed_total{%s}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], 'Failures / sec') +
         { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
       )
     )

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -523,7 +523,7 @@ local filename = 'mimir-tenants.json';
       .addPanel(
         local title = 'Failed notifications rate';
         $.panel(title) +
-        $.queryPanel(
+        $.failurePanel(
           'sum(rate(cortex_prometheus_notifications_errors_total{%(job)s, user="$user"}[$__rate_interval]))'
           % { job: $.jobMatcher($._config.job_names.ruler) },
           'rate',


### PR DESCRIPTION
#### What this PR does
In this PR I'm doing a small refactoring to our dashboards generation, to use a consistent color (red) to show errors and failures. I manually tested each of the affected panel and should be good.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
