### PR TITLE
Refactoring: enforce usage of safeQueryStats in bucketIndexReader

### DIFF
--- a/pkg/storegateway/stats_test.go
+++ b/pkg/storegateway/stats_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeQueryStats_merge(t *testing.T) {
+	first := newSafeQueryStats()
+	first.update(func(stats *queryStats) {
+		stats.blocksQueried = 1
+	})
+
+	second := newSafeQueryStats()
+	second.update(func(stats *queryStats) {
+		stats.blocksQueried = 2
+	})
+
+	merged := first.merge(second.export())
+
+	// Ensure first is not modified in-place.
+	assert.Equal(t, 1, first.export().blocksQueried)
+
+	// Ensure the returned merged stats are correct.
+	assert.Equal(t, 3, merged.export().blocksQueried)
+}
+
+func TestSafeQueryStats_export(t *testing.T) {
+	orig := newSafeQueryStats()
+	orig.update(func(stats *queryStats) {
+		stats.blocksQueried = 10
+	})
+
+	exported := orig.export()
+	assert.Equal(t, 10, exported.blocksQueried)
+
+	orig.update(func(stats *queryStats) {
+		stats.blocksQueried = 20
+	})
+
+	assert.Equal(t, 20, orig.unsafeStats.blocksQueried)
+	assert.Equal(t, 10, exported.blocksQueried)
+}


### PR DESCRIPTION
#### What this PR does
This PR is a follow up of #3396. In this PR I'm enforcing the usage of `safeQueryStats` in `bucketIndexReader`. To enforce it, I've introduced a function `update()` to manipulate the stats and `export()` to get a copy of the stats.

The "unsafe" version `queryStats` is still directly accessed in few places which we haven't refactored yet (e.g. chunks reader). These will be addressed in follow up PRs, as soon as we begin addressing the chunks reader.

This PR is on top of #3398.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
