### PR TITLE
Use labels.FromString abstraction

### DIFF
--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -265,25 +265,25 @@ func TestGroupCompactE2E(t *testing.T) {
 		assert.True(t, os.IsNotExist(err), "dir %s should be remove after compaction.", dir)
 
 		// Test label name with slash, regression: https://github.com/thanos-io/thanos/issues/1661.
-		extLabels := labels.Labels{{Name: "e1", Value: "1/weird"}}
-		extLabels2 := labels.Labels{{Name: "e1", Value: "1"}}
+		extLabels := labels.FromStrings("e1", "1/weird")
+		extLabels2 := labels.FromStrings("e1", "1")
 		metas := createAndUpload(t, bkt, []blockgenSpec{
 			{
 				numSamples: 100, mint: 500, maxt: 1000, extLset: extLabels, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "1"}},
-					{{Name: "a", Value: "2"}, {Name: "b", Value: "2"}},
-					{{Name: "a", Value: "3"}},
-					{{Name: "a", Value: "4"}},
+					labels.FromStrings("a", "1"),
+					labels.FromStrings("a", "2", "b", "2"),
+					labels.FromStrings("a", "3"),
+					labels.FromStrings("a", "4"),
 				},
 			},
 			{
 				numSamples: 100, mint: 2000, maxt: 3000, extLset: extLabels, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "3"}},
-					{{Name: "a", Value: "4"}},
-					{{Name: "a", Value: "5"}},
-					{{Name: "a", Value: "6"}},
+					labels.FromStrings("a", "3"),
+					labels.FromStrings("a", "4"),
+					labels.FromStrings("a", "5"),
+					labels.FromStrings("a", "6"),
 				},
 			},
 			// Mix order to make sure compactor is able to deduct min time / max time.
@@ -297,56 +297,56 @@ func TestGroupCompactE2E(t *testing.T) {
 			{
 				numSamples: 100, mint: 3000, maxt: 4000, extLset: extLabels, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "7"}},
+					labels.FromStrings("a", "7"),
 				},
 			},
 			// Extra block for "distraction" for different resolution and one for different labels.
 			{
-				numSamples: 100, mint: 5000, maxt: 6000, extLset: labels.Labels{{Name: "e1", Value: "2"}}, res: 124,
+				numSamples: 100, mint: 5000, maxt: 6000, extLset: labels.FromStrings("e1", "2"), res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "7"}},
+					labels.FromStrings("a", "7"),
 				},
 			},
 			// Extra block for "distraction" for different resolution and one for different labels.
 			{
 				numSamples: 100, mint: 4000, maxt: 5000, extLset: extLabels, res: 0,
 				series: []labels.Labels{
-					{{Name: "a", Value: "7"}},
+					labels.FromStrings("a", "7"),
 				},
 			},
 			// Second group (extLabels2).
 			{
 				numSamples: 100, mint: 2000, maxt: 3000, extLset: extLabels2, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "3"}},
-					{{Name: "a", Value: "4"}},
-					{{Name: "a", Value: "6"}},
+					labels.FromStrings("a", "3"),
+					labels.FromStrings("a", "4"),
+					labels.FromStrings("a", "6"),
 				},
 			},
 			{
 				numSamples: 100, mint: 0, maxt: 1000, extLset: extLabels2, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "1"}},
-					{{Name: "a", Value: "2"}, {Name: "b", Value: "2"}},
-					{{Name: "a", Value: "3"}},
-					{{Name: "a", Value: "4"}},
+					labels.FromStrings("a", "1"),
+					labels.FromStrings("a", "2", "b", "2"),
+					labels.FromStrings("a", "3"),
+					labels.FromStrings("a", "4"),
 				},
 			},
 			// Due to TSDB compaction delay (not compacting fresh block), we need one more block to be pushed to trigger compaction.
 			{
 				numSamples: 100, mint: 3000, maxt: 4000, extLset: extLabels2, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "7"}},
+					labels.FromStrings("a", "7"),
 				},
 			},
 		}, []blockgenSpec{
 			{
 				numSamples: 100, mint: 0, maxt: 499, extLset: extLabels, res: 124,
 				series: []labels.Labels{
-					{{Name: "a", Value: "1"}},
+					labels.FromStrings("a", "1"),
 					{{Name: "a", Value: "2"}, {Name: "b", Value: "2"}},
-					{{Name: "a", Value: "3"}},
-					{{Name: "a", Value: "4"}},
+					labels.FromStrings("a", "3"),
+					labels.FromStrings("a", "4"),
 				},
 			},
 		})

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1316,7 +1316,7 @@ func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, max
 	db.DisableCompactions()
 
 	appendSample := func(seriesID int, ts int64, value float64) {
-		lbls := labels.Labels{labels.Label{Name: "series_id", Value: strconv.Itoa(seriesID)}}
+		lbls := labels.FromStrings("series_id", strconv.Itoa(seriesID))
 
 		app := db.Appender(context.Background())
 		_, err := app.Append(0, lbls, ts, value)
@@ -1919,7 +1919,7 @@ func TestMultitenantCompactor_OutOfOrderCompaction(t *testing.T) {
 	// Generate a single block with out of order chunks.
 	specs := []*testutil.BlockSeriesSpec{
 		{
-			Labels: labels.Labels{labels.Label{Name: "case", Value: "out_of_order"}},
+			Labels: labels.FromStrings("case", "out_of_order"),
 			Chunks: []chunks.Meta{
 				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{newSample(20, 20), newSample(21, 21)}),
 				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{newSample(10, 10), newSample(11, 11)}),

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1201,46 +1201,24 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 	cases := []testcase{
 		// Remove both cluster and replica label.
 		{
-			removeReplica: true,
-			removeLabels:  []string{"cluster"},
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "some_metric"},
-				{Name: "cluster", Value: "one"},
-				{Name: "__replica__", Value: "two"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "some_metric"},
-			},
+			removeReplica:  true,
+			removeLabels:   []string{"cluster"},
+			inputSeries:    labels.FromStrings("__name__", "some_metric", "cluster", "one", "__replica__", "two"),
+			expectedSeries: labels.FromStrings("__name__", "some_metric"),
 		},
 		// Remove multiple labels and replica.
 		{
 			removeReplica: true,
 			removeLabels:  []string{"foo", "some"},
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "some_metric"},
-				{Name: "cluster", Value: "one"},
-				{Name: "__replica__", Value: "two"},
-				{Name: "foo", Value: "bar"},
-				{Name: "some", Value: "thing"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "some_metric"},
-				{Name: "cluster", Value: "one"},
-			},
+			inputSeries: labels.FromStrings("__name__", "some_metric", "cluster", "one", "__replica__", "two",
+				"foo", "bar", "some", "thing"),
+			expectedSeries: labels.FromStrings("__name__", "some_metric", "cluster", "one"),
 		},
 		// Don't remove any labels.
 		{
-			removeReplica: false,
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "some_metric"},
-				{Name: "__replica__", Value: "two"},
-				{Name: "cluster", Value: "one"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "some_metric"},
-				{Name: "__replica__", Value: "two"},
-				{Name: "cluster", Value: "one"},
-			},
+			removeReplica:  false,
+			inputSeries:    labels.FromStrings("__name__", "some_metric", "__replica__", "two", "cluster", "one"),
+			expectedSeries: labels.FromStrings("__name__", "some_metric", "__replica__", "two", "cluster", "one"),
 		},
 	}
 
@@ -1283,67 +1261,31 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 		expectedToken  uint32
 	}{
 		"metric_1 with value_1": {
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
-				{Name: "key", Value: "value_1"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
-				{Name: "key", Value: "value_1"},
-			},
-			expectedToken: 0xec0a2e9d,
+			inputSeries:    labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedToken:  0xec0a2e9d,
 		},
 		"metric_1 with value_1 and dropped label due to config": {
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
-				{Name: "key", Value: "value_1"},
-				{Name: "dropped", Value: "unused"}, // will be dropped, doesn't need to be in correct order
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
-				{Name: "key", Value: "value_1"},
-			},
-			expectedToken: 0xec0a2e9d,
+			inputSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1",
+				"dropped", "unused"),
+			expectedSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedToken:  0xec0a2e9d,
 		},
 		"metric_1 with value_1 and dropped HA replica label": {
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
-				{Name: "key", Value: "value_1"},
-				{Name: "__replica__", Value: "replica_1"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
-				{Name: "key", Value: "value_1"},
-			},
-			expectedToken: 0xec0a2e9d,
+			inputSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1",
+				"__replica__", "replica_1"),
+			expectedSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedToken:  0xec0a2e9d,
 		},
 		"metric_2 with value_1": {
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_2"},
-				{Name: "key", Value: "value_1"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_2"},
-				{Name: "key", Value: "value_1"},
-			},
-			expectedToken: 0xa60906f2,
+			inputSeries:    labels.FromStrings("__name__", "metric_2", "key", "value_1"),
+			expectedSeries: labels.FromStrings("__name__", "metric_2", "key", "value_1"),
+			expectedToken:  0xa60906f2,
 		},
 		"metric_1 with value_2": {
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "key", Value: "value_2"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "metric_1"},
-				{Name: "key", Value: "value_2"},
-			},
-			expectedToken: 0x18abc8a2,
+			inputSeries:    labels.FromStrings("__name__", "metric_1", "key", "value_2"),
+			expectedSeries: labels.FromStrings("__name__", "metric_1", "key", "value_2"),
+			expectedToken:  0x18abc8a2,
 		},
 	}
 
@@ -1381,10 +1323,7 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 }
 
 func TestDistributor_Push_LabelNameValidation(t *testing.T) {
-	inputLabels := labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-		{Name: "999.illegal", Value: "baz"},
-	}
+	inputLabels := labels.FromStrings(model.MetricNameLabel, "foo", "999.illegal", "baz")
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	tests := map[string]struct {
@@ -1649,7 +1588,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
 					for i := 0; i < 10; i++ {
 						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 					}
@@ -1675,7 +1614,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
 					for i := 0; i < 10; i++ {
 						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 					}
@@ -1700,7 +1639,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
 					for i := 1; i < 31; i++ {
 						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 					}
@@ -1725,7 +1664,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
 					for i := 0; i < 10; i++ {
 						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 					}
@@ -1753,7 +1692,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
 					for i := 0; i < 10; i++ {
 						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 					}
@@ -1781,7 +1720,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
 					for i := 0; i < 10; i++ {
 						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 					}
@@ -1908,12 +1847,12 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 		value     float64
 		timestamp int64
 	}{
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "200"}}, 1, 100000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "500"}}, 1, 110000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_2"}}, 2, 200000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "500"), 1, 110000},
+		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
 		// The two following series have the same FastFingerprint=e002a3a451262627
-		{labels.Labels{{Name: labels.MetricName, Value: "fast_fingerprint_collision"}, {Name: "app", Value: "l"}, {Name: "uniq0", Value: "0"}, {Name: "uniq1", Value: "1"}}, 1, 300000},
-		{labels.Labels{{Name: labels.MetricName, Value: "fast_fingerprint_collision"}, {Name: "app", Value: "m"}, {Name: "uniq0", Value: "1"}, {Name: "uniq1", Value: "1"}}, 1, 300000},
+		{labels.FromStrings(labels.MetricName, "fast_fingerprint_collision", "app", "l", "uniq0", "0", "uniq1", "1"), 1, 300000},
+		{labels.FromStrings(labels.MetricName, "fast_fingerprint_collision", "app", "m", "uniq0", "1", "uniq1", "1"), 1, 300000},
 	}
 
 	tests := map[string]struct {
@@ -2014,9 +1953,9 @@ func TestDistributor_LabelNames(t *testing.T) {
 		value     float64
 		timestamp int64
 	}{
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "200"}}, 1, 100000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "500"}, {Name: "reason", Value: "broken"}}, 1, 110000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_2"}}, 2, 200000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
 	}
 
 	tests := map[string]struct {
@@ -2146,9 +2085,9 @@ func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 		value     float64
 		timestamp int64
 	}{
-		{labels.Labels{{Name: labels.MetricName, Value: "label_00"}}, 1, 100000},
-		{labels.Labels{{Name: labels.MetricName, Value: "label_11"}}, 1, 110000},
-		{labels.Labels{{Name: labels.MetricName, Value: "label_11"}}, 2, 200000},
+		{labels.FromStrings(labels.MetricName, "label_00"), 1, 100000},
+		{labels.FromStrings(labels.MetricName, "label_11"), 1, 110000},
+		{labels.FromStrings(labels.MetricName, "label_11"), 2, 200000},
 	}
 	tests := map[string]struct {
 		sizeLimitBytes int
@@ -2203,9 +2142,9 @@ func TestDistributor_LabelNamesAndValues(t *testing.T) {
 		value     float64
 		timestamp int64
 	}{
-		{labels.Labels{{Name: labels.MetricName, Value: "label_0"}, {Name: "status", Value: "200"}}, 1, 100000},
-		{labels.Labels{{Name: labels.MetricName, Value: "label_1"}, {Name: "status", Value: "500"}, {Name: "reason", Value: "broken"}}, 1, 110000},
-		{labels.Labels{{Name: labels.MetricName, Value: "label_1"}}, 2, 200000},
+		{labels.FromStrings(labels.MetricName, "label_0", "status", "200"), 1, 100000},
+		{labels.FromStrings(labels.MetricName, "label_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labels.FromStrings(labels.MetricName, "label_1"), 2, 200000},
 	}
 	expectedLabelValues := []*client.LabelValues{
 		{
@@ -2619,7 +2558,7 @@ func createSeries(count int) []series {
 	fixtures := make([]series, 0, count)
 	for i := 0; i < count; i++ {
 		fixtures = append(fixtures, series{
-			labels.Labels{{Name: labels.MetricName, Value: "metric" + strconv.Itoa(i)}}, 1, int64(100000 + i),
+			labels.FromStrings(labels.MetricName, "metric"+strconv.Itoa(i)), 1, int64(100000 + i),
 		})
 	}
 	return fixtures
@@ -2634,9 +2573,9 @@ func TestDistributor_LabelValuesCardinality(t *testing.T) {
 		value     float64
 		timestamp int64
 	}{
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "200"}}, 1, 100000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "500"}, {Name: "reason", Value: "broken"}}, 1, 110000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_2"}}, 2, 200000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
 	}
 
 	tests := map[string]struct {
@@ -2738,9 +2677,9 @@ func TestDistributor_LabelValuesCardinalityLimit(t *testing.T) {
 		value     float64
 		timestamp int64
 	}{
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "200"}}, 1, 100000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "500"}, {Name: "reason", Value: "broken"}}, 1, 110000},
-		{labels.Labels{{Name: labels.MetricName, Value: "test_2"}}, 2, 200000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labels.FromStrings(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
 	}
 
 	tests := map[string]struct {
@@ -4151,7 +4090,7 @@ func TestDistributorValidation(t *testing.T) {
 		// Test validation passes.
 		{
 			metadata: []*mimirpb.MetricMetadata{{MetricFamilyName: "testmetric", Help: "a test metric.", Unit: "", Type: mimirpb.COUNTER}},
-			labels:   []labels.Labels{{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}},
+			labels:   []labels.Labels{labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar")},
 			samples: []mimirpb.Sample{{
 				TimestampMs: int64(now),
 				Value:       1,
@@ -4165,7 +4104,7 @@ func TestDistributorValidation(t *testing.T) {
 
 		// Test validation fails for samples from the future.
 		{
-			labels: []labels.Labels{{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}},
+			labels: []labels.Labels{labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar")},
 			samples: []mimirpb.Sample{{
 				TimestampMs: int64(future),
 				Value:       4,
@@ -4176,7 +4115,7 @@ func TestDistributorValidation(t *testing.T) {
 
 		// Test maximum labels names per series.
 		{
-			labels: []labels.Labels{{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}, {Name: "foo2", Value: "bar2"}}},
+			labels: []labels.Labels{labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar", "foo2", "bar2")},
 			samples: []mimirpb.Sample{{
 				TimestampMs: int64(now),
 				Value:       2,
@@ -4187,8 +4126,8 @@ func TestDistributorValidation(t *testing.T) {
 		// Test multiple validation fails return the first one.
 		{
 			labels: []labels.Labels{
-				{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}, {Name: "foo2", Value: "bar2"}},
-				{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}},
+				labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar", "foo2", "bar2"),
+				labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar"),
 			},
 			samples: []mimirpb.Sample{
 				{TimestampMs: int64(now), Value: 2},
@@ -4211,7 +4150,7 @@ func TestDistributorValidation(t *testing.T) {
 		// Test empty exemplar labels fails.
 		{
 			metadata: []*mimirpb.MetricMetadata{{MetricFamilyName: "testmetric", Help: "a test metric.", Unit: "", Type: mimirpb.COUNTER}},
-			labels:   []labels.Labels{{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}},
+			labels:   []labels.Labels{labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar")},
 			samples: []mimirpb.Sample{{
 				TimestampMs: int64(now),
 				Value:       1,
@@ -4353,24 +4292,12 @@ func TestDistributor_Push_Relabel(t *testing.T) {
 	cases := []testcase{
 		// No relabel config.
 		{
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "foo"},
-				{Name: "cluster", Value: "one"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "foo"},
-				{Name: "cluster", Value: "one"},
-			},
+			inputSeries:    labels.FromStrings("__name__", "foo", "cluster", "one"),
+			expectedSeries: labels.FromStrings("__name__", "foo", "cluster", "one"),
 		},
 		{
-			inputSeries: labels.Labels{
-				{Name: "__name__", Value: "foo"},
-				{Name: "cluster", Value: "one"},
-			},
-			expectedSeries: labels.Labels{
-				{Name: "__name__", Value: "foo"},
-				{Name: "cluster", Value: "two"},
-			},
+			inputSeries:    labels.FromStrings("__name__", "foo", "cluster", "one"),
+			expectedSeries: labels.FromStrings("__name__", "foo", "cluster", "two"),
 			metricRelabelConfigs: []*relabel.Config{
 				{
 					SourceLabels: []model.LabelName{"cluster"},

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -195,7 +195,8 @@ func makeExemplarQueryResponse(numSeries int) *ingester_client.ExemplarQueryResp
 	now := time.Now()
 	ts := make([]mimirpb.TimeSeries, numSeries)
 	for i := 0; i < numSeries; i++ {
-		lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+		lbls := labels.NewBuilder(labels.EmptyLabels())
+		lbls.Set(model.MetricNameLabel, "foo")
 		for i := 0; i < 10; i++ {
 			lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
 		}

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -878,7 +878,7 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "bazz"), start.Add(-lookbackDelta), end, step, factor(7)),
 					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "buzz"), start.Add(-lookbackDelta), end, step, factor(12)),
 					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bozz"), start.Add(-lookbackDelta), end, step, factor(11)),
-					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blip", "foo", "buzz"), start.Add(-lookbackDelta), end, step, factor(8)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "buzz"), start.Add(-lookbackDelta), end, step, factor(8)),
 					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bazz"), start.Add(-lookbackDelta), end, step, arithmeticSequence(10)),
 				})
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -874,12 +874,12 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 		for _, query := range mkQueries(tc.tpl, tc.fn, tc.rangeQuery, tc.args) {
 			t.Run(query, func(t *testing.T) {
 				queryable := storageSeriesQueryable([]*promql.StorageSeries{
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "barr"}}, start.Add(-lookbackDelta), end, step, factor(5)),
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "bazz"}}, start.Add(-lookbackDelta), end, step, factor(7)),
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "buzz"}}, start.Add(-lookbackDelta), end, step, factor(12)),
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bozz"}}, start.Add(-lookbackDelta), end, step, factor(11)),
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blop"}, {Name: "foo", Value: "buzz"}}, start.Add(-lookbackDelta), end, step, factor(8)),
-					newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}, {Name: "baz", Value: "blip"}, {Name: "bar", Value: "blap"}, {Name: "foo", Value: "bazz"}}, start.Add(-lookbackDelta), end, step, arithmeticSequence(10)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "barr"), start.Add(-lookbackDelta), end, step, factor(5)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "bazz"), start.Add(-lookbackDelta), end, step, factor(7)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "buzz"), start.Add(-lookbackDelta), end, step, factor(12)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bozz"), start.Add(-lookbackDelta), end, step, factor(11)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blip", "foo", "buzz"), start.Add(-lookbackDelta), end, step, factor(8)),
+					newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bazz"), start.Add(-lookbackDelta), end, step, arithmeticSequence(10)),
 				})
 
 				req := &PrometheusRangeQueryRequest{
@@ -1225,7 +1225,7 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 			return nil, apierror.Newf(apierror.TypeExec, "expanding series: %s", validation.NewMaxQueryLengthError(744*time.Hour, 720*time.Hour))
 		})
 		queryable = storageSeriesQueryable([]*promql.StorageSeries{
-			newSeries(labels.Labels{{Name: "__name__", Value: "bar1"}}, start.Add(-lookbackDelta), end, step, factor(5)),
+			newSeries(labels.FromStrings("__name__", "bar1"), start.Add(-lookbackDelta), end, step, factor(5)),
 		})
 		queryableSlow = newMockShardedQueryable(
 			2,
@@ -1543,18 +1543,12 @@ func TestPromqlResultToSampleStreams(t *testing.T) {
 			input: &promql.Result{
 				Value: promql.Vector{
 					promql.Sample{
-						Point: promql.Point{T: 1, V: 1},
-						Metric: labels.Labels{
-							{Name: "a", Value: "a1"},
-							{Name: "b", Value: "b1"},
-						},
+						Point:  promql.Point{T: 1, V: 1},
+						Metric: labels.FromStrings("a", "a1", "b", "b1"),
 					},
 					promql.Sample{
-						Point: promql.Point{T: 2, V: 2},
-						Metric: labels.Labels{
-							{Name: "a", Value: "a2"},
-							{Name: "b", Value: "b2"},
-						},
+						Point:  promql.Point{T: 2, V: 2},
+						Metric: labels.FromStrings("a", "a2", "b", "b2"),
 					},
 				},
 			},
@@ -1591,20 +1585,14 @@ func TestPromqlResultToSampleStreams(t *testing.T) {
 			input: &promql.Result{
 				Value: promql.Matrix{
 					{
-						Metric: labels.Labels{
-							{Name: "a", Value: "a1"},
-							{Name: "b", Value: "b1"},
-						},
+						Metric: labels.FromStrings("a", "a1", "b", "b1"),
 						Points: []promql.Point{
 							{T: 1, V: 1},
 							{T: 2, V: 2},
 						},
 					},
 					{
-						Metric: labels.Labels{
-							{Name: "a", Value: "a2"},
-							{Name: "b", Value: "b2"},
-						},
+						Metric: labels.FromStrings("a", "a2", "b", "b2"),
 						Points: []promql.Point{
 							{T: 1, V: 8},
 							{T: 2, V: 9},
@@ -1798,25 +1786,25 @@ func newSeries(metric labels.Labels, from, to time.Time, step time.Duration, gen
 
 // newTestCounterLabels generates series labels for a counter metric used in tests.
 func newTestCounterLabels(id int) labels.Labels {
-	return labels.Labels{
-		{Name: "__name__", Value: "metric_counter"},
-		{Name: "const", Value: "fixed"},                 // A constant label.
-		{Name: "unique", Value: strconv.Itoa(id)},       // A unique label.
-		{Name: "group_1", Value: strconv.Itoa(id % 10)}, // A first grouping label.
-		{Name: "group_2", Value: strconv.Itoa(id % 3)},  // A second grouping label.
-	}
+	return labels.FromStrings(
+		"__name__", "metric_counter",
+		"const", "fixed", // A constant label.
+		"unique", strconv.Itoa(id), // A unique label.
+		"group_1", strconv.Itoa(id%10), // A first grouping label.
+		"group_2", strconv.Itoa(id%3), // A second grouping label.
+	)
 }
 
 // newTestCounterLabels generates series labels for an histogram metric used in tests.
 func newTestHistogramLabels(id int, bucketLe float64) labels.Labels {
-	return labels.Labels{
-		{Name: "__name__", Value: "metric_histogram_bucket"},
-		{Name: "le", Value: fmt.Sprintf("%f", bucketLe)},
-		{Name: "const", Value: "fixed"},                 // A constant label.
-		{Name: "unique", Value: strconv.Itoa(id)},       // A unique label.
-		{Name: "group_1", Value: strconv.Itoa(id % 10)}, // A first grouping label.
-		{Name: "group_2", Value: strconv.Itoa(id % 5)},  // A second grouping label.
-	}
+	return labels.FromStrings(
+		"__name__", "metric_histogram_bucket",
+		"le", fmt.Sprintf("%f", bucketLe),
+		"const", "fixed", // A constant label.
+		"unique", strconv.Itoa(id), // A unique label.
+		"group_1", strconv.Itoa(id%10), // A first grouping label.
+		"group_2", strconv.Itoa(id%3), // A second grouping label.
+	)
 }
 
 // generator defined a function used to generate sample values in tests.

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -200,46 +200,10 @@ func TestGenLabelsCorrectness(t *testing.T) {
 		sort.Sort(set)
 	}
 	expected := []labels.Labels{
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "0",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "0",
-			},
-		},
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "0",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "1",
-			},
-		},
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "1",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "0",
-			},
-		},
-		{
-			labels.Label{
-				Name:  "a",
-				Value: "1",
-			},
-			labels.Label{
-				Name:  "b",
-				Value: "1",
-			},
-		},
+		labels.FromStrings("a", "0", "b", "0"),
+		labels.FromStrings("a", "0", "b", "1"),
+		labels.FromStrings("a", "1", "b", "0"),
+		labels.FromStrings("a", "1", "b", "1"),
 	}
 	require.Equal(t, expected, ls)
 }

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -354,9 +354,7 @@ func BenchmarkActiveSeriesTest_single_series(b *testing.B) {
 }
 
 func benchmarkActiveSeriesConcurrencySingleSeries(b *testing.B, goroutines int) {
-	series := labels.Labels{
-		{Name: "a", Value: "a"},
-	}
+	series := labels.FromStrings("a", "a")
 
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 
@@ -451,7 +449,7 @@ func benchmarkPurge(b *testing.B, twice bool) {
 
 	series := [numSeries]labels.Labels{}
 	for s := 0; s < numSeries; s++ {
-		series[s] = labels.Labels{{Name: "a", Value: strconv.Itoa(s)}}
+		series[s] = labels.FromStrings("a", strconv.Itoa(s))
 	}
 
 	for i := 0; i < b.N; i++ {

--- a/pkg/ingester/activeseries/matchers_test.go
+++ b/pkg/ingester/activeseries/matchers_test.go
@@ -27,13 +27,13 @@ func TestMatcher_MatchesSeries(t *testing.T) {
 		expected []int
 	}{
 		{
-			series: labels.Labels{{Name: "foo", Value: "true"}, {Name: "baz", Value: "unrelated"}},
+			series: labels.FromStrings("foo", "true", "baz", "unrelated"),
 			expected: []int{
 				3, // has_foo_label
 			},
 		},
 		{
-			series: labels.Labels{{Name: "foo", Value: "true"}, {Name: "bar", Value: "100"}, {Name: "baz", Value: "unrelated"}},
+			series: labels.FromStrings("foo", "true", "bar", "100", "baz", "unrelated"),
 			expected: []int{
 				0, // bar_starts_with_1
 				2, // has_foo_and_bar_starts_with_1
@@ -41,26 +41,26 @@ func TestMatcher_MatchesSeries(t *testing.T) {
 			},
 		},
 		{
-			series: labels.Labels{{Name: "foo", Value: "true"}, {Name: "bar", Value: "200"}, {Name: "baz", Value: "unrelated"}},
+			series: labels.FromStrings("foo", "true", "bar", "200", "baz", "unrelated"),
 			expected: []int{
 				3, // has_foo_label
 			},
 		},
 		{
-			series: labels.Labels{{Name: "bar", Value: "200"}, {Name: "baz", Value: "unrelated"}},
+			series: labels.FromStrings("bar", "200", "baz", "unrelated"),
 			expected: []int{
 				1, // does_not_have_foo_label
 			},
 		},
 		{
-			series: labels.Labels{{Name: "bar", Value: "100"}, {Name: "baz", Value: "unrelated"}},
+			series: labels.FromStrings("bar", "100", "baz", "unrelated"),
 			expected: []int{
 				0, // bar_starts_with_1
 				1, // does_not_have_foo_label
 			},
 		},
 		{
-			series: labels.Labels{{Name: "baz", Value: "unrelated"}},
+			series: labels.FromStrings("baz", "unrelated"),
 			expected: []int{
 				1, // does_not_have_foo_label
 			},

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -111,7 +111,7 @@ func TestMetricMetadataToMetricTypeToMetricType(t *testing.T) {
 
 func TestFromLabelAdaptersToLabels(t *testing.T) {
 	input := []LabelAdapter{{Name: "hello", Value: "world"}}
-	expected := labels.Labels{labels.Label{Name: "hello", Value: "world"}}
+	expected := labels.FromStrings("hello", "world")
 	actual := FromLabelAdaptersToLabels(input)
 
 	assert.Equal(t, expected, actual)
@@ -123,7 +123,7 @@ func TestFromLabelAdaptersToLabels(t *testing.T) {
 
 func TestFromLabelAdaptersToLabelsWithCopy(t *testing.T) {
 	input := []LabelAdapter{{Name: "hello", Value: "world"}}
-	expected := labels.Labels{labels.Label{Name: "hello", Value: "world"}}
+	expected := labels.FromStrings("hello", "world")
 	actual := FromLabelAdaptersToLabelsWithCopy(input)
 
 	assert.Equal(t, expected, actual)

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -53,9 +53,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: mockTSDBChunkData()}},
 				},
 			},
-			expectedMetric: labels.Labels{
-				{Name: "foo", Value: "bar"},
-			},
+			expectedMetric: labels.FromStrings("foo", "bar"),
 			expectedSamples: []model.SamplePair{
 				{Timestamp: model.TimeFromUnixNano(time.Unix(1, 0).UnixNano()), Value: model.SampleValue(1)},
 				{Timestamp: model.TimeFromUnixNano(time.Unix(2, 0).UnixNano()), Value: model.SampleValue(2)},
@@ -68,7 +66,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: []byte{0, 1}}},
 				},
 			},
-			expectedMetric: labels.Labels{labels.Label{Name: "foo", Value: "bar"}},
+			expectedMetric: labels.FromStrings("foo", "bar"),
 			expectedErr:    `cannot iterate chunk for series: {foo="bar"}: EOF`,
 		},
 	}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -55,9 +55,9 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 		block2           = ulid.MustNew(2, nil)
 		block3           = ulid.MustNew(3, nil)
 		block4           = ulid.MustNew(4, nil)
-		metricNameLabel  = labels.Label{Name: labels.MetricName, Value: metricName}
-		series1Label     = labels.Label{Name: "series", Value: "1"}
-		series2Label     = labels.Label{Name: "series", Value: "2"}
+		metricNameLabel  = labels.FromStrings(labels.MetricName, metricName)
+		series1Label     = labels.FromStrings(labels.MetricName, metricName, "series", "1")
+		series2Label     = labels.FromStrings(labels.MetricName, metricName, "series", "2")
 		noOpQueryLimiter = limiter.NewQueryLimiter(0, 0, 0)
 	)
 
@@ -114,8 +114,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT, 1),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block1, block2),
 						mockStatsResponse(50),
 					}}: {block1, block2},
@@ -125,7 +125,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel),
+					lbls: metricNameLabel,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
@@ -141,9 +141,9 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 3),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
+						mockSeriesResponse(series2Label, minT, 3),
 						mockHintsResponse(block1, block2),
 					}}: {block1, block2},
 				},
@@ -152,13 +152,13 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel, series1Label),
+					lbls: series1Label,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
 					},
 				}, {
-					lbls: labels.New(metricNameLabel, series2Label),
+					lbls: series2Label,
 					values: []valueResult{
 						{t: minT, v: 3},
 					},
@@ -173,11 +173,11 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+						mockSeriesResponse(metricNameLabel, minT, 1),
 						mockHintsResponse(block1),
 					}}: {block1},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block2),
 					}}: {block2},
 				},
@@ -186,7 +186,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel),
+					lbls: metricNameLabel,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
@@ -202,12 +202,12 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block1),
 					}}: {block1},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT, 1),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block2),
 					}}: {block2},
 				},
@@ -216,7 +216,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel),
+					lbls: metricNameLabel,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
@@ -232,18 +232,18 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
+						mockSeriesResponse(series2Label, minT, 1),
 						mockHintsResponse(block1),
 					}}: {block1},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block2),
 					}}: {block2},
 					&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+						mockSeriesResponse(series2Label, minT, 1),
+						mockSeriesResponse(series2Label, minT+1, 3),
 						mockHintsResponse(block3),
 					}}: {block3},
 				},
@@ -252,13 +252,13 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel, series1Label),
+					lbls: series1Label,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
 					},
 				}, {
-					lbls: labels.New(metricNameLabel, series2Label),
+					lbls: series2Label,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 3},
@@ -312,8 +312,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				// First attempt returns a client whose response does not include all expected blocks.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block1),
 					}}: {block1},
 				},
@@ -335,11 +335,11 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				// First attempt returns a client whose response does not include all expected blocks.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block1),
 					}}: {block1},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block2),
 					}}: {block2},
 				},
@@ -361,25 +361,25 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				// First attempt returns a client whose response does not include all expected blocks.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockSeriesResponse(series1Label, minT, 1),
 						mockHintsResponse(block1),
 					}}: {block1, block3},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 2),
+						mockSeriesResponse(series2Label, minT, 2),
 						mockHintsResponse(block2),
 					}}: {block2, block4},
 				},
 				// Second attempt returns 1 missing block.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block3),
 					}}: {block3, block4},
 				},
 				// Third attempt returns the last missing block.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "4.4.4.4", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+						mockSeriesResponse(series2Label, minT+1, 3),
 						mockHintsResponse(block4),
 					}}: {block4},
 				},
@@ -388,13 +388,13 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel, series1Label),
+					lbls: series1Label,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
 					},
 				}, {
-					lbls: labels.New(metricNameLabel, series2Label),
+					lbls: series2Label,
 					values: []valueResult{
 						{t: minT, v: 2},
 						{t: minT + 1, v: 3},
@@ -447,8 +447,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block1, block2),
 					}}: {block1, block2},
 				},
@@ -457,7 +457,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel, series1Label),
+					lbls: series1Label,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
@@ -473,8 +473,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block1, block2),
 					}}: {block1, block2},
 				},
@@ -491,8 +491,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block1, block2),
 					}}: {block1, block2},
 				},
@@ -512,25 +512,25 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				// First attempt returns a client whose response does not include all expected blocks.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockSeriesResponse(series1Label, minT, 1),
 						mockHintsResponse(block1),
 					}}: {block1, block3},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 2),
+						mockSeriesResponse(series2Label, minT, 2),
 						mockHintsResponse(block2),
 					}}: {block2, block4},
 				},
 				// Second attempt returns 1 missing block.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block3),
 					}}: {block3, block4},
 				},
 				// Third attempt returns the last missing block.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "4.4.4.4", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+						mockSeriesResponse(series2Label, minT+1, 3),
 						mockHintsResponse(block4),
 					}}: {block4},
 				},
@@ -550,25 +550,25 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				// First attempt returns a client whose response does not include all expected blocks.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockSeriesResponse(series1Label, minT, 1),
 						mockHintsResponse(block1),
 					}}: {block1, block3},
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 2),
+						mockSeriesResponse(series2Label, minT, 2),
 						mockHintsResponse(block2),
 					}}: {block2, block4},
 				},
 				// Second attempt returns 1 missing block.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block3),
 					}}: {block3, block4},
 				},
 				// Third attempt returns the last missing block.
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "4.4.4.4", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+						mockSeriesResponse(series2Label, minT+1, 3),
 						mockHintsResponse(block4),
 					}}: {block4},
 				},
@@ -585,8 +585,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series2Label, minT+1, 2),
 						mockHintsResponse(block1, block2),
 					}}: {block1, block2},
 				},
@@ -603,8 +603,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(series1Label, minT, 1),
+						mockSeriesResponse(series1Label, minT+1, 2),
 						mockHintsResponse(block1, block2),
 					}}: {block1, block2},
 				},
@@ -624,8 +624,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT, 1),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block2),
 					}}: {block2}, // Only block2 will be queried
 				},
@@ -634,7 +634,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel),
+					lbls: metricNameLabel,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
@@ -691,8 +691,8 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			storeSetResponses: []interface{}{
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockSeriesResponse(metricNameLabel, minT, 1),
+						mockSeriesResponse(metricNameLabel, minT+1, 2),
 						mockHintsResponse(block1, block2, block3, block4),
 					}}: {block1, block2, block3, block4},
 				},
@@ -701,7 +701,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel),
+					lbls: metricNameLabel,
 					values: []valueResult{
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
@@ -760,7 +760,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				},
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 2),
+						mockSeriesResponse(series1Label, minT, 2),
 						mockHintsResponse(block1),
 					}}: {block1},
 				},
@@ -769,7 +769,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			queryLimiter: noOpQueryLimiter,
 			expectedSeries: []seriesResult{
 				{
-					lbls: labels.New(metricNameLabel, series1Label),
+					lbls: series1Label,
 					values: []valueResult{
 						{t: minT, v: 2},
 					},
@@ -1572,10 +1572,10 @@ func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 
 func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 	// Prepare series fixtures.
-	series1 := labels.Labels{{Name: "__name__", Value: "metric_1"}}
-	series2 := labels.Labels{{Name: "__name__", Value: "metric_2"}}
-	series3 := labels.Labels{{Name: "__name__", Value: "metric_3_ooo"}}
-	series4 := labels.Labels{{Name: "__name__", Value: "metric_4_ooo_and_overlapping"}}
+	series1 := labels.FromStrings("__name__", "metric_1")
+	series2 := labels.FromStrings("__name__", "metric_2")
+	series3 := labels.FromStrings("__name__", "metric_3_ooo")
+	series4 := labels.FromStrings("__name__", "metric_4_ooo_and_overlapping")
 
 	generateSeriesSamples := func(value float64) []promql.Point {
 		return []promql.Point{

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -173,11 +173,11 @@ func TestIngesterStreaming(t *testing.T) {
 
 	require.True(t, seriesSet.Next())
 	series := seriesSet.At()
-	require.Equal(t, labels.Labels{{Name: "bar", Value: "baz"}}, series.Labels())
+	require.Equal(t, labels.FromStrings("bar", "baz"), series.Labels())
 
 	require.True(t, seriesSet.Next())
 	series = seriesSet.At()
-	require.Equal(t, labels.Labels{{Name: "foo", Value: "bar"}}, series.Labels())
+	require.Equal(t, labels.FromStrings("foo", "bar"), series.Labels())
 
 	require.False(t, seriesSet.Next())
 	require.NoError(t, seriesSet.Err())
@@ -248,13 +248,13 @@ func TestIngesterStreamingMixedResults(t *testing.T) {
 	require.NoError(t, seriesSet.Err())
 
 	require.True(t, seriesSet.Next())
-	verifySeries(t, seriesSet.At(), labels.Labels{{Name: labels.MetricName, Value: "one"}}, s1)
+	verifySeries(t, seriesSet.At(), labels.FromStrings(labels.MetricName, "one"), s1)
 
 	require.True(t, seriesSet.Next())
-	verifySeries(t, seriesSet.At(), labels.Labels{{Name: labels.MetricName, Value: "three"}}, s1)
+	verifySeries(t, seriesSet.At(), labels.FromStrings(labels.MetricName, "three"), s1)
 
 	require.True(t, seriesSet.Next())
-	verifySeries(t, seriesSet.At(), labels.Labels{{Name: labels.MetricName, Value: "two"}}, mergedSamplesS1S2)
+	verifySeries(t, seriesSet.At(), labels.FromStrings(labels.MetricName, "two"), mergedSamplesS1S2)
 
 	require.False(t, seriesSet.Next())
 	require.NoError(t, seriesSet.Err())

--- a/pkg/querier/iterators/chunk_merge_iterator_test.go
+++ b/pkg/querier/iterators/chunk_merge_iterator_test.go
@@ -95,9 +95,7 @@ func TestChunkMergeIteratorSeek(t *testing.T) {
 }
 
 func mkChunk(t require.TestingT, mint, maxt model.Time, step time.Duration, encoding chunk.Encoding) chunk.Chunk {
-	metric := labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-	}
+	metric := labels.FromStrings(model.MetricNameLabel, "foo")
 	pc, err := chunk.NewForEncoding(encoding)
 	require.NoError(t, err)
 	for i := mint; i.Before(maxt); i = i.Add(step) {

--- a/pkg/querier/partitioner_test.go
+++ b/pkg/querier/partitioner_test.go
@@ -22,9 +22,7 @@ import (
 var _ SeriesWithChunks = &chunkSeries{}
 
 func mkChunk(t require.TestingT, mint, maxt model.Time, step time.Duration, encoding chunk.Encoding) chunk.Chunk {
-	metric := labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-	}
+	metric := labels.FromStrings(model.MetricNameLabel, "foo")
 	pc, err := chunk.NewForEncoding(encoding)
 	require.NoError(t, err)
 	for i := mint; i.Before(maxt); i = i.Add(step) {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -73,11 +73,9 @@ func TestQuerier(t *testing.T) {
 		// Very simple single-point gets, with low step.  Performance should be
 		// similar to above.
 		{
-			query: "foo",
-			step:  sampleRate * 4,
-			labels: labels.Labels{
-				labels.Label{Name: model.MetricNameLabel, Value: "foo"},
-			},
+			query:  "foo",
+			step:   sampleRate * 4,
+			labels: labels.FromStrings(model.MetricNameLabel, "foo"),
 			samples: func(from, through time.Time, step time.Duration) int {
 				return int(through.Sub(from)/step) + 1
 			},
@@ -101,11 +99,9 @@ func TestQuerier(t *testing.T) {
 
 		// Single points gets with large step; excersise Seek performance.
 		{
-			query: "foo",
-			step:  sampleRate * 4 * 10,
-			labels: labels.Labels{
-				labels.Label{Name: model.MetricNameLabel, Value: "foo"},
-			},
+			query:  "foo",
+			step:   sampleRate * 4 * 10,
+			labels: labels.FromStrings(model.MetricNameLabel, "foo"),
 			samples: func(from, through time.Time, step time.Duration) int {
 				return int(through.Sub(from)/step) + 1
 			},
@@ -242,9 +238,7 @@ func mockTSDB(t *testing.T, mint model.Time, samples int, step, chunkOffset time
 
 	app := head.Appender(context.Background())
 
-	l := labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-	}
+	l := labels.FromStrings(model.MetricNameLabel, "foo")
 
 	cnt := 0
 	chunkStartTs := mint

--- a/pkg/querier/tenantfederation/merge_exemplar_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_exemplar_queryable_test.go
@@ -167,15 +167,10 @@ func TestMergeExemplarQuerier_Select(t *testing.T) {
 	fixtureResults := func() ([]exemplar.QueryResult, []exemplar.QueryResult) {
 		res1 := []exemplar.QueryResult{
 			{
-				SeriesLabels: labels.Labels{
-					{
-						Name:  "__name__",
-						Value: "request_duration_seconds",
-					},
-				},
+				SeriesLabels: labels.FromStrings("__name__", "request_duration_seconds"),
 				Exemplars: []exemplar.Exemplar{
 					{
-						Labels: labels.Labels{{Name: "traceID", Value: "abc123"}},
+						Labels: labels.FromStrings("traceID", "abc123"),
 						Value:  123.4,
 						Ts:     now.UnixMilli(),
 					},
@@ -185,15 +180,10 @@ func TestMergeExemplarQuerier_Select(t *testing.T) {
 
 		res2 := []exemplar.QueryResult{
 			{
-				SeriesLabels: labels.Labels{
-					{
-						Name:  "__name__",
-						Value: "request_duration_seconds",
-					},
-				},
+				SeriesLabels: labels.FromStrings("__name__", "request_duration_seconds"),
 				Exemplars: []exemplar.Exemplar{
 					{
-						Labels: labels.Labels{{Name: "traceID", Value: "abc456"}},
+						Labels: labels.FromStrings("traceID", "abc456"),
 						Value:  456.7,
 						Ts:     now.UnixMilli(),
 					},

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -438,39 +438,12 @@ func TestMergeQueryable_Select(t *testing.T) {
 					name:                "should return all series when no matchers are provided",
 					expectedSeriesCount: 6,
 					expectedLabels: []labels.Labels{
-						{
-							{Name: "__tenant_id__", Value: "team-a"},
-							{Name: "instance", Value: "host1"},
-							{Name: "original___tenant_id__", Value: "original-value"},
-							{Name: "tenant-team-a", Value: "static"},
-						},
-						{
-							{Name: "__tenant_id__", Value: "team-a"},
-							{Name: "instance", Value: "host2.team-a"},
-							{Name: "original___tenant_id__", Value: "original-value"},
-						},
-						{
-							{Name: "__tenant_id__", Value: "team-b"},
-							{Name: "instance", Value: "host1"},
-							{Name: "original___tenant_id__", Value: "original-value"},
-							{Name: "tenant-team-b", Value: "static"},
-						},
-						{
-							{Name: "__tenant_id__", Value: "team-b"},
-							{Name: "instance", Value: "host2.team-b"},
-							{Name: "original___tenant_id__", Value: "original-value"},
-						},
-						{
-							{Name: "__tenant_id__", Value: "team-c"},
-							{Name: "instance", Value: "host1"},
-							{Name: "original___tenant_id__", Value: "original-value"},
-							{Name: "tenant-team-c", Value: "static"},
-						},
-						{
-							{Name: "__tenant_id__", Value: "team-c"},
-							{Name: "instance", Value: "host2.team-c"},
-							{Name: "original___tenant_id__", Value: "original-value"},
-						},
+						labels.FromStrings("__tenant_id__", "team-a", "instance", "host1", "original___tenant_id__", "original-value", "tenant-team-a", "static"),
+						labels.FromStrings("__tenant_id__", "team-a", "instance", "host2.team-a", "original___tenant_id__", "original-value"),
+						labels.FromStrings("__tenant_id__", "team-b", "instance", "host1", "original___tenant_id__", "original-value", "tenant-team-b", "static"),
+						labels.FromStrings("__tenant_id__", "team-b", "instance", "host2.team-b", "original___tenant_id__", "original-value"),
+						labels.FromStrings("__tenant_id__", "team-c", "instance", "host1", "original___tenant_id__", "original-value", "tenant-team-c", "static"),
+						labels.FromStrings("__tenant_id__", "team-c", "instance", "host2.team-c", "original___tenant_id__", "original-value"),
 					},
 				},
 				{
@@ -889,30 +862,30 @@ func TestSetLabelsRetainExisting(t *testing.T) {
 	}{
 		// Test adding labels at the end.
 		{
-			labels:           labels.Labels{{Name: "a", Value: "b"}},
-			additionalLabels: labels.Labels{{Name: "c", Value: "d"}},
-			expected:         labels.Labels{{Name: "a", Value: "b"}, {Name: "c", Value: "d"}},
+			labels:           labels.FromStrings("a", "b"),
+			additionalLabels: labels.FromStrings("c", "d"),
+			expected:         labels.FromStrings("a", "b", "c", "d"),
 		},
 
 		// Test adding labels at the beginning.
 		{
-			labels:           labels.Labels{{Name: "c", Value: "d"}},
-			additionalLabels: labels.Labels{{Name: "a", Value: "b"}},
-			expected:         labels.Labels{{Name: "a", Value: "b"}, {Name: "c", Value: "d"}},
+			labels:           labels.FromStrings("c", "d"),
+			additionalLabels: labels.FromStrings("a", "b"),
+			expected:         labels.FromStrings("a", "b", "c", "d"),
 		},
 
 		// Test we do override existing labels and expose the original value.
 		{
-			labels:           labels.Labels{{Name: "a", Value: "b"}},
-			additionalLabels: labels.Labels{{Name: "a", Value: "c"}},
-			expected:         labels.Labels{{Name: "a", Value: "c"}, {Name: "original_a", Value: "b"}},
+			labels:           labels.FromStrings("a", "b"),
+			additionalLabels: labels.FromStrings("a", "c"),
+			expected:         labels.FromStrings("a", "c", "original_a", "b"),
 		},
 
 		// Test we do override existing labels but don't do it recursively.
 		{
-			labels:           labels.Labels{{Name: "a", Value: "b"}, {Name: "original_a", Value: "i am lost"}},
-			additionalLabels: labels.Labels{{Name: "a", Value: "d"}},
-			expected:         labels.Labels{{Name: "a", Value: "d"}, {Name: "original_a", Value: "b"}},
+			labels:           labels.FromStrings("a", "b", "original_a", "i am lost"),
+			additionalLabels: labels.FromStrings("a", "d"),
+			expected:         labels.FromStrings("a", "d", "original_a", "b"),
 		},
 	} {
 		assert.Equal(t, tc.expected, setLabelsRetainExisting(tc.labels, tc.additionalLabels...))

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1584,10 +1584,7 @@ func newBucketBlock(
 		meta:              meta,
 		indexHeaderReader: indexHeadReader,
 		// Inject the block ID as a label to allow to match blocks by ID.
-		blockLabels: labels.Labels{labels.Label{
-			Name:  block.BlockIDLabel,
-			Value: meta.ULID.String(),
-		}},
+		blockLabels: labels.FromStrings(block.BlockIDLabel, meta.ULID.String()),
 	}
 
 	// Get object handles for all chunk files (segment files) from meta.json, if available.

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -815,7 +815,7 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, series in
 	id := createBlockFromHead(t, filepath.Join(tmpDir, "tmp"), h)
 
 	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(tmpDir, "tmp", id.String()), metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}, nil)
@@ -984,7 +984,7 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 		random = rand.New(rand.NewSource(120))
 	)
 
-	extLset := labels.Labels{{Name: "ext1", Value: "1"}}
+	extLset := labels.FromStrings("ext1", "1")
 	thanosMeta := metadata.Thanos{
 		Labels:     extLset.Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
@@ -1145,7 +1145,7 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 
 	logger := log.NewNopLogger()
 	thanosMeta := metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}
@@ -1462,7 +1462,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 	blk := createBlockFromHead(t, headOpts.ChunkDirRoot, h)
 
 	thanosMeta := metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}
@@ -1631,7 +1631,7 @@ func setupStoreForHintsTest(t *testing.T) (test.TB, *BucketStore, []*storepb.Ser
 		random   = rand.New(rand.NewSource(120))
 	)
 
-	prependLabels := labels.Labels{{Name: "ext1", Value: "1"}}
+	prependLabels := labels.FromStrings("ext1", "1")
 	// Inject the Thanos meta to each block in the storage.
 	thanosMeta := metadata.Thanos{
 		Labels:     prependLabels.Map(),
@@ -1882,7 +1882,7 @@ func BenchmarkBucketBlock_readChunkRange(b *testing.B) {
 
 	// Upload the block to the bucket.
 	thanosMeta := metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}
@@ -1954,7 +1954,7 @@ func prepareBucket(b *testing.B) (*bucketBlock, *metadata.Meta) {
 
 	// Upload the block to the bucket.
 	thanosMeta := metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1083,11 +1083,11 @@ func TestStoreGateway_Series_QuerySharding(t *testing.T) {
 		ctx    = context.Background()
 		userID = "user-1"
 		series = []labels.Labels{
-			labels.New(labels.Label{Name: labels.MetricName, Value: "series_1"}), // Hash: 12248531033489120077
-			labels.New(labels.Label{Name: labels.MetricName, Value: "series_2"}), // Hash: 4624373102974193462
-			labels.New(labels.Label{Name: labels.MetricName, Value: "series_3"}), // Hash: 11488854180004364397
-			labels.New(labels.Label{Name: labels.MetricName, Value: "series_4"}), // Hash: 7076372709108762848
-			labels.New(labels.Label{Name: labels.MetricName, Value: "series_5"}), // Hash: 2682489904774096023
+			labels.FromStrings(labels.MetricName, "series_1"), // Hash: 12248531033489120077
+			labels.FromStrings(labels.MetricName, "series_2"), // Hash: 4624373102974193462
+			labels.FromStrings(labels.MetricName, "series_3"), // Hash: 11488854180004364397
+			labels.FromStrings(labels.MetricName, "series_4"), // Hash: 7076372709108762848
+			labels.FromStrings(labels.MetricName, "series_5"), // Hash: 2682489904774096023
 		}
 	)
 
@@ -1413,7 +1413,7 @@ func mockTSDB(t *testing.T, dir string, numSeries, numBlocks int, minT, maxT int
 
 	step := (maxT - minT) / int64(numSeries)
 	addSample := func(i int) {
-		lbls := labels.Labels{labels.Label{Name: "series_id", Value: strconv.Itoa(i)}}
+		lbls := labels.FromStrings("series_id", strconv.Itoa(i))
 
 		app := db.Appender(context.Background())
 		_, err := app.Append(0, lbls, minT+(step*int64(i)), float64(i))

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -60,7 +60,7 @@ func TestReaders(t *testing.T) {
 		{{Name: "a", Value: "13"}},
 		{{Name: "a", Value: "1"}, {Name: "longer-string", Value: "1"}},
 		{{Name: "a", Value: "1"}, {Name: "longer-string", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, id1.String()), metadata.NoneFunc))
@@ -87,7 +87,7 @@ func TestReaders(t *testing.T) {
 	test.Copy(t, "./testdata/index_format_v1", filepath.Join(tmpDir, m.ULID.String()))
 
 	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(tmpDir, m.ULID.String()), metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}, &m.BlockMeta)
@@ -331,7 +331,7 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *meta
 	test.Copy(t, "./testdata/index_format_v2", filepath.Join(tmpDir, m.ULID.String()))
 
 	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(tmpDir, m.ULID.String()), metadata.Thanos{
-		Labels:     labels.Labels{{Name: "ext1", Value: "1"}}.Map(),
+		Labels:     labels.FromStrings("ext1", "1").Map(),
 		Downsample: metadata.ThanosDownsample{Resolution: 0},
 		Source:     metadata.TestSource,
 	}, &m.BlockMeta)
@@ -407,11 +407,11 @@ func benchmarkBinaryReaderLookupSymbol(b *testing.B, numSeries int) {
 	// Generate series labels.
 	seriesLabels := make([]labels.Labels, 0, numSeries)
 	for i := 0; i < numSeries; i++ {
-		seriesLabels = append(seriesLabels, labels.Labels{{Name: "a", Value: strconv.Itoa(i)}})
+		seriesLabels = append(seriesLabels, labels.FromStrings("a", strconv.Itoa(i)))
 	}
 
 	// Create a block.
-	id1, err := testhelper.CreateBlock(ctx, tmpDir, seriesLabels, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	id1, err := testhelper.CreateBlock(ctx, tmpDir, seriesLabels, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(b, err)
 	require.NoError(b, block.Upload(ctx, logger, bkt, filepath.Join(tmpDir, id1.String()), metadata.NoneFunc))
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -57,7 +57,7 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -98,7 +98,7 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -138,7 +138,7 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -190,7 +190,7 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -241,7 +241,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -56,7 +56,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 
@@ -94,7 +94,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
 		{{Name: "a", Value: "1"}},
 		{{Name: "a", Value: "2"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "1"}}, 124, metadata.NoneFunc)
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
 


### PR DESCRIPTION
#### What this PR does

Use `labels.FromString` abstraction instead of assuming `labels.Labels` is a slice that we can construct directly. This will allow flexibility in the implementation.

All but one of the changes are in tests; none are performance-sensitive.

Similar PR upstream: https://github.com/prometheus/prometheus/pull/11048

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-visible.
