### PR TITLE
Integration test tidy up

### DIFF
--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -9,7 +9,6 @@ package integration
 
 import (
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -65,15 +64,11 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	// Work around the Prometheus client lib not having a way to omit the start and end params.
-	minTime := time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
-	maxTime := time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
-
-	labelValues, err := c.LabelValues("foo", minTime, maxTime, nil)
+	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(minTime, maxTime)
+	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -6,7 +6,6 @@ package integration
 
 import (
 	"fmt"
-	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -92,15 +91,11 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService) {
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	// Work around the Prometheus client lib not having a way to omit the start and end params.
-	minTime := time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
-	maxTime := time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
-
-	labelValues, err := c.LabelValues("foo", minTime, maxTime, nil)
+	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(minTime, maxTime)
+	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -6,7 +6,6 @@ package integration
 
 import (
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -62,15 +61,11 @@ func TestOTLPIngestion(t *testing.T) {
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	// Work around the Prometheus client lib not having a way to omit the start and end params.
-	minTime := time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
-	maxTime := time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
-
-	labelValues, err := c.LabelValues("foo", minTime, maxTime, nil)
+	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(minTime, maxTime)
+	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -5,7 +5,6 @@
 package integration
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -58,15 +57,12 @@ func TestReadWriteMode(t *testing.T) {
 	_, err = c.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 
-	minTime := time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
-	maxTime := time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
-
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := c.LabelValues("foo", minTime, maxTime, nil)
+	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(minTime, maxTime)
+	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }

--- a/integration/util.go
+++ b/integration/util.go
@@ -9,9 +9,11 @@ package integration
 
 import (
 	"bytes"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -24,6 +26,14 @@ var (
 	mergeFlags      = e2e.MergeFlags
 	generateSeries  = e2e.GenerateSeries
 	generateNSeries = e2e.GenerateNSeries
+
+	// These are the earliest and latest possible timestamps supported by the Prometheus API -
+	// the Prometheus API does not support omitting a time range from query requests,
+	// so we use these when we want to query over all time.
+	// These values are defined in github.com/prometheus/prometheus/web/api/v1/api.go but
+	// sadly not exported.
+	prometheusMinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
+	prometheusMaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
 )
 
 func getMimirProjectDir() string {


### PR DESCRIPTION
#### What this PR does

I've [extracted Prometheus' minimum and maximum timestamp values to a single location](https://github.com/grafana/mimir/commit/0e5dad35cdf93635c2d88823230c3b1c878c4bfb) and updated all integration tests to use these instead of calculating them each time.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
