### PR TITLE
Release: add pre-requisite check on git remote for all release scripts

### DIFF
--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -6,11 +6,19 @@
 
 set -e
 
-check_required_tools() {
+check_required_setup() {
   # Ensure "gh" tool is installed.
   if ! command -v gh &> /dev/null; then
-      echo "The 'gh' command cannot be found. Please install it: https://cli.github.com"
-      exit 1
+    echo "The 'gh' command cannot be found. Please install it: https://cli.github.com"
+    exit 1
+  fi
+
+  # Ensure the repository has only 1 remote named "origin".
+  if [ "$(git remote)" != "origin" ]; then
+    echo "The release automation scripts require the git clone to only have 1 remote named 'origin', but found:"
+    git remote
+
+    exit 1
   fi
 }
 

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -7,6 +7,7 @@ set -e
 CURR_DIR="$(dirname "$0")"
 . "${CURR_DIR}/common.sh"
 
+check_required_setup
 find_last_release
 find_prev_release
 

--- a/tools/release/create-draft-release.sh
+++ b/tools/release/create-draft-release.sh
@@ -7,7 +7,7 @@ set -e
 CURR_DIR="$(dirname "$0")"
 . "${CURR_DIR}/common.sh"
 
-check_required_tools
+check_required_setup
 find_last_release
 find_prev_release
 

--- a/tools/release/create-pr-to-merge-release-branch-to-main.sh
+++ b/tools/release/create-pr-to-merge-release-branch-to-main.sh
@@ -19,7 +19,7 @@ fi
 CURR_DIR="$(dirname "$0")"
 . "${CURR_DIR}/common.sh"
 
-check_required_tools
+check_required_setup
 
 # Ensure there are not uncommitted changes.
 if [ -n "$(git status --porcelain=v1 2> /dev/null)" ]; then

--- a/tools/release/notify-changelog-cut.sh
+++ b/tools/release/notify-changelog-cut.sh
@@ -7,7 +7,7 @@ set -e
 CURR_DIR="$(dirname "$0")"
 . "${CURR_DIR}/common.sh"
 
-check_required_tools
+check_required_setup
 
 # Config
 NOTIFICATION_LABEL="release/notified-changelog-cut"

--- a/tools/release/tag-release.sh
+++ b/tools/release/tag-release.sh
@@ -3,6 +3,12 @@
 
 set -e
 
+# Load common lib.
+CURR_DIR="$(dirname "$0")"
+. "${CURR_DIR}/common.sh"
+
+check_required_setup
+
 # Ensure the current branch is a release one.
 BRANCH=$(git branch --show-current)
 if [[ ! $BRANCH =~ ^release-([0-9]+\.[0-9]+)$ ]]; then


### PR DESCRIPTION
#### What this PR does
Following up an offline conversation I had with @pstibrany, I propose to add a pre-requisite check for all release scripts and require that the git clone only has 1 remote named "origin". This helps to keep the scripts easier instead of having to handle the case there are multiple remotes or the name is different than "origin".

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
