### PR TITLE
Convert MaxTime to seconds when recording compactor lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [ENHANCEMENT] Ingester: Reduce activity tracker memory allocation. #3203
 * [ENHANCEMENT] Query-frontend: Log more detailed information in the case of a failed query. #3190
 * [ENHANCEMENT] Added `-usage-stats.installation-mode` configuration to track the installation mode via the anonymous usage statistics. #3244
-* [ENHANCEMENT] Compactor: Add new `cortex_compactor_block_max_time_delta_seconds` histogram for detecting if compaction of blocks is lagging behind. #3240
+* [ENHANCEMENT] Compactor: Add new `cortex_compactor_block_max_time_delta_seconds` histogram for detecting if compaction of blocks is lagging behind. #3240 #3429
 * [ENHANCEMENT] Ingester: reduced the memory footprint of active series custom trackers. #2568
 * [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -815,11 +815,9 @@ func (c *BucketCompactor) Compact(ctx context.Context, maxCompactionTime time.Du
 		// Record the difference between now and the max time for a block being compacted. This
 		// is used to detect compactors not being able to keep up with the rate of blocks being
 		// created. The idea is that most blocks should be for within 24h or 48h.
-		now := time.Now().Unix()
-		for _, gr := range jobs {
-			for _, meta := range gr.Metas() {
-				c.metrics.blocksMaxTimeDelta.Observe(float64(now - meta.MaxTime))
-			}
+		now := time.Now()
+		for _, delta := range c.blockMaxTimeDeltas(now, jobs) {
+			c.metrics.blocksMaxTimeDelta.Observe(delta)
 		}
 
 		// Sort jobs based on the configured ordering algorithm.
@@ -875,6 +873,21 @@ func (c *BucketCompactor) Compact(ctx context.Context, maxCompactionTime time.Du
 	}
 	level.Info(c.logger).Log("msg", "compaction iterations done")
 	return nil
+}
+
+// blockMaxTimeDeltas returns a slice of the difference between now and the MaxTime of each
+// block that will be compacted as part of the provided jobs, in seconds.
+func (c *BucketCompactor) blockMaxTimeDeltas(now time.Time, jobs []*Job) []float64 {
+	var out []float64
+	nowMs := now.UnixMilli()
+
+	for _, j := range jobs {
+		for _, m := range j.Metas() {
+			out = append(out, float64((nowMs-m.MaxTime)/1000))
+		}
+	}
+
+	return out
 }
 
 func (c *BucketCompactor) filterOwnJobs(jobs []*Job) ([]*Job, error) {

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -879,11 +879,10 @@ func (c *BucketCompactor) Compact(ctx context.Context, maxCompactionTime time.Du
 // block that will be compacted as part of the provided jobs, in seconds.
 func (c *BucketCompactor) blockMaxTimeDeltas(now time.Time, jobs []*Job) []float64 {
 	var out []float64
-	nowMs := now.UnixMilli()
 
 	for _, j := range jobs {
 		for _, m := range j.Metas() {
-			out = append(out, float64((nowMs-m.MaxTime)/1000))
+			out = append(out, now.Sub(time.UnixMilli(m.MaxTime)).Seconds())
 		}
 	}
 

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -147,6 +147,12 @@ func TestBlockMaxTimeDeltas(t *testing.T) {
 			MaxTime: 1500002700159,
 		},
 	}))
+	require.NoError(t, j2.AppendMeta(&metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			MinTime: 1500002700159,
+			MaxTime: 1500002800159,
+		},
+	}))
 
 	metrics := NewBucketCompactorMetrics(promauto.With(nil).NewCounter(prometheus.CounterOpts{}), nil)
 	now := time.UnixMilli(1500002900159)
@@ -154,7 +160,7 @@ func TestBlockMaxTimeDeltas(t *testing.T) {
 	require.NoError(t, err)
 
 	deltas := bc.blockMaxTimeDeltas(now, []*Job{j1, j2})
-	assert.Equal(t, []float64{100, 200}, deltas)
+	assert.Equal(t, []float64{100, 200, 100}, deltas)
 }
 
 func TestNoCompactionMarkFilter(t *testing.T) {

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
@@ -128,6 +129,32 @@ func TestFilterOwnJobs(t *testing.T) {
 			assert.Len(t, res, testCase.expectedJobs)
 		})
 	}
+}
+
+func TestBlockMaxTimeDeltas(t *testing.T) {
+	j1 := NewJob("user", "key1", nil, 0, metadata.NoneFunc, false, 0, "")
+	require.NoError(t, j1.AppendMeta(&metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			MinTime: 1500002700159,
+			MaxTime: 1500002800159,
+		},
+	}))
+
+	j2 := NewJob("user", "key2", nil, 0, metadata.NoneFunc, false, 0, "")
+	require.NoError(t, j2.AppendMeta(&metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			MinTime: 1500002600159,
+			MaxTime: 1500002700159,
+		},
+	}))
+
+	metrics := NewBucketCompactorMetrics(promauto.With(nil).NewCounter(prometheus.CounterOpts{}), nil)
+	now := time.UnixMilli(1500002900159)
+	bc, err := NewBucketCompactor(log.NewNopLogger(), nil, nil, nil, nil, "", nil, 2, false, nil, nil, 4, metrics)
+	require.NoError(t, err)
+
+	deltas := bc.blockMaxTimeDeltas(now, []*Job{j1, j2})
+	assert.Equal(t, []float64{100, 200}, deltas)
 }
 
 func TestNoCompactionMarkFilter(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Fixes an issue where a timestamp in milliseconds was subtracted from a timestamp in seconds, resulting in negative deltas being recorded instead of the actual delay between the block maxtime and "now".

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
