### PR TITLE
ruler: Clean up tests a bit

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -289,7 +289,7 @@ func newRuler(cfg Config, manager MultiTenantManager, reg prometheus.Registerer,
 		return nil, errors.Wrap(err, "create KV store client")
 	}
 
-	if err = enableSharding(ruler, ringStore); err != nil {
+	if err := enableSharding(ruler, ringStore); err != nil {
 		return nil, errors.Wrap(err, "setup ruler sharding ring")
 	}
 


### PR DESCRIPTION
#### What this PR does
Clean up the ruler tests a bit, such as making sure that arguments to `(require|assert).Equal` are in the right order (expectation first).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
