### PR TITLE
backport GH action: pin to older version

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -14,7 +14,9 @@ jobs:
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions
-          ref: main
+          # pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
+          # we don't want to have the same strict rules for PR labels
+          ref: 514e35ce4c2bb64ee4407749e8b9ae77f42a5d29
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run backport


### PR DESCRIPTION
Pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because we don't
 want to have the same strict rules for PR labels.

It's also probably a better idea to pin the action to a version or a revision so we don't pull in similar bugs from `main`