### PR TITLE
Clarify changelog and remove duplicate flag in the documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [CHANGE] Experimental flag `-blocks-storage.tsdb.out-of-order-capacity-min` has been removed. #3261
 * [CHANGE] Distributor: Wrap errors from pushing to ingesters with useful context, for example clarifying timeouts. #3307
 * [FEATURE] Alertmanager: added Discord support. #3309
-* [ENHANCEMENT] Added `<prefix>.tls-min-version` and `<prefix>.tls-cipher-suites` flags to configure cipher suites and min TLS version supported by servers. #2898
+* [ENHANCEMENT] Added `-server.tls-min-version` and `-server.tls-cipher-suites` flags to configure cipher suites and min TLS version supported by HTTP and gRPC servers. #2898
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172

--- a/docs/sources/operators-guide/secure/securing-communications-with-tls.md
+++ b/docs/sources/operators-guide/secure/securing-communications-with-tls.md
@@ -116,9 +116,6 @@ In the following example, both of the server authorization flags, `-server.http-
 
     # Path to the Client CA Cert for the gRPC Server
     -server.grpc-tls-ca-path=/path/to/root.crt
-
-    # Path to the Client CA Cert for the gRPC Server
-    -server.grpc-tls-ca-path=/path/to/root.crt
 ```
 
 #### Client flags


### PR DESCRIPTION
This PR updates changelog to clarify new TLS server-side flags. It also removes duplicate flag in the documentation.

Ref: https://github.com/grafana/mimir/pull/2898/files#r1010509253