### PR TITLE
Use specific types when reading offset table

### DIFF
--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/dskit/runutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -533,37 +534,33 @@ func newFileBinaryReader(path string, postingOffsetsInMemSampling int, cfg Binar
 		return nil, errors.Wrap(err, "read symbols")
 	}
 
-	var lastKey []string
+	var lastLbl labels.Label
 	if r.indexVersion == index.FormatV1 {
 		// Earlier V1 formats don't have a sorted postings offset table, so
 		// load the whole offset table into memory.
 		r.postingsV1 = map[string]map[string]index.Range{}
 
 		var prevRng index.Range
-		if err := index.ReadOffsetTable(r.b, r.toc.PostingsOffsetTable, func(key []string, off uint64, _ int) error {
-			if len(key) != 2 {
-				return errors.Errorf("unexpected key length for posting table %d", len(key))
-			}
-
-			if lastKey != nil {
+		if err := readOffsetTable(r.b, r.toc.PostingsOffsetTable, postingTableReader, func(lbl labels.Label, off uint64, _ int) error {
+			if lastLbl.Name != "" {
 				prevRng.End = int64(off - crc32.Size)
-				r.postingsV1[lastKey[0]][lastKey[1]] = prevRng
+				r.postingsV1[lastLbl.Name][lastLbl.Value] = prevRng
 			}
 
-			if _, ok := r.postingsV1[key[0]]; !ok {
-				r.postingsV1[key[0]] = map[string]index.Range{}
-				r.postings[key[0]] = nil // Used to get a list of labelnames in places.
+			if _, ok := r.postingsV1[lbl.Name]; !ok {
+				r.postingsV1[lbl.Name] = map[string]index.Range{}
+				r.postings[lbl.Name] = nil // Used to get a list of labelnames in places.
 			}
 
-			lastKey = key
+			lastLbl = lbl
 			prevRng = index.Range{Start: int64(off + postingLengthFieldSize)}
 			return nil
 		}); err != nil {
 			return nil, errors.Wrap(err, "read postings table")
 		}
-		if lastKey != nil {
+		if lastLbl.Name != "" {
 			prevRng.End = r.indexLastPostingEnd - crc32.Size
-			r.postingsV1[lastKey[0]][lastKey[1]] = prevRng
+			r.postingsV1[lastLbl.Name][lastLbl.Value] = prevRng
 		}
 	} else {
 		lastTableOff := 0
@@ -571,46 +568,41 @@ func newFileBinaryReader(path string, postingOffsetsInMemSampling int, cfg Binar
 
 		// For the postings offset table we keep every label name but only every nth
 		// label value (plus the first and last one), to save memory.
-		if err := index.ReadOffsetTable(r.b, r.toc.PostingsOffsetTable, func(key []string, off uint64, tableOff int) error {
-			if len(key) != 2 {
-				return errors.Errorf("unexpected key length for posting table %d", len(key))
-			}
-
-			if _, ok := r.postings[key[0]]; !ok {
+		if err := readOffsetTable(r.b, r.toc.PostingsOffsetTable, postingTableReader, func(lbl labels.Label, off uint64, tableOff int) error {
+			if _, ok := r.postings[lbl.Name]; !ok {
 				// Not seen before label name.
-				r.postings[key[0]] = &postingValueOffsets{}
-				if lastKey != nil {
+				r.postings[lbl.Name] = &postingValueOffsets{}
+				if lastLbl.Name != "" {
 					// Always include last value for each label name, unless it was just added in previous iteration based
 					// on valueCount.
 					if (valueCount-1)%postingOffsetsInMemSampling != 0 {
-						r.postings[lastKey[0]].offsets = append(r.postings[lastKey[0]].offsets, postingOffset{value: lastKey[1], tableOff: lastTableOff})
+						r.postings[lastLbl.Name].offsets = append(r.postings[lastLbl.Name].offsets, postingOffset{value: lastLbl.Value, tableOff: lastTableOff})
 					}
-					r.postings[lastKey[0]].lastValOffset = int64(off - crc32.Size)
-					lastKey = nil
+					r.postings[lastLbl.Name].lastValOffset = int64(off - crc32.Size)
 				}
 				valueCount = 0
 			}
 
-			lastKey = key
+			lastLbl = lbl
 			lastTableOff = tableOff
 			valueCount++
 
 			if (valueCount-1)%postingOffsetsInMemSampling == 0 {
-				r.postings[key[0]].offsets = append(r.postings[key[0]].offsets, postingOffset{value: key[1], tableOff: tableOff})
+				r.postings[lbl.Name].offsets = append(r.postings[lbl.Name].offsets, postingOffset{value: lbl.Value, tableOff: tableOff})
 			}
 
 			return nil
 		}); err != nil {
 			return nil, errors.Wrap(err, "read postings table")
 		}
-		if lastKey != nil {
+		if lastLbl.Name != "" {
 			if (valueCount-1)%postingOffsetsInMemSampling != 0 {
 				// Always include last value for each label name if not included already based on valueCount.
-				r.postings[lastKey[0]].offsets = append(r.postings[lastKey[0]].offsets, postingOffset{value: lastKey[1], tableOff: lastTableOff})
+				r.postings[lastLbl.Name].offsets = append(r.postings[lastLbl.Name].offsets, postingOffset{value: lastLbl.Value, tableOff: lastTableOff})
 			}
 			// In any case lastValOffset is unknown as don't have next posting anymore. Guess from TOC table.
 			// In worst case we will overfetch a few bytes.
-			r.postings[lastKey[0]].lastValOffset = r.indexLastPostingEnd - crc32.Size
+			r.postings[lastLbl.Name].lastValOffset = r.indexLastPostingEnd - crc32.Size
 		}
 		// Trim any extra space in the slices.
 		for k, v := range r.postings {
@@ -942,4 +934,44 @@ func (b realByteSlice) Range(start, end int) []byte {
 
 func (b realByteSlice) Sub(start, end int) index.ByteSlice {
 	return b[start:end]
+}
+
+// ReadOffsetTable reads an offset table and at the given position calls f for each
+// found entry. If f returns an error it stops decoding and returns the received error.
+// TODO: use the upstreamed version from Prometheus tsdb/index package when available.
+func readOffsetTable[T any](bs index.ByteSlice, off uint64, read func(d *encoding.Decbuf) (T, error), f func(T, uint64, int) error) error {
+	d := encoding.NewDecbufAt(bs, int(off), castagnoliTable)
+	startLen := d.Len()
+	cnt := d.Be32()
+
+	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
+		offsetPos := startLen - d.Len()
+
+		item, err := read(&d)
+		if err != nil {
+			return err
+		}
+
+		o := d.Uvarint64()
+		if d.Err() != nil {
+			break
+		}
+		if err := f(item, o, offsetPos); err != nil {
+			return err
+		}
+		cnt--
+	}
+	return d.Err()
+}
+
+// PostingTableReader can be used as read function for ReadOffsetTable to read the posting offset table.
+// TODO: use the upstreamed version from Prometheus tsdb/index package when available.
+func postingTableReader(d *encoding.Decbuf) (labels.Label, error) {
+	if keyCount := d.Uvarint(); keyCount != 2 {
+		return labels.Label{}, errors.Errorf("unexpected key length for posting table %d", keyCount)
+	}
+	var lbl labels.Label
+	lbl.Name = d.UvarintStr()
+	lbl.Value = d.UvarintStr()
+	return lbl, nil
 }

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -361,11 +361,11 @@ func BenchmarkBinaryWrite(t *testing.B) {
 	}
 }
 
-func BenchmarkBinaryReader(t *testing.B) {
+func BenchmarkBinaryReader_ThanosbenchBlock(t *testing.B) {
 	ctx := context.Background()
 	tmpDir, err := os.MkdirTemp("", "bench-indexheader")
 	require.NoError(t, err)
-	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmpDir)) })
 
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	require.NoError(t, err)
@@ -380,6 +380,49 @@ func BenchmarkBinaryReader(t *testing.B) {
 		require.NoError(t, err)
 		require.NoError(t, br.Close())
 	}
+}
+
+func BenchmarkBinaryReader_LargerBlock(b *testing.B) {
+	const (
+		// labelLongSuffix is a label with ~50B in size, to emulate real-world high cardinality.
+		labelLongSuffix = "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd"
+		series          = 1e6
+	)
+
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "bench-indexheader-large")
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, os.RemoveAll(tmpDir)) })
+
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	require.NoError(b, err)
+
+	seriesLabels := make([]labels.Labels, 0, series)
+	for n := 0; n < 10; n++ {
+		for i := 0; i < series/10/5; i++ {
+			seriesLabels = append(seriesLabels, labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", strconv.Itoa(n)+labelLongSuffix, "j", "foo", "p", "foo"))
+			seriesLabels = append(seriesLabels, labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", strconv.Itoa(n)+labelLongSuffix, "j", "bar", "q", "foo"))
+			seriesLabels = append(seriesLabels, labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "0_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "r", "foo"))
+			seriesLabels = append(seriesLabels, labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "1_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "s", "foo"))
+			seriesLabels = append(seriesLabels, labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "2_"+strconv.Itoa(n)+labelLongSuffix, "j", "foo", "t", "foo"))
+		}
+	}
+
+	blockID, err := testhelper.CreateBlock(ctx, tmpDir, seriesLabels, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
+	require.NoError(b, err)
+	require.NoError(b, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
+
+	filename := filepath.Join(tmpDir, "bkt", blockID.String(), block.IndexHeaderFilename)
+	require.NoError(b, WriteBinary(ctx, bkt, blockID, filename))
+
+	b.ResetTimer()
+	b.Run("benchmark", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			br, err := newFileBinaryReader(filename, 32, BinaryReaderConfig{})
+			require.NoError(b, err)
+			require.NoError(b, br.Close())
+		}
+	})
 }
 
 func BenchmarkBinaryReader_LookupSymbol(b *testing.B) {


### PR DESCRIPTION
#### What this PR does

Modified the `index.ReadOffsetTable` function to use a specific type instead of a slice, that escapes to heap (for every label value in the postings offset table).

I will upstream this change to Prometheus, and then use the upstreamed version again when it's available, but wanted to bring it here first, especially because we already have benchmarks for this.

```
name          old time/op    new time/op    delta
BinaryReader    42.7µs ± 3%    33.9µs ± 8%  -20.63%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
BinaryReader    41.7kB ± 0%    35.3kB ± 0%  -15.31%  (p=0.000 n=5+4)

name          old allocs/op  new allocs/op  delta
BinaryReader       623 ± 0%       423 ± 0%  -32.10%  (p=0.008 n=5+5)
```

I also added a benchmark with a larger block size:

```
name                                old time/op    new time/op    delta
BinaryReader_LargerBlock/benchmark    2.72ms ± 4%    1.89ms ± 3%  -30.51%  (p=0.008 n=5+5)

name                                old alloc/op   new alloc/op   delta
BinaryReader_LargerBlock/benchmark    1.70MB ± 0%    1.06MB ± 0%     ~     (p=0.079 n=4+5)

name                                old allocs/op  new allocs/op  delta
BinaryReader_LargerBlock/benchmark     40.2k ± 0%     20.1k ± 0%  -49.93%  (p=0.008 n=5+5)
```

#### Which issue(s) this PR fixes or relates to

None, just was surfing the code.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
