### PR TITLE
store-gateway streaming: Fix configuration options naming

### DIFF
--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -302,8 +302,7 @@ type BucketStoreConfig struct {
 
 	// Controls what to do when MaxConcurrent is exceeded: fail immediately or wait for a slot to run.
 	MaxConcurrentRejectOverLimit bool `yaml:"max_concurrent_reject_over_limit" category:"experimental"`
-	BatchedSeriesLoading         bool `yaml:"batched_series_loading" category:"experimental"`
-	BatchSeriesSize              int  `yaml:"batch_series_size" category:"experimental"`
+	StreamingBatchSize           int  `yaml:"streaming_series_batch_size" category:"experimental"`
 }
 
 // RegisterFlags registers the BucketStore flags
@@ -333,8 +332,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.IndexHeaderLazyLoadingEnabled, "blocks-storage.bucket-store.index-header-lazy-loading-enabled", true, "If enabled, store-gateway will lazy load an index-header only once required by a query.")
 	f.DurationVar(&cfg.IndexHeaderLazyLoadingIdleTimeout, "blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout", 60*time.Minute, "If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity.")
 	f.Uint64Var(&cfg.PartitionerMaxGapBytes, "blocks-storage.bucket-store.partitioner-max-gap-bytes", DefaultPartitionerMaxGapSize, "Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests.")
-	f.BoolVar(&cfg.BatchedSeriesLoading, "blocks-storage.bucket-store.batched-series-loading", false, "If enabled, store-gateway will load series from the store in batches instead of loading them all in memory.")
-	f.IntVar(&cfg.BatchSeriesSize, "blocks-storage.bucket-store.batch-series-size", 65536, "How many series to fetch per batch when batched-series-loading is enabled.")
+	f.IntVar(&cfg.StreamingBatchSize, "blocks-storage.bucket-store.batch-series-size", 0, "If larger than 0, store-gateway will load series from the store in batches and stream them to the querier instead of loading them all in memory. This option controls how many series to fetch per batch")
 }
 
 // Validate the config.

--- a/pkg/storegateway/batch_series.go
+++ b/pkg/storegateway/batch_series.go
@@ -130,14 +130,14 @@ func unloadedBucketBatches(
 	batchSize int,
 	indexr *bucketIndexReader, // Index reader for block.
 	blockID ulid.ULID,
-	matchers []*labels.Matcher,                      // Series matchers.
-	shard *sharding.ShardSelector,                   // Shard selector.
+	matchers []*labels.Matcher, // Series matchers.
+	shard *sharding.ShardSelector, // Shard selector.
 	seriesHashCache *hashcache.BlockSeriesHashCache, // Block-specific series hash cache (used only if shard selector is specified).
-	chunksLimiter ChunksLimiter,                     // Rate limiter for loading chunks.
-	seriesLimiter SeriesLimiter,                     // Rate limiter for loading series.
-	skipChunks bool,                                 // If true chunks are not loaded and minTime/maxTime are ignored.
-	minTime, maxTime int64,                          // Series must have data in this time range to be returned (ignored if skipChunks=true).
-	loadAggregates []storepb.Aggr,                   // List of aggregates to load when loading chunks.
+	chunksLimiter ChunksLimiter, // Rate limiter for loading chunks.
+	seriesLimiter SeriesLimiter, // Rate limiter for loading series.
+	skipChunks bool, // If true chunks are not loaded and minTime/maxTime are ignored.
+	minTime, maxTime int64, // Series must have data in this time range to be returned (ignored if skipChunks=true).
+	loadAggregates []storepb.Aggr, // List of aggregates to load when loading chunks.
 	logger log.Logger,
 ) (unloadedBatchSet, error) {
 	if batchSize <= 0 {
@@ -349,7 +349,7 @@ func (s *BucketStore) batchSetsForBlocks(ctx context.Context, req *storepb.Serie
 			)
 
 			part, err = unloadedBucketBatches(
-				ctx, s.seriesPerBatch, indexr, b.meta.ULID, matchers, shardSelector, blockSeriesHashCache, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates, s.logger)
+				ctx, s.maxSeriesPerBatch, indexr, b.meta.ULID, matchers, shardSelector, blockSeriesHashCache, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, req.Aggregates, s.logger)
 			if err != nil {
 				return errors.Wrapf(err, "fetch series for block %s", b.meta.ULID)
 			}
@@ -380,7 +380,7 @@ func (s *BucketStore) batchSetsForBlocks(ctx context.Context, req *storepb.Serie
 	stats.blocksQueried = len(batches)
 	stats.getAllDuration = time.Since(begin)
 
-	mergedBatches := mergedBatchSets(s.seriesPerBatch, batches...)
+	mergedBatches := mergedBatchSets(s.maxSeriesPerBatch, batches...)
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
 		set = newSeriesSetWithChunks(ctx, *chunkReaders, mergedBatches)

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -175,8 +175,7 @@ func prepareStoreWithTestBlocksForSeries(t testing.TB, dir string, bkt objstore.
 		NewBucketStoreMetrics(nil),
 		WithLogger(s.logger),
 		WithIndexCache(s.cache),
-		WithBatchedSeries(true),
-		WithBatchSeriesSize(65536),
+		WithStreamingSeriesPerBatch(65536),
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -463,8 +463,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 		WithIndexCache(u.indexCache),
 		WithQueryGate(u.queryGate),
 		WithChunkPool(u.chunksPool),
-		WithBatchedSeries(u.cfg.BucketStore.BatchedSeriesLoading),
-		WithBatchSeriesSize(u.cfg.BucketStore.BatchSeriesSize),
+		WithStreamingSeriesPerBatch(u.cfg.BucketStore.StreamingBatchSize),
 	}
 	if u.logLevel.String() == "debug" {
 		bucketStoreOpts = append(bucketStoreOpts, WithDebugLogging())

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1051,8 +1051,7 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithChunkPool(chunkPool),
-		WithBatchedSeries(true),
-		WithBatchSeriesSize(65536),
+		WithStreamingSeriesPerBatch(65536),
 	)
 	assert.NoError(t, err)
 
@@ -1254,12 +1253,11 @@ func TestBucketSeries_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 			b1.meta.ULID: b1,
 			b2.meta.ULID: b2,
 		},
-		queryGate:                     gate.NewNoop(),
-		chunksLimiterFactory:          NewChunksLimiterFactory(0),
-		seriesLimiterFactory:          NewSeriesLimiterFactory(0),
-		disableSeriesLoadingInBatches: false,
-		seriesPerBatch:                65536,
-		chunkPool:                     chunkPool,
+		queryGate:            gate.NewNoop(),
+		chunksLimiterFactory: NewChunksLimiterFactory(0),
+		seriesLimiterFactory: NewSeriesLimiterFactory(0),
+		maxSeriesPerBatch:    65536,
+		chunkPool:            chunkPool,
 	}
 
 	t.Run("invoke series for one block. Fill the cache on the way.", func(t *testing.T) {
@@ -1410,8 +1408,7 @@ func TestSeries_ErrorUnmarshallingRequestHints(t *testing.T) {
 		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
-		WithBatchedSeries(true),
-		WithBatchSeriesSize(65536),
+		WithStreamingSeriesPerBatch(65536),
 	)
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
@@ -1502,8 +1499,7 @@ func TestSeries_BlockWithMultipleChunks(t *testing.T) {
 		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
-		WithBatchedSeries(true),
-		WithBatchSeriesSize(65536),
+		WithStreamingSeriesPerBatch(65536),
 	)
 	assert.NoError(t, err)
 	assert.NoError(t, store.SyncBlocks(context.Background()))
@@ -1669,8 +1665,7 @@ func setupStoreForHintsTest(t *testing.T) (test.TB, *BucketStore, []*storepb.Ser
 		NewBucketStoreMetrics(nil),
 		WithLogger(logger),
 		WithIndexCache(indexCache),
-		WithBatchedSeries(true),
-		WithBatchSeriesSize(65536),
+		WithStreamingSeriesPerBatch(65536),
 	)
 	assert.NoError(tb, err)
 	assert.NoError(tb, store.SyncBlocks(context.Background()))


### PR DESCRIPTION
Removes `-blocks-storage.bucket-store.batched-series-loading`. To disable streaming the user can set `-blocks-storage.bucket-store.batch-series-size` to `0`

Also renames some internal config options to make them positive instead of negative.