### PR TITLE
Chore: remove settings equal to default values from jsonnet tests

### DIFF
--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_remote_evaluation_enabled: true,

--- a/operations/mimir-tests/test-consul-multi-zone.jsonnet
+++ b/operations/mimir-tests/test-consul-multi-zone.jsonnet
@@ -9,10 +9,7 @@ mimir {
     memberlist_ring_enabled: false,
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-consul-ruler-disabled.jsonnet
+++ b/operations/mimir-tests/test-consul-ruler-disabled.jsonnet
@@ -9,10 +9,7 @@ mimir {
     memberlist_ring_enabled: false,
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: false,
 

--- a/operations/mimir-tests/test-consul.jsonnet
+++ b/operations/mimir-tests/test-consul.jsonnet
@@ -9,10 +9,7 @@ mimir {
     memberlist_ring_enabled: false,
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-defaults.jsonnet
+++ b/operations/mimir-tests/test-defaults.jsonnet
@@ -6,7 +6,6 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
   },
 }

--- a/operations/mimir-tests/test-disable-chunk-streaming.jsonnet
+++ b/operations/mimir-tests/test-disable-chunk-streaming.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-extra-runtime-config.jsonnet
+++ b/operations/mimir-tests/test-extra-runtime-config.jsonnet
@@ -5,13 +5,8 @@ mimir {
     namespace: 'default',
     external_url: 'http://test',
 
-    memberlist_ring_enabled: true,
-
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-helm-parity.jsonnet
+++ b/operations/mimir-tests/test-helm-parity.jsonnet
@@ -12,17 +12,15 @@ mimir + overridesExporter {
     ruler_storage_bucket_name: 'example-ruler-bucket',
     alertmanager_enabled: true,
     ruler_enabled: true,
-    memberlist_ring_enabled: true,
     unregister_ingesters_on_shutdown: false,
-    query_scheduler_enabled: true,
     query_sharding_enabled: true,
   },
 
-  # These are properties that are set differently on different components in jsonnet.
-  # We unset them all here so the default values are used like in Helm.
-  # TODO: Once the read-write deployment is stable, we can revisit these settings.
-  # At that point there will likely be less deviation between components.
-  # See the tracking issue: https://github.com/grafana/mimir/issues/2749
+  // These are properties that are set differently on different components in jsonnet.
+  // We unset them all here so the default values are used like in Helm.
+  // TODO: Once the read-write deployment is stable, we can revisit these settings.
+  // At that point there will likely be less deviation between components.
+  // See the tracking issue: https://github.com/grafana/mimir/issues/2749
   querier_args+:: {
     'store.max-query-length': null,
     'server.http-write-timeout': null,

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before.jsonnet
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,6 +15,5 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 0: Memberlist is enabled without any cluster label.
-    memberlist_ring_enabled: true,
   },
 }

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1.jsonnet
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -19,7 +16,6 @@ mimir {
 
     // Step 1: Disable verification of cluster label (becaue during the migration we'll
     // have members both with and without the cluster label set).
-    memberlist_ring_enabled: true,
     memberlist_cluster_label_verification_disabled: true,
   },
 }

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2.jsonnet
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,7 +15,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 2: Set the cluster label.
-    memberlist_ring_enabled: true,
     memberlist_cluster_label: 'my-cluster-label',
     memberlist_cluster_label_verification_disabled: true,
   },

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3.jsonnet
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,7 +15,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 3: Re-enable the cluster label verification.
-    memberlist_ring_enabled: true,
     memberlist_cluster_label: 'my-cluster-label',
     memberlist_cluster_label_verification_disabled: false,
   },

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-memberlist-migration-step-1.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-1.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,7 +15,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 1: start migration from consul to memberlist.
-    memberlist_ring_enabled: true,
     multikv_migration_enabled: true,
   },
 }

--- a/operations/mimir-tests/test-memberlist-migration-step-2.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-2.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,7 +15,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 2: enable mirroring.
-    memberlist_ring_enabled: true,
     multikv_migration_enabled: true,
     multikv_mirror_enabled: true,
   },

--- a/operations/mimir-tests/test-memberlist-migration-step-3.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-3.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,7 +15,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 3: switch primary (consul) and secondary (memberlist), make memberlist primary KV.
-    memberlist_ring_enabled: true,
     multikv_migration_enabled: true,
     multikv_mirror_enabled: true,
     multikv_switch_primary_secondary: true,

--- a/operations/mimir-tests/test-memberlist-migration-step-4.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-4.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,7 +15,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 4: disable mirroring from primary (now memberlist) to secondary (now Consul) KV.
-    memberlist_ring_enabled: true,
     multikv_migration_enabled: true,
     multikv_mirror_enabled: false,
     multikv_switch_primary_secondary: true,

--- a/operations/mimir-tests/test-memberlist-migration-step-5.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-5.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -19,7 +16,6 @@ mimir {
 
     // Step 5: disable migration (ie. use of multi KV), but keep runtime config around for components that haven't restarted yet.
     // Note: this also removes Consul. That's fine, because it's not used anymore (mirroring to it was disabled in step 4).
-    memberlist_ring_enabled: true,
     multikv_migration_enabled: false,
     multikv_mirror_enabled: false,
     multikv_switch_primary_secondary: true,

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final.jsonnet
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -18,6 +15,5 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Step 6: remove all migration options, but keep memberlist ring enabled.
-    memberlist_ring_enabled: true,
   },
 }

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration.jsonnet
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-multi-zone.jsonnet
+++ b/operations/mimir-tests/test-multi-zone.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-query-scheduler-consul-ring.jsonnet
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring.jsonnet
@@ -9,9 +9,7 @@ mimir {
     memberlist_ring_enabled: false,
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -20,7 +18,6 @@ mimir {
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
     // Enable query-scheduler with ring-based service discovery.
-    query_scheduler_enabled: true,
     query_scheduler_service_discovery_mode: 'ring',
   },
 }

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation.jsonnet
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation.jsonnet
@@ -7,9 +7,7 @@ mimir {
     aws_region: 'eu-west-1',
 
     storage_backend: 's3',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -17,7 +15,6 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
-    query_scheduler_enabled: true,
     query_scheduler_service_discovery_mode: 'ring',
 
     ruler_remote_evaluation_enabled: true,

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled.jsonnet
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled.jsonnet
@@ -8,7 +8,6 @@ mimir {
 
     storage_backend: 's3',
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -16,7 +15,6 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
-    query_scheduler_enabled: true,
     query_scheduler_service_discovery_mode: 'ring',
     query_scheduler_service_discovery_ring_read_path_enabled: false,
   },

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring.jsonnet
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring.jsonnet
@@ -8,7 +8,6 @@ mimir {
 
     storage_backend: 's3',
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',
@@ -16,7 +15,6 @@ mimir {
     alertmanager_enabled: true,
     alertmanager_storage_bucket_name: 'alerts-bucket',
 
-    query_scheduler_enabled: true,
     query_scheduler_service_discovery_mode: 'ring',
   },
 }

--- a/operations/mimir-tests/test-query-sharding.jsonnet
+++ b/operations/mimir-tests/test-query-sharding.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration.jsonnet
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-ruler-remote-evaluation.jsonnet
+++ b/operations/mimir-tests/test-ruler-remote-evaluation.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled.jsonnet
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-shuffle-sharding.jsonnet
+++ b/operations/mimir-tests/test-shuffle-sharding.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-storage-azure.jsonnet
+++ b/operations/mimir-tests/test-storage-azure.jsonnet
@@ -10,8 +10,6 @@ mimir {
     storage_azure_account_key: 'azure-account-key',
 
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-storage-gcs.jsonnet
+++ b/operations/mimir-tests/test-storage-gcs.jsonnet
@@ -6,10 +6,7 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-storage-s3.jsonnet
+++ b/operations/mimir-tests/test-storage-s3.jsonnet
@@ -8,8 +8,6 @@ mimir {
 
     storage_backend: 's3',
     blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
 
     ruler_enabled: true,
     ruler_storage_bucket_name: 'rules-bucket',

--- a/operations/mimir-tests/test-without-query-scheduler.jsonnet
+++ b/operations/mimir-tests/test-without-query-scheduler.jsonnet
@@ -6,8 +6,8 @@ mimir {
     external_url: 'http://test',
 
     storage_backend: 'gcs',
-
     blocks_storage_bucket_name: 'blocks-bucket',
+
     query_scheduler_enabled: false,
   },
 }


### PR DESCRIPTION
#### What this PR does
This PR addresses a comment received in https://github.com/grafana/mimir/pull/3379 about removing from jsonnet tests config settings equal to their default values. In this PR I've addressed:

- `bucket_index_enabled: true`
- `query_scheduler_enabled: true`
- `memberlist_ring_enabled: true`

This PR is expected to a no-op for any `*-generated.yaml` file (which is the output of compiled jsonnet).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
