### PR TITLE
Import Prometheus tsdb/encoding and tsdb/index packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/alecthomas/chroma v0.10.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/cespare/xxhash v1.1.0
+	github.com/dennwc/varint v1.0.0
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/go-cmp v0.5.9
@@ -67,6 +68,7 @@ require (
 	go.opentelemetry.io/collector/pdata v0.54.0
 	go.opentelemetry.io/otel v1.10.0
 	go.opentelemetry.io/otel/trace v1.10.0
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
 	google.golang.org/api v0.97.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
@@ -108,7 +110,6 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dnaeon/go-vcr v1.2.0 // indirect
 	github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 // indirect
@@ -209,7 +210,6 @@ require (
 	go.opentelemetry.io/otel/metric v0.32.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/encoding/encoding.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package encoding
+
+import (
+	"encoding/binary"
+	"hash"
+	"hash/crc32"
+	"math"
+	"unsafe"
+
+	"github.com/dennwc/varint"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrInvalidSize     = errors.New("invalid size")
+	ErrInvalidChecksum = errors.New("invalid checksum")
+)
+
+// Encbuf is a helper type to populate a byte slice with various types.
+type Encbuf struct {
+	B []byte
+	C [binary.MaxVarintLen64]byte
+}
+
+func (e *Encbuf) Reset()      { e.B = e.B[:0] }
+func (e *Encbuf) Get() []byte { return e.B }
+func (e *Encbuf) Len() int    { return len(e.B) }
+
+func (e *Encbuf) PutString(s string) { e.B = append(e.B, s...) }
+func (e *Encbuf) PutByte(c byte)     { e.B = append(e.B, c) }
+func (e *Encbuf) PutBytes(b []byte)  { e.B = append(e.B, b...) }
+
+func (e *Encbuf) PutBE32int(x int)      { e.PutBE32(uint32(x)) }
+func (e *Encbuf) PutUvarint32(x uint32) { e.PutUvarint64(uint64(x)) }
+func (e *Encbuf) PutBE64int64(x int64)  { e.PutBE64(uint64(x)) }
+func (e *Encbuf) PutUvarint(x int)      { e.PutUvarint64(uint64(x)) }
+
+func (e *Encbuf) PutBE32(x uint32) {
+	binary.BigEndian.PutUint32(e.C[:], x)
+	e.B = append(e.B, e.C[:4]...)
+}
+
+func (e *Encbuf) PutBE64(x uint64) {
+	binary.BigEndian.PutUint64(e.C[:], x)
+	e.B = append(e.B, e.C[:8]...)
+}
+
+func (e *Encbuf) PutBEFloat64(x float64) {
+	e.PutBE64(math.Float64bits(x))
+}
+
+func (e *Encbuf) PutUvarint64(x uint64) {
+	n := binary.PutUvarint(e.C[:], x)
+	e.B = append(e.B, e.C[:n]...)
+}
+
+func (e *Encbuf) PutVarint64(x int64) {
+	n := binary.PutVarint(e.C[:], x)
+	e.B = append(e.B, e.C[:n]...)
+}
+
+// PutUvarintStr writes a string to the buffer prefixed by its varint length (in bytes!).
+func (e *Encbuf) PutUvarintStr(s string) {
+	b := *(*[]byte)(unsafe.Pointer(&s))
+	e.PutUvarint(len(b))
+	e.PutString(s)
+}
+
+// PutUvarintBytes writes a variable length byte buffer.
+func (e *Encbuf) PutUvarintBytes(b []byte) {
+	e.PutUvarint(len(b))
+	e.PutBytes(b)
+}
+
+// PutHash appends a hash over the buffers current contents to the buffer.
+func (e *Encbuf) PutHash(h hash.Hash) {
+	h.Reset()
+	e.WriteToHash(h)
+	e.PutHashSum(h)
+}
+
+// WriteToHash writes the current buffer contents to the given hash.
+func (e *Encbuf) WriteToHash(h hash.Hash) {
+	_, err := h.Write(e.B)
+	if err != nil {
+		panic(err) // The CRC32 implementation does not error
+	}
+}
+
+// PutHashSum writes the Sum of the given hash to the buffer.
+func (e *Encbuf) PutHashSum(h hash.Hash) {
+	e.B = h.Sum(e.B)
+}
+
+// Decbuf provides safe methods to extract data from a byte slice. It does all
+// necessary bounds checking and advancing of the byte slice.
+// Several datums can be extracted without checking for errors. However, before using
+// any datum, the err() method must be checked.
+type Decbuf struct {
+	B []byte
+	E error
+}
+
+// NewDecbufAt returns a new decoding buffer. It expects the first 4 bytes
+// after offset to hold the big endian encoded content length, followed by the contents and the expected
+// checksum.
+func NewDecbufAt(bs ByteSlice, off int, castagnoliTable *crc32.Table) Decbuf {
+	if bs.Len() < off+4 {
+		return Decbuf{E: ErrInvalidSize}
+	}
+	b := bs.Range(off, off+4)
+	l := int(binary.BigEndian.Uint32(b))
+
+	if bs.Len() < off+4+l+4 {
+		return Decbuf{E: ErrInvalidSize}
+	}
+
+	// Load bytes holding the contents plus a CRC32 checksum.
+	b = bs.Range(off+4, off+4+l+4)
+	dec := Decbuf{B: b[:len(b)-4]}
+
+	if castagnoliTable != nil {
+		if exp := binary.BigEndian.Uint32(b[len(b)-4:]); dec.Crc32(castagnoliTable) != exp {
+			return Decbuf{E: ErrInvalidChecksum}
+		}
+	}
+	return dec
+}
+
+// NewDecbufUvarintAt returns a new decoding buffer. It expects the first bytes
+// after offset to hold the uvarint-encoded buffers length, followed by the contents and the expected
+// checksum.
+func NewDecbufUvarintAt(bs ByteSlice, off int, castagnoliTable *crc32.Table) Decbuf {
+	// We never have to access this method at the far end of the byte slice. Thus just checking
+	// against the MaxVarintLen32 is sufficient.
+	if bs.Len() < off+binary.MaxVarintLen32 {
+		return Decbuf{E: ErrInvalidSize}
+	}
+	b := bs.Range(off, off+binary.MaxVarintLen32)
+
+	l, n := varint.Uvarint(b)
+	if n <= 0 || n > binary.MaxVarintLen32 {
+		return Decbuf{E: errors.Errorf("invalid uvarint %d", n)}
+	}
+
+	if bs.Len() < off+n+int(l)+4 {
+		return Decbuf{E: ErrInvalidSize}
+	}
+
+	// Load bytes holding the contents plus a CRC32 checksum.
+	b = bs.Range(off+n, off+n+int(l)+4)
+	dec := Decbuf{B: b[:len(b)-4]}
+
+	if dec.Crc32(castagnoliTable) != binary.BigEndian.Uint32(b[len(b)-4:]) {
+		return Decbuf{E: ErrInvalidChecksum}
+	}
+	return dec
+}
+
+// NewDecbufRaw returns a new decoding buffer of the given length.
+func NewDecbufRaw(bs ByteSlice, length int) Decbuf {
+	if bs.Len() < length {
+		return Decbuf{E: ErrInvalidSize}
+	}
+	return Decbuf{B: bs.Range(0, length)}
+}
+
+func (d *Decbuf) Uvarint() int     { return int(d.Uvarint64()) }
+func (d *Decbuf) Be32int() int     { return int(d.Be32()) }
+func (d *Decbuf) Be64int64() int64 { return int64(d.Be64()) }
+
+// Crc32 returns a CRC32 checksum over the remaining bytes.
+func (d *Decbuf) Crc32(castagnoliTable *crc32.Table) uint32 {
+	return crc32.Checksum(d.B, castagnoliTable)
+}
+
+func (d *Decbuf) Skip(l int) {
+	if len(d.B) < l {
+		d.E = ErrInvalidSize
+		return
+	}
+	d.B = d.B[l:]
+}
+
+func (d *Decbuf) UvarintStr() string {
+	return string(d.UvarintBytes())
+}
+
+// The return value becomes invalid if the byte slice goes away.
+// Compared to UvarintStr, this avoid allocations.
+func (d *Decbuf) UvarintBytes() []byte {
+	l := d.Uvarint64()
+	if d.E != nil {
+		return []byte{}
+	}
+	if len(d.B) < int(l) {
+		d.E = ErrInvalidSize
+		return []byte{}
+	}
+	s := d.B[:l]
+	d.B = d.B[l:]
+	return s
+}
+
+func (d *Decbuf) Varint64() int64 {
+	if d.E != nil {
+		return 0
+	}
+	// Decode as unsigned first, since that's what the varint library implements.
+	ux, n := varint.Uvarint(d.B)
+	if n < 1 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+	// Now decode "ZigZag encoding" https://developers.google.com/protocol-buffers/docs/encoding#signed_integers.
+	x := int64(ux >> 1)
+	if ux&1 != 0 {
+		x = ^x
+	}
+	d.B = d.B[n:]
+	return x
+}
+
+func (d *Decbuf) Uvarint64() uint64 {
+	if d.E != nil {
+		return 0
+	}
+	x, n := varint.Uvarint(d.B)
+	if n < 1 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+	d.B = d.B[n:]
+	return x
+}
+
+func (d *Decbuf) Be64() uint64 {
+	if d.E != nil {
+		return 0
+	}
+	if len(d.B) < 8 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+	x := binary.BigEndian.Uint64(d.B)
+	d.B = d.B[8:]
+	return x
+}
+
+func (d *Decbuf) Be64Float64() float64 {
+	return math.Float64frombits(d.Be64())
+}
+
+func (d *Decbuf) Be32() uint32 {
+	if d.E != nil {
+		return 0
+	}
+	if len(d.B) < 4 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+	x := binary.BigEndian.Uint32(d.B)
+	d.B = d.B[4:]
+	return x
+}
+
+func (d *Decbuf) Byte() byte {
+	if d.E != nil {
+		return 0
+	}
+	if len(d.B) < 1 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+	x := d.B[0]
+	d.B = d.B[1:]
+	return x
+}
+
+func (d *Decbuf) ConsumePadding() {
+	if d.E != nil {
+		return
+	}
+	for len(d.B) > 1 && d.B[0] == '\x00' {
+		d.B = d.B[1:]
+	}
+	if len(d.B) < 1 {
+		d.E = ErrInvalidSize
+	}
+}
+
+func (d *Decbuf) Err() error  { return d.E }
+func (d *Decbuf) Len() int    { return len(d.B) }
+func (d *Decbuf) Get() []byte { return d.B }
+
+// ByteSlice abstracts a byte slice.
+type ByteSlice interface {
+	Len() int
+	Range(start, end int) []byte
+}

--- a/pkg/storegateway/indexheader/index/index.go
+++ b/pkg/storegateway/indexheader/index/index.go
@@ -1,0 +1,1986 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/index/index.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package index
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/hashcache"
+
+	"github.com/grafana/mimir/pkg/storegateway/indexheader/encoding"
+)
+
+const (
+	// MagicIndex 4 bytes at the head of an index file.
+	MagicIndex = 0xBAAAD700
+	// HeaderLen represents number of bytes reserved of index for header.
+	HeaderLen = 5
+
+	// FormatV1 represents 1 version of index.
+	FormatV1 = 1
+	// FormatV2 represents 2 version of index.
+	FormatV2 = 2
+
+	indexFilename = "index"
+)
+
+type indexWriterSeries struct {
+	labels labels.Labels
+	chunks []chunks.Meta // series file offset of chunks
+}
+
+type indexWriterSeriesSlice []*indexWriterSeries
+
+func (s indexWriterSeriesSlice) Len() int      { return len(s) }
+func (s indexWriterSeriesSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s indexWriterSeriesSlice) Less(i, j int) bool {
+	return labels.Compare(s[i].labels, s[j].labels) < 0
+}
+
+type indexWriterStage uint8
+
+const (
+	idxStageNone indexWriterStage = iota
+	idxStageSymbols
+	idxStageSeries
+	idxStageDone
+)
+
+func (s indexWriterStage) String() string {
+	switch s {
+	case idxStageNone:
+		return "none"
+	case idxStageSymbols:
+		return "symbols"
+	case idxStageSeries:
+		return "series"
+	case idxStageDone:
+		return "done"
+	}
+	return "<unknown>"
+}
+
+// The table gets initialized with sync.Once but may still cause a race
+// with any other use of the crc32 package anywhere. Thus we initialize it
+// before.
+var castagnoliTable *crc32.Table
+
+func init() {
+	castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
+}
+
+// newCRC32 initializes a CRC32 hash with a preconfigured polynomial, so the
+// polynomial may be easily changed in one location at a later time, if necessary.
+func newCRC32() hash.Hash32 {
+	return crc32.New(castagnoliTable)
+}
+
+type symbolCacheEntry struct {
+	index          uint32
+	lastValue      string
+	lastValueIndex uint32
+}
+
+// Writer implements the IndexWriter interface for the standard
+// serialization format.
+type Writer struct {
+	ctx context.Context
+
+	// For the main index file.
+	f *FileWriter
+
+	// Temporary file for postings.
+	fP *FileWriter
+	// Temporary file for posting offsets table.
+	fPO   *FileWriter
+	cntPO uint64
+
+	toc           TOC
+	stage         indexWriterStage
+	postingsStart uint64 // Due to padding, can differ from TOC entry.
+
+	// Reusable memory.
+	buf1 encoding.Encbuf
+	buf2 encoding.Encbuf
+
+	numSymbols  int
+	symbols     *Symbols
+	symbolFile  *fileutil.MmapFile
+	lastSymbol  string
+	symbolCache map[string]symbolCacheEntry
+
+	labelIndexes []labelIndexHashEntry // Label index offsets.
+	labelNames   map[string]uint64     // Label names, and their usage.
+
+	// Hold last series to validate that clients insert new series in order.
+	lastSeries labels.Labels
+	lastRef    storage.SeriesRef
+
+	crc32 hash.Hash
+
+	Version int
+}
+
+// TOC represents index Table Of Content that states where each section of index starts.
+type TOC struct {
+	Symbols           uint64
+	Series            uint64
+	LabelIndices      uint64
+	LabelIndicesTable uint64
+	Postings          uint64
+	PostingsTable     uint64
+}
+
+// NewTOCFromByteSlice return parsed TOC from given index byte slice.
+func NewTOCFromByteSlice(bs ByteSlice) (*TOC, error) {
+	if bs.Len() < indexTOCLen {
+		return nil, encoding.ErrInvalidSize
+	}
+	b := bs.Range(bs.Len()-indexTOCLen, bs.Len())
+
+	expCRC := binary.BigEndian.Uint32(b[len(b)-4:])
+	d := encoding.Decbuf{B: b[:len(b)-4]}
+
+	if d.Crc32(castagnoliTable) != expCRC {
+		return nil, errors.Wrap(encoding.ErrInvalidChecksum, "read TOC")
+	}
+
+	if err := d.Err(); err != nil {
+		return nil, err
+	}
+
+	return &TOC{
+		Symbols:           d.Be64(),
+		Series:            d.Be64(),
+		LabelIndices:      d.Be64(),
+		LabelIndicesTable: d.Be64(),
+		Postings:          d.Be64(),
+		PostingsTable:     d.Be64(),
+	}, nil
+}
+
+// NewWriter returns a new Writer to the given filename. It serializes data in format version 2.
+func NewWriter(ctx context.Context, fn string) (*Writer, error) {
+	dir := filepath.Dir(fn)
+
+	df, err := fileutil.OpenDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer df.Close() // Close for platform windows.
+
+	if err := os.RemoveAll(fn); err != nil {
+		return nil, errors.Wrap(err, "remove any existing index at path")
+	}
+
+	// Main index file we are building.
+	f, err := NewFileWriter(fn)
+	if err != nil {
+		return nil, err
+	}
+	// Temporary file for postings.
+	fP, err := NewFileWriter(fn + "_tmp_p")
+	if err != nil {
+		return nil, err
+	}
+	// Temporary file for posting offset table.
+	fPO, err := NewFileWriter(fn + "_tmp_po")
+	if err != nil {
+		return nil, err
+	}
+	if err := df.Sync(); err != nil {
+		return nil, errors.Wrap(err, "sync dir")
+	}
+
+	iw := &Writer{
+		ctx:   ctx,
+		f:     f,
+		fP:    fP,
+		fPO:   fPO,
+		stage: idxStageNone,
+
+		// Reusable memory.
+		buf1: encoding.Encbuf{B: make([]byte, 0, 1<<22)},
+		buf2: encoding.Encbuf{B: make([]byte, 0, 1<<22)},
+
+		symbolCache: make(map[string]symbolCacheEntry, 1<<8),
+		labelNames:  make(map[string]uint64, 1<<8),
+		crc32:       newCRC32(),
+	}
+	if err := iw.writeMeta(); err != nil {
+		return nil, err
+	}
+	return iw, nil
+}
+
+func (w *Writer) write(bufs ...[]byte) error {
+	return w.f.Write(bufs...)
+}
+
+func (w *Writer) writeAt(buf []byte, pos uint64) error {
+	return w.f.WriteAt(buf, pos)
+}
+
+func (w *Writer) addPadding(size int) error {
+	return w.f.AddPadding(size)
+}
+
+type FileWriter struct {
+	f    *os.File
+	fbuf *bufio.Writer
+	pos  uint64
+	name string
+}
+
+func NewFileWriter(name string) (*FileWriter, error) {
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0o666)
+	if err != nil {
+		return nil, err
+	}
+	return &FileWriter{
+		f:    f,
+		fbuf: bufio.NewWriterSize(f, 1<<22),
+		pos:  0,
+		name: name,
+	}, nil
+}
+
+func (fw *FileWriter) Pos() uint64 {
+	return fw.pos
+}
+
+func (fw *FileWriter) Write(bufs ...[]byte) error {
+	for _, b := range bufs {
+		n, err := fw.fbuf.Write(b)
+		fw.pos += uint64(n)
+		if err != nil {
+			return err
+		}
+		// For now the index file must not grow beyond 64GiB. Some of the fixed-sized
+		// offset references in v1 are only 4 bytes large.
+		// Once we move to compressed/varint representations in those areas, this limitation
+		// can be lifted.
+		if fw.pos > 16*math.MaxUint32 {
+			return errors.Errorf("%q exceeding max size of 64GiB", fw.name)
+		}
+	}
+	return nil
+}
+
+func (fw *FileWriter) Flush() error {
+	return fw.fbuf.Flush()
+}
+
+func (fw *FileWriter) WriteAt(buf []byte, pos uint64) error {
+	if err := fw.Flush(); err != nil {
+		return err
+	}
+	_, err := fw.f.WriteAt(buf, int64(pos))
+	return err
+}
+
+// AddPadding adds zero byte padding until the file size is a multiple size.
+func (fw *FileWriter) AddPadding(size int) error {
+	p := fw.pos % uint64(size)
+	if p == 0 {
+		return nil
+	}
+	p = uint64(size) - p
+
+	if err := fw.Write(make([]byte, p)); err != nil {
+		return errors.Wrap(err, "add padding")
+	}
+	return nil
+}
+
+func (fw *FileWriter) Close() error {
+	if err := fw.Flush(); err != nil {
+		return err
+	}
+	if err := fw.f.Sync(); err != nil {
+		return err
+	}
+	return fw.f.Close()
+}
+
+func (fw *FileWriter) Remove() error {
+	return os.Remove(fw.name)
+}
+
+// ensureStage handles transitions between write stages and ensures that IndexWriter
+// methods are called in an order valid for the implementation.
+func (w *Writer) ensureStage(s indexWriterStage) error {
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	default:
+	}
+
+	if w.stage == s {
+		return nil
+	}
+	if w.stage < s-1 {
+		// A stage has been skipped.
+		if err := w.ensureStage(s - 1); err != nil {
+			return err
+		}
+	}
+	if w.stage > s {
+		return errors.Errorf("invalid stage %q, currently at %q", s, w.stage)
+	}
+
+	// Mark start of sections in table of contents.
+	switch s {
+	case idxStageSymbols:
+		w.toc.Symbols = w.f.pos
+		if err := w.startSymbols(); err != nil {
+			return err
+		}
+	case idxStageSeries:
+		if err := w.finishSymbols(); err != nil {
+			return err
+		}
+		w.toc.Series = w.f.pos
+
+	case idxStageDone:
+		w.toc.LabelIndices = w.f.pos
+		// LabelIndices generation depends on the posting offset
+		// table produced at this stage.
+		if err := w.writePostingsToTmpFiles(); err != nil {
+			return err
+		}
+		if err := w.writeLabelIndices(); err != nil {
+			return err
+		}
+
+		w.toc.Postings = w.f.pos
+		if err := w.writePostings(); err != nil {
+			return err
+		}
+
+		w.toc.LabelIndicesTable = w.f.pos
+		if err := w.writeLabelIndexesOffsetTable(); err != nil {
+			return err
+		}
+
+		w.toc.PostingsTable = w.f.pos
+		if err := w.writePostingsOffsetTable(); err != nil {
+			return err
+		}
+		if err := w.writeTOC(); err != nil {
+			return err
+		}
+	}
+
+	w.stage = s
+	return nil
+}
+
+func (w *Writer) writeMeta() error {
+	w.buf1.Reset()
+	w.buf1.PutBE32(MagicIndex)
+	w.buf1.PutByte(FormatV2)
+
+	return w.write(w.buf1.Get())
+}
+
+// AddSeries adds the series one at a time along with its chunks.
+func (w *Writer) AddSeries(ref storage.SeriesRef, lset labels.Labels, chunks ...chunks.Meta) error {
+	if err := w.ensureStage(idxStageSeries); err != nil {
+		return err
+	}
+	if labels.Compare(lset, w.lastSeries) <= 0 {
+		return errors.Errorf("out-of-order series added with label set %q", lset)
+	}
+
+	if ref < w.lastRef && len(w.lastSeries) != 0 {
+		return errors.Errorf("series with reference greater than %d already added", ref)
+	}
+	// We add padding to 16 bytes to increase the addressable space we get through 4 byte
+	// series references.
+	if err := w.addPadding(16); err != nil {
+		return errors.Errorf("failed to write padding bytes: %v", err)
+	}
+
+	if w.f.pos%16 != 0 {
+		return errors.Errorf("series write not 16-byte aligned at %d", w.f.pos)
+	}
+
+	w.buf2.Reset()
+	w.buf2.PutUvarint(len(lset))
+
+	for _, l := range lset {
+		var err error
+		cacheEntry, ok := w.symbolCache[l.Name]
+		nameIndex := cacheEntry.index
+		if !ok {
+			nameIndex, err = w.symbols.ReverseLookup(l.Name)
+			if err != nil {
+				return errors.Errorf("symbol entry for %q does not exist, %v", l.Name, err)
+			}
+		}
+		w.labelNames[l.Name]++
+		w.buf2.PutUvarint32(nameIndex)
+
+		valueIndex := cacheEntry.lastValueIndex
+		if !ok || cacheEntry.lastValue != l.Value {
+			valueIndex, err = w.symbols.ReverseLookup(l.Value)
+			if err != nil {
+				return errors.Errorf("symbol entry for %q does not exist, %v", l.Value, err)
+			}
+			w.symbolCache[l.Name] = symbolCacheEntry{
+				index:          nameIndex,
+				lastValue:      l.Value,
+				lastValueIndex: valueIndex,
+			}
+		}
+		w.buf2.PutUvarint32(valueIndex)
+	}
+
+	w.buf2.PutUvarint(len(chunks))
+
+	if len(chunks) > 0 {
+		c := chunks[0]
+		w.buf2.PutVarint64(c.MinTime)
+		w.buf2.PutUvarint64(uint64(c.MaxTime - c.MinTime))
+		w.buf2.PutUvarint64(uint64(c.Ref))
+		t0 := c.MaxTime
+		ref0 := int64(c.Ref)
+
+		for _, c := range chunks[1:] {
+			w.buf2.PutUvarint64(uint64(c.MinTime - t0))
+			w.buf2.PutUvarint64(uint64(c.MaxTime - c.MinTime))
+			t0 = c.MaxTime
+
+			w.buf2.PutVarint64(int64(c.Ref) - ref0)
+			ref0 = int64(c.Ref)
+		}
+	}
+
+	w.buf1.Reset()
+	w.buf1.PutUvarint(w.buf2.Len())
+
+	w.buf2.PutHash(w.crc32)
+
+	if err := w.write(w.buf1.Get(), w.buf2.Get()); err != nil {
+		return errors.Wrap(err, "write series data")
+	}
+
+	w.lastSeries = append(w.lastSeries[:0], lset...)
+	w.lastRef = ref
+
+	return nil
+}
+
+func (w *Writer) startSymbols() error {
+	// We are at w.toc.Symbols.
+	// Leave 4 bytes of space for the length, and another 4 for the number of symbols
+	// which will both be calculated later.
+	return w.write([]byte("alenblen"))
+}
+
+func (w *Writer) AddSymbol(sym string) error {
+	if err := w.ensureStage(idxStageSymbols); err != nil {
+		return err
+	}
+	if w.numSymbols != 0 && sym <= w.lastSymbol {
+		return errors.Errorf("symbol %q out-of-order", sym)
+	}
+	w.lastSymbol = sym
+	w.numSymbols++
+	w.buf1.Reset()
+	w.buf1.PutUvarintStr(sym)
+	return w.write(w.buf1.Get())
+}
+
+func (w *Writer) finishSymbols() error {
+	symbolTableSize := w.f.pos - w.toc.Symbols - 4
+	// The symbol table's <len> part is 4 bytes. So the total symbol table size must be less than or equal to 2^32-1
+	if symbolTableSize > math.MaxUint32 {
+		return errors.Errorf("symbol table size exceeds %d bytes: %d", uint32(math.MaxUint32), symbolTableSize)
+	}
+
+	// Write out the length and symbol count.
+	w.buf1.Reset()
+	w.buf1.PutBE32int(int(symbolTableSize))
+	w.buf1.PutBE32int(int(w.numSymbols))
+	if err := w.writeAt(w.buf1.Get(), w.toc.Symbols); err != nil {
+		return err
+	}
+
+	hashPos := w.f.pos
+	// Leave space for the hash. We can only calculate it
+	// now that the number of symbols is known, so mmap and do it from there.
+	if err := w.write([]byte("hash")); err != nil {
+		return err
+	}
+	if err := w.f.Flush(); err != nil {
+		return err
+	}
+
+	sf, err := fileutil.OpenMmapFile(w.f.name)
+	if err != nil {
+		return err
+	}
+	w.symbolFile = sf
+	hash := crc32.Checksum(w.symbolFile.Bytes()[w.toc.Symbols+4:hashPos], castagnoliTable)
+	w.buf1.Reset()
+	w.buf1.PutBE32(hash)
+	if err := w.writeAt(w.buf1.Get(), hashPos); err != nil {
+		return err
+	}
+
+	// Load in the symbol table efficiently for the rest of the index writing.
+	w.symbols, err = NewSymbols(realByteSlice(w.symbolFile.Bytes()), FormatV2, int(w.toc.Symbols))
+	if err != nil {
+		return errors.Wrap(err, "read symbols")
+	}
+	return nil
+}
+
+func (w *Writer) writeLabelIndices() error {
+	if err := w.fPO.Flush(); err != nil {
+		return err
+	}
+
+	// Find all the label values in the tmp posting offset table.
+	f, err := fileutil.OpenMmapFile(w.fPO.name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.fPO.pos))
+	cnt := w.cntPO
+	current := []byte{}
+	values := []uint32{}
+	for d.Err() == nil && cnt > 0 {
+		cnt--
+		d.Uvarint()                           // Keycount.
+		name := d.UvarintBytes()              // Label name.
+		value := yoloString(d.UvarintBytes()) // Label value.
+		d.Uvarint64()                         // Offset.
+		if len(name) == 0 {
+			continue // All index is ignored.
+		}
+
+		if !bytes.Equal(name, current) && len(values) > 0 {
+			// We've reached a new label name.
+			if err := w.writeLabelIndex(string(current), values); err != nil {
+				return err
+			}
+			values = values[:0]
+		}
+		current = name
+		sid, err := w.symbols.ReverseLookup(value)
+		if err != nil {
+			return err
+		}
+		values = append(values, sid)
+	}
+	if d.Err() != nil {
+		return d.Err()
+	}
+
+	// Handle the last label.
+	if len(values) > 0 {
+		if err := w.writeLabelIndex(string(current), values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Writer) writeLabelIndex(name string, values []uint32) error {
+	// Align beginning to 4 bytes for more efficient index list scans.
+	if err := w.addPadding(4); err != nil {
+		return err
+	}
+
+	w.labelIndexes = append(w.labelIndexes, labelIndexHashEntry{
+		keys:   []string{name},
+		offset: w.f.pos,
+	})
+
+	startPos := w.f.pos
+	// Leave 4 bytes of space for the length, which will be calculated later.
+	if err := w.write([]byte("alen")); err != nil {
+		return err
+	}
+	w.crc32.Reset()
+
+	w.buf1.Reset()
+	w.buf1.PutBE32int(1) // Number of names.
+	w.buf1.PutBE32int(len(values))
+	w.buf1.WriteToHash(w.crc32)
+	if err := w.write(w.buf1.Get()); err != nil {
+		return err
+	}
+
+	for _, v := range values {
+		w.buf1.Reset()
+		w.buf1.PutBE32(v)
+		w.buf1.WriteToHash(w.crc32)
+		if err := w.write(w.buf1.Get()); err != nil {
+			return err
+		}
+	}
+
+	// Write out the length.
+	w.buf1.Reset()
+	l := w.f.pos - startPos - 4
+	if l > math.MaxUint32 {
+		return errors.Errorf("label index size exceeds 4 bytes: %d", l)
+	}
+	w.buf1.PutBE32int(int(l))
+	if err := w.writeAt(w.buf1.Get(), startPos); err != nil {
+		return err
+	}
+
+	w.buf1.Reset()
+	w.buf1.PutHashSum(w.crc32)
+	return w.write(w.buf1.Get())
+}
+
+// writeLabelIndexesOffsetTable writes the label indices offset table.
+func (w *Writer) writeLabelIndexesOffsetTable() error {
+	startPos := w.f.pos
+	// Leave 4 bytes of space for the length, which will be calculated later.
+	if err := w.write([]byte("alen")); err != nil {
+		return err
+	}
+	w.crc32.Reset()
+
+	w.buf1.Reset()
+	w.buf1.PutBE32int(len(w.labelIndexes))
+	w.buf1.WriteToHash(w.crc32)
+	if err := w.write(w.buf1.Get()); err != nil {
+		return err
+	}
+
+	for _, e := range w.labelIndexes {
+		w.buf1.Reset()
+		w.buf1.PutUvarint(len(e.keys))
+		for _, k := range e.keys {
+			w.buf1.PutUvarintStr(k)
+		}
+		w.buf1.PutUvarint64(e.offset)
+		w.buf1.WriteToHash(w.crc32)
+		if err := w.write(w.buf1.Get()); err != nil {
+			return err
+		}
+	}
+	// Write out the length.
+	w.buf1.Reset()
+	l := w.f.pos - startPos - 4
+	if l > math.MaxUint32 {
+		return errors.Errorf("label indexes offset table size exceeds 4 bytes: %d", l)
+	}
+	w.buf1.PutBE32int(int(l))
+	if err := w.writeAt(w.buf1.Get(), startPos); err != nil {
+		return err
+	}
+
+	w.buf1.Reset()
+	w.buf1.PutHashSum(w.crc32)
+	return w.write(w.buf1.Get())
+}
+
+// writePostingsOffsetTable writes the postings offset table.
+func (w *Writer) writePostingsOffsetTable() error {
+	// Ensure everything is in the temporary file.
+	if err := w.fPO.Flush(); err != nil {
+		return err
+	}
+
+	startPos := w.f.pos
+	// Leave 4 bytes of space for the length, which will be calculated later.
+	if err := w.write([]byte("alen")); err != nil {
+		return err
+	}
+
+	// Copy over the tmp posting offset table, however we need to
+	// adjust the offsets.
+	adjustment := w.postingsStart
+
+	w.buf1.Reset()
+	w.crc32.Reset()
+	w.buf1.PutBE32int(int(w.cntPO)) // Count.
+	w.buf1.WriteToHash(w.crc32)
+	if err := w.write(w.buf1.Get()); err != nil {
+		return err
+	}
+
+	f, err := fileutil.OpenMmapFile(w.fPO.name)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+	}()
+	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.fPO.pos))
+	cnt := w.cntPO
+	for d.Err() == nil && cnt > 0 {
+		w.buf1.Reset()
+		w.buf1.PutUvarint(d.Uvarint())                     // Keycount.
+		w.buf1.PutUvarintStr(yoloString(d.UvarintBytes())) // Label name.
+		w.buf1.PutUvarintStr(yoloString(d.UvarintBytes())) // Label value.
+		w.buf1.PutUvarint64(d.Uvarint64() + adjustment)    // Offset.
+		w.buf1.WriteToHash(w.crc32)
+		if err := w.write(w.buf1.Get()); err != nil {
+			return err
+		}
+		cnt--
+	}
+	if d.Err() != nil {
+		return d.Err()
+	}
+
+	// Cleanup temporary file.
+	if err := f.Close(); err != nil {
+		return err
+	}
+	f = nil
+	if err := w.fPO.Close(); err != nil {
+		return err
+	}
+	if err := w.fPO.Remove(); err != nil {
+		return err
+	}
+	w.fPO = nil
+
+	// Write out the length.
+	w.buf1.Reset()
+	l := w.f.pos - startPos - 4
+	if l > math.MaxUint32 {
+		return errors.Errorf("postings offset table size exceeds 4 bytes: %d", l)
+	}
+	w.buf1.PutBE32int(int(l))
+	if err := w.writeAt(w.buf1.Get(), startPos); err != nil {
+		return err
+	}
+
+	// Finally write the hash.
+	w.buf1.Reset()
+	w.buf1.PutHashSum(w.crc32)
+	return w.write(w.buf1.Get())
+}
+
+const indexTOCLen = 6*8 + crc32.Size
+
+func (w *Writer) writeTOC() error {
+	w.buf1.Reset()
+
+	w.buf1.PutBE64(w.toc.Symbols)
+	w.buf1.PutBE64(w.toc.Series)
+	w.buf1.PutBE64(w.toc.LabelIndices)
+	w.buf1.PutBE64(w.toc.LabelIndicesTable)
+	w.buf1.PutBE64(w.toc.Postings)
+	w.buf1.PutBE64(w.toc.PostingsTable)
+
+	w.buf1.PutHash(w.crc32)
+
+	return w.write(w.buf1.Get())
+}
+
+func (w *Writer) writePostingsToTmpFiles() error {
+	names := make([]string, 0, len(w.labelNames))
+	for n := range w.labelNames {
+		names = append(names, n)
+	}
+	slices.Sort(names)
+
+	if err := w.f.Flush(); err != nil {
+		return err
+	}
+	f, err := fileutil.OpenMmapFile(w.f.name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Write out the special all posting.
+	offsets := []uint32{}
+	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.toc.LabelIndices))
+	d.Skip(int(w.toc.Series))
+	for d.Len() > 0 {
+		d.ConsumePadding()
+		startPos := w.toc.LabelIndices - uint64(d.Len())
+		if startPos%16 != 0 {
+			return errors.Errorf("series not 16-byte aligned at %d", startPos)
+		}
+		offsets = append(offsets, uint32(startPos/16))
+		// Skip to next series.
+		x := d.Uvarint()
+		d.Skip(x + crc32.Size)
+		if err := d.Err(); err != nil {
+			return err
+		}
+	}
+	if err := w.writePosting("", "", offsets); err != nil {
+		return err
+	}
+	maxPostings := uint64(len(offsets)) // No label name can have more postings than this.
+
+	for len(names) > 0 {
+		batchNames := []string{}
+		var c uint64
+		// Try to bunch up label names into one loop, but avoid
+		// using more memory than a single label name can.
+		for len(names) > 0 {
+			if w.labelNames[names[0]]+c > maxPostings {
+				break
+			}
+			batchNames = append(batchNames, names[0])
+			c += w.labelNames[names[0]]
+			names = names[1:]
+		}
+
+		nameSymbols := map[uint32]string{}
+		for _, name := range batchNames {
+			sid, err := w.symbols.ReverseLookup(name)
+			if err != nil {
+				return err
+			}
+			nameSymbols[sid] = name
+		}
+		// Label name -> label value -> positions.
+		postings := map[uint32]map[uint32][]uint32{}
+
+		d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.toc.LabelIndices))
+		d.Skip(int(w.toc.Series))
+		for d.Len() > 0 {
+			d.ConsumePadding()
+			startPos := w.toc.LabelIndices - uint64(d.Len())
+			l := d.Uvarint() // Length of this series in bytes.
+			startLen := d.Len()
+
+			// See if label names we want are in the series.
+			numLabels := d.Uvarint()
+			for i := 0; i < numLabels; i++ {
+				lno := uint32(d.Uvarint())
+				lvo := uint32(d.Uvarint())
+
+				if _, ok := nameSymbols[lno]; ok {
+					if _, ok := postings[lno]; !ok {
+						postings[lno] = map[uint32][]uint32{}
+					}
+					postings[lno][lvo] = append(postings[lno][lvo], uint32(startPos/16))
+				}
+			}
+			// Skip to next series.
+			d.Skip(l - (startLen - d.Len()) + crc32.Size)
+			if err := d.Err(); err != nil {
+				return err
+			}
+		}
+
+		for _, name := range batchNames {
+			// Write out postings for this label name.
+			sid, err := w.symbols.ReverseLookup(name)
+			if err != nil {
+				return err
+			}
+			values := make([]uint32, 0, len(postings[sid]))
+			for v := range postings[sid] {
+				values = append(values, v)
+			}
+			// Symbol numbers are in order, so the strings will also be in order.
+			sort.Sort(uint32slice(values))
+			for _, v := range values {
+				value, err := w.symbols.Lookup(v)
+				if err != nil {
+					return err
+				}
+				if err := w.writePosting(name, value, postings[sid][v]); err != nil {
+					return err
+				}
+			}
+		}
+		select {
+		case <-w.ctx.Done():
+			return w.ctx.Err()
+		default:
+		}
+
+	}
+	return nil
+}
+
+func (w *Writer) writePosting(name, value string, offs []uint32) error {
+	// Align beginning to 4 bytes for more efficient postings list scans.
+	if err := w.fP.AddPadding(4); err != nil {
+		return err
+	}
+
+	// Write out postings offset table to temporary file as we go.
+	w.buf1.Reset()
+	w.buf1.PutUvarint(2)
+	w.buf1.PutUvarintStr(name)
+	w.buf1.PutUvarintStr(value)
+	w.buf1.PutUvarint64(w.fP.pos) // This is relative to the postings tmp file, not the final index file.
+	if err := w.fPO.Write(w.buf1.Get()); err != nil {
+		return err
+	}
+	w.cntPO++
+
+	w.buf1.Reset()
+	w.buf1.PutBE32int(len(offs))
+
+	for _, off := range offs {
+		if off > (1<<32)-1 {
+			return errors.Errorf("series offset %d exceeds 4 bytes", off)
+		}
+		w.buf1.PutBE32(off)
+	}
+
+	w.buf2.Reset()
+	l := w.buf1.Len()
+	// We convert to uint to make code compile on 32-bit systems, as math.MaxUint32 doesn't fit into int there.
+	if uint(l) > math.MaxUint32 {
+		return errors.Errorf("posting size exceeds 4 bytes: %d", l)
+	}
+	w.buf2.PutBE32int(l)
+	w.buf1.PutHash(w.crc32)
+	return w.fP.Write(w.buf2.Get(), w.buf1.Get())
+}
+
+func (w *Writer) writePostings() error {
+	// There's padding in the tmp file, make sure it actually works.
+	if err := w.f.AddPadding(4); err != nil {
+		return err
+	}
+	w.postingsStart = w.f.pos
+
+	// Copy temporary file into main index.
+	if err := w.fP.Flush(); err != nil {
+		return err
+	}
+	if _, err := w.fP.f.Seek(0, 0); err != nil {
+		return err
+	}
+	// Don't need to calculate a checksum, so can copy directly.
+	n, err := io.CopyBuffer(w.f.fbuf, w.fP.f, make([]byte, 1<<20))
+	if err != nil {
+		return err
+	}
+	if uint64(n) != w.fP.pos {
+		return errors.Errorf("wrote %d bytes to posting temporary file, but only read back %d", w.fP.pos, n)
+	}
+	w.f.pos += uint64(n)
+
+	if err := w.fP.Close(); err != nil {
+		return err
+	}
+	if err := w.fP.Remove(); err != nil {
+		return err
+	}
+	w.fP = nil
+	return nil
+}
+
+type uint32slice []uint32
+
+func (s uint32slice) Len() int           { return len(s) }
+func (s uint32slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s uint32slice) Less(i, j int) bool { return s[i] < s[j] }
+
+type labelIndexHashEntry struct {
+	keys   []string
+	offset uint64
+}
+
+func (w *Writer) Close() error {
+	// Even if this fails, we need to close all the files.
+	ensureErr := w.ensureStage(idxStageDone)
+
+	if w.symbolFile != nil {
+		if err := w.symbolFile.Close(); err != nil {
+			return err
+		}
+	}
+	if w.fP != nil {
+		if err := w.fP.Close(); err != nil {
+			return err
+		}
+	}
+	if w.fPO != nil {
+		if err := w.fPO.Close(); err != nil {
+			return err
+		}
+	}
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	return ensureErr
+}
+
+// StringIter iterates over a sorted list of strings.
+type StringIter interface {
+	// Next advances the iterator and returns true if another value was found.
+	Next() bool
+
+	// At returns the value at the current iterator position.
+	At() string
+
+	// Err returns the last error of the iterator.
+	Err() error
+}
+
+type ReaderCacheProvider interface {
+	SeriesHashCache() *hashcache.BlockSeriesHashCache
+}
+
+type Reader struct {
+	b   ByteSlice
+	toc *TOC
+
+	// Close that releases the underlying resources of the byte slice.
+	c io.Closer
+
+	// Map of LabelName to a list of some LabelValues's position in the offset table.
+	// The first and last values for each name are always present.
+	postings map[string][]postingOffset
+	// For the v1 format, labelname -> labelvalue -> offset.
+	postingsV1 map[string]map[string]uint64
+
+	symbols     *Symbols
+	nameSymbols map[uint32]string // Cache of the label name symbol lookups,
+	// as there are not many and they are half of all lookups.
+
+	dec *Decoder
+
+	version int
+
+	// Provides a cache mapping series labels hash by series ID.
+	cacheProvider ReaderCacheProvider
+}
+
+type postingOffset struct {
+	value string
+	off   int
+}
+
+// ByteSlice abstracts a byte slice.
+type ByteSlice interface {
+	Len() int
+	Range(start, end int) []byte
+}
+
+type realByteSlice []byte
+
+func (b realByteSlice) Len() int {
+	return len(b)
+}
+
+func (b realByteSlice) Range(start, end int) []byte {
+	return b[start:end]
+}
+
+func (b realByteSlice) Sub(start, end int) ByteSlice {
+	return b[start:end]
+}
+
+// NewReader returns a new index reader on the given byte slice. It automatically
+// handles different format versions.
+func NewReader(b ByteSlice) (*Reader, error) {
+	return newReader(b, io.NopCloser(nil), nil)
+}
+
+// NewReaderWithCache is like NewReader but allows to pass a cache provider.
+func NewReaderWithCache(b ByteSlice, cacheProvider ReaderCacheProvider) (*Reader, error) {
+	return newReader(b, io.NopCloser(nil), cacheProvider)
+}
+
+// NewFileReader returns a new index reader against the given index file.
+func NewFileReader(path string) (*Reader, error) {
+	return NewFileReaderWithCache(path, nil)
+}
+
+// NewFileReaderWithCache is like NewFileReader but allows to pass a cache provider.
+func NewFileReaderWithCache(path string, cacheProvider ReaderCacheProvider) (*Reader, error) {
+	f, err := fileutil.OpenMmapFile(path)
+	if err != nil {
+		return nil, err
+	}
+	r, err := newReader(realByteSlice(f.Bytes()), f, cacheProvider)
+	if err != nil {
+		return nil, tsdb_errors.NewMulti(
+			err,
+			f.Close(),
+		).Err()
+	}
+
+	return r, nil
+}
+
+func newReader(b ByteSlice, c io.Closer, cacheProvider ReaderCacheProvider) (*Reader, error) {
+	r := &Reader{
+		b:             b,
+		c:             c,
+		postings:      map[string][]postingOffset{},
+		cacheProvider: cacheProvider,
+	}
+
+	// Verify header.
+	if r.b.Len() < HeaderLen {
+		return nil, errors.Wrap(encoding.ErrInvalidSize, "index header")
+	}
+	if m := binary.BigEndian.Uint32(r.b.Range(0, 4)); m != MagicIndex {
+		return nil, errors.Errorf("invalid magic number %x", m)
+	}
+	r.version = int(r.b.Range(4, 5)[0])
+
+	if r.version != FormatV1 && r.version != FormatV2 {
+		return nil, errors.Errorf("unknown index file version %d", r.version)
+	}
+
+	var err error
+	r.toc, err = NewTOCFromByteSlice(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "read TOC")
+	}
+
+	r.symbols, err = NewSymbols(r.b, r.version, int(r.toc.Symbols))
+	if err != nil {
+		return nil, errors.Wrap(err, "read symbols")
+	}
+
+	if r.version == FormatV1 {
+		// Earlier V1 formats don't have a sorted postings offset table, so
+		// load the whole offset table into memory.
+		r.postingsV1 = map[string]map[string]uint64{}
+		if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, off uint64, _ int) error {
+			if len(key) != 2 {
+				return errors.Errorf("unexpected key length for posting table %d", len(key))
+			}
+			if _, ok := r.postingsV1[key[0]]; !ok {
+				r.postingsV1[key[0]] = map[string]uint64{}
+				r.postings[key[0]] = nil // Used to get a list of labelnames in places.
+			}
+			r.postingsV1[key[0]][key[1]] = off
+			return nil
+		}); err != nil {
+			return nil, errors.Wrap(err, "read postings table")
+		}
+	} else {
+		var lastKey []string
+		lastOff := 0
+		valueCount := 0
+		// For the postings offset table we keep every label name but only every nth
+		// label value (plus the first and last one), to save memory.
+		if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, _ uint64, off int) error {
+			if len(key) != 2 {
+				return errors.Errorf("unexpected key length for posting table %d", len(key))
+			}
+			if _, ok := r.postings[key[0]]; !ok {
+				// Next label name.
+				r.postings[key[0]] = []postingOffset{}
+				if lastKey != nil {
+					// Always include last value for each label name.
+					r.postings[lastKey[0]] = append(r.postings[lastKey[0]], postingOffset{value: lastKey[1], off: lastOff})
+				}
+				lastKey = nil
+				valueCount = 0
+			}
+			if valueCount%symbolFactor == 0 {
+				r.postings[key[0]] = append(r.postings[key[0]], postingOffset{value: key[1], off: off})
+				lastKey = nil
+			} else {
+				lastKey = key
+				lastOff = off
+			}
+			valueCount++
+			return nil
+		}); err != nil {
+			return nil, errors.Wrap(err, "read postings table")
+		}
+		if lastKey != nil {
+			r.postings[lastKey[0]] = append(r.postings[lastKey[0]], postingOffset{value: lastKey[1], off: lastOff})
+		}
+		// Trim any extra space in the slices.
+		for k, v := range r.postings {
+			l := make([]postingOffset, len(v))
+			copy(l, v)
+			r.postings[k] = l
+		}
+	}
+
+	r.nameSymbols = make(map[uint32]string, len(r.postings))
+	for k := range r.postings {
+		if k == "" {
+			continue
+		}
+		off, err := r.symbols.ReverseLookup(k)
+		if err != nil {
+			return nil, errors.Wrap(err, "reverse symbol lookup")
+		}
+		r.nameSymbols[off] = k
+	}
+
+	r.dec = &Decoder{LookupSymbol: r.lookupSymbol}
+
+	return r, nil
+}
+
+// Version returns the file format version of the underlying index.
+func (r *Reader) Version() int {
+	return r.version
+}
+
+// Range marks a byte range.
+type Range struct {
+	Start, End int64
+}
+
+// PostingsRanges returns a new map of byte range in the underlying index file
+// for all postings lists.
+func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
+	m := map[labels.Label]Range{}
+	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, off uint64, _ int) error {
+		if len(key) != 2 {
+			return errors.Errorf("unexpected key length for posting table %d", len(key))
+		}
+		d := encoding.NewDecbufAt(r.b, int(off), castagnoliTable)
+		if d.Err() != nil {
+			return d.Err()
+		}
+		m[labels.Label{Name: key[0], Value: key[1]}] = Range{
+			Start: int64(off) + 4,
+			End:   int64(off) + 4 + int64(d.Len()),
+		}
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "read postings table")
+	}
+	return m, nil
+}
+
+type Symbols struct {
+	bs      ByteSlice
+	version int
+	off     int
+
+	offsets []int
+	seen    int
+}
+
+const symbolFactor = 32
+
+// NewSymbols returns a Symbols object for symbol lookups.
+func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
+	s := &Symbols{
+		bs:      bs,
+		version: version,
+		off:     off,
+	}
+	d := encoding.NewDecbufAt(bs, off, castagnoliTable)
+	var (
+		origLen = d.Len()
+		cnt     = d.Be32int()
+		basePos = off + 4
+	)
+	s.offsets = make([]int, 0, 1+cnt/symbolFactor)
+	for d.Err() == nil && s.seen < cnt {
+		if s.seen%symbolFactor == 0 {
+			s.offsets = append(s.offsets, basePos+origLen-d.Len())
+		}
+		d.UvarintBytes() // The symbol.
+		s.seen++
+	}
+	if d.Err() != nil {
+		return nil, d.Err()
+	}
+	return s, nil
+}
+
+func (s Symbols) Lookup(o uint32) (string, error) {
+	d := encoding.Decbuf{
+		B: s.bs.Range(0, s.bs.Len()),
+	}
+
+	if s.version == FormatV2 {
+		if int(o) >= s.seen {
+			return "", errors.Errorf("unknown symbol offset %d", o)
+		}
+		d.Skip(s.offsets[int(o/symbolFactor)])
+		// Walk until we find the one we want.
+		for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
+			d.UvarintBytes()
+		}
+	} else {
+		d.Skip(int(o))
+	}
+	sym := d.UvarintStr()
+	if d.Err() != nil {
+		return "", d.Err()
+	}
+	return sym, nil
+}
+
+func (s Symbols) ReverseLookup(sym string) (uint32, error) {
+	if len(s.offsets) == 0 {
+		return 0, errors.Errorf("unknown symbol %q - no symbols", sym)
+	}
+	i := sort.Search(len(s.offsets), func(i int) bool {
+		// Any decoding errors here will be lost, however
+		// we already read through all of this at startup.
+		d := encoding.Decbuf{
+			B: s.bs.Range(0, s.bs.Len()),
+		}
+		d.Skip(s.offsets[i])
+		return yoloString(d.UvarintBytes()) > sym
+	})
+	d := encoding.Decbuf{
+		B: s.bs.Range(0, s.bs.Len()),
+	}
+	if i > 0 {
+		i--
+	}
+	d.Skip(s.offsets[i])
+	res := i * symbolFactor
+	var lastLen int
+	var lastSymbol string
+	for d.Err() == nil && res <= s.seen {
+		lastLen = d.Len()
+		lastSymbol = yoloString(d.UvarintBytes())
+		if lastSymbol >= sym {
+			break
+		}
+		res++
+	}
+	if d.Err() != nil {
+		return 0, d.Err()
+	}
+	if lastSymbol != sym {
+		return 0, errors.Errorf("unknown symbol %q", sym)
+	}
+	if s.version == FormatV2 {
+		return uint32(res), nil
+	}
+	return uint32(s.bs.Len() - lastLen), nil
+}
+
+func (s Symbols) Size() int {
+	return len(s.offsets) * 8
+}
+
+func (s Symbols) Iter() StringIter {
+	d := encoding.NewDecbufAt(s.bs, s.off, castagnoliTable)
+	cnt := d.Be32int()
+	return &symbolsIter{
+		d:   d,
+		cnt: cnt,
+	}
+}
+
+// symbolsIter implements StringIter.
+type symbolsIter struct {
+	d   encoding.Decbuf
+	cnt int
+	cur string
+	err error
+}
+
+func (s *symbolsIter) Next() bool {
+	if s.cnt == 0 || s.err != nil {
+		return false
+	}
+	s.cur = yoloString(s.d.UvarintBytes())
+	s.cnt--
+	if s.d.Err() != nil {
+		s.err = s.d.Err()
+		return false
+	}
+	return true
+}
+
+func (s symbolsIter) At() string { return s.cur }
+func (s symbolsIter) Err() error { return s.err }
+
+// ReadOffsetTable reads an offset table and at the given position calls f for each
+// found entry. If f returns an error it stops decoding and returns the received error.
+func ReadOffsetTable(bs ByteSlice, off uint64, f func([]string, uint64, int) error) error {
+	d := encoding.NewDecbufAt(bs, int(off), castagnoliTable)
+	startLen := d.Len()
+	cnt := d.Be32()
+
+	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
+		offsetPos := startLen - d.Len()
+		keyCount := d.Uvarint()
+		// The Postings offset table takes only 2 keys per entry (name and value of label),
+		// and the LabelIndices offset table takes only 1 key per entry (a label name).
+		// Hence setting the size to max of both, i.e. 2.
+		keys := make([]string, 0, 2)
+
+		for i := 0; i < keyCount; i++ {
+			keys = append(keys, d.UvarintStr())
+		}
+		o := d.Uvarint64()
+		if d.Err() != nil {
+			break
+		}
+		if err := f(keys, o, offsetPos); err != nil {
+			return err
+		}
+		cnt--
+	}
+	return d.Err()
+}
+
+// Close the reader and its underlying resources.
+func (r *Reader) Close() error {
+	return r.c.Close()
+}
+
+func (r *Reader) lookupSymbol(o uint32) (string, error) {
+	if s, ok := r.nameSymbols[o]; ok {
+		return s, nil
+	}
+	return r.symbols.Lookup(o)
+}
+
+// Symbols returns an iterator over the symbols that exist within the index.
+func (r *Reader) Symbols() StringIter {
+	return r.symbols.Iter()
+}
+
+// SymbolTableSize returns the symbol table size in bytes.
+func (r *Reader) SymbolTableSize() uint64 {
+	return uint64(r.symbols.Size())
+}
+
+// SortedLabelValues returns value tuples that exist for the given label name.
+// It is not safe to use the return value beyond the lifetime of the byte slice
+// passed into the Reader.
+func (r *Reader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+	values, err := r.LabelValues(name, matchers...)
+	if err == nil && r.version == FormatV1 {
+		slices.Sort(values)
+	}
+	return values, err
+}
+
+// LabelValues returns value tuples that exist for the given label name.
+// It is not safe to use the return value beyond the lifetime of the byte slice
+// passed into the Reader.
+// TODO(replay): Support filtering by matchers
+func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+	if len(matchers) > 0 {
+		return nil, errors.Errorf("matchers parameter is not implemented: %+v", matchers)
+	}
+
+	if r.version == FormatV1 {
+		e, ok := r.postingsV1[name]
+		if !ok {
+			return nil, nil
+		}
+		values := make([]string, 0, len(e))
+		for k := range e {
+			values = append(values, k)
+		}
+		return values, nil
+
+	}
+	e, ok := r.postings[name]
+	if !ok {
+		return nil, nil
+	}
+	if len(e) == 0 {
+		return nil, nil
+	}
+	values := make([]string, 0, len(e)*symbolFactor)
+
+	d := encoding.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil)
+	d.Skip(e[0].off)
+	lastVal := e[len(e)-1].value
+
+	skip := 0
+	for d.Err() == nil {
+		if skip == 0 {
+			// These are always the same number of bytes,
+			// and it's faster to skip than parse.
+			skip = d.Len()
+			d.Uvarint()      // Keycount.
+			d.UvarintBytes() // Label name.
+			skip -= d.Len()
+		} else {
+			d.Skip(skip)
+		}
+		s := yoloString(d.UvarintBytes()) // Label value.
+		values = append(values, s)
+		if s == lastVal {
+			break
+		}
+		d.Uvarint64() // Offset.
+	}
+	if d.Err() != nil {
+		return nil, errors.Wrap(d.Err(), "get postings offset entry")
+	}
+	return values, nil
+}
+
+// LabelNamesFor returns all the label names for the series referred to by IDs.
+// The names returned are sorted.
+func (r *Reader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
+	// Gather offsetsMap the name offsetsMap in the symbol table first
+	offsetsMap := make(map[uint32]struct{})
+	for _, id := range ids {
+		offset := id
+		// In version 2 series IDs are no longer exact references but series are 16-byte padded
+		// and the ID is the multiple of 16 of the actual position.
+		if r.version == FormatV2 {
+			offset = id * 16
+		}
+
+		d := encoding.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable)
+		buf := d.Get()
+		if d.Err() != nil {
+			return nil, errors.Wrap(d.Err(), "get buffer for series")
+		}
+
+		offsets, err := r.dec.LabelNamesOffsetsFor(buf)
+		if err != nil {
+			return nil, errors.Wrap(err, "get label name offsets")
+		}
+		for _, off := range offsets {
+			offsetsMap[off] = struct{}{}
+		}
+	}
+
+	// Lookup the unique symbols.
+	names := make([]string, 0, len(offsetsMap))
+	for off := range offsetsMap {
+		name, err := r.lookupSymbol(off)
+		if err != nil {
+			return nil, errors.Wrap(err, "lookup symbol in LabelNamesFor")
+		}
+		names = append(names, name)
+	}
+
+	slices.Sort(names)
+
+	return names, nil
+}
+
+// LabelValueFor returns label value for the given label name in the series referred to by ID.
+func (r *Reader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
+	offset := id
+	// In version 2 series IDs are no longer exact references but series are 16-byte padded
+	// and the ID is the multiple of 16 of the actual position.
+	if r.version == FormatV2 {
+		offset = id * 16
+	}
+	d := encoding.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable)
+	buf := d.Get()
+	if d.Err() != nil {
+		return "", errors.Wrap(d.Err(), "label values for")
+	}
+
+	value, err := r.dec.LabelValueFor(buf, label)
+	if err != nil {
+		return "", storage.ErrNotFound
+	}
+
+	if value == "" {
+		return "", storage.ErrNotFound
+	}
+
+	return value, nil
+}
+
+// Series reads the series with the given ID and writes its labels and chunks into lbls and chks.
+// Chunks will be skipped if chks is nil.
+func (r *Reader) Series(id storage.SeriesRef, lbls *labels.Labels, chks *[]chunks.Meta) error {
+	offset := id
+	// In version 2 series IDs are no longer exact references but series are 16-byte padded
+	// and the ID is the multiple of 16 of the actual position.
+	if r.version == FormatV2 {
+		offset = id * 16
+	}
+	d := encoding.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable)
+	if d.Err() != nil {
+		return d.Err()
+	}
+	return errors.Wrap(r.dec.Series(d.Get(), lbls, chks), "read series")
+}
+
+func (r *Reader) Postings(name string, values ...string) (Postings, error) {
+	if r.version == FormatV1 {
+		e, ok := r.postingsV1[name]
+		if !ok {
+			return EmptyPostings(), nil
+		}
+		res := make([]Postings, 0, len(values))
+		for _, v := range values {
+			postingsOff, ok := e[v]
+			if !ok {
+				continue
+			}
+			// Read from the postings table.
+			d := encoding.NewDecbufAt(r.b, int(postingsOff), castagnoliTable)
+			_, p, err := r.dec.Postings(d.Get())
+			if err != nil {
+				return nil, errors.Wrap(err, "decode postings")
+			}
+			res = append(res, p)
+		}
+		return Merge(res...), nil
+	}
+
+	e, ok := r.postings[name]
+	if !ok {
+		return EmptyPostings(), nil
+	}
+
+	if len(values) == 0 {
+		return EmptyPostings(), nil
+	}
+
+	res := make([]Postings, 0, len(values))
+	skip := 0
+	valueIndex := 0
+	for valueIndex < len(values) && values[valueIndex] < e[0].value {
+		// Discard values before the start.
+		valueIndex++
+	}
+	for valueIndex < len(values) {
+		value := values[valueIndex]
+
+		i := sort.Search(len(e), func(i int) bool { return e[i].value >= value })
+		if i == len(e) {
+			// We're past the end.
+			break
+		}
+		if i > 0 && e[i].value != value {
+			// Need to look from previous entry.
+			i--
+		}
+		// Don't Crc32 the entire postings offset table, this is very slow
+		// so hope any issues were caught at startup.
+		d := encoding.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil)
+		d.Skip(e[i].off)
+
+		// Iterate on the offset table.
+		var postingsOff uint64 // The offset into the postings table.
+		for d.Err() == nil {
+			if skip == 0 {
+				// These are always the same number of bytes,
+				// and it's faster to skip than parse.
+				skip = d.Len()
+				d.Uvarint()      // Keycount.
+				d.UvarintBytes() // Label name.
+				skip -= d.Len()
+			} else {
+				d.Skip(skip)
+			}
+			v := d.UvarintBytes()       // Label value.
+			postingsOff = d.Uvarint64() // Offset.
+			for string(v) >= value {
+				if string(v) == value {
+					// Read from the postings table.
+					d2 := encoding.NewDecbufAt(r.b, int(postingsOff), castagnoliTable)
+					_, p, err := r.dec.Postings(d2.Get())
+					if err != nil {
+						return nil, errors.Wrap(err, "decode postings")
+					}
+					res = append(res, p)
+				}
+				valueIndex++
+				if valueIndex == len(values) {
+					break
+				}
+				value = values[valueIndex]
+			}
+			if i+1 == len(e) || value >= e[i+1].value || valueIndex == len(values) {
+				// Need to go to a later postings offset entry, if there is one.
+				break
+			}
+		}
+		if d.Err() != nil {
+			return nil, errors.Wrap(d.Err(), "get postings offset entry")
+		}
+	}
+
+	return Merge(res...), nil
+}
+
+// SortedPostings returns the given postings list reordered so that the backing series
+// are sorted.
+func (r *Reader) SortedPostings(p Postings) Postings {
+	return p
+}
+
+// ShardedPostings returns a postings list filtered by the provided shardIndex out of shardCount.
+func (r *Reader) ShardedPostings(p Postings, shardIndex, shardCount uint64) Postings {
+	var (
+		out     = make([]storage.SeriesRef, 0, 128)
+		bufLbls = make(labels.Labels, 0, 10)
+	)
+
+	// Request the cache each time because the cache implementation requires
+	// that the cache reference is retained for a short period.
+	var seriesHashCache *hashcache.BlockSeriesHashCache
+	if r.cacheProvider != nil {
+		seriesHashCache = r.cacheProvider.SeriesHashCache()
+	}
+
+	for p.Next() {
+		id := p.At()
+
+		var (
+			hash uint64
+			ok   bool
+		)
+
+		// Check if the hash is cached.
+		if seriesHashCache != nil {
+			hash, ok = seriesHashCache.Fetch(id)
+		}
+
+		if !ok {
+			// Get the series labels (no chunks).
+			err := r.Series(id, &bufLbls, nil)
+			if err != nil {
+				return ErrPostings(errors.Errorf("series %d not found", id))
+			}
+
+			hash = bufLbls.Hash()
+			if seriesHashCache != nil {
+				seriesHashCache.Store(id, hash)
+			}
+		}
+
+		// Check if the series belong to the shard.
+		if hash%shardCount != shardIndex {
+			continue
+		}
+
+		out = append(out, id)
+	}
+
+	return NewListPostings(out)
+}
+
+// Size returns the size of an index file.
+func (r *Reader) Size() int64 {
+	return int64(r.b.Len())
+}
+
+// LabelNames returns all the unique label names present in the index.
+// TODO(twilkie) implement support for matchers
+func (r *Reader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+	if len(matchers) > 0 {
+		return nil, errors.Errorf("matchers parameter is not implemented: %+v", matchers)
+	}
+
+	labelNames := make([]string, 0, len(r.postings))
+	for name := range r.postings {
+		if name == allPostingsKey.Name {
+			// This is not from any metric.
+			continue
+		}
+		labelNames = append(labelNames, name)
+	}
+	slices.Sort(labelNames)
+	return labelNames, nil
+}
+
+// NewStringListIter returns a StringIter for the given sorted list of strings.
+func NewStringListIter(s []string) StringIter {
+	return &stringListIter{l: s}
+}
+
+// symbolsIter implements StringIter.
+type stringListIter struct {
+	l   []string
+	cur string
+}
+
+func (s *stringListIter) Next() bool {
+	if len(s.l) == 0 {
+		return false
+	}
+	s.cur = s.l[0]
+	s.l = s.l[1:]
+	return true
+}
+func (s stringListIter) At() string { return s.cur }
+func (s stringListIter) Err() error { return nil }
+
+// Decoder provides decoding methods for the v1 and v2 index file format.
+//
+// It currently does not contain decoding methods for all entry types but can be extended
+// by them if there's demand.
+type Decoder struct {
+	LookupSymbol func(uint32) (string, error)
+}
+
+// Postings returns a postings list for b and its number of elements.
+func (dec *Decoder) Postings(b []byte) (int, Postings, error) {
+	d := encoding.Decbuf{B: b}
+	n := d.Be32int()
+	l := d.Get()
+	if d.Err() != nil {
+		return 0, nil, d.Err()
+	}
+	if len(l) != 4*n {
+		return 0, nil, fmt.Errorf("unexpected postings length, should be %d bytes for %d postings, got %d bytes", 4*n, n, len(l))
+	}
+	return n, newBigEndianPostings(l), nil
+}
+
+// LabelNamesOffsetsFor decodes the offsets of the name symbols for a given series.
+// They are returned in the same order they're stored, which should be sorted lexicographically.
+func (dec *Decoder) LabelNamesOffsetsFor(b []byte) ([]uint32, error) {
+	d := encoding.Decbuf{B: b}
+	k := d.Uvarint()
+
+	offsets := make([]uint32, k)
+	for i := 0; i < k; i++ {
+		offsets[i] = uint32(d.Uvarint())
+		_ = d.Uvarint() // skip the label value
+
+		if d.Err() != nil {
+			return nil, errors.Wrap(d.Err(), "read series label offsets")
+		}
+	}
+
+	return offsets, d.Err()
+}
+
+// LabelValueFor decodes a label for a given series.
+func (dec *Decoder) LabelValueFor(b []byte, label string) (string, error) {
+	d := encoding.Decbuf{B: b}
+	k := d.Uvarint()
+
+	for i := 0; i < k; i++ {
+		lno := uint32(d.Uvarint())
+		lvo := uint32(d.Uvarint())
+
+		if d.Err() != nil {
+			return "", errors.Wrap(d.Err(), "read series label offsets")
+		}
+
+		ln, err := dec.LookupSymbol(lno)
+		if err != nil {
+			return "", errors.Wrap(err, "lookup label name")
+		}
+
+		if ln == label {
+			lv, err := dec.LookupSymbol(lvo)
+			if err != nil {
+				return "", errors.Wrap(err, "lookup label value")
+			}
+
+			return lv, nil
+		}
+	}
+
+	return "", d.Err()
+}
+
+// Series decodes a series entry from the given byte slice into lset and chks.
+// Skips reading chunks metadata if chks is nil.
+func (dec *Decoder) Series(b []byte, lbls *labels.Labels, chks *[]chunks.Meta) error {
+	*lbls = (*lbls)[:0]
+	if chks != nil {
+		*chks = (*chks)[:0]
+	}
+
+	d := encoding.Decbuf{B: b}
+
+	k := d.Uvarint()
+
+	for i := 0; i < k; i++ {
+		lno := uint32(d.Uvarint())
+		lvo := uint32(d.Uvarint())
+
+		if d.Err() != nil {
+			return errors.Wrap(d.Err(), "read series label offsets")
+		}
+
+		ln, err := dec.LookupSymbol(lno)
+		if err != nil {
+			return errors.Wrap(err, "lookup label name")
+		}
+		lv, err := dec.LookupSymbol(lvo)
+		if err != nil {
+			return errors.Wrap(err, "lookup label value")
+		}
+
+		*lbls = append(*lbls, labels.Label{Name: ln, Value: lv})
+	}
+
+	// Skip reading chunks metadata if chks is nil.
+	if chks == nil {
+		return d.Err()
+	}
+
+	// Read the chunks meta data.
+	k = d.Uvarint()
+
+	if k == 0 {
+		return d.Err()
+	}
+
+	t0 := d.Varint64()
+	maxt := int64(d.Uvarint64()) + t0
+	ref0 := int64(d.Uvarint64())
+
+	*chks = append(*chks, chunks.Meta{
+		Ref:     chunks.ChunkRef(ref0),
+		MinTime: t0,
+		MaxTime: maxt,
+	})
+	t0 = maxt
+
+	for i := 1; i < k; i++ {
+		mint := int64(d.Uvarint64()) + t0
+		maxt := int64(d.Uvarint64()) + mint
+
+		ref0 += d.Varint64()
+		t0 = maxt
+
+		if d.Err() != nil {
+			return errors.Wrapf(d.Err(), "read meta for chunk %d", i)
+		}
+
+		*chks = append(*chks, chunks.Meta{
+			Ref:     chunks.ChunkRef(ref0),
+			MinTime: mint,
+			MaxTime: maxt,
+		})
+	}
+	return d.Err()
+}
+
+func yoloString(b []byte) string {
+	return *((*string)(unsafe.Pointer(&b)))
+}

--- a/pkg/storegateway/indexheader/index/index_test.go
+++ b/pkg/storegateway/indexheader/index/index_test.go
@@ -1,0 +1,657 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/index/index_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package index
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/hashcache"
+	"github.com/prometheus/prometheus/util/testutil"
+
+	"github.com/grafana/mimir/pkg/storegateway/indexheader/encoding"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+type series struct {
+	l      labels.Labels
+	chunks []chunks.Meta
+}
+
+type mockIndex struct {
+	series   map[storage.SeriesRef]series
+	postings map[labels.Label][]storage.SeriesRef
+	symbols  map[string]struct{}
+}
+
+func newMockIndex() mockIndex {
+	ix := mockIndex{
+		series:   make(map[storage.SeriesRef]series),
+		postings: make(map[labels.Label][]storage.SeriesRef),
+		symbols:  make(map[string]struct{}),
+	}
+	ix.postings[allPostingsKey] = []storage.SeriesRef{}
+	return ix
+}
+
+func (m mockIndex) Symbols() (map[string]struct{}, error) {
+	return m.symbols, nil
+}
+
+func (m mockIndex) AddSeries(ref storage.SeriesRef, l labels.Labels, chunks ...chunks.Meta) error {
+	if _, ok := m.series[ref]; ok {
+		return errors.Errorf("series with reference %d already added", ref)
+	}
+	for _, lbl := range l {
+		m.symbols[lbl.Name] = struct{}{}
+		m.symbols[lbl.Value] = struct{}{}
+		if _, ok := m.postings[lbl]; !ok {
+			m.postings[lbl] = []storage.SeriesRef{}
+		}
+		m.postings[lbl] = append(m.postings[lbl], ref)
+	}
+	m.postings[allPostingsKey] = append(m.postings[allPostingsKey], ref)
+
+	s := series{l: l}
+	// Actual chunk data is not stored in the index.
+	for _, c := range chunks {
+		c.Chunk = nil
+		s.chunks = append(s.chunks, c)
+	}
+	m.series[ref] = s
+
+	return nil
+}
+
+func (m mockIndex) Close() error {
+	return nil
+}
+
+func (m mockIndex) LabelValues(name string) ([]string, error) {
+	values := []string{}
+	for l := range m.postings {
+		if l.Name == name {
+			values = append(values, l.Value)
+		}
+	}
+	return values, nil
+}
+
+func (m mockIndex) Postings(name string, values ...string) (Postings, error) {
+	p := []Postings{}
+	for _, value := range values {
+		l := labels.Label{Name: name, Value: value}
+		p = append(p, m.SortedPostings(NewListPostings(m.postings[l])))
+	}
+	return Merge(p...), nil
+}
+
+func (m mockIndex) SortedPostings(p Postings) Postings {
+	ep, err := ExpandPostings(p)
+	if err != nil {
+		return ErrPostings(errors.Wrap(err, "expand postings"))
+	}
+
+	sort.Slice(ep, func(i, j int) bool {
+		return labels.Compare(m.series[ep[i]].l, m.series[ep[j]].l) < 0
+	})
+	return NewListPostings(ep)
+}
+
+func (m mockIndex) Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]chunks.Meta) error {
+	s, ok := m.series[ref]
+	if !ok {
+		return errors.New("not found")
+	}
+	*lset = append((*lset)[:0], s.l...)
+	*chks = append((*chks)[:0], s.chunks...)
+
+	return nil
+}
+
+func TestIndexRW_Create_Open(t *testing.T) {
+	dir := t.TempDir()
+
+	fn := filepath.Join(dir, indexFilename)
+
+	// An empty index must still result in a readable file.
+	iw, err := NewWriter(context.Background(), fn)
+	require.NoError(t, err)
+	require.NoError(t, iw.Close())
+
+	ir, err := NewFileReader(fn)
+	require.NoError(t, err)
+	require.NoError(t, ir.Close())
+
+	// Modify magic header must cause open to fail.
+	f, err := os.OpenFile(fn, os.O_WRONLY, 0o666)
+	require.NoError(t, err)
+	_, err = f.WriteAt([]byte{0, 0}, 0)
+	require.NoError(t, err)
+	f.Close()
+
+	_, err = NewFileReader(dir)
+	require.Error(t, err)
+}
+
+func TestIndexRW_Postings(t *testing.T) {
+	dir := t.TempDir()
+
+	fn := filepath.Join(dir, indexFilename)
+
+	iw, err := NewWriter(context.Background(), fn)
+	require.NoError(t, err)
+
+	series := []labels.Labels{
+		labels.FromStrings("a", "1", "b", "1"),
+		labels.FromStrings("a", "1", "b", "2"),
+		labels.FromStrings("a", "1", "b", "3"),
+		labels.FromStrings("a", "1", "b", "4"),
+	}
+
+	require.NoError(t, iw.AddSymbol("1"))
+	require.NoError(t, iw.AddSymbol("2"))
+	require.NoError(t, iw.AddSymbol("3"))
+	require.NoError(t, iw.AddSymbol("4"))
+	require.NoError(t, iw.AddSymbol("a"))
+	require.NoError(t, iw.AddSymbol("b"))
+
+	// Postings lists are only written if a series with the respective
+	// reference was added before.
+	require.NoError(t, iw.AddSeries(1, series[0]))
+	require.NoError(t, iw.AddSeries(2, series[1]))
+	require.NoError(t, iw.AddSeries(3, series[2]))
+	require.NoError(t, iw.AddSeries(4, series[3]))
+
+	require.NoError(t, iw.Close())
+
+	ir, err := NewFileReader(fn)
+	require.NoError(t, err)
+
+	p, err := ir.Postings("a", "1")
+	require.NoError(t, err)
+
+	var l labels.Labels
+	var c []chunks.Meta
+
+	for i := 0; p.Next(); i++ {
+		err := ir.Series(p.At(), &l, &c)
+
+		require.NoError(t, err)
+		require.Equal(t, 0, len(c))
+		require.Equal(t, series[i], l)
+	}
+	require.NoError(t, p.Err())
+
+	// The label indices are no longer used, so test them by hand here.
+	labelIndices := map[string][]string{}
+	require.NoError(t, ReadOffsetTable(ir.b, ir.toc.LabelIndicesTable, func(key []string, off uint64, _ int) error {
+		if len(key) != 1 {
+			return errors.Errorf("unexpected key length for label indices table %d", len(key))
+		}
+
+		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
+		vals := []string{}
+		nc := d.Be32int()
+		if nc != 1 {
+			return errors.Errorf("unexpected number of label indices table names %d", nc)
+		}
+		for i := d.Be32(); i > 0; i-- {
+			v, err := ir.lookupSymbol(d.Be32())
+			if err != nil {
+				return err
+			}
+			vals = append(vals, v)
+		}
+		labelIndices[key[0]] = vals
+		return d.Err()
+	}))
+	require.Equal(t, map[string][]string{
+		"a": {"1"},
+		"b": {"1", "2", "3", "4"},
+	}, labelIndices)
+
+	// Test ShardedPostings() with and without series hash cache.
+	for _, cacheEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ShardedPostings() cache enabled: %v", cacheEnabled), func(t *testing.T) {
+			var cache ReaderCacheProvider
+			if cacheEnabled {
+				cache = hashcache.NewSeriesHashCache(1024 * 1024 * 1024).GetBlockCacheProvider("test")
+			}
+
+			ir, err := NewFileReaderWithCache(fn, cache)
+			require.NoError(t, err)
+
+			// List all postings for a given label value. This is what we expect to get
+			// in output from all shards.
+			p, err = ir.Postings("a", "1")
+			require.NoError(t, err)
+
+			var expected []storage.SeriesRef
+			for p.Next() {
+				expected = append(expected, p.At())
+			}
+			require.NoError(t, p.Err())
+			require.Greater(t, len(expected), 0)
+
+			// Query the same postings for each shard.
+			const shardCount = uint64(4)
+			actualShards := make(map[uint64][]storage.SeriesRef)
+			actualPostings := make([]storage.SeriesRef, 0, len(expected))
+
+			for shardIndex := uint64(0); shardIndex < shardCount; shardIndex++ {
+				p, err = ir.Postings("a", "1")
+				require.NoError(t, err)
+
+				p = ir.ShardedPostings(p, shardIndex, shardCount)
+				for p.Next() {
+					ref := p.At()
+
+					actualShards[shardIndex] = append(actualShards[shardIndex], ref)
+					actualPostings = append(actualPostings, ref)
+				}
+				require.NoError(t, p.Err())
+			}
+
+			// We expect the postings merged out of shards is the exact same of the non sharded ones.
+			require.ElementsMatch(t, expected, actualPostings)
+
+			// We expect the series in each shard are the expected ones.
+			for shardIndex, ids := range actualShards {
+				for _, id := range ids {
+					var lbls labels.Labels
+
+					require.NoError(t, ir.Series(id, &lbls, nil))
+					require.Equal(t, shardIndex, lbls.Hash()%shardCount)
+				}
+			}
+		})
+	}
+
+	require.NoError(t, ir.Close())
+}
+
+func TestPostingsMany(t *testing.T) {
+	dir := t.TempDir()
+
+	fn := filepath.Join(dir, indexFilename)
+
+	iw, err := NewWriter(context.Background(), fn)
+	require.NoError(t, err)
+
+	// Create a label in the index which has 999 values.
+	symbols := map[string]struct{}{}
+	series := []labels.Labels{}
+	for i := 1; i < 1000; i++ {
+		v := fmt.Sprintf("%03d", i)
+		series = append(series, labels.FromStrings("i", v, "foo", "bar"))
+		symbols[v] = struct{}{}
+	}
+	symbols["i"] = struct{}{}
+	symbols["foo"] = struct{}{}
+	symbols["bar"] = struct{}{}
+	syms := []string{}
+	for s := range symbols {
+		syms = append(syms, s)
+	}
+	sort.Strings(syms)
+	for _, s := range syms {
+		require.NoError(t, iw.AddSymbol(s))
+	}
+
+	for i, s := range series {
+		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), s))
+	}
+	require.NoError(t, iw.Close())
+
+	ir, err := NewFileReader(fn)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ir.Close()) }()
+
+	cases := []struct {
+		in []string
+	}{
+		// Simple cases, everything is present.
+		{in: []string{"002"}},
+		{in: []string{"031", "032", "033"}},
+		{in: []string{"032", "033"}},
+		{in: []string{"127", "128"}},
+		{in: []string{"127", "128", "129"}},
+		{in: []string{"127", "129"}},
+		{in: []string{"128", "129"}},
+		{in: []string{"998", "999"}},
+		{in: []string{"999"}},
+		// Before actual values.
+		{in: []string{"000"}},
+		{in: []string{"000", "001"}},
+		{in: []string{"000", "002"}},
+		// After actual values.
+		{in: []string{"999a"}},
+		{in: []string{"999", "999a"}},
+		{in: []string{"998", "999", "999a"}},
+		// In the middle of actual values.
+		{in: []string{"126a", "127", "128"}},
+		{in: []string{"127", "127a", "128"}},
+		{in: []string{"127", "127a", "128", "128a", "129"}},
+		{in: []string{"127", "128a", "129"}},
+		{in: []string{"128", "128a", "129"}},
+		{in: []string{"128", "129", "129a"}},
+		{in: []string{"126a", "126b", "127", "127a", "127b", "128", "128a", "128b", "129", "129a", "129b"}},
+	}
+
+	for _, c := range cases {
+		it, err := ir.Postings("i", c.in...)
+		require.NoError(t, err)
+
+		got := []string{}
+		var lbls labels.Labels
+		var metas []chunks.Meta
+		for it.Next() {
+			require.NoError(t, ir.Series(it.At(), &lbls, &metas))
+			got = append(got, lbls.Get("i"))
+		}
+		require.NoError(t, it.Err())
+		exp := []string{}
+		for _, e := range c.in {
+			if _, ok := symbols[e]; ok && e != "l" {
+				exp = append(exp, e)
+			}
+		}
+		require.Equal(t, exp, got, fmt.Sprintf("input: %v", c.in))
+	}
+}
+
+func TestPersistence_index_e2e(t *testing.T) {
+	dir := t.TempDir()
+
+	lbls, err := labels.ReadLabels(filepath.Join("..", "testdata", "20kseries.json"), 20000)
+	require.NoError(t, err)
+
+	// Sort labels as the index writer expects series in sorted order.
+	sort.Sort(labels.Slice(lbls))
+
+	symbols := map[string]struct{}{}
+	for _, lset := range lbls {
+		for _, l := range lset {
+			symbols[l.Name] = struct{}{}
+			symbols[l.Value] = struct{}{}
+		}
+	}
+
+	var input indexWriterSeriesSlice
+
+	// Generate ChunkMetas for every label set.
+	for i, lset := range lbls {
+		var metas []chunks.Meta
+
+		for j := 0; j <= (i % 20); j++ {
+			metas = append(metas, chunks.Meta{
+				MinTime: int64(j * 10000),
+				MaxTime: int64((j + 1) * 10000),
+				Ref:     chunks.ChunkRef(rand.Uint64()),
+				Chunk:   chunkenc.NewXORChunk(),
+			})
+		}
+		input = append(input, &indexWriterSeries{
+			labels: lset,
+			chunks: metas,
+		})
+	}
+
+	iw, err := NewWriter(context.Background(), filepath.Join(dir, indexFilename))
+	require.NoError(t, err)
+
+	syms := []string{}
+	for s := range symbols {
+		syms = append(syms, s)
+	}
+	sort.Strings(syms)
+	for _, s := range syms {
+		require.NoError(t, iw.AddSymbol(s))
+	}
+
+	// Population procedure as done by compaction.
+	var (
+		postings = NewMemPostings()
+		values   = map[string]map[string]struct{}{}
+	)
+
+	mi := newMockIndex()
+
+	for i, s := range input {
+		err = iw.AddSeries(storage.SeriesRef(i), s.labels, s.chunks...)
+		require.NoError(t, err)
+		require.NoError(t, mi.AddSeries(storage.SeriesRef(i), s.labels, s.chunks...))
+
+		for _, l := range s.labels {
+			valset, ok := values[l.Name]
+			if !ok {
+				valset = map[string]struct{}{}
+				values[l.Name] = valset
+			}
+			valset[l.Value] = struct{}{}
+		}
+		postings.Add(storage.SeriesRef(i), s.labels)
+	}
+
+	err = iw.Close()
+	require.NoError(t, err)
+
+	ir, err := NewFileReader(filepath.Join(dir, indexFilename))
+	require.NoError(t, err)
+
+	for p := range mi.postings {
+		gotp, err := ir.Postings(p.Name, p.Value)
+		require.NoError(t, err)
+
+		expp, err := mi.Postings(p.Name, p.Value)
+		require.NoError(t, err)
+
+		var lset, explset labels.Labels
+		var chks, expchks []chunks.Meta
+
+		for gotp.Next() {
+			require.True(t, expp.Next())
+
+			ref := gotp.At()
+
+			err := ir.Series(ref, &lset, &chks)
+			require.NoError(t, err)
+
+			err = mi.Series(expp.At(), &explset, &expchks)
+			require.NoError(t, err)
+			require.Equal(t, explset, lset)
+			require.Equal(t, expchks, chks)
+		}
+		require.False(t, expp.Next(), "Expected no more postings for %q=%q", p.Name, p.Value)
+		require.NoError(t, gotp.Err())
+	}
+
+	labelPairs := map[string][]string{}
+	for l := range mi.postings {
+		labelPairs[l.Name] = append(labelPairs[l.Name], l.Value)
+	}
+	for k, v := range labelPairs {
+		sort.Strings(v)
+
+		res, err := ir.SortedLabelValues(k)
+		require.NoError(t, err)
+
+		require.Equal(t, len(v), len(res))
+		for i := 0; i < len(v); i++ {
+			require.Equal(t, v[i], res[i])
+		}
+	}
+
+	gotSymbols := []string{}
+	it := ir.Symbols()
+	for it.Next() {
+		gotSymbols = append(gotSymbols, it.At())
+	}
+	require.NoError(t, it.Err())
+	expSymbols := []string{}
+	for s := range mi.symbols {
+		expSymbols = append(expSymbols, s)
+	}
+	sort.Strings(expSymbols)
+	require.Equal(t, expSymbols, gotSymbols)
+
+	require.NoError(t, ir.Close())
+}
+
+func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
+	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+
+	db := encoding.NewDecbufUvarintAt(b, 0, castagnoliTable)
+	require.Error(t, db.Err())
+}
+
+func TestReaderWithInvalidBuffer(t *testing.T) {
+	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+
+	_, err := NewReader(b)
+	require.Error(t, err)
+}
+
+// TestNewFileReaderErrorNoOpenFiles ensures that in case of an error no file remains open.
+func TestNewFileReaderErrorNoOpenFiles(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("block", t)
+
+	idxName := filepath.Join(dir.Path(), "index")
+	err := os.WriteFile(idxName, []byte("corrupted contents"), 0o666)
+	require.NoError(t, err)
+
+	_, err = NewFileReader(idxName)
+	require.Error(t, err)
+
+	// dir.Close will fail on Win if idxName fd is not closed on error path.
+	dir.Close()
+}
+
+func TestSymbols(t *testing.T) {
+	buf := encoding.Encbuf{}
+
+	// Add prefix to the buffer to simulate symbols as part of larger buffer.
+	buf.PutUvarintStr("something")
+
+	symbolsStart := buf.Len()
+	buf.PutBE32int(204) // Length of symbols table.
+	buf.PutBE32int(100) // Number of symbols.
+	for i := 0; i < 100; i++ {
+		// i represents index in unicode characters table.
+		buf.PutUvarintStr(string(rune(i))) // Symbol.
+	}
+	checksum := crc32.Checksum(buf.Get()[symbolsStart+4:], castagnoliTable)
+	buf.PutBE32(checksum) // Check sum at the end.
+
+	s, err := NewSymbols(realByteSlice(buf.Get()), FormatV2, symbolsStart)
+	require.NoError(t, err)
+
+	// We store only 4 offsets to symbols.
+	require.Equal(t, 32, s.Size())
+
+	for i := 99; i >= 0; i-- {
+		s, err := s.Lookup(uint32(i))
+		require.NoError(t, err)
+		require.Equal(t, string(rune(i)), s)
+	}
+	_, err = s.Lookup(100)
+	require.Error(t, err)
+
+	for i := 99; i >= 0; i-- {
+		r, err := s.ReverseLookup(string(rune(i)))
+		require.NoError(t, err)
+		require.Equal(t, uint32(i), r)
+	}
+	_, err = s.ReverseLookup(string(rune(100)))
+	require.Error(t, err)
+
+	iter := s.Iter()
+	i := 0
+	for iter.Next() {
+		require.Equal(t, string(rune(i)), iter.At())
+		i++
+	}
+	require.NoError(t, iter.Err())
+}
+
+func BenchmarkReader_ShardedPostings(b *testing.B) {
+	const (
+		numSeries = 10000
+		numShards = 16
+	)
+
+	dir, err := os.MkdirTemp("", "benchmark_reader_sharded_postings")
+	require.NoError(b, err)
+	defer func() {
+		require.NoError(b, os.RemoveAll(dir))
+	}()
+
+	// Generate an index.
+	fn := filepath.Join(dir, indexFilename)
+
+	iw, err := NewWriter(context.Background(), fn)
+	require.NoError(b, err)
+
+	for i := 1; i <= numSeries; i++ {
+		require.NoError(b, iw.AddSymbol(fmt.Sprintf("%10d", i)))
+	}
+	require.NoError(b, iw.AddSymbol("const"))
+	require.NoError(b, iw.AddSymbol("unique"))
+
+	for i := 1; i <= numSeries; i++ {
+		require.NoError(b, iw.AddSeries(storage.SeriesRef(i), labels.Labels{
+			{Name: "const", Value: fmt.Sprintf("%10d", 1)},
+			{Name: "unique", Value: fmt.Sprintf("%10d", i)},
+		}))
+	}
+
+	require.NoError(b, iw.Close())
+
+	for _, cacheEnabled := range []bool{true, false} {
+		b.Run(fmt.Sprintf("cached enabled: %v", cacheEnabled), func(b *testing.B) {
+			var cache ReaderCacheProvider
+			if cacheEnabled {
+				cache = hashcache.NewSeriesHashCache(1024 * 1024 * 1024).GetBlockCacheProvider("test")
+			}
+
+			// Create a reader to read back all postings from the index.
+			ir, err := NewFileReaderWithCache(fn, cache)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				allPostings, err := ir.Postings("const", fmt.Sprintf("%10d", 1))
+				require.NoError(b, err)
+
+				ir.ShardedPostings(allPostings, uint64(n%numShards), numShards)
+			}
+		})
+	}
+}
+
+func TestDecoder_Postings_WrongInput(t *testing.T) {
+	_, _, err := (&Decoder{}).Postings([]byte("the cake is a lie"))
+	require.Error(t, err)
+}

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -1,0 +1,962 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/index/postings.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package index
+
+import (
+	"container/heap"
+	"encoding/binary"
+	"runtime"
+	"sort"
+	"sync"
+
+	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+var allPostingsKey = labels.Label{}
+
+// AllPostingsKey returns the label key that is used to store the postings list of all existing IDs.
+func AllPostingsKey() (name, value string) {
+	return allPostingsKey.Name, allPostingsKey.Value
+}
+
+// ensureOrderBatchSize is the max number of postings passed to a worker in a single batch in MemPostings.EnsureOrder().
+const ensureOrderBatchSize = 1024
+
+// ensureOrderBatchPool is a pool used to recycle batches passed to workers in MemPostings.EnsureOrder().
+var ensureOrderBatchPool = sync.Pool{
+	New: func() interface{} {
+		x := make([][]storage.SeriesRef, 0, ensureOrderBatchSize)
+		return &x // Return pointer type as preferred by Pool.
+	},
+}
+
+// MemPostings holds postings list for series ID per label pair. They may be written
+// to out of order.
+// EnsureOrder() must be called once before any reads are done. This allows for quick
+// unordered batch fills on startup.
+type MemPostings struct {
+	mtx     sync.RWMutex
+	m       map[string]map[string][]storage.SeriesRef
+	ordered bool
+}
+
+// NewMemPostings returns a memPostings that's ready for reads and writes.
+func NewMemPostings() *MemPostings {
+	return &MemPostings{
+		m:       make(map[string]map[string][]storage.SeriesRef, 512),
+		ordered: true,
+	}
+}
+
+// NewUnorderedMemPostings returns a memPostings that is not safe to be read from
+// until EnsureOrder() was called once.
+func NewUnorderedMemPostings() *MemPostings {
+	return &MemPostings{
+		m:       make(map[string]map[string][]storage.SeriesRef, 512),
+		ordered: false,
+	}
+}
+
+// Symbols returns an iterator over all unique name and value strings, in order.
+func (p *MemPostings) Symbols() StringIter {
+	p.mtx.RLock()
+
+	// Add all the strings to a map to de-duplicate.
+	symbols := make(map[string]struct{}, 512)
+	for n, e := range p.m {
+		symbols[n] = struct{}{}
+		for v := range e {
+			symbols[v] = struct{}{}
+		}
+	}
+	p.mtx.RUnlock()
+
+	res := make([]string, 0, len(symbols))
+	for k := range symbols {
+		res = append(res, k)
+	}
+
+	slices.Sort(res)
+	return NewStringListIter(res)
+}
+
+// SortedKeys returns a list of sorted label keys of the postings.
+func (p *MemPostings) SortedKeys() []labels.Label {
+	p.mtx.RLock()
+	keys := make([]labels.Label, 0, len(p.m))
+
+	for n, e := range p.m {
+		for v := range e {
+			keys = append(keys, labels.Label{Name: n, Value: v})
+		}
+	}
+	p.mtx.RUnlock()
+
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Name != keys[j].Name {
+			return keys[i].Name < keys[j].Name
+		}
+		return keys[i].Value < keys[j].Value
+	})
+	return keys
+}
+
+// LabelNames returns all the unique label names.
+func (p *MemPostings) LabelNames() []string {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+	n := len(p.m)
+	if n == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, n-1)
+	for name := range p.m {
+		if name != allPostingsKey.Name {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// LabelValues returns label values for the given name.
+func (p *MemPostings) LabelValues(name string) []string {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	values := make([]string, 0, len(p.m[name]))
+	for v := range p.m[name] {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PostingsStats contains cardinality based statistics for postings.
+type PostingsStats struct {
+	CardinalityMetricsStats []Stat
+	CardinalityLabelStats   []Stat
+	LabelValueStats         []Stat
+	LabelValuePairsStats    []Stat
+	NumLabelPairs           int
+}
+
+// Stats calculates the cardinality statistics from postings.
+func (p *MemPostings) Stats(label string) *PostingsStats {
+	const maxNumOfRecords = 10
+	var size uint64
+
+	p.mtx.RLock()
+
+	metrics := &maxHeap{}
+	labels := &maxHeap{}
+	labelValueLength := &maxHeap{}
+	labelValuePairs := &maxHeap{}
+	numLabelPairs := 0
+
+	metrics.init(maxNumOfRecords)
+	labels.init(maxNumOfRecords)
+	labelValueLength.init(maxNumOfRecords)
+	labelValuePairs.init(maxNumOfRecords)
+
+	for n, e := range p.m {
+		if n == "" {
+			continue
+		}
+		labels.push(Stat{Name: n, Count: uint64(len(e))})
+		numLabelPairs += len(e)
+		size = 0
+		for name, values := range e {
+			if n == label {
+				metrics.push(Stat{Name: name, Count: uint64(len(values))})
+			}
+			labelValuePairs.push(Stat{Name: n + "=" + name, Count: uint64(len(values))})
+			size += uint64(len(name))
+		}
+		labelValueLength.push(Stat{Name: n, Count: size})
+	}
+
+	p.mtx.RUnlock()
+
+	return &PostingsStats{
+		CardinalityMetricsStats: metrics.get(),
+		CardinalityLabelStats:   labels.get(),
+		LabelValueStats:         labelValueLength.get(),
+		LabelValuePairsStats:    labelValuePairs.get(),
+		NumLabelPairs:           numLabelPairs,
+	}
+}
+
+// Get returns a postings list for the given label pair.
+func (p *MemPostings) Get(name, value string) Postings {
+	var lp []storage.SeriesRef
+	p.mtx.RLock()
+	l := p.m[name]
+	if l != nil {
+		lp = l[value]
+	}
+	p.mtx.RUnlock()
+
+	if lp == nil {
+		return EmptyPostings()
+	}
+	return newListPostings(lp...)
+}
+
+// All returns a postings list over all documents ever added.
+func (p *MemPostings) All() Postings {
+	return p.Get(AllPostingsKey())
+}
+
+// EnsureOrder ensures that all postings lists are sorted. After it returns all further
+// calls to add and addFor will insert new IDs in a sorted manner.
+func (p *MemPostings) EnsureOrder() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.ordered {
+		return
+	}
+
+	n := runtime.GOMAXPROCS(0)
+	workc := make(chan *[][]storage.SeriesRef)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			for job := range workc {
+				for _, l := range *job {
+					slices.Sort(l)
+				}
+
+				*job = (*job)[:0]
+				ensureOrderBatchPool.Put(job)
+			}
+			wg.Done()
+		}()
+	}
+
+	nextJob := ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
+	for _, e := range p.m {
+		for _, l := range e {
+			*nextJob = append(*nextJob, l)
+
+			if len(*nextJob) >= ensureOrderBatchSize {
+				workc <- nextJob
+				nextJob = ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
+			}
+		}
+	}
+
+	// If the last job was partially filled, we need to push it to workers too.
+	if len(*nextJob) > 0 {
+		workc <- nextJob
+	}
+
+	close(workc)
+	wg.Wait()
+
+	p.ordered = true
+}
+
+// Delete removes all ids in the given map from the postings lists.
+func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}) {
+	var keys, vals []string
+
+	// Collect all keys relevant for deletion once. New keys added afterwards
+	// can by definition not be affected by any of the given deletes.
+	p.mtx.RLock()
+	for n := range p.m {
+		keys = append(keys, n)
+	}
+	p.mtx.RUnlock()
+
+	for _, n := range keys {
+		p.mtx.RLock()
+		vals = vals[:0]
+		for v := range p.m[n] {
+			vals = append(vals, v)
+		}
+		p.mtx.RUnlock()
+
+		// For each posting we first analyse whether the postings list is affected by the deletes.
+		// If yes, we actually reallocate a new postings list.
+		for _, l := range vals {
+			// Only lock for processing one postings list so we don't block reads for too long.
+			p.mtx.Lock()
+
+			found := false
+			for _, id := range p.m[n][l] {
+				if _, ok := deleted[id]; ok {
+					found = true
+					break
+				}
+			}
+			if !found {
+				p.mtx.Unlock()
+				continue
+			}
+			repl := make([]storage.SeriesRef, 0, len(p.m[n][l]))
+
+			for _, id := range p.m[n][l] {
+				if _, ok := deleted[id]; !ok {
+					repl = append(repl, id)
+				}
+			}
+			if len(repl) > 0 {
+				p.m[n][l] = repl
+			} else {
+				delete(p.m[n], l)
+			}
+			p.mtx.Unlock()
+		}
+		p.mtx.Lock()
+		if len(p.m[n]) == 0 {
+			delete(p.m, n)
+		}
+		p.mtx.Unlock()
+	}
+}
+
+// Iter calls f for each postings list. It aborts if f returns an error and returns it.
+func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	for n, e := range p.m {
+		for v, p := range e {
+			if err := f(labels.Label{Name: n, Value: v}, newListPostings(p...)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Add a label set to the postings index.
+func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
+	p.mtx.Lock()
+
+	for _, l := range lset {
+		p.addFor(id, l)
+	}
+	p.addFor(id, allPostingsKey)
+
+	p.mtx.Unlock()
+}
+
+func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
+	nm, ok := p.m[l.Name]
+	if !ok {
+		nm = map[string][]storage.SeriesRef{}
+		p.m[l.Name] = nm
+	}
+	list := append(nm[l.Value], id)
+	nm[l.Value] = list
+
+	if !p.ordered {
+		return
+	}
+	// There is no guarantee that no higher ID was inserted before as they may
+	// be generated independently before adding them to postings.
+	// We repair order violations on insert. The invariant is that the first n-1
+	// items in the list are already sorted.
+	for i := len(list) - 1; i >= 1; i-- {
+		if list[i] >= list[i-1] {
+			break
+		}
+		list[i], list[i-1] = list[i-1], list[i]
+	}
+}
+
+// ExpandPostings returns the postings expanded as a slice.
+func ExpandPostings(p Postings) (res []storage.SeriesRef, err error) {
+	for p.Next() {
+		res = append(res, p.At())
+	}
+	return res, p.Err()
+}
+
+// Postings provides iterative access over a postings list.
+type Postings interface {
+	// Next advances the iterator and returns true if another value was found.
+	Next() bool
+
+	// Seek advances the iterator to value v or greater and returns
+	// true if a value was found.
+	Seek(v storage.SeriesRef) bool
+
+	// At returns the value at the current iterator position.
+	At() storage.SeriesRef
+
+	// Err returns the last error of the iterator.
+	Err() error
+}
+
+// errPostings is an empty iterator that always errors.
+type errPostings struct {
+	err error
+}
+
+func (e errPostings) Next() bool                  { return false }
+func (e errPostings) Seek(storage.SeriesRef) bool { return false }
+func (e errPostings) At() storage.SeriesRef       { return 0 }
+func (e errPostings) Err() error                  { return e.err }
+
+var emptyPostings = errPostings{}
+
+// EmptyPostings returns a postings list that's always empty.
+// NOTE: Returning EmptyPostings sentinel when Postings struct has no postings is recommended.
+// It triggers optimized flow in other functions like Intersect, Without etc.
+func EmptyPostings() Postings {
+	return emptyPostings
+}
+
+// ErrPostings returns new postings that immediately error.
+func ErrPostings(err error) Postings {
+	return errPostings{err}
+}
+
+// Intersect returns a new postings list over the intersection of the
+// input postings.
+func Intersect(its ...Postings) Postings {
+	if len(its) == 0 {
+		return EmptyPostings()
+	}
+	if len(its) == 1 {
+		return its[0]
+	}
+	for _, p := range its {
+		if p == EmptyPostings() {
+			return EmptyPostings()
+		}
+	}
+
+	return newIntersectPostings(its...)
+}
+
+type intersectPostings struct {
+	arr []Postings
+	cur storage.SeriesRef
+}
+
+func newIntersectPostings(its ...Postings) *intersectPostings {
+	return &intersectPostings{arr: its}
+}
+
+func (it *intersectPostings) At() storage.SeriesRef {
+	return it.cur
+}
+
+func (it *intersectPostings) doNext() bool {
+Loop:
+	for {
+		for _, p := range it.arr {
+			if !p.Seek(it.cur) {
+				return false
+			}
+			if p.At() > it.cur {
+				it.cur = p.At()
+				continue Loop
+			}
+		}
+		return true
+	}
+}
+
+func (it *intersectPostings) Next() bool {
+	for _, p := range it.arr {
+		if !p.Next() {
+			return false
+		}
+		if p.At() > it.cur {
+			it.cur = p.At()
+		}
+	}
+	return it.doNext()
+}
+
+func (it *intersectPostings) Seek(id storage.SeriesRef) bool {
+	it.cur = id
+	return it.doNext()
+}
+
+func (it *intersectPostings) Err() error {
+	for _, p := range it.arr {
+		if p.Err() != nil {
+			return p.Err()
+		}
+	}
+	return nil
+}
+
+// Merge returns a new iterator over the union of the input iterators.
+func Merge(its ...Postings) Postings {
+	if len(its) == 0 {
+		return EmptyPostings()
+	}
+	if len(its) == 1 {
+		return its[0]
+	}
+
+	p, ok := newMergedPostings(its)
+	if !ok {
+		return EmptyPostings()
+	}
+	return p
+}
+
+type postingsHeap []Postings
+
+func (h postingsHeap) Len() int           { return len(h) }
+func (h postingsHeap) Less(i, j int) bool { return h[i].At() < h[j].At() }
+func (h *postingsHeap) Swap(i, j int)     { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+
+func (h *postingsHeap) Push(x interface{}) {
+	*h = append(*h, x.(Postings))
+}
+
+func (h *postingsHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+type mergedPostings struct {
+	h           postingsHeap
+	initialized bool
+	cur         storage.SeriesRef
+	err         error
+}
+
+func newMergedPostings(p []Postings) (m *mergedPostings, nonEmpty bool) {
+	ph := make(postingsHeap, 0, len(p))
+
+	for _, it := range p {
+		// NOTE: mergedPostings struct requires the user to issue an initial Next.
+		if it.Next() {
+			ph = append(ph, it)
+		} else {
+			if it.Err() != nil {
+				return &mergedPostings{err: it.Err()}, true
+			}
+		}
+	}
+
+	if len(ph) == 0 {
+		return nil, false
+	}
+	return &mergedPostings{h: ph}, true
+}
+
+func (it *mergedPostings) Next() bool {
+	if it.h.Len() == 0 || it.err != nil {
+		return false
+	}
+
+	// The user must issue an initial Next.
+	if !it.initialized {
+		heap.Init(&it.h)
+		it.cur = it.h[0].At()
+		it.initialized = true
+		return true
+	}
+
+	for {
+		cur := it.h[0]
+		if !cur.Next() {
+			heap.Pop(&it.h)
+			if cur.Err() != nil {
+				it.err = cur.Err()
+				return false
+			}
+			if it.h.Len() == 0 {
+				return false
+			}
+		} else {
+			// Value of top of heap has changed, re-heapify.
+			heap.Fix(&it.h, 0)
+		}
+
+		if it.h[0].At() != it.cur {
+			it.cur = it.h[0].At()
+			return true
+		}
+	}
+}
+
+func (it *mergedPostings) Seek(id storage.SeriesRef) bool {
+	if it.h.Len() == 0 || it.err != nil {
+		return false
+	}
+	if !it.initialized {
+		if !it.Next() {
+			return false
+		}
+	}
+	for it.cur < id {
+		cur := it.h[0]
+		if !cur.Seek(id) {
+			heap.Pop(&it.h)
+			if cur.Err() != nil {
+				it.err = cur.Err()
+				return false
+			}
+			if it.h.Len() == 0 {
+				return false
+			}
+		} else {
+			// Value of top of heap has changed, re-heapify.
+			heap.Fix(&it.h, 0)
+		}
+
+		it.cur = it.h[0].At()
+	}
+	return true
+}
+
+func (it mergedPostings) At() storage.SeriesRef {
+	return it.cur
+}
+
+func (it mergedPostings) Err() error {
+	return it.err
+}
+
+// Without returns a new postings list that contains all elements from the full list that
+// are not in the drop list.
+func Without(full, drop Postings) Postings {
+	if full == EmptyPostings() {
+		return EmptyPostings()
+	}
+
+	if drop == EmptyPostings() {
+		return full
+	}
+	return newRemovedPostings(full, drop)
+}
+
+type removedPostings struct {
+	full, remove Postings
+
+	cur storage.SeriesRef
+
+	initialized bool
+	fok, rok    bool
+}
+
+func newRemovedPostings(full, remove Postings) *removedPostings {
+	return &removedPostings{
+		full:   full,
+		remove: remove,
+	}
+}
+
+func (rp *removedPostings) At() storage.SeriesRef {
+	return rp.cur
+}
+
+func (rp *removedPostings) Next() bool {
+	if !rp.initialized {
+		rp.fok = rp.full.Next()
+		rp.rok = rp.remove.Next()
+		rp.initialized = true
+	}
+	for {
+		if !rp.fok {
+			return false
+		}
+
+		if !rp.rok {
+			rp.cur = rp.full.At()
+			rp.fok = rp.full.Next()
+			return true
+		}
+
+		fcur, rcur := rp.full.At(), rp.remove.At()
+		if fcur < rcur {
+			rp.cur = fcur
+			rp.fok = rp.full.Next()
+
+			return true
+		} else if rcur < fcur {
+			// Forward the remove postings to the right position.
+			rp.rok = rp.remove.Seek(fcur)
+		} else {
+			// Skip the current posting.
+			rp.fok = rp.full.Next()
+		}
+	}
+}
+
+func (rp *removedPostings) Seek(id storage.SeriesRef) bool {
+	if rp.cur >= id {
+		return true
+	}
+
+	rp.fok = rp.full.Seek(id)
+	rp.rok = rp.remove.Seek(id)
+	rp.initialized = true
+
+	return rp.Next()
+}
+
+func (rp *removedPostings) Err() error {
+	if rp.full.Err() != nil {
+		return rp.full.Err()
+	}
+
+	return rp.remove.Err()
+}
+
+// ListPostings implements the Postings interface over a plain list.
+type ListPostings struct {
+	list []storage.SeriesRef
+	cur  storage.SeriesRef
+}
+
+func NewListPostings(list []storage.SeriesRef) Postings {
+	return newListPostings(list...)
+}
+
+func newListPostings(list ...storage.SeriesRef) *ListPostings {
+	return &ListPostings{list: list}
+}
+
+func (it *ListPostings) At() storage.SeriesRef {
+	return it.cur
+}
+
+func (it *ListPostings) Next() bool {
+	if len(it.list) > 0 {
+		it.cur = it.list[0]
+		it.list = it.list[1:]
+		return true
+	}
+	it.cur = 0
+	return false
+}
+
+func (it *ListPostings) Seek(x storage.SeriesRef) bool {
+	// If the current value satisfies, then return.
+	if it.cur >= x {
+		return true
+	}
+	if len(it.list) == 0 {
+		return false
+	}
+
+	// Do binary search between current position and end.
+	i := sort.Search(len(it.list), func(i int) bool {
+		return it.list[i] >= x
+	})
+	if i < len(it.list) {
+		it.cur = it.list[i]
+		it.list = it.list[i+1:]
+		return true
+	}
+	it.list = nil
+	return false
+}
+
+func (it *ListPostings) Err() error {
+	return nil
+}
+
+// bigEndianPostings implements the Postings interface over a byte stream of
+// big endian numbers.
+type bigEndianPostings struct {
+	list []byte
+	cur  uint32
+}
+
+func newBigEndianPostings(list []byte) *bigEndianPostings {
+	return &bigEndianPostings{list: list}
+}
+
+func (it *bigEndianPostings) At() storage.SeriesRef {
+	return storage.SeriesRef(it.cur)
+}
+
+func (it *bigEndianPostings) Next() bool {
+	if len(it.list) >= 4 {
+		it.cur = binary.BigEndian.Uint32(it.list)
+		it.list = it.list[4:]
+		return true
+	}
+	return false
+}
+
+func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
+	if storage.SeriesRef(it.cur) >= x {
+		return true
+	}
+
+	num := len(it.list) / 4
+	// Do binary search between current position and end.
+	i := sort.Search(num, func(i int) bool {
+		return binary.BigEndian.Uint32(it.list[i*4:]) >= uint32(x)
+	})
+	if i < num {
+		j := i * 4
+		it.cur = binary.BigEndian.Uint32(it.list[j:])
+		it.list = it.list[j+4:]
+		return true
+	}
+	it.list = nil
+	return false
+}
+
+func (it *bigEndianPostings) Err() error {
+	return nil
+}
+
+// PostingsCloner takes an existing Postings and allows independently clone them.
+type PostingsCloner struct {
+	ids []storage.SeriesRef
+	err error
+}
+
+// NewPostingsCloner takes an existing Postings and allows independently clone them.
+// The instance provided shouldn't have been used before (no Next() calls should have been done)
+// and it shouldn't be used once provided to the PostingsCloner.
+func NewPostingsCloner(p Postings) *PostingsCloner {
+	ids, err := ExpandPostings(p)
+	return &PostingsCloner{ids: ids, err: err}
+}
+
+// Clone returns another independent Postings instance.
+func (c *PostingsCloner) Clone() Postings {
+	if c.err != nil {
+		return ErrPostings(c.err)
+	}
+	return newListPostings(c.ids...)
+}
+
+// FindIntersectingPostings checks the intersection of p and candidates[i] for each i in candidates,
+// if intersection is non empty, then i is added to the indexes returned.
+// Returned indexes are not sorted.
+func FindIntersectingPostings(p Postings, candidates []Postings) (indexes []int, err error) {
+	h := make(postingsWithIndexHeap, 0, len(candidates))
+	for idx, it := range candidates {
+		if it.Next() {
+			h = append(h, postingsWithIndex{index: idx, p: it})
+		} else if it.Err() != nil {
+			return nil, it.Err()
+		}
+	}
+	if h.empty() {
+		return nil, nil
+	}
+	heap.Init(&h)
+
+	for !h.empty() {
+		if !p.Seek(h.at()) {
+			return indexes, p.Err()
+		}
+		if p.At() == h.at() {
+			indexes = append(indexes, h.popIndex())
+		} else if err := h.next(); err != nil {
+			return nil, err
+		}
+	}
+
+	return indexes, nil
+}
+
+// postingsWithIndex is used as postingsWithIndexHeap elements by FindIntersectingPostings,
+// keeping track of the original index of each postings while they move inside the heap.
+type postingsWithIndex struct {
+	index int
+	p     Postings
+	// popped means that these postings shouldn't be considered anymore.
+	// See popIndex() comment to understand why we need this.
+	popped bool
+}
+
+// postingsWithIndexHeap implements heap.Interface,
+// with root always pointing to the postings with minimum Postings.At() value.
+// It also implements a special way of removing elements that marks them as popped and moves them to the bottom of the
+// heap instead of actually removing them, see popIndex() for more details.
+type postingsWithIndexHeap []postingsWithIndex
+
+// empty checks whether the heap is empty, which is true if it has no elements, of if the smallest element is popped.
+func (h *postingsWithIndexHeap) empty() bool {
+	return len(*h) == 0 || (*h)[0].popped
+}
+
+// popIndex pops the smallest heap element and returns its index.
+// In our implementation we don't actually do heap.Pop(), instead we mark the element as `popped` and fix its position, which
+// should be after all the non-popped elements according to our sorting strategy.
+// By skipping the `heap.Pop()` call we avoid an extra allocation in this heap's Pop() implementation which returns an interface{}.
+func (h *postingsWithIndexHeap) popIndex() int {
+	index := (*h)[0].index
+	(*h)[0].popped = true
+	heap.Fix(h, 0)
+	return index
+}
+
+// at provides the storage.SeriesRef where root Postings is pointing at this moment.
+func (h postingsWithIndexHeap) at() storage.SeriesRef { return h[0].p.At() }
+
+// next performs the Postings.Next() operation on the root of the heap, performing the related operation on the heap
+// and conveniently returning the result of calling Postings.Err() if the result of calling Next() was false.
+// If Next() succeeds, heap is fixed to move the root to its new position, according to its Postings.At() value.
+// If Next() returns fails and there's no error reported by Postings.Err(), then root is marked as removed and heap is fixed.
+func (h *postingsWithIndexHeap) next() error {
+	pi := (*h)[0]
+	next := pi.p.Next()
+	if next {
+		heap.Fix(h, 0)
+		return nil
+	}
+
+	if err := pi.p.Err(); err != nil {
+		return errors.Wrapf(err, "postings %d", pi.index)
+	}
+	h.popIndex()
+	return nil
+}
+
+// Len implements heap.Interface.
+// Notice that Len() > 0 does not imply that heap is not empty as elements are not removed from this heap.
+// Use empty() to check whether heap is empty or not.
+func (h postingsWithIndexHeap) Len() int { return len(h) }
+
+// Less implements heap.Interface, it puts all the popped elements at the bottom,
+// and then sorts by Postings.At() property of each node.
+func (h postingsWithIndexHeap) Less(i, j int) bool {
+	if h[i].popped != h[j].popped {
+		return h[j].popped
+	}
+	return h[i].p.At() < h[j].p.At()
+}
+
+// Swap implements heap.Interface.
+func (h *postingsWithIndexHeap) Swap(i, j int) { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+
+// Push implements heap.Interface.
+func (h *postingsWithIndexHeap) Push(x interface{}) {
+	*h = append(*h, x.(postingsWithIndex))
+}
+
+// Pop implements heap.Interface and pops the last element, which is NOT the min element,
+// so this doesn't return the same heap.Pop()
+// Although this method is implemented for correctness, we don't expect it to be used, see popIndex() method for details.
+func (h *postingsWithIndexHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/pkg/storegateway/indexheader/index/postings_test.go
+++ b/pkg/storegateway/indexheader/index/postings_test.go
@@ -1,0 +1,1188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/index/postings_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package index
+
+import (
+	"container/heap"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func TestMemPostings_addFor(t *testing.T) {
+	p := NewMemPostings()
+	p.m[allPostingsKey.Name] = map[string][]storage.SeriesRef{}
+	p.m[allPostingsKey.Name][allPostingsKey.Value] = []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8}
+
+	p.addFor(5, allPostingsKey)
+
+	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, p.m[allPostingsKey.Name][allPostingsKey.Value])
+}
+
+func TestMemPostings_ensureOrder(t *testing.T) {
+	p := NewUnorderedMemPostings()
+	p.m["a"] = map[string][]storage.SeriesRef{}
+
+	for i := 0; i < 100; i++ {
+		l := make([]storage.SeriesRef, 100)
+		for j := range l {
+			l[j] = storage.SeriesRef(rand.Uint64())
+		}
+		v := fmt.Sprintf("%d", i)
+
+		p.m["a"][v] = l
+	}
+
+	p.EnsureOrder()
+
+	for _, e := range p.m {
+		for _, l := range e {
+			ok := sort.SliceIsSorted(l, func(i, j int) bool {
+				return l[i] < l[j]
+			})
+			if !ok {
+				t.Fatalf("postings list %v is not sorted", l)
+			}
+		}
+	}
+}
+
+func BenchmarkMemPostings_ensureOrder(b *testing.B) {
+	tests := map[string]struct {
+		numLabels         int
+		numValuesPerLabel int
+		numRefsPerValue   int
+	}{
+		"many values per label": {
+			numLabels:         100,
+			numValuesPerLabel: 10000,
+			numRefsPerValue:   100,
+		},
+		"few values per label": {
+			numLabels:         1000000,
+			numValuesPerLabel: 1,
+			numRefsPerValue:   100,
+		},
+		"few refs per label value": {
+			numLabels:         1000,
+			numValuesPerLabel: 1000,
+			numRefsPerValue:   10,
+		},
+	}
+
+	for testName, testData := range tests {
+		b.Run(testName, func(b *testing.B) {
+			p := NewUnorderedMemPostings()
+
+			// Generate postings.
+			for l := 0; l < testData.numLabels; l++ {
+				labelName := strconv.Itoa(l)
+				p.m[labelName] = map[string][]storage.SeriesRef{}
+
+				for v := 0; v < testData.numValuesPerLabel; v++ {
+					refs := make([]storage.SeriesRef, testData.numRefsPerValue)
+					for j := range refs {
+						refs[j] = storage.SeriesRef(rand.Uint64())
+					}
+
+					labelValue := strconv.Itoa(v)
+					p.m[labelName][labelValue] = refs
+				}
+			}
+
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				p.EnsureOrder()
+				p.ordered = false
+			}
+		})
+	}
+}
+
+func TestIntersect(t *testing.T) {
+	a := newListPostings(1, 2, 3)
+	b := newListPostings(2, 3, 4)
+
+	cases := []struct {
+		in []Postings
+
+		res Postings
+	}{
+		{
+			in:  []Postings{},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{a, b, EmptyPostings()},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{b, a, EmptyPostings()},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{EmptyPostings(), b, a},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{EmptyPostings(), a, b},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{a, EmptyPostings(), b},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{b, EmptyPostings(), a},
+			res: EmptyPostings(),
+		},
+		{
+			in:  []Postings{b, EmptyPostings(), a, a, b, a, a, a},
+			res: EmptyPostings(),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 5),
+				newListPostings(6, 7, 8, 9, 10),
+			},
+			res: newListPostings(),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 5),
+				newListPostings(4, 5, 6, 7, 8),
+			},
+			res: newListPostings(4, 5),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 9, 10),
+				newListPostings(1, 4, 5, 6, 7, 8, 10, 11),
+			},
+			res: newListPostings(1, 4, 10),
+		},
+		{
+			in: []Postings{
+				newListPostings(1),
+				newListPostings(0, 1),
+			},
+			res: newListPostings(1),
+		},
+		{
+			in: []Postings{
+				newListPostings(1),
+			},
+			res: newListPostings(1),
+		},
+		{
+			in: []Postings{
+				newListPostings(1),
+				newListPostings(),
+			},
+			res: newListPostings(),
+		},
+		{
+			in: []Postings{
+				newListPostings(),
+				newListPostings(),
+			},
+			res: newListPostings(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			if c.res == nil {
+				t.Fatal("intersect result expectancy cannot be nil")
+			}
+
+			expected, err := ExpandPostings(c.res)
+			require.NoError(t, err)
+
+			i := Intersect(c.in...)
+
+			if c.res == EmptyPostings() {
+				require.Equal(t, EmptyPostings(), i)
+				return
+			}
+
+			if i == EmptyPostings() {
+				t.Fatal("intersect unexpected result: EmptyPostings sentinel")
+			}
+
+			res, err := ExpandPostings(i)
+			require.NoError(t, err)
+			require.Equal(t, expected, res)
+		})
+	}
+}
+
+func TestMultiIntersect(t *testing.T) {
+	cases := []struct {
+		p   [][]storage.SeriesRef
+		res []storage.SeriesRef
+	}{
+		{
+			p: [][]storage.SeriesRef{
+				{1, 2, 3, 4, 5, 6, 1000, 1001},
+				{2, 4, 5, 6, 7, 8, 999, 1001},
+				{1, 2, 5, 6, 7, 8, 1001, 1200},
+			},
+			res: []storage.SeriesRef{2, 5, 6, 1001},
+		},
+		// One of the reproducible cases for:
+		// https://github.com/prometheus/prometheus/issues/2616
+		// The initialisation of intersectPostings was moving the iterator forward
+		// prematurely making us miss some postings.
+		{
+			p: [][]storage.SeriesRef{
+				{1, 2},
+				{1, 2},
+				{1, 2},
+				{2},
+			},
+			res: []storage.SeriesRef{2},
+		},
+	}
+
+	for _, c := range cases {
+		ps := make([]Postings, 0, len(c.p))
+		for _, postings := range c.p {
+			ps = append(ps, newListPostings(postings...))
+		}
+
+		res, err := ExpandPostings(Intersect(ps...))
+
+		require.NoError(t, err)
+		require.Equal(t, c.res, res)
+	}
+}
+
+func BenchmarkIntersect(t *testing.B) {
+	t.Run("LongPostings1", func(bench *testing.B) {
+		var a, b, c, d []storage.SeriesRef
+
+		for i := 0; i < 10000000; i += 2 {
+			a = append(a, storage.SeriesRef(i))
+		}
+		for i := 5000000; i < 5000100; i += 4 {
+			b = append(b, storage.SeriesRef(i))
+		}
+		for i := 5090000; i < 5090600; i += 4 {
+			b = append(b, storage.SeriesRef(i))
+		}
+		for i := 4990000; i < 5100000; i++ {
+			c = append(c, storage.SeriesRef(i))
+		}
+		for i := 4000000; i < 6000000; i++ {
+			d = append(d, storage.SeriesRef(i))
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+		i3 := newListPostings(c...)
+		i4 := newListPostings(d...)
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("LongPostings2", func(bench *testing.B) {
+		var a, b, c, d []storage.SeriesRef
+
+		for i := 0; i < 12500000; i++ {
+			a = append(a, storage.SeriesRef(i))
+		}
+		for i := 7500000; i < 12500000; i++ {
+			b = append(b, storage.SeriesRef(i))
+		}
+		for i := 9000000; i < 20000000; i++ {
+			c = append(c, storage.SeriesRef(i))
+		}
+		for i := 10000000; i < 12000000; i++ {
+			d = append(d, storage.SeriesRef(i))
+		}
+
+		i1 := newListPostings(a...)
+		i2 := newListPostings(b...)
+		i3 := newListPostings(c...)
+		i4 := newListPostings(d...)
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := ExpandPostings(Intersect(i1, i2, i3, i4)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+
+	// Many matchers(k >> n).
+	t.Run("ManyPostings", func(bench *testing.B) {
+		var its []Postings
+
+		// 100000 matchers(k=100000).
+		for i := 0; i < 100000; i++ {
+			var temp []storage.SeriesRef
+			for j := storage.SeriesRef(1); j < 100; j++ {
+				temp = append(temp, j)
+			}
+			its = append(its, newListPostings(temp...))
+		}
+
+		bench.ResetTimer()
+		bench.ReportAllocs()
+		for i := 0; i < bench.N; i++ {
+			if _, err := ExpandPostings(Intersect(its...)); err != nil {
+				bench.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestMultiMerge(t *testing.T) {
+	i1 := newListPostings(1, 2, 3, 4, 5, 6, 1000, 1001)
+	i2 := newListPostings(2, 4, 5, 6, 7, 8, 999, 1001)
+	i3 := newListPostings(1, 2, 5, 6, 7, 8, 1001, 1200)
+
+	res, err := ExpandPostings(Merge(i1, i2, i3))
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8, 999, 1000, 1001, 1200}, res)
+}
+
+func TestMergedPostings(t *testing.T) {
+	cases := []struct {
+		in []Postings
+
+		res Postings
+	}{
+		{
+			in:  []Postings{},
+			res: EmptyPostings(),
+		},
+		{
+			in: []Postings{
+				newListPostings(),
+				newListPostings(),
+			},
+			res: EmptyPostings(),
+		},
+		{
+			in: []Postings{
+				newListPostings(),
+			},
+			res: newListPostings(),
+		},
+		{
+			in: []Postings{
+				EmptyPostings(),
+				EmptyPostings(),
+				EmptyPostings(),
+				EmptyPostings(),
+			},
+			res: EmptyPostings(),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 5),
+				newListPostings(6, 7, 8, 9, 10),
+			},
+			res: newListPostings(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 5),
+				newListPostings(4, 5, 6, 7, 8),
+			},
+			res: newListPostings(1, 2, 3, 4, 5, 6, 7, 8),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 9, 10),
+				newListPostings(1, 4, 5, 6, 7, 8, 10, 11),
+			},
+			res: newListPostings(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2, 3, 4, 9, 10),
+				EmptyPostings(),
+				newListPostings(1, 4, 5, 6, 7, 8, 10, 11),
+			},
+			res: newListPostings(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2),
+				newListPostings(),
+			},
+			res: newListPostings(1, 2),
+		},
+		{
+			in: []Postings{
+				newListPostings(1, 2),
+				EmptyPostings(),
+			},
+			res: newListPostings(1, 2),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			if c.res == nil {
+				t.Fatal("merge result expectancy cannot be nil")
+			}
+
+			expected, err := ExpandPostings(c.res)
+			require.NoError(t, err)
+
+			m := Merge(c.in...)
+
+			if c.res == EmptyPostings() {
+				require.Equal(t, EmptyPostings(), m)
+				return
+			}
+
+			if m == EmptyPostings() {
+				t.Fatal("merge unexpected result: EmptyPostings sentinel")
+			}
+
+			res, err := ExpandPostings(m)
+			require.NoError(t, err)
+			require.Equal(t, expected, res)
+		})
+	}
+}
+
+func TestMergedPostingsSeek(t *testing.T) {
+	cases := []struct {
+		a, b []storage.SeriesRef
+
+		seek    storage.SeriesRef
+		success bool
+		res     []storage.SeriesRef
+	}{
+		{
+			a: []storage.SeriesRef{2, 3, 4, 5},
+			b: []storage.SeriesRef{6, 7, 8, 9, 10},
+
+			seek:    1,
+			success: true,
+			res:     []storage.SeriesRef{2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 5},
+			b: []storage.SeriesRef{6, 7, 8, 9, 10},
+
+			seek:    2,
+			success: true,
+			res:     []storage.SeriesRef{2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 5},
+			b: []storage.SeriesRef{4, 5, 6, 7, 8},
+
+			seek:    9,
+			success: false,
+			res:     nil,
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b: []storage.SeriesRef{1, 4, 5, 6, 7, 8, 10, 11},
+
+			seek:    10,
+			success: true,
+			res:     []storage.SeriesRef{10, 11},
+		},
+	}
+
+	for _, c := range cases {
+		a := newListPostings(c.a...)
+		b := newListPostings(c.b...)
+
+		p := Merge(a, b)
+
+		require.Equal(t, c.success, p.Seek(c.seek))
+
+		// After Seek(), At() should be called.
+		if c.success {
+			start := p.At()
+			lst, err := ExpandPostings(p)
+			require.NoError(t, err)
+
+			lst = append([]storage.SeriesRef{start}, lst...)
+			require.Equal(t, c.res, lst)
+		}
+	}
+}
+
+func TestRemovedPostings(t *testing.T) {
+	cases := []struct {
+		a, b []storage.SeriesRef
+		res  []storage.SeriesRef
+	}{
+		{
+			a:   nil,
+			b:   nil,
+			res: []storage.SeriesRef(nil),
+		},
+		{
+			a:   []storage.SeriesRef{1, 2, 3, 4},
+			b:   nil,
+			res: []storage.SeriesRef{1, 2, 3, 4},
+		},
+		{
+			a:   nil,
+			b:   []storage.SeriesRef{1, 2, 3, 4},
+			res: []storage.SeriesRef(nil),
+		},
+		{
+			a:   []storage.SeriesRef{1, 2, 3, 4, 5},
+			b:   []storage.SeriesRef{6, 7, 8, 9, 10},
+			res: []storage.SeriesRef{1, 2, 3, 4, 5},
+		},
+		{
+			a:   []storage.SeriesRef{1, 2, 3, 4, 5},
+			b:   []storage.SeriesRef{4, 5, 6, 7, 8},
+			res: []storage.SeriesRef{1, 2, 3},
+		},
+		{
+			a:   []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b:   []storage.SeriesRef{1, 4, 5, 6, 7, 8, 10, 11},
+			res: []storage.SeriesRef{2, 3, 9},
+		},
+		{
+			a:   []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b:   []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+			res: []storage.SeriesRef(nil),
+		},
+	}
+
+	for _, c := range cases {
+		a := newListPostings(c.a...)
+		b := newListPostings(c.b...)
+
+		res, err := ExpandPostings(newRemovedPostings(a, b))
+		require.NoError(t, err)
+		require.Equal(t, c.res, res)
+	}
+}
+
+func TestRemovedNextStackoverflow(t *testing.T) {
+	var full []storage.SeriesRef
+	var remove []storage.SeriesRef
+
+	var i storage.SeriesRef
+	for i = 0; i < 1e7; i++ {
+		full = append(full, i)
+		remove = append(remove, i)
+	}
+
+	flp := newListPostings(full...)
+	rlp := newListPostings(remove...)
+	rp := newRemovedPostings(flp, rlp)
+	gotElem := false
+	for rp.Next() {
+		gotElem = true
+	}
+
+	require.NoError(t, rp.Err())
+	require.False(t, gotElem)
+}
+
+func TestRemovedPostingsSeek(t *testing.T) {
+	cases := []struct {
+		a, b []storage.SeriesRef
+
+		seek    storage.SeriesRef
+		success bool
+		res     []storage.SeriesRef
+	}{
+		{
+			a: []storage.SeriesRef{2, 3, 4, 5},
+			b: []storage.SeriesRef{6, 7, 8, 9, 10},
+
+			seek:    1,
+			success: true,
+			res:     []storage.SeriesRef{2, 3, 4, 5},
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 5},
+			b: []storage.SeriesRef{6, 7, 8, 9, 10},
+
+			seek:    2,
+			success: true,
+			res:     []storage.SeriesRef{2, 3, 4, 5},
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 5},
+			b: []storage.SeriesRef{4, 5, 6, 7, 8},
+
+			seek:    9,
+			success: false,
+			res:     nil,
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b: []storage.SeriesRef{1, 4, 5, 6, 7, 8, 10, 11},
+
+			seek:    10,
+			success: false,
+			res:     nil,
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b: []storage.SeriesRef{1, 4, 5, 6, 7, 8, 11},
+
+			seek:    4,
+			success: true,
+			res:     []storage.SeriesRef{9, 10},
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b: []storage.SeriesRef{1, 4, 5, 6, 7, 8, 11},
+
+			seek:    5,
+			success: true,
+			res:     []storage.SeriesRef{9, 10},
+		},
+		{
+			a: []storage.SeriesRef{1, 2, 3, 4, 9, 10},
+			b: []storage.SeriesRef{1, 4, 5, 6, 7, 8, 11},
+
+			seek:    10,
+			success: true,
+			res:     []storage.SeriesRef{10},
+		},
+	}
+
+	for _, c := range cases {
+		a := newListPostings(c.a...)
+		b := newListPostings(c.b...)
+
+		p := newRemovedPostings(a, b)
+
+		require.Equal(t, c.success, p.Seek(c.seek))
+
+		// After Seek(), At() should be called.
+		if c.success {
+			start := p.At()
+			lst, err := ExpandPostings(p)
+			require.NoError(t, err)
+
+			lst = append([]storage.SeriesRef{start}, lst...)
+			require.Equal(t, c.res, lst)
+		}
+	}
+}
+
+func TestBigEndian(t *testing.T) {
+	num := 1000
+	// mock a list as postings
+	ls := make([]uint32, num)
+	ls[0] = 2
+	for i := 1; i < num; i++ {
+		ls[i] = ls[i-1] + uint32(rand.Int31n(25)) + 2
+	}
+
+	beLst := make([]byte, num*4)
+	for i := 0; i < num; i++ {
+		b := beLst[i*4 : i*4+4]
+		binary.BigEndian.PutUint32(b, ls[i])
+	}
+
+	t.Run("Iteration", func(t *testing.T) {
+		bep := newBigEndianPostings(beLst)
+		for i := 0; i < num; i++ {
+			require.True(t, bep.Next())
+			require.Equal(t, storage.SeriesRef(ls[i]), bep.At())
+		}
+
+		require.False(t, bep.Next())
+		require.NoError(t, bep.Err())
+	})
+
+	t.Run("Seek", func(t *testing.T) {
+		table := []struct {
+			seek  uint32
+			val   uint32
+			found bool
+		}{
+			{
+				ls[0] - 1, ls[0], true,
+			},
+			{
+				ls[4], ls[4], true,
+			},
+			{
+				ls[500] - 1, ls[500], true,
+			},
+			{
+				ls[600] + 1, ls[601], true,
+			},
+			{
+				ls[600] + 1, ls[601], true,
+			},
+			{
+				ls[600] + 1, ls[601], true,
+			},
+			{
+				ls[0], ls[601], true,
+			},
+			{
+				ls[600], ls[601], true,
+			},
+			{
+				ls[999], ls[999], true,
+			},
+			{
+				ls[999] + 10, ls[999], false,
+			},
+		}
+
+		bep := newBigEndianPostings(beLst)
+
+		for _, v := range table {
+			require.Equal(t, v.found, bep.Seek(storage.SeriesRef(v.seek)))
+			require.Equal(t, storage.SeriesRef(v.val), bep.At())
+			require.NoError(t, bep.Err())
+		}
+	})
+}
+
+func TestIntersectWithMerge(t *testing.T) {
+	// One of the reproducible cases for:
+	// https://github.com/prometheus/prometheus/issues/2616
+	a := newListPostings(21, 22, 23, 24, 25, 30)
+
+	b := Merge(
+		newListPostings(10, 20, 30),
+		newListPostings(15, 26, 30),
+	)
+
+	p := Intersect(a, b)
+	res, err := ExpandPostings(p)
+
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{30}, res)
+}
+
+func TestWithoutPostings(t *testing.T) {
+	cases := []struct {
+		base Postings
+		drop Postings
+
+		res Postings
+	}{
+		{
+			base: EmptyPostings(),
+			drop: EmptyPostings(),
+
+			res: EmptyPostings(),
+		},
+		{
+			base: EmptyPostings(),
+			drop: newListPostings(1, 2),
+
+			res: EmptyPostings(),
+		},
+		{
+			base: newListPostings(1, 2),
+			drop: EmptyPostings(),
+
+			res: newListPostings(1, 2),
+		},
+		{
+			base: newListPostings(),
+			drop: newListPostings(),
+
+			res: newListPostings(),
+		},
+		{
+			base: newListPostings(1, 2, 3),
+			drop: newListPostings(),
+
+			res: newListPostings(1, 2, 3),
+		},
+		{
+			base: newListPostings(1, 2, 3),
+			drop: newListPostings(4, 5, 6),
+
+			res: newListPostings(1, 2, 3),
+		},
+		{
+			base: newListPostings(1, 2, 3),
+			drop: newListPostings(3, 4, 5),
+
+			res: newListPostings(1, 2),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			if c.res == nil {
+				t.Fatal("without result expectancy cannot be nil")
+			}
+
+			expected, err := ExpandPostings(c.res)
+			require.NoError(t, err)
+
+			w := Without(c.base, c.drop)
+
+			if c.res == EmptyPostings() {
+				require.Equal(t, EmptyPostings(), w)
+				return
+			}
+
+			if w == EmptyPostings() {
+				t.Fatal("without unexpected result: EmptyPostings sentinel")
+			}
+
+			res, err := ExpandPostings(w)
+			require.NoError(t, err)
+			require.Equal(t, expected, res)
+		})
+	}
+}
+
+func BenchmarkPostings_Stats(b *testing.B) {
+	p := NewMemPostings()
+
+	var seriesID storage.SeriesRef
+
+	createPostingsLabelValues := func(name, valuePrefix string, count int) {
+		for n := 1; n < count; n++ {
+			value := fmt.Sprintf("%s-%d", valuePrefix, n)
+			p.Add(seriesID, labels.FromStrings(name, value))
+			seriesID++
+		}
+	}
+	createPostingsLabelValues("__name__", "metrics_name_can_be_very_big_and_bad", 1e3)
+	for i := 0; i < 20; i++ {
+		createPostingsLabelValues(fmt.Sprintf("host-%d", i), "metrics_name_can_be_very_big_and_bad", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("instance-%d", i), "10.0.IP.", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("job-%d", i), "Small_Job_name", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("err-%d", i), "avg_namespace-", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("team-%d", i), "team-", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("container_name-%d", i), "pod-", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("cluster-%d", i), "newcluster-", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("uid-%d", i), "123412312312312311-", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("area-%d", i), "new_area_of_work-", 1e3)
+		createPostingsLabelValues(fmt.Sprintf("request_id-%d", i), "owner_name_work-", 1e3)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		p.Stats("__name__")
+	}
+}
+
+func TestMemPostings_Delete(t *testing.T) {
+	p := NewMemPostings()
+	p.Add(1, labels.FromStrings("lbl1", "a"))
+	p.Add(2, labels.FromStrings("lbl1", "b"))
+	p.Add(3, labels.FromStrings("lbl2", "a"))
+
+	before := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+	p.Delete(map[storage.SeriesRef]struct{}{
+		2: {},
+	})
+	after := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+
+	// Make sure postings gotten before the delete have the old data when
+	// iterated over.
+	expanded, err := ExpandPostings(before)
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{1, 2, 3}, expanded)
+
+	// Make sure postings gotten after the delete have the new data when
+	// iterated over.
+	expanded, err = ExpandPostings(after)
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{1, 3}, expanded)
+
+	deleted := p.Get("lbl1", "b")
+	expanded, err = ExpandPostings(deleted)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(expanded), "expected empty postings, got %v", expanded)
+}
+
+func TestPostingsCloner(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		check func(testing.TB, *PostingsCloner)
+	}{
+		{
+			name: "seek beyond highest value of postings, then other clone seeks higher",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p1 := pc.Clone()
+				require.False(t, p1.Seek(9))
+				require.Equal(t, storage.SeriesRef(0), p1.At())
+
+				p2 := pc.Clone()
+				require.False(t, p2.Seek(10))
+				require.Equal(t, storage.SeriesRef(0), p2.At())
+			},
+		},
+		{
+			name: "seek beyond highest value of postings, then other clone seeks lower",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p1 := pc.Clone()
+				require.False(t, p1.Seek(9))
+				require.Equal(t, storage.SeriesRef(0), p1.At())
+
+				p2 := pc.Clone()
+				require.True(t, p2.Seek(2))
+				require.Equal(t, storage.SeriesRef(2), p2.At())
+			},
+		},
+		{
+			name: "seek to posting with value 3 or higher",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p := pc.Clone()
+				require.True(t, p.Seek(3))
+				require.Equal(t, storage.SeriesRef(4), p.At())
+				require.True(t, p.Seek(4))
+				require.Equal(t, storage.SeriesRef(4), p.At())
+			},
+		},
+		{
+			name: "seek alternatively on different postings",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p1 := pc.Clone()
+				require.True(t, p1.Seek(1))
+				require.Equal(t, storage.SeriesRef(1), p1.At())
+
+				p2 := pc.Clone()
+				require.True(t, p2.Seek(2))
+				require.Equal(t, storage.SeriesRef(2), p2.At())
+
+				p3 := pc.Clone()
+				require.True(t, p3.Seek(4))
+				require.Equal(t, storage.SeriesRef(4), p3.At())
+
+				p4 := pc.Clone()
+				require.True(t, p4.Seek(5))
+				require.Equal(t, storage.SeriesRef(8), p4.At())
+
+				require.True(t, p1.Seek(3))
+				require.Equal(t, storage.SeriesRef(4), p1.At())
+				require.True(t, p1.Seek(4))
+				require.Equal(t, storage.SeriesRef(4), p1.At())
+			},
+		},
+		{
+			name: "iterate through the postings",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p1 := pc.Clone()
+				p2 := pc.Clone()
+
+				// both one step
+				require.True(t, p1.Next())
+				require.Equal(t, storage.SeriesRef(1), p1.At())
+				require.True(t, p2.Next())
+				require.Equal(t, storage.SeriesRef(1), p2.At())
+
+				require.True(t, p1.Next())
+				require.Equal(t, storage.SeriesRef(2), p1.At())
+				require.True(t, p1.Next())
+				require.Equal(t, storage.SeriesRef(4), p1.At())
+				require.True(t, p1.Next())
+				require.Equal(t, storage.SeriesRef(8), p1.At())
+				require.False(t, p1.Next())
+
+				require.True(t, p2.Next())
+				require.Equal(t, storage.SeriesRef(2), p2.At())
+				require.True(t, p2.Next())
+				require.Equal(t, storage.SeriesRef(4), p2.At())
+			},
+		},
+		{
+			name: "at before call of next shouldn't panic",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p := pc.Clone()
+				require.Equal(t, storage.SeriesRef(0), p.At())
+			},
+		},
+		{
+			name: "ensure a failed seek doesn't allow more next calls",
+			check: func(t testing.TB, pc *PostingsCloner) {
+				p := pc.Clone()
+				require.False(t, p.Seek(9))
+				require.Equal(t, storage.SeriesRef(0), p.At())
+				require.False(t, p.Next())
+				require.Equal(t, storage.SeriesRef(0), p.At())
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := NewPostingsCloner(newListPostings(1, 2, 4, 8))
+			tc.check(t, pc)
+		})
+	}
+
+	t.Run("cloning an err postings", func(t *testing.T) {
+		expectedErr := fmt.Errorf("foobar")
+		pc := NewPostingsCloner(ErrPostings(expectedErr))
+		p := pc.Clone()
+		require.False(t, p.Next())
+		require.Equal(t, expectedErr, p.Err())
+	})
+}
+
+func TestFindIntersectingPostings(t *testing.T) {
+	t.Run("multiple intersections", func(t *testing.T) {
+		p := NewListPostings([]storage.SeriesRef{10, 15, 20, 25, 30, 35, 40, 45, 50})
+		candidates := []Postings{
+			0: NewListPostings([]storage.SeriesRef{7, 13, 14, 27}), // Does not intersect.
+			1: NewListPostings([]storage.SeriesRef{10, 20}),        // Does intersect.
+			2: NewListPostings([]storage.SeriesRef{29, 30, 31}),    // Does intersect.
+			3: NewListPostings([]storage.SeriesRef{29, 30, 31}),    // Does intersect (same again).
+			4: NewListPostings([]storage.SeriesRef{60}),            // Does not intersect.
+			5: NewListPostings([]storage.SeriesRef{45}),            // Does intersect.
+			6: EmptyPostings(),                                     // Does not intersect.
+		}
+
+		indexes, err := FindIntersectingPostings(p, candidates)
+		require.NoError(t, err)
+		sort.Ints(indexes)
+		require.Equal(t, []int{1, 2, 3, 5}, indexes)
+	})
+
+	t.Run("no intersections", func(t *testing.T) {
+		p := NewListPostings([]storage.SeriesRef{10, 15, 20, 25, 30, 35, 40, 45, 50})
+		candidates := []Postings{
+			0: NewListPostings([]storage.SeriesRef{7, 13, 14, 27}), // Does not intersect.
+			1: NewListPostings([]storage.SeriesRef{60}),            // Does not intersect.
+			2: EmptyPostings(),                                     // Does not intersect.
+		}
+
+		indexes, err := FindIntersectingPostings(p, candidates)
+		require.NoError(t, err)
+		require.Empty(t, indexes)
+	})
+
+	t.Run("p is ErrPostings", func(t *testing.T) {
+		p := ErrPostings(context.Canceled)
+		candidates := []Postings{NewListPostings([]storage.SeriesRef{1})}
+		_, err := FindIntersectingPostings(p, candidates)
+		require.Error(t, err)
+	})
+
+	t.Run("one of the candidates is ErrPostings", func(t *testing.T) {
+		p := NewListPostings([]storage.SeriesRef{1})
+		candidates := []Postings{
+			NewListPostings([]storage.SeriesRef{1}),
+			ErrPostings(context.Canceled),
+		}
+		_, err := FindIntersectingPostings(p, candidates)
+		require.Error(t, err)
+	})
+
+	t.Run("one of the candidates fails on nth call", func(t *testing.T) {
+		p := NewListPostings([]storage.SeriesRef{10, 20, 30, 40, 50, 60, 70})
+		candidates := []Postings{
+			NewListPostings([]storage.SeriesRef{7, 13, 14, 27}),
+			&postingsFailingAfterNthCall{2, NewListPostings([]storage.SeriesRef{29, 30, 31, 40})},
+		}
+		_, err := FindIntersectingPostings(p, candidates)
+		require.Error(t, err)
+	})
+
+	t.Run("p fails on the nth call", func(t *testing.T) {
+		p := &postingsFailingAfterNthCall{2, NewListPostings([]storage.SeriesRef{10, 20, 30, 40, 50, 60, 70})}
+		candidates := []Postings{
+			NewListPostings([]storage.SeriesRef{7, 13, 14, 27}),
+			NewListPostings([]storage.SeriesRef{29, 30, 31, 40}),
+		}
+		_, err := FindIntersectingPostings(p, candidates)
+		require.Error(t, err)
+	})
+}
+
+type postingsFailingAfterNthCall struct {
+	ttl int
+	Postings
+}
+
+func (p *postingsFailingAfterNthCall) Seek(v storage.SeriesRef) bool {
+	p.ttl--
+	if p.ttl <= 0 {
+		return false
+	}
+	return p.Postings.Seek(v)
+}
+
+func (p *postingsFailingAfterNthCall) Next() bool {
+	p.ttl--
+	if p.ttl <= 0 {
+		return false
+	}
+	return p.Postings.Next()
+}
+
+func (p *postingsFailingAfterNthCall) Err() error {
+	if p.ttl <= 0 {
+		return errors.New("ttl exceeded")
+	}
+	return p.Postings.Err()
+}
+
+func TestPostingsWithIndexHeap(t *testing.T) {
+	t.Run("iterate", func(t *testing.T) {
+		h := postingsWithIndexHeap{
+			{index: 0, p: NewListPostings([]storage.SeriesRef{10, 20, 30})},
+			{index: 1, p: NewListPostings([]storage.SeriesRef{1, 5})},
+			{index: 2, p: NewListPostings([]storage.SeriesRef{25, 50})},
+		}
+		for _, node := range h {
+			node.p.Next()
+		}
+		heap.Init(&h)
+
+		for _, expected := range []storage.SeriesRef{1, 5, 10, 20, 25, 30, 50} {
+			require.Equal(t, expected, h.at())
+			require.NoError(t, h.next())
+		}
+		require.True(t, h.empty())
+	})
+
+	t.Run("pop", func(t *testing.T) {
+		h := postingsWithIndexHeap{
+			{index: 0, p: NewListPostings([]storage.SeriesRef{10, 20, 30})},
+			{index: 1, p: NewListPostings([]storage.SeriesRef{1, 5})},
+			{index: 2, p: NewListPostings([]storage.SeriesRef{25, 50})},
+		}
+		for _, node := range h {
+			node.p.Next()
+		}
+		heap.Init(&h)
+
+		for _, expected := range []storage.SeriesRef{1, 5, 10, 20} {
+			require.Equal(t, expected, h.at())
+			require.NoError(t, h.next())
+		}
+		require.Equal(t, storage.SeriesRef(25), h.at())
+		node := heap.Pop(&h).(postingsWithIndex)
+		require.Equal(t, 2, node.index)
+		require.Equal(t, storage.SeriesRef(25), node.p.At())
+	})
+}

--- a/pkg/storegateway/indexheader/index/postingsstats.go
+++ b/pkg/storegateway/indexheader/index/postingsstats.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/index/postingsstats.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package index
+
+import (
+	"math"
+	"sort"
+)
+
+// Stat holds values for a single cardinality statistic.
+type Stat struct {
+	Name  string
+	Count uint64
+}
+
+type maxHeap struct {
+	maxLength int
+	minValue  uint64
+	minIndex  int
+	Items     []Stat
+}
+
+func (m *maxHeap) init(len int) {
+	m.maxLength = len
+	m.minValue = math.MaxUint64
+	m.Items = make([]Stat, 0, len)
+}
+
+func (m *maxHeap) push(item Stat) {
+	if len(m.Items) < m.maxLength {
+		if item.Count < m.minValue {
+			m.minValue = item.Count
+			m.minIndex = len(m.Items)
+		}
+		m.Items = append(m.Items, item)
+		return
+	}
+	if item.Count < m.minValue {
+		return
+	}
+
+	m.Items[m.minIndex] = item
+	m.minValue = item.Count
+
+	for i, stat := range m.Items {
+		if stat.Count < m.minValue {
+			m.minValue = stat.Count
+			m.minIndex = i
+		}
+	}
+}
+
+func (m *maxHeap) get() []Stat {
+	sort.Slice(m.Items, func(i, j int) bool {
+		return m.Items[i].Count > m.Items[j].Count
+	})
+	return m.Items
+}

--- a/pkg/storegateway/indexheader/index/postingsstats_test.go
+++ b/pkg/storegateway/indexheader/index/postingsstats_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/index/postingsstats_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostingsStats(t *testing.T) {
+	stats := &maxHeap{}
+	max := 3000000
+	heapLength := 10
+	stats.init(heapLength)
+	for i := 0; i < max; i++ {
+		item := Stat{
+			Name:  "Label-da",
+			Count: uint64(i),
+		}
+		stats.push(item)
+	}
+	stats.push(Stat{Name: "Stuff", Count: 3000000})
+
+	data := stats.get()
+	require.Equal(t, 10, len(data))
+	for i := 0; i < heapLength; i++ {
+		require.Equal(t, uint64(max-i), data[i].Count)
+	}
+}
+
+func TestPostingsStats2(t *testing.T) {
+	stats := &maxHeap{}
+	heapLength := 10
+
+	stats.init(heapLength)
+	stats.push(Stat{Name: "Stuff", Count: 10})
+	stats.push(Stat{Name: "Stuff", Count: 11})
+	stats.push(Stat{Name: "Stuff", Count: 1})
+	stats.push(Stat{Name: "Stuff", Count: 6})
+
+	data := stats.get()
+
+	require.Equal(t, 4, len(data))
+	require.Equal(t, uint64(11), data[0].Count)
+}
+
+func BenchmarkPostingStatsMaxHep(b *testing.B) {
+	stats := &maxHeap{}
+	max := 9000000
+	heapLength := 10
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		stats.init(heapLength)
+		for i := 0; i < max; i++ {
+			item := Stat{
+				Name:  "Label-da",
+				Count: uint64(i),
+			}
+			stats.push(item)
+		}
+		stats.get()
+	}
+}


### PR DESCRIPTION
#### What this PR does

In preparation for #3465, import the Prometheus TSDB packages that will need to be modified to work with a `ReadSeeker`-like interface instead of a `ByteSlice` interface.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

See #3465

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
