### PR TITLE
Helm: Default to sending metamonitoring inside Mimir

### DIFF
--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -133,7 +133,7 @@ metaMonitoring:
 
   metrics:
 remote:
-  url: 'GATEWAY_URL'
+  url: "GATEWAY_URL"
   auth:
     username: metamonitoring
     passwordSecretName: gem-tokens

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -113,7 +113,7 @@ You can also send the collected metamonitoring metrics to the installation of Mi
 The configuration varies slightly for GEM and Mimir.
 
 If you have deployed Mimir, and the URL is not set, then metrics will be sent to the Mimir cluster.
-You can query these metrics using the `__metamonitoring__` tenant.
+You can query these metrics using the `metamonitoring` tenant.
 
 If you have deployed GEM, then you need to configure the remote endpoint. The URL should point to
 the GEM gateway Service. If you are using the GEM authentication model, then you also need to

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -117,15 +117,15 @@ or the Mimir NGINX Service.
 
 If you have deployed Mimir, and `metamonitoring.grafanaAgent.metrics.remote.url` is not set,
 then the metamonitoring metrics are be sent to the Mimir cluster.
-You can query these metrics using X-Scope-OrgID: metamonitoring
+You can query these metrics using the HTTP header X-Scope-OrgID: metamonitoring
 
 If you have deployed GEM, then there are two cases:
-- If are using the `trust` authentication type (`mimir.structuredConfig.auth.type: trust`),
+- If are using the `trust` authentication type (`mimir.structuredConfig.auth.type=trust`),
   then the same instructions apply as for Mimir.
 
-- If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type: enterprise`), which is 
-  also the default,then you also need to provide a Secret with the authentication token for the tenant.
-  The token should be to an access policy with metrics:write scope.
+- If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type=enterprise`, which is 
+  also the default when `enterprise.enabled=true`), then you also need to provide a Secret with the authentication 
+  token for the tenant.The token should be to an access policy with metrics:write scope.
   To set up the Secret, refer to [Credentials](#credentials).
   Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
 

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -125,7 +125,7 @@ If you have deployed GEM, then there are two cases:
 
 - If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type: enterprise`), which is 
   also the default,then you also need to provide a Secret with the authentication token for the tenant.
-  The token should be to an access policy with metrics:read scope.
+  The token should be to an access policy with metrics:write scope.
   To set up the Secret, refer to [Credentials](#credentials).
   Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
 

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -107,21 +107,27 @@ metaMonitoring:
             app.kubernetes.io/name: kube-state-metrics
 ```
 
-#### Sending metrics back into Mimir/GEM
+#### Send metrics back into Mimir/GEM
 
 You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
-The configuration varies slightly for GEM and Mimir.
 
-If you have deployed Mimir, and the URL is not set, then metrics will be sent to the Mimir cluster.
-You can query these metrics using the `metamonitoring` tenant.
+When you leave the `metamonitoring.grafanaAgent.metrics.remote.url` field empty,
+then the chart automatically fills in the address of the GEM gateway Service
+or the Mimir NGINX Service.
 
-If you have deployed GEM, then you need to configure the remote endpoint. The URL should point to
-the GEM gateway Service. If you are using the GEM authentication model, then you also need to
-provide a Secret with the authentication token for the tenant.
-To set up the Secret, refer to [Credentials](#credentials).
-Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
-Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service; the
-`helm install` and `helm upgrade` commands output that address.
+If you have deployed Mimir, and `metamonitoring.grafanaAgent.metrics.remote.url` is not set,
+then the metamonitoring metrics are be sent to the Mimir cluster.
+You can query these metrics using X-Scope-OrgID: metamonitoring
+
+If you have deployed GEM, then there are two cases:
+- If are using the `trust` authentication type (`mimir.structuredConfig.auth.type: trust`),
+  then the same instructions apply as for Mimir.
+
+- If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type: enterprise`), which is 
+  also the default,then you also need to provide a Secret with the authentication token for the tenant.
+  The token should be to an access policy with metrics:read scope.
+  To set up the Secret, refer to [Credentials](#credentials).
+  Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
 
 ```yaml
 metaMonitoring:
@@ -131,13 +137,12 @@ metaMonitoring:
     enabled: true
     installOperator: true
 
-  metrics:
-remote:
-  url: "GATEWAY_URL"
-  auth:
-    username: metamonitoring
-    passwordSecretName: gem-tokens
-    passwordSecretKey: metamonitoring
+    metrics:
+      remote:
+        auth:
+          username: metamonitoring
+          passwordSecretName: gem-tokens
+          passwordSecretKey: metamonitoring
 ```
 
 ### Collect metrics and logs via Grafana Agent

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -107,7 +107,7 @@ metaMonitoring:
             app.kubernetes.io/name: kube-state-metrics
 ```
 
-#### Send metrics back into Mimir/GEM
+#### Send metrics back into Mimir or GEM
 
 You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
 
@@ -119,13 +119,13 @@ If you have deployed Mimir, and `metamonitoring.grafanaAgent.metrics.remote.url`
 then the metamonitoring metrics are be sent to the Mimir cluster.
 You can query these metrics using the HTTP header X-Scope-OrgID: metamonitoring
 
-If you have deployed GEM, then there are two cases:
+If you have deployed GEM, then there are two alternatives:
 - If are using the `trust` authentication type (`mimir.structuredConfig.auth.type=trust`),
   then the same instructions apply as for Mimir.
 
 - If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type=enterprise`, which is 
   also the default when `enterprise.enabled=true`), then you also need to provide a Secret with the authentication 
-  token for the tenant.The token should be to an access policy with metrics:write scope.
+  token for the tenant.The token should be to an access policy with `metrics:write` scope.
   To set up the Secret, refer to [Credentials](#credentials).
   Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
 

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -118,10 +118,10 @@ You can query these metrics using the `__metamonitoring__` tenant.
 If you have deployed GEM, then you need to configure the remote endpoint. The URL should point to
 the GEM gateway Service. If you are using the GEM authentication model, then you also need to
 provide a Secret with the authentication token for the tenant.
-For setting up the Secret, refer to [Credentials](#credentials).
+To set up the Secret, refer to [Credentials](#credentials).
 Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
-Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service; that service is also displayed after
-`helm install` and `helm upgrade` commands.
+Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service; the
+`helm install` and `helm upgrade` commands output that address.
 
 ```yaml
 metaMonitoring:

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -112,30 +112,16 @@ metaMonitoring:
 You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
 The configuration varies slightly for GEM and Mimir.
 
-If you have deployed Mimir, then the Helm chart values should look like the following example.
-Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+If you have deployed Mimir, and the URL is not set, then metrics will be sent to the Mimir cluster.
+You can query these metrics using the `__metamonitoring__` tenant.
 
-```yaml
-metaMonitoring:
-  serviceMonitor:
-    enabled: true
-  grafanaAgent:
-    enabled: true
-    installOperator: true
-
-  metrics:
-    remote:
-      url: "http://<HELM_RELEASE_NAME>-mimir-nginx.mimir.svc/api/v1/push"
-      headers:
-        X-Scope-OrgID: metamonitoring
-```
-
-If you have deployed GEM, then the URL will point to the GEM gateway instead of the nginx Deployment.
-If you are using the GEM authentication model, then you also need to provide a Secret with the
-authentication token for a tenant. Refer to [Credentials](#credentials) for setting up the Secret.
-
+If you have deployed GEM, then you need to configure the remote endpoint. The URL should point to
+the GEM gateway Service. If you are using the GEM authentication model, then you also need to
+provide a Secret with the authentication token for the tenant.
+For setting up the Secret, refer to [Credentials](#credentials).
 Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
-Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service; that service is also displayed after
+`helm install` and `helm upgrade` commands.
 
 ```yaml
 metaMonitoring:
@@ -146,12 +132,12 @@ metaMonitoring:
     installOperator: true
 
   metrics:
-    remote:
-      url: "http://<HELM_RELEASE_NAME>-mimir-gateway.mimir.svc/api/v1/push"
-      auth:
-        username: metamonitoring
-        passwordSecretName: gem-tokens
-        passwordSecretKey: metamonitoring
+remote:
+  url: 'GATEWAY_URL'
+  auth:
+    username: metamonitoring
+    passwordSecretName: gem-tokens
+    passwordSecretKey: metamonitoring
 ```
 
 ### Collect metrics and logs via Grafana Agent

--- a/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -120,11 +120,12 @@ then the metamonitoring metrics are be sent to the Mimir cluster.
 You can query these metrics using the HTTP header X-Scope-OrgID: metamonitoring
 
 If you have deployed GEM, then there are two alternatives:
+
 - If are using the `trust` authentication type (`mimir.structuredConfig.auth.type=trust`),
   then the same instructions apply as for Mimir.
 
-- If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type=enterprise`, which is 
-  also the default when `enterprise.enabled=true`), then you also need to provide a Secret with the authentication 
+- If you are using the enterprise authentication type (`mimir.structuredConfig.auth.type=enterprise`, which is
+  also the default when `enterprise.enabled=true`), then you also need to provide a Secret with the authentication
   token for the tenant.The token should be to an access policy with `metrics:write` scope.
   To set up the Secret, refer to [Credentials](#credentials).
   Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -25,6 +25,9 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to 
+  Mimir under the `metamonitoring` tenant. Does not apply for GEM. #3176
+
 ## 3.2.0
 
 * [CHANGE] Nginx: replace topology key previously used in `podAntiAffinity` (`failure-domain.beta.kubernetes.io/zone`) with a different one `topologySpreadConstraints` (`kubernetes.io/hostname`). #2722

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -26,7 +26,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to
-  Mimir under the `metamonitoring` tenant. Does not apply for GEM. #3176
+  Mimir under the `metamonitoring` tenant; this enhancement does not apply to GEM. #3176
 
 ## 3.2.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -25,7 +25,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to 
+* [ENHANCEMENT] Metamonitoring: If enabled and no URL is configured, then metamonitoring metrics will be sent to
   Mimir under the `metamonitoring` tenant. Does not apply for GEM. #3176
 
 ## 3.2.0

--- a/operations/helm/charts/mimir-distributed/templates/NOTES.txt
+++ b/operations/helm/charts/mimir-distributed/templates/NOTES.txt
@@ -17,7 +17,7 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  {{ include "mimir.remoteWriteUrl.inCluster" (dict "ctx" .) }}
+  {{ include "mimir.remoteWriteUrl.inCluster" . }}
 
 Read address, Grafana data source (Prometheus) URL:
 {{ with $gateway.ingress -}}
@@ -30,6 +30,6 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  {{ include "mimir.gatewayUrl" . }}{{ template "mimir.prometheusHttpPrefix" $ }}
+  {{ include "mimir.gatewayUrl" $ }}{{ template "mimir.prometheusHttpPrefix" $ }}
 
 **IMPORTANT**: Always consult CHANGELOG.md file at https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md and the deprecation list there to learn about breaking changes that require action during upgrade.

--- a/operations/helm/charts/mimir-distributed/templates/NOTES.txt
+++ b/operations/helm/charts/mimir-distributed/templates/NOTES.txt
@@ -17,7 +17,7 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port }}/api/v1/push
+  {{ include "mimir.remoteWriteEndpoint.inCluster" (dict "ctx" .) }}
 
 Read address, Grafana data source (Prometheus) URL:
 {{ with $gateway.ingress -}}

--- a/operations/helm/charts/mimir-distributed/templates/NOTES.txt
+++ b/operations/helm/charts/mimir-distributed/templates/NOTES.txt
@@ -17,7 +17,7 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  {{ include "mimir.remoteWriteEndpoint.inCluster" (dict "ctx" .) }}
+  {{ include "mimir.remoteWriteUrl.inCluster" (dict "ctx" .) }}
 
 Read address, Grafana data source (Prometheus) URL:
 {{ with $gateway.ingress -}}
@@ -30,6 +30,6 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  http://{{ include "mimir.fullname" $ }}-{{ if .Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .Release.Namespace }}.svc:{{ $gateway.service.port }}{{ template "mimir.prometheusHttpPrefix" $ }}
+  {{ include "mimir.gatewayUrl" . }}{{ template "mimir.prometheusHttpPrefix" $ }}
 
 **IMPORTANT**: Always consult CHANGELOG.md file at https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md and the deprecation list there to learn about breaking changes that require action during upgrade.

--- a/operations/helm/charts/mimir-distributed/templates/NOTES.txt
+++ b/operations/helm/charts/mimir-distributed/templates/NOTES.txt
@@ -17,7 +17,7 @@ Ingress is not enabled, see the {{ if $.Values.enterprise.enabled }}gateway{{ el
 {{- end -}}
 {{- end }}
 From inside the cluster:
-  {{ include "mimir.remoteWriteUrl.inCluster" . }}
+  {{ include "mimir.remoteWriteUrl.inCluster" $ }}
 
 Read address, Grafana data source (Prometheus) URL:
 {{ with $gateway.ingress -}}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -401,5 +401,5 @@ Return if we should create a SecurityContextConstraints. Takes into account user
 {{- end -}}
 
 {{- define "mimir.remoteWriteUrl.inCluster" -}}
-{{ include "mimir.gatewayUrl" .ctx }}/api/v1/push
+{{ include "mimir.gatewayUrl" . }}/api/v1/push
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -399,3 +399,9 @@ Return if we should create a SecurityContextConstraints. Takes into account user
 {{- define "mimir.rbac.useSecurityContextConstraints" -}}
 {{- and .Values.rbac.create (eq .Values.rbac.type "scc") -}}
 {{- end -}}
+
+{{- define  "mimir.remoteWriteEndpoint.inCluster" -}}
+{{- $gateway := .ctx.Values.nginx }}
+{{- if .ctx.Values.enterprise.enabled -}}{{- $gateway = .ctx.Values.gateway -}}{{- end -}}
+http://{{ include "mimir.fullname" .ctx }}-{{ if .ctx.Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .ctx.Release.Namespace }}.svc:{{ $gateway.service.port }}/api/v1/push
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -400,8 +400,6 @@ Return if we should create a SecurityContextConstraints. Takes into account user
 {{- and .Values.rbac.create (eq .Values.rbac.type "scc") -}}
 {{- end -}}
 
-{{- define  "mimir.remoteWriteEndpoint.inCluster" -}}
-{{- $gateway := .ctx.Values.nginx }}
-{{- if .ctx.Values.enterprise.enabled -}}{{- $gateway = .ctx.Values.gateway -}}{{- end -}}
-http://{{ include "mimir.fullname" .ctx }}-{{ if .ctx.Values.enterprise.enabled }}gateway{{ else }}nginx{{ end }}.{{ .ctx.Release.Namespace }}.svc:{{ $gateway.service.port }}/api/v1/push
+{{- define "mimir.remoteWriteUrl.inCluster" -}}
+{{ include "mimir.gatewayUrl" .ctx }}/api/v1/push
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -1,49 +1,60 @@
 {{- define "mimir.metaMonitoring.metrics.remoteWrite" -}}
-url: {{ .url }}
-{{- if .auth }}
-basicAuth:
-{{- if .auth.username }}
-  username:
-    name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" "metrics-instance-usernames") }}
-    key: {{ .usernameKey | quote }}
-{{- end }}
-{{- with .auth }}
-{{- if and .passwordSecretKey .passwordSecretName }}
-  password:
-    name: {{ .passwordSecretName | quote }}
-    key: {{ .passwordSecretKey | quote }}
-{{- else if or .passwordSecretKey .passwordSecretName }}{{ required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- with .headers }}
-headers:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+{{- $writeBackToMimir := and (not .url) (not .ctx.Values.enterprise.enabled) -}}
+{{- $url := .url -}}
+{{- if $writeBackToMimir -}}
+{{- $url = include "mimir.remoteWriteEndpoint.inCluster" . }}
+{{- end -}}
+{{- if $url }}
+- url: {{ $url }}
+  {{- if .auth }}
+  basicAuth:
+  {{- if .auth.username }}
+    username:
+      name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" "metrics-instance-usernames") }}
+      key: {{ .usernameKey | quote }}
+  {{- end }}
+  {{- with .auth }}
+  {{- if and .passwordSecretKey .passwordSecretName }}
+    password:
+      name: {{ .passwordSecretName | quote }}
+      key: {{ .passwordSecretKey | quote }}
+  {{- else if or .passwordSecretKey .passwordSecretName }}{{ required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- $headers := .headers -}}
+  {{- if $writeBackToMimir -}}{{- $_ := set $headers "X-Scope-OrgID" "metamonitoring" -}}{{- end -}}
+  {{- with $headers }}
+  headers:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end -}}
 {{- end -}}
 
 {{- define "mimir.metaMonitoring.logs.client" -}}
-url: {{ .url }}
-{{- if .auth }}
-{{- if .auth.tenantId }}
-tenantId: {{ .auth.tenantId | quote }}
-{{- end }}
-basicAuth:
-{{- if .auth.username }}
-  username:
-    name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" "logs-instance-usernames") }}
-    key: {{ .usernameKey | quote }}
-{{- end }}
-{{- with .auth }}
-{{- if and .passwordSecretKey .passwordSecretName }}
-  password:
-    name: {{ .passwordSecretName | quote }}
-    key: {{ .passwordSecretKey | quote }}
-{{- else if or .passwordSecretKey .passwordSecretName }}
-{{ required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
-{{- end }}
-{{- end }}
-{{- end }}
-externalLabels:
-  cluster: {{ include "mimir.clusterName" $.ctx | quote}}
+{{- if .url }}
+- url: {{ .url }}
+  {{- if .auth }}
+  {{- if .auth.tenantId }}
+  tenantId: {{ .auth.tenantId | quote }}
+  {{- end }}
+  basicAuth:
+  {{- if .auth.username }}
+    username:
+      name: {{ include "mimir.resourceName" (dict "ctx" $.ctx "component" "logs-instance-usernames") }}
+      key: {{ .usernameKey | quote }}
+  {{- end }}
+  {{- with .auth }}
+  {{- if and .passwordSecretKey .passwordSecretName }}
+    password:
+      name: {{ .passwordSecretName | quote }}
+      key: {{ .passwordSecretKey | quote }}
+  {{- else if or .passwordSecretKey .passwordSecretName }}
+  {{ required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalLabels:
+    cluster: {{ include "mimir.clusterName" $.ctx | quote}}
+{{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -2,7 +2,7 @@
 {{- $writeBackToMimir := and (not .url) (not .ctx.Values.enterprise.enabled) -}}
 {{- $url := .url -}}
 {{- if $writeBackToMimir -}}
-{{- $url = include "mimir.remoteWriteEndpoint.inCluster" . }}
+{{- $url = include "mimir.remoteWriteUrl.inCluster" . }}
 {{- end -}}
 {{- if $url }}
 - url: {{ $url }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -2,7 +2,7 @@
 {{- $writeBackToMimir := and (not .url) (not .ctx.Values.enterprise.enabled) -}}
 {{- $url := .url -}}
 {{- if $writeBackToMimir -}}
-{{- $url = include "mimir.remoteWriteUrl.inCluster" . }}
+{{- $url = include "mimir.remoteWriteUrl.inCluster" .ctx }}
 {{- end -}}
 {{- if $url }}
 - url: {{ $url }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -1,10 +1,9 @@
 {{- define "mimir.metaMonitoring.metrics.remoteWrite" -}}
-{{- $writeBackToMimir := and (not .url) (not .ctx.Values.enterprise.enabled) -}}
+{{- $writeBackToMimir := not .url -}}
 {{- $url := .url -}}
 {{- if $writeBackToMimir -}}
 {{- $url = include "mimir.remoteWriteUrl.inCluster" .ctx }}
 {{- end -}}
-{{- if $url }}
 - url: {{ $url }}
   {{- if .auth }}
   basicAuth:
@@ -28,7 +27,6 @@
   headers:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- end -}}
 {{- end -}}
 
 {{- define "mimir.metaMonitoring.logs.client" -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance.yaml
@@ -19,9 +19,7 @@ spec:
     {{- if or (.logs).additionalClientConfigs (.logs).remote }}
     {{- range $i, $cfg := prepend ((.logs).additionalClientConfigs | default list) (.logs).remote }}
     {{- with $cfg }}
-    {{- if $cfg.url }}
-    - {{- include "mimir.metaMonitoring.logs.client" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i)) | nindent 6 -}}
-    {{- end }}
+    {{- include "mimir.metaMonitoring.logs.client" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i)) | nindent 6 -}}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -19,9 +19,7 @@ spec:
     {{- if or (.metrics).additionalRemoteWriteConfigs (.metrics).remote }}
     {{- range $i, $cfg := prepend ((.metrics).additionalRemoteWriteConfigs | default list) (.metrics).remote }}
     {{- with $cfg }}
-    {{- if $cfg.url }}
-    - {{- include "mimir.metaMonitoring.metrics.remoteWrite" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i) "headers" .headers ) | nindent 6 -}}
-    {{- end }}
+    {{- include "mimir.metaMonitoring.metrics.remoteWrite" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i) "headers" .headers ) | nindent 6 -}}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1933,13 +1933,13 @@ metaMonitoring:
       #
       # If you have deployed Mimir, and metamonitoring.grafanaAgent.metrics.remote.url is not set,
       # then the metamonitoring metrics are be sent to the Mimir cluster.
-      # You can query these metrics using X-Scope-OrgID: metamonitoring
+      # You can query these metrics using the HTTP header X-Scope-OrgID: metamonitoring
       #
       # If you have deployed GEM, then there are two cases:
       # * If are using the 'trust' authentication type (mimir.structuredConfig.auth.type: trust),
       #   then the same instructions apply as for Mimir.
       #
-      # * If you are using the enterprise authentication type (mimir.structuredConfig.auth.type: enterprise, which is also the default),
+      # * If you are using the enterprise authentication type (mimir.structuredConfig.auth.type=enterprise, which is also the default when enterprise.enabled=true),
       #   then you also need to provide a Secret with the authentication token for the tenant.
       #   The token should be to an access policy with metrics:read scope.
       #   To set up the Secret, refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1940,7 +1940,7 @@ metaMonitoring:
       # `helm install` and `helm upgrade` commands.
       #
       # remote:
-      #   url: 'GATEWAY_URL'
+      #   url: "GATEWAY_URL"
       #   auth:
       #     username: metamonitoring
       #     passwordSecretName: gem-tokens

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1927,26 +1927,33 @@ metaMonitoring:
       # configuration to push metrics to this Prometheus-compatible remote. Optional.
       # Note that you need to configure serviceMonitor in order to have some metrics available.
       #
-      # If you have deployed Mimir, and metamonitoring.grafanaAgent.metrics.remove.url is not set,
+      # If you leave the metamonitoring.grafanaAgent.metrics.remote.url field empty,
+      # then the chart automatically fills in the address of the GEM gateway Service
+      # or the Mimir NGINX Service.
+      #
+      # If you have deployed Mimir, and metamonitoring.grafanaAgent.metrics.remote.url is not set,
       # then the metamonitoring metrics are be sent to the Mimir cluster.
       # You can query these metrics using X-Scope-OrgID: metamonitoring
       #
-      # If you have deployed GEM, then you need to configure the remote endpoint yourself. The URL should point to
-      # the GEM gateway Service. If you are using the GEM authentication model, then you also need to
-      # provide a Secret with the authentication token for the tenant.
-      # To set up the Secret, refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
-      # Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
-      # Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service;
-      # the `helm install` and `helm upgrade` commands output that address.
+      # If you have deployed GEM, then there are two cases:
+      # * If are using the 'trust' authentication type (mimir.structuredConfig.auth.type: trust),
+      #   then the same instructions apply as for Mimir.
+      #
+      # * If you are using the enterprise authentication type (mimir.structuredConfig.auth.type: enterprise, which is also the default),
+      #   then you also need to provide a Secret with the authentication token for the tenant.
+      #   The token should be to an access policy with metrics:read scope.
+      #   To set up the Secret, refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
+      #   Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
       #
       # remote:
-      #   url: "GATEWAY_URL"
       #   auth:
       #     username: metamonitoring
       #     passwordSecretName: gem-tokens
       #     passwordSecretKey: metamonitoring
       remote:
-        # -- Full URL for Prometheus remote-write. Usually ends in /push
+        # -- Full URL for Prometheus remote-write. Usually ends in /push.
+        # If you leave the url field empty, then the chart automatically fills in the
+        # address of the GEM gateway Service or the Mimir NGINX Service.
         url: ''
 
         # -- Used to add HTTP headers to remote-write requests.

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1927,26 +1927,20 @@ metaMonitoring:
       # configuration to push metrics to this Prometheus-compatible remote. Optional.
       # Note that you need to configure serviceMonitor in order to have some metrics available.
       #
-      # You can also send the collected metamonitoring metrics to the installation of Mimir or GEM.
-      # The configuration varies slightly for GEM and Mimir.
+      # If you have deployed Mimir, and metamonitoring.grafanaAgent.metrics.remove.url is not set,
+      # then the metamonitoring metrics are be sent to the Mimir cluster.
+      # You can query these metrics using X-Scope-OrgID: metamonitoring
       #
-      # If you have deployed Mimir, then the Helm chart values should look like the following example.
-      # Replace `HELM_RELEASE_NAME` with the name of your Helm release:
-      #
-      # remote:
-      #   url: 'http://<HELM_RELEASE_NAME>-mimir-nginx.mimir.svc/api/v1/push'
-      #   headers:
-      #     X-Scope-OrgID: metamonitoring
-      #
-      # If you have deployed GEM, then the URL will point to the GEM gateway instead of the nginx Deployment.
-      # If you are using the GEM authentication model, then you also need to provide a Secret with the
-      # authentication token for a tenant. Refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
-      # for setting up the Secret.
+      # If you have deployed GEM, then you need to configure the remote endpoint yourself. The URL should point to
+      # the GEM gateway Service. If you are using the GEM authentication model, then you also need to
+      # provide a Secret with the authentication token for the tenant.
+      # For setting up the Secret, refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
       # Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
-      # Replace `HELM_RELEASE_NAME` with the name of your Helm release:
+      # Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service; that service is also displayed after
+      # `helm install` and `helm upgrade` commands.
       #
       # remote:
-      #   url: 'http://<HELM_RELEASE_NAME>-mimir-gateway.mimir.svc/api/v1/push'
+      #   url: 'GATEWAY_URL'
       #   auth:
       #     username: metamonitoring
       #     passwordSecretName: gem-tokens

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1934,10 +1934,10 @@ metaMonitoring:
       # If you have deployed GEM, then you need to configure the remote endpoint yourself. The URL should point to
       # the GEM gateway Service. If you are using the GEM authentication model, then you also need to
       # provide a Secret with the authentication token for the tenant.
-      # For setting up the Secret, refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
+      # To set up the Secret, refer to https://grafana.com/docs/mimir/latest/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-via-the-helm-chart
       # Assuming you are using the GEM authentication model, the Helm chart values should look like the following example.
-      # Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service; that service is also displayed after
-      # `helm install` and `helm upgrade` commands.
+      # Replace `GATEWAY_URL` with the in-cluster address of the GEM gateway Service;
+      # the `helm install` and `helm upgrade` commands output that address.
       #
       # remote:
       #   url: "GATEWAY_URL"

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/logs-instance.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   clients:
+      
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the LogsInstance CR

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -12,6 +12,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   remoteWrite:
+      
+      - url: http://metamonitoring-values-mimir-nginx.citestns.svc:80/api/v1/push
+        basicAuth:
+        headers:
+          X-Scope-OrgID: metamonitoring
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the MetricsInstance CR

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   remoteWrite:
-      
       - url: http://metamonitoring-values-mimir-nginx.citestns.svc:80/api/v1/push
         basicAuth:
         headers:


### PR DESCRIPTION
As a follow up of #2984 

this PR sends metamonitoring metrics automatically to mimir if no URL is configured (and if metamonitoring is enabled)