### PR TITLE
Rename loaded structs

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+// seriesChunksSetIterator is the interface implemented by an iterator over a sequence of seriesChunksSet.
+type seriesChunksSetIterator interface {
+	Next() bool
+	At() seriesChunksSet
+	Err() error
+}
+
+// seriesChunksSet holds a set of series, each with its own chunks.
+type seriesChunksSet struct {
+	series []seriesEntry // this should ideally be its own type that doesn't have the refs
+	stats  *queryStats
+
+	bytesReleaser releaser
+}
+
+func (b *seriesChunksSet) release() {
+	if len(b.series) == 0 {
+		// There's nothing to release, just return; this also allows to call release() on a zero-valued seriesChunksSet.
+		return
+	}
+
+	b.bytesReleaser.Release()
+
+	// Make it harder to do a "use after free".
+	b.series = nil
+}
+
+func (b seriesChunksSet) len() int {
+	return len(b.series)
+}

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+// sliceSeriesChunksSetIterator implements seriesChunksSetIterator and
+// returns the provided err when the batches are exhausted
+type sliceSeriesChunksSetIterator struct {
+	current int
+	batches []seriesChunksSet
+
+	err error
+}
+
+func newSliceSeriesChunksSetIterator(err error, batches ...seriesChunksSet) seriesChunksSetIterator {
+	return &sliceSeriesChunksSetIterator{
+		current: -1,
+		batches: batches,
+		err:     err,
+	}
+}
+
+func (s *sliceSeriesChunksSetIterator) Next() bool {
+	s.current++
+	return s.current < len(s.batches)
+}
+
+func (s *sliceSeriesChunksSetIterator) At() seriesChunksSet {
+	return s.batches[s.current]
+}
+
+func (s *sliceSeriesChunksSetIterator) Err() error {
+	if s.current >= len(s.batches) {
+		return s.err
+	}
+	return nil
+}

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSeriesChunkRef_Compare(t *testing.T) {
@@ -32,4 +35,138 @@ func TestSeriesChunkRef_Compare(t *testing.T) {
 	})
 
 	assert.Equal(t, expected, input)
+}
+
+func TestSeriesChunkRefsIterator(t *testing.T) {
+	c := generateSeriesChunkRef(5)
+	series1 := labels.FromStrings(labels.MetricName, "metric_1")
+	series2 := labels.FromStrings(labels.MetricName, "metric_2")
+	series3 := labels.FromStrings(labels.MetricName, "metric_3")
+	series4 := labels.FromStrings(labels.MetricName, "metric_4")
+
+	t.Run("should iterate an empty set", func(t *testing.T) {
+		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
+			series: []seriesChunkRefs{},
+		})
+
+		require.True(t, it.Done())
+
+		require.False(t, it.Next())
+		require.True(t, it.Done())
+	})
+
+	t.Run("should iterate a set with some items", func(t *testing.T) {
+		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
+			series: []seriesChunkRefs{
+				{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
+				{lset: series2, chunks: []seriesChunkRef{c[2]}},
+				{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}},
+			},
+		})
+
+		require.True(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series2, chunks: []seriesChunkRef{c[2]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}}, it.At())
+		require.False(t, it.Done())
+
+		require.False(t, it.Next())
+		require.True(t, it.Done())
+	})
+
+	t.Run("should re-initialize the internal state on reset()", func(t *testing.T) {
+		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
+			series: []seriesChunkRefs{
+				{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
+				{lset: series2, chunks: []seriesChunkRef{c[2]}},
+				{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}},
+			},
+		})
+
+		require.True(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series2, chunks: []seriesChunkRef{c[2]}}, it.At())
+		require.False(t, it.Done())
+
+		// Reset.
+		it.reset(seriesChunkRefsSet{
+			series: []seriesChunkRefs{
+				{lset: series1, chunks: []seriesChunkRef{c[3]}},
+				{lset: series4, chunks: []seriesChunkRef{c[4]}},
+			},
+		})
+
+		require.False(t, it.Done())
+
+		// No need to call Next() because it's implicitly called by reset().
+		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[3]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series4, chunks: []seriesChunkRef{c[4]}}, it.At())
+		require.False(t, it.Done())
+
+		require.False(t, it.Next())
+		require.True(t, it.Done())
+	})
+}
+
+// sliceSeriesChunkRefsSetIterator implements seriesChunkRefsSetIterator and
+// returns the provided err when the sets are exhausted.
+type sliceSeriesChunkRefsSetIterator struct {
+	current int
+	sets    []seriesChunkRefsSet
+	err     error
+}
+
+func newSliceSeriesChunkRefsSetIterator(err error, batches ...seriesChunkRefsSet) seriesChunkRefsSetIterator {
+	return &sliceSeriesChunkRefsSetIterator{
+		current: -1,
+		sets:    batches,
+		err:     err,
+	}
+}
+
+func (s *sliceSeriesChunkRefsSetIterator) Next() bool {
+	s.current++
+	return s.current < len(s.sets)
+}
+
+func (s *sliceSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
+	return s.sets[s.current]
+}
+
+func (s *sliceSeriesChunkRefsSetIterator) Err() error {
+	if s.current >= len(s.sets) {
+		return s.err
+	}
+	return nil
+}
+
+func generateSeriesChunkRef(num int) []seriesChunkRef {
+	out := make([]seriesChunkRef, 0, num)
+
+	for i := 0; i < num; i++ {
+		out = append(out, seriesChunkRef{
+			blockID: ulid.MustNew(uint64(i), nil),
+			ref:     chunks.ChunkRef(i),
+			minTime: int64(i),
+			maxTime: int64(i),
+		})
+	}
+
+	return out
 }


### PR DESCRIPTION
#### What this PR does
In this PR, as separate commits:
- [Move loaded structs to dedicated file](https://github.com/grafana/mimir/commit/85c202ec8054b1ae1011a9cb7f6562d745813bcf) 
- [Renamed 'loaded' structs](https://github.com/grafana/mimir/commit/793b222bba5d02da0c7ab1039381db4ac3e91b6c) 
- [Unexported struct fields](https://github.com/grafana/mimir/commit/8334ef003dd451bacb80d387d1f4d4d2782d858a) 
- [Formatted comments in seriesChunksSet.release()](https://github.com/grafana/mimir/commit/5867c17c502e17ccea8223bbce66b19ef897c2e3) 
- [Removed seriesChunks because unused](https://github.com/grafana/mimir/commit/2f70a4c18a31b439672ba1b08e023033f521f4aa). I initially wanted to use `seriesChunks` in `seriesChunksSet.series` but it turned out to be more complicated than expected because used by the `bucketChunkReader`. I will attempt the refactoring in a dedicated PR.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
