### PR TITLE
Chore: use upstream rules.SendAlerts()

### DIFF
--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -277,7 +277,7 @@ func DefaultTenantManagerFactory(
 			Context:                    user.InjectOrgID(ctx, userID),
 			GroupEvaluationContextFunc: FederatedGroupContextFunc,
 			ExternalURL:                cfg.ExternalURL.URL,
-			NotifyFunc:                 SendAlerts(notifier, cfg.ExternalURL.String()),
+			NotifyFunc:                 rules.SendAlerts(notifier, cfg.ExternalURL.String()),
 			Logger:                     log.With(logger, "user", userID),
 			Registerer:                 reg,
 			OutageTolerance:            cfg.OutageTolerance,

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/rules"
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
@@ -1128,7 +1129,7 @@ func TestSendAlerts(t *testing.T) {
 				}
 				require.Equal(t, tc.exp, alerts)
 			})
-			SendAlerts(senderFunc, "http://localhost:9090")(context.TODO(), "up", tc.in...)
+			rules.SendAlerts(senderFunc, "http://localhost:9090")(context.TODO(), "up", tc.in...)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/3261 we updated the upstream Prometheus, which finally exposed `rules.SendAlerts()`. Since the function is the exact same of our `SendAlerts()` we can finally get rid of it and use the upstream one.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
