### PR TITLE
Streaming store-gateway: add structs and interfaces for sets of series

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+// seriesChunksSetIterator is the interface implemented by an iterator returning a sequence of seriesChunksSet.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunksSetIterator interface {
+	Next() bool
+	At() seriesChunksSet
+	Err() error
+}
+
+// seriesChunksSet holds a set of series, each with its own chunks.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunksSet struct {
+	series []seriesEntry // this should ideally be its own type that doesn't have the refs
+
+	bytesReleaser releaser
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+type releaser interface{ Release() }
+
+//nolint:unused // dead code while we are working on PR 3355
+func (b *seriesChunksSet) release() {
+	if len(b.series) == 0 {
+		// There's nothing to release, just return; this also allows to call release() on a zero-valued seriesChunksSet.
+		return
+	}
+
+	b.bytesReleaser.Release()
+
+	// Make it harder to do a "use after free".
+	b.series = nil
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (b seriesChunksSet) len() int {
+	return len(b.series)
+}

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+// sliceSeriesChunksSetIterator implements seriesChunksSetIterator and
+// returns the provided err when the sets are exhausted
+//
+//nolint:unused // dead code while we are working on PR 3355
+type sliceSeriesChunksSetIterator struct {
+	current int
+	sets    []seriesChunksSet
+
+	err error
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func newSliceSeriesChunksSetIterator(err error, sets ...seriesChunksSet) seriesChunksSetIterator {
+	return &sliceSeriesChunksSetIterator{
+		current: -1,
+		sets:    sets,
+		err:     err,
+	}
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (s *sliceSeriesChunksSetIterator) Next() bool {
+	s.current++
+	return s.current < len(s.sets)
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (s *sliceSeriesChunksSetIterator) At() seriesChunksSet {
+	return s.sets[s.current]
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (s *sliceSeriesChunksSetIterator) Err() error {
+	if s.current >= len(s.sets) {
+		return s.err
+	}
+	return nil
+}

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// seriesChunkRefsSetIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefsSet.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunkRefsSetIterator interface {
+	Next() bool
+	At() seriesChunkRefsSet
+	Err() error
+}
+
+// seriesChunkRefsIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefs.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunkRefsIterator interface {
+	Next() bool
+	At() seriesChunkRefs
+	Err() error
+}
+
+// seriesChunkRefsSet holds a set of a set of series (sorted by labels) and their chunk references.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunkRefsSet struct {
+	// series sorted by labels.
+	series []seriesChunkRefs
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func newSeriesChunkRefsSet(capacity int) seriesChunkRefsSet {
+	return seriesChunkRefsSet{
+		series: make([]seriesChunkRefs, 0, capacity),
+	}
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (b seriesChunkRefsSet) len() int {
+	return len(b.series)
+}
+
+// seriesChunkRefs holds a series with a list of chunk references.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunkRefs struct {
+	lset   labels.Labels
+	chunks []seriesChunkRef
+}
+
+// seriesChunkRef holds the reference to a chunk in a given block.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type seriesChunkRef struct {
+	blockID          ulid.ULID
+	ref              chunks.ChunkRef
+	minTime, maxTime int64
+}
+
+// Compare returns > 0 if m should be before other when sorting seriesChunkRef,
+// 0 if they're equal or < 0 if m should be after other.
+//
+//nolint:unused // dead code while we are working on PR 3355
+func (m seriesChunkRef) Compare(other seriesChunkRef) int {
+	if m.minTime < other.minTime {
+		return 1
+	}
+	if m.minTime > other.minTime {
+		return -1
+	}
+
+	// Same min time.
+	if m.maxTime < other.maxTime {
+		return 1
+	}
+	if m.maxTime > other.maxTime {
+		return -1
+	}
+	return 0
+}
+
+// seriesChunkRefsIteratorImpl implements an iterator returning a sequence of seriesChunkRefs.
+type seriesChunkRefsIteratorImpl struct {
+	currentOffset int
+	set           seriesChunkRefsSet
+}
+
+func newSeriesChunkRefsIterator(set seriesChunkRefsSet) *seriesChunkRefsIteratorImpl {
+	c := &seriesChunkRefsIteratorImpl{}
+	c.reset(set)
+
+	return c
+}
+
+// reset replaces the current set with the provided one. After calling reset() you
+// must call Next() to advance the iterator to the first element.
+func (c *seriesChunkRefsIteratorImpl) reset(set seriesChunkRefsSet) {
+	c.set = set
+	c.currentOffset = -1
+}
+
+func (c *seriesChunkRefsIteratorImpl) Next() bool {
+	c.currentOffset++
+	return !c.Done()
+}
+
+// Done returns true if the iterator trespassed the end and the item returned by At()
+// is the zero value. If the iterator is on the last item, the value returned by At()
+// is the actual item and Done() returns false.
+func (c *seriesChunkRefsIteratorImpl) Done() bool {
+	setLength := c.set.len()
+	return setLength == 0 || c.currentOffset >= setLength
+}
+
+func (c *seriesChunkRefsIteratorImpl) At() seriesChunkRefs {
+	if c.currentOffset < 0 || c.currentOffset >= c.set.len() {
+		return seriesChunkRefs{}
+	}
+	return c.set.series[c.currentOffset]
+}
+
+func (c *seriesChunkRefsIteratorImpl) Err() error {
+	return nil
+}

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeriesChunkRef_Compare(t *testing.T) {
+	input := []seriesChunkRef{
+		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
+		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
+		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
+		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
+		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
+	}
+
+	expected := []seriesChunkRef{
+		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
+		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
+		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
+		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
+		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
+	}
+
+	sort.Slice(input, func(i, j int) bool {
+		return input[i].Compare(input[j]) > 0
+	})
+
+	assert.Equal(t, expected, input)
+}
+
+func TestSeriesChunkRefsIterator(t *testing.T) {
+	c := generateSeriesChunkRef(5)
+	series1 := labels.FromStrings(labels.MetricName, "metric_1")
+	series2 := labels.FromStrings(labels.MetricName, "metric_2")
+	series3 := labels.FromStrings(labels.MetricName, "metric_3")
+	series4 := labels.FromStrings(labels.MetricName, "metric_4")
+
+	t.Run("should iterate an empty set", func(t *testing.T) {
+		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
+			series: []seriesChunkRefs{},
+		})
+
+		require.True(t, it.Done())
+		require.Zero(t, it.At())
+
+		require.False(t, it.Next())
+		require.True(t, it.Done())
+		require.Zero(t, it.At())
+	})
+
+	t.Run("should iterate a set with some items", func(t *testing.T) {
+		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
+			series: []seriesChunkRefs{
+				{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
+				{lset: series2, chunks: []seriesChunkRef{c[2]}},
+				{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}},
+			},
+		})
+
+		require.False(t, it.Done())
+		require.Zero(t, it.At())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series2, chunks: []seriesChunkRef{c[2]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}}, it.At())
+		require.False(t, it.Done())
+
+		require.False(t, it.Next())
+		require.True(t, it.Done())
+		require.Zero(t, it.At())
+	})
+
+	t.Run("should re-initialize the internal state on reset()", func(t *testing.T) {
+		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
+			series: []seriesChunkRefs{
+				{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
+				{lset: series2, chunks: []seriesChunkRef{c[2]}},
+				{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}},
+			},
+		})
+
+		require.False(t, it.Done())
+		require.Zero(t, it.At())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series2, chunks: []seriesChunkRef{c[2]}}, it.At())
+		require.False(t, it.Done())
+
+		// Reset.
+		it.reset(seriesChunkRefsSet{
+			series: []seriesChunkRefs{
+				{lset: series1, chunks: []seriesChunkRef{c[3]}},
+				{lset: series4, chunks: []seriesChunkRef{c[4]}},
+			},
+		})
+
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[3]}}, it.At())
+		require.False(t, it.Done())
+
+		require.True(t, it.Next())
+		require.Equal(t, seriesChunkRefs{lset: series4, chunks: []seriesChunkRef{c[4]}}, it.At())
+		require.False(t, it.Done())
+
+		require.False(t, it.Next())
+		require.True(t, it.Done())
+		require.Zero(t, it.At())
+	})
+}
+
+// sliceSeriesChunkRefsSetIterator implements seriesChunkRefsSetIterator and
+// returns the provided err when the sets are exhausted.
+//
+//nolint:unused // dead code while we are working on PR 3355
+type sliceSeriesChunkRefsSetIterator struct {
+	current int
+	sets    []seriesChunkRefsSet
+	err     error
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func newSliceSeriesChunkRefsSetIterator(err error, sets ...seriesChunkRefsSet) seriesChunkRefsSetIterator {
+	return &sliceSeriesChunkRefsSetIterator{
+		current: -1,
+		sets:    sets,
+		err:     err,
+	}
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (s *sliceSeriesChunkRefsSetIterator) Next() bool {
+	s.current++
+	return s.current < len(s.sets)
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (s *sliceSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
+	return s.sets[s.current]
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func (s *sliceSeriesChunkRefsSetIterator) Err() error {
+	if s.current >= len(s.sets) {
+		return s.err
+	}
+	return nil
+}
+
+func generateSeriesChunkRef(num int) []seriesChunkRef {
+	out := make([]seriesChunkRef, 0, num)
+
+	for i := 0; i < num; i++ {
+		out = append(out, seriesChunkRef{
+			blockID: ulid.MustNew(uint64(i), nil),
+			ref:     chunks.ChunkRef(i),
+			minTime: int64(i),
+			maxTime: int64(i),
+		})
+	}
+
+	return out
+}


### PR DESCRIPTION
This is the first PR in which we are introducing code related to the
streaming implementation of the store-gateway.

This PR introduces two prod files and two test files.

- `series_refs.go` contains structs and interfaces for holding and
iterating over a set of series which still doesn't have chunks yet.
It only contains refs to chunks and labels.

- `series_chunks.go`, in turn, contains structs and interfaces for
representing and iterating over a set of series which has its labels
_and_ chunks loaded.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
Co-authored-by: Marco Pracucci <marco@pracucci.com>