### PR TITLE
The query-tee node port is now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Jsonnet
 
+* [ENHANCEMENT] The query-tee node port (`$._config.query_tee_node_port`) is now optional. #3272
 * [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237 #3239
 
 ### Mimirtool

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -87,6 +87,7 @@
     query_tee_enabled: false,
     query_tee_backend_endpoints: [],
     query_tee_backend_preferred: '',
+    query_tee_node_port: null,
 
     grpcConfig:: {
       'server.grpc.keepalive.min-time-between-pings': '10s',

--- a/operations/mimir/query-tee.libsonnet
+++ b/operations/mimir/query-tee.libsonnet
@@ -27,7 +27,7 @@
   query_tee_service: if !($._config.query_tee_enabled) then {} else
     service.new('query-tee', { name: 'query-tee' }, [
       servicePort.newNamed('http', 80, 80) +
-      servicePort.withNodePort($._config.query_tee_node_port),
+      (if $._config.query_tee_node_port == null then {} else servicePort.withNodePort($._config.query_tee_node_port)),
     ]) +
     service.mixin.spec.withType('NodePort'),
 }


### PR DESCRIPTION
#### What this PR does
I'm testing the read-write deployment mode in a dev cluster at Grafana Labs and I want to use the query-tee to tee read path traffic, but I don't need/want to set the node port on the service, so I'm making it optional.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
