### PR TITLE
mixin: ruler emote eval failing alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309
 * [ENHANCEMENT] Add experimental flag `-shutdown-delay` to allow components to wait after receiving SIGTERM and before stopping. In this time the component returns 503 from /ready endpoint. #3298
 * [ENHANCEMENT] Go: update to go 1.19.3. #3371
+* [ENHANCEMENT] Alerts: added `RulerRemoteEvaluationFailing` alert, firing when communication between ruler and frontend fails in remote operational mode. #3177
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -346,6 +346,20 @@ How to **fix** it:
 - Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes.
 - Try splitting up the rule group into multiple rule groups. Rule groups are evaluated in parallel, so the same rules may still fit in the same resolution.
 
+### MimirRulerRemoteEvaluationFailing
+
+This alert fires when communication between `ruler` and `ruler-query-frontend` is failing to be established.
+
+The `ruler-query-frontend` component is exclusively used by the `ruler` to evaluate rule expressions when running in remote operational mode. If communication between these two components breaks, gaps are expected to appear in the case of recording rules or alerting rules will not fire when they should.
+
+How to **investigate**:
+
+- Check the `Mimir / Remote ruler reads` dashboard to see if the issue is caused by failures or high latency
+  - **Failures**
+    - Check the `ruler-query-frontend` logs to find out more details about the error
+  - **High latency**
+    - Check the `Mimir / Remote ruler reads resources` dashboard to see if CPU or Memory usage increased unexpectedly
+
 ### MimirIngesterHasNotShippedBlocks
 
 This alert fires when a Mimir ingester is not uploading any block to the long-term storage. An ingester is expected to upload a block to the storage every block range period (defaults to 2h) and if a longer time elapse since the last successful upload it means something is not working correctly.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -393,9 +393,9 @@ groups:
         Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to perform {{ printf "%.2f" $value }}% of remote evaluations when communicating with ruler-query-frontend.
     expr: |
       100 * (
-      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", job=~".*/ruler-query-frontend"}[5m]))
+      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", cluster=~"$cluster", job=~"($namespace)/((ruler-query-frontend.*))"}[5m]))
         /
-      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", job=~".*/ruler-query-frontend"}[5m]))
+      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", cluster=~"$cluster", job=~"($namespace)/((ruler-query-frontend.*))"}[5m]))
       ) > 1
     for: 5m
     labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -387,6 +387,19 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirRulerRemoteEvaluationFailing
+    annotations:
+      message: |
+        Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to perform {{ printf "%.2f" $value }}% of remote evaluations when communicating with ruler-query-frontend.
+    expr: |
+      100 * (
+      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", job=~".*/ruler-query-frontend"}[5m]))
+        /
+      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", job=~".*/ruler-query-frontend"}[5m]))
+      ) > 1
+    for: 5m
+    labels:
+      severity: warning
 - name: gossip_alerts
   rules:
   - alert: MimirGossipMembersMismatch

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -393,9 +393,9 @@ groups:
         Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to perform {{ printf "%.2f" $value }}% of remote evaluations when communicating with ruler-query-frontend.
     expr: |
       100 * (
-      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", cluster=~"$cluster", job=~"($namespace)/((ruler-query-frontend.*))"}[5m]))
+      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code=~"5..", job=~".*/(ruler-query-frontend.*)"}[5m]))
         /
-      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", cluster=~"$cluster", job=~"($namespace)/((ruler-query-frontend.*))"}[5m]))
+      sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m]))
       ) > 1
     for: 5m
     labels:

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -12,7 +12,5 @@
   // The mixin allow specialism of the job selector depending on if its a single binary
   // deployment or a namespaced one.
   jobMatcher(job)::
-    if $._config.singleBinary
-    then 'job=~"$job"'
-    else '%s=~"$cluster", job=~"($namespace)/(%s)"' % [$._config.per_cluster_label, job],
+    'job=~".*/%s"' % job,
 }

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -9,8 +9,6 @@
   alertName(name)::
     $._config.product + name,
 
-  // The mixin allow specialism of the job selector depending on if its a single binary
-  // deployment or a namespaced one.
   jobMatcher(job)::
     'job=~".*/%s"' % job,
 }

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -8,4 +8,11 @@
   // The alert name is prefixed with the product name (eg. AlertName -> MimirAlertName).
   alertName(name)::
     $._config.product + name,
+
+  // The mixin allow specialism of the job selector depending on if its a single binary
+  // deployment or a namespaced one.
+  jobMatcher(job)::
+    if $._config.singleBinary
+    then 'job=~"$job"'
+    else '%s=~"$cluster", job=~"($namespace)/(%s)"' % [$._config.per_cluster_label, job],
 }

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -640,6 +640,25 @@
             ||| % $._config,
           },
         },
+        {
+          alert: $.alertName('RulerRemoteEvaluationFailing'),
+          expr: |||
+            100 * (
+            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", job=~".*/ruler-query-frontend"}[5m]))
+              /
+            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", job=~".*/ruler-query-frontend"}[5m]))
+            ) > 1
+          ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
+          'for': '5m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is failing to perform {{ printf "%%.2f" $value }}%% of remote evaluations when communicating with ruler-query-frontend.
+            ||| % $._config,
+          },
+        },
       ],
     },
     {

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -644,11 +644,11 @@
           alert: $.alertName('RulerRemoteEvaluationFailing'),
           expr: |||
             100 * (
-            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", job=~".*/ruler-query-frontend"}[5m]))
+            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", %s}[5m]))
               /
-            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", job=~".*/ruler-query-frontend"}[5m]))
+            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", %s}[5m]))
             ) > 1
-          ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
+          ||| % [$._config.alert_aggregation_labels, $.jobMatcher($._config.job_names.ruler_query_frontend), $._config.alert_aggregation_labels, $.jobMatcher($._config.job_names.ruler_query_frontend)],
           'for': '5m',
           labels: {
             severity: 'warning',

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -644,7 +644,7 @@
           alert: $.alertName('RulerRemoteEvaluationFailing'),
           expr: |||
             100 * (
-            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code!~"5..", %s}[5m]))
+            sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", status_code=~"5..", %s}[5m]))
               /
             sum by (%s) (rate(cortex_request_duration_seconds_count{route="/httpgrpc.HTTP/Handle", %s}[5m]))
             ) > 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

The experimental `RulerRemoteEvaluationFailing` alert has proven to work correctly at the ops cluster. 

This PR moves the alert definition to upstream. 

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
