### PR TITLE
Refactoring: remove queryStats from bucketChunkReader

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -569,7 +569,7 @@ func blockSeries(
 	)
 	defer span.Finish()
 
-	indexStats := newSafeQueryStats()
+	reqStats := newSafeQueryStats()
 
 	if skipChunks {
 		span.LogKV("msg", "manipulating mint/maxt to cover the entire block as skipChunks=true")
@@ -578,11 +578,11 @@ func blockSeries(
 		res, ok := fetchCachedSeries(ctx, indexr.block.userID, indexr.block.indexCache, indexr.block.meta.ULID, matchers, shard, logger)
 		if ok {
 			span.LogKV("msg", "using cached result", "len", len(res))
-			return newBucketSeriesSet(res), indexStats, nil
+			return newBucketSeriesSet(res), reqStats, nil
 		}
 	}
 
-	ps, err := indexr.ExpandedPostings(ctx, matchers, indexStats)
+	ps, err := indexr.ExpandedPostings(ctx, matchers, reqStats)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "expanded matching posting")
 	}
@@ -596,13 +596,13 @@ func blockSeries(
 	}
 
 	if len(ps) == 0 {
-		return storepb.EmptySeriesSet(), indexStats, nil
+		return storepb.EmptySeriesSet(), reqStats, nil
 	}
 
 	// Preload all series index data.
 	// TODO(bwplotka): Consider not keeping all series in memory all the time.
 	// TODO(bwplotka): Do lazy loading in one step as `ExpandingPostings` method.
-	loadedSeries, err := indexr.preloadSeries(ctx, ps, indexStats)
+	loadedSeries, err := indexr.preloadSeries(ctx, ps, reqStats)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "preload series")
 	}
@@ -625,7 +625,7 @@ func blockSeries(
 		// and then merge it once done. We do it to avoid the lock overhead because loadSeriesForTime()
 		// may be called many times.
 		defer func() {
-			indexStats = indexStats.merge(postingsStats)
+			reqStats.merge(postingsStats)
 		}()
 
 		for _, id := range ps {
@@ -705,14 +705,16 @@ func blockSeries(
 
 	if skipChunks {
 		storeCachedSeries(ctx, indexr.block.indexCache, indexr.block.userID, indexr.block.meta.ULID, matchers, shard, res, logger)
-		return newBucketSeriesSet(res), indexStats.merge(&seriesCacheStats), nil
+		reqStats.merge(&seriesCacheStats)
+		return newBucketSeriesSet(res), reqStats, nil
 	}
 
-	if err := chunkr.load(res, loadAggregates); err != nil {
+	if err := chunkr.load(res, loadAggregates, reqStats); err != nil {
 		return nil, nil, errors.Wrap(err, "load chunks")
 	}
 
-	return newBucketSeriesSet(res), indexStats.merge(chunkr.stats).merge(&seriesCacheStats), nil
+	reqStats.merge(&seriesCacheStats)
+	return newBucketSeriesSet(res), reqStats, nil
 }
 
 type seriesCacheEntry struct {

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -118,14 +118,12 @@ func (s *safeQueryStats) update(fn func(stats *queryStats)) {
 	fn(s.unsafeStats)
 }
 
-// merge the statistics while holding the lock. Returns a new object with the merged statistics.
-func (s *safeQueryStats) merge(o *queryStats) *safeQueryStats {
+// merge the statistics while holding the lock. Statistics are merged in the receiver.
+func (s *safeQueryStats) merge(o *queryStats) {
 	s.unsafeStatsMx.Lock()
 	defer s.unsafeStatsMx.Unlock()
 
-	return &safeQueryStats{
-		unsafeStats: s.unsafeStats.merge(o),
-	}
+	s.unsafeStats = s.unsafeStats.merge(o)
 }
 
 // export returns a copy of the internal statistics.

--- a/pkg/storegateway/stats_test.go
+++ b/pkg/storegateway/stats_test.go
@@ -19,13 +19,13 @@ func TestSafeQueryStats_merge(t *testing.T) {
 		stats.blocksQueried = 2
 	})
 
-	merged := first.merge(second.export())
+	first.merge(second.export())
 
-	// Ensure first is not modified in-place.
-	assert.Equal(t, 1, first.export().blocksQueried)
+	// Ensure first is modified in-place.
+	assert.Equal(t, 3, first.export().blocksQueried)
 
-	// Ensure the returned merged stats are correct.
-	assert.Equal(t, 3, merged.export().blocksQueried)
+	// Ensure second is not modified.
+	assert.Equal(t, 2, second.export().blocksQueried)
 }
 
 func TestSafeQueryStats_export(t *testing.T) {


### PR DESCRIPTION
#### What this PR does
This PR is a follow up of https://github.com/grafana/mimir/pull/3396. In this PR I'm moving `queryStats` out of `bucketChunkReader` (in #3396 I moved it out of `bucketIndexReader`). To make it happen conveniently, I've changed the `safeQueryStats.merge()` contract to do the merging in place.

#### Which issue(s) this PR fixes or relates to

N/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
