### PR TITLE
WIP: Prototype exposing S3 SSE-C configuration

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3387,6 +3387,15 @@
         },
         {
           "kind": "field",
+          "name": "s3_sse_encryption_key_path",
+          "required": false,
+          "desc": "S3 server-side encryption encryption key path for the key used with SSE-C. Ignored if the SSE type override is not set.",
+          "fieldValue": null,
+          "fieldDefaultValue": "",
+          "fieldType": "string"
+        },
+        {
+          "kind": "field",
           "name": "alertmanager_receivers_firewall_block_cidr_networks",
           "required": false,
           "desc": "Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.",
@@ -4443,12 +4452,12 @@
                 },
                 {
                   "kind": "field",
-                  "name": "encryption_key",
+                  "name": "encryption_key_path",
                   "required": false,
-                  "desc": "File name for the file containing the SSE-C key in bytes.",
+                  "desc": "File path for the file containing the SSE-C key in bytes.",
                   "fieldValue": null,
                   "fieldDefaultValue": "",
-                  "fieldFlag": "blocks-storage.s3.sse.encryption-key",
+                  "fieldFlag": "blocks-storage.s3.sse.encryption-key-path",
                   "fieldType": "string"
                 }
               ],
@@ -8388,12 +8397,12 @@
                 },
                 {
                   "kind": "field",
-                  "name": "encryption_key",
+                  "name": "encryption_key_path",
                   "required": false,
-                  "desc": "File name for the file containing the SSE-C key in bytes.",
+                  "desc": "File path for the file containing the SSE-C key in bytes.",
                   "fieldValue": null,
                   "fieldDefaultValue": "",
-                  "fieldFlag": "ruler-storage.s3.sse.encryption-key",
+                  "fieldFlag": "ruler-storage.s3.sse.encryption-key-path",
                   "fieldType": "string"
                 }
               ],
@@ -9761,12 +9770,12 @@
                 },
                 {
                   "kind": "field",
-                  "name": "encryption_key",
+                  "name": "encryption_key_path",
                   "required": false,
-                  "desc": "File name for the file containing the SSE-C key in bytes.",
+                  "desc": "File path for the file containing the SSE-C key in bytes.",
                   "fieldValue": null,
                   "fieldDefaultValue": "",
-                  "fieldFlag": "alertmanager-storage.s3.sse.encryption-key",
+                  "fieldFlag": "alertmanager-storage.s3.sse.encryption-key-path",
                   "fieldType": "string"
                 }
               ],
@@ -11471,12 +11480,12 @@
                     },
                     {
                       "kind": "field",
-                      "name": "encryption_key",
+                      "name": "encryption_key_path",
                       "required": false,
-                      "desc": "File name for the file containing the SSE-C key in bytes.",
+                      "desc": "File path for the file containing the SSE-C key in bytes.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "common.storage.s3.sse.encryption-key",
+                      "fieldFlag": "common.storage.s3.sse.encryption-key-path",
                       "fieldType": "string"
                     }
                   ],

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4415,7 +4415,7 @@
                   "kind": "field",
                   "name": "type",
                   "required": false,
-                  "desc": "Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.",
+                  "desc": "Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.",
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "blocks-storage.s3.sse.type",
@@ -4439,6 +4439,16 @@
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "blocks-storage.s3.sse.kms-encryption-context",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "encryption_key",
+                  "required": false,
+                  "desc": "File name for the file containing the SSE-C key in bytes.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "blocks-storage.s3.sse.encryption-key",
                   "fieldType": "string"
                 }
               ],
@@ -8350,7 +8360,7 @@
                   "kind": "field",
                   "name": "type",
                   "required": false,
-                  "desc": "Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.",
+                  "desc": "Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.",
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "ruler-storage.s3.sse.type",
@@ -8374,6 +8384,16 @@
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "ruler-storage.s3.sse.kms-encryption-context",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "encryption_key",
+                  "required": false,
+                  "desc": "File name for the file containing the SSE-C key in bytes.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "ruler-storage.s3.sse.encryption-key",
                   "fieldType": "string"
                 }
               ],
@@ -9713,7 +9733,7 @@
                   "kind": "field",
                   "name": "type",
                   "required": false,
-                  "desc": "Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.",
+                  "desc": "Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.",
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "alertmanager-storage.s3.sse.type",
@@ -9737,6 +9757,16 @@
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "alertmanager-storage.s3.sse.kms-encryption-context",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "encryption_key",
+                  "required": false,
+                  "desc": "File name for the file containing the SSE-C key in bytes.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "alertmanager-storage.s3.sse.encryption-key",
                   "fieldType": "string"
                 }
               ],
@@ -11413,7 +11443,7 @@
                       "kind": "field",
                       "name": "type",
                       "required": false,
-                      "desc": "Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.",
+                      "desc": "Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
                       "fieldFlag": "common.storage.s3.sse.type",
@@ -11437,6 +11467,16 @@
                       "fieldValue": null,
                       "fieldDefaultValue": "",
                       "fieldFlag": "common.storage.s3.sse.kms-encryption-context",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "encryption_key",
+                      "required": false,
+                      "desc": "File name for the file containing the SSE-C key in bytes.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "common.storage.s3.sse.encryption-key",
                       "fieldType": "string"
                     }
                   ],

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -53,8 +53,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -alertmanager-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
-  -alertmanager-storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -alertmanager-storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -alertmanager-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -alertmanager-storage.s3.sse.kms-key-id string
@@ -435,8 +435,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -blocks-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
-  -blocks-storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -blocks-storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -blocks-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -blocks-storage.s3.sse.kms-key-id string
@@ -571,8 +571,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -common.storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
-  -common.storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -common.storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -common.storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -common.storage.s3.sse.kms-key-id string
@@ -1553,8 +1553,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -ruler-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
-  -ruler-storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -ruler-storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -ruler-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -ruler-storage.s3.sse.kms-key-id string

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -53,12 +53,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -alertmanager-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
+  -alertmanager-storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -alertmanager-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -alertmanager-storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -alertmanager-storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -alertmanager-storage.s3.tls-handshake-timeout duration
     	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
   -alertmanager-storage.storage-prefix string
@@ -433,12 +435,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -blocks-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
+  -blocks-storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -blocks-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -blocks-storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -blocks-storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -blocks-storage.s3.tls-handshake-timeout duration
     	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
   -blocks-storage.storage-prefix string
@@ -567,12 +571,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -common.storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
+  -common.storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -common.storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -common.storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -common.storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -common.storage.s3.tls-handshake-timeout duration
     	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
   -common.storage.swift.auth-url string
@@ -1547,12 +1553,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -ruler-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
+  -ruler-storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -ruler-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -ruler-storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -ruler-storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -ruler-storage.s3.tls-handshake-timeout duration
     	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
   -ruler-storage.storage-prefix string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -29,12 +29,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -alertmanager-storage.s3.secret-access-key string
     	S3 secret access key
+  -alertmanager-storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -alertmanager-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -alertmanager-storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -alertmanager-storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -alertmanager-storage.swift.auth-url string
     	OpenStack Swift authentication URL
   -alertmanager-storage.swift.auth-version int
@@ -153,12 +155,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -blocks-storage.s3.secret-access-key string
     	S3 secret access key
+  -blocks-storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -blocks-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -blocks-storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -blocks-storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -blocks-storage.swift.auth-url string
     	OpenStack Swift authentication URL
   -blocks-storage.swift.auth-version int
@@ -219,12 +223,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -common.storage.s3.secret-access-key string
     	S3 secret access key
+  -common.storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -common.storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -common.storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -common.storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -common.storage.swift.auth-url string
     	OpenStack Swift authentication URL
   -common.storage.swift.auth-version int
@@ -467,12 +473,14 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -ruler-storage.s3.secret-access-key string
     	S3 secret access key
+  -ruler-storage.s3.sse.encryption-key string
+    	File name for the file containing the SSE-C key in bytes.
   -ruler-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -ruler-storage.s3.sse.kms-key-id string
     	KMS Key ID used to encrypt objects in S3
   -ruler-storage.s3.sse.type string
-    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+    	Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   -ruler-storage.swift.auth-url string
     	OpenStack Swift authentication URL
   -ruler-storage.swift.auth-version int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -29,8 +29,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -alertmanager-storage.s3.secret-access-key string
     	S3 secret access key
-  -alertmanager-storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -alertmanager-storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -alertmanager-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -alertmanager-storage.s3.sse.kms-key-id string
@@ -155,8 +155,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -blocks-storage.s3.secret-access-key string
     	S3 secret access key
-  -blocks-storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -blocks-storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -blocks-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -blocks-storage.s3.sse.kms-key-id string
@@ -223,8 +223,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -common.storage.s3.secret-access-key string
     	S3 secret access key
-  -common.storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -common.storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -common.storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -common.storage.s3.sse.kms-key-id string
@@ -473,8 +473,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -ruler-storage.s3.secret-access-key string
     	S3 secret access key
-  -ruler-storage.s3.sse.encryption-key string
-    	File name for the file containing the SSE-C key in bytes.
+  -ruler-storage.s3.sse.encryption-key-path string
+    	File path for the file containing the SSE-C key in bytes.
   -ruler-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -ruler-storage.s3.sse.kms-key-id string

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -3528,7 +3528,7 @@ The s3_backend block configures the connection to Amazon S3 object storage backe
 [signature_version: <string> | default = "v4"]
 
 sse:
-  # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+  # Enable AWS Server Side Encryption. Supported values: SSE-C, SSE-KMS, SSE-S3.
   # CLI flag: -<prefix>.s3.sse.type
   [type: <string> | default = ""]
 
@@ -3540,6 +3540,10 @@ sse:
   # string.
   # CLI flag: -<prefix>.s3.sse.kms-encryption-context
   [kms_encryption_context: <string> | default = ""]
+
+  # File name for the file containing the SSE-C key in bytes.
+  # CLI flag: -<prefix>.s3.sse.encryption-key
+  [encryption_key: <string> | default = ""]
 
 http:
   # (advanced) The time an idle connection will remain idle before closing.

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2654,6 +2654,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # the SSE type override is not set.
 [s3_sse_kms_encryption_context: <string> | default = ""]
 
+# S3 server-side encryption encryption key path for the key used with SSE-C.
+# Ignored if the SSE type override is not set.
+[s3_sse_encryption_key_path: <string> | default = ""]
+
 # Comma-separated list of network CIDRs to block in Alertmanager receiver
 # integrations.
 # CLI flag: -alertmanager.receivers-firewall-block-cidr-networks
@@ -3541,9 +3545,9 @@ sse:
   # CLI flag: -<prefix>.s3.sse.kms-encryption-context
   [kms_encryption_context: <string> | default = ""]
 
-  # File name for the file containing the SSE-C key in bytes.
-  # CLI flag: -<prefix>.s3.sse.encryption-key
-  [encryption_key: <string> | default = ""]
+  # File path for the file containing the SSE-C key in bytes.
+  # CLI flag: -<prefix>.s3.sse.encryption-key-path
+  [encryption_key_path: <string> | default = ""]
 
 http:
   # (advanced) The time an idle connection will remain idle before closing.

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1018,6 +1018,10 @@ func (m *mockConfigProvider) S3SSEKMSEncryptionContext(userID string) string {
 	return ""
 }
 
+func (m *mockConfigProvider) S3SSEEncryptionKeyPath(userID string) string {
+	return ""
+}
+
 func (c *BlocksCleaner) runCleanupWithErr(ctx context.Context) error {
 	allUsers, isDeleted, err := c.refreshOwnedUsers(ctx)
 	if err != nil {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1910,6 +1910,10 @@ func (m *blocksStoreLimitsMock) S3SSEKMSEncryptionContext(_ string) string {
 	return ""
 }
 
+func (m *blocksStoreLimitsMock) S3SSEEncryptionKeyPath(_ string) string {
+	return ""
+}
+
 func mockSeriesResponse(lbls labels.Labels, timeMillis int64, value float64) *storepb.SeriesResponse {
 	return mockSeriesResponseWithSamples(lbls, promql.Point{T: timeMillis, V: value})
 }

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -25,18 +26,22 @@ const (
 	SignatureVersionV4 = "v4"
 	SignatureVersionV2 = "v2"
 
+	// SSE-C config type constant to configure S3 server side encryption using customer keys.
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html
+	SSEC = "SSE-C"
+
 	// SSEKMS config type constant to configure S3 server side encryption using KMS
-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
 	SSEKMS = "SSE-KMS"
 
 	// SSES3 config type constant to configure S3 server side encryption with AES-256
-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html
 	SSES3 = "SSE-S3"
 )
 
 var (
 	supportedSignatureVersions     = []string{SignatureVersionV4, SignatureVersionV2}
-	supportedSSETypes              = []string{SSEKMS, SSES3}
+	supportedSSETypes              = []string{SSEC, SSEKMS, SSES3}
 	errUnsupportedSignatureVersion = fmt.Errorf("unsupported signature version (supported values: %s)", strings.Join(supportedSignatureVersions, ", "))
 	errUnsupportedSSEType          = errors.New("unsupported S3 SSE type")
 	errInvalidSSEContext           = errors.New("invalid S3 SSE encryption context")
@@ -120,6 +125,7 @@ type SSEConfig struct {
 	Type                 string `yaml:"type"`
 	KMSKeyID             string `yaml:"kms_key_id"`
 	KMSEncryptionContext string `yaml:"kms_encryption_context"`
+	EncryptionKey        string `yaml:"encryption_key"`
 }
 
 func (cfg *SSEConfig) RegisterFlags(f *flag.FlagSet) {
@@ -131,6 +137,7 @@ func (cfg *SSEConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Type, prefix+"type", "", fmt.Sprintf("Enable AWS Server Side Encryption. Supported values: %s.", strings.Join(supportedSSETypes, ", ")))
 	f.StringVar(&cfg.KMSKeyID, prefix+"kms-key-id", "", "KMS Key ID used to encrypt objects in S3")
 	f.StringVar(&cfg.KMSEncryptionContext, prefix+"kms-encryption-context", "", "KMS Encryption Context used for object encryption. It expects JSON formatted string.")
+	f.StringVar(&cfg.EncryptionKey, prefix+"encryption-key", "", "File name for the file containing the SSE-C key in bytes.")
 }
 
 func (cfg *SSEConfig) Validate() error {
@@ -150,6 +157,11 @@ func (cfg *SSEConfig) BuildThanosConfig() (s3.SSEConfig, error) {
 	switch cfg.Type {
 	case "":
 		return s3.SSEConfig{}, nil
+	case SSEC:
+		return s3.SSEConfig{
+			Type:          s3.SSEC,
+			EncryptionKey: cfg.EncryptionKey,
+		}, nil
 	case SSEKMS:
 		encryptionCtx, err := parseKMSEncryptionContext(cfg.KMSEncryptionContext)
 		if err != nil {
@@ -175,6 +187,12 @@ func (cfg *SSEConfig) BuildMinioConfig() (encrypt.ServerSide, error) {
 	switch cfg.Type {
 	case "":
 		return nil, nil
+	case SSEC:
+		key, err := os.ReadFile(cfg.EncryptionKey)
+		if err != nil {
+			return nil, err
+		}
+		return encrypt.NewSSEC(key)
 	case SSEKMS:
 		encryptionCtx, err := parseKMSEncryptionContext(cfg.KMSEncryptionContext)
 		if err != nil {

--- a/pkg/storage/bucket/sse_bucket_client.go
+++ b/pkg/storage/bucket/sse_bucket_client.go
@@ -27,6 +27,9 @@ type TenantConfigProvider interface {
 
 	// S3SSEKMSEncryptionContext returns the per-tenant S3 KMS-SSE key id or an empty string if not set.
 	S3SSEKMSEncryptionContext(userID string) string
+
+	// S3SSEEncryptionKeyPath returns the per-tenant S3 SSE-C encryption key path or an empty string if not set.
+	S3SSEEncryptionKeyPath(userID string) string
 }
 
 // SSEBucketClient is a wrapper around a objstore.BucketReader that configures the object
@@ -89,6 +92,7 @@ func (b *SSEBucketClient) getCustomS3SSEConfig() (encrypt.ServerSide, error) {
 		Type:                 sseType,
 		KMSKeyID:             b.cfgProvider.S3SSEKMSKeyID(b.userID),
 		KMSEncryptionContext: b.cfgProvider.S3SSEKMSEncryptionContext(b.userID),
+		EncryptionKeyPath:    b.cfgProvider.S3SSEEncryptionKeyPath(b.userID),
 	}
 
 	sse, err := cfg.BuildMinioConfig()

--- a/pkg/storage/bucket/sse_bucket_client_test.go
+++ b/pkg/storage/bucket/sse_bucket_client_test.go
@@ -114,6 +114,7 @@ type mockTenantConfigProvider struct {
 	s3SseType              string
 	s3KmsKeyID             string
 	s3KmsEncryptionContext string
+	s3EncryptionKeyPath    string
 }
 
 func (m *mockTenantConfigProvider) S3SSEType(_ string) string {
@@ -126,4 +127,8 @@ func (m *mockTenantConfigProvider) S3SSEKMSKeyID(_ string) string {
 
 func (m *mockTenantConfigProvider) S3SSEKMSEncryptionContext(_ string) string {
 	return m.s3KmsEncryptionContext
+}
+
+func (m *mockTenantConfigProvider) S3SSEEncryptionKeyPath(_ string) string {
+	return m.s3EncryptionKeyPath
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -146,6 +146,7 @@ type Limits struct {
 	S3SSEType                 string `yaml:"s3_sse_type" json:"s3_sse_type" doc:"nocli|description=S3 server-side encryption type. Required to enable server-side encryption overrides for a specific tenant. If not set, the default S3 client settings are used."`
 	S3SSEKMSKeyID             string `yaml:"s3_sse_kms_key_id" json:"s3_sse_kms_key_id" doc:"nocli|description=S3 server-side encryption KMS Key ID. Ignored if the SSE type override is not set."`
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
+	S3SSEEncryptionKeyPath    string `yaml:"s3_sse_encryption_key_path" json:"s3_sse_encryption_key_path" doc:"nocli|description=S3 server-side encryption encryption key path for the key used with SSE-C. Ignored if the SSE type override is not set."`
 
 	// Alertmanager.
 	AlertmanagerReceiversBlockCIDRNetworks     flagext.CIDRSliceCSV `yaml:"alertmanager_receivers_firewall_block_cidr_networks" json:"alertmanager_receivers_firewall_block_cidr_networks"`
@@ -637,6 +638,11 @@ func (o *Overrides) S3SSEKMSKeyID(user string) string {
 // S3SSEKMSEncryptionContext returns the per-tenant S3 KMS-SSE encryption context.
 func (o *Overrides) S3SSEKMSEncryptionContext(user string) string {
 	return o.getOverridesForUser(user).S3SSEKMSEncryptionContext
+}
+
+// S3SSEEncryptionKeyPath returns the per-tenant S3 SSE-C encryption key path.
+func (o *Overrides) S3SSEEncryptionKeyPath(user string) string {
+	return o.getOverridesForUser(user).S3SSEEncryptionKeyPath
 }
 
 // AlertmanagerReceiversBlockCIDRNetworks returns the list of network CIDRs that should be blocked


### PR DESCRIPTION
#### What this PR does

Allows configuring [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html) for the S3 client. The configuration provides a file path that is read to derive the key.

TODO:
- [x] Test configuration injection in `sse_bucket_client_test`
- [ ] Look at override behavior more closely
- [ ] Decide if there needs to be helm/jsonnet changes
- [ ] Manual/e2e tests

#### Which issue(s) this PR fixes or relates to

Fixes #3381

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
