### PR TITLE
Updates delve version used by development/mimir-microservices-mode setup

### DIFF
--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.19.2
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.7.3
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 
 FROM alpine:3.16.2
 


### PR DESCRIPTION
#### What this PR does
This PR updates delve version used by development/mimir-microservices-mode setup, because previous version is no longer compatible with Go 1.19.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
