### PR TITLE
Add optional matcher to IndexReader.LabelValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Alerts: added `RulerRemoteEvaluationFailing` alert, firing when communication between ruler and frontend fails in remote operational mode. #3177 #3389
 * [ENHANCEMENT] Clarify which S3 signature versions are supported in the error "unsupported signature version". #3376
 * [ENHANCEMENT] Store-gateway: improved index header reading performance. #3393
+* [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -715,13 +715,13 @@ func (iir *interceptedIndexReader) LabelNames() ([]string, error) {
 	return iir.Reader.LabelNames()
 }
 
-func (iir *interceptedIndexReader) LabelValues(name string) ([]string, error) {
+func (iir *interceptedIndexReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
 	if iir.onLabelValuesCalled != nil {
 		if err := iir.onLabelValuesCalled(name); err != nil {
 			return nil, err
 		}
 	}
-	return iir.Reader.LabelValues(name)
+	return iir.Reader.LabelValues(name, filter)
 }
 
 type contextNotifyingOnDoneWaiting struct {

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -853,7 +853,7 @@ func (r *BinaryReader) LookupSymbol(o uint32) (string, error) {
 	return s, nil
 }
 
-func (r *BinaryReader) LabelValues(name string) ([]string, error) {
+func (r *BinaryReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
 	if r.indexVersion == index.FormatV1 {
 		e, ok := r.postingsV1[name]
 		if !ok {
@@ -861,7 +861,9 @@ func (r *BinaryReader) LabelValues(name string) ([]string, error) {
 		}
 		values := make([]string, 0, len(e))
 		for k := range e {
-			values = append(values, k)
+			if filter == nil || filter(k) {
+				values = append(values, k)
+			}
 		}
 		sort.Strings(values)
 		return values, nil
@@ -893,7 +895,9 @@ func (r *BinaryReader) LabelValues(name string) ([]string, error) {
 			d.Skip(skip)
 		}
 		s := yoloString(d.UvarintBytes()) // Label value.
-		values = append(values, s)
+		if filter == nil || filter(s) {
+			values = append(values, s)
+		}
 		if s == lastVal {
 			break
 		}

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -35,7 +35,8 @@ type Reader interface {
 	// LabelValues returns all label values for given label name or error.
 	// If no values are found for label name, or label name does not exists,
 	// then empty string is returned and no error.
-	LabelValues(name string) ([]string, error)
+	// If non-nil filter is provided, then only values for which filter returns true are returned.
+	LabelValues(name string, filter func(string) bool) ([]string, error)
 
 	// LabelNames returns all label names in sorted order.
 	LabelNames() ([]string, error)

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -143,7 +143,7 @@ func TestReaders(t *testing.T) {
 						},
 					}, br.postings)
 
-					vals, err := br.LabelValues("not-existing")
+					vals, err := br.LabelValues("not-existing", nil)
 					require.NoError(t, err)
 					require.Equal(t, []string(nil), vals)
 
@@ -252,7 +252,7 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 		expectedLabelVals, err := indexReader.SortedLabelValues(lname)
 		require.NoError(t, err)
 
-		vals, err := headerReader.LabelValues(lname)
+		vals, err := headerReader.LabelValues(lname, nil)
 		require.NoError(t, err)
 		require.Equal(t, expectedLabelVals, vals)
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -188,7 +188,7 @@ func (r *LazyBinaryReader) LookupSymbol(o uint32) (string, error) {
 }
 
 // LabelValues implements Reader.
-func (r *LazyBinaryReader) LabelValues(name string) ([]string, error) {
+func (r *LazyBinaryReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
 	r.readerMx.RLock()
 	defer r.readerMx.RUnlock()
 
@@ -197,7 +197,7 @@ func (r *LazyBinaryReader) LabelValues(name string) ([]string, error) {
 	}
 
 	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.LabelValues(name)
+	return r.reader.LabelValues(name, filter)
 }
 
 // LabelNames implements Reader.


### PR DESCRIPTION
#### What this PR does

More often than not we retrieve label values to filter them using a matcher later. If we pass in the matcher as a filter function, we can avoid moving some extra values.

This shows a -5% cpu improvement when this path is hit, and no change otherwise.

```
name                                                               old time/op  new time/op  delta
BucketIndexReader_ExpandedPostings/n="1"                           7.27ms ± 2%  7.24ms ± 2%    ~     (p=0.447 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",j="foo"                   32.9ms ± 5%  32.5ms ± 1%    ~     (p=0.236 n=9+8)
BucketIndexReader_ExpandedPostings/j="foo",n="1"                   32.5ms ± 1%  32.5ms ± 2%    ~     (p=0.631 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"                  28.3ms ± 2%  28.0ms ± 2%    ~     (p=0.089 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".*"                          142ms ± 5%   135ms ± 3%  -5.03%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".+"                          374ms ± 3%   371ms ± 4%    ~     (p=0.579 n=10+10)
BucketIndexReader_ExpandedPostings/i=~""                            366ms ± 3%   364ms ± 3%    ~     (p=0.529 n=10+10)
BucketIndexReader_ExpandedPostings/i!=""                            374ms ± 2%   370ms ± 4%    ~     (p=0.278 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"           35.5ms ± 2%  35.4ms ± 1%    ~     (p=0.905 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"    43.2ms ± 5%  43.6ms ± 3%    ~     (p=0.280 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i!=""                      190ms ± 3%   178ms ± 2%  -6.41%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"              210ms ± 2%   192ms ± 1%  -8.71%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"            211ms ± 2%   193ms ± 1%  -8.48%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"          42.0ms ± 3%  40.5ms ± 2%  -3.71%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"     214ms ± 2%   201ms ± 3%  -5.82%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"   239ms ± 1%   226ms ± 1%  -5.30%  (p=0.000 n=8+10)
BucketIndexReader_ExpandedPostings/i=~"0xxx|1xxx|2xxx"             32.7µs ± 1%  32.7µs ± 1%    ~     (p=0.897 n=10+8)
BucketIndexReader_ExpandedPostings/i=~"(0|1|2)xxx"                 32.7µs ± 2%  32.5µs ± 3%    ~     (p=0.280 n=10+10)
BucketIndexReader_ExpandedPostings/i=~"[0-2]xxx"                   32.6µs ± 1%  32.3µs ± 2%    ~     (p=0.101 n=8+10)
BucketIndexReader_ExpandedPostings/i!~[0-2]xxx                      151ms ± 3%   144ms ± 2%  -4.35%  (p=0.000 n=10+9)
BucketIndexReader_ExpandedPostings/i=~".*",_i!~[0-2]xxx             152ms ± 4%   149ms ± 1%  -2.30%  (p=0.009 n=10+10)
BucketIndexReader_ExpandedPostings/p!=""                           38.4ms ± 3%  39.3ms ± 2%  +2.31%  (p=0.004 n=10+10)
```

Before submitting this PR I tried to understand _why is it really better_?
I ran cpu profiling on the most improving case `BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"` on both versions, and zoomed in to the `toPostingsGroup` function:

##### cpu on `main`
![image](https://user-images.githubusercontent.com/1511481/199961533-80e77df3-8c40-495e-b13c-9faf569717ab.png)

##### cpu after this change
![image](https://user-images.githubusercontent.com/1511481/199961727-3e94c1a1-77ab-4c86-a0df-14ae15377878.png)

Since the extra time was clearly spent growing a slice, I validated two things:
First I thought that maybe inside of LabelValues we were not building enough space for the values:

https://github.com/grafana/mimir/blob/4d586af90d9c38cbe18a4b2cb0ede46b74a1e824/pkg/storegateway/indexheader/binary_reader.go#L884-L884

After double checking the logic itself, I just checked that this was not the case by adding a check at the end of that method and checking that it was not hit in the benchmarks:

```go
	if len(values) > len(e.offsets)*r.postingOffsetsInMemSampling {
		panic("underallocated")
	}
```

Then I thought, okay, we're just growing the `toAdd` and `toRemove` in `toPostingsGroup`, so maybe by preallocating those to their worst case would solve that?

```diff
diff --git pkg/storegateway/bucket.go pkg/storegateway/bucket.go
index 7726b6649..9d3f0c49a 100644
--- pkg/storegateway/bucket.go
+++ pkg/storegateway/bucket.go
@@ -2003,7 +2003,7 @@ func toPostingGroup(lvalsFn func(name string) ([]string, error), m *labels.Match
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
 	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.
 	if m.Matches("") {
-		var toRemove []labels.Label
+		toRemove := make([]labels.Label, 0, len(vals))
 		for _, val := range vals {
 			if !m.Matches(val) {
 				toRemove = append(toRemove, labels.Label{Name: m.Name, Value: val})
@@ -2015,7 +2015,7 @@ func toPostingGroup(lvalsFn func(name string) ([]string, error), m *labels.Match
 
 	// Our matcher does not match the empty value, so we just need the postings that correspond
 	// to label values matched by the matcher.
-	var toAdd []labels.Label
+	toAdd := make([]labels.Label, 0, len(vals))
 	for _, val := range vals {
 		if m.Matches(val) {
 			toAdd = append(toAdd, labels.Label{Name: m.Name, Value: val})
```

However, I benchmarked that comparing it to both this PR (the results below: old is this PR, new is `main` with just the preallocated slice) and to main (results not posted, not really interesting, but you can infer them), and while it's comparable and even improving in some cases, it is much worse in some other:

```
name                                                               old time/op  new time/op  delta
BucketIndexReader_ExpandedPostings/n="1"                           7.24ms ± 2%  7.13ms ± 4%     ~     (p=0.123 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",j="foo"                   32.5ms ± 1%  32.0ms ± 2%   -1.36%  (p=0.001 n=8+9)
BucketIndexReader_ExpandedPostings/j="foo",n="1"                   32.5ms ± 2%  32.4ms ± 1%     ~     (p=0.315 n=10+9)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"                  28.0ms ± 2%  28.3ms ± 1%   +0.89%  (p=0.023 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".*"                          135ms ± 3%   131ms ± 3%   -2.32%  (p=0.007 n=10+10)
BucketIndexReader_ExpandedPostings/i=~".+"                          371ms ± 4%   366ms ± 2%     ~     (p=0.123 n=10+10)
BucketIndexReader_ExpandedPostings/i=~""                            364ms ± 3%   355ms ± 2%   -2.42%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/i!=""                            370ms ± 4%   367ms ± 4%     ~     (p=0.315 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"           35.4ms ± 1%  40.1ms ± 1%  +13.05%  (p=0.000 n=9+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"    43.6ms ± 3%  47.8ms ± 1%   +9.64%  (p=0.000 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i!=""                      178ms ± 2%   179ms ± 2%     ~     (p=0.666 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"              192ms ± 1%   195ms ± 1%   +1.89%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"            193ms ± 1%   194ms ± 1%     ~     (p=0.055 n=10+8)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"          40.5ms ± 2%  42.9ms ± 2%   +6.03%  (p=0.000 n=9+9)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"     201ms ± 3%   204ms ± 2%     ~     (p=0.165 n=10+10)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"   226ms ± 1%   230ms ± 2%   +1.38%  (p=0.004 n=10+9)
BucketIndexReader_ExpandedPostings/i=~"0xxx|1xxx|2xxx"             32.7µs ± 1%  32.9µs ± 3%     ~     (p=0.173 n=8+10)
BucketIndexReader_ExpandedPostings/i=~"(0|1|2)xxx"                 32.5µs ± 3%  32.9µs ± 2%   +1.33%  (p=0.043 n=10+10)
BucketIndexReader_ExpandedPostings/i=~"[0-2]xxx"                   32.3µs ± 2%  32.9µs ± 2%   +1.85%  (p=0.009 n=10+10)
BucketIndexReader_ExpandedPostings/i!~[0-2]xxx                      144ms ± 2%   145ms ± 4%     ~     (p=0.182 n=9+10)
BucketIndexReader_ExpandedPostings/i=~".*",_i!~[0-2]xxx             149ms ± 1%   149ms ± 2%     ~     (p=0.971 n=10+10)
BucketIndexReader_ExpandedPostings/p!=""                           39.3ms ± 2%  37.7ms ± 3%   -4.15%  (p=0.000 n=10+10)
```

I think this change makes sense and it's not making it much more complex, so we can go forward with it.

#### Which issue(s) this PR fixes or relates to

None, just was surfing the code.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
