### PR TITLE
Adds highest number of inflight object storage requests

### DIFF
--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -1023,7 +1023,15 @@
                         "expr": "sum(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"alertmanager-storage\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Total",
+                        "legendFormat": "total",
+                        "legendLink": null,
+                        "step": 10
+                     },
+                     {
+                        "expr": "max(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"alertmanager-storage\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "highest",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -1568,7 +1568,15 @@
                         "expr": "sum(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"compactor\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Total",
+                        "legendFormat": "total",
+                        "legendLink": null,
+                        "step": 10
+                     },
+                     {
+                        "expr": "max(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"compactor\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "highest",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -3384,7 +3384,15 @@
                         "expr": "sum(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"store-gateway\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Total",
+                        "legendFormat": "total",
+                        "legendLink": null,
+                        "step": 10
+                     },
+                     {
+                        "expr": "max(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"store-gateway\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "highest",
                         "legendLink": null,
                         "step": 10
                      }
@@ -4200,7 +4208,15 @@
                         "expr": "sum(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"querier\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Total",
+                        "legendFormat": "total",
+                        "legendLink": null,
+                        "step": 10
+                     },
+                     {
+                        "expr": "max(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"querier\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "highest",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -2126,7 +2126,15 @@
                         "expr": "sum(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"ruler-storage\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Total",
+                        "legendFormat": "total",
+                        "legendLink": null,
+                        "step": 10
+                     },
+                     {
+                        "expr": "max(cortex_bucket_stores_gate_queries_in_flight{cluster=~\"$cluster\", namespace=~\"$namespace\", component=\"ruler-storage\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "highest",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -597,7 +597,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addPanel(
       $.panel('Inflight requests') +
-      $.queryPanel('sum(cortex_bucket_stores_gate_queries_in_flight{%s, component="%s"})' % [$.namespaceMatcher(), component], 'Total')
+      $.queryPanel(
+        [
+          'sum(cortex_bucket_stores_gate_queries_in_flight{%s, component="%s"})' % [$.namespaceMatcher(), component],
+          'max(cortex_bucket_stores_gate_queries_in_flight{%s, component="%s"})' % [$.namespaceMatcher(), component],
+        ],
+        [
+          'total',
+          'highest',
+        ]
+      )
     ),
     $.row('')
     .addPanel(


### PR DESCRIPTION
In addition to the total number of inflight requests to object storage, show the highest number of inflight requests for an instance of the given component (store-gateway, compactor, etc.).

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
