### PR TITLE
Improve speed of Golang-related Makefile targets when running on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,8 @@ GO_FLAGS := -ldflags "\
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 
-GOVOLUMES=	-v $(shell pwd)/.cache:/go/cache:$(CONTAINER_MOUNT_OPTIONS) \
-			-v $(shell pwd)/.pkg:/go/pkg:$(CONTAINER_MOUNT_OPTIONS) \
+GOVOLUMES=	-v mimir-go-cache:/go/cache \
+			-v mimir-go-pkg:/go/pkg \
 			-v $(shell pwd):/go/src/github.com/grafana/mimir:$(CONTAINER_MOUNT_OPTIONS)
 
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`

--- a/Makefile
+++ b/Makefile
@@ -223,9 +223,6 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
 exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt conftest-test conftest-verify check-helm-tests build-helm-tests: fetch-build-image
-	@mkdir -p $(shell pwd)/.pkg
-	@mkdir -p $(shell pwd)/.cache
-	@echo
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
 
@@ -463,7 +460,8 @@ format-makefiles: $(MAKE_FILES)
 
 clean: ## Cleanup the docker images, object files and executables.
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true
-	rm -rf -- $(UPTODATE_FILES) $(EXES) .cache dist
+	$(SUDO) docker volume rm -f mimir-go-pkg mimir-go-cache
+	rm -rf -- $(UPTODATE_FILES) $(EXES) dist
 	# Remove executables built for multiarch images.
 	find . -type f -name '*_linux_arm64' -perm +u+x -exec rm {} \;
 	find . -type f -name '*_linux_amd64' -perm +u+x -exec rm {} \;
@@ -497,7 +495,7 @@ reference-help: cmd/mimir/mimir
 	@(go run ./tools/config-inspector || true) > cmd/mimir/config-descriptor.json
 
 clean-white-noise: ## Clean the white noise in the markdown files.
-	@find . -path ./.pkg -prune -o -path "*/vendor/*" -prune -or -type f -name "*.md" -print | \
+	@find . -path ./.pkg -prune -o -path ./.cache -prune -o -path "*/vendor/*" -prune -or -type f -name "*.md" -print | \
 	SED_BIN="$(SED)" xargs ./tools/cleanup-white-noise.sh
 
 check-white-noise: ## Check the white noise in the markdown files.
@@ -592,8 +590,6 @@ ifeq ($(PACKAGE_IN_CONTAINER), true)
 
 .PHONY: packages
 packages: dist packaging/fpm/$(UPTODATE)
-	@mkdir -p $(shell pwd)/.pkg
-	@mkdir -p $(shell pwd)/.cache
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) \
 		-v  $(shell pwd):/go/src/github.com/grafana/mimir:$(CONTAINER_MOUNT_OPTIONS) \


### PR DESCRIPTION
Alternate title: improve the speed of our local builds by 30-40% with this one neat trick

#### What this PR does

Currently, our `Makefile` runs most targets (builds, tests etc.) within a container. To avoid needing to recompile everything for every `make` invocation, we [mount a directory](https://github.com/grafana/mimir/blob/2275d9b0a232ea964cb4809ab62e00a42b64fcb3/Makefile#L218) from the host machine into this container for [Go's cache](https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching).

However, file I/O latency between a container and a macOS host's filesystem is relatively high with Docker Desktop on macOS hosts ([reference 1](https://github.com/docker/roadmap/issues/7), [reference 2](https://github.com/docker/for-mac/issues/77)). Despite recent improvements in Docker Desktop, this increased latency makes these targets slower than they need to be.

This PR replaces the use of a mounted directory with a Docker volume. Volumes do not have the same latency issues on macOS hosts (they remain within the Linux VM), and perform just as well as a mounted directory on Linux hosts.

For example, this change improves the performance of `make cmd/mimir/mimir` with no code changes by ~30% on my machine (from 11.3s to 7.8s), and shaves ~40% off the time for `make test` with cached results (from 22.7s to 13.8s).

<details>

##### Before

```
$ make cmd/mimir/mimir
docker pull grafana/mimir-build-image:chore-upgrade-go-036177f2f
chore-upgrade-go-036177f2f: Pulling from grafana/mimir-build-image
Digest: sha256:32b19d51465d633b684e605fd37513fc1633712aecc7d5b4a9f0989c45b8da26
Status: Image is up to date for grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker.io/grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker tag grafana/mimir-build-image:chore-upgrade-go-036177f2f grafana/mimir-build-image:latest
touch mimir-build-image/.uptodate

>>>> Entering build container: protos
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.cache:/go/cache:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.pkg:/go/pkg:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" protos;
make: Entering directory '/go/src/github.com/grafana/mimir'
make: Nothing to be done for 'protos'.
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m2.434s
user	0m0.037s
sys	0m0.017s

>>>> Entering build container: cmd/mimir/mimir
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.cache:/go/cache:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.pkg:/go/pkg:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" cmd/mimir/mimir;
make: Entering directory '/go/src/github.com/grafana/mimir'
CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags " -X github.com/grafana/mimir/pkg/util/version.Branch=main -X github.com/grafana/mimir/pkg/util/version.Revision=2275d9b0a -X github.com/grafana/mimir/pkg/util/version.Version=2.4.0 -extldflags \"-static\" -s -w" -tags netgo -o "cmd/mimir/mimir" ./cmd/mimir
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m11.330s
user	0m0.035s
sys	0m0.021s

$ make test
docker pull grafana/mimir-build-image:chore-upgrade-go-036177f2f
chore-upgrade-go-036177f2f: Pulling from grafana/mimir-build-image
Digest: sha256:32b19d51465d633b684e605fd37513fc1633712aecc7d5b4a9f0989c45b8da26
Status: Image is up to date for grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker.io/grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker tag grafana/mimir-build-image:chore-upgrade-go-036177f2f grafana/mimir-build-image:latest
touch mimir-build-image/.uptodate

>>>> Entering build container: protos
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.cache:/go/cache:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.pkg:/go/pkg:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" protos;
make: Entering directory '/go/src/github.com/grafana/mimir'
make: Nothing to be done for 'protos'.
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m2.384s
user	0m0.040s
sys	0m0.021s

>>>> Entering build container: test
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.cache:/go/cache:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir/.pkg:/go/pkg:delegated,z -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" test;
make: Entering directory '/go/src/github.com/grafana/mimir'
go test -timeout 30m ./...
ok  	github.com/grafana/mimir/cmd/metaconvert	(cached)
ok  	github.com/grafana/mimir/cmd/mimir	(cached)
?   	github.com/grafana/mimir/cmd/mimir-continuous-test	[no test files]
?   	github.com/grafana/mimir/cmd/mimirtool	[no test files]
ok  	github.com/grafana/mimir/cmd/query-tee	(cached)
?   	github.com/grafana/mimir/integration	[no test files]
?   	github.com/grafana/mimir/integration/ca	[no test files]
?   	github.com/grafana/mimir/integration/e2emimir	[no test files]
ok  	github.com/grafana/mimir/operations/compare-helm-with-jsonnet/plugins/resolve-config	(cached)
ok  	github.com/grafana/mimir/pkg/alertmanager	(cached)
?   	github.com/grafana/mimir/pkg/alertmanager/alertmanagerpb	[no test files]
?   	github.com/grafana/mimir/pkg/alertmanager/alertspb	[no test files]
ok  	github.com/grafana/mimir/pkg/alertmanager/alertstore	(cached)
ok  	github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient	(cached) [no tests to run]
ok  	github.com/grafana/mimir/pkg/alertmanager/alertstore/local	(cached)
ok  	github.com/grafana/mimir/pkg/alertmanager/merger	(cached)
ok  	github.com/grafana/mimir/pkg/api	(cached)
?   	github.com/grafana/mimir/pkg/api/error	[no test files]
ok  	github.com/grafana/mimir/pkg/cache	(cached)
?   	github.com/grafana/mimir/pkg/cacheutil	[no test files]
ok  	github.com/grafana/mimir/pkg/compactor	(cached)
ok  	github.com/grafana/mimir/pkg/continuoustest	(cached)
ok  	github.com/grafana/mimir/pkg/distributor	(cached)
?   	github.com/grafana/mimir/pkg/distributor/distributorpb	[no test files]
ok  	github.com/grafana/mimir/pkg/distributor/forwarding	(cached)
?   	github.com/grafana/mimir/pkg/flusher	[no test files]
ok  	github.com/grafana/mimir/pkg/frontend	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/querymiddleware	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/transport	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/v1	(cached)
?   	github.com/grafana/mimir/pkg/frontend/v1/frontendv1pb	[no test files]
ok  	github.com/grafana/mimir/pkg/frontend/v2	(cached)
?   	github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb	[no test files]
ok  	github.com/grafana/mimir/pkg/ingester	(cached)
ok  	github.com/grafana/mimir/pkg/ingester/activeseries	(cached)
ok  	github.com/grafana/mimir/pkg/ingester/client	(cached)
ok  	github.com/grafana/mimir/pkg/mimir	(cached)
ok  	github.com/grafana/mimir/pkg/mimirpb	(cached)
?   	github.com/grafana/mimir/pkg/mimirtool/analyze	[no test files]
?   	github.com/grafana/mimir/pkg/mimirtool/backfill	[no test files]
ok  	github.com/grafana/mimir/pkg/mimirtool/client	(cached)
ok  	github.com/grafana/mimir/pkg/mimirtool/commands	(cached)
ok  	github.com/grafana/mimir/pkg/mimirtool/config	(cached)
?   	github.com/grafana/mimir/pkg/mimirtool/minisdk	[no test files]
ok  	github.com/grafana/mimir/pkg/mimirtool/printer	(cached)
ok  	github.com/grafana/mimir/pkg/mimirtool/rules	(cached)
?   	github.com/grafana/mimir/pkg/mimirtool/rules/rwrulefmt	[no test files]
?   	github.com/grafana/mimir/pkg/mimirtool/version	[no test files]
ok  	github.com/grafana/mimir/pkg/querier	(cached)
ok  	github.com/grafana/mimir/pkg/querier/batch	(cached)
ok  	github.com/grafana/mimir/pkg/querier/engine	(cached)
ok  	github.com/grafana/mimir/pkg/querier/iterators	(cached)
ok  	github.com/grafana/mimir/pkg/querier/stats	(cached)
ok  	github.com/grafana/mimir/pkg/querier/tenantfederation	(cached)
ok  	github.com/grafana/mimir/pkg/querier/worker	(cached)
ok  	github.com/grafana/mimir/pkg/ruler	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulespb	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulestore	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulestore/bucketclient	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulestore/local	(cached)
ok  	github.com/grafana/mimir/pkg/scheduler	(cached)
ok  	github.com/grafana/mimir/pkg/scheduler/queue	(cached)
ok  	github.com/grafana/mimir/pkg/scheduler/schedulerdiscovery	(cached)
?   	github.com/grafana/mimir/pkg/scheduler/schedulerpb	[no test files]
ok  	github.com/grafana/mimir/pkg/shipper	(cached)
ok  	github.com/grafana/mimir/pkg/storage/bucket	(cached)
?   	github.com/grafana/mimir/pkg/storage/bucket/azure	[no test files]
?   	github.com/grafana/mimir/pkg/storage/bucket/filesystem	[no test files]
?   	github.com/grafana/mimir/pkg/storage/bucket/gcs	[no test files]
ok  	github.com/grafana/mimir/pkg/storage/bucket/s3	(cached)
?   	github.com/grafana/mimir/pkg/storage/bucket/swift	[no test files]
ok  	github.com/grafana/mimir/pkg/storage/chunk	(cached)
?   	github.com/grafana/mimir/pkg/storage/lazyquery	[no test files]
ok  	github.com/grafana/mimir/pkg/storage/series	(cached)
ok  	github.com/grafana/mimir/pkg/storage/sharding	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb/block	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb/bucketcache	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb/bucketindex	(cached)
?   	github.com/grafana/mimir/pkg/storage/tsdb/metadata	[no test files]
?   	github.com/grafana/mimir/pkg/storage/tsdb/testutil	[no test files]
ok  	github.com/grafana/mimir/pkg/storegateway	(cached)
?   	github.com/grafana/mimir/pkg/storegateway/hintspb	[no test files]
ok  	github.com/grafana/mimir/pkg/storegateway/indexcache	(cached)
ok  	github.com/grafana/mimir/pkg/storegateway/indexheader	(cached)
?   	github.com/grafana/mimir/pkg/storegateway/indexheader/fileutil	[no test files]
?   	github.com/grafana/mimir/pkg/storegateway/storegatewaypb	[no test files]
?   	github.com/grafana/mimir/pkg/storegateway/storepb	[no test files]
?   	github.com/grafana/mimir/pkg/storegateway/testhelper	[no test files]
ok  	github.com/grafana/mimir/pkg/usagestats	(cached)
ok  	github.com/grafana/mimir/pkg/util	(cached)
ok  	github.com/grafana/mimir/pkg/util/activitytracker	(cached)
?   	github.com/grafana/mimir/pkg/util/chunkcompat	[no test files]
?   	github.com/grafana/mimir/pkg/util/extprom	[no test files]
?   	github.com/grafana/mimir/pkg/util/extract	[no test files]
?   	github.com/grafana/mimir/pkg/util/fieldcategory	[no test files]
?   	github.com/grafana/mimir/pkg/util/fs	[no test files]
ok  	github.com/grafana/mimir/pkg/util/gate	(cached)
ok  	github.com/grafana/mimir/pkg/util/globalerror	(cached)
ok  	github.com/grafana/mimir/pkg/util/gziphandler	(cached)
ok  	github.com/grafana/mimir/pkg/util/httpgrpcutil	(cached)
ok  	github.com/grafana/mimir/pkg/util/instrumentation	(cached)
ok  	github.com/grafana/mimir/pkg/util/limiter	(cached)
?   	github.com/grafana/mimir/pkg/util/listblocks	[no test files]
ok  	github.com/grafana/mimir/pkg/util/log	(cached)
ok  	github.com/grafana/mimir/pkg/util/math	(cached)
ok  	github.com/grafana/mimir/pkg/util/net	(cached)
?   	github.com/grafana/mimir/pkg/util/noauth	[no test files]
ok  	github.com/grafana/mimir/pkg/util/pool	(cached)
ok  	github.com/grafana/mimir/pkg/util/process	(cached)
ok  	github.com/grafana/mimir/pkg/util/push	(cached)
ok  	github.com/grafana/mimir/pkg/util/servicediscovery	(cached)
?   	github.com/grafana/mimir/pkg/util/spanlogger	[no test files]
?   	github.com/grafana/mimir/pkg/util/test	[no test files]
?   	github.com/grafana/mimir/pkg/util/usage	[no test files]
ok  	github.com/grafana/mimir/pkg/util/validation	(cached)
ok  	github.com/grafana/mimir/pkg/util/version	(cached)
?   	github.com/grafana/mimir/tools/add-license	[no test files]
?   	github.com/grafana/mimir/tools/compaction-planner	[no test files]
ok  	github.com/grafana/mimir/tools/config-inspector	(cached)
?   	github.com/grafana/mimir/tools/copyblocks	[no test files]
?   	github.com/grafana/mimir/tools/doc-generator	[no test files]
ok  	github.com/grafana/mimir/tools/doc-generator/parse	(cached)
?   	github.com/grafana/mimir/tools/list-deduplicated-blocks	[no test files]
?   	github.com/grafana/mimir/tools/listblocks	[no test files]
?   	github.com/grafana/mimir/tools/markblocks	[no test files]
?   	github.com/grafana/mimir/tools/pre-pull-images	[no test files]
?   	github.com/grafana/mimir/tools/query-step-alignment-analysis	[no test files]
ok  	github.com/grafana/mimir/tools/querytee	(cached)
?   	github.com/grafana/mimir/tools/tenant-injector	[no test files]
?   	github.com/grafana/mimir/tools/trafficdump	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-chunks	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-compact	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-index	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-index-health	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-index-toc	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-print-chunk	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-symbols	[no test files]
?   	github.com/grafana/mimir/tools/ulidtime	[no test files]
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m22.741s
user	0m0.036s
sys	0m0.024s
```

##### After 

```
$ make cmd/mimir/mimir
docker pull grafana/mimir-build-image:chore-upgrade-go-036177f2f
chore-upgrade-go-036177f2f: Pulling from grafana/mimir-build-image
Digest: sha256:32b19d51465d633b684e605fd37513fc1633712aecc7d5b4a9f0989c45b8da26
Status: Image is up to date for grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker.io/grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker tag grafana/mimir-build-image:chore-upgrade-go-036177f2f grafana/mimir-build-image:latest
touch mimir-build-image/.uptodate

>>>> Entering build container: protos
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v mimir-go-cache:/go/cache -v mimir-go-pkg:/go/pkg -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" protos;
make: Entering directory '/go/src/github.com/grafana/mimir'
make: Nothing to be done for 'protos'.
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m2.344s
user	0m0.038s
sys	0m0.022s

>>>> Entering build container: cmd/mimir/mimir
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v mimir-go-cache:/go/cache -v mimir-go-pkg:/go/pkg -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" cmd/mimir/mimir;
make: Entering directory '/go/src/github.com/grafana/mimir'
CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags " -X github.com/grafana/mimir/pkg/util/version.Branch=main -X github.com/grafana/mimir/pkg/util/version.Revision=2275d9b0a -X github.com/grafana/mimir/pkg/util/version.Version=2.4.0 -extldflags \"-static\" -s -w" -tags netgo -o "cmd/mimir/mimir" ./cmd/mimir
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m7.802s
user	0m0.036s
sys	0m0.023s

$ make test
docker pull grafana/mimir-build-image:chore-upgrade-go-036177f2f
chore-upgrade-go-036177f2f: Pulling from grafana/mimir-build-image
Digest: sha256:32b19d51465d633b684e605fd37513fc1633712aecc7d5b4a9f0989c45b8da26
Status: Image is up to date for grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker.io/grafana/mimir-build-image:chore-upgrade-go-036177f2f
docker tag grafana/mimir-build-image:chore-upgrade-go-036177f2f grafana/mimir-build-image:latest
touch mimir-build-image/.uptodate

>>>> Entering build container: protos
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v mimir-go-cache:/go/cache -v mimir-go-pkg:/go/pkg -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" protos;
make: Entering directory '/go/src/github.com/grafana/mimir'
make: Nothing to be done for 'protos'.
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m2.388s
user	0m0.036s
sys	0m0.019s

>>>> Entering build container: test
time docker run --rm --tty -i -v ~/.ssh/:/root/.ssh:delegated,z -v mimir-go-cache:/go/cache -v mimir-go-pkg:/go/pkg -v /Users/charleskorn/Repositories/Grafana/mimir:/go/src/github.com/grafana/mimir:delegated,z grafana/mimir-build-image GOOS=darwin GOARCH=arm64 BINARY_SUFFIX="" test;
make: Entering directory '/go/src/github.com/grafana/mimir'
go test -timeout 30m ./...
ok  	github.com/grafana/mimir/cmd/metaconvert	(cached)
ok  	github.com/grafana/mimir/cmd/mimir	(cached)
?   	github.com/grafana/mimir/cmd/mimir-continuous-test	[no test files]
?   	github.com/grafana/mimir/cmd/mimirtool	[no test files]
ok  	github.com/grafana/mimir/cmd/query-tee	(cached)
?   	github.com/grafana/mimir/integration	[no test files]
?   	github.com/grafana/mimir/integration/ca	[no test files]
?   	github.com/grafana/mimir/integration/e2emimir	[no test files]
ok  	github.com/grafana/mimir/operations/compare-helm-with-jsonnet/plugins/resolve-config	(cached)
ok  	github.com/grafana/mimir/pkg/alertmanager	(cached)
?   	github.com/grafana/mimir/pkg/alertmanager/alertmanagerpb	[no test files]
?   	github.com/grafana/mimir/pkg/alertmanager/alertspb	[no test files]
ok  	github.com/grafana/mimir/pkg/alertmanager/alertstore	(cached)
ok  	github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient	(cached) [no tests to run]
ok  	github.com/grafana/mimir/pkg/alertmanager/alertstore/local	(cached)
ok  	github.com/grafana/mimir/pkg/alertmanager/merger	(cached)
ok  	github.com/grafana/mimir/pkg/api	(cached)
?   	github.com/grafana/mimir/pkg/api/error	[no test files]
ok  	github.com/grafana/mimir/pkg/cache	(cached)
?   	github.com/grafana/mimir/pkg/cacheutil	[no test files]
ok  	github.com/grafana/mimir/pkg/compactor	(cached)
ok  	github.com/grafana/mimir/pkg/continuoustest	(cached)
ok  	github.com/grafana/mimir/pkg/distributor	(cached)
?   	github.com/grafana/mimir/pkg/distributor/distributorpb	[no test files]
ok  	github.com/grafana/mimir/pkg/distributor/forwarding	(cached)
?   	github.com/grafana/mimir/pkg/flusher	[no test files]
ok  	github.com/grafana/mimir/pkg/frontend	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/querymiddleware	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/transport	(cached)
ok  	github.com/grafana/mimir/pkg/frontend/v1	(cached)
?   	github.com/grafana/mimir/pkg/frontend/v1/frontendv1pb	[no test files]
ok  	github.com/grafana/mimir/pkg/frontend/v2	(cached)
?   	github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb	[no test files]
ok  	github.com/grafana/mimir/pkg/ingester	(cached)
ok  	github.com/grafana/mimir/pkg/ingester/activeseries	(cached)
ok  	github.com/grafana/mimir/pkg/ingester/client	(cached)
ok  	github.com/grafana/mimir/pkg/mimir	(cached)
ok  	github.com/grafana/mimir/pkg/mimirpb	(cached)
?   	github.com/grafana/mimir/pkg/mimirtool/analyze	[no test files]
?   	github.com/grafana/mimir/pkg/mimirtool/backfill	[no test files]
ok  	github.com/grafana/mimir/pkg/mimirtool/client	(cached)
ok  	github.com/grafana/mimir/pkg/mimirtool/commands	(cached)
ok  	github.com/grafana/mimir/pkg/mimirtool/config	(cached)
?   	github.com/grafana/mimir/pkg/mimirtool/minisdk	[no test files]
ok  	github.com/grafana/mimir/pkg/mimirtool/printer	(cached)
ok  	github.com/grafana/mimir/pkg/mimirtool/rules	(cached)
?   	github.com/grafana/mimir/pkg/mimirtool/rules/rwrulefmt	[no test files]
?   	github.com/grafana/mimir/pkg/mimirtool/version	[no test files]
ok  	github.com/grafana/mimir/pkg/querier	(cached)
ok  	github.com/grafana/mimir/pkg/querier/batch	(cached)
ok  	github.com/grafana/mimir/pkg/querier/engine	(cached)
ok  	github.com/grafana/mimir/pkg/querier/iterators	(cached)
ok  	github.com/grafana/mimir/pkg/querier/stats	(cached)
ok  	github.com/grafana/mimir/pkg/querier/tenantfederation	(cached)
ok  	github.com/grafana/mimir/pkg/querier/worker	(cached)
ok  	github.com/grafana/mimir/pkg/ruler	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulespb	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulestore	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulestore/bucketclient	(cached)
ok  	github.com/grafana/mimir/pkg/ruler/rulestore/local	(cached)
ok  	github.com/grafana/mimir/pkg/scheduler	(cached)
ok  	github.com/grafana/mimir/pkg/scheduler/queue	(cached)
ok  	github.com/grafana/mimir/pkg/scheduler/schedulerdiscovery	(cached)
?   	github.com/grafana/mimir/pkg/scheduler/schedulerpb	[no test files]
ok  	github.com/grafana/mimir/pkg/shipper	(cached)
ok  	github.com/grafana/mimir/pkg/storage/bucket	(cached)
?   	github.com/grafana/mimir/pkg/storage/bucket/azure	[no test files]
?   	github.com/grafana/mimir/pkg/storage/bucket/filesystem	[no test files]
?   	github.com/grafana/mimir/pkg/storage/bucket/gcs	[no test files]
ok  	github.com/grafana/mimir/pkg/storage/bucket/s3	(cached)
?   	github.com/grafana/mimir/pkg/storage/bucket/swift	[no test files]
ok  	github.com/grafana/mimir/pkg/storage/chunk	(cached)
?   	github.com/grafana/mimir/pkg/storage/lazyquery	[no test files]
ok  	github.com/grafana/mimir/pkg/storage/series	(cached)
ok  	github.com/grafana/mimir/pkg/storage/sharding	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb/block	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb/bucketcache	(cached)
ok  	github.com/grafana/mimir/pkg/storage/tsdb/bucketindex	(cached)
?   	github.com/grafana/mimir/pkg/storage/tsdb/metadata	[no test files]
?   	github.com/grafana/mimir/pkg/storage/tsdb/testutil	[no test files]
ok  	github.com/grafana/mimir/pkg/storegateway	(cached)
?   	github.com/grafana/mimir/pkg/storegateway/hintspb	[no test files]
ok  	github.com/grafana/mimir/pkg/storegateway/indexcache	(cached)
ok  	github.com/grafana/mimir/pkg/storegateway/indexheader	(cached)
?   	github.com/grafana/mimir/pkg/storegateway/indexheader/fileutil	[no test files]
?   	github.com/grafana/mimir/pkg/storegateway/storegatewaypb	[no test files]
?   	github.com/grafana/mimir/pkg/storegateway/storepb	[no test files]
?   	github.com/grafana/mimir/pkg/storegateway/testhelper	[no test files]
ok  	github.com/grafana/mimir/pkg/usagestats	(cached)
ok  	github.com/grafana/mimir/pkg/util	(cached)
ok  	github.com/grafana/mimir/pkg/util/activitytracker	(cached)
?   	github.com/grafana/mimir/pkg/util/chunkcompat	[no test files]
?   	github.com/grafana/mimir/pkg/util/extprom	[no test files]
?   	github.com/grafana/mimir/pkg/util/extract	[no test files]
?   	github.com/grafana/mimir/pkg/util/fieldcategory	[no test files]
?   	github.com/grafana/mimir/pkg/util/fs	[no test files]
ok  	github.com/grafana/mimir/pkg/util/gate	(cached)
ok  	github.com/grafana/mimir/pkg/util/globalerror	(cached)
ok  	github.com/grafana/mimir/pkg/util/gziphandler	(cached)
ok  	github.com/grafana/mimir/pkg/util/httpgrpcutil	(cached)
ok  	github.com/grafana/mimir/pkg/util/instrumentation	(cached)
ok  	github.com/grafana/mimir/pkg/util/limiter	(cached)
?   	github.com/grafana/mimir/pkg/util/listblocks	[no test files]
ok  	github.com/grafana/mimir/pkg/util/log	(cached)
ok  	github.com/grafana/mimir/pkg/util/math	(cached)
ok  	github.com/grafana/mimir/pkg/util/net	(cached)
?   	github.com/grafana/mimir/pkg/util/noauth	[no test files]
ok  	github.com/grafana/mimir/pkg/util/pool	(cached)
ok  	github.com/grafana/mimir/pkg/util/process	(cached)
ok  	github.com/grafana/mimir/pkg/util/push	(cached)
ok  	github.com/grafana/mimir/pkg/util/servicediscovery	(cached)
?   	github.com/grafana/mimir/pkg/util/spanlogger	[no test files]
?   	github.com/grafana/mimir/pkg/util/test	[no test files]
?   	github.com/grafana/mimir/pkg/util/usage	[no test files]
ok  	github.com/grafana/mimir/pkg/util/validation	(cached)
ok  	github.com/grafana/mimir/pkg/util/version	(cached)
?   	github.com/grafana/mimir/tools/add-license	[no test files]
?   	github.com/grafana/mimir/tools/compaction-planner	[no test files]
ok  	github.com/grafana/mimir/tools/config-inspector	(cached)
?   	github.com/grafana/mimir/tools/copyblocks	[no test files]
?   	github.com/grafana/mimir/tools/doc-generator	[no test files]
ok  	github.com/grafana/mimir/tools/doc-generator/parse	(cached)
?   	github.com/grafana/mimir/tools/list-deduplicated-blocks	[no test files]
?   	github.com/grafana/mimir/tools/listblocks	[no test files]
?   	github.com/grafana/mimir/tools/markblocks	[no test files]
?   	github.com/grafana/mimir/tools/pre-pull-images	[no test files]
?   	github.com/grafana/mimir/tools/query-step-alignment-analysis	[no test files]
ok  	github.com/grafana/mimir/tools/querytee	(cached)
?   	github.com/grafana/mimir/tools/tenant-injector	[no test files]
?   	github.com/grafana/mimir/tools/trafficdump	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-chunks	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-compact	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-index	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-index-health	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-index-toc	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-print-chunk	[no test files]
?   	github.com/grafana/mimir/tools/tsdb-symbols	[no test files]
?   	github.com/grafana/mimir/tools/ulidtime	[no test files]
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	0m13.796s
user	0m0.037s
sys	0m0.031s
```

---

</details>



We also [mount a directory](https://github.com/grafana/mimir/blob/2275d9b0a232ea964cb4809ab62e00a42b64fcb3/Makefile#L219) for downloaded packages, which seems unused given we vendor our dependencies. I've converted this to use a volume as well for completeness, but we may be able to remove this altogether.

The only drawback of this approach is that it makes it slightly harder to clear the cache (instead of `rm -rf .cache`, you'd need to run `docker volume rm mimir-go-cache`).

A future improvement would be to do something similar for `golangci-lint`, as it maintains its [own cache directory](https://golangci-lint.run/usage/configuration/#cache) which we're not persisting at all at the moment.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
