### PR TITLE
Release: fix create release scripts when publishing a stable release

### DIFF
--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -9,7 +9,7 @@ set -e
 check_required_setup() {
   # Ensure "gh" tool is installed.
   if ! command -v gh &> /dev/null; then
-    echo "The 'gh' command cannot be found. Please install it: https://cli.github.com"
+    echo "The 'gh' command cannot be found. Please install it: https://cli.github.com" > /dev/stderr
     exit 1
   fi
 
@@ -23,10 +23,10 @@ check_required_setup() {
 }
 
 find_last_release() {
-  LAST_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | sort -V | tail -1)
+  LAST_RELEASE_TAG=$(git tag --list --sort=taggerdate 'mimir-[0-9]*' | tail -1)
 
   if [ -z "${LAST_RELEASE_TAG}" ]; then
-    echo "Unable to find the last release git tag"
+    echo "Unable to find the last release git tag" > /dev/stderr
     exit 1
   fi
 
@@ -38,11 +38,19 @@ find_last_release() {
   export LAST_RELEASE_VERSION
 }
 
+# Find the previous release. If the last release is a stable release then it only takes in account stable releases
+# (the previous release of a stable release must be another stable release).
 find_prev_release() {
-  PREV_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | sort -V | tail -2 | head -1)
+  find_last_release
+
+  if [[ $LAST_RELEASE_VERSION =~ "-rc" ]]; then
+    PREV_RELEASE_TAG=$(git tag --list --sort=taggerdate 'mimir-[0-9]*' | tail -2 | head -1)
+  else
+    PREV_RELEASE_TAG=$(git tag --list --sort=taggerdate 'mimir-[0-9]*' | grep -v -- '-rc' | tail -2 | head -1)
+  fi
 
   if [ -z "${PREV_RELEASE_TAG}" ]; then
-    echo "Unable to find the previous release git tag"
+    echo "Unable to find the previous release git tag" > /dev/stderr
     exit 1
   fi
 

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -52,14 +52,14 @@ fi
 CHANGELOG_SECTION_TITLE="## ${LAST_RELEASE_VERSION}"
 CHANGELOG_BEGIN_LINE=$(awk "/^${CHANGELOG_SECTION_TITLE}$/{ print NR; exit }" "${CHANGELOG_PATH}")
 if [ -z "${CHANGELOG_BEGIN_LINE}" ]; then
-  echo "Unable to find the section title '${CHANGELOG_SECTION_TITLE}' in the ${CHANGELOG_PATH}"
+  echo "Unable to find the section title '${CHANGELOG_SECTION_TITLE}' in the ${CHANGELOG_PATH}" > /dev/stderr
   exit 1
 fi
 
 # Find the line at which the CHANGELOG for this version ends.
 CHANGELOG_END_LINE=$(tail -n +$((CHANGELOG_BEGIN_LINE + 1)) "${CHANGELOG_PATH}" | awk "/^## /{ print NR - 1; exit }")
 if [ -z "${CHANGELOG_END_LINE}" ]; then
-  echo "Unable to find the end of the section '${CHANGELOG_SECTION_TITLE}' in the ${CHANGELOG_PATH}"
+  echo "Unable to find the end of the section '${CHANGELOG_SECTION_TITLE}' in the ${CHANGELOG_PATH}" > /dev/stderr
   exit 1
 fi
 

--- a/tools/release/create-draft-release.sh
+++ b/tools/release/create-draft-release.sh
@@ -9,7 +9,6 @@ CURR_DIR="$(dirname "$0")"
 
 check_required_setup
 find_last_release
-find_prev_release
 
 # Build binaries and packages.
 echo "Building binaries (this may take a while)..."

--- a/tools/release/tag-release.sh
+++ b/tools/release/tag-release.sh
@@ -12,7 +12,7 @@ check_required_setup
 # Ensure the current branch is a release one.
 BRANCH=$(git branch --show-current)
 if [[ ! $BRANCH =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
-  echo "The current branch '${BRANCH}' is not a release branch."
+  echo "The current branch '${BRANCH}' is not a release branch." > /dev/stderr
   exit 1
 fi
 
@@ -22,7 +22,7 @@ BRANCH_VERSION=${BASH_REMATCH[1]}
 # Load the version and ensure it matches.
 ACTUAL_VERSION=$(cat VERSION)
 if [[ ! $ACTUAL_VERSION =~ ^$BRANCH_VERSION ]]; then
-  echo "The current branch '${BRANCH}' doesn't match the content of the VERSION file '${ACTUAL_VERSION}'"
+  echo "The current branch '${BRANCH}' doesn't match the content of the VERSION file '${ACTUAL_VERSION}'" > /dev/stderr
   exit 1
 fi
 
@@ -30,7 +30,7 @@ fi
 read -p "You're about to tag the version '${ACTUAL_VERSION}'. Do you want to continue? (y/n) " -n 1 -r
 echo ""
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Aborting ..."
+    echo "Aborting ..." > /dev/stderr
     exit 1
 fi
 


### PR DESCRIPTION
#### What this PR does
I just published Mimir 2.4.0 stable release (🎉 ) and I've found few issues with the release scripts when doing the stable release:
1. When comparing releases, we need to compare with the previous stable release (skipping candidate releases)
2. The sorting of release tags is not correct when using `sort -V`. I switched to `git tag --list --sort=taggerdate` which fixes it.
3. `tools/release/create-draft-release.sh` calls `tools/release/create-draft-release-notes.sh > /file.txt` so if error messages are sent to stdout they will not be visible in the console. I redirected all error messages to stderr instead.

The Mimir 2.4.0 release has been published with these updated scripts.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
