### PR TITLE
Add ability to load index-headers without using mmap

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5678,6 +5678,17 @@
                   "fieldFlag": "blocks-storage.bucket-store.index-header.map-populate-enabled",
                   "fieldType": "boolean",
                   "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "native_file_reads",
+                  "required": false,
+                  "desc": "If enabled, the store-gateway will use native reads to load index-headers and keep them in memory, NOT memory-mapped files.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "blocks-storage.bucket-store.index-header.native-file-reads",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 }
               ],
               "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -339,6 +339,8 @@ Usage of ./cmd/mimir/mimir:
     	If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
   -blocks-storage.bucket-store.index-header.map-populate-enabled
     	[experimental] If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.
+  -blocks-storage.bucket-store.index-header.native-file-reads
+    	[experimental] If enabled, the store-gateway will use native reads to load index-headers and keep them in memory, NOT memory-mapped files.
   -blocks-storage.bucket-store.max-chunk-pool-bytes uint
     	Max size - in bytes - of a chunks pool, used to reduce memory allocations. The pool is shared across all tenants. 0 to disable the limit. (default 2147483648)
   -blocks-storage.bucket-store.max-concurrent int

--- a/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/operators-guide/configure/reference-configuration-parameters/index.md
@@ -3012,6 +3012,11 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.map-populate-enabled
     [map_populate_enabled: <boolean> | default = false]
 
+    # (experimental) If enabled, the store-gateway will use native reads to load
+    # index-headers and keep them in memory, NOT memory-mapped files.
+    # CLI flag: -blocks-storage.bucket-store.index-header.native-file-reads
+    [native_file_reads: <boolean> | default = false]
+
   # (experimental) True to reject queries above the max number of concurrent
   # queries to execute against long-term storage. If false, queries will block
   # until they are able to run.


### PR DESCRIPTION
Adds a flag that allows store-gateways to load index-headers from disk using regular file reads and store the contents of the file on the go heap instead of using mmap for both.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
