### PR TITLE
Release: add notify-changelog-cut.sh script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,7 +59,7 @@ This helps ongoing PRs to get their changes in the right place, and to consider 
    - Add a new section for the new release so that `## main / unreleased` is blank and at the top.
    - The new section should say `## x.y.0-rc.0`.
 1. Get this PR reviewed and merged.
-1. Comment on open PRs with a CHANGELOG entry to rebase on `main` and move the CHANGELOG entry to the top under `## main / unreleased`
+1. Run `./tools/release/notify-changelog-cut.sh` to comment on open PRs with a CHANGELOG entry to rebase on `main` and move the CHANGELOG entry to the top under `## main / unreleased`
 
 ### Prepare your release
 

--- a/tools/release/notify-changelog-cut.sh
+++ b/tools/release/notify-changelog-cut.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure "gh" tool is installed.
+if ! command -v gh &> /dev/null; then
+    echo "The 'gh' command cannot be find. Please install it: https://cli.github.com"
+    exit
+fi
+
+# Config
+NOTIFICATION_LABEL="release/notified-changelog-cut"
+
+# List all open PRs.
+OPEN_PR_IDS=$(gh pr list --repo grafana/mimir --limit 1000 --state open --json number,title --jq '.[].number')
+
+for PR_ID in ${OPEN_PR_IDS}; do
+  # Get PR details
+  PR_TITLE=$(gh pr view --comments "${PR_ID}" --json title --jq '.title')
+  PR_LABELS=$(gh pr view --comments "${PR_ID}" --json labels --jq '.labels[].name')
+
+  # Log the PR we're currently processing.
+  echo "- ${PR_ID}: ${PR_TITLE}"
+
+  # Check if the notification has already been posted.
+  # We suppress the linter warning about looking for the extract substring instead of doing a regex
+  # match, but that's exactly what we want.
+  # shellcheck disable=SC2076
+  if [[ ${PR_LABELS} =~ "${NOTIFICATION_LABEL}" ]]; then
+    echo "  Notification already posted, nothing to do"
+    continue
+  fi
+
+  # The backtick here is markdown and we don't want to get it evaluated by the shell.
+  # shellcheck disable=SC2016
+  PR_COMMENT_LINK=$(gh pr comment "${PR_ID}" --body 'The CHANGELOG has just been cut to prepare for the next Mimir release. Please rebase `main` and eventually move the CHANGELOG entry added / updated in this PR to the top of the CHANGELOG document. Thanks!')
+  gh pr edit "${PR_ID}" --add-label "${NOTIFICATION_LABEL}" > /dev/null
+
+  echo "  Notification posted: ${PR_COMMENT_LINK}"
+done

--- a/tools/release/notify-changelog-cut.sh
+++ b/tools/release/notify-changelog-cut.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
 set -e
 
 # Ensure "gh" tool is installed.


### PR DESCRIPTION
#### What this PR does
Adding a script to notify open PRs that the CHANGELOG has just been just. I've just run it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
