### PR TITLE
cacheutil: added cache `Delete` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386 #3458
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
-* [ENHANCEMENT] Memcached: added extra `Del`method for cache item invalidation. #3515
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386 #3458
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
+* [ENHANCEMENT] Memcached: added extra `Del`method for cache item invalidation. #3515
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -481,7 +481,6 @@ func (c *memcachedClient) Del(ctx context.Context, key string) error {
 			c.duration.WithLabelValues(opDelete).Observe(time.Since(start).Seconds())
 		}
 		errCh <- err
-		return
 	})
 
 	if errors.Is(err, errMemcachedAsyncBufferFull) {

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -776,7 +776,7 @@ func (c *mockedMemcachedClient) SetAsync(ctx context.Context, key string, value 
 	return nil
 }
 
-func (c *mockedMemcachedClient) Del(_ context.Context, key string) error {
+func (c *mockedMemcachedClient) Delete(_ context.Context, key string) error {
 	delete(c.cache, key)
 
 	return nil

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -776,6 +776,12 @@ func (c *mockedMemcachedClient) SetAsync(ctx context.Context, key string, value 
 	return nil
 }
 
+func (c *mockedMemcachedClient) Del(_ context.Context, key string) error {
+	delete(c.cache, key)
+
+	return nil
+}
+
 func (c *mockedMemcachedClient) Stop() {
 	// Nothing to do.
 }


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Extend `cacheutil.Cache` interface to support invalidation by adding the extra `Delete` method.

The necessity of this arises from the _Object Storage Resilience_ initiative for GEM, as we want to leverage all same memcached logic that is shared across components. 

However, current memcached implementation wasn't designed with invalidation in mind, so the additional method is necessary. 

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
