### PR TITLE
runbooks: Augment MimirQuerierAutoscalerNotActive runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Documentation
 
+* [ENHANCEMENT] Improve `MimirQuerierAutoscalerNotActive` runbook. #3186
+
 ### Tools
 
 ## 2.4.0-rc.0

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -1007,7 +1007,7 @@ How to **investigate**:
   # Assuming KEDA is running in a dedicated namespace "keda":
   kubectl logs -n keda deployment/keda-operator
   ```
-- Check that Prometheus is running (since KEDA depends on it)
+- Check that Prometheus is running (since we configure KEDA to scrape custom metrics from it by default)
   ```
   # Assuming Prometheus is running in namespace "default":
   kubectl -n default get pod -lname=prometheus

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -992,7 +992,7 @@ How to **investigate**:
   ```
   kubectl describe hpa -n <namespace> keda-hpa-querier
   ```
-- Ensure KEDA custom metrics API server is up and running
+- Ensure KEDA pods are up and running
   ```
   # Assuming KEDA is running in a dedicated namespace "keda":
   kubectl get pods -n keda
@@ -1001,6 +1001,16 @@ How to **investigate**:
   ```
   # Assuming KEDA is running in a dedicated namespace "keda":
   kubectl logs -n keda deployment/keda-operator-metrics-apiserver
+  ```
+- Check KEDA operator logs
+  ```
+  # Assuming KEDA is running in a dedicated namespace "keda":
+  kubectl logs -n keda deployment/keda-operator
+  ```
+- Check that Prometheus is running (since KEDA depends on it)
+  ```
+  # Assuming Prometheus is running in namespace "default":
+  kubectl -n default get pod -lname=prometheus
   ```
 
 ### MimirContinuousTestNotRunningOnWrites


### PR DESCRIPTION
#### What this PR does
Augment MimirQuerierAutoscalerNotActive runbook with some more advice:

* Check KEDA operator logs
* Check Prometheus pods

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
