### PR TITLE
mimir-mixins: dashboards: fix: use product name in overview dashboard instead of hardcoded "Mimir"

### DIFF
--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -246,8 +246,8 @@
           },
           annotations: {
             message: |||
-              Number of members in Mimir %(component)s hash ring does not match the expected number in %(alert_aggregation_variables)s.
-            ||| % { component: component_job[0], alert_aggregation_variables: $._config.alert_aggregation_variables },
+              Number of members in %(product)s %(component)s hash ring does not match the expected number in %(alert_aggregation_variables)s.
+            ||| % { component: component_job[0], alert_aggregation_variables: $._config.alert_aggregation_variables, product: $._config.product },
           },
         }
         // NOTE(jhesketh): It is expected that the stateless components may trigger this alert

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -32,7 +32,7 @@ local filename = 'mimir-overview.json';
     .addClusterSelectorTemplates()
 
     .addRow(
-      $.row('Mimir cluster health')
+      $.row('%(product)s cluster health' % $._config)
       .addPanel(
         $.textPanel('', |||
           The 'Status' panel shows an overview on the cluster health over the time.
@@ -85,7 +85,7 @@ local filename = 'mimir-overview.json';
         )
       )
       .addPanel(
-        $.alertListPanel('Firing alerts', 'Mimir', $.namespaceMatcher())
+        $.alertListPanel('Firing alerts', $._config.product, $.namespaceMatcher())
       ) + {
         panels: [
           // Custom width for panels, so that the text panel (description) has the same width of the description in the following rows,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
On the Overview dashboard:
- Instead of using the hardcoded "Mimir" name, delegate to the `$._config.product` name.
- This affects:
  - A panel title: "Mimir cluster health"
  - An alert list panel filter which searches for alert names containing the text "Mimir".
    - Note that the alert creation makes use of the product name as a prefix, so this should be more appropriate.
      See https://github.com/grafana/mimir/blob/main/operations/mimir-mixin/alerts/alerts-utils.libsonnet#L10


#### Checklist

- [ ] ~Tests updated~
- [ ] ~Documentation added~
- [ ] ~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
