### PR TITLE
Remove reference to file that no longer exists in contributing guide.

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -91,7 +91,7 @@ Please see the dedicated "[Design patterns and Code conventions](design-patterns
 
 ## Documentation
 
-The Grafana Mimir documentation is compiled into a website published at [grafana.com](https://grafana.com/). Please see "[How to run the website locally](./how-to-run-website-locally.md)" for instructions.
+The Grafana Mimir documentation is compiled into a website published at [grafana.com](https://grafana.com/). Run `make docs` to build and serve the documentation locally.
 
 Note: if you attempt to view pages on Github, it's likely that you might find broken links or pages. That is expected and should not be addressed unless it is causing issues with the site that occur as part of the build.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The contributing guide refers to `how-to-run-website-locally.md`, but this file was removed in https://github.com/grafana/mimir/pull/772. 

It seems that `make docs` is the easiest way to run the website locally now.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
