### PR TITLE
Update MimirSchedulerQueriesStuck alert and runbook to reflect querier auto-scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Mixin
 
+* [CHANGE] Alerts: Change `MimirSchedulerQueriesStuck` `min_over_time` range to 90 Seconds. #3223
 * [ENHANCEMENT] Alerts: Add MimirRingMembersMismatch firing when a component does not have the expected number of running jobs. #2404
 * [ENHANCEMENT] Dashboards: Add optional row about the Distributor's metric forwarding feature to the `Mimir / Writes` dashboard. #3182
 * [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173
@@ -27,6 +28,7 @@
 ### Documentation
 
 * [ENHANCEMENT] Improve `MimirQuerierAutoscalerNotActive` runbook. #3186
+* [ENHANCEMENT] Improve `MimirSchedulerQueriesStuck` runbook to reflect debug steps with querier auto-scaling enabled. #3223
 
 ### Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Mixin
 
-* [CHANGE] Alerts: Change `MimirSchedulerQueriesStuck` `min_over_time` range to 90 Seconds. #3223
+* [CHANGE] Alerts: Change `MimirSchedulerQueriesStuck` `for` time to 7 minutes to account for the time it takes for HPA to scale up. #3223
 * [ENHANCEMENT] Alerts: Add MimirRingMembersMismatch firing when a component does not have the expected number of running jobs. #2404
 * [ENHANCEMENT] Dashboards: Add optional row about the Distributor's metric forwarding feature to the `Mimir / Writes` dashboard. #3182
 * [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173

--- a/docs/sources/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/operators-guide/mimir-runbooks/_index.md
@@ -690,6 +690,7 @@ How to **investigate**:
   - On multi-tenant Mimir clusters with **query-sharding enabled** and **only a single tenant** being affected:
     - Verify if the particular queries are hitting edge cases, where query-sharding is not benefical, by getting traces from the `Mimir / Slow Queries` dashboard and then look where time is spent. If time is spent in the query-frontend running PromQL engine, then it means query-sharding is not beneficial for this tenant. Consider disabling query-sharding or reduce the shard count using the `query_sharding_total_shards` override.
     - Otherwise and only if the queries by the tenant are within reason representing normal usage, consider scaling of queriers and potentially store-gateways.
+  - On a Mimir cluster with **querier auto-scaling enabled** after checking the health of the existing querier replicas, check to see if the auto-scaler has added additional querier replicas or if the maximum number of querier replicas has been reached and is not sufficient and should be increased.
 
 ### MimirMemcachedRequestErrors
 

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -68,7 +68,7 @@ groups:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
     expr: |
-      sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[90s])) > 0
+      sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
     for: 5m
     labels:
       severity: critical
@@ -77,8 +77,8 @@ groups:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
     expr: |
-      sum by (cluster, namespace, job) (min_over_time(cortex_query_scheduler_queue_length[90s])) > 0
-    for: 5m
+      sum by (cluster, namespace, job) (min_over_time(cortex_query_scheduler_queue_length[1m])) > 0
+    for: 7m
     labels:
       severity: critical
   - alert: MimirMemcachedRequestErrors

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -68,7 +68,7 @@ groups:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
     expr: |
-      sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
+      sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[90s])) > 0
     for: 5m
     labels:
       severity: critical
@@ -77,7 +77,7 @@ groups:
       message: |
         There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
     expr: |
-      sum by (cluster, namespace, job) (min_over_time(cortex_query_scheduler_queue_length[1m])) > 0
+      sum by (cluster, namespace, job) (min_over_time(cortex_query_scheduler_queue_length[90s])) > 0
     for: 5m
     labels:
       severity: critical

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -127,7 +127,7 @@
         {
           alert: $.alertName('FrontendQueriesStuck'),
           expr: |||
-            sum by (%s, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
+            sum by (%s, job) (min_over_time(cortex_query_frontend_queue_length[90s])) > 0
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {
@@ -142,7 +142,7 @@
         {
           alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
-            sum by (%s, job) (min_over_time(cortex_query_scheduler_queue_length[1m])) > 0
+            sum by (%s, job) (min_over_time(cortex_query_scheduler_queue_length[90s])) > 0
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -127,7 +127,7 @@
         {
           alert: $.alertName('FrontendQueriesStuck'),
           expr: |||
-            sum by (%s, job) (min_over_time(cortex_query_frontend_queue_length[90s])) > 0
+            sum by (%s, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
           ||| % $._config.alert_aggregation_labels,
           'for': '5m',  // We don't want to block for longer.
           labels: {
@@ -142,9 +142,9 @@
         {
           alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
-            sum by (%s, job) (min_over_time(cortex_query_scheduler_queue_length[90s])) > 0
+            sum by (%s, job) (min_over_time(cortex_query_scheduler_queue_length[1m])) > 0
           ||| % $._config.alert_aggregation_labels,
-          'for': '5m',  // We don't want to block for longer.
+          'for': '7m',  // We don't want to block for longer.
           labels: {
             severity: 'critical',
           },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
With our current HPA querier auto-scaling setup it takes sometimes more than a minute for us to detect that we need to scale up and request the additional querier replicas be created. This change allows more time for that to happen before the alert triggers.

#### Checklist

- [ -] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
