### PR TITLE
Log failed query information in the query-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172
 * [ENHANCEMENT] Ingester: Reduce activity tracker memory allocation. #3203
+* [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin
@@ -125,7 +126,6 @@
 * [ENHANCEMENT] Query-frontend: Include multiple tenant IDs in query logs when present instead of dropping them. #3125
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3143
 * [ENHANCEMENT] Store-gateway: added extra span logging to improve observability. #3131
-* [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 * [ENHANCEMENT] Query-frontend: Include multiple tenant IDs in query logs when present instead of dropping them. #3125
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3143
 * [ENHANCEMENT] Store-gateway: added extra span logging to improve observability. #3131
+* [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
 * [BUGFIX] Querier: Fix 400 response while handling streaming remote read. #2963
 * [BUGFIX] Fix a bug causing query-frontend, query-scheduler, and querier not failing if one of their internal components fail. #2978
 * [BUGFIX] Querier: re-balance the querier worker connections when a query-frontend or query-scheduler is terminated. #3005

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -231,7 +231,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 	if queryErr != nil {
 		logMessage = append(logMessage, []interface{}{
 			"status", "failed",
-			"error", queryErr,
+			"err", queryErr,
 		})
 	} else {
 		logMessage = append(logMessage, []interface{}{

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -201,9 +201,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 	numBytes := stats.LoadFetchedChunkBytes()
 	numChunks := stats.LoadFetchedChunks()
 	sharded := strconv.FormatBool(stats.GetShardedQueries() > 0)
-
-	// This function will be called in case of a queryErr regardless of
-	// whether the `QueryStatsEnabled` flag is true or not
+	
 	if stats != nil {
 		// Track stats.
 		f.querySeconds.WithLabelValues(userID, sharded).Add(wallTime.Seconds())

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -201,7 +201,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 	numBytes := stats.LoadFetchedChunkBytes()
 	numChunks := stats.LoadFetchedChunks()
 	sharded := strconv.FormatBool(stats.GetShardedQueries() > 0)
-	
+
 	if stats != nil {
 		// Track stats.
 		f.querySeconds.WithLabelValues(userID, sharded).Add(wallTime.Seconds())

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -227,14 +227,12 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 	}, formatQueryString(queryString)...)
 
 	if queryErr != nil {
-		logMessage = append(logMessage, []interface{}{
+		logMessage = append(logMessage,
 			"status", "failed",
-			"err", queryErr,
-		})
+			"err", queryErr)
 	} else {
-		logMessage = append(logMessage, []interface{}{
-			"status", "success",
-		})
+		logMessage = append(logMessage,
+			"status", "success")
 	}
 
 	level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -204,7 +204,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 
 	// This function will be called in case of a queryErr regardless of
 	// whether the `QueryStatsEnabled` flag is true or not
-	if queryErr == nil {
+	if stats != nil {
 		// Track stats.
 		f.querySeconds.WithLabelValues(userID, sharded).Add(wallTime.Seconds())
 		f.querySeries.WithLabelValues(userID).Add(float64(numSeries))

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -148,7 +148,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 				"cortex_query_fetched_chunks_total",
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, strings.TrimSpace(logs.String()), "sharded_queries")
 			if test.expectQueryParamLog {
 				assert.Contains(t, strings.TrimSpace(logs.String()), "param_query")

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -152,7 +152,9 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 			)
 
 			require.NoError(t, err)
+
 			assert.Contains(t, strings.TrimSpace(logs.String()), "sharded_queries")
+			assert.Contains(t, strings.TrimSpace(logs.String()), "status")
 			if test.expectQueryParamLog {
 				assert.Contains(t, strings.TrimSpace(logs.String()), "param_query")
 			}

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -130,7 +130,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			logs := &concurrency.SyncBuffer{}
 			logger := log.NewLogfmtLogger(logs)
-			handler := NewHandler(HandlerConfig{QueryStatsEnabled: true}, roundTripper, logger, reg)
+			handler := NewHandler(HandlerConfig{QueryStatsEnabled: false}, roundTripper, logger, reg)
 
 			ctx := user.InjectOrgID(context.Background(), "12345")
 			req := httptest.NewRequest("GET", test.path, nil)

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -127,7 +127,6 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 			resp := httptest.NewRecorder()
 
 			handler.ServeHTTP(resp, req)
-			_, _ = io.ReadAll(resp.Body)
 			require.Equal(t, StatusClientClosedRequest, resp.Code)
 
 			count, _ := promtest.GatherAndCount(

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -101,35 +101,46 @@ func TestHandler_ServeHTTP(t *testing.T) {
 
 func TestHandler_FailedRoundTrip(t *testing.T) {
 	for _, test := range []struct {
-		name            string
-		cfg             HandlerConfig
-		expectedMetrics int
+		name                string
+		expectedMetrics     int
+		path                string
+		expectQueryParamLog bool
+		queryErr            error
 	}{
 		{
-			name:            "Failed round trip with context cancelled",
-			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 0,
+			name:                "Failed round trip with context cancelled",
+			expectedMetrics:     0,
+			path:                "/api/v1/query?query=up&time=2015-07-01T20:10:51.781Z",
+			expectQueryParamLog: true,
+			queryErr:            context.Canceled,
+		},
+		{
+			name:                "Failed round trip with no query params",
+			expectedMetrics:     0,
+			path:                "/api/v1/query",
+			expectQueryParamLog: false,
+			queryErr:            context.Canceled,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			roundTripper := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				return nil, context.Canceled
+				return nil, test.queryErr
 			})
 
 			reg := prometheus.NewPedanticRegistry()
 			logs := &concurrency.SyncBuffer{}
 			logger := log.NewLogfmtLogger(logs)
-			handler := NewHandler(test.cfg, roundTripper, logger, reg)
+			handler := NewHandler(HandlerConfig{QueryStatsEnabled: true}, roundTripper, logger, reg)
 
 			ctx := user.InjectOrgID(context.Background(), "12345")
-			req := httptest.NewRequest("GET", "/api/v1/query?query=up&time=2015-07-01T20:10:51.781Z", nil)
+			req := httptest.NewRequest("GET", test.path, nil)
 			req = req.WithContext(ctx)
 			resp := httptest.NewRecorder()
 
 			handler.ServeHTTP(resp, req)
 			require.Equal(t, StatusClientClosedRequest, resp.Code)
 
-			count, _ := promtest.GatherAndCount(
+			count, err := promtest.GatherAndCount(
 				reg,
 				"cortex_query_seconds_total",
 				"cortex_query_fetched_series_total",
@@ -137,7 +148,11 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 				"cortex_query_fetched_chunks_total",
 			)
 
-			assert.Contains(t, strings.TrimSpace(logs.String()), "sharded_queries", "param_query")
+			assert.NoError(t, err)
+			assert.Contains(t, strings.TrimSpace(logs.String()), "sharded_queries")
+			if test.expectQueryParamLog {
+				assert.Contains(t, strings.TrimSpace(logs.String()), "param_query")
+			}
 			assert.Equal(t, test.expectedMetrics, count)
 		})
 	}

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -7,7 +7,6 @@ package transport
 
 import (
 	"context"
-	"github.com/grafana/dskit/concurrency"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"


### PR DESCRIPTION
#### What this PR does
Logs useful information about the query in the case of a failed query (context cancelled etc) - current logging information was making it hard for other engineers to debug issues.

#### Which issue(s) this PR fixes or relates to
https://github.com/grafana/mimir/issues/3146

Fixes #3146

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
