### PR TITLE
Improve 'Mimir / Writes resources' dashboard to work with read-write deployment mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [ENHANCEMENT] Dashboards: If enabled, add new row to the `Mimir / Writes` for distributor autoscaling metrics. #3378
 * [ENHANCEMENT] Dashboards: Add read path insights row to the "Mimir / Tenants" dashboard. #3326
 * [ENHANCEMENT] Alerts: Add runbook urls for alerts. #3452
+* [ENHANCEMENT] Dashboards: improved "Mimir / Writes resources" dashboard to work with read-write deployment mode too. #3497
 * [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173
 * [BUGFIX] Alerts: Fixed `MimirGossipMembersMismatch` alert when Mimir is deployed in read-write mode. #3489
 

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-resources.json
@@ -66,7 +66,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}[$__rate_interval]))",
+                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -142,7 +142,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}\n",
+                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -304,7 +304,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_written_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}[$__rate_interval]\n  )\n)\n",
+                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_written_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}[$__rate_interval]\n  )\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}} - {{device}}",
@@ -380,7 +380,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_read_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\"}[$__rate_interval]\n  )\n)\n",
+                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_read_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}[$__rate_interval]\n  )\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}} - {{device}}",
@@ -456,7 +456,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "1 - ((node_filesystem_avail_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\", mountpoint=\"/\"})\n    / node_filesystem_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor|ingester|mimir-write.*\", mountpoint=\"/\"})\n",
+                        "expr": "1 - ((node_filesystem_avail_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\", mountpoint=\"/\"})\n    / node_filesystem_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\", mountpoint=\"/\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{instance}}",
@@ -544,7 +544,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}[$__rate_interval]))",
+                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -620,7 +620,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read.*\"}\n",
+                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-frontend|querier|ruler-query-frontend|ruler-querier|mimir-read).*.*\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -782,7 +782,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}[$__rate_interval]))",
+                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -858,7 +858,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}\n",
+                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -1020,7 +1020,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_written_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}[$__rate_interval]\n  )\n)\n",
+                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_written_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}[$__rate_interval]\n  )\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}} - {{device}}",
@@ -1096,7 +1096,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_read_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\"}[$__rate_interval]\n  )\n)\n",
+                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_read_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\"}[$__rate_interval]\n  )\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}} - {{device}}",
@@ -1172,7 +1172,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "1 - ((node_filesystem_avail_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\", mountpoint=\"/\"})\n    / node_filesystem_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend.*\", mountpoint=\"/\"})\n",
+                        "expr": "1 - ((node_filesystem_avail_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\", mountpoint=\"/\"})\n    / node_filesystem_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(query-scheduler|ruler-query-scheduler|ruler|store-gateway|compactor|alertmanager|overrides-exporter|mimir-backend).*.*\", mountpoint=\"/\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{instance}}",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
@@ -40,8 +40,246 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 0,
+                  "fill": 10,
                   "id": 1,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "CPU",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 2,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"}\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Memory (workingset)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 3,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?(distributor|ingester|mimir-write).*.*\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Memory (go heap inuse)",
+                  "tooltip": {
+                     "sort": 2
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Summary",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 0,
+                  "id": 4,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -81,7 +319,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}[$__rate_interval]))",
+                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -130,7 +368,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 2,
+                  "id": 5,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -170,7 +408,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*distributor.*\"}\n",
+                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -219,7 +457,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 3,
+                  "id": 6,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -244,7 +482,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?distributor.*.*\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -305,7 +543,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 4,
+                  "id": 7,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -379,7 +617,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 5,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -419,7 +657,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}[$__rate_interval]))",
+                        "expr": "sum by(pod) (rate(node_cpu_seconds_total{mode=\"user\",cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -480,7 +718,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 6,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -520,7 +758,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "node_memory_Active_anon_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n+ node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n",
+                        "expr": "node_memory_Active_anon_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n+ node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -569,7 +807,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 7,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -609,7 +847,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}\n",
+                        "expr": "node_memory_MemTotal_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n- node_memory_MemFree_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n- node_memory_Buffers_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n- node_memory_Cached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n- node_memory_Slab_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n- node_memory_PageTables_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n- node_memory_SwapCached_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -658,7 +896,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 8,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -683,7 +921,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -744,7 +982,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 9,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -769,7 +1007,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_written_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}[$__rate_interval]\n  )\n)\n",
+                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_written_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}[$__rate_interval]\n  )\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}} - {{device}}",
@@ -820,7 +1058,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 10,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -845,7 +1083,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_read_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\"}[$__rate_interval]\n  )\n)\n",
+                        "expr": "sum by(instance, pod, device) (\n  rate(\n    node_disk_read_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\"}[$__rate_interval]\n  )\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}} - {{device}}",
@@ -896,7 +1134,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 11,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -921,7 +1159,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "1 - ((node_filesystem_avail_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\", mountpoint=\"/\"})\n    / node_filesystem_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*ingester.*\", mountpoint=\"/\"})\n",
+                        "expr": "1 - ((node_filesystem_avail_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\", mountpoint=\"/\"})\n    / node_filesystem_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(.*-mimir-)?ingester.*.*\", mountpoint=\"/\"})\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{instance}}",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -40,8 +40,246 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 0,
+                  "fill": 10,
                   "id": 1,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\"distributor|ingester|mimir-write\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "CPU",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 2,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\"distributor|ingester|mimir-write\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Memory (workingset)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 3,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\"distributor|ingester|mimir-write\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Memory (go heap inuse)",
+                  "tooltip": {
+                     "sort": 2
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Summary",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 0,
+                  "id": 4,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -146,7 +384,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 2,
+                  "id": 5,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -251,7 +489,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 3,
+                  "id": 6,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -276,7 +514,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\"distributor\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -337,7 +575,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 4,
+                  "id": 7,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -411,7 +649,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 5,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -528,7 +766,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 6,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -633,7 +871,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 7,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -738,7 +976,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 8,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -763,7 +1001,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
+                        "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",container=~\"ingester\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{pod}}",
@@ -824,7 +1062,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 9,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -900,7 +1138,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 10,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -976,7 +1214,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 11,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -118,6 +118,7 @@
       mimir_backend: instanceMatcher(componentNameRegexp.mimir_backend),
 
       // The following are instance matchers used to select all components in a given "path".
+      // These matchers CAN match both instances deployed in "microservices" and "read-write" mode.
       local componentsGroupMatcher = function(components)
         instanceMatcher('(%s)' % std.join('|', std.map(function(name) componentNameRegexp[name], components))),
 
@@ -135,6 +136,7 @@
       ingester: componentNameRegexp.ingester,
 
       // The following are container matchers used to select all components in a given "path".
+      // These matchers CAN match both instances deployed in "microservices" and "read-write" mode.
       local componentsGroupMatcher = function(components) std.join('|', std.map(function(name) componentNameRegexp[name], components)),
 
       write: componentsGroupMatcher(componentGroups.write),

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -29,7 +29,9 @@
     // This mapping is intentionally local and can't be overridden. If the final user needs to customize
     // dashboards and alerts, they should override the final matcher regexp (e.g. container_names or instance_names).
     local componentNameRegexp = {
-      // Microservices deployment mode.
+      // Microservices deployment mode. The following matchers MUST match only
+      // the instance when deployed in microservices mode (e.g. "distributor"
+      // matcher shouldn't match "mimir-write" too).
       compactor: 'compactor',
       alertmanager: 'alertmanager',
       ingester: 'ingester',
@@ -45,7 +47,9 @@
       overrides_exporter: 'overrides-exporter',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
 
-      // Read-write deployment mode.
+      // Read-write deployment mode. The following matchers MUST match only
+      // the instance when deployed in read-write deployment mode (e.g. "mimir-write"
+      // matcher shouldn't match "distributor" too).
       mimir_write: 'mimir-write',
       mimir_read: 'mimir-read',
       mimir_backend: 'mimir-backend',
@@ -91,7 +95,9 @@
       local helmCompatibleMatcher = function(regexp) '(.*-mimir-)?%s' % regexp,
       local instanceMatcher = function(regexp) helmCompatibleMatcher('%s.*' % regexp),
 
-      // Microservices deployment mode.
+      // Microservices deployment mode. The following matchers MUST match only
+      // the instance when deployed in microservices mode (e.g. "distributor"
+      // matcher shouldn't match "mimir-write" too).
       compactor: instanceMatcher(componentNameRegexp.compactor),
       alertmanager: instanceMatcher(componentNameRegexp.alertmanager),
       ingester: instanceMatcher(componentNameRegexp.ingester),
@@ -104,7 +110,9 @@
       overrides_exporter: instanceMatcher(componentNameRegexp.overrides_exporter),
       gateway: instanceMatcher(componentNameRegexp.gateway),
 
-      // Read-write deployment mode.
+      // Read-write deployment mode. The following matchers MUST match only
+      // the instance when deployed in read-write deployment mode (e.g. "mimir-write"
+      // matcher shouldn't match "distributor" too).
       mimir_write: instanceMatcher(componentNameRegexp.mimir_write),
       mimir_read: instanceMatcher(componentNameRegexp.mimir_read),
       mimir_backend: instanceMatcher(componentNameRegexp.mimir_backend),
@@ -119,6 +127,13 @@
     },
 
     container_names: {
+      // Microservices deployment mode. The following matchers MUST match only
+      // the instance when deployed in microservices mode (e.g. "distributor"
+      // matcher shouldn't match "mimir-write" too).
+      gateway: componentNameRegexp.gateway,
+      distributor: componentNameRegexp.distributor,
+      ingester: componentNameRegexp.ingester,
+
       // The following are container matchers used to select all components in a given "path".
       local componentsGroupMatcher = function(components) std.join('|', std.map(function(name) componentNameRegexp[name], components)),
 
@@ -174,23 +189,23 @@
     },
     resources_panel_queries: {
       kubernetes: {
-        cpu_usage: 'sum by(%(instance)s) (rate(container_cpu_usage_seconds_total{%(namespace)s,container=~"%(instanceName)s"}[$__rate_interval]))',
-        cpu_limit: 'min(container_spec_cpu_quota{%(namespace)s,container=~"%(instanceName)s"} / container_spec_cpu_period{%(namespace)s,container=~"%(instanceName)s"})',
-        cpu_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="cpu"})',
+        cpu_usage: 'sum by(%(instanceLabel)s) (rate(container_cpu_usage_seconds_total{%(namespace)s,container=~"%(containerName)s"}[$__rate_interval]))',
+        cpu_limit: 'min(container_spec_cpu_quota{%(namespace)s,container=~"%(containerName)s"} / container_spec_cpu_period{%(namespace)s,container=~"%(containerName)s"})',
+        cpu_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="cpu"})',
         // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
         // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-        memory_working_usage: 'max by(%(instance)s) (container_memory_working_set_bytes{%(namespace)s,container=~"%(instanceName)s"})',
-        memory_working_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(instanceName)s"} > 0)',
-        memory_working_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="memory"})',
+        memory_working_usage: 'max by(%(instanceLabel)s) (container_memory_working_set_bytes{%(namespace)s,container=~"%(containerName)s"})',
+        memory_working_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
+        memory_working_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
         // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
         // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-        memory_rss_usage: 'max by(%(instance)s) (container_memory_rss{%(namespace)s,container=~"%(instanceName)s"})',
-        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(instanceName)s"} > 0)',
-        memory_rss_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(instanceName)s",resource="memory"})',
+        memory_rss_usage: 'max by(%(instanceLabel)s) (container_memory_rss{%(namespace)s,container=~"%(containerName)s"})',
+        memory_rss_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
+        memory_rss_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
         network: 'sum by(%(instanceLabel)s) (rate(%(metric)s{%(namespaceMatcher)s,%(instanceLabel)s=~"%(instanceName)s"}[$__rate_interval]))',
         disk_writes:
           |||
-            sum by(%(instanceLabel)s, %(instance)s, device) (
+            sum by(%(nodeLabel)s, %(instanceLabel)s, device) (
               rate(
                 node_disk_written_bytes_total[$__rate_interval]
               )
@@ -200,7 +215,7 @@
           |||,
         disk_reads:
           |||
-            sum by(%(instanceLabel)s, %(instance)s, device) (
+            sum by(%(nodeLabel)s, %(instanceLabel)s, device) (
               rate(
                 node_disk_read_bytes_total[$__rate_interval]
               )
@@ -224,38 +239,38 @@
       baremetal: {
         // Somes queries does not makes sense when running mimir on baremetal
         // no need to define them
-        cpu_usage: 'sum by(%(instance)s) (rate(node_cpu_seconds_total{mode="user",%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]))',
+        cpu_usage: 'sum by(%(instanceLabel)s) (rate(node_cpu_seconds_total{mode="user",%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}[$__rate_interval]))',
         memory_working_usage:
           |||
-            node_memory_MemTotal_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            - node_memory_MemFree_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            - node_memory_Buffers_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            - node_memory_Cached_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            - node_memory_Slab_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            - node_memory_PageTables_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            - node_memory_SwapCached_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            node_memory_MemTotal_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            - node_memory_MemFree_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            - node_memory_Buffers_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            - node_memory_Cached_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            - node_memory_Slab_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            - node_memory_PageTables_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            - node_memory_SwapCached_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
           |||,
         // From cAdvisor code, the memory RSS is:
         // The amount of anonymous and swap cache memory (includes transparent hugepages).
         memory_rss_usage:
           |||
-            node_memory_Active_anon_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
-            + node_memory_SwapCached_bytes{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}
+            node_memory_Active_anon_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
+            + node_memory_SwapCached_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
           |||,
         network: 'sum by(%(instanceLabel)s) (rate(%(metric)s{%(namespaceMatcher)s,%(instanceLabel)s=~".*%(instanceName)s.*"}[$__rate_interval]))',
         disk_writes:
           |||
-            sum by(%(instanceLabel)s, %(instance)s, device) (
+            sum by(%(nodeLabel)s, %(instanceLabel)s, device) (
               rate(
-                node_disk_written_bytes_total{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]
+                node_disk_written_bytes_total{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}[$__rate_interval]
               )
             )
           |||,
         disk_reads:
           |||
-            sum by(%(instanceLabel)s, %(instance)s, device) (
+            sum by(%(nodeLabel)s, %(instanceLabel)s, device) (
               rate(
-                node_disk_read_bytes_total{%(namespace)s,%(instance)s=~".*%(instanceName)s.*"}[$__rate_interval]
+                node_disk_read_bytes_total{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}[$__rate_interval]
               )
             )
           |||,

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -202,6 +202,7 @@
         memory_rss_usage: 'max by(%(instanceLabel)s) (container_memory_rss{%(namespace)s,container=~"%(containerName)s"})',
         memory_rss_limit: 'min(container_spec_memory_limit_bytes{%(namespace)s,container=~"%(containerName)s"} > 0)',
         memory_rss_request: 'min(kube_pod_container_resource_requests{%(namespace)s,container=~"%(containerName)s",resource="memory"})',
+        memory_go_heap_usage: 'sum by(%(instanceLabel)s) (go_memstats_heap_inuse_bytes{%(namespace)s,container=~"%(containerName)s"})',
         network: 'sum by(%(instanceLabel)s) (rate(%(metric)s{%(namespaceMatcher)s,%(instanceLabel)s=~"%(instanceName)s"}[$__rate_interval]))',
         disk_writes:
           |||
@@ -257,6 +258,7 @@
             node_memory_Active_anon_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
             + node_memory_SwapCached_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"}
           |||,
+        memory_go_heap_usage: 'sum by(%(instanceLabel)s) (go_memstats_heap_inuse_bytes{%(namespace)s,%(instanceLabel)s=~".*%(instanceName)s.*"})',
         network: 'sum by(%(instanceLabel)s) (rate(%(metric)s{%(namespaceMatcher)s,%(instanceLabel)s=~".*%(instanceName)s.*"}[$__rate_interval]))',
         disk_writes:
           |||

--- a/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
@@ -9,38 +9,38 @@ local filename = 'mimir-alertmanager-resources.json';
       $._config.gateway_enabled,
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
+        $.containerCPUUsagePanel($._config.job_names.gateway, $._config.job_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
+        $.containerMemoryWorkingSetPanel($._config.job_names.gateway, $._config.job_names.gateway),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
+        $.goHeapInUsePanel($._config.job_names.gateway),
       )
     )
     .addRow(
       $.row('Alertmanager')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'alertmanager'),
+        $.containerCPUUsagePanel('alertmanager', 'alertmanager'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'alertmanager'),
+        $.containerMemoryWorkingSetPanel('alertmanager', 'alertmanager'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'alertmanager'),
+        $.goHeapInUsePanel('alertmanager'),
       )
     )
     .addRowIf(
       $._config.alertmanager_im_enabled,
       $.row('Instance mapper')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'alertmanager-im'),
+        $.containerCPUUsagePanel('alertmanager-im', 'alertmanager-im'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'alertmanager-im'),
+        $.containerMemoryWorkingSetPanel('alertmanager-im', 'alertmanager-im'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'alertmanager-im'),
+        $.goHeapInUsePanel('alertmanager-im'),
       )
     )
     .addRow(
@@ -55,16 +55,16 @@ local filename = 'mimir-alertmanager-resources.json';
     .addRow(
       $.row('Disk')
       .addPanel(
-        $.containerDiskWritesPanel('Writes', 'alertmanager'),
+        $.containerDiskWritesPanel('Writes', 'alertmanager', 'alertmanager'),
       )
       .addPanel(
-        $.containerDiskReadsPanel('Reads', 'alertmanager'),
+        $.containerDiskReadsPanel('Reads', 'alertmanager', 'alertmanager'),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk space utilization', 'alertmanager'),
+        $.containerDiskSpaceUtilization('Disk space utilization', 'alertmanager', 'alertmanager'),
       )
     ),
 }

--- a/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
@@ -8,19 +8,19 @@ local filename = 'mimir-compactor-resources.json';
     .addRow(
       $.row('CPU and memory')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'compactor'),
+        $.containerCPUUsagePanel('compactor', 'compactor'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.compactor),
+        $.goHeapInUsePanel($._config.job_names.compactor),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerMemoryRSSPanel('Memory (RSS)', 'compactor'),
+        $.containerMemoryRSSPanel('compactor', 'compactor'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'compactor'),
+        $.containerMemoryWorkingSetPanel('compactor', 'compactor'),
       )
     )
     .addRow(
@@ -35,13 +35,13 @@ local filename = 'mimir-compactor-resources.json';
     .addRow(
       $.row('Disk')
       .addPanel(
-        $.containerDiskWritesPanel('Disk writes', 'compactor'),
+        $.containerDiskWritesPanel('Disk writes', 'compactor', 'compactor'),
       )
       .addPanel(
-        $.containerDiskReadsPanel('Disk reads', 'compactor'),
+        $.containerDiskReadsPanel('Disk reads', 'compactor', 'compactor'),
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk space utilization', 'compactor'),
+        $.containerDiskSpaceUtilization('Disk space utilization', 'compactor', 'compactor'),
       )
     ) + {
       templating+: {

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -254,33 +254,40 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // limit and request does not makes sense when running on baremetal
     else [resourceName],
 
-  resourceUtilizationQuery(metric, instanceName)::
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  resourceUtilizationQuery(metric, instanceName, containerName)::
     $._config.resources_panel_queries[$._config.deployment_type]['%s_usage' % metric] % {
-      instance: $._config.per_instance_label,
+      instanceLabel: $._config.per_instance_label,
       namespace: $.namespaceMatcher(),
       instanceName: instanceName,
+      containerName: containerName,
     },
 
-  resourceUtilizationAndLimitQueries(metric, instanceName)::
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  resourceUtilizationAndLimitQueries(metric, instanceName, containerName)::
     if $._config.deployment_type == 'kubernetes'
     then [
-      $.resourceUtilizationQuery(metric, instanceName),
+      $.resourceUtilizationQuery(metric, instanceName, containerName),
       $._config.resources_panel_queries[$._config.deployment_type]['%s_limit' % metric] % {
         namespace: $.namespaceMatcher(),
-        instanceName: instanceName,
+        containerName: containerName,
       },
       $._config.resources_panel_queries[$._config.deployment_type]['%s_request' % metric] % {
         namespace: $.namespaceMatcher(),
-        instanceName: instanceName,
+        containerName: containerName,
       },
     ]
     else [
-      $.resourceUtilizationQuery(metric, instanceName),
+      $.resourceUtilizationQuery(metric, instanceName, containerName),
     ],
 
-  containerCPUUsagePanel(title, instanceName)::
-    $.panel(title) +
-    $.queryPanel($.resourceUtilizationAndLimitQueries('cpu', instanceName), $.resourceUtilizationAndLimitLegend('{{%s}}' % $._config.per_instance_label)) +
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerCPUUsagePanel(instanceName, containerName)::
+    $.panel('CPU') +
+    $.queryPanel($.resourceUtilizationAndLimitQueries('cpu', instanceName, containerName), $.resourceUtilizationAndLimitLegend('{{%s}}' % $._config.per_instance_label)) +
     {
       seriesOverrides: [
         resourceRequestStyle,
@@ -290,9 +297,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  containerMemoryWorkingSetPanel(title, instanceName)::
-    $.panel(title) +
-    $.queryPanel($.resourceUtilizationAndLimitQueries('memory_working', instanceName), $.resourceUtilizationAndLimitLegend('{{%s}}' % $._config.per_instance_label)) +
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerMemoryWorkingSetPanel(instanceName, containerName)::
+    $.panel('Memory (workingset)') +
+    $.queryPanel($.resourceUtilizationAndLimitQueries('memory_working', instanceName, containerName), $.resourceUtilizationAndLimitLegend('{{%s}}' % $._config.per_instance_label)) +
     {
       seriesOverrides: [
         resourceRequestStyle,
@@ -303,14 +312,33 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  containerMemoryRSSPanel(title, instanceName)::
-    $.panel(title) +
-    $.queryPanel($.resourceUtilizationAndLimitQueries('memory_rss', instanceName), $.resourceUtilizationAndLimitLegend('{{%s}}' % $._config.per_instance_label)) +
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerMemoryRSSPanel(instanceName, containerName)::
+    $.panel('Memory (RSS)') +
+    $.queryPanel($.resourceUtilizationAndLimitQueries('memory_rss', instanceName, containerName), $.resourceUtilizationAndLimitLegend('{{%s}}' % $._config.per_instance_label)) +
     {
       seriesOverrides: [
         resourceRequestStyle,
         resourceLimitStyle,
       ],
+      yaxes: $.yaxes('bytes'),
+      tooltip: { sort: 2 },  // Sort descending.
+      fill: 0,
+    },
+
+  // The provided containerName should be a regexp from $._config.container_names.
+  containerGoHeapInUsePanel(containerName)::
+    $.panel('Memory (go heap inuse)') +
+    $.queryPanel(
+      'sum by(%(instanceLabel)s) (go_memstats_heap_inuse_bytes{%(namespaceMatcher)s,container=~"%(containerName)s"})' % {
+        instanceLabel: $._config.per_instance_label,
+        namespaceMatcher: $.namespaceMatcher(),
+        containerName: containerName,
+      },
+      '{{%s}}' % $._config.per_instance_label
+    ) +
+    {
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.
       fill: 0,
@@ -335,29 +363,33 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerNetworkTransmitBytesPanel(instanceName)::
     $.containerNetworkPanel('Transmit bandwidth', $._config.resources_panel_series[$._config.deployment_type].network_transmit_bytes_metrics, instanceName),
 
-  containerDiskWritesPanel(title, instanceName)::
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerDiskWritesPanel(title, instanceName, containerName)::
     $.panel(title) +
     $.queryPanel(
       $._config.resources_panel_queries[$._config.deployment_type].disk_writes % {
         namespace: $.namespaceMatcher(),
-        instanceLabel: $._config.per_node_label,
-        instance: $._config.per_instance_label,
-        filterNodeDiskContainer: $.filterNodeDiskContainer(instanceName),
+        nodeLabel: $._config.per_node_label,
+        instanceLabel: $._config.per_instance_label,
         instanceName: instanceName,
+        filterNodeDiskContainer: $.filterNodeDiskContainer(containerName),
       },
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
     $.stack +
     { yaxes: $.yaxes('Bps') },
 
-  containerDiskReadsPanel(title, instanceName)::
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerDiskReadsPanel(title, instanceName, containerName)::
     $.panel(title) +
     $.queryPanel(
       $._config.resources_panel_queries[$._config.deployment_type].disk_reads % {
         namespace: $.namespaceMatcher(),
-        instanceLabel: $._config.per_node_label,
-        instance: $._config.per_instance_label,
-        filterNodeDiskContainer: $.filterNodeDiskContainer(instanceName),
+        nodeLabel: $._config.per_node_label,
+        instanceLabel: $._config.per_instance_label,
+        filterNodeDiskContainer: $.filterNodeDiskContainer(containerName),
         instanceName: instanceName,
       },
       '{{%s}} - {{device}}' % $._config.per_instance_label
@@ -365,14 +397,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
     $.stack +
     { yaxes: $.yaxes('Bps') },
 
-  containerDiskSpaceUtilization(title, instanceName)::
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerDiskSpaceUtilization(title, instanceName, containerName)::
     local label = if $._config.deployment_type == 'kubernetes' then '{{persistentvolumeclaim}}' else '{{instance}}';
 
     $.panel(title) +
     $.queryPanel(
       $._config.resources_panel_queries[$._config.deployment_type].disk_utilization % {
         namespaceMatcher: $.namespaceMatcher(),
-        containerMatcher: $.containerLabelNameMatcher(instanceName),
+        containerMatcher: $.containerLabelNameMatcher(containerName),
         instanceLabel: $._config.per_instance_label,
         instanceName: instanceName,
         instanceDataDir: $._config.instance_data_mountpoint,
@@ -383,9 +417,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  containerLabelNameMatcher(containerNameOrRegex)::
+  // The provided containerName should be a regexp from $._config.container_names.
+  containerLabelNameMatcher(containerName)::
     // Check only the prefix so that a multi-zone deployment matches too.
-    'label_name=~"(%s).*"' % containerNameOrRegex,
+    'label_name=~"(%s).*"' % containerName,
 
   jobNetworkingRow(title, name)::
     local vars = $._config {
@@ -424,8 +459,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.latencyPanel('cortex_kv_request_duration_seconds', '{%s, kv_name=~"%s"}' % [$.jobMatcher($._config.job_names[jobName]), kvName])
     ),
 
-  goHeapInUsePanel(title, jobName)::
-    $.panel(title) +
+  // Deprecated: use containerGoHeapInUsePanel() instead.
+  goHeapInUsePanel(jobName)::
+    $.panel('Memory (go heap inuse)') +
     $.queryPanel(
       'sum by(%s) (go_memstats_heap_inuse_bytes{%s})' % [$._config.per_instance_label, $.jobMatcher(jobName)],
       '{{%s}}' % $._config.per_instance_label
@@ -695,19 +731,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { yaxes: $.yaxes('percentunit') }
     ),
 
-  filterNodeDiskContainer(instanceName)::
+  filterNodeDiskContainer(containerName)::
     |||
-      ignoring(%s) group_right() (
+      ignoring(%(instanceLabel)s) group_right() (
         label_replace(
           count by(
-            %s,
-            %s,
+            %(nodeLabel)s,
+            %(instanceLabel)s,
             device
           )
           (
             container_fs_writes_bytes_total{
-              %s,
-              container=~"%s",
+              %(namespaceMatcher)s,
+              container=~"%(containerName)s",
               device!~".*sda.*"
             }
           ),
@@ -717,13 +753,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           "/dev/(.*)"
         ) * 0
       )
-    ||| % [
-      $._config.per_instance_label,
-      $._config.per_node_label,
-      $._config.per_instance_label,
-      $.namespaceMatcher(),
-      instanceName,
-    ],
+    ||| % {
+      instanceLabel: $._config.per_instance_label,
+      containerName: containerName,
+      nodeLabel: $._config.per_node_label,
+      namespaceMatcher: $.namespaceMatcher(),
+    },
 
   filterKedaMetricByHPA(query, hpa_name)::
     |||

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -327,17 +327,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fill: 0,
     },
 
-  // The provided containerName should be a regexp from $._config.container_names.
-  containerGoHeapInUsePanel(containerName)::
+  // The provided instanceName should be a regexp from $._config.instance_names, while
+  // the provided containerName should be a regexp from $._config.container_names.
+  containerGoHeapInUsePanel(instanceName, containerName)::
     $.panel('Memory (go heap inuse)') +
-    $.queryPanel(
-      'sum by(%(instanceLabel)s) (go_memstats_heap_inuse_bytes{%(namespaceMatcher)s,container=~"%(containerName)s"})' % {
-        instanceLabel: $._config.per_instance_label,
-        namespaceMatcher: $.namespaceMatcher(),
-        containerName: containerName,
-      },
-      '{{%s}}' % $._config.per_instance_label
-    ) +
+    $.queryPanel($.resourceUtilizationQuery('memory_go_heap', instanceName, containerName), '{{%s}}' % $._config.per_instance_label) +
     {
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.

--- a/operations/mimir-mixin/dashboards/overview-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview-resources.libsonnet
@@ -11,13 +11,13 @@ local filename = 'mimir-overview-resources.json';
       $._config.gateway_enabled,
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
+        $.containerCPUUsagePanel($._config.instance_names.gateway, $._config.container_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
+        $.containerMemoryWorkingSetPanel($._config.instance_names.gateway, $._config.container_names.gateway),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
+        $.goHeapInUsePanel($._config.job_names.gateway),
       )
     )
 
@@ -25,27 +25,27 @@ local filename = 'mimir-overview-resources.json';
       $.row('Writes')
       .addPanel(
         $.panel('CPU') +
-        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.container_names.write), '{{%s}}' % $._config.per_instance_label),
+        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.instance_names.write, $._config.container_names.write), '{{%s}}' % $._config.per_instance_label),
       )
       .addPanel(
         $.panel('Memory (workingset)') +
-        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.container_names.write), '{{%s}}' % $._config.per_instance_label) +
+        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.instance_names.write, $._config.container_names.write), '{{%s}}' % $._config.per_instance_label) +
         { yaxes: $.yaxes('bytes') },
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.write),
+        $.goHeapInUsePanel($._config.job_names.write),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerDiskWritesPanel('Disk writes', $._config.container_names.write)
+        $.containerDiskWritesPanel('Disk writes', $._config.instance_names.write, $._config.container_names.write)
       )
       .addPanel(
-        $.containerDiskReadsPanel('Disk reads', $._config.container_names.write)
+        $.containerDiskReadsPanel('Disk reads', $._config.instance_names.write, $._config.container_names.write)
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk space utilization', $._config.container_names.write),
+        $.containerDiskSpaceUtilization('Disk space utilization', $._config.instance_names.write, $._config.container_names.write),
       )
     )
 
@@ -53,15 +53,15 @@ local filename = 'mimir-overview-resources.json';
       $.row('Reads')
       .addPanel(
         $.panel('CPU') +
-        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.container_names.read), '{{%s}}' % $._config.per_instance_label),
+        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.instance_names.read, $._config.container_names.read), '{{%s}}' % $._config.per_instance_label),
       )
       .addPanel(
         $.panel('Memory (workingset)') +
-        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.container_names.read), '{{%s}}' % $._config.per_instance_label) +
+        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.instance_names.read, $._config.container_names.read), '{{%s}}' % $._config.per_instance_label) +
         { yaxes: $.yaxes('bytes') },
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.read),
+        $.goHeapInUsePanel($._config.job_names.read),
       )
     )
 
@@ -69,27 +69,27 @@ local filename = 'mimir-overview-resources.json';
       $.row('Backend')
       .addPanel(
         $.panel('CPU') +
-        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.container_names.backend), '{{%s}}' % $._config.per_instance_label),
+        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.instance_names.backend, $._config.container_names.backend), '{{%s}}' % $._config.per_instance_label),
       )
       .addPanel(
         $.panel('Memory (workingset)') +
-        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.container_names.backend), '{{%s}}' % $._config.per_instance_label) +
+        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.instance_names.backend, $._config.container_names.backend), '{{%s}}' % $._config.per_instance_label) +
         { yaxes: $.yaxes('bytes') },
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.backend),
+        $.goHeapInUsePanel($._config.job_names.backend),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerDiskWritesPanel('Disk writes', $._config.container_names.backend)
+        $.containerDiskWritesPanel('Disk writes', $._config.instance_names.backend, $._config.container_names.backend)
       )
       .addPanel(
-        $.containerDiskReadsPanel('Disk reads', $._config.container_names.backend)
+        $.containerDiskReadsPanel('Disk reads', $._config.instance_names.backend, $._config.container_names.backend)
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk space utilization', $._config.container_names.backend),
+        $.containerDiskSpaceUtilization('Disk space utilization', $._config.instance_names.backend, $._config.container_names.backend),
       )
     ),
 }

--- a/operations/mimir-mixin/dashboards/reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-resources.libsonnet
@@ -9,67 +9,67 @@ local filename = 'mimir-reads-resources.json';
       $._config.gateway_enabled,
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
+        $.containerCPUUsagePanel($._config.job_names.gateway, $._config.job_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
+        $.containerMemoryWorkingSetPanel($._config.job_names.gateway, $._config.job_names.gateway),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
+        $.goHeapInUsePanel($._config.job_names.gateway),
       )
     )
     .addRow(
       $.row('Query-frontend')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'query-frontend'),
+        $.containerCPUUsagePanel('query-frontend', 'query-frontend'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
+        $.containerMemoryWorkingSetPanel('query-frontend', 'query-frontend'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.query_frontend),
+        $.goHeapInUsePanel($._config.job_names.query_frontend),
       )
     )
     .addRow(
       $.row('Query-scheduler')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'query-scheduler'),
+        $.containerCPUUsagePanel('query-scheduler', 'query-scheduler'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
+        $.containerMemoryWorkingSetPanel('query-scheduler', 'query-scheduler'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.query_scheduler),
+        $.goHeapInUsePanel($._config.job_names.query_scheduler),
       )
     )
     .addRow(
       $.row('Querier')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'querier'),
+        $.containerCPUUsagePanel('querier', 'querier'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
+        $.containerMemoryWorkingSetPanel('querier', 'querier'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.querier),
+        $.goHeapInUsePanel($._config.job_names.querier),
       )
     )
     .addRow(
       $.row('Ingester')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ingester'),
+        $.containerCPUUsagePanel('ingester', 'ingester'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ingester),
+        $.goHeapInUsePanel($._config.job_names.ingester),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerMemoryRSSPanel('Memory (RSS)', 'ingester'),
+        $.containerMemoryRSSPanel('ingester', 'ingester'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ingester'),
+        $.containerMemoryWorkingSetPanel('ingester', 'ingester'),
       )
     )
     .addRow(
@@ -82,46 +82,46 @@ local filename = 'mimir-reads-resources.json';
         ),
       )
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ruler'),
+        $.containerCPUUsagePanel('ruler', 'ruler'),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
+        $.containerMemoryWorkingSetPanel('ruler', 'ruler'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ruler),
+        $.goHeapInUsePanel($._config.job_names.ruler),
       )
     )
     .addRow(
       $.row('Store-gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'store-gateway'),
+        $.containerCPUUsagePanel('store-gateway', 'store-gateway'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.store_gateway),
-      )
-    )
-    .addRow(
-      $.row('')
-      .addPanel(
-        $.containerMemoryRSSPanel('Memory (RSS)', 'store-gateway'),
-      )
-      .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'store-gateway'),
+        $.goHeapInUsePanel($._config.job_names.store_gateway),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerDiskWritesPanel('Disk writes', 'store-gateway'),
+        $.containerMemoryRSSPanel('store-gateway', 'store-gateway'),
       )
       .addPanel(
-        $.containerDiskReadsPanel('Disk reads', 'store-gateway'),
+        $.containerMemoryWorkingSetPanel('store-gateway', 'store-gateway'),
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.containerDiskWritesPanel('Disk writes', 'store-gateway', 'store-gateway'),
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk space utilization', 'store-gateway'),
+        $.containerDiskReadsPanel('Disk reads', 'store-gateway', 'store-gateway'),
+      )
+      .addPanel(
+        $.containerDiskSpaceUtilization('Disk space utilization', 'store-gateway', 'store-gateway'),
       )
     ) + {
       templating+: {

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
@@ -8,37 +8,37 @@ local filename = 'mimir-remote-ruler-reads-resources.json';
     .addRow(
       $.row('Query-frontend (dedicated to ruler)')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ruler-query-frontend'),
+        $.containerCPUUsagePanel('ruler-query-frontend', 'ruler-query-frontend'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler-query-frontend'),
+        $.containerMemoryWorkingSetPanel('ruler-query-frontend', 'ruler-query-frontend'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ruler_query_frontend),
+        $.goHeapInUsePanel($._config.job_names.ruler_query_frontend),
       )
     )
     .addRow(
       $.row('Query-scheduler (dedicated to ruler)')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ruler-query-scheduler'),
+        $.containerCPUUsagePanel('ruler-query-scheduler', 'ruler-query-scheduler'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler-query-scheduler'),
+        $.containerMemoryWorkingSetPanel('ruler-query-scheduler', 'ruler-query-scheduler'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ruler_query_scheduler),
+        $.goHeapInUsePanel($._config.job_names.ruler_query_scheduler),
       )
     )
     .addRow(
       $.row('Querier (dedicated to ruler)')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ruler-querier'),
+        $.containerCPUUsagePanel('ruler-querier', 'ruler-querier'),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler-querier'),
+        $.containerMemoryWorkingSetPanel('ruler-querier', 'ruler-querier'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ruler_querier),
+        $.goHeapInUsePanel($._config.job_names.ruler_querier),
       )
     ) + {
       templating+: {

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -19,7 +19,7 @@ local filename = 'mimir-writes-resources.json';
         { yaxes: $.yaxes('bytes') },
       )
       .addPanel(
-        $.containerGoHeapInUsePanel($._config.container_names.write) +
+        $.containerGoHeapInUsePanel($._config.instance_names.write, $._config.container_names.write) +
         $.stack,
       )
     )
@@ -33,7 +33,7 @@ local filename = 'mimir-writes-resources.json';
         $.containerMemoryWorkingSetPanel($._config.instance_names.gateway, $._config.container_names.gateway),
       )
       .addPanel(
-        $.containerGoHeapInUsePanel($._config.container_names.gateway),
+        $.containerGoHeapInUsePanel($._config.instance_names.gateway, $._config.container_names.gateway),
       )
     )
     .addRow(
@@ -45,7 +45,7 @@ local filename = 'mimir-writes-resources.json';
         $.containerMemoryWorkingSetPanel($._config.instance_names.distributor, $._config.container_names.distributor),
       )
       .addPanel(
-        $.containerGoHeapInUsePanel($._config.container_names.distributor),
+        $.containerGoHeapInUsePanel($._config.instance_names.distributor, $._config.container_names.distributor),
       )
     )
     .addRow(
@@ -74,7 +74,7 @@ local filename = 'mimir-writes-resources.json';
         $.containerMemoryWorkingSetPanel($._config.instance_names.ingester, $._config.container_names.ingester),
       )
       .addPanel(
-        $.containerGoHeapInUsePanel($._config.container_names.ingester),
+        $.containerGoHeapInUsePanel($._config.instance_names.ingester, $._config.container_names.ingester),
       )
     )
     .addRow(

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -5,29 +5,47 @@ local filename = 'mimir-writes-resources.json';
   [filename]:
     ($.dashboard('Writes resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
+    .addRow(
+      $.row('Summary')
+      .addPanel(
+        $.panel('CPU') +
+        $.queryPanel($.resourceUtilizationQuery('cpu', $._config.instance_names.write, $._config.container_names.write), '{{%s}}' % $._config.per_instance_label) +
+        $.stack,
+      )
+      .addPanel(
+        $.panel('Memory (workingset)') +
+        $.queryPanel($.resourceUtilizationQuery('memory_working', $._config.instance_names.write, $._config.container_names.write), '{{%s}}' % $._config.per_instance_label) +
+        $.stack +
+        { yaxes: $.yaxes('bytes') },
+      )
+      .addPanel(
+        $.containerGoHeapInUsePanel($._config.container_names.write) +
+        $.stack,
+      )
+    )
     .addRowIf(
       $._config.gateway_enabled,
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
+        $.containerCPUUsagePanel($._config.instance_names.gateway, $._config.container_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
+        $.containerMemoryWorkingSetPanel($._config.instance_names.gateway, $._config.container_names.gateway),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
+        $.containerGoHeapInUsePanel($._config.container_names.gateway),
       )
     )
     .addRow(
       $.row('Distributor')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'distributor'),
+        $.containerCPUUsagePanel($._config.instance_names.distributor, $._config.container_names.distributor),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
+        $.containerMemoryWorkingSetPanel($._config.instance_names.distributor, $._config.container_names.distributor),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.distributor),
+        $.containerGoHeapInUsePanel($._config.container_names.distributor),
       )
     )
     .addRow(
@@ -44,31 +62,31 @@ local filename = 'mimir-writes-resources.json';
         },
       )
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ingester'),
+        $.containerCPUUsagePanel($._config.instance_names.ingester, $._config.container_names.ingester),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerMemoryRSSPanel('Memory (RSS)', 'ingester'),
+        $.containerMemoryRSSPanel($._config.instance_names.ingester, $._config.container_names.ingester),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ingester'),
+        $.containerMemoryWorkingSetPanel($._config.instance_names.ingester, $._config.container_names.ingester),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ingester),
+        $.containerGoHeapInUsePanel($._config.container_names.ingester),
       )
     )
     .addRow(
       $.row('')
       .addPanel(
-        $.containerDiskWritesPanel('Disk writes', 'ingester')
+        $.containerDiskWritesPanel('Disk writes', $._config.instance_names.ingester, $._config.container_names.ingester)
       )
       .addPanel(
-        $.containerDiskReadsPanel('Disk reads', 'ingester')
+        $.containerDiskReadsPanel('Disk reads', $._config.instance_names.ingester, $._config.container_names.ingester)
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk space utilization', 'ingester'),
+        $.containerDiskSpaceUtilization('Disk space utilization', $._config.instance_names.ingester, $._config.container_names.ingester),
       )
     )
     + {


### PR DESCRIPTION
#### What this PR does
This PR introduces a refactoring to utility functions used to generate CPU and memory panels. The current problem is that we support both K8S and baremetal, but they have different queries. When running on K8S we filter by "container" while on baremetal we filter by "instance" (which is a node in practice). However, we shouldn't just use different queries but also different matchers whether the mixin is compiled to run on K8S or baremetal, which is what I'm doing in this PR.

I've also introduced a "Summary" row in the "Writes resources dashboard". The idea is that if you run microservices you both see data in "Summary" **and** per-component rows (e.g. "Distributor"), but if you run read-write you also see summary because there's no dedicated deployment for each component.

**Scope of this PR**:
- Address CPU, memory and disk in the overview dashboards

**Out of the scope of this PR** (will be done in follow up PRs):
- Address CPU, memory and disk in other dashboards
- Address networking in all dashboards

Due to the limited scope of this PR, you can see all this refactoring is a no-op in other dashboards.

**Screenshot from microservices cluster:**
![Screenshot 2022-11-23 at 11 42 14](https://user-images.githubusercontent.com/1701904/203527094-bd93a841-c7fd-41de-afbf-fdaa59ef229d.png)

**Screenshot from read-write cluster:**
![Screenshot 2022-11-23 at 11 42 22](https://user-images.githubusercontent.com/1701904/203527139-7980b5ff-e8ea-461f-884f-77a402b91e31.png)

#### Which issue(s) this PR fixes or relates to

Part of #3361

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
