### PR TITLE
Include tenant in forwarded requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
 * [ENHANCEMENT] Added `-usage-stats.installation-mode` configuration to track the installation mode via the anonymous usage statistics. #3244
 * [ENHANCEMENT] Compactor: Add new `cortex_compactor_block_max_time_delta_seconds` histogram for detecting if compaction of blocks is lagging behind. #3240
-* [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint.
+* [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
 * [ENHANCEMENT] Added `-usage-stats.installation-mode` configuration to track the installation mode via the anonymous usage statistics. #3244
 * [ENHANCEMENT] Compactor: Add new `cortex_compactor_block_max_time_delta_seconds` histogram for detecting if compaction of blocks is lagging behind. #3240
+* [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint.
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 
 ### Mixin

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
@@ -253,7 +254,7 @@ func (f *forwarder) Forward(ctx context.Context, endpoint string, dontForwardBef
 		var requestWg sync.WaitGroup
 		requestWg.Add(1)
 
-		f.submitForwardingRequest(ctx, endpoint, toForward, counts, &requestWg, errCh)
+		f.submitForwardingRequest(ctx, user, endpoint, toForward, counts, &requestWg, errCh)
 
 		// keep span running until goroutine finishes.
 		finishSpanlogInDefer = false
@@ -405,6 +406,7 @@ type request struct {
 	errCh           chan error
 	requestWg       *sync.WaitGroup
 
+	user     string
 	endpoint string
 	ts       []mimirpb.PreallocTimeseries
 	counts   TimeseriesCounts
@@ -418,7 +420,7 @@ type request struct {
 
 // submitForwardingRequest launches a new forwarding request and sends it to a worker via a channel.
 // It might block if all the workers are busy.
-func (f *forwarder) submitForwardingRequest(ctx context.Context, endpoint string, ts []mimirpb.PreallocTimeseries, counts TimeseriesCounts, requestWg *sync.WaitGroup, errCh chan error) {
+func (f *forwarder) submitForwardingRequest(ctx context.Context, user string, endpoint string, ts []mimirpb.PreallocTimeseries, counts TimeseriesCounts, requestWg *sync.WaitGroup, errCh chan error) {
 	req := f.pools.getReq()
 
 	req.pools = f.pools
@@ -432,6 +434,7 @@ func (f *forwarder) submitForwardingRequest(ctx context.Context, endpoint string
 	req.requestWg = requestWg
 
 	// Target endpoint and TimeSeries to forward.
+	req.user = user
 	req.endpoint = endpoint
 	req.ts = ts
 	req.counts = counts
@@ -503,6 +506,7 @@ func (r *request) doHTTP(ctx context.Context, body []byte) error {
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 	// Mark request as idempotent, so that http client can retry them on (some) errors.
 	httpReq.Header.Set("Idempotency-Key", "true")
+	httpReq.Header.Set(user.OrgIDHeaderName, r.user)
 
 	r.requests.Inc()
 	r.samples.Add(float64(r.counts.SampleCount))
@@ -562,10 +566,13 @@ func (r *request) doHTTPGrpc(ctx context.Context, body []byte) error {
 	}
 
 	req := &httpgrpc.HTTPRequest{
-		Method:  "POST",
-		Url:     u.Path,
-		Body:    body,
-		Headers: headers,
+		Method: "POST",
+		Url:    u.Path,
+		Body:   body,
+		Headers: append(headers, &httpgrpc.Header{
+			Key:    user.OrgIDHeaderName,
+			Values: []string{r.user},
+		}),
 	}
 
 	// Use dns:/// prefix to enable client-side load balancing inside gRPC client.

--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -433,7 +433,7 @@ func (f *forwarder) submitForwardingRequest(ctx context.Context, user string, en
 	req.errCh = errCh
 	req.requestWg = requestWg
 
-	// Target endpoint and TimeSeries to forward.
+	// Request parameters.
 	req.user = user
 	req.endpoint = endpoint
 	req.ts = ts

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -75,6 +76,7 @@ func TestForwardingSamplesSuccessfullyToSingleTarget(t *testing.T) {
 	for _, req := range reqs() {
 		require.Equal(t, "snappy", req.Header.Get("Content-Encoding"))
 		require.Equal(t, "application/x-protobuf", req.Header.Get("Content-Type"))
+		require.Equal(t, "user", req.Header.Get(user.OrgIDHeaderName))
 	}
 
 	bodies := bodiesFn()
@@ -873,6 +875,7 @@ func TestForwardingToHTTPGrpcTarget(t *testing.T) {
 	for _, req := range reqs1() {
 		ce := ""
 		ct := ""
+		us := ""
 
 		for _, h := range req.Headers {
 			if h.Key == "Content-Encoding" {
@@ -881,9 +884,13 @@ func TestForwardingToHTTPGrpcTarget(t *testing.T) {
 			if h.Key == "Content-Type" {
 				ct = h.Values[0]
 			}
+			if h.Key == user.OrgIDHeaderName {
+				us = h.Values[0]
+			}
 		}
 		require.Equal(t, "snappy", ce)
 		require.Equal(t, "application/x-protobuf", ct)
+		require.Equal(t, "user", us)
 	}
 
 	bodies := reqs1()


### PR DESCRIPTION
#### What this PR does
This PR modifies Distributor's forwarding feature to always include `X-Scope-OrgId` header with tenant when forwarding requests to the configured endpoint.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
