### PR TITLE
Improve speed of Golang-related Makefile targets when running on macOS (and don't break Linux hosts)

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -134,7 +134,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:chore-upgrade-go-036177f2f
+      image: grafana/mimir-build-image:pr3584-1806872c5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -215,17 +215,14 @@ GO_FLAGS := -ldflags "\
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 
-GOVOLUMES=	-v $(shell pwd)/.cache:/go/cache:$(CONTAINER_MOUNT_OPTIONS) \
-			-v $(shell pwd)/.pkg:/go/pkg:$(CONTAINER_MOUNT_OPTIONS) \
+GOVOLUMES=	-v mimir-go-cache:/go/cache \
+			-v mimir-go-pkg:/go/pkg \
 			-v $(shell pwd):/go/src/github.com/grafana/mimir:$(CONTAINER_MOUNT_OPTIONS)
 
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
 exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt conftest-test conftest-verify check-helm-tests build-helm-tests: fetch-build-image
-	@mkdir -p $(shell pwd)/.pkg
-	@mkdir -p $(shell pwd)/.cache
-	@echo
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
 
@@ -463,7 +460,8 @@ format-makefiles: $(MAKE_FILES)
 
 clean: ## Cleanup the docker images, object files and executables.
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true
-	rm -rf -- $(UPTODATE_FILES) $(EXES) .cache dist
+	$(SUDO) docker volume rm -f mimir-go-pkg mimir-go-cache
+	rm -rf -- $(UPTODATE_FILES) $(EXES) dist
 	# Remove executables built for multiarch images.
 	find . -type f -name '*_linux_arm64' -perm +u+x -exec rm {} \;
 	find . -type f -name '*_linux_amd64' -perm +u+x -exec rm {} \;
@@ -497,7 +495,7 @@ reference-help: cmd/mimir/mimir
 	@(go run ./tools/config-inspector || true) > cmd/mimir/config-descriptor.json
 
 clean-white-noise: ## Clean the white noise in the markdown files.
-	@find . -path ./.pkg -prune -o -path "*/vendor/*" -prune -or -type f -name "*.md" -print | \
+	@find . -path ./.pkg -prune -o -path ./.cache -prune -o -path "*/vendor/*" -prune -or -type f -name "*.md" -print | \
 	SED_BIN="$(SED)" xargs ./tools/cleanup-white-noise.sh
 
 check-white-noise: ## Check the white noise in the markdown files.
@@ -592,8 +590,6 @@ ifeq ($(PACKAGE_IN_CONTAINER), true)
 
 .PHONY: packages
 packages: dist packaging/fpm/$(UPTODATE)
-	@mkdir -p $(shell pwd)/.pkg
-	@mkdir -p $(shell pwd)/.cache
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) \
 		-v  $(shell pwd):/go/src/github.com/grafana/mimir:$(CONTAINER_MOUNT_OPTIONS) \

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= chore-upgrade-go-036177f2f
+LATEST_BUILD_IMAGE_TAG ?= pr3584-1806872c5
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,7 @@ format-makefiles: $(MAKE_FILES)
 clean: ## Cleanup the docker images, object files and executables.
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true
 	$(SUDO) docker volume rm -f mimir-go-pkg mimir-go-cache
-	rm -rf -- $(UPTODATE_FILES) $(EXES) dist
+	rm -rf -- $(UPTODATE_FILES) $(EXES) .cache dist
 	# Remove executables built for multiarch images.
 	find . -type f -name '*_linux_arm64' -perm +u+x -exec rm {} \;
 	find . -type f -name '*_linux_amd64' -perm +u+x -exec rm {} \;

--- a/mimir-build-image/build.sh
+++ b/mimir-build-image/build.sh
@@ -18,4 +18,7 @@ echo "weave:x:$uid:$gid::$SRC_PATH:/bin/sh" >>/etc/passwd
 echo "weave:*:::::::" >>/etc/shadow
 echo "weave	ALL=(ALL)	NOPASSWD: ALL" >>/etc/sudoers
 
+chown "$uid:$gid" /go/cache
+chown "$uid:$gid" /go/pkg
+
 su weave -c "PATH=$PATH make -C $SRC_PATH BUILD_IN_CONTAINER=false $*"


### PR DESCRIPTION
#### What this PR does

Same as #3527 + a fix for Linux hosts (see https://github.com/grafana/mimir/pull/3527#issuecomment-1330810445 and #3569)

I don't have permission to push an updated build image - could a maintainer please follow the instructions in https://github.com/grafana/mimir/blob/1806872c575eeaaaab132cce55cd157360cfdaca/docs/internal/how-to-update-the-build-image.md to build, push and update the image reference everywhere?

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
