### PR TITLE
Removed stats from seriesChunksSet

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -12,7 +12,6 @@ type seriesChunksSetIterator interface {
 // seriesChunksSet holds a set of series, each with its own chunks.
 type seriesChunksSet struct {
 	series []seriesEntry // this should ideally be its own type that doesn't have the refs
-	stats  *queryStats
 
 	bytesReleaser releaser
 }


### PR DESCRIPTION
#### What this PR does
Removing `stats` from `seriesChunksSet`. The stats were unused, while in this PR stats should be updated (but we're still lacking unit tests).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
