### PR TITLE
mark version in changelog as rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Grafana Mimir - main / unreleased
 
-## 2.5.0
+## 2.5.0-rc.0
 
 ### Grafana Mimir
 


### PR DESCRIPTION
I noticed too late that as long as the new version isn't released it should be marked as an `rc` in the changelog

Signed-off-by: Mauro Stettler <mauro.stettler@gmail.com>
