### PR TITLE
Query-frontend: use activity tracker for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
+* [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 
 ### Mixin

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -254,7 +254,7 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	r.PathPrefix("/").Handler(middleware.Merge(
 		middleware.AuthenticateUser,
 		middleware.Tracer{},
-	).Wrap(transport.NewHandler(config.Handler, rt, logger, nil)))
+	).Wrap(transport.NewHandler(config.Handler, rt, logger, nil, nil)))
 
 	httpServer := http.Server{
 		Handler: r,

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -132,7 +132,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	defer func() { _ = r.Body.Close() }()
 
-	// Store the body contents in a seeker, so we can read it multiple times.
+	// Store the body contents, so we can read it multiple times.
 	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize))
 	if err != nil {
 		writeError(w, err)

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -266,7 +266,7 @@ func testFrontend(t *testing.T, config Config, handler http.Handler, test func(a
 	r.PathPrefix("/").Handler(middleware.Merge(
 		middleware.AuthenticateUser,
 		middleware.Tracer{},
-	).Wrap(transport.NewHandler(handlerCfg, rt, logger, nil)))
+	).Wrap(transport.NewHandler(handlerCfg, rt, logger, nil, nil)))
 
 	httpServer := http.Server{
 		Handler: r,

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -541,7 +541,7 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 	// Wrap roundtripper into Tripperware.
 	roundTripper = t.QueryFrontendTripperware(roundTripper)
 
-	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, t.Registerer)
+	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, t.Registerer, t.ActivityTracker)
 	t.API.RegisterQueryFrontendHandler(handler, t.BuildInfoHandler)
 
 	if frontendV1 != nil {


### PR DESCRIPTION
#### What this PR does

Query-frontend uses the activity-tracker for the PromQL engine, but that is just for the sharded queries execution. Query-frontend does much more than that, and we should also track that.

This adds every HTTP request received by the Handler to the activity tracker.

#### Which issue(s) this PR fixes or relates to

Fixes (none)

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
