### PR TITLE
Release: add Mimir 2.4.0 to backward compatibility tests

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,4 +11,5 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.1.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 	"grafana/mimir:2.2.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 	"grafana/mimir:2.3.1": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
+	"grafana/mimir:2.4.0": nil,
 }

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,5 +11,5 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.1.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 	"grafana/mimir:2.2.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 	"grafana/mimir:2.3.1": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-	"grafana/mimir:2.4.0": nil,
+	"grafana/mimir:2.4.0": e2emimir.NoopFlagMapper,
 }


### PR DESCRIPTION
#### What this PR does
Last week we published Mimir 2.4.0 stable. In this PR I'm adding it to the backward compatibility tests.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
