### PR TITLE
Verify range query result matches expected value in integration tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.0
 	github.com/grafana/dskit v0.0.0-20221110225216-188592c3d6fc
-	github.com/grafana/e2e v0.1.1-0.20221018202458-cffd2bb71c7b
+	github.com/grafana/e2e v0.1.1-0.20221115065638-fe4609fcbc71
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/json-iterator/go v1.1.12
 	github.com/minio/minio-go/v7 v7.0.37

--- a/go.sum
+++ b/go.sum
@@ -482,8 +482,8 @@ github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9 h1:LQAhgcUPnzdjU
 github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/dskit v0.0.0-20221110225216-188592c3d6fc h1:wJH74LRQcSiB4WH0N0LfysF1Hx/5DA1+TsfOmuQ6VTQ=
 github.com/grafana/dskit v0.0.0-20221110225216-188592c3d6fc/go.mod h1:rJRGBDtyQNA3OFh7WecUILvxkgGrdIuA4f9wgZOn3V0=
-github.com/grafana/e2e v0.1.1-0.20221018202458-cffd2bb71c7b h1:Ha+kSIoTutf4ytlVw/SaEclDUloYx0+FXDKJWKhNbE4=
-github.com/grafana/e2e v0.1.1-0.20221018202458-cffd2bb71c7b/go.mod h1:3UsooRp7yW5/NJQBlXcTsAHOoykEhNUYXkQ3r6ehEEY=
+github.com/grafana/e2e v0.1.1-0.20221115065638-fe4609fcbc71 h1:sAMF3CGAtlWLimTyvsO46Slwu1p6Fm5EMB64XzG5btI=
+github.com/grafana/e2e v0.1.1-0.20221115065638-fe4609fcbc71/go.mod h1:3UsooRp7yW5/NJQBlXcTsAHOoykEhNUYXkQ3r6ehEEY=
 github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb h1:CqfZjjd8iK3G1TV8Wf0u7WTY+0RxIEbmcgxftt9qVtw=
 github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -90,8 +90,8 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, oldFlagsMa
 	// Push some series to Mimir.
 	series1Timestamp := time.Now()
 	series2Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
-	series1, expectedVector1 := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
-	series2, expectedVector2 := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
+	series1, expectedVector1, _ := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
+	series2, expectedVector2, _ := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
 
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, oldFlagsMa
 	// Push another series to further compact another block and delete the first block
 	// due to expired retention.
 	series3Timestamp := series2Timestamp.Add(blockRangePeriod * 2)
-	series3, expectedVector3 := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
+	series3, expectedVector3, _ := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
 
 	res, err = c.Push(series3)
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func runNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T, previo
 
 	// Push some series to Mimir.
 	now := time.Now()
-	series, expectedVector := generateSeries("series_1", now)
+	series, expectedVector, _ := generateSeries("series_1", now)
 
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)

--- a/integration/distributor_forwarding_test.go
+++ b/integration/distributor_forwarding_test.go
@@ -153,7 +153,7 @@ func TestDistributorForwarding(t *testing.T) {
 			// Submit metrics to Mimir.
 			now := time.Now()
 			for _, metric := range tc.submitMetrics {
-				series, _ := generateSeries(metric, now)
+				series, _, _ := generateSeries(metric, now)
 				res, err := mimirClient.Push(series)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -52,7 +52,7 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 
 	// Push some series to Mimir.
 	now := time.Now()
-	series, expectedVector := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := c.Push(series)
 	require.NoError(t, err)
@@ -72,7 +72,8 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	// Check that a range query does not return an error to sanity check the queryrange tripperware.
-	_, err = c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, err := c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
+	require.Equal(t, model.ValMatrix, rangeResult.Type())
+	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 }

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -108,7 +108,7 @@ func TestGettingStartedWithGossipedRing(t *testing.T) {
 
 	// Push some series to Mimir2
 	now := time.Now()
-	series, expectedVector := generateSeries("series_1", now)
+	series, expectedVector, _ := generateSeries("series_1", now)
 
 	res, err := c2.Push(series)
 	require.NoError(t, err)

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -79,7 +79,7 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService) {
 
 	// Push some series to Mimir.
 	now := time.Now()
-	series, expectedVector := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := c.Push(series)
 	require.NoError(t, err)
@@ -99,7 +99,8 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	// Check that a range query does not return an error to sanity check the queryrange tripperware.
-	_, err = c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, err := c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
+	require.Equal(t, model.ValMatrix, rangeResult.Type())
+	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 }

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -91,7 +91,7 @@ func TestIngesterGlobalLimits(t *testing.T) {
 
 			// Try to push as many series with the same metric name as we can.
 			for i, errs := 0, 0; i < 10000; i++ {
-				series, _ := generateSeries("test_limit_per_metric", now, prompb.Label{
+				series, _, _ := generateSeries("test_limit_per_metric", now, prompb.Label{
 					Name:  "cardinality",
 					Value: strconv.Itoa(rand.Int()),
 				})
@@ -109,7 +109,7 @@ func TestIngesterGlobalLimits(t *testing.T) {
 
 			// Try to push as many series with the different metric name as we can.
 			for i, errs := 0, 0; i < 10000; i++ {
-				series, _ := generateSeries(fmt.Sprintf("test_limit_per_tenant_%d", rand.Int()), now)
+				series, _, _ := generateSeries(fmt.Sprintf("test_limit_per_tenant_%d", rand.Int()), now)
 				res, err := client.Push(series)
 				require.NoError(t, err)
 

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -96,7 +96,7 @@ func TestIngesterSharding(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				series, expectedVector := generateSeries(metricName, now)
+				series, expectedVector, _ := generateSeries(metricName, now)
 				res, err := client.Push(series)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -49,7 +49,7 @@ func TestOTLPIngestion(t *testing.T) {
 
 	// Push some series to Mimir.
 	now := time.Now()
-	series, expectedVector := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := c.PushOTLP(series)
 	require.NoError(t, err)
@@ -69,7 +69,8 @@ func TestOTLPIngestion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	// Check that a range query does not return an error to sanity check the queryrange tripperware.
-	_, err = c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, err := c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
+	require.Equal(t, model.ValMatrix, rangeResult.Type())
+	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 }

--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -142,7 +142,7 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				series, _ := generateSeries(metricName, now,
+				series, _, _ := generateSeries(metricName, now,
 					prompb.Label{Name: "env", Value: cardinalityEnvLabelValues[i%len(cardinalityEnvLabelValues)]},
 					prompb.Label{Name: "job", Value: cardinalityJobLabelValues[i%len(cardinalityJobLabelValues)]},
 				)
@@ -365,7 +365,7 @@ func TestQuerierLabelValuesCardinality(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				series, _ := generateSeries(metricName, now,
+				series, _, _ := generateSeries(metricName, now,
 					prompb.Label{Name: "env", Value: cardinalityEnvLabelValues[i%len(cardinalityEnvLabelValues)]},
 					prompb.Label{Name: "job", Value: cardinalityJobLabelValues[i%len(cardinalityJobLabelValues)]},
 				)

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -61,7 +61,7 @@ func TestQuerierRemoteRead(t *testing.T) {
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
 
-	series, expectedVectors := generateSeries("series_1", now)
+	series, expectedVectors, _ := generateSeries("series_1", now)
 	res, err := c.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -124,7 +124,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	require.NoError(t, err)
 
 	var series []prompb.TimeSeries
-	series, expectedVector := generateSeries("series_1", now)
+	series, expectedVector, _ := generateSeries("series_1", now)
 
 	res, err := distClient.Push(series)
 	require.NoError(t, err)

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -132,7 +132,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 		require.NoError(t, err)
 
 		var series []prompb.TimeSeries
-		series, expectedVectors[u] = generateSeries("series_1", now)
+		series, expectedVectors[u], _ = generateSeries("series_1", now)
 
 		res, err := c.Push(series)
 		require.NoError(t, err)
@@ -154,7 +154,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	assert.Len(t, exemplars, numUsers)
 
 	// ensure a push to multiple tenants is failing
-	series, _ := generateSeries("series_1", now)
+	series, _, _ := generateSeries("series_1", now)
 	res, err := c.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 500, res.StatusCode)

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -99,8 +99,8 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 
 	series1Timestamp := time.Now()
 	series2Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
-	series1, expectedVector1 := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
-	series2, expectedVector2 := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
+	series1, expectedVector1, _ := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
+	series2, expectedVector2, _ := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
 
 	res, err := writeClient.Push(series1)
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T) {
 	// Push another series to further compact another block and delete the first block
 	// due to expired retention.
 	series3Timestamp := series2Timestamp.Add(blockRangePeriod * 2)
-	series3, expectedVector3 := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
+	series3, expectedVector3, _ := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
 
 	res, err = writeClient.Push(series3)
 	require.NoError(t, err)
@@ -398,8 +398,8 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			// Push some series to Mimir.
 			series1Timestamp := time.Now()
 			series2Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
-			series1, expectedVector1 := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
-			series2, expectedVector2 := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
+			series1, expectedVector1, _ := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
+			series2, expectedVector2, _ := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
 
 			res, err := c.Push(series1)
 			require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			// Push another series to further compact another block and delete the first block
 			// due to expired retention.
 			series3Timestamp := series2Timestamp.Add(blockRangePeriod * 2)
-			series3, expectedVector3 := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
+			series3, expectedVector3, _ := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
 
 			res, err = c.Push(series3)
 			require.NoError(t, err)
@@ -749,8 +749,8 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 
 	series1Timestamp := time.Now()
 	series2Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
-	series1, expectedVector1 := generateSeries("series_1", series1Timestamp)
-	series2, _ := generateSeries("series_2", series2Timestamp)
+	series1, expectedVector1, _ := generateSeries("series_1", series1Timestamp)
+	series2, _, _ := generateSeries("series_2", series2Timestamp)
 
 	res, err := c.Push(series1)
 	require.NoError(t, err)
@@ -854,10 +854,10 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	series3Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
 	series4Timestamp := series1Timestamp.Add(blockRangePeriod * 3)
 
-	series1, _ := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
-	series2, _ := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
-	series3, _ := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
-	series4, _ := generateSeries("series_4", series4Timestamp, prompb.Label{Name: "series_4", Value: "series_4"})
+	series1, _, _ := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "series_1", Value: "series_1"})
+	series2, _, _ := generateSeries("series_2", series2Timestamp, prompb.Label{Name: "series_2", Value: "series_2"})
+	series3, _, _ := generateSeries("series_3", series3Timestamp, prompb.Label{Name: "series_3", Value: "series_3"})
+	series4, _, _ := generateSeries("series_4", series4Timestamp, prompb.Label{Name: "series_4", Value: "series_4"})
 
 	res, err := c.Push(series1)
 	require.NoError(t, err)

--- a/integration/query_frontend_cache_test.go
+++ b/integration/query_frontend_cache_test.go
@@ -87,7 +87,7 @@ func TestQueryFrontendUnalignedQuery(t *testing.T) {
 
 	sampleTime := now.Add(-3 * time.Minute)
 
-	series, expectedVector := generateSeries("series_1", sampleTime)
+	series, expectedVector, _ := generateSeries("series_1", sampleTime)
 	val := expectedVector[0].Value
 
 	res, err := c.Push(series)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -273,7 +273,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 		require.NoError(t, err)
 
 		var series []prompb.TimeSeries
-		series, expectedVectors[u] = generateSeries("series_1", now)
+		series, expectedVectors[u], _ = generateSeries("series_1", now)
 
 		res, err := c.Push(series)
 		require.NoError(t, err)
@@ -433,7 +433,7 @@ overrides:
 	require.NoError(t, err)
 
 	for i := 0; i < 50; i++ {
-		series, _ := generateSeries(
+		series, _, _ := generateSeries(
 			"metric",
 			now,
 			prompb.Label{Name: "unique", Value: strconv.Itoa(i)},
@@ -741,7 +741,7 @@ func runQueryFrontendWithQueryShardingHTTPTest(t *testing.T, cfg queryFrontendTe
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)
 	var series []prompb.TimeSeries
-	series, _ = generateSeries("series_1", now)
+	series, _, _ = generateSeries("series_1", now)
 
 	res, err := c.Push(series)
 	require.NoError(t, err)

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -89,7 +89,7 @@ func TestQuerySchedulerWithMaxUsedInstances(t *testing.T) {
 
 	// Push some series to Mimir.
 	now := time.Now()
-	series, expectedVector := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, _ := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -42,20 +42,22 @@ func TestReadWriteMode(t *testing.T) {
 
 	// Push some data to the cluster.
 	now := time.Now()
-	series, expectedVector := generateSeries("test_series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := generateSeries("test_series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := c.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
 	// Verify we can read the data we just pushed, both with an instant query and a range query.
-	result, err := c.Query("test_series_1", now)
+	queryResult, err := c.Query("test_series_1", now)
 	require.NoError(t, err)
-	require.Equal(t, model.ValVector, result.Type())
-	require.Equal(t, expectedVector, result.(model.Vector))
+	require.Equal(t, model.ValVector, queryResult.Type())
+	require.Equal(t, expectedVector, queryResult.(model.Vector))
 
-	_, err = c.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
+	rangeResult, err := c.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
+	require.Equal(t, model.ValMatrix, rangeResult.Type())
+	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
 	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -598,7 +598,7 @@ func TestRulerMetricsForInvalidQueries(t *testing.T) {
 
 	// Push some series to Mimir -- enough so that we can hit some limits.
 	for i := 0; i < 10; i++ {
-		series, _ := generateSeries("metric", time.Now(), prompb.Label{Name: "foo", Value: fmt.Sprintf("%d", i)})
+		series, _, _ := generateSeries("metric", time.Now(), prompb.Label{Name: "foo", Value: fmt.Sprintf("%d", i)})
 
 		res, err := c.Push(series)
 		require.NoError(t, err)
@@ -784,7 +784,7 @@ func TestRulerFederatedRules(t *testing.T) {
 				client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantID)
 				require.NoError(t, err)
 
-				series, _ := generateSeries("metric", sampleTime)
+				series, _, _ := generateSeries("metric", sampleTime)
 
 				res, err := client.Push(series)
 				require.NoError(t, err)
@@ -908,7 +908,7 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 				client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantID)
 				require.NoError(t, err)
 
-				series, _ := generateSeries("metric", sampleTime)
+				series, _, _ := generateSeries("metric", sampleTime)
 
 				res, err := client.Push(series)
 				require.NoError(t, err)

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -77,7 +77,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	for i := 1; i <= numSeries; i++ {
 		metricName := fmt.Sprintf("series_%d", i)
-		series, expectedVector := generateSeries(metricName, now)
+		series, expectedVector, _ := generateSeries(metricName, now)
 		res, err := client.Push(series)
 		require.NoError(t, err)
 		require.Equal(t, 200, res.StatusCode)
@@ -99,7 +99,7 @@ func TestZoneAwareReplication(t *testing.T) {
 	// Push 1 more series => all good
 	numSeries++
 	metricName := fmt.Sprintf("series_%d", numSeries)
-	series, expectedVector := generateSeries(metricName, now)
+	series, expectedVector, _ := generateSeries(metricName, now)
 	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
@@ -120,7 +120,7 @@ func TestZoneAwareReplication(t *testing.T) {
 	// Push 1 more series => all good
 	numSeries++
 	metricName = fmt.Sprintf("series_%d", numSeries)
-	series, expectedVector = generateSeries(metricName, now)
+	series, expectedVector, _ = generateSeries(metricName, now)
 	res, err = client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
@@ -149,7 +149,7 @@ func TestZoneAwareReplication(t *testing.T) {
 	require.NoError(t, ingester4.Kill())
 
 	// Push 1 more series => fail
-	series, _ = generateSeries("series_last", now)
+	series, _, _ = generateSeries("series_last", now)
 	res, err = client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 500, res.StatusCode)

--- a/vendor/github.com/grafana/e2e/util.go
+++ b/vendor/github.com/grafana/e2e/util.go
@@ -125,7 +125,7 @@ func TimeToMilliseconds(t time.Time) int64 {
 	return (int64(s) * 1e3) + (int64(ns * 1e3))
 }
 
-func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector) {
+func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
 	tsMillis := TimeToMilliseconds(ts)
 	value := rand.Float64()
 
@@ -149,7 +149,7 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 		},
 	})
 
-	// Generate the expected vector when querying it
+	// Generate the expected vector and matrix when querying it
 	metric := model.Metric{}
 	metric[labels.MetricName] = model.LabelValue(name)
 	for _, lbl := range additionalLabels {
@@ -160,6 +160,16 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 		Metric:    metric,
 		Value:     model.SampleValue(value),
 		Timestamp: model.Time(tsMillis),
+	})
+
+	matrix = append(matrix, &model.SampleStream{
+		Metric: metric,
+		Values: []model.SamplePair{
+			{
+				Timestamp: model.Time(tsMillis),
+				Value:     model.SampleValue(value),
+			},
+		},
 	})
 
 	return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -494,7 +494,7 @@ github.com/grafana/dskit/services
 github.com/grafana/dskit/spanlogger
 github.com/grafana/dskit/tenant
 github.com/grafana/dskit/test
-# github.com/grafana/e2e v0.1.1-0.20221018202458-cffd2bb71c7b
+# github.com/grafana/e2e v0.1.1-0.20221115065638-fe4609fcbc71
 ## explicit; go 1.17
 github.com/grafana/e2e
 github.com/grafana/e2e/cache


### PR DESCRIPTION
#### What this PR does

Builds on https://github.com/grafana/mimir/pull/3423, split from https://github.com/grafana/mimir/pull/3433.

The integration tests currently only check that range queries don't return an error - they don't check the query response. This PR pulls in https://github.com/grafana/e2e/pull/7 and then adds assertions on the query responses to the integration tests where we make range queries.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/3363

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
