### PR TITLE
Alerts: Include query-scheduler for MimirGossipMembersMismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Mixin
 * [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173
+* [BUGFIX] Alerts: Include query-scheduler among ring members so alert MimirGossipMembersMismatch takes it into account. #3195
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -365,7 +365,7 @@ groups:
       message: Mimir instance {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} sees incorrect number of gossip members.
     expr: |
-      avg by (cluster, namespace) (memberlist_client_cluster_members_count) != sum by (cluster, namespace) (up{job=~".+/(alertmanager|compactor|distributor|ingester.*|querier.*|ruler|ruler-querier.*|store-gateway.*|cortex|mimir)"})
+      avg by (cluster, namespace) (memberlist_client_cluster_members_count) != sum by (cluster, namespace) (up{job=~".+/(alertmanager|compactor|distributor|ingester.*|querier.*|ruler|ruler-querier.*|store-gateway.*|query-scheduler|cortex|mimir)"})
     for: 15m
     labels:
       severity: warning

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -36,7 +36,7 @@
       ruler_query_frontend: '(ruler-query-frontend.*)',  // Match also custom ruler-query-frontend deployments.
       query_scheduler: '(query-scheduler.*|mimir-backend)',  // Not part of single-binary. Match also custom query-scheduler deployments.
       ruler_query_scheduler: '(ruler-query-scheduler.*)',  // Not part of single-binary. Match also custom query-scheduler deployments.
-      ring_members: ['alertmanager', 'compactor', 'distributor', 'ingester.*', 'querier.*', 'ruler', 'ruler-querier.*', 'store-gateway.*', 'cortex', 'mimir'],
+      ring_members: ['alertmanager', 'compactor', 'distributor', 'ingester.*', 'querier.*', 'ruler', 'ruler-querier.*', 'store-gateway.*', 'query-scheduler', 'cortex', 'mimir'],
       store_gateway: '(store-gateway.*|cortex|mimir|mimir-backend)',  // Match also per-zone store-gateway deployments.
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: '(compactor.*|cortex|mimir|mimir-backend)',  // Match also custom compactor deployments.


### PR DESCRIPTION
#### What this PR does
Include query-scheduler among the ring members for the MimirGossipMembersMismatch alert, to stop it from firing.

#### Which issue(s) this PR fixes or relates to

Fixes #3194.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
