### PR TITLE
Store series labels as a single string, to save memory

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -212,6 +212,34 @@ jobs:
           echo "Running unit tests (group ${{ matrix.test_group_id }} of ${{ matrix.test_group_total }}) with Go version: $(go version)"
           ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
 
+  test-stringlabels:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    container:
+      image: ${{ needs.prepare.outputs.build_image }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
+      - name: Symlink Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/grafana/mimir
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
+      - name: Get Go build cache path
+        id: gocache
+        run: |
+          echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+      - name: Cache Go build cache
+        uses: actions/cache@v3
+        with:
+          key: build-go-test-stringlabels-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
+          path: ${{ steps.gocache.outputs.path }}
+      - name: Run Tests with -tags stringlabels
+        run: |
+          go test -tags=netgo,stringlabels -timeout 5m -count 1 ./...
+
   test-docs:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Querier: Refine error messages for per-tenant query limits, informing the user of the preferred strategy for not hitting the limit, in addition to how they may tweak the limit. #5059
 * [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. For now this optimization can be disabled by setting `-distributor.write-requests-buffer-pooling-enabled` to `false`. #5195
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests` option to initially query only the minimum set of ingesters required to reach quorum. #5202 #5259 #5263
+* [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 
 ### Mixin

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -776,7 +776,7 @@ func (d *Distributor) prePushRelabelMiddleware(next push.Func) push.Func {
 			ts := req.Timeseries[tsIdx]
 
 			if mrc := d.limits.MetricRelabelConfigs(userID); len(mrc) > 0 {
-				lb.Reset(mimirpb.FromLabelAdaptersToLabels(ts.Labels))
+				mimirpb.FromLabelAdaptersToBuilder(ts.Labels, lb)
 				lb.Set(metaLabelTenantID, userID)
 				keep := relabel.ProcessBuilder(lb, mrc...)
 				if !keep {
@@ -784,7 +784,7 @@ func (d *Distributor) prePushRelabelMiddleware(next push.Func) push.Func {
 					continue
 				}
 				lb.Del(metaLabelTenantID)
-				req.Timeseries[tsIdx].SetLabels(lb.Labels())
+				req.Timeseries[tsIdx].SetLabels(mimirpb.FromBuilderToLabelAdapters(lb, ts.Labels))
 			}
 
 			for _, labelName := range d.limits.DropLabels(userID) {

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -154,6 +154,12 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
 	if ls1.Hash() != ls2.Hash() {
+		// These ones are the same when using -tags stringlabels
+		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+	}
+
+	if ls1.Hash() != ls2.Hash() {
 		panic("This code needs to be updated: find new labels with colliding hash values.")
 	}
 

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -181,7 +181,7 @@ func TestWriteRequestBufferingClient_PushConcurrent(t *testing.T) {
 
 			for i := 0; i < requestsPerGoroutine; i++ {
 				for _, ts := range req.Timeseries {
-					ser := mimirpb.FromLabelAdaptersToLabelsWithCopy(ts.Labels).String()
+					ser := mimirpb.FromLabelAdaptersToLabels(ts.Labels).String()
 					sentSamples[ser] = append(sentSamples[ser], ts.Samples...)
 				}
 
@@ -241,7 +241,7 @@ func (ms *mockServer) Push(_ context.Context, r *mimirpb.WriteRequest) (*mimirpb
 		}
 
 		for _, ts := range r.Timeseries {
-			ser := mimirpb.FromLabelAdaptersToLabelsWithCopy(ts.Labels).String()
+			ser := mimirpb.FromLabelAdaptersToLabels(ts.Labels).String()
 			ms.samplesPerSeries[ser] = append(ms.samplesPerSeries[ser], ts.Samples...)
 		}
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -900,6 +900,8 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 	// fetch once per push request to avoid processing half the request differently
 	nativeHistogramsIngestionEnabled := i.limits.NativeHistogramsIngestionEnabled(userID)
 
+	var builder labels.ScratchBuilder
+	var nonCopiedLabels labels.Labels
 	for _, ts := range timeseries {
 		// The labels must be sorted (in our case, it's guaranteed a write request
 		// has sorted labels once hit the ingester).
@@ -947,7 +949,8 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 			}
 		}
 
-		nonCopiedLabels := mimirpb.FromLabelAdaptersToLabels(ts.Labels)
+		// MUST BE COPIED before being retained.
+		mimirpb.FromLabelAdaptersOverwriteLabels(&builder, ts.Labels, &nonCopiedLabels)
 		hash := nonCopiedLabels.Hash()
 		// Look up a reference for this series. The hash passed should be the output of Labels.Hash()
 		// and NOT the stable hashing because we use the stable hashing in ingesters only for query sharding.
@@ -967,7 +970,7 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 				}
 			} else {
 				// Copy the label set because both TSDB and the active series tracker may retain it.
-				copiedLabels = mimirpb.FromLabelAdaptersToLabelsWithCopy(ts.Labels)
+				copiedLabels = mimirpb.CopyLabels(nonCopiedLabels)
 
 				// Retain the reference in case there are multiple samples for the series.
 				if ref, err = app.Append(0, copiedLabels, s.TimestampMs, s.Value); err == nil {
@@ -1009,7 +1012,7 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 					}
 				} else {
 					// Copy the label set because both TSDB and the active series tracker may retain it.
-					copiedLabels = mimirpb.FromLabelAdaptersToLabelsWithCopy(ts.Labels)
+					copiedLabels = mimirpb.CopyLabels(nonCopiedLabels)
 
 					// Retain the reference in case there are multiple samples for the series.
 					if ref, err = app.AppendHistogram(0, copiedLabels, h.Timestamp, ih, fh); err == nil {

--- a/pkg/mimirpb/compat_slice.go
+++ b/pkg/mimirpb/compat_slice.go
@@ -23,6 +23,11 @@ func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 	return *(*labels.Labels)(unsafe.Pointer(&ls))
 }
 
+// This is like FromLabelAdaptersToLabels but easier for stringlabels to implement.
+func FromLabelAdaptersOverwriteLabels(_ *labels.ScratchBuilder, ls []LabelAdapter, dest *labels.Labels) {
+	*dest = FromLabelAdaptersToLabels(ls)
+}
+
 // FromLabelAdaptersToLabelsWithCopy converts []LabelAdapter to labels.Labels.
 // Do NOT use unsafe to convert between data types because this function may
 // get in input labels whose data structure is reused.
@@ -30,8 +35,8 @@ func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
 	return CopyLabels(FromLabelAdaptersToLabels(input))
 }
 
-// CopyLabels efficiently copies labels input slice. To be used in cases where input slice
-// can be reused, but long-term copy is needed.
+// Copy data in Labels, such that any future Overwrite of input won't modify the returned value.
+// We make a single block of bytes to hold all strings, to save memory compared to Go rounding up the allocations.
 func CopyLabels(input []labels.Label) labels.Labels {
 	result := make(labels.Labels, len(input))
 

--- a/pkg/mimirpb/compat_slice.go
+++ b/pkg/mimirpb/compat_slice.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/cortexpb/compat.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+//go:build !stringlabels
+
+package mimirpb
+
+import (
+	"unsafe"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// FromLabelAdaptersToLabels casts []LabelAdapter to labels.Labels.
+// It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
+// This allows us to use labels.Labels directly in protos.
+//
+// Note: while resulting labels.Labels is supposedly sorted, this function
+// doesn't enforce that. If input is not sorted, output will be wrong.
+func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
+	return *(*labels.Labels)(unsafe.Pointer(&ls))
+}
+
+// FromLabelAdaptersToLabelsWithCopy converts []LabelAdapter to labels.Labels.
+// Do NOT use unsafe to convert between data types because this function may
+// get in input labels whose data structure is reused.
+func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
+	return CopyLabels(FromLabelAdaptersToLabels(input))
+}
+
+// CopyLabels efficiently copies labels input slice. To be used in cases where input slice
+// can be reused, but long-term copy is needed.
+func CopyLabels(input []labels.Label) labels.Labels {
+	result := make(labels.Labels, len(input))
+
+	size := 0
+	for _, l := range input {
+		size += len(l.Name)
+		size += len(l.Value)
+	}
+
+	// Copy all strings into the buffer, and use 'yoloString' to convert buffer
+	// slices to strings.
+	buf := make([]byte, size)
+
+	for i, l := range input {
+		result[i].Name, buf = copyStringToBuffer(l.Name, buf)
+		result[i].Value, buf = copyStringToBuffer(l.Value, buf)
+	}
+	return result
+}
+
+// Copies string to buffer (which must be big enough), and converts buffer slice containing
+// the string copy into new string.
+func copyStringToBuffer(in string, buf []byte) (string, []byte) {
+	l := len(in)
+	c := copy(buf, in)
+	if c != l {
+		panic("not copied full string")
+	}
+
+	return yoloString(buf[0:l]), buf[l:]
+}
+
+// FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.
+// It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
+// This allows us to use labels.Labels directly in protos.
+func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
+	return *(*[]LabelAdapter)(unsafe.Pointer(&ls))
+}

--- a/pkg/mimirpb/compat_slice.go
+++ b/pkg/mimirpb/compat_slice.go
@@ -69,6 +69,16 @@ func copyStringToBuffer(in string, buf []byte) (string, []byte) {
 	return yoloString(buf[0:l]), buf[l:]
 }
 
+// FromLabelAdaptersToBuilder converts []LabelAdapter to labels.Builder.
+func FromLabelAdaptersToBuilder(ls []LabelAdapter, builder *labels.Builder) {
+	builder.Reset(FromLabelAdaptersToLabels(ls))
+}
+
+// FromBuilderToLabelAdapters converts labels.Builder to []LabelAdapter.
+func FromBuilderToLabelAdapters(builder *labels.Builder, _ []LabelAdapter) []LabelAdapter {
+	return FromLabelsToLabelAdapters(builder.Labels())
+}
+
 // FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.
 // It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
 // This allows us to use labels.Labels directly in protos.

--- a/pkg/mimirpb/compat_stringlabels.go
+++ b/pkg/mimirpb/compat_stringlabels.go
@@ -8,8 +8,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-// FromLabelAdaptersToLabels casts []LabelAdapter to labels.Labels.
-// For now it's doing an expensive conversion: TODO figure out a faster way, maybe via PreallocTimeSeries.
+// FromLabelAdaptersToLabels converts []LabelAdapter to labels.Labels.
+// Note this is relatively expensive; see FromLabelAdaptersOverwriteLabels for a fast unsafe way.
 func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 	builder := labels.NewScratchBuilder(len(ls))
 	for _, v := range ls {
@@ -19,10 +19,23 @@ func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 }
 
 // FromLabelAdaptersToLabelsWithCopy converts []LabelAdapter to labels.Labels.
-// Do NOT use unsafe to convert between data types because this function may
-// get in input labels whose data structure is reused.
+// The output does not retain any part of the input.
 func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
-	return FromLabelAdaptersToLabels(input).Copy()
+	return FromLabelAdaptersToLabels(input)
+}
+
+// Copy data in Labels, such that any future Overwrite of input won't modify the returned value.
+func CopyLabels(input labels.Labels) labels.Labels {
+	return input.Copy()
+}
+
+// Build a labels.Labels from LabelAdaptors, with amortized zero allocations.
+func FromLabelAdaptersOverwriteLabels(builder *labels.ScratchBuilder, ls []LabelAdapter, dest *labels.Labels) {
+	builder.Reset()
+	for _, v := range ls {
+		builder.Add(v.Name, v.Value)
+	}
+	builder.Overwrite(dest)
 }
 
 // FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.

--- a/pkg/mimirpb/compat_stringlabels.go
+++ b/pkg/mimirpb/compat_stringlabels.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build stringlabels
+
+package mimirpb
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// FromLabelAdaptersToLabels casts []LabelAdapter to labels.Labels.
+// For now it's doing an expensive conversion: TODO figure out a faster way, maybe via PreallocTimeSeries.
+func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
+	builder := labels.NewScratchBuilder(len(ls))
+	for _, v := range ls {
+		builder.Add(v.Name, v.Value)
+	}
+	return builder.Labels()
+}
+
+// FromLabelAdaptersToLabelsWithCopy converts []LabelAdapter to labels.Labels.
+// Do NOT use unsafe to convert between data types because this function may
+// get in input labels whose data structure is reused.
+func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
+	return FromLabelAdaptersToLabels(input).Copy()
+}
+
+// FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.
+// For now it's doing an expensive conversion: TODO figure out a faster way.
+func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
+	r := make([]LabelAdapter, 0, ls.Len())
+	ls.Range(func(l labels.Label) {
+		r = append(r, LabelAdapter{Name: l.Name, Value: l.Value})
+	})
+	return r
+}

--- a/pkg/mimirpb/compat_stringlabels.go
+++ b/pkg/mimirpb/compat_stringlabels.go
@@ -38,6 +38,24 @@ func FromLabelAdaptersOverwriteLabels(builder *labels.ScratchBuilder, ls []Label
 	builder.Overwrite(dest)
 }
 
+// FromLabelAdaptersToBuilder converts []LabelAdapter to labels.Builder.
+func FromLabelAdaptersToBuilder(ls []LabelAdapter, builder *labels.Builder) {
+	builder.Reset(labels.EmptyLabels())
+	for _, v := range ls {
+		builder.Set(v.Name, v.Value)
+	}
+}
+
+// FromBuilderToLabelAdapters converts labels.Builder to []LabelAdapter, reusing ls.
+// Note the result may not be sorted.
+func FromBuilderToLabelAdapters(builder *labels.Builder, ls []LabelAdapter) []LabelAdapter {
+	ls = ls[:0]
+	builder.Range(func(l labels.Label) {
+		ls = append(ls, LabelAdapter{Name: l.Name, Value: l.Value})
+	})
+	return ls
+}
+
 // FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.
 // For now it's doing an expensive conversion: TODO figure out a faster way.
 func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -8,6 +8,7 @@ package mimirpb
 import (
 	stdlibjson "encoding/json"
 	"math"
+	"reflect"
 	"strconv"
 	"testing"
 	"unsafe"
@@ -186,10 +187,6 @@ func TestFromLabelAdaptersToLabels(t *testing.T) {
 	actual := FromLabelAdaptersToLabels(input)
 
 	assert.Equal(t, expected, actual)
-
-	// All strings must NOT be copied.
-	assert.Equal(t, uintptr(unsafe.Pointer(&input[0].Name)), uintptr(unsafe.Pointer(&actual[0].Name)))
-	assert.Equal(t, uintptr(unsafe.Pointer(&input[0].Value)), uintptr(unsafe.Pointer(&actual[0].Value)))
 }
 
 func TestFromLabelAdaptersToLabelsWithCopy(t *testing.T) {
@@ -200,8 +197,10 @@ func TestFromLabelAdaptersToLabelsWithCopy(t *testing.T) {
 	assert.Equal(t, expected, actual)
 
 	// All strings must be copied.
-	assert.NotEqual(t, uintptr(unsafe.Pointer(&input[0].Name)), uintptr(unsafe.Pointer(&actual[0].Name)))
-	assert.NotEqual(t, uintptr(unsafe.Pointer(&input[0].Value)), uintptr(unsafe.Pointer(&actual[0].Value)))
+	actualValue := actual.Get("hello")
+	hInputValue := (*reflect.StringHeader)(unsafe.Pointer(&input[0].Value))
+	hActualValue := (*reflect.StringHeader)(unsafe.Pointer(&actualValue))
+	assert.NotEqual(t, hInputValue.Data, hActualValue.Data)
 }
 
 func BenchmarkFromLabelAdaptersToLabelsWithCopy(b *testing.B) {

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -96,8 +96,8 @@ func (p *PreallocTimeseries) RemoveLabel(labelName string) {
 	}
 }
 
-func (p *PreallocTimeseries) SetLabels(lbls labels.Labels) {
-	p.Labels = FromLabelsToLabelAdapters(lbls)
+func (p *PreallocTimeseries) SetLabels(lbls []LabelAdapter) {
+	p.Labels = lbls
 
 	// We can't reuse raw unmarshalled data for the timeseries after setting new labels.
 	// (Maybe we could, if labels are exactly the same, but it's expensive to check.)

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -420,7 +420,7 @@ func TestPreallocTimeseries_SetLabels(t *testing.T) {
 		},
 		marshalledData: []byte{1, 2, 3},
 	}
-	p.SetLabels(labels.FromStrings("__name__", "hello", "lbl", "world"))
+	p.SetLabels(FromLabelsToLabelAdapters(labels.FromStrings("__name__", "hello", "lbl", "world")))
 
 	require.Equal(t, []LabelAdapter{{Name: "__name__", Value: "hello"}, {Name: "lbl", Value: "world"}}, p.Labels)
 	require.Nil(t, p.marshalledData)

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -42,7 +42,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 	}{
 		"empty series": {
 			series:         &storepb.Series{},
-			expectedMetric: labels.Labels(nil),
+			expectedMetric: labels.EmptyLabels(),
 			expectedErr:    "no chunks",
 		},
 		"should return float series on success": {
@@ -120,7 +120,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			series := newBlockQuerierSeries(mimirpb.FromLabelAdaptersToLabels(testData.series.Labels), testData.series.Chunks)
 
-			assert.Equal(t, testData.expectedMetric, series.Labels())
+			assert.True(t, labels.Equal(testData.expectedMetric, series.Labels()))
 
 			sampleIx := int64(0)
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -977,7 +977,7 @@ func (s *loadingSeriesChunkRefsSetIterator) filterSeries(set seriesChunkRefsSet,
 	for sIdx, series := range set.series {
 		// An empty label set means the series had no chunks in this block, so we skip it.
 		// No chunk ranges means the series doesn't have a single chunk range in the requested range.
-		if len(series.lset) == 0 || (!s.skipChunks && len(series.chunksRanges) == 0) {
+		if series.lset.IsEmpty() || (!s.skipChunks && len(series.chunksRanges) == 0) {
 			continue
 		}
 		if !shardOwned(s.shard, s.seriesHasher, postings[sIdx], series.lset, stats) {


### PR DESCRIPTION
#### What this PR does

This is porting Mimir to use https://github.com/prometheus/prometheus/pull/10991

~Still a bit experimental.~

~Requires a couple more changes in mimir-prometheus; currently overriding to branch `fixup-labels-usage3`.~

#### Checklist

- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
