### PR TITLE
Refactoring: removed mutex from bucketIndexReader

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -622,14 +622,14 @@ func blockSeries(
 		)
 
 		// Keep track of postings lookup stats in a dedicated stats structure that doesn't require lock
-		// and then merge it once done. We do it to avoid the lock overhead because loadSeriesForTime()
+		// and then merge it once done. We do it to avoid the lock overhead because unsafeLoadSeriesForTime()
 		// may be called many times.
 		defer func() {
 			indexStats = indexStats.merge(postingsStats)
 		}()
 
 		for _, id := range ps {
-			ok, err := loadedSeries.loadSeriesForTime(id, &symbolizedLset, &chks, skipChunks, minTime, maxTime, postingsStats)
+			ok, err := loadedSeries.unsafeLoadSeriesForTime(id, &symbolizedLset, &chks, skipChunks, minTime, maxTime, postingsStats)
 			if err != nil {
 				lookupErr = errors.Wrap(err, "read series")
 				return

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -413,10 +413,10 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 					compressionErrors = 1
 				}
 
-				r.mtx.Lock()
 				// Return postings. Truncate first 4 bytes which are length of posting.
+				// Access to output is not protected by a mutex because each goroutine
+				// is expected to handle a different set of keys.
 				output[p.keyID] = newBigEndianPostings(pBytes[4:])
-				r.mtx.Unlock()
 
 				r.block.indexCache.StorePostings(ctx, r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache)
 
@@ -474,7 +474,7 @@ func (r *bucketIndexReader) preloadSeries(ctx context.Context, ids []storage.Ser
 	// with the missing ones.
 	fromCache, ids := r.block.indexCache.FetchMultiSeriesForRefs(ctx, r.block.userID, r.block.meta.ULID, ids)
 	for id, b := range fromCache {
-		loaded.series[id] = b
+		loaded.addSeries(id, b)
 	}
 
 	parts := r.block.partitioner.Partition(len(ids), func(i int) (start, end uint64) {
@@ -527,9 +527,8 @@ func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.Series
 			return r.loadSeries(ctx, ids[i:], true, uint64(id), uint64(id)+uint64(n+int(l)+1), loaded, stats)
 		}
 		c = c[n : n+int(l)]
-		r.mtx.Lock()
-		loaded.series[id] = c
-		r.mtx.Unlock()
+
+		loaded.addSeries(id, c)
 
 		r.block.indexCache.StoreSeriesForRef(ctx, r.block.userID, r.block.meta.ULID, id, c)
 	}
@@ -560,10 +559,10 @@ func (r *bucketIndexReader) LookupLabelsSymbols(symbolized []symbolizedLabel) (l
 }
 
 // bucketIndexLoadedSeries holds the result of a series load operation.
-// This data structure is NOT concurrency safe.
 type bucketIndexLoadedSeries struct {
 	// Keeps the series that have been loaded from the index.
-	series map[storage.SeriesRef][]byte
+	seriesMx sync.Mutex
+	series   map[storage.SeriesRef][]byte
 }
 
 func newBucketIndexLoadedSeries() *bucketIndexLoadedSeries {
@@ -572,13 +571,23 @@ func newBucketIndexLoadedSeries() *bucketIndexLoadedSeries {
 	}
 }
 
-// loadSeriesForTime populates the given symbolized labels for the series identified by the reference if at least one chunk is within
+// addSeries stores a series raw data in the data structure. A stored series can be loaded via unsafeLoadSeriesForTime().
+// This function is concurrency safe.
+func (l *bucketIndexLoadedSeries) addSeries(ref storage.SeriesRef, data []byte) {
+	l.seriesMx.Lock()
+	l.series[ref] = data
+	l.seriesMx.Unlock()
+}
+
+// unsafeLoadSeriesForTime populates the given symbolized labels for the series identified by the reference if at least one chunk is within
 // time selection.
-// loadSeriesForTime also populates chunk metas slices if skipChunks if set to false. Chunks are also limited by the given time selection.
-// loadSeriesForTime returns false, when there are no series data for given time range.
+// unsafeLoadSeriesForTime also populates chunk metas slices if skipChunks if set to false. Chunks are also limited by the given time selection.
+// unsafeLoadSeriesForTime returns false, when there are no series data for given time range.
 //
 // Error is returned on decoding error or if the reference does not resolve to a known series.
-func (l *bucketIndexLoadedSeries) loadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64, stats *queryStats) (ok bool, err error) {
+//
+// This function is NOT concurrency safe.
+func (l *bucketIndexLoadedSeries) unsafeLoadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64, stats *queryStats) (ok bool, err error) {
 	b, ok := l.series[ref]
 	if !ok {
 		return false, errors.Errorf("series %d not found", ref)

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -584,7 +584,7 @@ func (l *bucketIndexLoadedSeries) addSeries(ref storage.SeriesRef, data []byte) 
 //
 // Error is returned on decoding error or if the reference does not resolve to a known series.
 //
-// This function is NOT concurrency safe.
+// It's NOT safe to call this function concurrently with addSeries().
 func (l *bucketIndexLoadedSeries) unsafeLoadSeriesForTime(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, mint, maxt int64, stats *queryStats) (ok bool, err error) {
 	b, ok := l.series[ref]
 	if !ok {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -39,8 +39,6 @@ type expandedPostingsPromise func(ctx context.Context) ([]storage.SeriesRef, boo
 type bucketIndexReader struct {
 	block *bucketBlock
 	dec   *index.Decoder
-
-	mtx sync.Mutex
 }
 
 func newBucketIndexReader(block *bucketBlock) *bucketIndexReader {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -579,7 +579,7 @@ func (l *bucketIndexLoadedSeries) addSeries(ref storage.SeriesRef, data []byte) 
 
 // unsafeLoadSeriesForTime populates the given symbolized labels for the series identified by the reference if at least one chunk is within
 // time selection.
-// unsafeLoadSeriesForTime also populates chunk metas slices if skipChunks if set to false. Chunks are also limited by the given time selection.
+// unsafeLoadSeriesForTime also populates chunk metas slices if skipChunks is set to false. Chunks are also limited by the given time selection.
 // unsafeLoadSeriesForTime returns false, when there are no series data for given time range.
 //
 // Error is returned on decoding error or if the reference does not resolve to a known series.


### PR DESCRIPTION
#### What this PR does
This is the last PR of a refactoring I've started a couple of weeks ago where I've moved `queryStats` outside of `bucketIndexReader`. In this last PR I'm removing `bucketIndexReader.mtx`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
