### PR TITLE
Fix sending all series to all ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [ENHANCEMENT] Clarify which S3 signature versions are supported in the error "unsupported signature version". #3376
 * [ENHANCEMENT] Store-gateway: improved index header reading performance. #3393 #3397 #3436
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
-* [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386
+* [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386 #3458
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3404,15 +3404,17 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, []*p
 	ingestersByAddr := map[string]*mockIngester{}
 	for i := range ingesters {
 		addr := fmt.Sprintf("%d", i)
+		tokens := []uint32{uint32((math.MaxUint32 / cfg.numIngesters) * i)}
 		ingesterDescs[addr] = ring.InstanceDesc{
 			Addr:                addr,
 			Zone:                ingesters[i].zone,
 			State:               ring.ACTIVE,
 			Timestamp:           time.Now().Unix(),
 			RegisteredTimestamp: time.Now().Add(-2 * time.Hour).Unix(),
-			Tokens:              []uint32{uint32((math.MaxUint32 / cfg.numIngesters) * i)},
+			Tokens:              tokens,
 		}
 		ingestersByAddr[addr] = &ingesters[i]
+		ingesters[i].tokens = tokens
 	}
 
 	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
@@ -3661,11 +3663,11 @@ type metaDataGen func(int, string) *mimirpb.MetricMetadata
 // The label set generator gets called once for each sample, the returned label set gets added to the request with the sample.
 // The exemplar label set generator also gets called once for each sample, if it isn't nil.
 // The metadata generator gets called once for each unique metric name that has been returned by the label generator, if it isn't nil.
-func makeWriteRequestForGenerators(samples int, lsg labelSetGen, elsg labelSetGen, mdg metaDataGen) *mimirpb.WriteRequest {
+func makeWriteRequestForGenerators(series int, lsg labelSetGen, elsg labelSetGen, mdg metaDataGen) *mimirpb.WriteRequest {
 	metricNames := make(map[string]struct{})
 
 	request := &mimirpb.WriteRequest{}
-	for i := 0; i < samples; i++ {
+	for i := 0; i < series; i++ {
 		labelSet := lsg(i)
 		metricName := mimirpb.FromLabelAdaptersToLabels(labelSet).Get(model.MetricNameLabel)
 		if metricName != "" {
@@ -3771,6 +3773,7 @@ type mockIngester struct {
 	zone                          string
 	labelNamesStreamResponseDelay time.Duration
 	timeOut                       bool
+	tokens                        []uint32
 }
 
 func (i *mockIngester) series() map[uint32]*mimirpb.PreallocTimeseries {
@@ -4905,4 +4908,96 @@ func TestDistributor_CleanupIsDoneAfterLastIngesterReturns(t *testing.T) {
 	// This means that the push request is counted as inflight, so another incoming request should be rejected.
 	_, err = distributors[0].Push(ctx, mockWriteRequest(nil, 1, 1))
 	assert.ErrorIs(t, err, errMaxInflightRequestsReached)
+}
+
+func TestSeriesAreShardedToCorrectIngesters(t *testing.T) {
+	config := prepConfig{
+		numIngesters:      5,
+		happyIngesters:    5,
+		numDistributors:   1,
+		replicationFactor: 1, // push each series to single ingester only
+	}
+	d, ing, _ := prepare(t, config)
+
+	uniqueMetricsGen := func(sampleIdx int) []mimirpb.LabelAdapter {
+		return []mimirpb.LabelAdapter{
+			{Name: "__name__", Value: fmt.Sprintf("%d", sampleIdx)},
+			{Name: "x", Value: fmt.Sprintf("%d", sampleIdx)},
+		}
+	}
+	exemplarLabelGen := func(sampleIdx int) []mimirpb.LabelAdapter {
+		return []mimirpb.LabelAdapter{{Name: "exemplarLabel", Value: fmt.Sprintf("value_%d", sampleIdx)}}
+	}
+	metaDataGen := func(metricIdx int, metricName string) *mimirpb.MetricMetadata {
+		return &mimirpb.MetricMetadata{
+			Type:             mimirpb.COUNTER,
+			MetricFamilyName: metricName,
+			Help:             "test metric",
+			Unit:             "unknown",
+		}
+	}
+
+	const series = 1000
+	const userName = "userName"
+
+	req := makeWriteRequestForGenerators(series, uniqueMetricsGen, exemplarLabelGen, metaDataGen)
+
+	ctx := user.InjectOrgID(context.Background(), userName)
+	// skip all the middlewares, just do the push
+	distrib := d[0]
+	_, err := distrib.push(ctx, push.NewParsedRequest(req))
+	require.NoError(t, err)
+
+	// Verify that each ingester only received series and metadata that it should receive.
+	totalSeries := 0
+	totalMetadata := 0
+	for ix := range ing {
+		totalSeries += len(ing[ix].timeseries)
+		totalMetadata += len(ing[ix].metadata)
+
+		for _, ts := range ing[ix].timeseries {
+			token, err := distrib.tokenForLabels(userName, ts.Labels)
+			require.NoError(t, err)
+
+			ingIx := getIngesterIndexForToken(token, ing)
+			assert.Equal(t, ix, ingIx)
+		}
+
+		for _, metadataMap := range ing[ix].metadata {
+			for m := range metadataMap {
+				token := distrib.tokenForMetadata(userName, m.MetricFamilyName)
+				ingIx := getIngesterIndexForToken(token, ing)
+				assert.Equal(t, ix, ingIx)
+			}
+		}
+	}
+	assert.Equal(t, series, totalSeries)
+	assert.Equal(t, series, totalMetadata) // each series has unique metric name, and each metric name gets metadata
+}
+
+func getIngesterIndexForToken(key uint32, ings []mockIngester) int {
+	tokens := []uint32{}
+	tokensMap := map[uint32]int{}
+
+	for ix := range ings {
+		tokens = append(tokens, ings[ix].tokens...)
+		for _, t := range ings[ix].tokens {
+			tokensMap[t] = ix
+		}
+	}
+
+	ix := searchToken(tokens, key)
+	t := tokens[ix]
+	return tokensMap[t]
+}
+
+// copied from vendor/github.com/grafana/dskit/ring/util.go
+func searchToken(tokens []uint32, key uint32) int {
+	i := sort.Search(len(tokens), func(x int) bool {
+		return tokens[x] > key
+	})
+	if i >= len(tokens) {
+		i = 0
+	}
+	return i
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes bug introduced in https://github.com/grafana/mimir/pull/3386: series and metadata should be properly sharded into ingesters. This PR also adds test to verify that each ingester only received series that "belong" to it based on ingester tokens.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
