### PR TITLE
canonicalize orgid header in forwarding

### DIFF
--- a/pkg/distributor/forwarding/forwarding.go
+++ b/pkg/distributor/forwarding/forwarding.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"strings"
@@ -570,7 +571,7 @@ func (r *request) doHTTPGrpc(ctx context.Context, body []byte) error {
 		Url:    u.Path,
 		Body:   body,
 		Headers: append(headers, &httpgrpc.Header{
-			Key:    user.OrgIDHeaderName,
+			Key:    textproto.CanonicalMIMEHeaderKey(user.OrgIDHeaderName),
 			Values: []string{r.user},
 		}),
 	}

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"strconv"
 	"strings"
 	"sync"
@@ -884,7 +885,7 @@ func TestForwardingToHTTPGrpcTarget(t *testing.T) {
 			if h.Key == "Content-Type" {
 				ct = h.Values[0]
 			}
-			if h.Key == user.OrgIDHeaderName {
+			if h.Key == textproto.CanonicalMIMEHeaderKey(user.OrgIDHeaderName) {
 				us = h.Values[0]
 			}
 		}


### PR DESCRIPTION
the http header needs to be canonicalized for the header lookup to work