### PR TITLE
Fix mimir-rules-action single line output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 * [FEATURE] Add `copyblocks` tool, to copy Mimir blocks between two GCS buckets. #3263
 * [ENHANCEMENT] copyblocks: copy no-compact global markers and optimize min time filter check. #3268
 * [ENHANCEMENT] Mimir rules GitHub action: Added the ability to change default value of `label` when running `prepare` command. #3236
+* [BUGFIX] Mimir rules Github action: Fix single line output. #3421
 
 ## 2.4.0
 

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -72,7 +72,7 @@ case "${ACTION}" in
     ;;
 esac
 
-SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
+SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="%0A" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
 echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
 echo ::set-output name=summary::"${SUMMARY}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes detailed output generated by `mimir-rules-action`, GitHub Actions does not support multiline output.
Adds `%0A` to the input record separator for generating single line output using `awk`.

<details>
<summary>Output Before Change</summary>

### Generated String
```text
Changes are indicated with the following symbols:%0A  + created%0A  - deleted
The following changes will be made if the provided rule set is synced:%0A+ Namespace: test%0A  + Group: mimir_api_1%0A  + Group: mimir_api_2%0A  + Group: mimir_api_3%0A  + Group: mimir_querier_api%0A  + Group: mimir_cache%0A  + Group: mimir_storage%0A  + Group: mimir_queries%0A  + Group: mimir_ingester_queries%0A  + Group: mimir_received_samples%0A  + Group: mimir_exemplars_in%0A  + Group: mimir_received_exemplars%0A  + Group: mimir_exemplars_ingested%0A  + Group: mimir_exemplars_appended%0A  + Group: mimir_scaling_rules%0A  + Group: mimir_alertmanager_rules%0A  + Group: mimir_ingester_rules%0A- Namespace: test-namespace%0A  - Group: test-group-federated-all%0A  - Group: test-group-federated-single%0A  - Group: test-group-single
Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted
```

### GitHub Actions Debug Logs

```diff
::set-output name=detailed::Changes are indicated with the following symbols:%0A  + created%0A  - deleted
##[debug]steps.rules_diff.outputs.detailed='Changes are indicated with the following symbols:
##[debug]  + created
##[debug]  - deleted'
The following changes will be made if the provided rule set is synced:%0A+ Namespace: test%0A  + Group: mimir_api_1%0A  + Group: mimir_api_2%0A  + Group: mimir_api_3%0A  + Group: mimir_querier_api%0A  + Group: mimir_cache%0A  + Group: mimir_storage%0A  + Group: mimir_queries%0A  + Group: mimir_ingester_queries%0A  + Group: mimir_received_samples%0A  + Group: mimir_exemplars_in%0A  + Group: mimir_received_exemplars%0A  + Group: mimir_exemplars_ingested%0A  + Group: mimir_exemplars_appended%0A  + Group: mimir_scaling_rules%0A  + Group: mimir_alertmanager_rules%0A  + Group: mimir_ingester_rules%0A- Namespace: test-namespace%0A  - Group: test-group-federated-all%0A  - Group: test-group-federated-single%0A  - Group: test-group-single
Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted%0A
::set-output name=summary::Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted
```

### Output 

```diff
Changes are indicated with the following symbols:
+ created
- deleted
```

</details>


<details>
<summary>Output After Change</summary>

### Generated String
```text
Changes are indicated with the following symbols:%0A  + created%0A  - deleted%0A%0AThe following changes will be made if the provided rule set is synced:%0A+ Namespace: test%0A  + Group: mimir_api_1%0A  + Group: mimir_api_2%0A  + Group: mimir_api_3%0A  + Group: mimir_querier_api%0A  + Group: mimir_cache%0A  + Group: mimir_storage%0A  + Group: mimir_queries%0A  + Group: mimir_ingester_queries%0A  + Group: mimir_received_samples%0A  + Group: mimir_exemplars_in%0A  + Group: mimir_received_exemplars%0A  + Group: mimir_exemplars_ingested%0A  + Group: mimir_exemplars_appended%0A  + Group: mimir_scaling_rules%0A  + Group: mimir_alertmanager_rules%0A  + Group: mimir_ingester_rules%0A- Namespace: test-namespace%0A  - Group: test-group-federated-all%0A  - Group: test-group-federated-single%0A  - Group: test-group-single%0A%0ADiff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted%0A
```

### Github Actions Debug Logs 
```diff
::set-output name=detailed::Changes are indicated with the following symbols:%0A  + created%0A  - deleted%0A%0AThe following changes will be made if the provided rule set is synced:%0A+ Namespace: test%0A  + Group: mimir_api_1%0A  + Group: mimir_api_2%0A  + Group: mimir_api_3%0A  + Group: mimir_querier_api%0A  + Group: mimir_cache%0A  + Group: mimir_storage%0A  + Group: mimir_queries%0A  + Group: mimir_ingester_queries%0A  + Group: mimir_received_samples%0A  + Group: mimir_exemplars_in%0A  + Group: mimir_received_exemplars%0A  + Group: mimir_exemplars_ingested%0A  + Group: mimir_exemplars_appended%0A  + Group: mimir_scaling_rules%0A  + Group: mimir_alertmanager_rules%0A  + Group: mimir_ingester_rules%0A- Namespace: test-namespace%0A  - Group: test-group-federated-all%0A  - Group: test-group-federated-single%0A  - Group: test-group-single%0A%0ADiff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted%0A
##[debug]steps.rules_diff.outputs.detailed='Changes are indicated with the following symbols:
##[debug]  + created
##[debug]  - deleted
##[debug]
##[debug]The following changes will be made if the provided rule set is synced:
##[debug]+ Namespace: test
##[debug]  + Group: mimir_api_1
##[debug]  + Group: mimir_api_2
##[debug]  + Group: mimir_api_3
##[debug]  + Group: mimir_querier_api
##[debug]  + Group: mimir_cache
##[debug]  + Group: mimir_storage
##[debug]  + Group: mimir_queries
##[debug]  + Group: mimir_ingester_queries
##[debug]  + Group: mimir_received_samples
##[debug]  + Group: mimir_exemplars_in
##[debug]  + Group: mimir_received_exemplars
##[debug]  + Group: mimir_exemplars_ingested
##[debug]  + Group: mimir_exemplars_appended
##[debug]  + Group: mimir_scaling_rules
##[debug]  + Group: mimir_alertmanager_rules
##[debug]  + Group: mimir_ingester_rules
##[debug]- Namespace: test-namespace
##[debug]  - Group: test-group-federated-all
##[debug]  - Group: test-group-federated-single
##[debug]  - Group: test-group-single
##[debug]
##[debug]Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted
##[debug]'
::set-output name=summary::Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted
##[debug]steps.rules_diff.outputs.summary='Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted'
##[debug]Docker Action run completed with exit code 0
##[debug]Finishing: Rules Diff
```

### Output

```diff
Changes are indicated with the following symbols:
+ created
- deleted

The following changes will be made if the provided rule set is synced:
+ Namespace: test
+ Group: mimir_api_1
+ Group: mimir_api_2
+ Group: mimir_api_3
+ Group: mimir_querier_api
+ Group: mimir_cache
+ Group: mimir_storage
+ Group: mimir_queries
+ Group: mimir_ingester_queries
+ Group: mimir_received_samples
+ Group: mimir_exemplars_in
+ Group: mimir_received_exemplars
+ Group: mimir_exemplars_ingested
+ Group: mimir_exemplars_appended
+ Group: mimir_scaling_rules
+ Group: mimir_alertmanager_rules
+ Group: mimir_ingester_rules
- Namespace: test-namespace
- Group: test-group-federated-all
- Group: test-group-federated-single
- Group: test-group-single

Diff Summary: 16 Groups Created, 0 Groups Updated, 3 Groups Deleted
```
</details>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
