### PR TITLE
Pin version of `doc-validator` tool in CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -48,7 +48,7 @@ jobs:
   doc-validator:
     runs-on: ubuntu-latest
     container:
-      image: grafana/doc-validator:latest
+      image: grafana/doc-validator:v1.0.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ check-doc: doc
 # https://github.com/grafana/technical-documentation/tree/main/tools/doc-validator
 check-doc-validator: ## Check documentation using doc-validator tool
 	docker pull grafana/doc-validator:latest
-	docker run -v "$(CURDIR)/docs/sources:/docs/sources" grafana/doc-validator:latest ./docs/sources
+	docker run -v "$(CURDIR)/docs/sources:/docs/sources" grafana/doc-validator:v1.0.0 ./docs/sources
 
 .PHONY: reference-help
 reference-help: ## Generates the reference help documentation.


### PR DESCRIPTION
Allows the team to opt in to changes in `doc-validator` linting.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
