### PR TITLE
Parse req form again after setting default time

### DIFF
--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -308,8 +308,10 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 		// No need to repeat the test on Server-Timing header for each user.
 		if userID == 0 && cfg.queryStatsEnabled {
-			res, _, err := c.QueryRaw("{instance=~\"hello.*\"}")
+			res, body, err := c.QueryRaw("{instance=~\"hello.*\"}")
+			require.Equal(t, 200, res.StatusCode, fmt.Sprintf("unexpected status code, body was: %s", string(body)))
 			require.NoError(t, err)
+			require.Len(t, res.Header.Values("Server-Timing"), 1)
 			require.Regexp(t, "querier_wall_time;dur=[0-9.]*, response_time;dur=[0-9.]*$", res.Header.Values("Server-Timing")[0])
 		}
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -312,6 +312,8 @@ func defaultInstantQueryParamsRoundTripper(next http.RoundTripper) http.RoundTri
 	return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// Check r.Form first as that's just looking up in a map, versus r.URL.Query() which parses the RawQuery again.
 		// Most of the clients send the POST urlencoded form anyway.
+		// ParseSeekerBodyForm will call the standard http.Request.ParseForm which will respect the precedence of the
+		// post form over the url query.
 		if isInstantQuery(r.URL.Path) && !r.Form.Has("time") && !r.URL.Query().Has("time") {
 			q := r.URL.Query()
 			q.Add("time", strconv.FormatInt(time.Now().Unix(), 10))

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -252,7 +252,6 @@ func newQueryTripperware(
 		queryrange := newLimitedParallelismRoundTripper(next, codec, limits, queryRangeMiddleware...)
 		instant := defaultInstantQueryParamsRoundTripper(
 			newLimitedParallelismRoundTripper(next, codec, limits, queryInstantMiddleware...),
-			time.Now,
 		)
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			switch {
@@ -309,7 +308,7 @@ func isInstantQuery(path string) bool {
 	return strings.HasSuffix(path, instantQueryPathSuffix)
 }
 
-func defaultInstantQueryParamsRoundTripper(next http.RoundTripper, now func() time.Time) http.RoundTripper {
+func defaultInstantQueryParamsRoundTripper(next http.RoundTripper) http.RoundTripper {
 	return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// Check r.Form first as that's just looking up in a map, versus r.URL.Query() which parses the RawQuery again.
 		// Most of the clients send the POST urlencoded form anyway.

--- a/pkg/frontend/transport/body_seeker.go
+++ b/pkg/frontend/transport/body_seeker.go
@@ -1,0 +1,49 @@
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ParseSeekerBodyForm will ensure that request body is a Seeker, parse the form and seek the body back to the beginning.
+func ParseSeekerBodyForm(r *http.Request) error {
+	return withSeekerBody(r, func(r *http.Request) error {
+		return r.ParseForm()
+	})
+}
+
+// withSeekerBody will ensure that request body is a Seeker, call the provided function and seek the body back to the beginning.
+func withSeekerBody(r *http.Request, f func(r *http.Request) error) (err error) {
+	if r.Body == nil {
+		return nil
+	}
+	seeker, ok := r.Body.(io.Seeker)
+	if !ok {
+		seeker, err = newReadCloseSeeker(r.Body)
+		if err != nil {
+			return fmt.Errorf("can't read body: %w", err)
+		}
+		if err := r.Body.Close(); err != nil {
+			return fmt.Errorf("can't close original body: %w", err)
+		}
+	}
+	defer func() {
+		if err == nil {
+			_, err = seeker.Seek(0, io.SeekStart)
+		}
+	}()
+
+	return f(r)
+}
+
+// newReadCloseSeeker will create a new readCloseSeeker from the data provided by io.Reader.
+func newReadCloseSeeker(r io.Reader) (readCloseSeeker, error) {
+	buf, err := io.ReadAll(r)
+	return readCloseSeeker{bytes.NewReader(buf)}, err
+}
+
+type readCloseSeeker struct{ *bytes.Reader }
+
+func (readCloseSeeker) Close() error { return nil }

--- a/pkg/frontend/transport/body_seeker.go
+++ b/pkg/frontend/transport/body_seeker.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package transport
 
 import (

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -135,7 +135,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Buffer the body for later use to track slow queries.
 	var err error
-	r.Body, err = newReadCloseSeeker(http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize))
+	r.Body, err = readIntoReadCloseSeeker(http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize))
 	if err != nil {
 		writeError(w, err)
 		return

--- a/pkg/frontend/transport/seeker_body.go
+++ b/pkg/frontend/transport/seeker_body.go
@@ -23,7 +23,7 @@ func withSeekerBody(r *http.Request, f func(r *http.Request) error) (err error) 
 	}
 	seeker, ok := r.Body.(io.Seeker)
 	if !ok {
-		bodySeeker, err := newReadCloseSeeker(r.Body)
+		bodySeeker, err := readIntoReadCloseSeeker(r.Body)
 		if err != nil {
 			return fmt.Errorf("can't read body: %w", err)
 		}
@@ -43,8 +43,8 @@ func withSeekerBody(r *http.Request, f func(r *http.Request) error) (err error) 
 	return f(r)
 }
 
-// newReadCloseSeeker will create a new readCloseSeeker from the data provided by io.Reader.
-func newReadCloseSeeker(r io.Reader) (readCloseSeeker, error) {
+// readIntoReadCloseSeeker will create a new readCloseSeeker from the data provided by io.Reader.
+func readIntoReadCloseSeeker(r io.Reader) (readCloseSeeker, error) {
 	buf, err := io.ReadAll(r)
 	return readCloseSeeker{bytes.NewReader(buf)}, err
 }

--- a/pkg/frontend/transport/seeker_body.go
+++ b/pkg/frontend/transport/seeker_body.go
@@ -23,13 +23,16 @@ func withSeekerBody(r *http.Request, f func(r *http.Request) error) (err error) 
 	}
 	seeker, ok := r.Body.(io.Seeker)
 	if !ok {
-		seeker, err = newReadCloseSeeker(r.Body)
+		bodySeeker, err := newReadCloseSeeker(r.Body)
 		if err != nil {
 			return fmt.Errorf("can't read body: %w", err)
 		}
 		if err := r.Body.Close(); err != nil {
 			return fmt.Errorf("can't close original body: %w", err)
 		}
+
+		r.Body = bodySeeker
+		seeker = bodySeeker
 	}
 	defer func() {
 		if err == nil {

--- a/pkg/frontend/transport/seeker_body_test.go
+++ b/pkg/frontend/transport/seeker_body_test.go
@@ -1,0 +1,67 @@
+package transport
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSeekerBodyForm(t *testing.T) {
+	t.Run("no body", func(t *testing.T) {
+		expectedForm := url.Values{
+			"bar": []string{"baz"},
+		}
+
+		req := httptest.NewRequest("GET", "/foo?bar=baz", nil)
+		require.NoError(t, ParseSeekerBodyForm(req))
+		require.Equal(t, expectedForm, req.Form)
+	})
+
+	t.Run("with body parsed twice for same form", func(t *testing.T) {
+		expectedForm := url.Values{
+			"bar": []string{"baz"},
+		}
+
+		req := httptest.NewRequest("POST", "/foo", strings.NewReader(expectedForm.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		require.NoError(t, ParseSeekerBodyForm(req))
+		require.Equal(t, expectedForm, req.Form)
+
+		// Reset the form value
+		req.Form, req.PostForm = nil, nil
+
+		require.NoError(t, ParseSeekerBodyForm(req))
+		require.Equal(t, expectedForm, req.Form)
+	})
+
+	t.Run("with body parsed twice and form changing", func(t *testing.T) {
+		encodedForm := url.Values{
+			"bar": []string{"baz"},
+		}
+
+		req := httptest.NewRequest("POST", "/foo", strings.NewReader(encodedForm.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		require.NoError(t, ParseSeekerBodyForm(req))
+		require.Equal(t, encodedForm, req.Form)
+
+		// Add a query param
+		query := req.URL.Query()
+		query.Add("query", "value")
+		req.URL.RawQuery = query.Encode()
+
+		// Reset the form value
+		req.Form, req.PostForm = nil, nil
+
+		expectedForm := url.Values{
+			"bar":   []string{"baz"},
+			"query": []string{"value"},
+		}
+		require.NoError(t, ParseSeekerBodyForm(req))
+		require.Equal(t, expectedForm, req.Form)
+	})
+}

--- a/pkg/frontend/transport/seeker_body_test.go
+++ b/pkg/frontend/transport/seeker_body_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package transport
 
 import (


### PR DESCRIPTION
#### What this PR does

When setting the default "time" param, if the form was already parsed (by some previous middleware) we didn't propagate that change into r.Form.

In order to solve that, we're now replacing the `r.Body` with a `readCloseSeeker`, that can be seeked to the beginning again and again.

This change isn't so important on itself, but it's needed to make https://github.com/grafana/mimir/pull/3561 work properly, as there we're going to parse the request form at the beginning of the request in order to generate the activity.

Additionally, though not important, note that we were never checking the POST request body, in case the "time" was specified there, and that's where Prometheus API client is sending it, so we were always setting the default "time" param on the Query, and it worked just because if it was also sent in the body, that would take precedence when parsing the form (but it was a waste of resources since we had to parse and render the query string again all the times).

I'm not stating this change in the code as user-facing it doesn't change anything, it only affects the code-users of that querymiddleware.

#### Which issue(s) this PR fixes or relates to

Will make https://github.com/grafana/mimir/pull/3561 easier to review.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
