### PR TITLE
Compactor: emit histogram of block max time delta to now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172
 * [ENHANCEMENT] Ingester: Reduce activity tracker memory allocation. #3203
 * [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
+* [ENHANCEMENT] Compactor: Add new `cortex_compactor_block_max_time_delta_seconds` histogram for detecting if compaction of blocks is lagging behind. #3240
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin

--- a/pkg/compactor/job.go
+++ b/pkg/compactor/job.go
@@ -99,6 +99,13 @@ func (job *Job) MaxTime() int64 {
 	return max
 }
 
+// Metas returns the metadata for each block that is part of this job, ordered by the block's MinTime
+func (job *Job) Metas() []*metadata.Meta {
+	out := make([]*metadata.Meta, len(job.metasByMinTime))
+	copy(out, job.metasByMinTime)
+	return out
+}
+
 // Labels returns the external labels for the output block(s) of this job.
 func (job *Job) Labels() labels.Labels {
 	return job.labels


### PR DESCRIPTION
#### What this PR does

Emit a histogram of the difference between `now` and the max time of a block being compacted as a number of seconds. This can be used to alert if compactors are not able to keep up with the number of blocks being generated. In this case, the delta will begin to fall into higher and higher buckets (> 24h).

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
