### PR TITLE
Add script to publish the release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,6 +111,17 @@ To publish a release candidate:
 
 ### Creating release on GitHub
 
+**How to create the release using the script:**
+
+```bash
+git checkout release-<version>
+
+# Then run the following script and follow the instructions:
+./tools/release/create-draft-release.sh
+```
+
+**How to create the release manually:**
+
 1. Go to https://github.com/grafana/mimir/releases/new to start a new release on GitHub (or click "Draft a new release" at https://github.com/grafana/mimir/releases page.)
 1. Select your new tag, use `Mimir <VERSION>` as Release Title. Check that "Previous tag" next to "Generate release notes" button shows previous Mimir release.
    Click "Generate release notes" button. This will pre-fill the changelog for the release.

--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This is a library shared between scripts for managing the release process.
+#
+
+set -e
+
+check_required_tools() {
+  # Ensure "gh" tool is installed.
+  if ! command -v gh &> /dev/null; then
+      echo "The 'gh' command cannot be found. Please install it: https://cli.github.com"
+      exit 1
+  fi
+}
+
+find_last_release() {
+  LAST_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | sort -V | tail -1)
+
+  if [ -z "${LAST_RELEASE_TAG}" ]; then
+    echo "Unable to find the last release git tag"
+    exit 1
+  fi
+
+  # Find the last release version. Since all tags start with "mimir-"
+  # we can simply find the version:
+  LAST_RELEASE_VERSION=$(echo "${LAST_RELEASE_TAG}" | cut -c 7-)
+
+  export LAST_RELEASE_TAG
+  export LAST_RELEASE_VERSION
+}
+
+find_prev_release() {
+  PREV_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | sort -V | tail -2 | head -1)
+
+  if [ -z "${PREV_RELEASE_TAG}" ]; then
+    echo "Unable to find the previous release git tag"
+    exit 1
+  fi
+
+  export PREV_RELEASE_TAG
+}

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -61,5 +61,5 @@ printf "# Changelog\n\n"
 tail -n +"${CHANGELOG_BEGIN_LINE}" "${CHANGELOG_PATH}" | head -$((CHANGELOG_END_LINE + 1))
 printf "\n"
 
-# Link to changes
-printf "**All commits merged in this release**: https://github.com/grafana/mimir/compare/%s...%s\n" "${PREV_RELEASE_TAG}" "${LAST_RELEASE_TAG}"
+# Link to changes.
+printf "**All changes in this release**: https://github.com/grafana/mimir/compare/%s...%s\n" "${PREV_RELEASE_TAG}" "${LAST_RELEASE_TAG}"

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -16,8 +16,9 @@ CHANGELOG_PATH="${CURR_DIR}/../../CHANGELOG.md"
 # Contributors
 #
 
-NUM_PRS=$(git log --pretty=format:"%s" "${LAST_RELEASE_TAG}...${PREV_RELEASE_TAG}" | grep -Eo '#[0-9]+' | wc -l | grep -Eo '[0-9]+')
-NUM_AUTHORS=$(git log --pretty=format:"%an" "${LAST_RELEASE_TAG}...${PREV_RELEASE_TAG}" | sort | uniq -i | wc -l | grep -Eo '[0-9]+')
+# We use the 2-dots notation to diff because in this context we only want to get the new commits in the last release.
+NUM_PRS=$(git log --pretty=format:"%s" "${PREV_RELEASE_TAG}..${LAST_RELEASE_TAG}" | grep -Eo '#[0-9]+' | wc -l | grep -Eo '[0-9]+')
+NUM_AUTHORS=$(git log --pretty=format:"%an" "${PREV_RELEASE_TAG}..${LAST_RELEASE_TAG}" | sort | uniq -i | wc -l | grep -Eo '[0-9]+')
 NEW_AUTHORS=$(diff <(git log --pretty=format:"%an" "${PREV_RELEASE_TAG}" | sort | uniq -i) <(git log --pretty=format:"%an" "${LAST_RELEASE_TAG}" | sort | uniq -i) | grep -E '^>' | cut -c 3- | gsed -z 's/\n/, /g;s/, $//')
 
 if [ -z "${NEW_AUTHORS}" ]; then

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -e
+
+# Load common lib.
+CURR_DIR="$(dirname "$0")"
+. "${CURR_DIR}/common.sh"
+
+find_last_release
+find_prev_release
+
+CHANGELOG_PATH="${CURR_DIR}/../../CHANGELOG.md"
+
+#
+# Contributors
+#
+
+NUM_PRS=$(git log --pretty=format:"%s" "${LAST_RELEASE_TAG}...${PREV_RELEASE_TAG}" | grep -Eo '#[0-9]+' | wc -l | grep -Eo '[0-9]+')
+NUM_AUTHORS=$(git log --pretty=format:"%an" "${LAST_RELEASE_TAG}...${PREV_RELEASE_TAG}" | sort | uniq -i | wc -l | grep -Eo '[0-9]+')
+printf "This release contains %s PRs from %s authors. Thank you!\n\n" "${NUM_PRS}" "${NUM_AUTHORS}"
+
+#
+# Release notes
+#
+
+# Title
+printf "# Grafana Mimir version %s release notes\n\n" "${LAST_RELEASE_VERSION}"
+
+# Add a place holder for the release notes.
+printf "**TODO: add release notes here**\n\n"
+
+#
+# CHANGELOG
+#
+
+# Find the line at which the CHANGELOG for this version begins.
+CHANGELOG_SECTION_TITLE="## ${LAST_RELEASE_VERSION}"
+CHANGELOG_BEGIN_LINE=$(awk "/^${CHANGELOG_SECTION_TITLE}$/{ print NR; exit }" "${CHANGELOG_PATH}")
+if [ -z "${CHANGELOG_BEGIN_LINE}" ]; then
+  echo "Unable to find the section title '${CHANGELOG_SECTION_TITLE}' in the ${CHANGELOG_PATH}"
+  exit 1
+fi
+
+# Find the line at which the CHANGELOG for this version ends.
+CHANGELOG_END_LINE=$(tail -n +$((CHANGELOG_BEGIN_LINE + 1)) "${CHANGELOG_PATH}" | awk "/^## /{ print NR - 1; exit }")
+if [ -z "${CHANGELOG_END_LINE}" ]; then
+  echo "Unable to find the end of the section '${CHANGELOG_SECTION_TITLE}' in the ${CHANGELOG_PATH}"
+  exit 1
+fi
+
+# Append the CHANGELOG section to the release notes.
+printf "# Changelog\n\n"
+tail -n +"${CHANGELOG_BEGIN_LINE}" "${CHANGELOG_PATH}" | head -$((CHANGELOG_END_LINE + 1))

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -18,7 +18,13 @@ CHANGELOG_PATH="${CURR_DIR}/../../CHANGELOG.md"
 
 NUM_PRS=$(git log --pretty=format:"%s" "${LAST_RELEASE_TAG}...${PREV_RELEASE_TAG}" | grep -Eo '#[0-9]+' | wc -l | grep -Eo '[0-9]+')
 NUM_AUTHORS=$(git log --pretty=format:"%an" "${LAST_RELEASE_TAG}...${PREV_RELEASE_TAG}" | sort | uniq -i | wc -l | grep -Eo '[0-9]+')
-printf "This release contains %s PRs from %s authors. Thank you!\n\n" "${NUM_PRS}" "${NUM_AUTHORS}"
+NEW_AUTHORS=$(diff <(git log --pretty=format:"%an" "${PREV_RELEASE_TAG}" | sort | uniq -i) <(git log --pretty=format:"%an" "${LAST_RELEASE_TAG}" | sort | uniq -i) | grep -E '^>' | cut -c 3- | gsed -z 's/\n/, /g;s/, $//')
+
+if [ -z "${NEW_AUTHORS}" ]; then
+  printf "This release contains %s PRs from %s authors. Thank you!\n\n" "${NUM_PRS}" "${NUM_AUTHORS}"
+else
+  printf "This release contains %s PRs from %s authors, including new contributors %s. Thank you!\n\n" "${NUM_PRS}" "${NUM_AUTHORS}" "${NEW_AUTHORS}"
+fi
 
 #
 # Release notes
@@ -52,3 +58,7 @@ fi
 # Append the CHANGELOG section to the release notes.
 printf "# Changelog\n\n"
 tail -n +"${CHANGELOG_BEGIN_LINE}" "${CHANGELOG_PATH}" | head -$((CHANGELOG_END_LINE + 1))
+printf "\n"
+
+# Link to changes
+printf "**All commits merged in this release**: https://github.com/grafana/mimir/compare/%s...%s\n" "${PREV_RELEASE_TAG}" "${LAST_RELEASE_TAG}"

--- a/tools/release/create-draft-release.sh
+++ b/tools/release/create-draft-release.sh
@@ -11,9 +11,9 @@ check_required_tools
 find_last_release
 find_prev_release
 
-# Build dist binaries.
+# Build binaries and packages.
 echo "Building binaries (this may take a while)..."
-cd "${CURR_DIR}"/../../ && make dist && cd -
+cd "${CURR_DIR}"/../../ && make dist packages && cd -
 
 # Generate release notes draft.
 echo "Generating the draft release notes..."

--- a/tools/release/create-draft-release.sh
+++ b/tools/release/create-draft-release.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -e
+
+# Load common lib.
+CURR_DIR="$(dirname "$0")"
+. "${CURR_DIR}/common.sh"
+
+check_required_tools
+find_last_release
+find_prev_release
+
+# Build dist binaries.
+echo "Building binaries (this may take a while)..."
+cd "${CURR_DIR}"/../../ && make dist && cd -
+
+# Generate release notes draft.
+echo "Generating the draft release notes..."
+RELEASE_NOTES_FILE="./tmp-release-notes.md"
+trap 'rm -f "${RELEASE_NOTES_FILE}"' EXIT
+"${CURR_DIR}"/create-draft-release-notes.sh > "${RELEASE_NOTES_FILE}"
+
+# Create the draft release.
+echo "Creating the draft release (uploading assets may take a while)..."
+gh release create \
+  --draft \
+  --prerelease \
+  --title "${LAST_RELEASE_VERSION}" \
+  --notes-file "${RELEASE_NOTES_FILE}" \
+  "${LAST_RELEASE_TAG}" "${CURR_DIR}"/../../dist/*
+
+# Print instructions to move on.
+echo ""
+echo "The draft release has been created. To continue:"
+echo "1. Copy the release notes from the documentation and fix the links."
+echo "2. Review the draft release."
+echo "3. If this is a stable release, remove the tick from 'This is a pre-release'."
+echo "4. Publish it."

--- a/tools/release/notify-changelog-cut.sh
+++ b/tools/release/notify-changelog-cut.sh
@@ -3,11 +3,11 @@
 
 set -e
 
-# Ensure "gh" tool is installed.
-if ! command -v gh &> /dev/null; then
-    echo "The 'gh' command cannot be find. Please install it: https://cli.github.com"
-    exit
-fi
+# Load common lib.
+CURR_DIR="$(dirname "$0")"
+. "${CURR_DIR}/common.sh"
+
+check_required_tools
 
 # Config
 NOTIFICATION_LABEL="release/notified-changelog-cut"


### PR DESCRIPTION
#### What this PR does
Like #3164 but from a branch name which allows me to force push (we have a protection on branches with name matching `release*`). Copied from #3164:

I've created the **draft** release `2.4.0-rc.0` ([link visible only to maintainers until will be published](https://github.com/grafana/mimir/releases/tag/untagged-58fc54db72d7598c982d)) with a script, which I'm upstreaming in the PR.

What's in this PR:
- Few helper functions in `tools/release/common.sh`
- `tools/release/create-draft-release-notes.sh` to generate the draft release notes (it gets called by the release publishing script)
- `tools/release/create-draft-release.sh` to create (but not publish) the draft pre-release

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
