### PR TITLE
storegateway: avoid unnecessary allocation in `seriesForRefCacheKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
+* [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin

--- a/pkg/storegateway/indexcache/memcached.go
+++ b/pkg/storegateway/indexcache/memcached.go
@@ -200,7 +200,9 @@ func (c *MemcachedIndexCache) FetchMultiSeriesForRefs(ctx context.Context, userI
 }
 
 func seriesForRefCacheKey(userID string, blockID ulid.ULID, id storage.SeriesRef) string {
-	return "S:" + userID + ":" + blockID.String() + ":" + strconv.FormatUint(uint64(id), 10)
+	// Max uint64 string representation is no longer than 20 characters.
+	b := make([]byte, 0, 20)
+	return "S:" + userID + ":" + blockID.String() + ":" + string(strconv.AppendUint(b, uint64(id), 10))
 }
 
 // StoreExpandedPostings stores the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

According to a `storegateway` memory profile from the ops cluster, the `strconv.FormatUint` function used in `seriesForRefCacheKey` is taking roughly `1.37%` of total allocated objects. That seems quite a lot for just an id generator function.

![mem-prof](https://user-images.githubusercontent.com/888899/194886648-40d93846-0b53-4b66-b35d-57ccf746e8fa.jpg)



This PR adapts `seriesForRefCacheKey` to parse series ref id using a stack a buffer to avoid unnecessary allocations. 

Below are the benchmark results comparing against the old implementation:

Previous:

```
BenchmarkStringCacheKeys/series_ref-8         	14691523	        81.81 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14615520	        81.87 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14474442	        81.29 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14345236	        81.50 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14785486	        81.70 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14608633	        81.88 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14584176	        81.90 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14644542	        81.68 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14593413	        81.64 ns/op	      88 B/op	       2 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	14616150	        81.88 ns/op	      88 B/op	       2 allocs/op
```

Current:

```
BenchmarkStringCacheKeys/series_ref-8         	16587760	        72.40 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16571724	        72.29 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16491350	        72.28 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16540212	        72.34 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16564346	        72.53 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16501989	        72.40 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16519273	        72.47 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16515446	        72.50 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	16552038	        72.55 ns/op	      64 B/op	       1 allocs/op
BenchmarkStringCacheKeys/series_ref-8         	15845139	        72.78 ns/op	      64 B/op	       1 allocs/op
```

Comparison:

```
name                          old time/op    new time/op    delta
StringCacheKeys/series_ref-8    81.7ns ± 1%    72.5ns ± 0%  -11.33%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
StringCacheKeys/series_ref-8     88.0B ± 0%     64.0B ± 0%  -27.27%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
StringCacheKeys/series_ref-8      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
```

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
