### PR TITLE
Streaming store-gateway: Add tests for loadingBatchSet

### DIFF
--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1172,7 +1172,7 @@ func TestLoadingBatchSet(t *testing.T) {
 	}
 }
 
-type fakeChunkReader struct {
+type chunkReaderMock struct {
 	chunks              map[chunks.ChunkRef]storepb.AggrChunk
 	addLoadErr, loadErr error
 
@@ -1180,14 +1180,14 @@ type fakeChunkReader struct {
 	toLoad     map[chunks.ChunkRef]loadIdx
 }
 
-func newFakeChunkReaderWithSeries(series []seriesEntry, addLoadErr, loadErr error, chunkBytes *pool.BatchBytes) *fakeChunkReader {
+func newFakeChunkReaderWithSeries(series []seriesEntry, addLoadErr, loadErr error, chunkBytes *pool.BatchBytes) *chunkReaderMock {
 	chks := map[chunks.ChunkRef]storepb.AggrChunk{}
 	for _, s := range series {
 		for i := range s.chks {
 			chks[s.refs[i]] = s.chks[i]
 		}
 	}
-	return &fakeChunkReader{
+	return &chunkReaderMock{
 		chunks:     chks,
 		addLoadErr: addLoadErr,
 		loadErr:    loadErr,
@@ -1196,11 +1196,11 @@ func newFakeChunkReaderWithSeries(series []seriesEntry, addLoadErr, loadErr erro
 	}
 }
 
-func (f *fakeChunkReader) Close() error {
+func (f *chunkReaderMock) Close() error {
 	return nil
 }
 
-func (f *fakeChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) error {
+func (f *chunkReaderMock) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) error {
 	if f.addLoadErr != nil {
 		return f.addLoadErr
 	}
@@ -1208,7 +1208,7 @@ func (f *fakeChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) er
 	return nil
 }
 
-func (f *fakeChunkReader) load(result []seriesEntry, _ []storepb.Aggr, _ *safeQueryStats) error {
+func (f *chunkReaderMock) load(result []seriesEntry, _ []storepb.Aggr, _ *safeQueryStats) error {
 	if f.loadErr != nil {
 		return f.loadErr
 	}
@@ -1225,7 +1225,7 @@ func (f *fakeChunkReader) load(result []seriesEntry, _ []storepb.Aggr, _ *safeQu
 	return nil
 }
 
-func (f *fakeChunkReader) reset(chunkBytes *pool.BatchBytes) {
+func (f *chunkReaderMock) reset(chunkBytes *pool.BatchBytes) {
 	f.chunkBytes = chunkBytes
 	f.toLoad = make(map[chunks.ChunkRef]loadIdx)
 }

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1068,10 +1068,10 @@ func TestLoadingBatchSet(t *testing.T) {
 		"loads single set from multiple blocks": {
 			existingBlocks: []testBlock{block1, block2},
 			setsToLoad: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block2, 1)}},
 			},
 			expectedSets: []seriesChunksSet{
-				{series: []seriesEntry{block1.series[0], block1.series[1]}},
+				{series: []seriesEntry{block1.series[0], block2.series[1]}},
 			},
 		},
 		"loads multiple sets from multiple blocks": {

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1011,12 +1011,12 @@ func TestLoadingBatchSet(t *testing.T) {
 
 	block1 := testBlock{
 		ulid:   ulid.MustNew(1, nil),
-		series: generateSeriesChunks(t, 10),
+		series: generateSeriesEntriesWithChunks(t, 10),
 	}
 
 	block2 := testBlock{
 		ulid:   ulid.MustNew(2, nil),
-		series: generateSeriesChunks(t, 10),
+		series: generateSeriesEntriesWithChunks(t, 10),
 	}
 
 	toSeriesChunkRefs := func(block testBlock, seriesIndex int) seriesChunkRefs {
@@ -1277,8 +1277,8 @@ func readAllSeriesLabels(it storepb.SeriesSet) []labels.Labels {
 	return out
 }
 
-// generateSeriesChunks generates seriesEntries with chunks. Each chunk is a random byte slice.
-func generateSeriesChunks(t *testing.T, numSeries int) []seriesEntry {
+// generateSeriesEntriesWithChunks generates seriesEntries with chunks. Each chunk is a random byte slice.
+func generateSeriesEntriesWithChunks(t *testing.T, numSeries int) []seriesEntry {
 	const numChunksPerSeries = 2
 
 	out := make([]seriesEntry, 0, numSeries)

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1096,6 +1096,23 @@ func TestLoadingBatchSet(t *testing.T) {
 				{series: []seriesEntry{block1.series[1], block2.series[1]}},
 			},
 		},
+		"loads series with chunks from different blocks": {
+			existingBlocks: []testBlock{block1, block2},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: func() []seriesChunkRefs {
+					series := toSeriesChunkRefs(block1, 0)
+					series.chunks = append(series.chunks, toSeriesChunkRefs(block2, 0).chunks...)
+					return []seriesChunkRefs{series}
+				}()},
+			},
+			expectedSets: []seriesChunksSet{
+				{series: func() []seriesEntry {
+					entry := block1.series[0]
+					entry.chks = append(entry.chks, block2.series[0].chks...)
+					return []seriesEntry{entry}
+				}()},
+			},
+		},
 		"handles error in addLoad": {
 			existingBlocks: []testBlock{block1, block2},
 			setsToLoad: []seriesChunkRefsSet{

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -4,11 +4,13 @@ package storegateway
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +19,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -1000,6 +1003,233 @@ func TestBatchedSeriesSet(t *testing.T) {
 	})
 }
 
+func TestLoadingBatchSet(t *testing.T) {
+	type testBlock struct {
+		ulid   ulid.ULID
+		series []seriesEntry
+	}
+
+	block1 := testBlock{
+		ulid:   ulid.MustNew(1, nil),
+		series: generateSeriesChunks(t, 10),
+	}
+
+	block2 := testBlock{
+		ulid:   ulid.MustNew(2, nil),
+		series: generateSeriesChunks(t, 10),
+	}
+
+	toSeriesChunkRefs := func(block testBlock, seriesIndex int) seriesChunkRefs {
+		series := block.series[seriesIndex]
+
+		chunkRefs := make([]seriesChunkRef, len(series.chks))
+		for i, c := range series.chks {
+			chunkRefs[i] = seriesChunkRef{
+				blockID: block.ulid,
+				ref:     series.refs[i],
+				minTime: c.MinTime,
+				maxTime: c.MaxTime,
+			}
+		}
+
+		return seriesChunkRefs{
+			lset:   series.lset,
+			chunks: chunkRefs,
+		}
+	}
+
+	testCases := map[string]struct {
+		existingBlocks      []testBlock
+		setsToLoad          []seriesChunkRefsSet
+		expectedSets        []seriesChunksSet
+		addLoadErr, loadErr error
+		expectedErr         string
+	}{
+		"loads single set": {
+			existingBlocks: []testBlock{block1},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+			},
+			expectedSets: []seriesChunksSet{
+				{series: []seriesEntry{block1.series[0], block1.series[1]}},
+			},
+		},
+		"loads multiple sets": {
+			existingBlocks: []testBlock{block1},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 2), toSeriesChunkRefs(block1, 3)}},
+			},
+			expectedSets: []seriesChunksSet{
+				{series: []seriesEntry{block1.series[0], block1.series[1]}},
+				{series: []seriesEntry{block1.series[2], block1.series[3]}},
+			},
+		},
+		"loads single set from multiple blocks": {
+			existingBlocks: []testBlock{block1, block2},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+			},
+			expectedSets: []seriesChunksSet{
+				{series: []seriesEntry{block1.series[0], block1.series[1]}},
+			},
+		},
+		"loads multiple sets from multiple blocks": {
+			existingBlocks: []testBlock{block1, block2},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block2, 0), toSeriesChunkRefs(block2, 1)}},
+			},
+			expectedSets: []seriesChunksSet{
+				{series: []seriesEntry{block1.series[0], block1.series[1]}},
+				{series: []seriesEntry{block2.series[0], block2.series[1]}},
+			},
+		},
+		"loads sets from multiple blocks mixed": {
+			existingBlocks: []testBlock{block1, block2},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block2, 0)}},
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 1), toSeriesChunkRefs(block2, 1)}},
+			},
+			expectedSets: []seriesChunksSet{
+				{series: []seriesEntry{block1.series[0], block2.series[0]}},
+				{series: []seriesEntry{block1.series[1], block2.series[1]}},
+			},
+		},
+		"handles error in addLoad": {
+			existingBlocks: []testBlock{block1, block2},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block2, 0), toSeriesChunkRefs(block2, 1)}},
+			},
+			expectedSets: []seriesChunksSet{},
+			addLoadErr:   errors.New("test err"),
+			expectedErr:  "test err",
+		},
+		"handles error in load": {
+			existingBlocks: []testBlock{block1, block2},
+			setsToLoad: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
+				{series: []seriesChunkRefs{toSeriesChunkRefs(block2, 0), toSeriesChunkRefs(block2, 1)}},
+			},
+			expectedSets: []seriesChunksSet{},
+			loadErr:      errors.New("test err"),
+			expectedErr:  "test err",
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testName, testCase := testName, testCase
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			// Setup
+			bytesPool := &mockedPool{parent: pool.NoopBytes{}}
+			chunkBytes := &pool.BatchBytes{Delegate: bytesPool}
+			readersMap := make(map[ulid.ULID]chunkReader, len(testCase.existingBlocks))
+			for _, block := range testCase.existingBlocks {
+				readersMap[block.ulid] = newFakeChunkReaderWithSeries(block.series, testCase.addLoadErr, testCase.loadErr, chunkBytes)
+			}
+			readers := newChunkReaders(readersMap, chunkBytes, bytesPool)
+
+			// Run test
+			set := newLoadingBatchSet(*readers, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), newSafeQueryStats())
+			loadedSets := readAllSeriesChunksSets(set)
+
+			// Assertions
+			if testCase.expectedErr != "" {
+				assert.ErrorContains(t, set.Err(), testCase.expectedErr)
+			} else {
+				assert.NoError(t, set.Err())
+			}
+			// NoopBytes should allocate slices just the right size, so the packing optimization in BatchBytes should not be used
+			// This allows to assert on the exact number of bytes allocated.
+			var expectedReservedBytes int
+			for _, set := range testCase.expectedSets {
+				for _, s := range set.series {
+					for _, c := range s.chks {
+						expectedReservedBytes += len(c.Raw.Data)
+					}
+				}
+			}
+			assert.Equal(t, expectedReservedBytes, int(bytesPool.balance.Load()))
+
+			// Check that chunks butes are what we expect
+			require.Len(t, loadedSets, len(testCase.expectedSets))
+			for i, loadedSet := range loadedSets {
+				require.Len(t, loadedSet.series, len(testCase.expectedSets[i].series))
+				for j, loadedSeries := range loadedSet.series {
+					testCase.expectedSets[i].series[j].refs = nil
+					assert.Equal(t, testCase.expectedSets[i].series[j], loadedSeries)
+				}
+			}
+
+			// Release the sets and expect that they also return their chunk bytes to the pool
+			for _, s := range loadedSets {
+				s.release()
+			}
+			assert.Zero(t, int(bytesPool.balance.Load()))
+		})
+	}
+}
+
+type fakeChunkReader struct {
+	chunks              map[chunks.ChunkRef]storepb.AggrChunk
+	addLoadErr, loadErr error
+
+	chunkBytes *pool.BatchBytes
+	toLoad     map[chunks.ChunkRef]loadIdx
+}
+
+func newFakeChunkReaderWithSeries(series []seriesEntry, addLoadErr, loadErr error, chunkBytes *pool.BatchBytes) *fakeChunkReader {
+	chks := map[chunks.ChunkRef]storepb.AggrChunk{}
+	for _, s := range series {
+		for i := range s.chks {
+			chks[s.refs[i]] = s.chks[i]
+		}
+	}
+	return &fakeChunkReader{
+		chunks:     chks,
+		addLoadErr: addLoadErr,
+		loadErr:    loadErr,
+		chunkBytes: chunkBytes,
+		toLoad:     make(map[chunks.ChunkRef]loadIdx),
+	}
+}
+
+func (f *fakeChunkReader) Close() error {
+	return nil
+}
+
+func (f *fakeChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) error {
+	if f.addLoadErr != nil {
+		return f.addLoadErr
+	}
+	f.toLoad[id] = loadIdx{seriesEntry: seriesEntry, chunk: chunk}
+	return nil
+}
+
+func (f *fakeChunkReader) load(result []seriesEntry, _ []storepb.Aggr, _ *safeQueryStats) error {
+	if f.loadErr != nil {
+		return f.loadErr
+	}
+	for chunkRef, indices := range f.toLoad {
+		// Take bytes from the pool, so we can assert on number of allocations and that frees are happening
+		chunkData := f.chunks[chunkRef].Raw.Data
+		copiedChunkData, err := f.chunkBytes.Get(len(chunkData))
+		if err != nil {
+			return fmt.Errorf("couldn't copy test data: %w", err)
+		}
+		copy(copiedChunkData, chunkData)
+		result[indices.seriesEntry].chks[indices.chunk].Raw = &storepb.Chunk{Data: copiedChunkData}
+	}
+	return nil
+}
+
+func (f *fakeChunkReader) reset(chunkBytes *pool.BatchBytes) {
+	f.chunkBytes = chunkBytes
+	f.toLoad = make(map[chunks.ChunkRef]loadIdx)
+}
+
 // nolint this is used in a skipped test
 type limiter struct {
 	limit   uint64
@@ -1030,11 +1260,51 @@ func readAllSeriesChunkRefs(it seriesChunkRefsIterator) []seriesChunkRefs {
 	return out
 }
 
+func readAllSeriesChunksSets(it seriesChunksSetIterator) []seriesChunksSet {
+	var out []seriesChunksSet
+	for it.Next() {
+		out = append(out, it.At())
+	}
+	return out
+}
+
 func readAllSeriesLabels(it storepb.SeriesSet) []labels.Labels {
 	var out []labels.Labels
 	for it.Next() {
 		lbls, _ := it.At()
 		out = append(out, lbls)
+	}
+	return out
+}
+
+// generateSeriesChunks generates seriesEntries with chunks. Each chunk is a random byte slice.
+func generateSeriesChunks(t *testing.T, numSeries int) []seriesEntry {
+	const numChunksPerSeries = 2
+
+	out := make([]seriesEntry, 0, numSeries)
+	labels := generateSeries([]int{numSeries})
+
+	for i := 0; i < numSeries; i++ {
+		entry := seriesEntry{
+			lset: labels[i],
+			refs: make([]chunks.ChunkRef, 0, numChunksPerSeries),
+			chks: make([]storepb.AggrChunk, 0, numChunksPerSeries),
+		}
+
+		for j := 0; j < numChunksPerSeries; j++ {
+			chunkBytes := make([]byte, 10)
+			readBytes, err := rand.Read(chunkBytes)
+			require.NoError(t, err, "couldn't generate test data")
+			require.Equal(t, 10, readBytes, "couldn't generate test data")
+
+			entry.refs = append(entry.refs, chunks.ChunkRef(i*numChunksPerSeries+j))
+			entry.chks = append(entry.chks, storepb.AggrChunk{
+				MinTime: int64(10 * j),
+				MaxTime: int64(10 * (j + 1)),
+				Raw:     &storepb.Chunk{Data: chunkBytes},
+			})
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1153,7 +1153,7 @@ func TestLoadingBatchSet(t *testing.T) {
 			}
 			assert.Equal(t, expectedReservedBytes, int(bytesPool.balance.Load()))
 
-			// Check that chunks butes are what we expect
+			// Check that chunks bytes are what we expect
 			require.Len(t, loadedSets, len(testCase.expectedSets))
 			for i, loadedSet := range loadedSets {
 				require.Len(t, loadedSet.series, len(testCase.expectedSets[i].series))

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1045,7 +1045,7 @@ func TestLoadingBatchSet(t *testing.T) {
 		addLoadErr, loadErr error
 		expectedErr         string
 	}{
-		"loads single set": {
+		"loads single set from single block": {
 			existingBlocks: []testBlock{block1},
 			setsToLoad: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},
@@ -1054,7 +1054,7 @@ func TestLoadingBatchSet(t *testing.T) {
 				{series: []seriesEntry{block1.series[0], block1.series[1]}},
 			},
 		},
-		"loads multiple sets": {
+		"loads multiple sets from single block": {
 			existingBlocks: []testBlock{block1},
 			setsToLoad: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{toSeriesChunkRefs(block1, 0), toSeriesChunkRefs(block1, 1)}},

--- a/pkg/storegateway/batch_series_test.go
+++ b/pkg/storegateway/batch_series_test.go
@@ -1158,8 +1158,10 @@ func TestLoadingBatchSet(t *testing.T) {
 			for i, loadedSet := range loadedSets {
 				require.Len(t, loadedSet.series, len(testCase.expectedSets[i].series))
 				for j, loadedSeries := range loadedSet.series {
-					testCase.expectedSets[i].series[j].refs = nil
-					assert.Equal(t, testCase.expectedSets[i].series[j], loadedSeries)
+					assert.ElementsMatch(t, testCase.expectedSets[i].series[j].chks, loadedSeries.chks)
+					assert.Truef(t, labels.Equal(testCase.expectedSets[i].series[j].lset, loadedSeries.lset),
+						"%d, %d: labels don't match, expected %s, got %s", i, j, testCase.expectedSets[i].series[j].lset, loadedSeries.lset,
+					)
 				}
 			}
 


### PR DESCRIPTION
This adds tests for `loadingBatchSet`. They end up exercising `chunkReaders` too.