### PR TITLE
ingester: reduce activity tracker memory allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172
+* [ENHANCEMENT] Ingester: Reduce activity tracker memory allocation. #3203
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -168,11 +168,16 @@ func queryRequestActivity(name, userID, traceID string, req *client.QueryRequest
 		make([]byte, 0, 8192),
 	)
 	sb.WriteString(name)
-	sb.WriteString(`: user="`)
-	sb.WriteString(userID)
-	sb.WriteString(`" trace="`)
-	sb.WriteString(traceID)
-	sb.WriteString(`" request="`)
+
+	sb.WriteString(`: user=`)
+	b := strconv.AppendQuote(sb.Bytes(), userID)
+	sb = bytes.NewBuffer(b)
+
+	sb.WriteString(` trace=`)
+	b = strconv.AppendQuote(sb.Bytes(), traceID)
+	sb = bytes.NewBuffer(b)
+
+	sb.WriteString(` request=`)
 	queryRequestToString(sb, req)
 
 	return sb.String()

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -3,13 +3,13 @@
 package ingester
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"net/http"
-
-	"github.com/weaveworks/common/tracing"
-
 	"github.com/grafana/dskit/tenant"
+	"github.com/weaveworks/common/tracing"
+	"net/http"
+	"strconv"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -150,5 +150,76 @@ func (i *ActivityTrackerWrapper) ShutdownHandler(w http.ResponseWriter, r *http.
 func requestActivity(ctx context.Context, name string, req interface{}) string {
 	userID, _ := tenant.TenantID(ctx)
 	traceID, _ := tracing.ExtractSampledTraceID(ctx)
-	return fmt.Sprintf("%s: user=%q trace=%q request=%v", name, userID, traceID, req)
+
+	switch r := req.(type) {
+	case *client.QueryRequest:
+		// To minimize memory allocation, make use of an optimized stringer implementation
+		// for *client.QueryRequest type, as this request can be invoked multiple times per second.
+		return queryRequestActivity(name, userID, traceID, r)
+
+	default:
+		return fmt.Sprintf("%s: user=%q trace=%q request=%v", name, userID, traceID, req)
+	}
+}
+
+func queryRequestActivity(name, userID, traceID string, req *client.QueryRequest) string {
+	sb := bytes.NewBuffer(
+		make([]byte, 0, 8192),
+	)
+	sb.WriteString(name)
+	sb.WriteString(`: user="`)
+	sb.WriteString(userID)
+	sb.WriteString(`"`)
+	sb.WriteString(` trace="`)
+	sb.WriteString(traceID)
+	sb.WriteString(`"`)
+	sb.WriteString(" request=")
+	queryRequestToString(sb, req)
+
+	return sb.String()
+}
+
+func queryRequestToString(sb *bytes.Buffer, req *client.QueryRequest) {
+	if req == nil {
+		sb.WriteString("nil")
+		return
+	}
+	b := make([]byte, 0, 32)
+
+	sb.WriteString("&QueryRequest{")
+
+	sb.WriteString("StartTimestampMs:")
+	sb.Write(strconv.AppendInt(b, req.StartTimestampMs, 10))
+	sb.WriteString(",")
+
+	sb.WriteString("EndTimestampMs:")
+	sb.Write(strconv.AppendInt(b, req.EndTimestampMs, 10))
+	sb.WriteString(",")
+
+	sb.WriteString("Matchers:")
+	sb.WriteString("[]*LabelMatcher{")
+	for _, m := range req.Matchers {
+		labelMatcherToString(sb, m)
+		sb.WriteString(",")
+	}
+	sb.WriteString("}")
+	sb.WriteString(",}")
+}
+
+func labelMatcherToString(sb *bytes.Buffer, m *client.LabelMatcher) {
+	if m == nil {
+		sb.WriteString("nil")
+		return
+	}
+	sb.WriteString("&LabelMatcher{")
+	sb.WriteString("Type:")
+	sb.WriteString(m.Type.String())
+	sb.WriteString(",")
+	sb.WriteString("Name:")
+	sb.WriteString(m.Name)
+	sb.WriteString(",")
+	sb.WriteString("Value:")
+	sb.WriteString(m.Value)
+	sb.WriteString(",")
+	sb.WriteString("}")
 }

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -170,11 +170,9 @@ func queryRequestActivity(name, userID, traceID string, req *client.QueryRequest
 	sb.WriteString(name)
 	sb.WriteString(`: user="`)
 	sb.WriteString(userID)
-	sb.WriteString(`"`)
-	sb.WriteString(` trace="`)
+	sb.WriteString(`" trace="`)
 	sb.WriteString(traceID)
-	sb.WriteString(`"`)
-	sb.WriteString(" request=")
+	sb.WriteString(`" request="`)
 	queryRequestToString(sb, req)
 
 	return sb.String()

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -193,18 +193,17 @@ func queryRequestToString(sb *bytes.Buffer, req *client.QueryRequest) {
 	sb.Write(strconv.AppendInt(b, req.StartTimestampMs, 10))
 	sb.WriteString(",")
 
+	b = b[:0]
 	sb.WriteString("EndTimestampMs:")
 	sb.Write(strconv.AppendInt(b, req.EndTimestampMs, 10))
 	sb.WriteString(",")
 
-	sb.WriteString("Matchers:")
-	sb.WriteString("[]*LabelMatcher{")
+	sb.WriteString("Matchers:[]*LabelMatcher{")
 	for _, m := range req.Matchers {
 		labelMatcherToString(sb, m)
 		sb.WriteString(",")
 	}
-	sb.WriteString("}")
-	sb.WriteString(",}")
+	sb.WriteString("},}")
 }
 
 func labelMatcherToString(sb *bytes.Buffer, m *client.LabelMatcher) {
@@ -221,6 +220,5 @@ func labelMatcherToString(sb *bytes.Buffer, m *client.LabelMatcher) {
 	sb.WriteString(",")
 	sb.WriteString("Value:")
 	sb.WriteString(m.Value)
-	sb.WriteString(",")
-	sb.WriteString("}")
+	sb.WriteString(",}")
 }

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -6,10 +6,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/grafana/dskit/tenant"
-	"github.com/weaveworks/common/tracing"
 	"net/http"
 	"strconv"
+
+	"github.com/grafana/dskit/tenant"
+	"github.com/weaveworks/common/tracing"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -211,14 +211,11 @@ func labelMatcherToString(sb *bytes.Buffer, m *client.LabelMatcher) {
 		sb.WriteString("nil")
 		return
 	}
-	sb.WriteString("&LabelMatcher{")
-	sb.WriteString("Type:")
+	sb.WriteString("&LabelMatcher{Type:")
 	sb.WriteString(m.Type.String())
-	sb.WriteString(",")
-	sb.WriteString("Name:")
+	sb.WriteString(",Name:")
 	sb.WriteString(m.Name)
-	sb.WriteString(",")
-	sb.WriteString("Value:")
+	sb.WriteString(",Value:")
 	sb.WriteString(m.Value)
 	sb.WriteString(",}")
 }

--- a/pkg/ingester/ingester_activity_test.go
+++ b/pkg/ingester/ingester_activity_test.go
@@ -3,10 +3,13 @@
 package ingester
 
 import (
+	"bytes"
 	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 )
@@ -30,5 +33,67 @@ func TestRequestActivity(t *testing.T) {
 		},
 	} {
 		assert.Equal(t, tc.expected, requestActivity(context.Background(), "test", tc.request))
+	}
+}
+
+func TestQueryRequest_CustomStringer(t *testing.T) {
+	tcs := map[string]struct {
+		request *client.QueryRequest
+	}{
+		"nil request": {
+			request: nil,
+		},
+		"empty request": {
+			request: &client.QueryRequest{},
+		},
+		"no matchers": {
+			request: &client.QueryRequest{
+				StartTimestampMs: rand.Int63(),
+				EndTimestampMs:   rand.Int63(),
+			},
+		},
+		"one matcher": {
+			request: &client.QueryRequest{
+				StartTimestampMs: rand.Int63(),
+				EndTimestampMs:   rand.Int63(),
+				Matchers: []*client.LabelMatcher{
+					{Type: client.EQUAL, Name: "n_1", Value: "v_1"},
+				},
+			},
+		},
+		"multiple matchers": {
+			request: &client.QueryRequest{
+				StartTimestampMs: rand.Int63(),
+				EndTimestampMs:   rand.Int63(),
+				Matchers: []*client.LabelMatcher{
+					{Type: client.EQUAL, Name: "n_1", Value: "v_1"},
+					{Type: client.EQUAL, Name: "n_2", Value: "v_2"},
+					{Type: client.EQUAL, Name: "n_3", Value: "v_3"},
+				},
+			},
+		},
+	}
+	for tn, tc := range tcs {
+		t.Run(tn, func(t *testing.T) {
+			sb := bytes.NewBuffer(nil)
+			queryRequestToString(sb, tc.request)
+
+			require.Equal(t, tc.request.String(), sb.String())
+		})
+	}
+}
+
+func BenchmarkRequestActivity(b *testing.B) {
+	request := &client.QueryRequest{
+		StartTimestampMs: rand.Int63(),
+		EndTimestampMs:   rand.Int63(),
+		Matchers: []*client.LabelMatcher{
+			{Type: client.EQUAL, Name: "a_name", Value: "a_value"},
+		},
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		requestActivity(context.Background(), "Ingester/QueryStream", request)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Added custom stringer for `*client.QueryRequest` to minimize memory allocation on ingester activity tracker record generator.  

old:
```
BenchmarkRequestActivity-8   	 1284216	       927.5 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1291141	       928.1 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1289739	       928.9 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1287590	       927.4 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1287128	       934.3 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1294728	       931.9 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1291026	       928.1 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1289536	       931.1 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1289566	       933.2 ns/op	     984 B/op	      21 allocs/op
BenchmarkRequestActivity-8   	 1289500	       929.1 ns/op	     984 B/op	      21 allocs/op
```

new:
```
BenchmarkRequestActivity-8   	 3293625	       355.1 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3372951	       356.3 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3375446	       355.1 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3357924	       356.0 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3372872	       355.6 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3371698	       355.7 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3369746	       355.9 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3374049	       355.5 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3373887	       356.5 ns/op	     224 B/op	       1 allocs/op
BenchmarkRequestActivity-8   	 3376087	       355.4 ns/op	     224 B/op	       1 allocs/op
```

comparison: 
```
name               old time/op    new time/op    delta
RequestActivity-8     930ns ± 0%     356ns ± 0%  -61.75%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
RequestActivity-8      984B ± 0%      224B ± 0%  -77.24%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
RequestActivity-8      21.0 ± 0%       1.0 ± 0%  -95.24%  (p=0.000 n=10+10)
```


#### Which issue(s) this PR fixes or relates to

Fixes #3192 

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
