### PR TITLE
Release: propose date for Mimir 2.6.0 release candidate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@ A new Grafana Mimir release is cut approximately every 6 weeks. The following ta
 | 2.3.0   | 2022-08-08 | Tyler Reid        |
 | 2.4.0   | 2022-10-10 | Marco Pracucci    |
 | 2.5.0   | 2022-11-28 | _To be announced_ |
+| 2.6.0   | 2023-01-16 | _To be announced_ |
 
 ## Release shepherd responsibilities
 


### PR DESCRIPTION
#### What this PR does
We plan to publish 2.5.0 release candidate on 28th Nov. That date + 6 weeks would be Jan 9th. Since there are some holidays in between, which will slow down a bit Mimir development, I propose to add +1 week before cutting 2.6.0, so Jan 16th.

WDYT?

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
