### PR TITLE
Helm: add remote destinations in metamonitoring offline test

### DIFF
--- a/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
@@ -7,3 +7,22 @@ metaMonitoring:
   grafanaAgent:
     enabled: true
     installOperator: true
+    metrics:
+      # Leaving the remote empty should use the default to send it to Mimir directly
+      # remote: #
+      additionalRemoteWriteConfigs:
+        - url: https://mimir.example.com
+          headers:
+            X-Scope-OrgID: tenant-1
+          auth:
+            username: tenant-1
+            passwordSecretName: my-secret
+            passwordSecretKey: metrics
+
+    logs:
+      remote:
+        url: https://loki.example.com
+        auth:
+          username: tenant-1
+          passwordSecretName: my-secret
+          passwordSecretKey: logs

--- a/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
@@ -8,7 +8,7 @@ metaMonitoring:
     enabled: true
     installOperator: true
     metrics:
-      # Leaving the remote empty should use the default to send it to Mimir directly
+      # Leave the remote empty to use the default to send it to Mimir directly
       # remote: #
       additionalRemoteWriteConfigs:
         - url: https://mimir.example.com

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
@@ -11,3 +11,4 @@ metadata:
     app.kubernetes.io/component: meta-monitoring
     app.kubernetes.io/managed-by: Helm
 data:
+  username-0: "dGVuYW50LTE="

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/logs-instance.yaml
@@ -13,6 +13,16 @@ metadata:
 spec:
   clients:
       
+      - url: https://loki.example.com
+        basicAuth:
+          username:
+            name: metamonitoring-values-mimir-logs-instance-usernames
+            key: "username-0"
+          password:
+            name: "my-secret"
+            key: "logs"
+        externalLabels:
+          cluster: "metamonitoring-values"
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the LogsInstance CR

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -11,3 +11,4 @@ metadata:
     app.kubernetes.io/component: meta-monitoring
     app.kubernetes.io/managed-by: Helm
 data:
+  username-1: "dGVuYW50LTE="

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -16,6 +16,16 @@ spec:
         basicAuth:
         headers:
           X-Scope-OrgID: metamonitoring
+      - url: https://mimir.example.com
+        basicAuth:
+          username:
+            name: metamonitoring-values-mimir-metrics-instance-usernames
+            key: "username-1"
+          password:
+            name: "my-secret"
+            key: "metrics"
+        headers:
+          X-Scope-OrgID: tenant-1
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the MetricsInstance CR


### PR DESCRIPTION

#### What this PR does
This adds remote destinations so that we can test more of the logic in
metamonitoring. Specifically to expose the bug that #3170 fixed.


#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
