### PR TITLE
docs: fix unsupported fields on query-frontend config

### DIFF
--- a/docs/configurations/prometheus-frontend.yml
+++ b/docs/configurations/prometheus-frontend.yml
@@ -17,6 +17,9 @@ server:
   http_listen_port: 9091
 
 query_range:
+  
+
+frontend:
   split_queries_by_interval: 24h
   align_queries_with_step: true
   cache_results: true
@@ -29,9 +32,7 @@ query_range:
       # instances using a SRV DNS query (host) or list comma separated memcached addresses.
       addresses: "dnssrvnoa+memcached.mimir.svc.cluster.local:11211"
 
-frontend:
   log_queries_longer_than: 1s
-  compress_responses: true
 
   # The Prometheus URL to which the query-frontend should connect to.
   downstream_url: http://prometheus.mydomain.com

--- a/docs/sources/operators-guide/configure/configuring-the-query-frontend-work-with-prometheus.md
+++ b/docs/sources/operators-guide/configure/configuring-the-query-frontend-work-with-prometheus.md
@@ -33,8 +33,8 @@ api:
 
 server:
   http_listen_port: 9091
-
-query_range:
+  
+frontend:
   split_queries_by_interval: 24h
   align_queries_with_step: true
   cache_results: true
@@ -47,9 +47,7 @@ query_range:
       # instances using a SRV DNS query (host) or list comma separated memcached addresses.
       addresses: "dnssrvnoa+memcached.mimir.svc.cluster.local:11211"
 
-frontend:
   log_queries_longer_than: 1s
-  compress_responses: true
 
   # The Prometheus URL to which the query-frontend should connect to.
   downstream_url: http://prometheus.mydomain.com


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
fix unsupported fields on query-frontend config. Error when running: 
```

error loading config from /etc/mimir/mimir.yaml: Error parsing config file: yaml: unmarshal errors:                 │
  line 15: field compress_responses not found in type frontend.CombinedFrontendConfig
```

Ref with #825

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
