### PR TITLE
Align the `-server.http-write-timeout` with `-querier.timeout` to 2m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309
 * [ENHANCEMENT] Add experimental flag `-shutdown-delay` to allow components to wait after receiving SIGTERM and before stopping. In this time the component returns 503 from /ready endpoint. #3298
+* [ENHANCEMENT] Align the `-server.http-write-timeout` with `-querier.timeout` to 2m. #3346
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Flag `-azure.msi-resource` is now ignored, and will be removed in Mimir 2.7. This setting is now made automatically by Azure. #2682
 * [CHANGE] Experimental flag `-blocks-storage.tsdb.out-of-order-capacity-min` has been removed. #3261
 * [CHANGE] Distributor: Wrap errors from pushing to ingesters with useful context, for example clarifying timeouts. #3307
+* [CHANGE] The default value of `-server.http-write-timeout` has changed from 30s to 2m. #3346
 * [FEATURE] Alertmanager: added Discord support. #3309
 * [ENHANCEMENT] Added `<prefix>.tls-min-version` and `<prefix>.tls-cipher-suites` flags to configure cipher suites and min TLS version supported by servers. #2898
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
@@ -20,7 +21,6 @@
 * [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309
 * [ENHANCEMENT] Add experimental flag `-shutdown-delay` to allow components to wait after receiving SIGTERM and before stopping. In this time the component returns 503 from /ready endpoint. #3298
-* [CHANGE] The default value of `-server.http-write-timeout` has changed from 30s to 2m. #3346
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309
 * [ENHANCEMENT] Add experimental flag `-shutdown-delay` to allow components to wait after receiving SIGTERM and before stopping. In this time the component returns 503 from /ready endpoint. #3298
-* [ENHANCEMENT] Align the `-server.http-write-timeout` with `-querier.timeout` to 2m. #3346
+* [CHANGE] The default value of `-server.http-write-timeout` has changed from 30s to 2m. #3346
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -346,7 +346,7 @@
           "required": false,
           "desc": "Write timeout for HTTP server",
           "fieldValue": null,
-          "fieldDefaultValue": 30000000000,
+          "fieldDefaultValue": 120000000000,
           "fieldFlag": "server.http-write-timeout",
           "fieldType": "duration",
           "fieldCategory": "advanced"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1854,7 +1854,7 @@ Usage of ./cmd/mimir/mimir:
   -server.http-tls-key-path string
     	HTTP server key path.
   -server.http-write-timeout duration
-    	Write timeout for HTTP server (default 30s)
+    	Write timeout for HTTP server (default 2m0s)
   -server.log-request-at-info-level-enabled
     	Optionally log requests at info level instead of debug level.
   -server.log-source-ips-enabled

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -369,7 +369,7 @@ grpc_tls_config:
 
 # (advanced) Write timeout for HTTP server
 # CLI flag: -server.http-write-timeout
-[http_server_write_timeout: <duration> | default = 30s]
+[http_server_write_timeout: <duration> | default = 2m]
 
 # (advanced) Idle timeout for HTTP server
 # CLI flag: -server.http-idle-timeout

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -222,7 +222,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.Distributor.Validate(c.LimitsConfig); err != nil {
 		return errors.Wrap(err, "invalid distributor config")
 	}
-	if err := c.Querier.Validate(); err != nil {
+	if err := c.Querier.Validate(c.Server.HTTPServerWriteTimeout); err != nil {
 		return errors.Wrap(err, "invalid querier config")
 	}
 	if err := c.IngesterClient.Validate(log); err != nil {

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -484,6 +484,7 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 	c.Server.RegisterFlags(throwaway)
 
 	defaultsOverrides := map[string]string{
+		"server.http-write-timeout":                         "2m",
 		"server.grpc.keepalive.min-time-between-pings":      "10s",
 		"server.grpc.keepalive.ping-without-stream-allowed": "true",
 		"server.http-listen-port":                           "8080",

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -222,8 +222,12 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.Distributor.Validate(c.LimitsConfig); err != nil {
 		return errors.Wrap(err, "invalid distributor config")
 	}
-	if err := c.Querier.Validate(c.Server.HTTPServerWriteTimeout); err != nil {
+	if err := c.Querier.Validate(); err != nil {
 		return errors.Wrap(err, "invalid querier config")
+	}
+	if c.Querier.EngineConfig.Timeout > c.Server.HTTPServerWriteTimeout {
+		return fmt.Errorf("querier timeout (%s) must be lower than HTTP server write timeout (%s)",
+			c.Querier.EngineConfig.Timeout, c.Server.HTTPServerWriteTimeout)
 	}
 	if err := c.IngesterClient.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid ingester_client config")

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -226,7 +226,7 @@ func (c *Config) Validate(log log.Logger) error {
 		return errors.Wrap(err, "invalid querier config")
 	}
 	if c.Querier.EngineConfig.Timeout > c.Server.HTTPServerWriteTimeout {
-		return fmt.Errorf("querier timeout (%s) must be lower than HTTP server write timeout (%s)",
+		return fmt.Errorf("querier timeout (%s) must be lower than or equal to HTTP server write timeout (%s)",
 			c.Querier.EngineConfig.Timeout, c.Server.HTTPServerWriteTimeout)
 	}
 	if err := c.IngesterClient.Validate(log); err != nil {

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -397,6 +397,17 @@ func TestConfigValidation(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			name: "should fail if querier timeout is bigger than http server timeout",
+			getTestConfig: func() *Config {
+				cfg := newDefaultConfig()
+				_ = cfg.Target.Set("all,alertmanager")
+				cfg.Querier.EngineConfig.Timeout = cfg.Server.HTTPServerWriteTimeout + time.Second
+
+				return cfg
+			},
+			expectAnyError: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.getTestConfig().Validate(nil)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -79,16 +79,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // Validate the config
-func (cfg *Config) Validate(httpServerWriteTimeout time.Duration) error {
+func (cfg *Config) Validate() error {
 	// Ensure the config wont create a situation where no queriers are returned.
 	if cfg.QueryIngestersWithin != 0 && cfg.QueryStoreAfter != 0 {
 		if cfg.QueryStoreAfter >= cfg.QueryIngestersWithin {
 			return errBadLookbackConfigs
 		}
-	}
-
-	if cfg.EngineConfig.Timeout > httpServerWriteTimeout {
-		return fmt.Errorf("querier timeout (%s) must be lower than HTTP server write timeout (%s)", cfg.EngineConfig.Timeout, httpServerWriteTimeout)
 	}
 
 	return nil

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -79,12 +79,16 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // Validate the config
-func (cfg *Config) Validate() error {
+func (cfg *Config) Validate(httpServerWriteTimeout time.Duration) error {
 	// Ensure the config wont create a situation where no queriers are returned.
 	if cfg.QueryIngestersWithin != 0 && cfg.QueryStoreAfter != 0 {
 		if cfg.QueryStoreAfter >= cfg.QueryIngestersWithin {
 			return errBadLookbackConfigs
 		}
+	}
+
+	if cfg.EngineConfig.Timeout > httpServerWriteTimeout {
+		return fmt.Errorf("querier timeout (%s) must be lower than HTTP server write timeout (%s)", cfg.EngineConfig.Timeout, httpServerWriteTimeout)
 	}
 
 	return nil

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1035,9 +1035,10 @@ func TestStoreQueryable(t *testing.T) {
 }
 
 func TestConfig_Validate(t *testing.T) {
+	httpServerTimeout := 2 * time.Minute
 	tests := map[string]struct {
 		setup    func(cfg *Config)
-		expected error
+		expected string
 	}{
 		"should pass with default config": {
 			setup: func(cfg *Config) {},
@@ -1058,7 +1059,13 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.QueryStoreAfter = 3 * time.Hour
 				cfg.QueryIngestersWithin = 2 * time.Hour
 			},
-			expected: errBadLookbackConfigs,
+			expected: errBadLookbackConfigs.Error(),
+		},
+		"should fail if querier timeout is bigger than http server timeout": {
+			setup: func(cfg *Config) {
+				cfg.EngineConfig.Timeout = httpServerTimeout + time.Second
+			},
+			expected: "querier timeout (2m1s) must be lower than HTTP server write timeout (2m0s)",
 		},
 	}
 
@@ -1067,8 +1074,11 @@ func TestConfig_Validate(t *testing.T) {
 			cfg := &Config{}
 			flagext.DefaultValues(cfg)
 			testData.setup(cfg)
-
-			assert.Equal(t, testData.expected, cfg.Validate())
+			if testData.expected == "" {
+				assert.NoError(t, cfg.Validate(httpServerTimeout))
+			} else {
+				assert.ErrorContains(t, cfg.Validate(httpServerTimeout), testData.expected)
+			}
 		})
 	}
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1035,10 +1035,9 @@ func TestStoreQueryable(t *testing.T) {
 }
 
 func TestConfig_Validate(t *testing.T) {
-	httpServerTimeout := 2 * time.Minute
 	tests := map[string]struct {
 		setup    func(cfg *Config)
-		expected string
+		expected error
 	}{
 		"should pass with default config": {
 			setup: func(cfg *Config) {},
@@ -1059,13 +1058,7 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.QueryStoreAfter = 3 * time.Hour
 				cfg.QueryIngestersWithin = 2 * time.Hour
 			},
-			expected: errBadLookbackConfigs.Error(),
-		},
-		"should fail if querier timeout is bigger than http server timeout": {
-			setup: func(cfg *Config) {
-				cfg.EngineConfig.Timeout = httpServerTimeout + time.Second
-			},
-			expected: "querier timeout (2m1s) must be lower than HTTP server write timeout (2m0s)",
+			expected: errBadLookbackConfigs,
 		},
 	}
 
@@ -1074,11 +1067,7 @@ func TestConfig_Validate(t *testing.T) {
 			cfg := &Config{}
 			flagext.DefaultValues(cfg)
 			testData.setup(cfg)
-			if testData.expected == "" {
-				assert.NoError(t, cfg.Validate(httpServerTimeout))
-			} else {
-				assert.ErrorContains(t, cfg.Validate(httpServerTimeout), testData.expected)
-			}
+			assert.Equal(t, testData.expected, cfg.Validate())
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Align the `-server.http-write-timeout` with `-querier.timeout` to 2m. Add validation for these values.
#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/3248

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
