### PR TITLE
Read-write deployment mode: add integration test for recording rule evaluation

### DIFF
--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/mimir/integration/e2emimir"
 )
 
-func TestReadWriteMode(t *testing.T) {
+func TestReadWriteModeQuerying(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -12,8 +12,10 @@ import (
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/integration/e2emimir"
 )
@@ -23,7 +25,7 @@ func TestReadWriteModeQuerying(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	c := startReadWriteModeCluster(t, s)
+	c, _ := startReadWriteModeCluster(t, s)
 
 	// Push some data to the cluster.
 	now := time.Now()
@@ -54,23 +56,97 @@ func TestReadWriteModeQuerying(t *testing.T) {
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }
 
-func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario) *e2emimir.Client {
-	minio := e2edb.NewMinio(9000, mimirBucketName)
-	require.NoError(t, s.StartAndWaitReady(minio))
+func TestReadWriteModeRecordingRule(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
 
-	flags := mergeFlags(
-		CommonStorageBackendFlags(),
+	c, backendInstance := startReadWriteModeCluster(
+		t,
+		s,
 		map[string]string{
-			"-memberlist.join": "mimir-backend-1",
+			// Evaluate rules often and with no delay, so that we don't need to wait for metrics to show up.
+			"-ruler.evaluation-interval":       "2s",
+			"-ruler.poll-interval":             "2s",
+			"-ruler.evaluation-delay-duration": "0",
 		},
 	)
 
+	// Create a recording rule
+	record := yaml.Node{}
+	testRuleName := "test_rule"
+	record.SetString(testRuleName)
+
+	expr := yaml.Node{}
+	expr.SetString("sum(test_series)")
+
+	ruleGroup := rulefmt.RuleGroup{
+		Name:     "test_rule_group",
+		Interval: 1,
+		Rules: []rulefmt.RuleNode{
+			{
+				Record: record,
+				Expr:   expr,
+			},
+		},
+	}
+
+	require.NoError(t, c.SetRuleGroup(ruleGroup, "test_rule_group_namespace"))
+
+	require.NoError(t, backendInstance.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
+	ruleEvaluationsBeforePush, err := backendInstance.SumMetrics([]string{"cortex_prometheus_rule_evaluations_total"})
+	require.NoError(t, err)
+
+	// Push data that should be captured by the recording rule
+	pushTime := time.Now()
+	series, _, _ := generateSeries("test_series", pushTime, prompb.Label{Name: "foo", Value: "bar"})
+
+	res, err := c.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	// Wait for recording rule to evaluate
+	require.NoError(t, backendInstance.WaitSumMetrics(e2e.Greater(ruleEvaluationsBeforePush[0]), "cortex_prometheus_rule_evaluations_total"))
+
+	// Verify recorded series is as expected
+	queryTime := time.Now()
+	queryResult, err := c.Query(testRuleName, queryTime)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, queryResult.Type())
+
+	expectedVector := model.Vector{
+		&model.Sample{
+			Metric: model.Metric{
+				labels.MetricName: model.LabelValue(testRuleName),
+			},
+			Value:     model.SampleValue(series[0].Samples[0].Value),
+			Timestamp: model.Time(e2e.TimeToMilliseconds(queryTime)),
+		},
+	}
+
+	require.Equal(t, expectedVector, queryResult.(model.Vector))
+}
+
+func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario, extraFlags ...map[string]string) (c *e2emimir.Client, backendInstance *e2emimir.MimirService) {
+	minio := e2edb.NewMinio(9000, mimirBucketName)
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	flagSets := []map[string]string{
+		CommonStorageBackendFlags(),
+		{
+			"-memberlist.join": "mimir-backend-1",
+		},
+	}
+
+	flagSets = append(flagSets, extraFlags...)
+	flags := mergeFlags(flagSets...)
+
 	readInstance := e2emimir.NewReadInstance("mimir-read-1", flags)
 	writeInstance := e2emimir.NewWriteInstance("mimir-write-1", flags)
-	backendInstance := e2emimir.NewBackendInstance("mimir-backend-1", flags)
+	backendInstance = e2emimir.NewBackendInstance("mimir-backend-1", flags)
 	require.NoError(t, s.StartAndWaitReady(readInstance, writeInstance, backendInstance))
 
-	c, err := e2emimir.NewClient(writeInstance.HTTPEndpoint(), readInstance.HTTPEndpoint(), "", "", "user-1")
+	c, err := e2emimir.NewClient(writeInstance.HTTPEndpoint(), readInstance.HTTPEndpoint(), backendInstance.HTTPEndpoint(), backendInstance.HTTPEndpoint(), "user-1")
 	require.NoError(t, err)
 
 	// Wait for the ingester to join the ring and become active - this prevents "empty ring" errors later when we try to query data.
@@ -80,5 +156,5 @@ func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario) *e2emimir.Client {
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"), labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
 	))
 
-	return c
+	return
 }


### PR DESCRIPTION
#### What this PR does

This PR adds an integration test for recording rule evaluation in read-write deployment mode.

I'm not 100% convinced I've found a robust method to avoid race conditions between setting up the rule, pushing data and then checking the evaluation of the rule - very open to feedback and alternative suggestions.

I will add a separate test for alertmanager in a subsequent PR.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/3363

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
