### PR TITLE
mimirpb: use jsonutil point marshal functions

### DIFF
--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/jsonutil"
 
 	"github.com/grafana/mimir/pkg/util"
 )
@@ -239,9 +240,9 @@ func SampleJsoniterEncode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	}
 
 	stream.WriteArrayStart()
-	marshalTimestamp(sample.TimestampMs, stream)
+	jsonutil.MarshalTimestamp(sample.TimestampMs, stream)
 	stream.WriteMore()
-	marshalValue(sample.Value, stream)
+	jsonutil.MarshalValue(sample.Value, stream)
 	stream.WriteArrayEnd()
 }
 
@@ -279,45 +280,6 @@ func SampleJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 		TimestampMs: int64(t),
 		Value:       v,
 	}
-}
-
-func marshalTimestamp(t int64, stm *jsoniter.Stream) {
-	// Write out the timestamp as a float divided by 1000.
-	// This is ~3x faster than converting to a float.
-	if t < 0 {
-		stm.WriteRaw(`-`)
-		t = -t
-	}
-	stm.WriteInt64(t / 1000)
-	fraction := t % 1000
-	if fraction != 0 {
-		stm.WriteRaw(`.`)
-		if fraction < 100 {
-			stm.WriteRaw(`0`)
-		}
-		if fraction < 10 {
-			stm.WriteRaw(`0`)
-		}
-		stm.WriteInt64(fraction)
-	}
-}
-
-func marshalValue(v float64, stm *jsoniter.Stream) {
-	stm.WriteRaw(`"`)
-	// Taken from https://github.com/json-iterator/go/blob/master/stream_float.go#L71 as a workaround
-	// to https://github.com/json-iterator/go/issues/365 (jsoniter, to follow json standard, doesn't allow inf/nan).
-	buf := stm.Buffer()
-	abs := math.Abs(v)
-	format := byte('f')
-	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
-	if abs != 0 {
-		if abs < 1e-6 || abs >= 1e21 {
-			format = 'e'
-		}
-	}
-	buf = strconv.AppendFloat(buf, v, format, -1, 64)
-	stm.SetBuffer(buf)
-	stm.WriteRaw(`"`)
 }
 
 func init() {


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This is a follow up PR for https://github.com/grafana/mimir/pull/2450

Replace custom point marshaling functions with the ones exposed in Prometheus `jsonutil` package. 

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
