### PR TITLE
Dashboards: fixed cluster status panel in the Overview dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 ### Mixin
 
 * [CHANGE] Alerts: MimirQuerierAutoscalerNotActive is now critical and fires after 1h instead of 15m. #2958
-* [FEATURE] Dashboards: Added "Mimir / Overview" dashboards, providing an high level view over a Mimir cluster. #3122 #3147
+* [FEATURE] Dashboards: Added "Mimir / Overview" dashboards, providing an high level view over a Mimir cluster. #3122 #3147 #3155
 * [ENHANCEMENT] Dashboards: Updated the "Writes" and "Rollout progress" dashboards to account for samples ingested via the new OTLP ingestion endpoint. #2919 #2938
 * [ENHANCEMENT] Dashboards: Include per-tenant request rate in "Tenants" dashboard. #2874
 * [ENHANCEMENT] Dashboards: Include inflight object store requests in "Reads" dashboard. #2914

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -52,7 +52,7 @@
                            "mode": "thresholds"
                         },
                         "thresholds": {
-                           "mode": "percentage",
+                           "mode": "absolute",
                            "steps": [
                               {
                                  "color": "#7EB26D",
@@ -60,11 +60,11 @@
                               },
                               {
                                  "color": "#EAB839",
-                                 "value": 1
+                                 "value": 0.01
                               },
                               {
                                  "color": "#E24D42",
-                                 "value": 5
+                                 "value": 0.050000000000000003
                               }
                            ]
                         }
@@ -111,7 +111,7 @@
                            "uid": "$datasource"
                         },
                         "exemplar": false,
-                        "expr": "# Failed notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n((sum(rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n/\nsum(rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n) or vector(0))\n+\n# Failed notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n((sum(cluster_job_integration:cortex_alertmanager_notifications_failed_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n/\nsum(cluster_job_integration:cortex_alertmanager_notifications_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n) or vector(0))\n",
+                        "expr": "(\n  # Failed notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n  ((sum(rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n) or vector(0))\n  +\n  # Failed notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n  ((sum(cluster_job_integration:cortex_alertmanager_notifications_failed_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n) or vector(0))\n)\n/\n(\n  # Total notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n  ((sum(rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend))\"}[$__rate_interval]))\n) or vector(0))\n  +\n  # Total notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n  ((sum(cluster_job_integration:cortex_alertmanager_notifications_total:rate5m{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend))\"})\n) or vector(0))\n)\n",
                         "instant": false,
                         "legendFormat": "Alerting notifications",
                         "range": true

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -133,6 +133,11 @@
         ||| % variables,
       },
       notifications: {
+        // Notifications / sec attempted to send to the Alertmanager.
+        totalPerSecond: |||
+          sum(rate(cortex_prometheus_notifications_sent_total{%(rulerMatcher)s}[$__rate_interval]))
+        ||| % variables,
+
         // Notifications / sec successfully sent to the Alertmanager.
         successPerSecond: |||
           sum(rate(cortex_prometheus_notifications_sent_total{%(rulerMatcher)s}[$__rate_interval]))
@@ -144,18 +149,16 @@
         failurePerSecond: |||
           sum(rate(cortex_prometheus_notifications_errors_total{%(rulerMatcher)s}[$__rate_interval]))
         ||| % variables,
-
-        // Notifications failed to be sent to the Alertmanager as percentage of total notifications attempted.
-        failuresRate: |||
-          sum(rate(cortex_prometheus_notifications_errors_total{%(rulerMatcher)s}[$__rate_interval]))
-          /
-          sum(rate(cortex_prometheus_notifications_sent_total{%(rulerMatcher)s}[$__rate_interval]))
-        ||| % variables,
       },
     },
 
     alertmanager: {
       notifications: {
+        // Notifications / sec attempted to deliver by the Alertmanager to the receivers.
+        totalPerSecond: |||
+          sum(%(perClusterLabel)s_job_integration:cortex_alertmanager_notifications_total:rate5m{%(alertmanagerMatcher)s})
+        ||| % variables,
+
         // Notifications / sec successfully delivered by the Alertmanager to the receivers.
         successPerSecond: |||
           sum(%(perClusterLabel)s_job_integration:cortex_alertmanager_notifications_total:rate5m{%(alertmanagerMatcher)s})
@@ -166,13 +169,6 @@
         // Notifications / sec failed to be delivered by the Alertmanager to the receivers.
         failurePerSecond: |||
           sum(%(perClusterLabel)s_job_integration:cortex_alertmanager_notifications_failed_total:rate5m{%(alertmanagerMatcher)s})
-        ||| % variables,
-
-        // Notifications failed to be sent by the Alertmanager to the receivers as percentage of total notifications attempted.
-        failuresRate: |||
-          sum(%(perClusterLabel)s_job_integration:cortex_alertmanager_notifications_failed_total:rate5m{%(alertmanagerMatcher)s})
-          /
-          sum(%(perClusterLabel)s_job_integration:cortex_alertmanager_notifications_total:rate5m{%(alertmanagerMatcher)s})
         ||| % variables,
       },
     },

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -564,11 +564,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           mode: 'thresholds',
         },
         thresholds: {
-          mode: 'percentage',
+          mode: 'absolute',
           steps: [
             { color: successColor, value: null },
-            { color: warningColor, value: 1 },
-            { color: errorColor, value: 5 },
+            { color: warningColor, value: 0.01 },  // 1%
+            { color: errorColor, value: 0.05 },  // 5%
           ],
         },
       },

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -57,14 +57,26 @@ local filename = 'mimir-overview.json';
             $.queries.ruler.evaluations.failuresRate,
             // Alerting notifications.
             |||
-              # Failed notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).
-              ((%(rulerFailuresRate)s) or vector(0))
-              +
-              # Failed notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).
-              ((%(alertmanagerFailuresRate)s) or vector(0))
+              (
+                # Failed notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).
+                ((%(rulerFailurePerSecond)s) or vector(0))
+                +
+                # Failed notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).
+                ((%(alertmanagerFailurePerSecond)s) or vector(0))
+              )
+              /
+              (
+                # Total notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).
+                ((%(rulerTotalPerSecond)s) or vector(0))
+                +
+                # Total notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).
+                ((%(alertmanagerTotalPerSecond)s) or vector(0))
+              )
             ||| % {
-              rulerFailuresRate: $.queries.ruler.notifications.failuresRate,
-              alertmanagerFailuresRate: $.queries.alertmanager.notifications.failuresRate,
+              rulerFailurePerSecond: $.queries.ruler.notifications.failurePerSecond,
+              rulerTotalPerSecond: $.queries.ruler.notifications.totalPerSecond,
+              alertmanagerFailurePerSecond: $.queries.alertmanager.notifications.failurePerSecond,
+              alertmanagerTotalPerSecond: $.queries.alertmanager.notifications.totalPerSecond,
             },
             // Object storage failures.
             $.queries.storage.failuresRate,


### PR DESCRIPTION
#### What this PR does
I did a couple of mistakes in the status panel of the Overview dashboard:
1. I didn't correctly understood how "percentage" thresholds work in the status timeline panel. They're a % compared to other values. What we actually want are absolute values (in the range 0-1).
2. In the "Alerting notifications" queries I was summing 2 percentages and, you know, mathematically doesn't.

This PR fixes both.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
