### PR TITLE
Rename unloaded structs

### DIFF
--- a/pkg/storegateway/batch_series.go
+++ b/pkg/storegateway/batch_series.go
@@ -52,51 +52,6 @@ type loadedBatchSet interface {
 	Err() error
 }
 
-type unloadedBatch struct {
-	Entries []unloadedBatchEntry
-	Stats   *safeQueryStats
-}
-
-func newBatch(size int) unloadedBatch {
-	return unloadedBatch{
-		Entries: make([]unloadedBatchEntry, size),
-		Stats:   newSafeQueryStats(),
-	}
-}
-
-func (b unloadedBatch) len() int {
-	return len(b.Entries)
-}
-
-type unloadedBatchEntry struct {
-	lset   labels.Labels
-	chunks []unloadedChunk
-}
-
-type unloadedChunk struct {
-	BlockID          ulid.ULID
-	Ref              chunks.ChunkRef
-	MinTime, MaxTime int64
-}
-
-func (m unloadedChunk) Compare(b unloadedChunk) int {
-	if m.MinTime < b.MinTime {
-		return 1
-	}
-	if m.MinTime > b.MinTime {
-		return -1
-	}
-
-	// Same min time.
-	if m.MaxTime < b.MaxTime {
-		return 1
-	}
-	if m.MaxTime > b.MaxTime {
-		return -1
-	}
-	return 0
-}
-
 type unloadedBatchSet interface {
 	Next() bool
 	At() unloadedBatch

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -28,8 +28,8 @@ type sliceUnloadedBatchSet struct {
 
 func newSliceUnloadedBatchSet(err error, batches ...seriesChunkRefsSet) *sliceUnloadedBatchSet {
 	for i := range batches {
-		if batches[i].Stats == nil {
-			batches[i].Stats = newSafeQueryStats()
+		if batches[i].stats == nil {
+			batches[i].stats = newSafeQueryStats()
 		}
 	}
 	return &sliceUnloadedBatchSet{
@@ -96,11 +96,11 @@ func TestDeduplicatingBatchSet(t *testing.T) {
 	series2 := labels.FromStrings("l1", "v2")
 	series3 := labels.FromStrings("l1", "v3")
 	sourceBatches := []seriesChunkRefsSet{
-		{Series: []seriesChunkRefs{
+		{series: []seriesChunkRefs{
 			{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
 			{lset: series1, chunks: []seriesChunkRef{c[2], c[3], c[4]}},
 		}},
-		{Series: []seriesChunkRefs{
+		{series: []seriesChunkRefs{
 			{lset: series2, chunks: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
 			{lset: series3, chunks: []seriesChunkRef{c[0]}},
 			{lset: series3, chunks: []seriesChunkRef{c[1]}},
@@ -115,17 +115,17 @@ func TestDeduplicatingBatchSet(t *testing.T) {
 		require.NoError(t, uniqueSet.Err())
 		require.Len(t, batches, 3)
 
-		require.Len(t, batches[0].Series, 1)
-		assert.Equal(t, series1, batches[0].Series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, batches[0].Series[0].chunks)
+		require.Len(t, batches[0].series, 1)
+		assert.Equal(t, series1, batches[0].series[0].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, batches[0].series[0].chunks)
 
-		require.Len(t, batches[1].Series, 1)
-		assert.Equal(t, series2, batches[1].Series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, batches[1].Series[0].chunks)
+		require.Len(t, batches[1].series, 1)
+		assert.Equal(t, series2, batches[1].series[0].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, batches[1].series[0].chunks)
 
-		require.Len(t, batches[2].Series, 1)
-		assert.Equal(t, series3, batches[2].Series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, batches[2].Series[0].chunks)
+		require.Len(t, batches[2].series, 1)
+		assert.Equal(t, series3, batches[2].series[0].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, batches[2].series[0].chunks)
 	})
 
 	t.Run("batch size: 2", func(t *testing.T) {
@@ -137,19 +137,19 @@ func TestDeduplicatingBatchSet(t *testing.T) {
 		require.Len(t, batches, 2)
 
 		// First batch.
-		require.Len(t, batches[0].Series, 2)
+		require.Len(t, batches[0].series, 2)
 
-		assert.Equal(t, series1, batches[0].Series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, batches[0].Series[0].chunks)
+		assert.Equal(t, series1, batches[0].series[0].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, batches[0].series[0].chunks)
 
-		assert.Equal(t, series2, batches[0].Series[1].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, batches[0].Series[1].chunks)
+		assert.Equal(t, series2, batches[0].series[1].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, batches[0].series[1].chunks)
 
 		// Second batch.
-		require.Len(t, batches[1].Series, 1)
+		require.Len(t, batches[1].series, 1)
 
-		assert.Equal(t, series3, batches[1].Series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, batches[1].Series[0].chunks)
+		assert.Equal(t, series3, batches[1].series[0].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, batches[1].series[0].chunks)
 	})
 
 	t.Run("batch size: 3", func(t *testing.T) {
@@ -159,22 +159,22 @@ func TestDeduplicatingBatchSet(t *testing.T) {
 
 		require.NoError(t, uniqueSet.Err())
 		require.Len(t, batches, 1)
-		require.Len(t, batches[0].Series, 3)
+		require.Len(t, batches[0].series, 3)
 
-		assert.Equal(t, series1, batches[0].Series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, batches[0].Series[0].chunks)
+		assert.Equal(t, series1, batches[0].series[0].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, batches[0].series[0].chunks)
 
-		assert.Equal(t, series2, batches[0].Series[1].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, batches[0].Series[1].chunks)
+		assert.Equal(t, series2, batches[0].series[1].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, batches[0].series[1].chunks)
 
-		assert.Equal(t, series3, batches[0].Series[2].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, batches[0].Series[2].chunks)
+		assert.Equal(t, series3, batches[0].series[2].lset)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, batches[0].series[2].chunks)
 	})
 }
 
 func TestDeduplicatingBatchSet_PropagatesErrors(t *testing.T) {
 	chainedSet := newDeduplicatingBatchSet(100, newSliceUnloadedBatchSet(errors.New("something went wrong"), seriesChunkRefsSet{
-		Series: []seriesChunkRefs{
+		series: []seriesChunkRefs{
 			{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
 			{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
 			{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
@@ -201,17 +201,17 @@ func TestMergedBatchSet(t *testing.T) {
 		"merges two batches without overlap": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1], c[2], c[3]}},
 				},
 			}),
 			expectedBatches: []seriesChunkRefsSet{
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1], c[2], c[3]}},
 				}},
@@ -220,18 +220,18 @@ func TestMergedBatchSet(t *testing.T) {
 		"merges two batches with last series from each overlapping": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[0]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[0], c[2], c[3]}},
 				},
 			}),
 			expectedBatches: []seriesChunkRefsSet{
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[0], c[0], c[2], c[3]}},
 				}},
@@ -241,13 +241,13 @@ func TestMergedBatchSet(t *testing.T) {
 			batchSize: 100,
 			set1:      emptyBatchSet{},
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
 				},
 			}),
 			expectedBatches: []seriesChunkRefsSet{
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
 				}},
@@ -256,12 +256,12 @@ func TestMergedBatchSet(t *testing.T) {
 		"merges two batches with first one erroring at the end": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(errors.New("something went wrong"), seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 				},
 			}),
@@ -271,12 +271,12 @@ func TestMergedBatchSet(t *testing.T) {
 		"merges two batches with second one erroring at the end": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(errors.New("something went wrong"), seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 				},
 			}),
@@ -286,13 +286,13 @@ func TestMergedBatchSet(t *testing.T) {
 		"merges two batches with shorter one erroring at the end": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(errors.New("something went wrong"), seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
 					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
 					{lset: labels.FromStrings("l1", "v3"), chunks: make([]seriesChunkRef, 1)},
 					{lset: labels.FromStrings("l1", "v4"), chunks: make([]seriesChunkRef, 1)},
@@ -304,25 +304,25 @@ func TestMergedBatchSet(t *testing.T) {
 		"should stop iterating as soon as the first underlying set returns an error": {
 			batchSize: 1, // Use a batch size of 1 in this test so that we can see when the iteration stops.
 			set1: newSliceUnloadedBatchSet(errors.New("something went wrong"), seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[2]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
 					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[3]}},
 				},
 			}),
 			expectedBatches: []seriesChunkRefsSet{
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
 				}},
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
 				}},
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[2]}},
 				}},
 			},
@@ -331,17 +331,17 @@ func TestMergedBatchSet(t *testing.T) {
 		"should return merged chunks sorted by min time (assuming source sets have sorted chunks) on first chunk on first set": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1], c[3]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[2]}},
 				},
 			}),
 			expectedBatches: []seriesChunkRefsSet{
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
 				}},
 			},
@@ -349,17 +349,17 @@ func TestMergedBatchSet(t *testing.T) {
 		"should return merged chunks sorted by min time (assuming source sets have sorted chunks) on first chunk on second set": {
 			batchSize: 100,
 			set1: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[3]}},
 				},
 			}),
 			set2: newSliceUnloadedBatchSet(nil, seriesChunkRefsSet{
-				Series: []seriesChunkRefs{
+				series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1], c[2]}},
 				},
 			}),
 			expectedBatches: []seriesChunkRefsSet{
-				{Series: []seriesChunkRefs{
+				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
 				}},
 			},
@@ -381,10 +381,10 @@ func TestMergedBatchSet(t *testing.T) {
 
 			assert.Len(t, batches, len(testCase.expectedBatches))
 			for batchIdx, expectedBatch := range testCase.expectedBatches {
-				assert.Len(t, batches[batchIdx].Series, len(expectedBatch.Series))
-				for expectedSeriesIdx, expectedSeries := range expectedBatch.Series {
-					assert.Equal(t, expectedSeries.lset, batches[batchIdx].Series[expectedSeriesIdx].lset)
-					assert.Equal(t, expectedSeries.chunks, batches[batchIdx].Series[expectedSeriesIdx].chunks)
+				assert.Len(t, batches[batchIdx].series, len(expectedBatch.series))
+				for expectedSeriesIdx, expectedSeries := range expectedBatch.series {
+					assert.Equal(t, expectedSeries.lset, batches[batchIdx].series[expectedSeriesIdx].lset)
+					assert.Equal(t, expectedSeries.chunks, batches[batchIdx].series[expectedSeriesIdx].chunks)
 				}
 			}
 		})
@@ -572,10 +572,10 @@ func generateUnloadedChunks(num int) []seriesChunkRef {
 
 	for i := 0; i < num; i++ {
 		out = append(out, seriesChunkRef{
-			BlockID: ulid.MustNew(uint64(i), nil),
-			Ref:     chunks.ChunkRef(i),
-			MinTime: int64(i),
-			MaxTime: int64(i),
+			blockID: ulid.MustNew(uint64(i), nil),
+			ref:     chunks.ChunkRef(i),
+			minTime: int64(i),
+			maxTime: int64(i),
 		})
 	}
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+type unloadedBatch struct {
+	Entries []unloadedBatchEntry
+	Stats   *safeQueryStats
+}
+
+func newBatch(size int) unloadedBatch {
+	return unloadedBatch{
+		Entries: make([]unloadedBatchEntry, size),
+		Stats:   newSafeQueryStats(),
+	}
+}
+
+func (b unloadedBatch) len() int {
+	return len(b.Entries)
+}
+
+type unloadedBatchEntry struct {
+	lset   labels.Labels
+	chunks []unloadedChunk
+}
+
+type unloadedChunk struct {
+	BlockID          ulid.ULID
+	Ref              chunks.ChunkRef
+	MinTime, MaxTime int64
+}
+
+func (m unloadedChunk) Compare(b unloadedChunk) int {
+	if m.MinTime < b.MinTime {
+		return 1
+	}
+	if m.MinTime > b.MinTime {
+		return -1
+	}
+
+	// Same min time.
+	if m.MaxTime < b.MaxTime {
+		return 1
+	}
+	if m.MaxTime > b.MaxTime {
+		return -1
+	}
+	return 0
+}

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -10,20 +10,20 @@ import (
 
 // seriesChunkRefsSet holds a set of series (sorted by labels) and their chunk references.
 type seriesChunkRefsSet struct {
-	// Series sorted by labels.
-	Series []seriesChunkRefs
-	Stats  *safeQueryStats
+	// series sorted by labels.
+	series []seriesChunkRefs
+	stats  *safeQueryStats
 }
 
 func newSeriesChunkRefsSet(size int) seriesChunkRefsSet {
 	return seriesChunkRefsSet{
-		Series: make([]seriesChunkRefs, size),
-		Stats:  newSafeQueryStats(),
+		series: make([]seriesChunkRefs, size),
+		stats:  newSafeQueryStats(),
 	}
 }
 
 func (b seriesChunkRefsSet) len() int {
-	return len(b.Series)
+	return len(b.series)
 }
 
 // seriesChunkRefs holds a series with a list of chunks.
@@ -34,26 +34,26 @@ type seriesChunkRefs struct {
 
 // seriesChunkRef holds the reference to a chunk in a given block.
 type seriesChunkRef struct {
-	BlockID          ulid.ULID
-	Ref              chunks.ChunkRef
-	MinTime, MaxTime int64
+	blockID          ulid.ULID
+	ref              chunks.ChunkRef
+	minTime, maxTime int64
 }
 
 // Compare returns > 0 if m should be before other when sorting seriesChunkRef,
 // 0 if they're equal or < 0 if m should be after other.
 func (m seriesChunkRef) Compare(other seriesChunkRef) int {
-	if m.MinTime < other.MinTime {
+	if m.minTime < other.minTime {
 		return 1
 	}
-	if m.MinTime > other.MinTime {
+	if m.minTime > other.minTime {
 		return -1
 	}
 
 	// Same min time.
-	if m.MaxTime < other.MaxTime {
+	if m.maxTime < other.maxTime {
 		return 1
 	}
-	if m.MaxTime > other.MaxTime {
+	if m.maxTime > other.maxTime {
 		return -1
 	}
 	return 0

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -8,46 +8,52 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
-type unloadedBatch struct {
-	Entries []unloadedBatchEntry
-	Stats   *safeQueryStats
+// seriesChunkRefsSet holds a set of series (sorted by labels) and their chunk references.
+type seriesChunkRefsSet struct {
+	// Series sorted by labels.
+	Series []seriesChunkRefs
+	Stats  *safeQueryStats
 }
 
-func newBatch(size int) unloadedBatch {
-	return unloadedBatch{
-		Entries: make([]unloadedBatchEntry, size),
-		Stats:   newSafeQueryStats(),
+func newSeriesChunkRefsSet(size int) seriesChunkRefsSet {
+	return seriesChunkRefsSet{
+		Series: make([]seriesChunkRefs, size),
+		Stats:  newSafeQueryStats(),
 	}
 }
 
-func (b unloadedBatch) len() int {
-	return len(b.Entries)
+func (b seriesChunkRefsSet) len() int {
+	return len(b.Series)
 }
 
-type unloadedBatchEntry struct {
+// seriesChunkRefs holds a series with a list of chunks.
+type seriesChunkRefs struct {
 	lset   labels.Labels
-	chunks []unloadedChunk
+	chunks []seriesChunkRef
 }
 
-type unloadedChunk struct {
+// seriesChunkRef holds the reference to a chunk in a given block.
+type seriesChunkRef struct {
 	BlockID          ulid.ULID
 	Ref              chunks.ChunkRef
 	MinTime, MaxTime int64
 }
 
-func (m unloadedChunk) Compare(b unloadedChunk) int {
-	if m.MinTime < b.MinTime {
+// Compare returns > 0 if m should be before other when sorting seriesChunkRef,
+// 0 if they're equal or < 0 if m should be after other.
+func (m seriesChunkRef) Compare(other seriesChunkRef) int {
+	if m.MinTime < other.MinTime {
 		return 1
 	}
-	if m.MinTime > b.MinTime {
+	if m.MinTime > other.MinTime {
 		return -1
 	}
 
 	// Same min time.
-	if m.MaxTime < b.MaxTime {
+	if m.MaxTime < other.MaxTime {
 		return 1
 	}
-	if m.MaxTime > b.MaxTime {
+	if m.MaxTime > other.MaxTime {
 		return -1
 	}
 	return 0

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -12,19 +12,19 @@ import (
 
 func TestSeriesChunkRef_Compare(t *testing.T) {
 	input := []seriesChunkRef{
-		{BlockID: ulid.MustNew(0, nil), MinTime: 2, MaxTime: 5},
-		{BlockID: ulid.MustNew(1, nil), MinTime: 1, MaxTime: 5},
-		{BlockID: ulid.MustNew(2, nil), MinTime: 1, MaxTime: 3},
-		{BlockID: ulid.MustNew(3, nil), MinTime: 4, MaxTime: 7},
-		{BlockID: ulid.MustNew(4, nil), MinTime: 3, MaxTime: 6},
+		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
+		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
+		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
+		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
+		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
 	}
 
 	expected := []seriesChunkRef{
-		{BlockID: ulid.MustNew(2, nil), MinTime: 1, MaxTime: 3},
-		{BlockID: ulid.MustNew(1, nil), MinTime: 1, MaxTime: 5},
-		{BlockID: ulid.MustNew(0, nil), MinTime: 2, MaxTime: 5},
-		{BlockID: ulid.MustNew(4, nil), MinTime: 3, MaxTime: 6},
-		{BlockID: ulid.MustNew(3, nil), MinTime: 4, MaxTime: 7},
+		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
+		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
+		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
+		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
+		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
 	}
 
 	sort.Slice(input, func(i, j int) bool {

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeriesChunkRef_Compare(t *testing.T) {
+	input := []seriesChunkRef{
+		{BlockID: ulid.MustNew(0, nil), MinTime: 2, MaxTime: 5},
+		{BlockID: ulid.MustNew(1, nil), MinTime: 1, MaxTime: 5},
+		{BlockID: ulid.MustNew(2, nil), MinTime: 1, MaxTime: 3},
+		{BlockID: ulid.MustNew(3, nil), MinTime: 4, MaxTime: 7},
+		{BlockID: ulid.MustNew(4, nil), MinTime: 3, MaxTime: 6},
+	}
+
+	expected := []seriesChunkRef{
+		{BlockID: ulid.MustNew(2, nil), MinTime: 1, MaxTime: 3},
+		{BlockID: ulid.MustNew(1, nil), MinTime: 1, MaxTime: 5},
+		{BlockID: ulid.MustNew(0, nil), MinTime: 2, MaxTime: 5},
+		{BlockID: ulid.MustNew(4, nil), MinTime: 3, MaxTime: 6},
+		{BlockID: ulid.MustNew(3, nil), MinTime: 4, MaxTime: 7},
+	}
+
+	sort.Slice(input, func(i, j int) bool {
+		return input[i].Compare(input[j]) > 0
+	})
+
+	assert.Equal(t, expected, input)
+}


### PR DESCRIPTION
#### What this PR does
Refactoring PR to rename the unloaded data structures. As separate commits:
- [Move unloaded structs to dedicated file](https://github.com/grafana/mimir/commit/6904b6e73819e543c31378b18dedc1c45a884711) 
- [Rename unloaded data structures](https://github.com/grafana/mimir/commit/b415772dff7b2ab4b7085c8813e8485576c679e5) 
- [Unexport fields](https://github.com/grafana/mimir/commit/bd964045ea28536cfbc5bd4de4e2723d79d00867)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
