### PR TITLE
Store-gateway: move chunk bytes pooling outside of chunk reader

### DIFF
--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -22,6 +22,7 @@ import (
 
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util/pool"
 )
 
 type bucketChunkReader struct {
@@ -34,24 +35,22 @@ type bucketChunkReader struct {
 	// After chunks are loaded, mutex is no longer used.
 	mtx        sync.Mutex
 	stats      *queryStats
-	chunkBytes []*[]byte // Byte slice to return to the chunk pool on close.
+	chunkBytes *pool.BatchBytes
 }
 
-func newBucketChunkReader(ctx context.Context, block *bucketBlock) *bucketChunkReader {
+func newBucketChunkReader(ctx context.Context, block *bucketBlock, chunkBytes *pool.BatchBytes) *bucketChunkReader {
 	return &bucketChunkReader{
-		ctx:    ctx,
-		block:  block,
-		stats:  &queryStats{},
-		toLoad: make([][]loadIdx, len(block.chunkObjs)),
+		ctx:        ctx,
+		block:      block,
+		stats:      &queryStats{},
+		toLoad:     make([][]loadIdx, len(block.chunkObjs)),
+		chunkBytes: chunkBytes,
 	}
 }
 
 func (r *bucketChunkReader) Close() error {
 	r.block.pendingReaders.Done()
-
-	for _, b := range r.chunkBytes {
-		r.block.chunkPool.Put(b)
-	}
+	r.chunkBytes.Release()
 	return nil
 }
 
@@ -213,18 +212,12 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 // save saves a copy of b's payload to a memory pool of its own and returns a new byte slice referencing said copy.
 // Returned slice becomes invalid once r.block.chunkPool.Put() is called.
 func (r *bucketChunkReader) save(b []byte) ([]byte, error) {
-	// Ensure we never grow slab beyond original capacity.
-	if len(r.chunkBytes) == 0 ||
-		cap(*r.chunkBytes[len(r.chunkBytes)-1])-len(*r.chunkBytes[len(r.chunkBytes)-1]) < len(b) {
-		s, err := r.block.chunkPool.Get(len(b))
-		if err != nil {
-			return nil, errors.Wrap(err, "allocate chunk bytes")
-		}
-		r.chunkBytes = append(r.chunkBytes, s)
+	dst, err := r.chunkBytes.Get(len(b))
+	if err != nil {
+		return nil, err
 	}
-	slab := r.chunkBytes[len(r.chunkBytes)-1]
-	*slab = append(*slab, b...)
-	return (*slab)[len(*slab)-len(b):], nil
+	copy(dst, b)
+	return dst, nil
 }
 
 type loadIdx struct {

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -50,7 +50,6 @@ func newBucketChunkReader(ctx context.Context, block *bucketBlock, chunkBytes *p
 
 func (r *bucketChunkReader) Close() error {
 	r.block.pendingReaders.Done()
-	r.chunkBytes.Release()
 	return nil
 }
 

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -132,7 +132,8 @@ func (p *BucketedBytes) Put(b *[]byte) {
 
 // BatchBytes uses a Bytes pool to hand out byte slices, but they don't need to be
 // individually put back into the pool. Instead, they can be all released at once.
-// Additionally, BatchBytes combines results from the other two
+// Additionally, BatchBytes combines results from the other two.
+// BatchBytes is concurrency safe.
 type BatchBytes struct {
 	Delegate Bytes
 


### PR DESCRIPTION
While working on #3355 I needed to share the byte slabs between
multiple chunkReaders. This PR makes it possible.
