### PR TITLE
Add validation for newS3Config (#3410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Store-gateway: improved index header reading performance. #3393 #3397 #3436
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386
+* [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -108,8 +108,8 @@ func (cfg *Config) Validate() error {
 		return errUnsupportedSignatureVersion
 	}
 	if cfg.Endpoint != "" {
-		endPoint := strings.Split(cfg.Endpoint, ".")
-		if cfg.BucketName != "" && endPoint[0] != "" && endPoint[0] == cfg.BucketName {
+		endpoint := strings.Split(cfg.Endpoint, ".")
+		if cfg.BucketName != "" && endpoint[0] != "" && endpoint[0] == cfg.BucketName {
 			return errInvalidEndpointPrefix
 		}
 	}

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -40,6 +40,7 @@ var (
 	errUnsupportedSignatureVersion = fmt.Errorf("unsupported signature version (supported values: %s)", strings.Join(supportedSignatureVersions, ", "))
 	errUnsupportedSSEType          = errors.New("unsupported S3 SSE type")
 	errInvalidSSEContext           = errors.New("invalid S3 SSE encryption context")
+	errInvalidEndpointPrefix       = errors.New("the endpoint must not prefixed with the bucket name")
 )
 
 // HTTPConfig stores the http.Transport configuration for the s3 minio client.
@@ -106,7 +107,12 @@ func (cfg *Config) Validate() error {
 	if !util.StringsContain(supportedSignatureVersions, cfg.SignatureVersion) {
 		return errUnsupportedSignatureVersion
 	}
-
+	if cfg.Endpoint != "" {
+		endPoint := strings.Split(cfg.Endpoint, ".")
+		if cfg.BucketName != "" && endPoint[0] != "" && endPoint[0] == cfg.BucketName {
+			return errInvalidEndpointPrefix
+		}
+	}
 	if err := cfg.SSE.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
* endpoint has prefixed with bucket name

Signed-off-by: u5surf <u5.horie@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

To fix the issue of 3410, we should be added the validation of endpoint which has not prefixed with bucket name.

#### Which issue(s) this PR fixes or relates to

Fixes #3410

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
