### PR TITLE
Chore: get 'make dist' always re-run and being less verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,14 +379,13 @@ check-license: ## Check license header of files.
 check-license: license
 	@git diff --exit-code || (echo "Please add the license header running 'make BUILD_IN_CONTAINER=false license'" && false)
 
-dist: dist/$(UPTODATE) ## Generates binaries for a Mimir release.
-
-dist/$(UPTODATE):
-	rm -fr ./dist
-	mkdir -p ./dist
-	# Build binaries for various architectures and operating systems. Only
-	# mimirtool supports Windows for now.
-	for os in linux darwin windows; do \
+dist: ## Generates binaries for a Mimir release.
+	echo "Cleaning up dist/"
+	@rm -fr ./dist
+	@mkdir -p ./dist
+	@# Build binaries for various architectures and operating systems. Only
+	@# mimirtool supports Windows for now.
+	@for os in linux darwin windows; do \
 		for arch in amd64 arm64; do \
 			suffix="" ; \
 			if [ "$$os" = "windows" ]; then \


### PR DESCRIPTION
#### What this PR does
In this PR:
- Remove `.uptodate` from dist, so that every time we run `make dist` it actually re-builds the binaries
- Make it less verbose, not printing the commands executed

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
