### PR TITLE
[packages] Fix incorrect OS value set in Mimir v2.3.* RPM package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
+* [BUGFIX] Fix incorrect OS value set in Mimir v2.3.* RPM packages. #3221
 
 ### Mixin
 

--- a/Makefile
+++ b/Makefile
@@ -624,6 +624,7 @@ dist/$(UPTODATE)-packages: $(wildcard packaging/deb/**) $(wildcard packaging/rpm
 			docs/configurations/single-process-config-blocks.yaml=/etc/mimir/config.example.yaml; \
 		$(FPM_OPTS) -t rpm  \
 			--architecture $$rpm_arch \
+			--rpm-os linux \
 			--after-install packaging/rpm/control/post \
 			--before-remove packaging/rpm/control/preun \
 			--package dist/mimir-$(VERSION)_$$arch.rpm \


### PR DESCRIPTION
#### What this PR does
When creating the packages on MacOS the `OS` applied on the package is not correct. The documentation says:

    --rpm-os OS
    The operating system to target this rpm for. You want to set this to ‘linux’ if you are using fpm on OS X, for example

See: https://fpm.readthedocs.io/en/latest/packages/rpm.html

#### Which issue(s) this PR fixes or relates to

Fixes #3216

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
