### PR TITLE
Fix mimirtool error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] Added `mimirtool rules delete-namespace` command to delete all of the rule groups in a namespace including the namespace itself. #3136
-* [BUGFIX] `--log.level=debug` not correctly prints the response from the remote endpoint when a request fails. #3180
+* [BUGFIX] `--log.level=debug` now correctly prints the response from the remote endpoint when a request fails. #3180
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 ### Jsonnet
 
 ### Mimirtool
+
 * [ENHANCEMENT] Added `mimirtool rules delete-namespace` command to delete all of the rule groups in a namespace including the namespace itself. #3136
+* [BUGFIX] `--log.level=debug` not correctly prints the response from the remote endpoint when a request fails. #3180
 
 ### Documentation
 

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -72,7 +72,7 @@ func TestMimirtoolBackfill(t *testing.T) {
 	{
 		// Try to upload block using mimirtool. Should fail because upload is not enabled for user.
 		output, err := runMimirtoolBackfill(tmpDir, compactor, block1)
-		require.Contains(t, output, "server returned HTTP status 400 Bad Request: block upload is disabled")
+		require.Contains(t, output, "server returned HTTP status: 400 Bad Request, body: block upload is disabled")
 		require.Error(t, err)
 	}
 

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -72,7 +72,8 @@ func TestMimirtoolBackfill(t *testing.T) {
 	{
 		// Try to upload block using mimirtool. Should fail because upload is not enabled for user.
 		output, err := runMimirtoolBackfill(tmpDir, compactor, block1)
-		require.Contains(t, output, "server returned HTTP status: 400 Bad Request, body: block upload is disabled")
+		require.Contains(t, output, "400 Bad Request")
+		require.Contains(t, output, "block upload is disabled")
 		require.Error(t, err)
 	}
 

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -177,31 +177,34 @@ func checkResponse(r *http.Response) error {
 	if err != nil {
 		return errors.Wrapf(err, "reading body")
 	}
-
-	msg := string(bodyHead)
-	var errMsg string
-	if msg == "" {
-		errMsg = fmt.Sprintf("server returned HTTP status: %s", r.Status)
-	} else {
-		errMsg = fmt.Sprintf("server returned HTTP status: %s, body: %s", r.Status, msg)
-	}
-
+	bodyStr := string(bodyHead)
+	const msg = "response"
 	if r.StatusCode == http.StatusNotFound {
 		log.WithFields(log.Fields{
 			"status": r.Status,
-		}).Debugln(errMsg)
+			"body":   bodyStr,
+		}).Debugln(msg)
 		return ErrResourceNotFound
 	}
 	if r.StatusCode == http.StatusConflict {
 		log.WithFields(log.Fields{
 			"status": r.Status,
-		}).Debugln(errMsg)
+			"body":   bodyStr,
+		}).Debugln(msg)
 		return errConflict
 	}
 
 	log.WithFields(log.Fields{
 		"status": r.Status,
-	}).Errorln(errMsg)
+		"body":   bodyStr,
+	}).Errorln(msg)
+
+	var errMsg string
+	if bodyStr == "" {
+		errMsg = fmt.Sprintf("server returned HTTP status: %s", r.Status)
+	} else {
+		errMsg = fmt.Sprintf("server returned HTTP status: %s, body: %q", r.Status, bodyStr)
+	}
 
 	return errors.New(errMsg)
 }


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When provided with `--log.level=debug` and a request fails mimirtool should print out some part of the response for easier debugging. Instead it uses a scanner which only reads the first token from the response.

The first token is by default the first line. Which in some cases can be fairly useless.

This PR 
* changes the logged reported content to be the first 1024 bytes regardless of new lines.
* removes duplication of the error content (logging both `errMsg` and `msg`)
* increases the number of bytes to read from the body from 512 to 1024 for good measure.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
