### PR TITLE
add missing entries and release section to changelog in preparation for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Grafana Mimir - main / unreleased
 
+## 2.5.0
+
 ### Grafana Mimir
 
 * [CHANGE] Flag `-azure.msi-resource` is now ignored, and will be removed in Mimir 2.7. This setting is now made automatically by Azure. #2682

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * [CHANGE] The default value of `-server.http-write-timeout` has changed from 30s to 2m. #3346
 * [CHANGE] Reduce period of health checks in connection pools for querier->store-gateway, ruler->ruler, and alertmanager->alertmanager clients to 10s. This reduces the time to fail a gRPC call when the remote stops responding. #3168
 * [CHANGE] Hide TSDB block ranges period config from doc and mark it experimental. #3518
-* [CHANGE] Chore: use upstream rules.SendAlerts(). #3271
 * [FEATURE] Alertmanager: added Discord support. #3309
 * [ENHANCEMENT] Added `-server.tls-min-version` and `-server.tls-cipher-suites` flags to configure cipher suites and min TLS version supported by HTTP and gRPC servers. #2898
 * [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3113
@@ -23,7 +22,7 @@
 * [ENHANCEMENT] Added `-usage-stats.installation-mode` configuration to track the installation mode via the anonymous usage statistics. #3244
 * [ENHANCEMENT] Compactor: Add new `cortex_compactor_block_max_time_delta_seconds` histogram for detecting if compaction of blocks is lagging behind. #3240 #3429
 * [ENHANCEMENT] Ingester: reduced the memory footprint of active series custom trackers. #2568
-* [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283
+* [ENHANCEMENT] Distributor: Include `X-Scope-OrgId` header in requests forwarded to configured forwarding endpoint. #3283 #3385
 * [ENHANCEMENT] Alertmanager: reduced memory utilization in Mimir clusters with a large number of tenants. #3309
 * [ENHANCEMENT] Add experimental flag `-shutdown-delay` to allow components to wait after receiving SIGTERM and before stopping. In this time the component returns 503 from /ready endpoint. #3298
 * [ENHANCEMENT] Go: update to go 1.19.3. #3371
@@ -33,7 +32,7 @@
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386 #3458
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
-* [ENHANCEMENT] Store-gateway: index stats response. #3206
+* [ENHANCEMENT] Query-frontend: added "fetched index bytes" to query statistics, so that the statistics contain the total bytes read by store-gateways from TSDB block indexes. #3206
 * [ENHANCEMENT] Distributor: push wrapper should only receive unforwarded samples. #2980
 * [ENHANCEMENT] Ruler: Added `ruler.tls-enabled` configuration for alertmanager client. #3432
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
@@ -43,7 +42,6 @@
 * [BUGFIX] Ruler: persist evaluation delay configured in the rulegroup. #3392
 * [BUGFIX] Ring status pages: show 100% ownership as "100%", not "1e+02%". #3435
 * [BUGFIX] Fix panics in OTLP ingest path when parse errors exist. #3538
-* [BUGFIX] Canonicalize orgid header in forwarding. #3385
 
 ### Mixin
 
@@ -158,7 +156,6 @@
 * [FEATURE] Add `copyblocks` tool, to copy Mimir blocks between two GCS buckets. #3264
 * [ENHANCEMENT] copyblocks: copy no-compact global markers and optimize min time filter check. #3268
 * [ENHANCEMENT] Mimir rules GitHub action: Added the ability to change default value of `label` when running `prepare` command. #3236
-* [ENHANCEMENT] Use delve compatible with Go 1.19.2. #3166
 * [BUGFIX] Mimir rules Github action: Fix single line output. #3421
 
 ## 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386 #3458
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
-* [ENHANCEMENT] Store-gateway: extract read locking during Series. #3546
 * [ENHANCEMENT] Store-gateway: index stats response. #3206
 * [ENHANCEMENT] Distributor: push wrapper should only receive unforwarded samples. #2980
 * [ENHANCEMENT] Ruler: Added `ruler.tls-enabled` configuration for alertmanager client. #3432

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@
 * [ENHANCEMENT] Alerts: Add runbook urls for alerts. #3452
 * [ENHANCEMENT] Configuration: Make it possible to configure namespace label, job label, and job prefix. #3482
 * [ENHANCEMENT] Dashboards: improved resources and networking dashboards to work with read-write deployment mode too. #3497 #3504 #3519 #3531
-* [ENHANCEMENT] Alerts: add alert for high error rate in Distributor's forwarding feature. #3200
-* [ENHANCEMENT] Dashboards: fix: use product name in overview dashboard instead of hardcoded "Mimir". #3209
+* [ENHANCEMENT] Alerts: Added "MimirDistributorForwardingErrorRate" alert, which fires on high error rates in the distributor’s forwarding feature. #3200
+* [ENHANCEMENT] Improve phrasing in Overview dashboard. #3488
 * [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173 #3184
 * [BUGFIX] Alerts: Fixed `MimirGossipMembersMismatch` alert when Mimir is deployed in read-write mode. #3489
 * [BUGFIX] Dashboards: Remove "Inflight requests" from object store panels because the panel is not tracking the inflight requests to object storage. #3521
@@ -97,7 +97,7 @@
     }
   }
   ```
-* [FEATURE] Added support for experimental read-write deployment mode. Enabling the read-write deployment mode on a existing Mimir cluster is a destructive operation, because the cluster will be re-created. If you're creating a new Mimir cluster, you can deploy it in read-write mode adding the following configuration: #3379 #3475
+* [FEATURE] Added support for experimental read-write deployment mode. Enabling the read-write deployment mode on a existing Mimir cluster is a destructive operation, because the cluster will be re-created. If you're creating a new Mimir cluster, you can deploy it in read-write mode adding the following configuration: #3379 #3475 #3405
   ```jsonnet
   {
     _config+:: {
@@ -115,8 +115,6 @@
 * [ENHANCEMENT] The query-tee node port (`$._config.query_tee_node_port`) is now optional. #3272
 * [ENHANCEMENT] Add support for autoscaling distributors. #3378
 * [ENHANCEMENT] Make auto-scaling logic ensure integer KEDA thresholds. #3512
-* [ENHANCEMENT] Refactor read-write-deployment jsonnet. #3405
-* [ENHANCEMENT] Improve phrasing in Overview dashboard. #3488
 * [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237 #3239
 * [BUGFIX] Jsonnet: Fix auto-scaling so that ruler-querier CPU threshold is a string-encoded integer millicores value. #3520
 
@@ -133,7 +131,6 @@
 * [ENHANCEMENT] Documented how to configure HA deduplication using Consul in a Mimir Helm deployment. #2972
 * [ENHANCEMENT] Improve `MimirQuerierAutoscalerNotActive` runbook. #3186
 * [ENHANCEMENT] Improve `MimirSchedulerQueriesStuck` runbook to reflect debug steps with querier auto-scaling enabled. #3223
-* [ENHANCEMENT] Mimir 2.4 release notes. #3104 #3319
 * [ENHANCEMENT] Use imperative for docs titles. #3178 #3332 #3343
 * [ENHANCEMENT] Docs: mention gRPC compression in "Production tips". #3201
 * [ENHANCEMENT] Update ADOPTERS.md. #3224 #3225
@@ -141,8 +138,7 @@
 * [ENHANCEMENT] out-of-order runbook update with use case. #3253
 * [ENHANCEMENT] Fixed TSDB retention mentioned in the "Recover source blocks from ingesters" runbook. #3280
 * [ENHANCEMENT] Run Grafana Mimir in production using the Helm chart. #3072
-* [ENHANCEMENT] Use common config in the tutorial again. #3282
-* [ENHANCEMENT] Clarify changelog and remove duplicate flag in the documentation. #3370
+* [ENHANCEMENT] Use common configuration in the tutorial. #3282
 * [ENHANCEMENT] Updated detailed steps for migrating blocks from Thanos to Mimir. #3290
 * [ENHANCEMENT] Add scheme to DNS service discovery docs. #3450
 * [BUGFIX] Remove reference to file that no longer exists in contributing guide. #3404

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 * [CHANGE] Distributor: Wrap errors from pushing to ingesters with useful context, for example clarifying timeouts. #3307
 * [CHANGE] The default value of `-server.http-write-timeout` has changed from 30s to 2m. #3346
 * [CHANGE] Reduce period of health checks in connection pools for querier->store-gateway, ruler->ruler, and alertmanager->alertmanager clients to 10s. This reduces the time to fail a gRPC call when the remote stops responding. #3168
+* [CHANGE] Hide TSDB block ranges period config from doc and mark it experimental. #3518
+* [CHANGE] Chore: use upstream rules.SendAlerts(). #3271
 * [FEATURE] Alertmanager: added Discord support. #3309
 * [ENHANCEMENT] Added `-server.tls-min-version` and `-server.tls-cipher-suites` flags to configure cipher suites and min TLS version supported by HTTP and gRPC servers. #2898
-* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3133
+* [ENHANCEMENT] Distributor: Add age filter to forwarding functionality, to not forward samples which are older than defined duration. If such samples are not ingested, `cortex_discarded_samples_total{reason="forwarded-sample-too-old"}` is increased. #3049 #3113
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation when generating ids in index cache. #3179
 * [ENHANCEMENT] Query-frontend: truncate queries based on the configured creation grace period (`--validation.create-grace-period`) to avoid querying too far into the future. #3172
 * [ENHANCEMENT] Ingester: Reduce activity tracker memory allocation. #3203
@@ -29,6 +31,9 @@
 * [ENHANCEMENT] Store-gateway: improved performance of series matching. #3391
 * [ENHANCEMENT] Move the validation of incoming series before the distributor's forwarding functionality, so that we don't forward invalid series. #3386 #3458
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
+* [ENHANCEMENT] Store-gateway: extract read locking during Series. #3546
+* [ENHANCEMENT] Store-gateway: index stats response. #3206
+* [ENHANCEMENT] Distributor: push wrapper should only receive unforwarded samples. #2980
 * [ENHANCEMENT] Ruler: Added `ruler.tls-enabled` configuration for alertmanager client. #3432
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
@@ -37,6 +42,7 @@
 * [BUGFIX] Ruler: persist evaluation delay configured in the rulegroup. #3392
 * [BUGFIX] Ring status pages: show 100% ownership as "100%", not "1e+02%". #3435
 * [BUGFIX] Fix panics in OTLP ingest path when parse errors exist. #3538
+* [BUGFIX] Canonicalize orgid header in forwarding. #3385
 
 ### Mixin
 
@@ -46,19 +52,21 @@
   * Instead of specific config variables for each component, they are listed in a dictionary. For example, `autoscaling.querier_enabled` becomes `autoscaling.querier.enabled`.
 * [FEATURE] Dashboards: Added "Mimir / Overview resources" dashboard, providing an high level view over a Mimir cluster resources utilization. #3481
 * [FEATURE] Dashboards: Added "Mimir / Overview networking" dashboard, providing an high level view over a Mimir cluster network bandwidth, inflight requests and TCP connections. #3487
-* [FEATURE] Compile baremetal mixin along k8s mixin. #3162 #3513
+* [FEATURE] Compile baremetal mixin along k8s mixin. #3162 #3514
 * [ENHANCEMENT] Alerts: Add MimirRingMembersMismatch firing when a component does not have the expected number of running jobs. #2404
 * [ENHANCEMENT] Dashboards: Add optional row about the Distributor's metric forwarding feature to the `Mimir / Writes` dashboard. #3182 #3394 #3394 #3461
 * [ENHANCEMENT] Dashboards: Remove the "Instance Mapper" row from the "Alertmanager Resources Dashboard". This is a Grafana Cloud specific service and not relevant for external users. #3152
 * [ENHANCEMENT] Dashboards: Add "remote read", "metadata", and "exemplar" queries to "Mimir / Overview" dashboard. #3245
 * [ENHANCEMENT] Dashboards: Use non-red colors for non-error series in the "Mimir / Overview" dashboard. #3246
-* [ENHANCEMENT] Dashboards: Add support to multi-zone deployments for the experimental read-write deployment mode. #3254
+* [ENHANCEMENT] Dashboards: Add support to multi-zone deployments for the experimental read-write deployment mode. #3256
 * [ENHANCEMENT] Dashboards: If enabled, add new row to the `Mimir / Writes` for distributor autoscaling metrics. #3378
 * [ENHANCEMENT] Dashboards: Add read path insights row to the "Mimir / Tenants" dashboard. #3326
 * [ENHANCEMENT] Alerts: Add runbook urls for alerts. #3452
 * [ENHANCEMENT] Configuration: Make it possible to configure namespace label, job label, and job prefix. #3482
 * [ENHANCEMENT] Dashboards: improved resources and networking dashboards to work with read-write deployment mode too. #3497 #3504 #3519 #3531
-* [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173
+* [ENHANCEMENT] Alerts: add alert for high error rate in Distributor's forwarding feature. #3200
+* [ENHANCEMENT] Dashboards: fix: use product name in overview dashboard instead of hardcoded "Mimir". #3209
+* [BUGFIX] Dashboards: Fix legend showing `persistentvolumeclaim` when using `deployment_type=baremetal` for `Disk space utilization` panels. #3173 #3184
 * [BUGFIX] Alerts: Fixed `MimirGossipMembersMismatch` alert when Mimir is deployed in read-write mode. #3489
 * [BUGFIX] Dashboards: Remove "Inflight requests" from object store panels because the panel is not tracking the inflight requests to object storage. #3521
 
@@ -108,8 +116,10 @@
 * [ENHANCEMENT] The query-tee node port (`$._config.query_tee_node_port`) is now optional. #3272
 * [ENHANCEMENT] Add support for autoscaling distributors. #3378
 * [ENHANCEMENT] Make auto-scaling logic ensure integer KEDA thresholds. #3512
+* [ENHANCEMENT] Refactor read-write-deployment jsonnet. #3405
+* [ENHANCEMENT] Improve phrasing in Overview dashboard. #3488
 * [BUGFIX] Fixed query-scheduler ring configuration for dedicated ruler's queries and query-frontends. #3237 #3239
-* [BUGFIX] Jsonnet: Fix auto-scaling so that ruler-querier CPU threshold is a string-encoded integer millicores value.
+* [BUGFIX] Jsonnet: Fix auto-scaling so that ruler-querier CPU threshold is a string-encoded integer millicores value. #3520
 
 ### Mimirtool
 
@@ -124,14 +134,30 @@
 * [ENHANCEMENT] Documented how to configure HA deduplication using Consul in a Mimir Helm deployment. #2972
 * [ENHANCEMENT] Improve `MimirQuerierAutoscalerNotActive` runbook. #3186
 * [ENHANCEMENT] Improve `MimirSchedulerQueriesStuck` runbook to reflect debug steps with querier auto-scaling enabled. #3223
+* [ENHANCEMENT] Mimir 2.4 release notes. #3104 #3319
+* [ENHANCEMENT] Use imperative for docs titles. #3178 #3332 #3343
+* [ENHANCEMENT] Docs: mention gRPC compression in "Production tips". #3201
+* [ENHANCEMENT] Update ADOPTERS.md. #3224 #3225
+* [ENHANCEMENT] Add a note for jsonnet deploying. #3213
+* [ENHANCEMENT] out-of-order runbook update with use case. #3253
+* [ENHANCEMENT] Fixed TSDB retention mentioned in the "Recover source blocks from ingesters" runbook. #3280
+* [ENHANCEMENT] Run Grafana Mimir in production using the Helm chart. #3072
+* [ENHANCEMENT] Use common config in the tutorial again. #3282
+* [ENHANCEMENT] Clarify changelog and remove duplicate flag in the documentation. #3370
+* [ENHANCEMENT] Updated detailed steps for migrating blocks from Thanos to Mimir. #3290
+* [ENHANCEMENT] Remove reference to file that no longer exists in contributing guide. #3404
+* [ENHANCEMENT] Fix some minor typos in the contributing guide and on the runbooks page. #3418
+* [ENHANCEMENT] Add scheme to DNS service discovery docs. #3450
+* [ENHANCEMENT] Fix small typos in API reference. #3526
 * [BUGFIX] Fixed TSDB retention mentioned in the "Recover source blocks from ingesters" runbook. #3278
-* [BUGFIX] Fixed configuration example in the "Configuring the Grafana Mimir query-frontend to work with Prometheus" guide. #3373
+* [BUGFIX] Fixed configuration example in the "Configuring the Grafana Mimir query-frontend to work with Prometheus" guide. #3374
 
 ### Tools
 
-* [FEATURE] Add `copyblocks` tool, to copy Mimir blocks between two GCS buckets. #3263
+* [FEATURE] Add `copyblocks` tool, to copy Mimir blocks between two GCS buckets. #3264
 * [ENHANCEMENT] copyblocks: copy no-compact global markers and optimize min time filter check. #3268
 * [ENHANCEMENT] Mimir rules GitHub action: Added the ability to change default value of `label` when running `prepare` command. #3236
+* [ENHANCEMENT] Use delve compatible with Go 1.19.2. #3166
 * [BUGFIX] Mimir rules Github action: Fix single line output. #3421
 
 ## 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,10 +144,10 @@
 * [ENHANCEMENT] Use common config in the tutorial again. #3282
 * [ENHANCEMENT] Clarify changelog and remove duplicate flag in the documentation. #3370
 * [ENHANCEMENT] Updated detailed steps for migrating blocks from Thanos to Mimir. #3290
-* [ENHANCEMENT] Remove reference to file that no longer exists in contributing guide. #3404
-* [ENHANCEMENT] Fix some minor typos in the contributing guide and on the runbooks page. #3418
 * [ENHANCEMENT] Add scheme to DNS service discovery docs. #3450
-* [ENHANCEMENT] Fix small typos in API reference. #3526
+* [BUGFIX] Remove reference to file that no longer exists in contributing guide. #3404
+* [BUGFIX] Fix some minor typos in the contributing guide and on the runbooks page. #3418
+* [BUGFIX] Fix small typos in API reference. #3526
 * [BUGFIX] Fixed TSDB retention mentioned in the "Recover source blocks from ingesters" runbook. #3278
 * [BUGFIX] Fixed configuration example in the "Configuring the Grafana Mimir query-frontend to work with Prometheus" guide. #3374
 


### PR DESCRIPTION
I ran this command: `./tools/release/check-changelog.sh release-2.4...main`
It resulted in `138` missing PRs, so I went through each of them to check whether it needs to be added to the changelog. 
This is the output of the script, I added a comment to each line indicating what decision I made about it:

```
Found 219 PRs from 43 authors.

List of missing PR in the CHANGELOG.md:
# ignoring because helm has its own changelog
- #3479: Add OTLP Endpoint to Helm NGINX configuration (#3479)

# ignoring because not user-facing
- #3546: store-gateways: extract read locking during Series (#3546)

# ignoring because not user-facing
- #3543: Refactoring: simplify BucketStore.Series() (#3543)

# added to changelog as change
- #3518: Hide TSDB block ranges period config from doc and mark it experimental (#3518)

# ignoring because not user-facing
- #3510: Read-write deployment mode: add integration test for recording rule evaluation (#3510)

# adding to docs as bug fix
- #3526: Fix small typos in API reference (#3526)

# already present but without PR id, fixing
- #3520: Jsonnet: Fix ruler-querier CPU threshold (#3520)

# ignoring because not user-facing
- #3515: cacheutil: added cache `Delete` method (#3515)

# already present but with wrong PR id, fixing
- #3514: Dashboards: change default per-instance label name in dashboards compiled for baremetal (#3514)

# ignoring because not user-facing
- #3503: fix mimir-tool rules delete method comment typo (#3503)

# ignoring because helm has its own changelog
- #3486: Release mimir-distributed Helm chart 4.0.0-weekly.213 (#3486)

# ignoring because not user-facing
- #3511: backport GH action: pin to older version (#3511)

# ignoring because not user-facing
- #3509: Refactoring: remove queryStats from bucketChunkReader (#3509)

# ignoring because not user-facing
- #3500: Refactoring: removed mutex from bucketIndexReader (#3500)

# ignoring because not user-facing
- #3506: Store-gateway: move chunk bytes pooling outside of chunk reader (#3506)

# ignoring because helm has its own changelog
- #3502: Do not build Helm-compatible matchers if dashboards are compiled for baremetal (#3502)

# ignoring because not user-facing
- #3492: announce releaser of 2.5.0 (#3492)

# ignoring because not user-facing
- #3477: Release: add release issue template to doc (#3477)

# added to jsonnet as enhancement
- #3488: Improve phrasing in Overview dashboard (#3488)

# ignoring because helm has its own changelog
- #3140: [Helm] Add schedulerName support in StatefulSets to allow for certain storage providers to work. (#3140)

# ignoring because not user-facing
- #3483: Remove unused index.Decoder field in BinaryReader (#3483)

# ignoring because helm has its own changelog
- #3449: Release mimir-distributed Helm chart 4.0.0-weekly.212 (#3449)

# ignoring because not user-facing
- #3466: chore: fix PR number (#3466)

# ignoring because not user-facing
- #3464: Use ReusePreallocTimeseries from ReuseSlice. (#3464)

# already present, not sure how this ended up in this list
- #3437: Alertmanager configuration validate-only mode #3437 (#3440)

# added to docs as enhancement
- #3450: Add scheme to DNS service discovery docs (#3450)

# ignoring because not user-facing
- #3462: Don't rebuild middlewares on each push. (#3462)

# already present, not sure how this ended up in this list
- #3410: Add validation for newS3Config (#3410) (#3414)

# ignoring because not user-facing
- #3446: Pin version of `doc-validator` tool in CI (#3446)

# ignoring because not user-facing
- #3448: Verify range query result matches expected value in integration tests. (#3448)

# ignoring because not user-facing
- #3447: Make read-write mode test robust to instance startup race condition. (#3447)

# ignoring because not user-facing
- #3441: store-gateway: fix error handling in Series() (#3441)

# ignoring because helm has its own changelog
- #3445: Helm: release 3.3.0 with GEM 2.4.0 (#3445)

# added as enhancement
- #2980: Distributor push wrapper should only receive unforwarded samples. (#2980)

# ignoring because not user-facing
- #3434: Extract minimum / maximum timestamp for Prometheus API to a single place. (#3434)

# ignoring because not user-facing
- #3423: Read-write deployment mode integration test (#3423)

# ignoring because not user-facing
- #3400: Do not call caching functions with mutex in bucketIndexReader (#3400)

# ignoring because not user-facing
- #3428: Chore: remove logic to conditionally enable store-gateway series hints (#3428)

# ignoring because not user-facing
- #3427: Refactoring: move bucketChunkReader to dedicated file (#3427)

# ignoring because not user-facing
- #3425: Refactoring: move postings reading utilities to dedicated file (#3425)

# ignoring because not user-facing
- #3399: Refactoring: enforce usage of safeQueryStats in bucketIndexReader (#3399)

# adding to docs as bug fix
- #3418: Fix some minor typos in the contributing guide and on the runbooks page (#3418)

# ignoring because not user-facing
- #3398: Refactoring: move bucketIndexReader to dedicated source file (#3398)

# ignoring because not user-facing
- #3417: Remove useless arg and fix typo (#3417)

# ignoring because not user-facing
- #3420: Replace person with team for documentation reviews (#3420)

# ignoring because helm has its own changelog
- #3336: helm: use mimir for nginx ingress examples (#3336)

# adding to jsonnet as enhancement
- #3405: Refactor read-write-deployment jsonnet (#3405)

# adding to docs as bug fix
- #3404: Remove reference to file that no longer exists in contributing guide. (#3404)

# ignoring because helm has its own changelog
- #3360: Helm: add alertmanager fallback config (#3360)

# ignoring because not user-facing
- #3396: Refactoring: do not store per-query data in bucketIndexReader (#3396)

# ignoring because helm has its own changelog
- #3395: Update mimir-distributed chart to 4.0.0-weekly.211 (#3395)

# ignoring because helm has its own changelog
- #3350: Helm: metamonitoring as non-root; update agent subchart (#3350)

# added to docs as enhancement
- #3290: Updated detailed steps for migrating blocks from Thanos to Mimir. (#3290)

# ignoring because not user-facing
- #3388: Chore: remove settings equal to default values from jsonnet tests (#3388)

# already present but with wrong PR id, fixing it 
- #3374: docs: fix unsupported fields on query-frontend config (#3374)

# added as bugfix
- #3385: canonicalize orgid header in forwarding (#3385)

# ignoring because not user-facing
- #3345: Remove Thanos ZLabel type in favour of identical LabelAdapter type  (#3345)

# ignoring because not user-facing
- #3334: mimirpb: use jsonutil point marshal functions (#3334)

# ignoring because not user-facing
- #3288: Remove dependencies on thanos-io/thanos (#3288)

# added to documentation as enhancement
- #3370: Clarify changelog and remove duplicate flag in the documentation. (#3370)

# ignoring because not user-facing
- #3356: Release: propose date for Mimir 2.6.0 release candidate (#3356)

# ignoring because not user-facing
- #3335: Remove unused GetLabels() function (#3335)

# ignoring because helm has its own changelog
- #3353: Update Helm compactor config to match Jsonnet (#3353)

# ignoring because not user-facing
- #3354: Release: add Mimir 2.4.0 to backward compatibility tests (#3354)

# ignoring because helm has its own changelog
- #3352: Helm: update minio subchart to 5.0.0 (#3352)

# ignoring because not user-facing
- #3330: Release: fix create release scripts when publishing a stable release (#3330)

# ignoring because not user-facing
- #3347: Remove CTA per @grafanawriter. (#3347)

# ignoring because not user-facing
- #3344: Rename migrating-from-consul-to-memberlist (#3344)

# added to existing entry about using imperatives in docs
- #3343: Use imperatives for operators-guide/configure docs (#3343)

# added to existing entry about using imperatives in docs
- #3332: Use imperative for "Deploy with jsonnet" docs (#3332)

# ignoring because helm has its own changelog
- #3341: Release mimir-distributed Helm chart 4.0.0-weekly.210 (#3341)

# ignoring because not user-facing
- #3333: Merge pull request #3333 from grafana/merge-release-2.4-to-main

# ignoring because helm has its own changelog
- #3331: Helm: release mimir-distributed 3.2.0 (#3331)

# added to existing entry about 2.4 release notes
- #3319: Update 2.4 release notes (#3319)

# ignoring because not user-facing
- #3312: ruler: Clean up tests a bit (#3312)

# ignoring because not user-facing
- #3310: Update puppeteer used to generate dashboard screenshots and re-generate screenshots (#3310)

# ignoring because helm has its own changelog
- #3181: Helm: unify NGINX and gateway values sections (#3181)

# ignored because it changes *almost* only tests, so isn't relevant for users
- #3303: Use labels.FromString abstraction (#3303)

# added to docs as enhancement
- #3282: Use common config in the tutorial again (#3282)

# ignoring because not user-facing
- #3219: Add regression test for distributor passing through GRPC statuses (#3219)

# ignoring because helm has its own changelog
- #2998: Helm <> Jsonnet: Fix read path differences (#2998)

# ignoring because helm has its own changelog
- #3304: Release mimir-distributed Helm chart 4.0.0-weekly.209 (#3304)

# added to documentation as enhancement
- #3072: Docs: Run Grafana Mimir in production using the Helm chart (#3072)

# ignoring because helm has its own changelog
- #3007: Helm: run under Restricted pod security policy (#3007)

# added to documentation as enhancement
- #3280: Fixed TSDB retention mentioned in the "Recover source blocks from ingesters" runbook (#3280)

# was already in changelog but with wrong PR id, fixed it
- #3264: Import blockscopy too and rename it to copyblocks (#3264)

# added as change
- #3271: Chore: use upstream rules.SendAlerts() (#3271)

# added as enhancement
- #3206: Store Gateway index stats response (#3206)

# ignoring because not user-facing
- #3267: Fix changelog entry kind for #3134 (#3267)

# ignoring because helm has its own changelog
- #3087: Trim return value of prometheusHttpPrefix and alertManagerHttpPrefix (#3087)

# ignoring because helm has its own changelog
- #3266: Helm: update helm tests (#3266)

# ignoring because helm has its own changelog
- #3218: Helm: add enterprise and oss offline test values for k8s 1.25 (#3218)

# ignoring because helm has its own changelog
- #3035: Helm: Update sizing plans (#3035)

# ignoring because helm has its own changelog
- #3262: Helm: prevent query-scheduler from terminating connections (#3262)

# ignoring because helm has its own changelog
- #3247: Release mimir-distributed Helm chart 4.0.0-weekly.208 (#3247)

# ignoring because not user-facing
- #3260: Update dependency on grafana/e2e to latest commit (#3260)

# ignoring because helm has its own changelog
- #3258: Check that kustomize is installed (#3258)

# ignoring because helm has its own changelog
- #2778: Support for rollout-operator and Zone Awareness (#2778)

# added to documentation as enhancement
- #3253: out-of-order runbook update with use case (#3253)

# already in changelog but with wrong PR number, fixing it
- #3256: Dashboards: Add support to multi-zone deployments for the experimental read-write deployment mode (#3256)

# ignoring because not relevant for users
- #3251: Update dskit dependency to 0d3fc3d6c266 (#3251)

# added to documentation as enhancement
- #3213: Add a note for jsonnet deploying (#3213)

# ignoring because not user-facing
- #3249: Update outdated comment (#3249)

# ignoring because not user-facing
- #3232: Release: improve release scripts (#3232)

# ignoring because not user-facing
- #3238: Release: add pre-requisite check on git remote for all release scripts (#3238)

# ignoring because not user-facing
- #3234: Release: add script to merge release branch to main (#3234)

# ignoring because not relevant for users
- #3222: Import Thanos protobuf definitions (#3222)

# ignoring because not relevant for users
- #3233: Merge pull request #3233 from grafana/merge-release-2.4-to-main

# ignoring because helm has its own changelog
- #3169: fix(helm): move the activity tracker log from /data to remove ignore log msg (#3169)

# added together to docs as enhancement
- #3225: Update ADOPTERS.md (#3225)
- #3224: Add OVHcloud to adopters list (#3224)

# ignoring because helm has its own changelog
- #3208: changed nginx imagePullSecret value reference (#3208)

# ignoring because not user-facing
- #3187: Add script to publish the release (#3187)

# added to mixin as enhancement
- #3209: mimir-mixins: dashboards: fix: use product name in overview dashboard instead of hardcoded "Mimir" (#3209)

# ignoring because not user-facing
- #3205: Replace internal thanos fork with latest thanos (#3205)

# added to docs as enhancement
- #3201: Docs: mention gRPC compression in "Production tips" (#3201)

# ignoring because helm has its own changelog
- #2945: helm: make metamonitoring scrape interval configurable (#2945)

# ignoring because helm has its own changelog
- #3029: Helm: Clean up default rollout strategies (#3029)

# added to mixin as enhancement
- #3200: add alert for high error rate in Distributor's forwarding feature (#3200)

# ignoring 3195 and 3196 because the merged PR has directly been reverted again
- #3195: Revert "Alerts: Include query-scheduler for MimirGossipMembersMismatch (#3195)" (#3196)
Alerts: Include query-scheduler for MimirGossipMembersMismatch (#3195)
- #3196: Revert "Alerts: Include query-scheduler for MimirGossipMembersMismatch (#3195)" (#3196)

# ignoring because helm has its own changelog
- #3185: Helm: add remote destinations in metamonitoring offline test (#3185)

# added as enhancement under tools
- #3166: Use delve compatible with Go 1.19.2. (#3166)

# ignoring because helm has its own changelog
- #3174: Release mimir-distributed Helm chart 4.0.0-weekly.207 (#3174)

# added as follow-up PR to an already existing entry
- #3184: Fix typo in CHANGELOG.md (#3184)

# ignoring because helm has its own changelog
- #3170: [Helm]: Fix metamonitoring secret configuration (#3170)

# ignoring because helm has its own changelog
- #3176: Helm: Default to sending metamonitoring inside Mimir (#3176)

# added as enhancement to docs
- #3178: Use imperative for docs titles (#3178)

# ignoring because helm has its own changelog
- #3092: Helm chore: Move build/check-helm-tests to build image (#3092)

# ignoring because helm has its own changelog
- #3076: Helm docs: Mention format of secret keys for injecting credentials (#3076)

# ignoring because helm has its own changelog
- #2984: Add examples for sending Helm metamonitoring to Mimir (#2984)

# was already in changelog, but had to fix a typo
- #3113: Increase discarded samples metric if forwarded series receives too old samples (#3113)

# added to changelog as enhancement under documentation
- #3104: Mimir 2.4 release notes (#3104)

# ignoring because not user-facing
- #3163: Chore: get 'make dist' always re-run and being less verbose (#3163)

# ignoring because not user-facing
- #3161: Release: add a script to tag the release (#3161)

# ignoring because not user-facing
- #3159: Release: add notify-changelog-cut.sh script (#3159)
```

Furthermore, this also adds the section for the new release v2.5

Signed-off-by: Mauro Stettler <mauro.stettler@gmail.com>
