### PR TITLE
Refactoring: do not store per-query data in bucketIndexReader

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -2137,12 +2137,12 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			}
 			fetchTime := time.Since(begin)
 
-			stats.lock()
+			stats.Lock()
 			stats.postingsFetchCount++
 			stats.postingsFetched += j - i
 			stats.postingsFetchDurationSum += fetchTime
 			stats.postingsFetchedSizeSum += int(length)
-			stats.unlock()
+			stats.Unlock()
 
 			for _, p := range ptrs[i:j] {
 				// index-header can estimate endings, which means we need to resize the endings.
@@ -2181,7 +2181,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 				r.mtx.Unlock()
 
 				// If we just fetched it we still have to update the stats for touched postings.
-				stats.lock()
+				stats.Lock()
 				stats.postingsTouched++
 				stats.postingsTouchedSizeSum += len(pBytes)
 				stats.cachedPostingsCompressions += compressions
@@ -2189,7 +2189,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 				stats.cachedPostingsOriginalSizeSum += len(pBytes)
 				stats.cachedPostingsCompressedSizeSum += compressedSize
 				stats.cachedPostingsCompressionTimeSum += compressionTime
-				stats.unlock()
+				stats.Unlock()
 			}
 			return nil
 		})
@@ -2327,12 +2327,12 @@ func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.Series
 		return errors.Wrap(err, "read series range")
 	}
 
-	stats.lock()
+	stats.Lock()
 	stats.seriesFetchCount++
 	stats.seriesFetched += len(ids)
 	stats.seriesFetchDurationSum += time.Since(begin)
 	stats.seriesFetchedSizeSum += int(end - start)
-	stats.unlock()
+	stats.Unlock()
 
 	for i, id := range ids {
 		c := b[uint64(id)-start:]

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1285,12 +1285,11 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		resHints.AddQueriedBlock(b.meta.ULID)
 
 		indexr := b.indexReader()
-		indexrStats := newSafeQueryStats()
 
 		g.Go(func() error {
 			defer runutil.CloseWithLogOnErr(s.logger, indexr, "label values")
 
-			result, err := blockLabelValues(gctx, indexr, req.Label, reqSeriesMatchers, s.logger, indexrStats)
+			result, err := blockLabelValues(gctx, indexr, req.Label, reqSeriesMatchers, s.logger, newSafeQueryStats())
 			if err != nil {
 				return errors.Wrapf(err, "block %s", b.meta.ULID)
 			}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -572,7 +572,7 @@ func blockSeries(
 	minTime, maxTime int64, // Series must have data in this time range to be returned (ignored if skipChunks=true).
 	loadAggregates []storepb.Aggr, // List of aggregates to load when loading chunks.
 	logger log.Logger,
-) (storepb.SeriesSet, *queryStats, error) {
+) (storepb.SeriesSet, *safeQueryStats, error) {
 	span, ctx := tracing.StartSpan(ctx, "blockSeries()")
 	span.LogKV(
 		"block ID", indexr.block.meta.ULID.String(),
@@ -581,6 +581,8 @@ func blockSeries(
 	)
 	defer span.Finish()
 
+	indexStats := newSafeQueryStats()
+
 	if skipChunks {
 		span.LogKV("msg", "manipulating mint/maxt to cover the entire block as skipChunks=true")
 		minTime, maxTime = indexr.block.meta.MinTime, indexr.block.meta.MaxTime
@@ -588,11 +590,11 @@ func blockSeries(
 		res, ok := fetchCachedSeries(ctx, indexr.block.userID, indexr.block.indexCache, indexr.block.meta.ULID, matchers, shard, logger)
 		if ok {
 			span.LogKV("msg", "using cached result", "len", len(res))
-			return newBucketSeriesSet(res), &queryStats{}, nil
+			return newBucketSeriesSet(res), indexStats, nil
 		}
 	}
 
-	ps, err := indexr.ExpandedPostings(ctx, matchers)
+	ps, err := indexr.ExpandedPostings(ctx, matchers, indexStats)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "expanded matching posting")
 	}
@@ -606,13 +608,13 @@ func blockSeries(
 	}
 
 	if len(ps) == 0 {
-		return storepb.EmptySeriesSet(), indexr.stats, nil
+		return storepb.EmptySeriesSet(), indexStats, nil
 	}
 
 	// Preload all series index data.
 	// TODO(bwplotka): Consider not keeping all series in memory all the time.
 	// TODO(bwplotka): Do lazy loading in one step as `ExpandingPostings` method.
-	if err := indexr.PreloadSeries(ctx, ps); err != nil {
+	if err := indexr.PreloadSeries(ctx, ps, indexStats); err != nil {
 		return nil, nil, errors.Wrap(err, "preload series")
 	}
 
@@ -629,7 +631,7 @@ func blockSeries(
 			chks           []chunks.Meta
 		)
 		for _, id := range ps {
-			ok, err := indexr.LoadSeriesForTime(id, &symbolizedLset, &chks, skipChunks, minTime, maxTime)
+			ok, err := indexr.LoadSeriesForTime(id, &symbolizedLset, &chks, skipChunks, minTime, maxTime, indexStats.queryStats)
 			if err != nil {
 				lookupErr = errors.Wrap(err, "read series")
 				return
@@ -705,14 +707,14 @@ func blockSeries(
 
 	if skipChunks {
 		storeCachedSeries(ctx, indexr.block.indexCache, indexr.block.userID, indexr.block.meta.ULID, matchers, shard, res, logger)
-		return newBucketSeriesSet(res), indexr.stats.merge(&seriesCacheStats), nil
+		return newBucketSeriesSet(res), indexStats.merge(&seriesCacheStats), nil
 	}
 
 	if err := chunkr.load(res, loadAggregates); err != nil {
 		return nil, nil, errors.Wrap(err, "load chunks")
 	}
 
-	return newBucketSeriesSet(res), indexr.stats.merge(chunkr.stats).merge(&seriesCacheStats), nil
+	return newBucketSeriesSet(res), indexStats.merge(chunkr.stats).merge(&seriesCacheStats), nil
 }
 
 type seriesCacheEntry struct {
@@ -957,7 +959,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 
 			mtx.Lock()
 			res = append(res, part)
-			stats = stats.merge(pstats)
+			stats = stats.merge(pstats.queryStats)
 			mtx.Unlock()
 
 			return nil
@@ -1282,11 +1284,12 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 		resHints.AddQueriedBlock(b.meta.ULID)
 
 		indexr := b.indexReader()
+		indexrStats := newSafeQueryStats()
 
 		g.Go(func() error {
 			defer runutil.CloseWithLogOnErr(s.logger, indexr, "label values")
 
-			result, err := blockLabelValues(gctx, indexr, req.Label, reqSeriesMatchers, s.logger)
+			result, err := blockLabelValues(gctx, indexr, req.Label, reqSeriesMatchers, s.logger, indexrStats)
 			if err != nil {
 				return errors.Wrapf(err, "block %s", b.meta.ULID)
 			}
@@ -1330,7 +1333,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 //
 // Notice that when no matchers are provided, the list of matched postings is AllPostings,
 // so we could also intersect those with each label's postings being each one non empty and leading to the same result.
-func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName string, matchers []*labels.Matcher, logger log.Logger) ([]string, error) {
+func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName string, matchers []*labels.Matcher, logger log.Logger, stats *safeQueryStats) ([]string, error) {
 	values, ok := fetchCachedLabelValues(ctx, indexr.block.indexCache, indexr.block.userID, indexr.block.meta.ULID, labelName, matchers, logger)
 	if ok {
 		return values, nil
@@ -1346,7 +1349,7 @@ func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName 
 		return allValues, nil
 	}
 
-	p, err := indexr.ExpandedPostings(ctx, matchers)
+	p, err := indexr.ExpandedPostings(ctx, matchers, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "expanded postings")
 	}
@@ -1356,7 +1359,7 @@ func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName 
 		keys[i] = labels.Label{Name: labelName, Value: value}
 	}
 
-	fetchedPostings, err := indexr.FetchPostings(ctx, keys)
+	fetchedPostings, err := indexr.FetchPostings(ctx, keys, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}
@@ -1701,7 +1704,6 @@ func (b *bucketBlock) Close() error {
 type bucketIndexReader struct {
 	block *bucketBlock
 	dec   *index.Decoder
-	stats *queryStats
 
 	mtx          sync.Mutex
 	loadedSeries map[storage.SeriesRef][]byte
@@ -1713,7 +1715,6 @@ func newBucketIndexReader(block *bucketBlock) *bucketIndexReader {
 		dec: &index.Decoder{
 			LookupSymbol: block.indexHeaderReader.LookupSymbol,
 		},
-		stats:        &queryStats{},
 		loadedSeries: map[storage.SeriesRef][]byte{},
 	}
 	return r
@@ -1728,7 +1729,7 @@ func newBucketIndexReader(block *bucketBlock) *bucketIndexReader {
 // Reminder: A posting is a reference (represented as a uint64) to a series reference, which in turn points to the first
 // chunk where the series contains the matching label-value pair for a given block of data. Postings can be fetched by
 // single label name=value.
-func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.Matcher) (returnRefs []storage.SeriesRef, returnErr error) {
+func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, returnErr error) {
 	var (
 		loaded bool
 		cached bool
@@ -1742,7 +1743,7 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 		span.Finish()
 	}()
 	var promise expandedPostingsPromise
-	promise, loaded = r.expandedPostingsPromise(ctx, ms)
+	promise, loaded = r.expandedPostingsPromise(ctx, ms, stats)
 	returnRefs, cached, returnErr = promise(ctx)
 	return returnRefs, returnErr
 }
@@ -1758,7 +1759,7 @@ type expandedPostingsPromise func(ctx context.Context) ([]storage.SeriesRef, boo
 // The promise returned by this function returns a bool value fromCache, set to true when data was loaded from cache.
 // TODO: if promise creator's context is canceled, the entire promise will fail, even if there are more callers waiting for the results
 // TODO: https://github.com/grafana/mimir/issues/331
-func (r *bucketIndexReader) expandedPostingsPromise(ctx context.Context, ms []*labels.Matcher) (promise expandedPostingsPromise, loaded bool) {
+func (r *bucketIndexReader) expandedPostingsPromise(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (promise expandedPostingsPromise, loaded bool) {
 	var (
 		refs   []storage.SeriesRef
 		err    error
@@ -1794,11 +1795,11 @@ func (r *bucketIndexReader) expandedPostingsPromise(ctx context.Context, ms []*l
 	defer close(done)
 	defer r.block.expandedPostingsPromises.Delete(key)
 
-	refs, cached = r.fetchCachedExpandedPostings(ctx, r.block.userID, key)
+	refs, cached = r.fetchCachedExpandedPostings(ctx, r.block.userID, key, stats.queryStats)
 	if cached {
 		return promise, false
 	}
-	refs, err = r.expandedPostings(ctx, ms)
+	refs, err = r.expandedPostings(ctx, ms, stats)
 	if err != nil {
 		return promise, false
 	}
@@ -1815,13 +1816,13 @@ func (r *bucketIndexReader) cacheExpandedPostings(ctx context.Context, userID st
 	r.block.indexCache.StoreExpandedPostings(ctx, userID, r.block.meta.ULID, key, data)
 }
 
-func (r *bucketIndexReader) fetchCachedExpandedPostings(ctx context.Context, userID string, key indexcache.LabelMatchersKey) ([]storage.SeriesRef, bool) {
+func (r *bucketIndexReader) fetchCachedExpandedPostings(ctx context.Context, userID string, key indexcache.LabelMatchersKey, stats *queryStats) ([]storage.SeriesRef, bool) {
 	data, ok := r.block.indexCache.FetchExpandedPostings(ctx, userID, r.block.meta.ULID, key)
 	if !ok {
 		return nil, false
 	}
 
-	p, err := r.decodePostings(data)
+	p, err := r.decodePostings(data, stats)
 	if err != nil {
 		level.Warn(r.block.logger).Log("msg", "can't decode expanded postings cache", "err", err, "matchers_key", key, "block", r.block.meta.ULID)
 		return nil, false
@@ -1836,7 +1837,7 @@ func (r *bucketIndexReader) fetchCachedExpandedPostings(ctx context.Context, use
 }
 
 // expandedPostings is the main logic of ExpandedPostings, without the promise wrapper.
-func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.Matcher) (returnRefs []storage.SeriesRef, returnErr error) {
+func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, returnErr error) {
 	var (
 		postingGroups []*postingGroup
 		allRequested  = false
@@ -1885,7 +1886,7 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 		keys = append(keys, allPostingsLabel)
 	}
 
-	fetchedPostings, err := r.fetchPostings(ctx, keys)
+	fetchedPostings, err := r.fetchPostings(ctx, keys, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}
@@ -2033,8 +2034,8 @@ type postingPtr struct {
 // FetchPostings fills postings requested by posting groups.
 // It returns one postings for each key, in the same order.
 // If postings for given key is not fetched, entry at given index will be an ErrPostings
-func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Label) ([]index.Postings, error) {
-	ps, err := r.fetchPostings(ctx, keys)
+func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) ([]index.Postings, error) {
+	ps, err := r.fetchPostings(ctx, keys, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -2057,7 +2058,7 @@ func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Lab
 // fetchPostings is the version-unaware private implementation of FetchPostings.
 // callers of this method may need to add padding to the results.
 // If postings for given key is not fetched, entry at given index will be nil.
-func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label) ([]index.Postings, error) {
+func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) ([]index.Postings, error) {
 	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
 	defer timer.ObserveDuration()
 
@@ -2074,10 +2075,10 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 	for ix, key := range keys {
 		// Get postings for the given key from cache first.
 		if b, ok := fromCache[key]; ok {
-			r.stats.postingsTouched++
-			r.stats.postingsTouchedSizeSum += len(b)
+			stats.postingsTouched++
+			stats.postingsTouchedSizeSum += len(b)
 
-			l, err := r.decodePostings(b)
+			l, err := r.decodePostings(b, stats.queryStats)
 			if err == nil {
 				output[ix] = l
 				continue
@@ -2105,7 +2106,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			return nil, errors.Wrap(err, "index header PostingsOffset")
 		}
 
-		r.stats.postingsToFetch++
+		stats.postingsToFetch++
 		ptrs = append(ptrs, postingPtr{ptr: ptr, keyID: ix})
 	}
 
@@ -2137,12 +2138,12 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			}
 			fetchTime := time.Since(begin)
 
-			r.mtx.Lock()
-			r.stats.postingsFetchCount++
-			r.stats.postingsFetched += j - i
-			r.stats.postingsFetchDurationSum += fetchTime
-			r.stats.postingsFetchedSizeSum += int(length)
-			r.mtx.Unlock()
+			stats.lock()
+			stats.postingsFetchCount++
+			stats.postingsFetched += j - i
+			stats.postingsFetchDurationSum += fetchTime
+			stats.postingsFetchedSizeSum += int(length)
+			stats.unlock()
 
 			for _, p := range ptrs[i:j] {
 				// index-header can estimate endings, which means we need to resize the endings.
@@ -2178,16 +2179,18 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 				output[p.keyID] = newBigEndianPostings(pBytes[4:])
 
 				r.block.indexCache.StorePostings(ctx, r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache)
+				r.mtx.Unlock()
 
 				// If we just fetched it we still have to update the stats for touched postings.
-				r.stats.postingsTouched++
-				r.stats.postingsTouchedSizeSum += len(pBytes)
-				r.stats.cachedPostingsCompressions += compressions
-				r.stats.cachedPostingsCompressionErrors += compressionErrors
-				r.stats.cachedPostingsOriginalSizeSum += len(pBytes)
-				r.stats.cachedPostingsCompressedSizeSum += compressedSize
-				r.stats.cachedPostingsCompressionTimeSum += compressionTime
-				r.mtx.Unlock()
+				stats.lock()
+				stats.postingsTouched++
+				stats.postingsTouchedSizeSum += len(pBytes)
+				stats.cachedPostingsCompressions += compressions
+				stats.cachedPostingsCompressionErrors += compressionErrors
+				stats.cachedPostingsOriginalSizeSum += len(pBytes)
+				stats.cachedPostingsCompressedSizeSum += compressedSize
+				stats.cachedPostingsCompressionTimeSum += compressionTime
+				stats.unlock()
 			}
 			return nil
 		})
@@ -2196,7 +2199,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 	return output, g.Wait()
 }
 
-func (r *bucketIndexReader) decodePostings(b []byte) (index.Postings, error) {
+func (r *bucketIndexReader) decodePostings(b []byte, stats *queryStats) (index.Postings, error) {
 	// Even if this instance is not using compression, there may be compressed
 	// entries in the cache written by other stores.
 	var (
@@ -2206,10 +2209,10 @@ func (r *bucketIndexReader) decodePostings(b []byte) (index.Postings, error) {
 	if isDiffVarintSnappyEncodedPostings(b) {
 		s := time.Now()
 		l, err = diffVarintSnappyDecode(b)
-		r.stats.cachedPostingsDecompressions++
-		r.stats.cachedPostingsDecompressionTimeSum += time.Since(s)
+		stats.cachedPostingsDecompressions++
+		stats.cachedPostingsDecompressionTimeSum += time.Since(s)
 		if err != nil {
-			r.stats.cachedPostingsDecompressionErrors++
+			stats.cachedPostingsDecompressionErrors++
 		}
 	} else {
 		_, l, err = r.dec.Postings(b)
@@ -2286,7 +2289,7 @@ func (it *bigEndianPostings) length() int {
 	return len(it.list) / 4
 }
 
-func (r *bucketIndexReader) PreloadSeries(ctx context.Context, ids []storage.SeriesRef) error {
+func (r *bucketIndexReader) PreloadSeries(ctx context.Context, ids []storage.SeriesRef, stats *safeQueryStats) error {
 	span, ctx := tracing.StartSpan(ctx, "PreloadSeries()")
 	defer span.Finish()
 
@@ -2309,13 +2312,13 @@ func (r *bucketIndexReader) PreloadSeries(ctx context.Context, ids []storage.Ser
 		i, j := p.ElemRng[0], p.ElemRng[1]
 
 		g.Go(func() error {
-			return r.loadSeries(ctx, ids[i:j], false, s, e)
+			return r.loadSeries(ctx, ids[i:j], false, s, e, stats)
 		})
 	}
 	return g.Wait()
 }
 
-func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.SeriesRef, refetch bool, start, end uint64) error {
+func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.SeriesRef, refetch bool, start, end uint64, stats *safeQueryStats) error {
 	begin := time.Now()
 
 	b, err := r.block.readIndexRange(ctx, int64(start), int64(end-start))
@@ -2323,12 +2326,12 @@ func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.Series
 		return errors.Wrap(err, "read series range")
 	}
 
-	r.mtx.Lock()
-	r.stats.seriesFetchCount++
-	r.stats.seriesFetched += len(ids)
-	r.stats.seriesFetchDurationSum += time.Since(begin)
-	r.stats.seriesFetchedSizeSum += int(end - start)
-	r.mtx.Unlock()
+	stats.lock()
+	stats.seriesFetchCount++
+	stats.seriesFetched += len(ids)
+	stats.seriesFetchDurationSum += time.Since(begin)
+	stats.seriesFetchedSizeSum += int(end - start)
+	stats.unlock()
 
 	for i, id := range ids {
 		c := b[uint64(id)-start:]
@@ -2347,7 +2350,7 @@ func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.Series
 			level.Warn(r.block.logger).Log("msg", "series size exceeded expected size; refetching", "id", id, "series length", n+int(l), "maxSeriesSize", maxSeriesSize)
 
 			// Fetch plus to get the size of next one if exists.
-			return r.loadSeries(ctx, ids[i:], true, uint64(id), uint64(id)+uint64(n+int(l)+1))
+			return r.loadSeries(ctx, ids[i:], true, uint64(id), uint64(id)+uint64(n+int(l)+1), stats)
 		}
 		c = c[n : n+int(l)]
 		r.mtx.Lock()
@@ -2383,14 +2386,14 @@ type symbolizedLabel struct {
 // LoadSeriesForTime returns false, when there are no series data for given time range.
 //
 // Error is returned on decoding error or if the reference does not resolve to a known series.
-func (r *bucketIndexReader) LoadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64) (ok bool, err error) {
+func (r *bucketIndexReader) LoadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64, stats *queryStats) (ok bool, err error) {
 	b, ok := r.loadedSeries[ref]
 	if !ok {
 		return false, errors.Errorf("series %d not found", ref)
 	}
 
-	r.stats.seriesTouched++
-	r.stats.seriesTouchedSizeSum += len(b)
+	stats.seriesTouched++
+	stats.seriesTouchedSizeSum += len(b)
 	return decodeSeriesForTime(b, lset, chks, skipChunks, mint, maxt)
 }
 
@@ -2709,93 +2712,6 @@ func (b rawChunk) Appender() (chunkenc.Appender, error) {
 
 func (b rawChunk) NumSamples() int {
 	panic("invalid call")
-}
-
-type queryStats struct {
-	blocksQueried int
-
-	postingsTouched          int
-	postingsTouchedSizeSum   int
-	postingsToFetch          int
-	postingsFetched          int
-	postingsFetchedSizeSum   int
-	postingsFetchCount       int
-	postingsFetchDurationSum time.Duration
-
-	cachedPostingsCompressions         int
-	cachedPostingsCompressionErrors    int
-	cachedPostingsOriginalSizeSum      int
-	cachedPostingsCompressedSizeSum    int
-	cachedPostingsCompressionTimeSum   time.Duration
-	cachedPostingsDecompressions       int
-	cachedPostingsDecompressionErrors  int
-	cachedPostingsDecompressionTimeSum time.Duration
-
-	seriesTouched          int
-	seriesTouchedSizeSum   int
-	seriesFetched          int
-	seriesFetchedSizeSum   int
-	seriesFetchCount       int
-	seriesFetchDurationSum time.Duration
-
-	seriesHashCacheRequests int
-	seriesHashCacheHits     int
-
-	chunksTouched          int
-	chunksTouchedSizeSum   int
-	chunksFetched          int
-	chunksFetchedSizeSum   int
-	chunksFetchCount       int
-	chunksFetchDurationSum time.Duration
-
-	getAllDuration    time.Duration
-	mergedSeriesCount int
-	mergedChunksCount int
-	mergeDuration     time.Duration
-}
-
-func (s queryStats) merge(o *queryStats) *queryStats {
-	s.blocksQueried += o.blocksQueried
-
-	s.postingsTouched += o.postingsTouched
-	s.postingsTouchedSizeSum += o.postingsTouchedSizeSum
-	s.postingsFetched += o.postingsFetched
-	s.postingsFetchedSizeSum += o.postingsFetchedSizeSum
-	s.postingsFetchCount += o.postingsFetchCount
-	s.postingsFetchDurationSum += o.postingsFetchDurationSum
-
-	s.cachedPostingsCompressions += o.cachedPostingsCompressions
-	s.cachedPostingsCompressionErrors += o.cachedPostingsCompressionErrors
-	s.cachedPostingsOriginalSizeSum += o.cachedPostingsOriginalSizeSum
-	s.cachedPostingsCompressedSizeSum += o.cachedPostingsCompressedSizeSum
-	s.cachedPostingsCompressionTimeSum += o.cachedPostingsCompressionTimeSum
-	s.cachedPostingsDecompressions += o.cachedPostingsDecompressions
-	s.cachedPostingsDecompressionErrors += o.cachedPostingsDecompressionErrors
-	s.cachedPostingsDecompressionTimeSum += o.cachedPostingsDecompressionTimeSum
-
-	s.seriesTouched += o.seriesTouched
-	s.seriesTouchedSizeSum += o.seriesTouchedSizeSum
-	s.seriesFetched += o.seriesFetched
-	s.seriesFetchedSizeSum += o.seriesFetchedSizeSum
-	s.seriesFetchCount += o.seriesFetchCount
-	s.seriesFetchDurationSum += o.seriesFetchDurationSum
-
-	s.seriesHashCacheRequests += o.seriesHashCacheRequests
-	s.seriesHashCacheHits += o.seriesHashCacheHits
-
-	s.chunksTouched += o.chunksTouched
-	s.chunksTouchedSizeSum += o.chunksTouchedSizeSum
-	s.chunksFetched += o.chunksFetched
-	s.chunksFetchedSizeSum += o.chunksFetchedSizeSum
-	s.chunksFetchCount += o.chunksFetchCount
-	s.chunksFetchDurationSum += o.chunksFetchDurationSum
-
-	s.getAllDuration += o.getAllDuration
-	s.mergedSeriesCount += o.mergedSeriesCount
-	s.mergedChunksCount += o.mergedChunksCount
-	s.mergeDuration += o.mergeDuration
-
-	return &s
 }
 
 // NewDefaultChunkBytesPool returns a chunk bytes pool with default settings.

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -614,7 +614,7 @@ func blockSeries(
 	// Preload all series index data.
 	// TODO(bwplotka): Consider not keeping all series in memory all the time.
 	// TODO(bwplotka): Do lazy loading in one step as `ExpandingPostings` method.
-	loadedSeries, err := indexr.PreloadSeries(ctx, ps, indexStats)
+	loadedSeries, err := indexr.preloadSeries(ctx, ps, indexStats)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "preload series")
 	}
@@ -2288,8 +2288,8 @@ func (it *bigEndianPostings) length() int {
 	return len(it.list) / 4
 }
 
-func (r *bucketIndexReader) PreloadSeries(ctx context.Context, ids []storage.SeriesRef, stats *safeQueryStats) (*bucketIndexLoadedSeries, error) {
-	span, ctx := tracing.StartSpan(ctx, "PreloadSeries()")
+func (r *bucketIndexReader) preloadSeries(ctx context.Context, ids []storage.SeriesRef, stats *safeQueryStats) (*bucketIndexLoadedSeries, error) {
+	span, ctx := tracing.StartSpan(ctx, "preloadSeries()")
 	defer span.Finish()
 
 	timer := prometheus.NewTimer(r.block.metrics.seriesFetchDuration)

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// bucketIndexLoadedSeries holds the result of a series load operation.
+// This data structure is NOT concurrency safe.
+type bucketIndexLoadedSeries struct {
+	// Keeps the series that have been loaded from the index.
+	series map[storage.SeriesRef][]byte
+}
+
+func newBucketIndexLoadedSeries() *bucketIndexLoadedSeries {
+	return &bucketIndexLoadedSeries{
+		series: map[storage.SeriesRef][]byte{},
+	}
+}
+
+// loadSeriesForTime populates the given symbolized labels for the series identified by the reference if at least one chunk is within
+// time selection.
+// loadSeriesForTime also populates chunk metas slices if skipChunks if set to false. Chunks are also limited by the given time selection.
+// loadSeriesForTime returns false, when there are no series data for given time range.
+//
+// Error is returned on decoding error or if the reference does not resolve to a known series.
+func (l *bucketIndexLoadedSeries) loadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64, stats *queryStats) (ok bool, err error) {
+	b, ok := l.series[ref]
+	if !ok {
+		return false, errors.Errorf("series %d not found", ref)
+	}
+
+	stats.seriesTouched++
+	stats.seriesTouchedSizeSum += len(b)
+	return decodeSeriesForTime(b, lset, chks, skipChunks, mint, maxt)
+}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -212,12 +212,11 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 
 	r := bucketIndexReader{
 		block:        b,
-		stats:        &queryStats{},
 		loadedSeries: map[storage.SeriesRef][]byte{},
 	}
 
 	// Success with no refetches.
-	assert.NoError(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2, 13, 24}, false, 2, 100))
+	assert.NoError(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2, 13, 24}, false, 2, 100, newSafeQueryStats()))
 	assert.Equal(t, map[storage.SeriesRef][]byte{
 		2:  []byte("aaaaaaaaaa"),
 		13: []byte("bbbbbbbbbb"),
@@ -227,7 +226,7 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 
 	// Success with 2 refetches.
 	r.loadedSeries = map[storage.SeriesRef][]byte{}
-	assert.NoError(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2, 13, 24}, false, 2, 15))
+	assert.NoError(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2, 13, 24}, false, 2, 15, newSafeQueryStats()))
 	assert.Equal(t, map[storage.SeriesRef][]byte{
 		2:  []byte("aaaaaaaaaa"),
 		13: []byte("bbbbbbbbbb"),
@@ -237,7 +236,7 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 
 	// Success with refetch on first element.
 	r.loadedSeries = map[storage.SeriesRef][]byte{}
-	assert.NoError(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2}, false, 2, 5))
+	assert.NoError(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2}, false, 2, 5, newSafeQueryStats()))
 	assert.Equal(t, map[storage.SeriesRef][]byte{
 		2: []byte("aaaaaaaaaa"),
 	}, r.loadedSeries)
@@ -251,7 +250,7 @@ func TestReadIndexCache_LoadSeries(t *testing.T) {
 	assert.NoError(t, bkt.Upload(context.Background(), filepath.Join(b.meta.ULID.String(), block.IndexFilename), bytes.NewReader(buf.Get())))
 
 	// Fail, but no recursion at least.
-	assert.Error(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2, 13, 24}, false, 1, 15))
+	assert.Error(t, r.loadSeries(context.TODO(), []storage.SeriesRef{2, 13, 24}, false, 1, 15, newSafeQueryStats()))
 }
 
 func TestBlockLabelNames(t *testing.T) {
@@ -377,7 +376,7 @@ func TestBlockLabelValues(t *testing.T) {
 
 	t.Run("happy case with no matchers", func(t *testing.T) {
 		b := newTestBucketBlock()
-		names, err := blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger())
+		names, err := blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"bar", "foo"}, names)
 	})
@@ -390,7 +389,7 @@ func TestBlockLabelValues(t *testing.T) {
 		}
 		b.indexCache = cacheNotExpectingToStoreLabelValues{t: t}
 
-		_, err := blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger())
+		_, err := blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger(), newSafeQueryStats())
 		require.Error(t, err)
 	})
 
@@ -409,12 +408,12 @@ func TestBlockLabelValues(t *testing.T) {
 		}
 		b.indexCache = newInMemoryIndexCache(t)
 
-		names, err := blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger())
+		names, err := blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"bar", "foo"}, names)
 
 		// hit the cache now
-		names, err = blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger())
+		names, err = blockLabelValues(context.Background(), b.indexReader(), "j", nil, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"bar", "foo"}, names)
 	})
@@ -430,7 +429,7 @@ func TestBlockLabelValues(t *testing.T) {
 		// This test relies on the fact that p~=foo.* has to call LabelValues(p) when doing ExpandedPostings().
 		// We make that call fail in order to make the entire LabelValues(p~=foo.*) call fail.
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "p", "foo.*")}
-		_, err := blockLabelValues(context.Background(), b.indexReader(), "j", matchers, log.NewNopLogger())
+		_, err := blockLabelValues(context.Background(), b.indexReader(), "j", matchers, log.NewNopLogger(), newSafeQueryStats())
 		require.Error(t, err)
 	})
 
@@ -439,12 +438,12 @@ func TestBlockLabelValues(t *testing.T) {
 		b.indexCache = newInMemoryIndexCache(t)
 
 		pFooMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "p", "foo")}
-		values, err := blockLabelValues(context.Background(), b.indexReader(), "j", pFooMatchers, log.NewNopLogger())
+		values, err := blockLabelValues(context.Background(), b.indexReader(), "j", pFooMatchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"foo"}, values)
 
 		qFooMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "q", "foo")}
-		values, err = blockLabelValues(context.Background(), b.indexReader(), "j", qFooMatchers, log.NewNopLogger())
+		values, err = blockLabelValues(context.Background(), b.indexReader(), "j", qFooMatchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"bar"}, values)
 
@@ -453,10 +452,10 @@ func TestBlockLabelValues(t *testing.T) {
 		indexrWithoutHeaderReader := b.indexReader()
 		indexrWithoutHeaderReader.block.indexHeaderReader = nil
 
-		values, err = blockLabelValues(context.Background(), indexrWithoutHeaderReader, "j", pFooMatchers, log.NewNopLogger())
+		values, err = blockLabelValues(context.Background(), indexrWithoutHeaderReader, "j", pFooMatchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"foo"}, values)
-		values, err = blockLabelValues(context.Background(), indexrWithoutHeaderReader, "j", qFooMatchers, log.NewNopLogger())
+		values, err = blockLabelValues(context.Background(), indexrWithoutHeaderReader, "j", qFooMatchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"bar"}, values)
 	})
@@ -487,7 +486,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 		// cache provides undecodable values
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-		refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers)
+		refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, series, len(refs))
 	})
@@ -544,7 +543,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 			indexr := b.indexReader()
 			defer indexr.Close()
 
-			ress[0], errs[0] = indexr.ExpandedPostings(context.Background(), deduplicatedCallMatchers)
+			ress[0], errs[0] = indexr.ExpandedPostings(context.Background(), deduplicatedCallMatchers, newSafeQueryStats())
 		}()
 		// wait for this call to actually create a promise and call LabelValues
 		labelValuesCalls["i"].Wait()
@@ -556,7 +555,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 			indexr := b.indexReader()
 			defer indexr.Close()
 
-			ress[1], errs[1] = indexr.ExpandedPostings(secondContext, deduplicatedCallMatchers)
+			ress[1], errs[1] = indexr.ExpandedPostings(secondContext, deduplicatedCallMatchers, newSafeQueryStats())
 		}()
 		// wait until this is waiting on the promise
 		<-secondContext.waitingDone
@@ -569,7 +568,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 			indexr := b.indexReader()
 			defer indexr.Close()
 
-			ress[2], errs[2] = indexr.ExpandedPostings(thirdContext, deduplicatedCallMatchers)
+			ress[2], errs[2] = indexr.ExpandedPostings(thirdContext, deduplicatedCallMatchers, newSafeQueryStats())
 		}()
 		// wait until this is waiting on the promise
 		<-thirdContext.waitingDone
@@ -582,7 +581,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 			indexr := b.indexReader()
 			defer indexr.Close()
 
-			ress[3], errs[3] = indexr.ExpandedPostings(context.Background(), otherMatchers)
+			ress[3], errs[3] = indexr.ExpandedPostings(context.Background(), otherMatchers, newSafeQueryStats())
 		}()
 		// wait for this call to actually create a promise and call LabelValues
 		labelValuesCalls["n"].Wait()
@@ -593,7 +592,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 			indexr := b.indexReader()
 			defer indexr.Close()
 
-			ress[4], errs[4] = indexr.ExpandedPostings(context.Background(), failingMatchers)
+			ress[4], errs[4] = indexr.ExpandedPostings(context.Background(), failingMatchers, newSafeQueryStats())
 		}()
 		// wait for this call to actually create a promise and call LabelValues
 		labelValuesCalls["fail"].Wait()
@@ -605,7 +604,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 			indexr := b.indexReader()
 			defer indexr.Close()
 
-			ress[5], errs[5] = indexr.ExpandedPostings(sixthContext, failingMatchers)
+			ress[5], errs[5] = indexr.ExpandedPostings(sixthContext, failingMatchers, newSafeQueryStats())
 		}()
 		// wait until this is waiting on the promise
 		<-sixthContext.waitingDone
@@ -649,20 +648,20 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 		// first call succeeds and caches value
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-		refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers)
+		refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, series, len(refs))
 		require.Equal(t, map[string]int{"i": 1}, labelValuesCalls, "Should have called LabelValues once for label 'i'.")
 
 		// second call uses cached value, so it doesn't call LabelValues again
-		refs, err = b.indexReader().ExpandedPostings(context.Background(), matchers)
+		refs, err = b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, series, len(refs))
 		require.Equal(t, map[string]int{"i": 1}, labelValuesCalls, "Should have used cached value, so it shouldn't call LabelValues again for label 'i'.")
 
 		// different matcher on same label should not be cached
 		differentMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "i", "")}
-		refs, err = b.indexReader().ExpandedPostings(context.Background(), differentMatchers)
+		refs, err = b.indexReader().ExpandedPostings(context.Background(), differentMatchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, series, len(refs))
 		require.Equal(t, map[string]int{"i": 2}, labelValuesCalls, "Should have called LabelValues again for label 'i'.")
@@ -673,7 +672,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 		b.indexCache = corruptedExpandedPostingsCache{}
 
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-		refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers)
+		refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, series, len(refs))
 	})
@@ -689,7 +688,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 		b.indexCache = cacheNotExpectingToStoreExpandedPostings{t: t}
 
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-		_, err := b.indexReader().ExpandedPostings(context.Background(), matchers)
+		_, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.Error(t, err)
 	})
 }
@@ -923,10 +922,11 @@ func benchmarkExpandedPostings(
 	for _, c := range cases {
 		t.Run(c.name, func(t test.TB) {
 			indexr := newBucketIndexReader(newTestBucketBlock())
+			indexrStats := newSafeQueryStats()
 
 			t.ResetTimer()
 			for i := 0; i < t.N(); i++ {
-				p, err := indexr.ExpandedPostings(ctx, c.matchers)
+				p, err := indexr.ExpandedPostings(ctx, c.matchers, indexrStats)
 
 				if err != nil {
 					t.Fatal(err.Error())

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package storegateway
+
+import "time"
+
+type queryStats struct {
+	blocksQueried int
+
+	postingsTouched          int
+	postingsTouchedSizeSum   int
+	postingsToFetch          int
+	postingsFetched          int
+	postingsFetchedSizeSum   int
+	postingsFetchCount       int
+	postingsFetchDurationSum time.Duration
+
+	cachedPostingsCompressions         int
+	cachedPostingsCompressionErrors    int
+	cachedPostingsOriginalSizeSum      int
+	cachedPostingsCompressedSizeSum    int
+	cachedPostingsCompressionTimeSum   time.Duration
+	cachedPostingsDecompressions       int
+	cachedPostingsDecompressionErrors  int
+	cachedPostingsDecompressionTimeSum time.Duration
+
+	seriesTouched          int
+	seriesTouchedSizeSum   int
+	seriesFetched          int
+	seriesFetchedSizeSum   int
+	seriesFetchCount       int
+	seriesFetchDurationSum time.Duration
+
+	seriesHashCacheRequests int
+	seriesHashCacheHits     int
+
+	chunksTouched          int
+	chunksTouchedSizeSum   int
+	chunksFetched          int
+	chunksFetchedSizeSum   int
+	chunksFetchCount       int
+	chunksFetchDurationSum time.Duration
+
+	getAllDuration    time.Duration
+	mergedSeriesCount int
+	mergedChunksCount int
+	mergeDuration     time.Duration
+}
+
+func (s queryStats) merge(o *queryStats) *queryStats {
+	s.blocksQueried += o.blocksQueried
+
+	s.postingsTouched += o.postingsTouched
+	s.postingsTouchedSizeSum += o.postingsTouchedSizeSum
+	s.postingsFetched += o.postingsFetched
+	s.postingsFetchedSizeSum += o.postingsFetchedSizeSum
+	s.postingsFetchCount += o.postingsFetchCount
+	s.postingsFetchDurationSum += o.postingsFetchDurationSum
+
+	s.cachedPostingsCompressions += o.cachedPostingsCompressions
+	s.cachedPostingsCompressionErrors += o.cachedPostingsCompressionErrors
+	s.cachedPostingsOriginalSizeSum += o.cachedPostingsOriginalSizeSum
+	s.cachedPostingsCompressedSizeSum += o.cachedPostingsCompressedSizeSum
+	s.cachedPostingsCompressionTimeSum += o.cachedPostingsCompressionTimeSum
+	s.cachedPostingsDecompressions += o.cachedPostingsDecompressions
+	s.cachedPostingsDecompressionErrors += o.cachedPostingsDecompressionErrors
+	s.cachedPostingsDecompressionTimeSum += o.cachedPostingsDecompressionTimeSum
+
+	s.seriesTouched += o.seriesTouched
+	s.seriesTouchedSizeSum += o.seriesTouchedSizeSum
+	s.seriesFetched += o.seriesFetched
+	s.seriesFetchedSizeSum += o.seriesFetchedSizeSum
+	s.seriesFetchCount += o.seriesFetchCount
+	s.seriesFetchDurationSum += o.seriesFetchDurationSum
+
+	s.seriesHashCacheRequests += o.seriesHashCacheRequests
+	s.seriesHashCacheHits += o.seriesHashCacheHits
+
+	s.chunksTouched += o.chunksTouched
+	s.chunksTouchedSizeSum += o.chunksTouchedSizeSum
+	s.chunksFetched += o.chunksFetched
+	s.chunksFetchedSizeSum += o.chunksFetchedSizeSum
+	s.chunksFetchCount += o.chunksFetchCount
+	s.chunksFetchDurationSum += o.chunksFetchDurationSum
+
+	s.getAllDuration += o.getAllDuration
+	s.mergedSeriesCount += o.mergedSeriesCount
+	s.mergedChunksCount += o.mergedChunksCount
+	s.mergeDuration += o.mergeDuration
+
+	return &s
+}

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -100,7 +100,7 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 
 // safeQueryStats wraps queryStats adding functions to lock/unlock a mutex before manipulating the statistics.
 type safeQueryStats struct {
-	mtx sync.Mutex
+	sync.Mutex
 	*queryStats
 }
 
@@ -108,14 +108,6 @@ func newSafeQueryStats() *safeQueryStats {
 	return &safeQueryStats{
 		queryStats: &queryStats{},
 	}
-}
-
-func (s *safeQueryStats) lock() {
-	s.mtx.Lock()
-}
-
-func (s *safeQueryStats) unlock() {
-	s.mtx.Unlock()
 }
 
 func (s *safeQueryStats) merge(o *queryStats) *safeQueryStats {


### PR DESCRIPTION
#### What this PR does
Dimitar is doing a work to make the store-gateway `Series()` streaming based in https://github.com/grafana/mimir/pull/3355. One of the implementation difficulties is the fact that `bucketIndexReader` keeps per-query data inside, so in #3355 we're introducing an unload function. To remove the need of that unload function from the `bucketIndexReader` I think we can stop storing per-query data in `bucketIndexReader` (which always looked a bad smell to me).

In this PR (se separate commits):
- [Moved queryStats to dedicated file](https://github.com/grafana/mimir/commit/fb06a8aed509a06f09449f933a6b346deac94e8d)
- [Move query statistics out of bucketIndexReader](https://github.com/grafana/mimir/commit/995e5ea4aed665ca5b24bbef8176358d9a495d17)
- [Do not store preloaded series in bucketIndexReader](https://github.com/grafana/mimir/commit/6540e1270d17fc2dcbefe9b352c07a8533f39ab2)

Note to reviewers:
- Query statistics are passed in input to functions reading the block index and then populated by these functions. I've also considered returning it and then calling `merge()` on the returned value but looked way more annoying to work with.
- The design of `safeQueryStats` is not perfect, but I tried to make it so that the diff is as easiest as possible to review. I think we can further improve it in follow up PRs.

Unless bugs, this PR is expected to be a no-op from the logic perspective.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
