### PR TITLE
store-gateway: fix error handling in Series()

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1016,6 +1016,10 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		err = nil
 	})
 
+	if err != nil {
+		return
+	}
+
 	var anyHints *types.Any
 	if anyHints, err = types.MarshalAny(resHints); err != nil {
 		err = status.Error(codes.Unknown, errors.Wrap(err, "marshal series response hints").Error())


### PR DESCRIPTION
When the other side closed the stream, the store gateway continues
to try to send the hints. This attempt fails because the stream is
closed and the error from the attempt overwrites the original error.

That error will likely not have much useful information, but it is lost
nonetheless.

The possible errors lost are either here https://github.com/grafana/mimir/blob/aa5aa4e08a97eed478a8ddc0e765aebe2be66a8d/pkg/storegateway/bucket.go#L1010 or here https://github.com/grafana/mimir/blob/aa5aa4e08a97eed478a8ddc0e765aebe2be66a8d/pkg/storegateway/bucket.go#L1005

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
