### PR TITLE
Fix panel with forwarded requests if there are no errors yet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 * [CHANGE] Alerts: Change `MimirSchedulerQueriesStuck` `for` time to 7 minutes to account for the time it takes for HPA to scale up. #3223
 * [CHANGE] Dashboards: Removed the `Querier > Stages` panel from the `Mimir / Queries` dashboard. #3311
 * [ENHANCEMENT] Alerts: Add MimirRingMembersMismatch firing when a component does not have the expected number of running jobs. #2404
-* [ENHANCEMENT] Dashboards: Add optional row about the Distributor's metric forwarding feature to the `Mimir / Writes` dashboard. #3182
+* [ENHANCEMENT] Dashboards: Add optional row about the Distributor's metric forwarding feature to the `Mimir / Writes` dashboard. #3182 #3394
 * [ENHANCEMENT] Dashboards: Remove the "Instance Mapper" row from the "Alertmanager Resources Dashboard". This is a Grafana Cloud specific service and not relevant for external users. #3152
 * [ENHANCEMENT] Dashboards: Add "remote read", "metadata", and "exemplar" queries to "Mimir / Overview" dashboard. #3245
 * [ENHANCEMENT] Dashboards: Use non-red colors for non-error series in the "Mimir / Overview" dashboard. #3246

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -145,16 +145,11 @@ local filename = 'mimir-writes.json';
         $.queryPanel(
           [
             |||
-              sum(
-                rate(
-                  cortex_distributor_forward_requests_total{%(distributorMatcher)s}[$__rate_interval]
-                )
-              )
+              (sum(rate(cortex_distributor_forward_requests_total{%(distributorMatcher)s}[$__rate_interval])))
               -
-              sum(
-                rate(
-                  cortex_distributor_forward_errors_total{%(distributorMatcher)s}[$__rate_interval]
-                )
+              (
+                sum(rate(cortex_distributor_forward_errors_total{%(distributorMatcher)s}[$__rate_interval]))
+                or 0 * sum(rate(cortex_distributor_forward_requests_total{%(distributorMatcher)s}[$__rate_interval]))
               )
             ||| % {
               distributorMatcher: $.jobMatcher($._config.job_names.distributor),


### PR DESCRIPTION
#### What this PR does

This PR fixes query showing successful forwarded requests. Previous query could return no results if `cortex_distributor_forward_requests_total` metric didn't exist yet.

Before:
<img width="1140" alt="Screenshot 2022-11-04 at 15 50 39" src="https://user-images.githubusercontent.com/895919/200004839-90dba3bf-8e37-4c71-ac8f-02a3cda2287d.png">

After:

<img width="1140" alt="Screenshot 2022-11-04 at 15 50 12" src="https://user-images.githubusercontent.com/895919/200004738-22ec82d1-647d-4239-a443-b16ab92916b0.png">

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
