### PR TITLE
Add regression test for distributor passing through GRPC statuses

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1008,7 +1008,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tc.expectedError.Error())
 
-				// Assert that downstream GRPC statuses are passed back upstream
+				// Assert that downstream gRPC statuses are passed back upstream
 				_, ok := httpgrpc.HTTPResponseFromError(err)
 				assert.True(t, ok, fmt.Sprintf("expected error to be an httpgrpc error, but got: %T", err))
 			}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -296,7 +296,7 @@ func TestDistributor_Push(t *testing.T) {
 				assert.Nil(t, response)
 				assert.EqualError(t, err, tc.expectedError.Error())
 
-				// Assert that downstream GRPC statuses are passed back upstream
+				// Assert that downstream gRPC statuses are passed back upstream
 				_, ok := httpgrpc.HTTPResponseFromError(err)
 				assert.True(t, ok, fmt.Sprintf("expected error to be an httpgrpc error, but got: %T", err))
 			}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -290,8 +290,8 @@ func TestDistributor_Push(t *testing.T) {
 			response, err := ds[0].Push(ctx, request)
 
 			if tc.expectedError == nil {
+				require.NoError(t, err)
 				assert.Equal(t, emptyResponse, response)
-				assert.Nil(t, err)
 			} else {
 				assert.Nil(t, response)
 				assert.EqualError(t, err, tc.expectedError.Error())

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -298,7 +298,7 @@ func TestDistributor_Push(t *testing.T) {
 
 				// Assert that downstream GRPC statuses are passed back upstream
 				_, ok := httpgrpc.HTTPResponseFromError(err)
-				assert.True(t, ok)
+				assert.True(t, ok, fmt.Sprintf("expected error to be an httpgrpc error, but got: %T", err))
 			}
 
 			// Check tracked Prometheus metrics. Since the Push() response is sent as soon as the quorum
@@ -1004,13 +1004,13 @@ func TestDistributor_PushQuery(t *testing.T) {
 			series, err := ds[0].QueryStream(ctx, 0, 10, tc.matchers...)
 
 			if tc.expectedError == nil {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tc.expectedError.Error())
 
 				// Assert that downstream GRPC statuses are passed back upstream
 				_, ok := httpgrpc.HTTPResponseFromError(err)
-				assert.True(t, ok)
+				assert.True(t, ok, fmt.Sprintf("expected error to be an httpgrpc error, but got: %T", err))
 			}
 
 			var response model.Matrix

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -114,27 +114,24 @@ func TestDistributor_Push(t *testing.T) {
 		startTimestampMs int64
 	}
 	for name, tc := range map[string]struct {
-		metricNames      []string
-		numIngesters     int
-		happyIngesters   int
-		samples          samplesIn
-		metadata         int
-		expectedResponse *mimirpb.WriteResponse
-		expectedError    error
-		expectedMetrics  string
+		metricNames     []string
+		numIngesters    int
+		happyIngesters  int
+		samples         samplesIn
+		metadata        int
+		expectedError   error
+		expectedMetrics string
 	}{
 		"A push of no samples shouldn't block or return error, even if ingesters are sad": {
-			numIngesters:     3,
-			happyIngesters:   0,
-			expectedResponse: emptyResponse,
+			numIngesters:   3,
+			happyIngesters: 0,
 		},
 		"A push to 3 happy ingesters should succeed": {
-			numIngesters:     3,
-			happyIngesters:   3,
-			samples:          samplesIn{num: 5, startTimestampMs: 123456789000},
-			metadata:         5,
-			expectedResponse: emptyResponse,
-			metricNames:      []string{lastSeenTimestamp},
+			numIngesters:   3,
+			happyIngesters: 3,
+			samples:        samplesIn{num: 5, startTimestampMs: 123456789000},
+			metadata:       5,
+			metricNames:    []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
@@ -142,12 +139,11 @@ func TestDistributor_Push(t *testing.T) {
 			`,
 		},
 		"A push to 2 happy ingesters should succeed": {
-			numIngesters:     3,
-			happyIngesters:   2,
-			samples:          samplesIn{num: 5, startTimestampMs: 123456789000},
-			metadata:         5,
-			expectedResponse: emptyResponse,
-			metricNames:      []string{lastSeenTimestamp},
+			numIngesters:   3,
+			happyIngesters: 2,
+			samples:        samplesIn{num: 5, startTimestampMs: 123456789000},
+			metadata:       5,
+			metricNames:    []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
@@ -192,12 +188,11 @@ func TestDistributor_Push(t *testing.T) {
 			`,
 		},
 		"A push to ingesters with an old sample should report the correct metrics with no metadata": {
-			numIngesters:     3,
-			happyIngesters:   2,
-			samples:          samplesIn{num: 1, startTimestampMs: now.UnixMilli() - 80000*1000}, // 80k seconds old
-			metadata:         0,
-			metricNames:      []string{distributorSampleDelay},
-			expectedResponse: emptyResponse,
+			numIngesters:   3,
+			happyIngesters: 2,
+			samples:        samplesIn{num: 1, startTimestampMs: now.UnixMilli() - 80000*1000}, // 80k seconds old
+			metadata:       0,
+			metricNames:    []string{distributorSampleDelay},
 			expectedMetrics: `
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
@@ -219,12 +214,11 @@ func TestDistributor_Push(t *testing.T) {
 			`,
 		},
 		"A push to ingesters with a current sample should report the correct metrics with no metadata": {
-			numIngesters:     3,
-			happyIngesters:   2,
-			samples:          samplesIn{num: 1, startTimestampMs: now.UnixMilli() - 1000}, // 1 second old
-			metadata:         0,
-			metricNames:      []string{distributorSampleDelay},
-			expectedResponse: emptyResponse,
+			numIngesters:   3,
+			happyIngesters: 2,
+			samples:        samplesIn{num: 1, startTimestampMs: now.UnixMilli() - 1000}, // 1 second old
+			metadata:       0,
+			metricNames:    []string{distributorSampleDelay},
 			expectedMetrics: `
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
@@ -246,12 +240,11 @@ func TestDistributor_Push(t *testing.T) {
 			`,
 		},
 		"A push to ingesters without samples should report the correct metrics": {
-			numIngesters:     3,
-			happyIngesters:   2,
-			samples:          samplesIn{num: 0, startTimestampMs: 123456789000},
-			metadata:         1,
-			metricNames:      []string{distributorSampleDelay},
-			expectedResponse: emptyResponse,
+			numIngesters:   3,
+			happyIngesters: 2,
+			samples:        samplesIn{num: 0, startTimestampMs: 123456789000},
+			metadata:       1,
+			metricNames:    []string{distributorSampleDelay},
 			expectedMetrics: `
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds a regression test for https://github.com/grafana/mimir/issues/3210, ensuring that errors returned by ingesters keep their GRPC context when being returned back upstream.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/3214

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
