### PR TITLE
Changed seriesChunkRefsIterator's reset() and Done() logic

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -2,7 +2,7 @@
 
 package storegateway
 
-// seriesChunksSetIterator is the interface implemented by an iterator over a sequence of seriesChunksSet.
+// seriesChunksSetIterator is the interface implemented by an iterator returning a sequence of seriesChunksSet.
 type seriesChunksSetIterator interface {
 	Next() bool
 	At() seriesChunksSet

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -3,33 +3,33 @@
 package storegateway
 
 // sliceSeriesChunksSetIterator implements seriesChunksSetIterator and
-// returns the provided err when the batches are exhausted
+// returns the provided err when the sets are exhausted
 type sliceSeriesChunksSetIterator struct {
 	current int
-	batches []seriesChunksSet
+	sets    []seriesChunksSet
 
 	err error
 }
 
-func newSliceSeriesChunksSetIterator(err error, batches ...seriesChunksSet) seriesChunksSetIterator {
+func newSliceSeriesChunksSetIterator(err error, sets ...seriesChunksSet) seriesChunksSetIterator {
 	return &sliceSeriesChunksSetIterator{
 		current: -1,
-		batches: batches,
+		sets:    sets,
 		err:     err,
 	}
 }
 
 func (s *sliceSeriesChunksSetIterator) Next() bool {
 	s.current++
-	return s.current < len(s.batches)
+	return s.current < len(s.sets)
 }
 
 func (s *sliceSeriesChunksSetIterator) At() seriesChunksSet {
-	return s.batches[s.current]
+	return s.sets[s.current]
 }
 
 func (s *sliceSeriesChunksSetIterator) Err() error {
-	if s.current >= len(s.batches) {
+	if s.current >= len(s.sets) {
 		return s.err
 	}
 	return nil

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -8,14 +8,21 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
-// seriesChunkRefsSetIterator is the interface implemented by an iterator over a sequence of seriesChunkRefsSet.
+// seriesChunkRefsSetIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefsSet.
 type seriesChunkRefsSetIterator interface {
 	Next() bool
 	At() seriesChunkRefsSet
 	Err() error
 }
 
-// seriesChunkRefsSet holds a set of series (sorted by labels) and their chunk references.
+// seriesChunkRefsIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefs.
+type seriesChunkRefsIterator interface {
+	Next() bool
+	At() seriesChunkRefs
+	Err() error
+}
+
+// seriesChunkRefsSet holds a set of a set of series (sorted by labels) and their chunk references.
 type seriesChunkRefsSet struct {
 	// series sorted by labels.
 	series []seriesChunkRefs
@@ -31,7 +38,7 @@ func (b seriesChunkRefsSet) len() int {
 	return len(b.series)
 }
 
-// seriesChunkRefs holds a series with a list of chunks.
+// seriesChunkRefs holds a series with a list of chunk references.
 type seriesChunkRefs struct {
 	lset   labels.Labels
 	chunks []seriesChunkRef
@@ -64,36 +71,41 @@ func (m seriesChunkRef) Compare(other seriesChunkRef) int {
 	return 0
 }
 
-// seriesChunkRefsIterator implements an interator over seriesChunkRefsSet.
-type seriesChunkRefsIterator struct {
+// seriesChunkRefsIteratorImpl implements an iterator returning a sequence of seriesChunkRefs.
+type seriesChunkRefsIteratorImpl struct {
 	currentOffset int
 	set           seriesChunkRefsSet
 }
 
-func newSeriesChunkRefsIterator(set seriesChunkRefsSet) *seriesChunkRefsIterator {
-	return &seriesChunkRefsIterator{
-		set:           set,
-		currentOffset: -1,
-	}
+func newSeriesChunkRefsIterator(set seriesChunkRefsSet) *seriesChunkRefsIteratorImpl {
+	c := &seriesChunkRefsIteratorImpl{}
+	c.reset(set)
+
+	return c
 }
 
-// reset replaces the current set with the provided one. There is no need to call Next() after reset().
-func (c *seriesChunkRefsIterator) reset(set seriesChunkRefsSet) {
+// reset replaces the current set with the provided one. After calling reset() you
+// must call Next() to advance the iterator to the first element.
+func (c *seriesChunkRefsIteratorImpl) reset(set seriesChunkRefsSet) {
 	c.set = set
-	c.currentOffset = 0
+	c.currentOffset = -1
 }
 
-func (c *seriesChunkRefsIterator) Next() bool {
+func (c *seriesChunkRefsIteratorImpl) Next() bool {
 	c.currentOffset++
 	return !c.Done()
 }
 
-func (c *seriesChunkRefsIterator) Done() bool {
-	return c.currentOffset < 0 || c.currentOffset >= c.set.len()
+// Done returns true if the iterator trespassed the end and the item returned by At()
+// is the zero value. If the iterator is on the last item, the value returned by At()
+// is the actual item and Done() returns false.
+func (c *seriesChunkRefsIteratorImpl) Done() bool {
+	setLength := c.set.len()
+	return setLength == 0 || c.currentOffset >= setLength
 }
 
-func (c *seriesChunkRefsIterator) At() seriesChunkRefs {
-	if c.Done() {
+func (c *seriesChunkRefsIteratorImpl) At() seriesChunkRefs {
+	if c.currentOffset < 0 || c.currentOffset >= c.set.len() {
 		return seriesChunkRefs{}
 	}
 	return c.set.series[c.currentOffset]

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -110,3 +110,7 @@ func (c *seriesChunkRefsIteratorImpl) At() seriesChunkRefs {
 	}
 	return c.set.series[c.currentOffset]
 }
+
+func (c *seriesChunkRefsIteratorImpl) Err() error {
+	return nil
+}

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -50,9 +50,11 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 		})
 
 		require.True(t, it.Done())
+		require.Zero(t, it.At())
 
 		require.False(t, it.Next())
 		require.True(t, it.Done())
+		require.Zero(t, it.At())
 	})
 
 	t.Run("should iterate a set with some items", func(t *testing.T) {
@@ -64,7 +66,8 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 			},
 		})
 
-		require.True(t, it.Done())
+		require.False(t, it.Done())
+		require.Zero(t, it.At())
 
 		require.True(t, it.Next())
 		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
@@ -80,6 +83,7 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 
 		require.False(t, it.Next())
 		require.True(t, it.Done())
+		require.Zero(t, it.At())
 	})
 
 	t.Run("should re-initialize the internal state on reset()", func(t *testing.T) {
@@ -91,7 +95,8 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 			},
 		})
 
-		require.True(t, it.Done())
+		require.False(t, it.Done())
+		require.Zero(t, it.At())
 
 		require.True(t, it.Next())
 		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
@@ -111,7 +116,7 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 
 		require.False(t, it.Done())
 
-		// No need to call Next() because it's implicitly called by reset().
+		require.True(t, it.Next())
 		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[3]}}, it.At())
 		require.False(t, it.Done())
 
@@ -121,6 +126,7 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 
 		require.False(t, it.Next())
 		require.True(t, it.Done())
+		require.Zero(t, it.At())
 	})
 }
 
@@ -132,10 +138,10 @@ type sliceSeriesChunkRefsSetIterator struct {
 	err     error
 }
 
-func newSliceSeriesChunkRefsSetIterator(err error, batches ...seriesChunkRefsSet) seriesChunkRefsSetIterator {
+func newSliceSeriesChunkRefsSetIterator(err error, sets ...seriesChunkRefsSet) seriesChunkRefsSetIterator {
 	return &sliceSeriesChunkRefsSetIterator{
 		current: -1,
-		sets:    batches,
+		sets:    sets,
 		err:     err,
 	}
 }


### PR DESCRIPTION
#### What this PR does
In this PR I propose to change `seriesChunkRefsIterator` `reset()` and `Done()` logic, aiming to make it slightly more consistent. The proposed changes are:
- `reset()` does **not** implicitly invoke `Next()`, so calling `reset()` is like creating a `newSeriesChunkRefsIterator()`
- `Done()` returns `false` before `Next()` is called for the first time if and only if `Next()` would call `true` the first time (which means `Done()` returns `true` if the underlying set is empty).

In this PR I've also handled the case a set is empty and unit tests for:
- `seriesSetWithoutChunks` (see changes to its `Next()`)
- `mergedBatchSet` (see changes to its `Next()`)
- `chainedBatchSetIterator` (see changes to its `Next()`)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
