### PR TITLE
We need larger user indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Jsonnet
 
 * [ENHANCEMENT] Update `rollout-operator` to `v0.2.0`. #3624
+* [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 
 ### Mimirtool
 
@@ -144,7 +145,6 @@
 * [ENHANCEMENT] The query-tee node port (`$._config.query_tee_node_port`) is now optional. #3272
 * [ENHANCEMENT] Add support for autoscaling distributors. #3378
 * [ENHANCEMENT] Make auto-scaling logic ensure integer KEDA thresholds. #3512
-* [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237 #3239
 * [BUGFIX] Jsonnet: Fix auto-scaling so that ruler-querier CPU threshold is a string-encoded integer millicores value. #3520
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 * [ENHANCEMENT] The query-tee node port (`$._config.query_tee_node_port`) is now optional. #3272
 * [ENHANCEMENT] Add support for autoscaling distributors. #3378
 * [ENHANCEMENT] Make auto-scaling logic ensure integer KEDA thresholds. #3512
+* [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237 #3239
 * [BUGFIX] Jsonnet: Fix auto-scaling so that ruler-querier CPU threshold is a string-encoded integer millicores value. #3520
 

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -389,7 +389,7 @@
         compactor_split_groups: 2,
       },
 
-      gigantic_user+:: {
+      user_24M+:: {
         max_global_series_per_user: 24000000,  // 24M
         max_global_metadata_per_user: std.ceil(self.max_global_series_per_user * 0.2),
         max_global_metadata_per_metric: 10,
@@ -406,7 +406,7 @@
         compactor_split_groups: 4,
       },
 
-      jumbo_user+:: {
+      user_32M+:: {
         max_global_series_per_user: 32000000,  // 32M
         max_global_metadata_per_user: std.ceil(self.max_global_series_per_user * 0.2),
         max_global_metadata_per_metric: 10,

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -388,6 +388,40 @@
         compactor_tenant_shard_size: 2,
         compactor_split_groups: 2,
       },
+
+      gigantic_user+:: {
+        max_global_series_per_user: 24000000,  // 24M
+        max_global_metadata_per_user: std.ceil(self.max_global_series_per_user * 0.2),
+        max_global_metadata_per_metric: 10,
+
+        ingestion_rate: 3500000,  // 3.5M
+        ingestion_burst_size: 35000000,  // 35M
+
+        // 3500 rules
+        ruler_max_rules_per_rule_group: 20,
+        ruler_max_rule_groups_per_tenant: 175,
+
+        compactor_split_and_merge_shards: 4,
+        compactor_tenant_shard_size: 4,
+        compactor_split_groups: 4,
+      },
+
+      jumbo_user+:: {
+        max_global_series_per_user: 32000000,  // 32M
+        max_global_metadata_per_user: std.ceil(self.max_global_series_per_user * 0.2),
+        max_global_metadata_per_metric: 10,
+
+        ingestion_rate: 4500000,  // 4.5M
+        ingestion_burst_size: 45000000,  // 45M
+
+        // 4000 rules
+        ruler_max_rules_per_rule_group: 20,
+        ruler_max_rule_groups_per_tenant: 200,
+
+        compactor_split_and_merge_shards: 4,
+        compactor_tenant_shard_size: 4,
+        compactor_split_groups: 8,
+      },
     },
 
     // if not empty, passed to overrides.yaml as another top-level field

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -16,6 +16,8 @@
       'big_user',
       'super_user',
       'mega_user',
+      'gigantic_user',
+      'jumbo_user',
     ],
   },
 

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -16,8 +16,8 @@
       'big_user',
       'super_user',
       'mega_user',
-      'gigantic_user',
-      'jumbo_user',
+      'user_24M',
+      'user_32M',
     ],
   },
 

--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -76,6 +76,20 @@
         store_gateway_tenant_shard_size: 24,
         ruler_tenant_shard_size: 8,
       },
+
+      // Target 24M active series.
+      gigantic_user+:: {
+        ingestion_tenant_shard_size: 360,
+        store_gateway_tenant_shard_size: 30,
+        ruler_tenant_shard_size: 8,
+      },
+
+      // Target 32M active series.
+      jumbo_user+:: {
+        ingestion_tenant_shard_size: 480,
+        store_gateway_tenant_shard_size: 42,
+        ruler_tenant_shard_size: 12,
+      },
     },
   },
 

--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -78,14 +78,14 @@
       },
 
       // Target 24M active series.
-      gigantic_user+:: {
+      user_24M+:: {
         ingestion_tenant_shard_size: 360,
         store_gateway_tenant_shard_size: 30,
         ruler_tenant_shard_size: 8,
       },
 
       // Target 32M active series.
-      jumbo_user+:: {
+      user_32M+:: {
         ingestion_tenant_shard_size: 480,
         store_gateway_tenant_shard_size: 42,
         ruler_tenant_shard_size: 12,


### PR DESCRIPTION
#### What this PR does
We scale past mega_user on a regular basis. We should give massive users an indicator of potential config that can be useful as they user higher AS counts. This is for non-insane-cardinality-users, just a large count of active series and accompanied growth.

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
