### PR TITLE
Fix gossip_ring_member label for ruler dedicated query-frontend and query-scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Jsonnet
 
 * [ENHANCEMENT] Dashboards: Remove the "Instance Mapper" row from the "Alertmanager Resources Dashboard". This is a Grafana Cloud specific service and not relevant for external users. #3152
-* [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237
+* [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237 #3239
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1007,6 +1007,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: ruler-query-frontend
     spec:
       containers:
@@ -1082,6 +1083,7 @@ spec:
   template:
     metadata:
       labels:
+        gossip_ring_member: "true"
         name: ruler-query-scheduler
     spec:
       affinity:

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -115,13 +115,15 @@
     (super.ingester_zone_c_statefulset + if !$._config.memberlist_ring_enabled then {} else gossipLabel),
 
   querier_deployment+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
-
   ruler_querier_deployment+: if !$._config.memberlist_ring_enabled || !$._config.ruler_remote_evaluation_enabled then {} else gossipLabel,
 
   ruler_deployment+: if !$._config.memberlist_ring_enabled || !$._config.ruler_enabled then {} else gossipLabel,
 
   query_scheduler_deployment+: if !querySchedulerMemberlistEnabled then {} else gossipLabel,
+  ruler_query_scheduler_deployment+: if !querySchedulerMemberlistEnabled || !$._config.ruler_remote_evaluation_enabled then {} else gossipLabel,
+
   query_frontend_deployment+: if !queryFrontendMemberlistEnabled then {} else gossipLabel,
+  ruler_query_frontend_deployment+: if !queryFrontendMemberlistEnabled || !$._config.ruler_remote_evaluation_enabled then {} else gossipLabel,
 
   store_gateway_statefulset: if $._config.multi_zone_store_gateway_enabled && !$._config.multi_zone_store_gateway_migration_enabled then null else
     (super.store_gateway_statefulset + if !$._config.memberlist_ring_enabled then {} else gossipLabel),


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/3237 I fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends, but I didn't notice the `gossip_ring_member` was missing for `ruler-query-frontend` and `ruler-query-scheduler`. This PR fixes it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
