### PR TITLE
Build: Upgrade to Go 1.19.3

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.2'
+        go-version: '1.19.3'
     - uses: helm/kind-action@v1.2.0
     - uses: frenck/action-setup-yq@a2ad11c46c5d7ba576861216963c9365b53f35bc
     - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -134,7 +134,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -176,7 +176,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.2
+          go-version: 1.19.3
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Docker Client
@@ -220,7 +220,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-1.19.2-e84f42bcd
+      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309
 * [ENHANCEMENT] Add experimental flag `-shutdown-delay` to allow components to wait after receiving SIGTERM and before stopping. In this time the component returns 503 from /ready endpoint. #3298
+* [ENHANCEMENT] Go: update to go 1.19.3. #3371
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= update-go-1.19.2-e84f42bcd
+LATEST_BUILD_IMAGE_TAG ?= chore-upgrade-go-036177f2f
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2
+FROM golang:1.19.3
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.8.2 as helm
-FROM golang:1.19.2-bullseye
+FROM golang:1.19.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev skopeo && \


### PR DESCRIPTION
#### What this PR does
Upgrade to Go [1.19.3](https://go.dev/doc/devel/release#go1.19.3), which is a security release.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
