### PR TITLE
Refactoring: simplify BucketStore.Series()

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -871,15 +871,15 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		}
 	}
 
+	gspan, gctx := tracing.StartSpan(gctx, "bucket_store_preload_all")
+
+	s.mtx.RLock()
+
 	// Find all blocks owned by this store-gateway instance and matching the request.
 	blocks := s.blockSet.getFor(req.MinTime, req.MaxTime, req.MaxResolutionWindow, reqBlockMatchers)
 	if s.debugLogging {
 		debugFoundBlockSetOverview(s.logger, req.MinTime, req.MaxTime, req.MaxResolutionWindow, blocks)
 	}
-
-	gspan, gctx := tracing.StartSpan(gctx, "bucket_store_preload_all")
-
-	s.mtx.RLock()
 
 	chunkBytes := &pool.BatchBytes{Delegate: s.chunkPool}
 	defer chunkBytes.Release()


### PR DESCRIPTION
#### What this PR does
This is a refactoring PR which aims to simplify #3540. My take in this PR is that `s.mtx.RLock()` it not required to log to `spanLogger`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
