### PR TITLE
Refactoring: move postings reading utilities to dedicated file

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -773,37 +773,6 @@ func storeCachedSeries(ctx context.Context, indexCache indexcache.IndexCache, us
 	indexCache.StoreSeries(ctx, userID, blockID, entry.MatchersKey, shard, data)
 }
 
-// filterPostingsByCachedShardHash filters the input postings by the provided shard. It filters only
-// postings for which we have their series hash already in the cache; if a series is not in the cache,
-// postings will be kept in the output.
-func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache *hashcache.BlockSeriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
-	writeIdx := 0
-	stats.seriesHashCacheRequests = len(ps)
-
-	for readIdx := 0; readIdx < len(ps); readIdx++ {
-		seriesID := ps[readIdx]
-		hash, ok := seriesHashCache.Fetch(seriesID)
-		if ok {
-			stats.seriesHashCacheHits++
-		}
-
-		// Keep the posting if it's not in the cache, or it's in the cache and belongs to our shard.
-		if !ok || hash%uint64(shard.ShardCount) == uint64(shard.ShardIndex) {
-			ps[writeIdx] = seriesID
-			writeIdx++
-			continue
-		}
-
-		// We can filter out the series because doesn't belong to the requested shard,
-		// so we're not going to increase the writeIdx.
-	}
-
-	// Shrink the size.
-	ps = ps[:writeIdx]
-
-	return ps, stats
-}
-
 func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, aggrs []storepb.Aggr, save func([]byte) ([]byte, error)) error {
 	if in.Encoding() == chunkenc.EncXOR {
 		b, err := save(in.Bytes())
@@ -1705,151 +1674,8 @@ func (b *bucketBlock) Close() error {
 	return b.indexHeaderReader.Close()
 }
 
-// postingGroup keeps posting keys for single matcher. Logical result of the group is:
-// If addAll is set: special All postings minus postings for removeKeys labels. No need to merge postings for addKeys in this case.
-// If addAll is not set: Merge of postings for "addKeys" labels minus postings for removeKeys labels
-// This computation happens in ExpandedPostings.
-type postingGroup struct {
-	addAll     bool
-	addKeys    []labels.Label
-	removeKeys []labels.Label
-}
-
-func newPostingGroup(addAll bool, addKeys, removeKeys []labels.Label) *postingGroup {
-	return &postingGroup{
-		addAll:     addAll,
-		addKeys:    addKeys,
-		removeKeys: removeKeys,
-	}
-}
-
-func checkNilPosting(l labels.Label, p index.Postings) index.Postings {
-	if p == nil {
-		// This should not happen. Debug for https://github.com/thanos-io/thanos/issues/874.
-		return index.ErrPostings(errors.Errorf("postings is nil for %s. It was never fetched.", l))
-	}
-	return p
-}
-
 type labelValuesReader interface {
 	LabelValues(name string, filter func(string) bool) ([]string, error)
-}
-
-// NOTE: Derived from tsdb.postingsForMatcher. index.Merge is equivalent to map duplication.
-func toPostingGroup(lvr labelValuesReader, m *labels.Matcher) (*postingGroup, error) {
-	if setMatches := m.SetMatches(); len(setMatches) > 0 && (m.Type == labels.MatchRegexp || m.Type == labels.MatchNotRegexp) {
-		keys := make([]labels.Label, 0, len(setMatches))
-		for _, val := range setMatches {
-			keys = append(keys, labels.Label{Name: m.Name, Value: val})
-		}
-		if m.Type == labels.MatchNotRegexp {
-			return newPostingGroup(true, nil, keys), nil
-		}
-		return newPostingGroup(false, keys, nil), nil
-	}
-
-	if m.Value != "" {
-		// Fast-path for equal matching.
-		// Works for every case except for `foo=""`, which is a special case, see below.
-		if m.Type == labels.MatchEqual {
-			return newPostingGroup(false, []labels.Label{{Name: m.Name, Value: m.Value}}, nil), nil
-		}
-
-		// If matcher is `label!="foo"`, we select an empty label value too,
-		// i.e., series that don't have this label.
-		// So this matcher selects all series in the storage,
-		// except for the ones that do have `label="foo"`
-		if m.Type == labels.MatchNotEqual {
-			return newPostingGroup(true, nil, []labels.Label{{Name: m.Name, Value: m.Value}}), nil
-		}
-	}
-
-	// This is a more generic approach for the previous case.
-	// Here we can enter with `label=""` or regexp matchers that match the empty value,
-	// like `=~"|foo" or `error!~"5..".
-	// Remember: if the matcher selects an empty value, it selects all the series which don't
-	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
-	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.
-	if m.Matches("") {
-		vals, err := lvr.LabelValues(m.Name, not(m.Matches))
-		toRemove := make([]labels.Label, len(vals))
-		for i := range vals {
-			toRemove[i] = labels.Label{Name: m.Name, Value: vals[i]}
-		}
-		return newPostingGroup(true, nil, toRemove), err
-	}
-
-	// Our matcher does not match the empty value, so we just need the postings that correspond
-	// to label values matched by the matcher.
-	vals, err := lvr.LabelValues(m.Name, m.Matches)
-	toAdd := make([]labels.Label, len(vals))
-	for i := range vals {
-		toAdd[i] = labels.Label{Name: m.Name, Value: vals[i]}
-	}
-	return newPostingGroup(false, toAdd, nil), err
-}
-
-func not(filter func(string) bool) func(string) bool {
-	return func(s string) bool { return !filter(s) }
-}
-
-type postingPtr struct {
-	keyID int
-	ptr   index.Range
-}
-
-// bigEndianPostings implements the Postings interface over a byte stream of
-// big endian numbers.
-type bigEndianPostings struct {
-	list []byte
-	cur  storage.SeriesRef
-}
-
-// TODO(bwplotka): Expose those inside Prometheus.
-func newBigEndianPostings(list []byte) *bigEndianPostings {
-	return &bigEndianPostings{list: list}
-}
-
-func (it *bigEndianPostings) At() storage.SeriesRef {
-	return it.cur
-}
-
-func (it *bigEndianPostings) Next() bool {
-	if len(it.list) >= 4 {
-		it.cur = storage.SeriesRef(binary.BigEndian.Uint32(it.list))
-		it.list = it.list[4:]
-		return true
-	}
-	return false
-}
-
-func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
-	if it.cur >= x {
-		return true
-	}
-
-	num := len(it.list) / 4
-	// Do binary search between current position and end.
-	i := sort.Search(num, func(i int) bool {
-		return binary.BigEndian.Uint32(it.list[i*4:]) >= uint32(x)
-	})
-	if i < num {
-		j := i * 4
-		it.cur = storage.SeriesRef(binary.BigEndian.Uint32(it.list[j:]))
-		it.list = it.list[j+4:]
-		return true
-	}
-	it.list = nil
-	return false
-}
-
-func (it *bigEndianPostings) Err() error {
-	return nil
-}
-
-// Returns number of remaining postings values.
-func (it *bigEndianPostings) length() int {
-	return len(it.list) / 4
 }
 
 type Part struct {
@@ -2168,26 +1994,6 @@ func (b rawChunk) NumSamples() int {
 // NewDefaultChunkBytesPool returns a chunk bytes pool with default settings.
 func NewDefaultChunkBytesPool(maxChunkPoolBytes uint64) (pool.Bytes, error) {
 	return pool.NewBucketedBytes(chunkBytesPoolMinSize, chunkBytesPoolMaxSize, 2, maxChunkPoolBytes)
-}
-
-// paddedPostings adds the v2 index padding to postings without expanding them
-type paddedPostings struct {
-	index.Postings
-}
-
-func (p paddedPostings) Seek(v storage.SeriesRef) bool {
-	unpadded := v / 16
-	if unpadded*16 != v {
-		// if someone is looking for 17 (they shouldn't but who knows)
-		// then we don't want stop seeking at 16 ((v/16) * 16), so we'll look for the next number
-		// this is semantically correct
-		unpadded++
-	}
-	return p.Postings.Seek(unpadded)
-}
-
-func (p paddedPostings) At() storage.SeriesRef {
-	return p.Postings.At() * 16
 }
 
 func maybeNilShard(shard *sharding.ShardSelector) sharding.ShardSelector {

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package storegateway
+
+import (
+	"encoding/binary"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/prometheus/prometheus/tsdb/hashcache"
+	"github.com/prometheus/prometheus/tsdb/index"
+
+	"github.com/grafana/mimir/pkg/storage/sharding"
+)
+
+// postingGroup keeps posting keys for single matcher. Logical result of the group is:
+// If addAll is set: special All postings minus postings for removeKeys labels. No need to merge postings for addKeys in this case.
+// If addAll is not set: Merge of postings for "addKeys" labels minus postings for removeKeys labels
+// This computation happens in ExpandedPostings.
+type postingGroup struct {
+	addAll     bool
+	addKeys    []labels.Label
+	removeKeys []labels.Label
+}
+
+func newPostingGroup(addAll bool, addKeys, removeKeys []labels.Label) *postingGroup {
+	return &postingGroup{
+		addAll:     addAll,
+		addKeys:    addKeys,
+		removeKeys: removeKeys,
+	}
+}
+
+// NOTE: Derived from tsdb.postingsForMatcher. index.Merge is equivalent to map duplication.
+func toPostingGroup(lvr labelValuesReader, m *labels.Matcher) (*postingGroup, error) {
+	if setMatches := m.SetMatches(); len(setMatches) > 0 && (m.Type == labels.MatchRegexp || m.Type == labels.MatchNotRegexp) {
+		keys := make([]labels.Label, 0, len(setMatches))
+		for _, val := range setMatches {
+			keys = append(keys, labels.Label{Name: m.Name, Value: val})
+		}
+		if m.Type == labels.MatchNotRegexp {
+			return newPostingGroup(true, nil, keys), nil
+		}
+		return newPostingGroup(false, keys, nil), nil
+	}
+
+	if m.Value != "" {
+		// Fast-path for equal matching.
+		// Works for every case except for `foo=""`, which is a special case, see below.
+		if m.Type == labels.MatchEqual {
+			return newPostingGroup(false, []labels.Label{{Name: m.Name, Value: m.Value}}, nil), nil
+		}
+
+		// If matcher is `label!="foo"`, we select an empty label value too,
+		// i.e., series that don't have this label.
+		// So this matcher selects all series in the storage,
+		// except for the ones that do have `label="foo"`
+		if m.Type == labels.MatchNotEqual {
+			return newPostingGroup(true, nil, []labels.Label{{Name: m.Name, Value: m.Value}}), nil
+		}
+	}
+
+	// This is a more generic approach for the previous case.
+	// Here we can enter with `label=""` or regexp matchers that match the empty value,
+	// like `=~"|foo" or `error!~"5..".
+	// Remember: if the matcher selects an empty value, it selects all the series which don't
+	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
+	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.
+	if m.Matches("") {
+		vals, err := lvr.LabelValues(m.Name, not(m.Matches))
+		toRemove := make([]labels.Label, len(vals))
+		for i := range vals {
+			toRemove[i] = labels.Label{Name: m.Name, Value: vals[i]}
+		}
+		return newPostingGroup(true, nil, toRemove), err
+	}
+
+	// Our matcher does not match the empty value, so we just need the postings that correspond
+	// to label values matched by the matcher.
+	vals, err := lvr.LabelValues(m.Name, m.Matches)
+	toAdd := make([]labels.Label, len(vals))
+	for i := range vals {
+		toAdd[i] = labels.Label{Name: m.Name, Value: vals[i]}
+	}
+	return newPostingGroup(false, toAdd, nil), err
+}
+
+func not(filter func(string) bool) func(string) bool {
+	return func(s string) bool { return !filter(s) }
+}
+
+type postingPtr struct {
+	keyID int
+	ptr   index.Range
+}
+
+// bigEndianPostings implements the Postings interface over a byte stream of
+// big endian numbers.
+type bigEndianPostings struct {
+	list []byte
+	cur  storage.SeriesRef
+}
+
+// TODO(bwplotka): Expose those inside Prometheus.
+func newBigEndianPostings(list []byte) *bigEndianPostings {
+	return &bigEndianPostings{list: list}
+}
+
+func (it *bigEndianPostings) At() storage.SeriesRef {
+	return it.cur
+}
+
+func (it *bigEndianPostings) Next() bool {
+	if len(it.list) >= 4 {
+		it.cur = storage.SeriesRef(binary.BigEndian.Uint32(it.list))
+		it.list = it.list[4:]
+		return true
+	}
+	return false
+}
+
+func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
+	if it.cur >= x {
+		return true
+	}
+
+	num := len(it.list) / 4
+	// Do binary search between current position and end.
+	i := sort.Search(num, func(i int) bool {
+		return binary.BigEndian.Uint32(it.list[i*4:]) >= uint32(x)
+	})
+	if i < num {
+		j := i * 4
+		it.cur = storage.SeriesRef(binary.BigEndian.Uint32(it.list[j:]))
+		it.list = it.list[j+4:]
+		return true
+	}
+	it.list = nil
+	return false
+}
+
+func (it *bigEndianPostings) Err() error {
+	return nil
+}
+
+// Returns number of remaining postings values.
+func (it *bigEndianPostings) length() int {
+	return len(it.list) / 4
+}
+
+// filterPostingsByCachedShardHash filters the input postings by the provided shard. It filters only
+// postings for which we have their series hash already in the cache; if a series is not in the cache,
+// postings will be kept in the output.
+func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache *hashcache.BlockSeriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
+	writeIdx := 0
+	stats.seriesHashCacheRequests = len(ps)
+
+	for readIdx := 0; readIdx < len(ps); readIdx++ {
+		seriesID := ps[readIdx]
+		hash, ok := seriesHashCache.Fetch(seriesID)
+		if ok {
+			stats.seriesHashCacheHits++
+		}
+
+		// Keep the posting if it's not in the cache, or it's in the cache and belongs to our shard.
+		if !ok || hash%uint64(shard.ShardCount) == uint64(shard.ShardIndex) {
+			ps[writeIdx] = seriesID
+			writeIdx++
+			continue
+		}
+
+		// We can filter out the series because doesn't belong to the requested shard,
+		// so we're not going to increase the writeIdx.
+	}
+
+	// Shrink the size.
+	ps = ps[:writeIdx]
+
+	return ps, stats
+}
+
+// paddedPostings adds the v2 index padding to postings without expanding them
+type paddedPostings struct {
+	index.Postings
+}
+
+func (p paddedPostings) Seek(v storage.SeriesRef) bool {
+	unpadded := v / 16
+	if unpadded*16 != v {
+		// if someone is looking for 17 (they shouldn't but who knows)
+		// then we don't want stop seeking at 16 ((v/16) * 16), so we'll look for the next number
+		// this is semantically correct
+		unpadded++
+	}
+	return p.Postings.Seek(unpadded)
+}
+
+func (p paddedPostings) At() storage.SeriesRef {
+	return p.Postings.At() * 16
+}
+
+func resizePostings(b []byte) ([]byte, error) {
+	d := encoding.Decbuf{B: b}
+	n := d.Be32int()
+	if d.Err() != nil {
+		return nil, errors.Wrap(d.Err(), "read postings list")
+	}
+
+	// 4 for postings number of entries, then 4, foreach each big endian posting.
+	size := 4 + n*4
+	if len(b) < size {
+		return nil, encoding.ErrInvalidSize
+	}
+	return b[:size], nil
+}
+
+func checkNilPosting(l labels.Label, p index.Postings) index.Postings {
+	if p == nil {
+		// This should not happen. Debug for https://github.com/thanos-io/thanos/issues/874.
+		return index.ErrPostings(errors.Errorf("postings is nil for %s. It was never fetched.", l))
+	}
+	return p
+}

--- a/pkg/storegateway/bucket_index_postings_test.go
+++ b/pkg/storegateway/bucket_index_postings_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package storegateway
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBigEndianPostingsCount(t *testing.T) {
+	const count = 1000
+	raw := make([]byte, count*4)
+
+	for ix := 0; ix < count; ix++ {
+		binary.BigEndian.PutUint32(raw[4*ix:], rand.Uint32())
+	}
+
+	p := newBigEndianPostings(raw)
+	assert.Equal(t, count, p.length())
+
+	c := 0
+	for p.Next() {
+		c++
+	}
+	assert.Equal(t, count, c)
+}

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/thanos-io/objstore/tracing"
 	"golang.org/x/sync/errgroup"
@@ -588,19 +587,4 @@ func (l *bucketIndexLoadedSeries) loadSeriesForTime(ref storage.SeriesRef, lset 
 	stats.seriesTouched++
 	stats.seriesTouchedSizeSum += len(b)
 	return decodeSeriesForTime(b, lset, chks, skipChunks, mint, maxt)
-}
-
-func resizePostings(b []byte) ([]byte, error) {
-	d := encoding.Decbuf{B: b}
-	n := d.Be32int()
-	if d.Err() != nil {
-		return nil, errors.Wrap(d.Err(), "read postings list")
-	}
-
-	// 4 for postings number of entries, then 4, foreach each big endian posting.
-	size := 4 + n*4
-	if len(b) < size {
-		return nil, encoding.ErrInvalidSize
-	}
-	return b[:size], nil
 }

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -11,7 +11,6 @@ package storegateway
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math"
 	"math/rand"
@@ -1571,24 +1570,6 @@ func mustMarshalAny(pb proto.Message) *types.Any {
 		panic(err)
 	}
 	return out
-}
-
-func TestBigEndianPostingsCount(t *testing.T) {
-	const count = 1000
-	raw := make([]byte, count*4)
-
-	for ix := 0; ix < count; ix++ {
-		binary.BigEndian.PutUint32(raw[4*ix:], rand.Uint32())
-	}
-
-	p := newBigEndianPostings(raw)
-	assert.Equal(t, count, p.length())
-
-	c := 0
-	for p.Next() {
-		c++
-	}
-	assert.Equal(t, count, c)
 }
 
 func createBlockWithOneSeriesWithStep(t test.TB, dir string, lbls labels.Labels, blockIndex, totalSamples int, random *rand.Rand, step int64) ulid.ULID {


### PR DESCRIPTION
#### What this PR does
This is a follow up PR to further reduce `bucket.go` file size. In this PR I'm moving all postings reading utilities to a dedicated file `bucket_index_postings.go`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
