### PR TITLE
Improve TestMergedBatchSet

### DIFF
--- a/pkg/storegateway/batch_series.go
+++ b/pkg/storegateway/batch_series.go
@@ -659,9 +659,9 @@ func nextUniqueEntry(a, b *unloadedBatchIterator) (toReturn unloadedBatchEntry, 
 		return toReturn, true
 	}
 
-	// Both a and b contains the same series. Go through all chunks, remove duplicates and concatenate chunks from both
-	// series sets. We best effortly assume chunks are sorted by min time. If not, we will not detect all deduplicate which will
-	// be account on select layer anyway. We do it still for early optimization.
+	// Both a and b contains the same series. Go through all chunk references and concatenate them from both
+	// series sets. We best effortly assume chunk references are sorted by min time, so that the sorting by min
+	// time is honored in the returned chunk references too.
 	toReturn.lset = lsetA
 
 	// Slice reuse is not generally safe with nested merge iterators.

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -99,6 +99,8 @@ func TestMergedBatchSet(t *testing.T) {
 		c = append(c, unloadedChunk{
 			BlockID: ulid.MustNew(uint64(i), nil),
 			Ref:     chunks.ChunkRef(i),
+			MinTime: int64(i),
+			MaxTime: int64(i),
 		})
 	}
 
@@ -142,7 +144,7 @@ func TestMergedBatchSet(t *testing.T) {
 			}),
 			expectedBatches: []unloadedBatch{
 				{Entries: []unloadedBatchEntry{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[1]}},
 					{lset: labels.FromStrings("l1", "v2"), chunks: []unloadedChunk{c[0], c[0], c[2], c[3]}},
 				}},
 			},
@@ -238,6 +240,42 @@ func TestMergedBatchSet(t *testing.T) {
 			},
 			expectedErr: "something went wrong",
 		},
+		"should return merged chunks sorted by min time (assuming source sets have sorted chunks) on first chunk on first set": {
+			batchSize: 100,
+			set1: newSliceUnloadedBatchSet(nil, unloadedBatch{
+				Entries: []unloadedBatchEntry{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[1], c[3]}},
+				},
+			}),
+			set2: newSliceUnloadedBatchSet(nil, unloadedBatch{
+				Entries: []unloadedBatchEntry{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[0], c[2]}},
+				},
+			}),
+			expectedBatches: []unloadedBatch{
+				{Entries: []unloadedBatchEntry{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[0], c[1], c[2], c[3]}},
+				}},
+			},
+		},
+		"should return merged chunks sorted by min time (assuming source sets have sorted chunks) on first chunk on second set": {
+			batchSize: 100,
+			set1: newSliceUnloadedBatchSet(nil, unloadedBatch{
+				Entries: []unloadedBatchEntry{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[0], c[3]}},
+				},
+			}),
+			set2: newSliceUnloadedBatchSet(nil, unloadedBatch{
+				Entries: []unloadedBatchEntry{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[1], c[2]}},
+				},
+			}),
+			expectedBatches: []unloadedBatch{
+				{Entries: []unloadedBatchEntry{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []unloadedChunk{c[0], c[1], c[2], c[3]}},
+				}},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -256,9 +294,9 @@ func TestMergedBatchSet(t *testing.T) {
 			assert.Len(t, batches, len(testCase.expectedBatches))
 			for batchIdx, expectedBatch := range testCase.expectedBatches {
 				assert.Len(t, batches[batchIdx].Entries, len(expectedBatch.Entries))
-				for entryIdx, entry := range expectedBatch.Entries {
-					assert.Len(t, batches[batchIdx].Entries[entryIdx].chunks, len(entry.chunks))
-					assert.Zero(t, labels.Compare(batches[batchIdx].Entries[entryIdx].lset, entry.lset), "series labels don't match")
+				for expectedSeriesIdx, expectedSeries := range expectedBatch.Entries {
+					assert.Equal(t, expectedSeries.lset, batches[batchIdx].Entries[expectedSeriesIdx].lset)
+					assert.Equal(t, expectedSeries.chunks, batches[batchIdx].Entries[expectedSeriesIdx].chunks)
 				}
 			}
 		})


### PR DESCRIPTION
#### What this PR does
This PR is expected to be merged on https://github.com/grafana/mimir/pull/3355 branch (not `main`).

This is really a nit. Since we expect chunks to be sorted by min time, I'm creating fixture batches with sorted chunks and adding a couple of explicit test cases to test it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
