### PR TITLE
[Helm]: Fix metamonitoring secret configuration

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -25,6 +25,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [BUGFIX] Fix an issue causing metamonitoring secrets to be created incorrectly #3170
+
 ## 3.2.0
 
 * [CHANGE] Nginx: replace topology key previously used in `podAntiAffinity` (`failure-domain.beta.kubernetes.io/zone`) with a different one `topologySpreadConstraints` (`kubernetes.io/hostname`). #2722

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -25,7 +25,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [BUGFIX] Fix an issue causing metamonitoring secrets to be created incorrectly #3170
+* [BUGFIX] Fix an issue that caused metamonitoring secrets to be created incorrectly #3170
 
 ## 3.2.0
 

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -1,5 +1,6 @@
 {{- with .Values.metaMonitoring.grafanaAgent }}
 {{- if and .enabled .metrics.enabled }}
+{{- with .metrics }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,5 +14,6 @@ data:
   username-{{ $i }}: {{ $cfg.auth.username | b64enc | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION


#### What this PR does

This fixes a regression caused by https://github.com/grafana/mimir/pull/2936.

Without this change, the agent operator is unable to find the usernames, because they aren't written to the secret correctly.

This bug was released in 3.2.0, and since this breaks metamonitoring completely, I suggest we cut a 3.2.1 release with this fix included.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
