### PR TITLE
Use labels.FromString abstraction more

### DIFF
--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -344,7 +344,7 @@ func TestGroupCompactE2E(t *testing.T) {
 				numSamples: 100, mint: 0, maxt: 499, extLset: extLabels, res: 124,
 				series: []labels.Labels{
 					labels.FromStrings("a", "1"),
-					{{Name: "a", Value: "2"}, {Name: "b", Value: "2"}},
+					labels.FromStrings("a", "1", "b", "2"),
 					labels.FromStrings("a", "3"),
 					labels.FromStrings("a", "4"),
 				},
@@ -800,9 +800,7 @@ func putOutOfOrderIndex(blockDir string, minTime int64, maxTime int64) error {
 	}
 
 	lbls := []labels.Labels{
-		[]labels.Label{
-			{Name: "lbl1", Value: "1"},
-		},
+		labels.FromStrings("lbl1", "1"),
 	}
 
 	// Sort labels as the index writer expects series in sorted order.

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,10 +83,10 @@ func TestGroupMaxMinTime(t *testing.T) {
 func TestFilterOwnJobs(t *testing.T) {
 	jobsFn := func() []*Job {
 		return []*Job{
-			NewJob("user", "key1", nil, 0, metadata.NoneFunc, false, 0, ""),
-			NewJob("user", "key2", nil, 0, metadata.NoneFunc, false, 0, ""),
-			NewJob("user", "key3", nil, 0, metadata.NoneFunc, false, 0, ""),
-			NewJob("user", "key4", nil, 0, metadata.NoneFunc, false, 0, ""),
+			NewJob("user", "key1", labels.EmptyLabels(), 0, metadata.NoneFunc, false, 0, ""),
+			NewJob("user", "key2", labels.EmptyLabels(), 0, metadata.NoneFunc, false, 0, ""),
+			NewJob("user", "key3", labels.EmptyLabels(), 0, metadata.NoneFunc, false, 0, ""),
+			NewJob("user", "key4", labels.EmptyLabels(), 0, metadata.NoneFunc, false, 0, ""),
 		}
 	}
 
@@ -132,7 +133,7 @@ func TestFilterOwnJobs(t *testing.T) {
 }
 
 func TestBlockMaxTimeDeltas(t *testing.T) {
-	j1 := NewJob("user", "key1", nil, 0, metadata.NoneFunc, false, 0, "")
+	j1 := NewJob("user", "key1", labels.EmptyLabels(), 0, metadata.NoneFunc, false, 0, "")
 	require.NoError(t, j1.AppendMeta(&metadata.Meta{
 		BlockMeta: tsdb.BlockMeta{
 			MinTime: 1500002700159,
@@ -140,7 +141,7 @@ func TestBlockMaxTimeDeltas(t *testing.T) {
 		},
 	}))
 
-	j2 := NewJob("user", "key2", nil, 0, metadata.NoneFunc, false, 0, "")
+	j2 := NewJob("user", "key2", labels.EmptyLabels(), 0, metadata.NoneFunc, false, 0, "")
 	require.NoError(t, j2.AppendMeta(&metadata.Meta{
 		BlockMeta: tsdb.BlockMeta{
 			MinTime: 1500002600159,

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -25,8 +25,8 @@ func copyFn(l labels.Labels) labels.Labels { return l }
 const DefaultTimeout = 5 * time.Minute
 
 func TestActiveSeries_UpdateSeries_NoMatchers(t *testing.T) {
-	ls1 := []labels.Label{{Name: "a", Value: "1"}}
-	ls2 := []labels.Label{{Name: "a", Value: "2"}}
+	ls1 := labels.FromStrings("a", "1")
+	ls2 := labels.FromStrings("a", "2")
 
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 	allActive, activeMatching, valid := c.Active(time.Now())
@@ -51,9 +51,9 @@ func TestActiveSeries_UpdateSeries_NoMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_UpdateSeries_WithMatchers(t *testing.T) {
-	ls1 := []labels.Label{{Name: "a", Value: "1"}}
-	ls2 := []labels.Label{{Name: "a", Value: "2"}}
-	ls3 := []labels.Label{{Name: "a", Value: "3"}}
+	ls1 := labels.FromStrings("a", "1")
+	ls2 := labels.FromStrings("a", "2")
+	ls3 := labels.FromStrings("a", "3")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{a=~"2|3"}`}))
 
@@ -104,12 +104,12 @@ func TestActiveSeries_ShouldCorrectlyHandleFingerprintCollisions(t *testing.T) {
 }
 
 func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
-	series := [][]labels.Label{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+	series := []labels.Labels{
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 		// The two following series have the same Fingerprint
-		{{Name: "_", Value: "ypfajYg2lsv"}, {Name: "__name__", Value: "logs"}},
-		{{Name: "_", Value: "KiqbryhzUpn"}, {Name: "__name__", Value: "logs"}},
+		labels.FromStrings("_", "ypfajYg2lsv", "__name__", "logs"),
+		labels.FromStrings("_", "KiqbryhzUpn", "__name__", "logs"),
 	}
 
 	// Run the same test for increasing TTL values
@@ -137,12 +137,12 @@ func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
-	series := [][]labels.Label{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+	series := []labels.Labels{
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 		// The two following series have the same Fingerprint
-		{{Name: "_", Value: "ypfajYg2lsv"}, {Name: "__name__", Value: "logs"}},
-		{{Name: "_", Value: "KiqbryhzUpn"}, {Name: "__name__", Value: "logs"}},
+		labels.FromStrings("_", "ypfajYg2lsv", "__name__", "logs"),
+		labels.FromStrings("_", "KiqbryhzUpn", "__name__", "logs"),
 	}
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{_=~"y.*"}`}))
@@ -210,10 +210,10 @@ func TestActiveSeries_PurgeOpt(t *testing.T) {
 }
 
 func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
-	ls1 := []labels.Label{{Name: "a", Value: "1"}}
-	ls2 := []labels.Label{{Name: "a", Value: "2"}}
-	ls3 := []labels.Label{{Name: "a", Value: "3"}}
-	ls4 := []labels.Label{{Name: "a", Value: "4"}}
+	ls1 := labels.FromStrings("a", "1")
+	ls2 := labels.FromStrings("a", "2")
+	ls3 := labels.FromStrings("a", "3")
+	ls4 := labels.FromStrings("a", "4")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{a=~.*}`}))
 
@@ -271,7 +271,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
-	ls1 := []labels.Label{{Name: "a", Value: "1"}}
+	ls1 := labels.FromStrings("a", "1")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{
 		"foo": `{a=~.+}`,
@@ -306,7 +306,7 @@ func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_ReloadSeriesMatchers_SameSizeNewLabels(t *testing.T) {
-	ls1 := []labels.Label{{Name: "a", Value: "1"}}
+	ls1 := labels.FromStrings("a", "1")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{
 		"foo": `{a=~.+}`,

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -34,9 +34,7 @@ func TestChunkIter(t *testing.T) {
 }
 
 func mkChunk(t require.TestingT, from model.Time, points int, enc chunk.Encoding) chunk.Chunk {
-	metric := labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-	}
+	metric := labels.FromStrings(model.MetricNameLabel, "foo")
 	pc, err := chunk.NewForEncoding(enc)
 	require.NoError(t, err)
 	ts := from

--- a/pkg/querier/tenantfederation/tenant_federation.go
+++ b/pkg/querier/tenantfederation/tenant_federation.go
@@ -83,7 +83,7 @@ func setLabelsRetainExisting(src labels.Labels, additionalLabels ...labels.Label
 		lb.Set(additionalL.Name, additionalL.Value)
 	}
 
-	return lb.Labels(nil)
+	return lb.Labels(labels.EmptyLabels())
 }
 
 func sliceToSet(values []string) map[string]struct{} {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -240,7 +240,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	n.Send(&notifier.Alert{
-		Labels: labels.Labels{labels.Label{Name: "alertname", Value: "testalert"}},
+		Labels: labels.FromStrings("alertname", "testalert"),
 	})
 
 	wg.Wait()
@@ -1080,8 +1080,8 @@ func TestSendAlerts(t *testing.T) {
 		{
 			in: []*promRules.Alert{
 				{
-					Labels:      []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations: []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:      labels.FromStrings("l1", "v1"),
+					Annotations: labels.FromStrings("a2", "v2"),
 					ActiveAt:    time.Unix(1, 0),
 					FiredAt:     time.Unix(2, 0),
 					ValidUntil:  time.Unix(3, 0),
@@ -1089,8 +1089,8 @@ func TestSendAlerts(t *testing.T) {
 			},
 			exp: []*notifier.Alert{
 				{
-					Labels:       []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations:  []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:       labels.FromStrings("l1", "v1"),
+					Annotations:  labels.FromStrings("a2", "v2"),
 					StartsAt:     time.Unix(2, 0),
 					EndsAt:       time.Unix(3, 0),
 					GeneratorURL: "http://localhost:9090/graph?g0.expr=up&g0.tab=1",
@@ -1100,8 +1100,8 @@ func TestSendAlerts(t *testing.T) {
 		{
 			in: []*promRules.Alert{
 				{
-					Labels:      []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations: []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:      labels.FromStrings("l1", "v1"),
+					Annotations: labels.FromStrings("a2", "v2"),
 					ActiveAt:    time.Unix(1, 0),
 					FiredAt:     time.Unix(2, 0),
 					ResolvedAt:  time.Unix(4, 0),
@@ -1109,8 +1109,8 @@ func TestSendAlerts(t *testing.T) {
 			},
 			exp: []*notifier.Alert{
 				{
-					Labels:       []labels.Label{{Name: "l1", Value: "v1"}},
-					Annotations:  []labels.Label{{Name: "a2", Value: "v2"}},
+					Labels:       labels.FromStrings("l1", "v1"),
+					Annotations:  labels.FromStrings("a2", "v2"),
 					StartsAt:     time.Unix(2, 0),
 					EndsAt:       time.Unix(4, 0),
 					GeneratorURL: "http://localhost:9090/graph?g0.expr=up&g0.tab=1",

--- a/pkg/storage/series/series_set_test.go
+++ b/pkg/storage/series/series_set_test.go
@@ -49,11 +49,5 @@ func TestMatrixToSeriesSetSortsMetricLabels(t *testing.T) {
 	require.NoError(t, ss.Err())
 
 	l := ss.At().Labels()
-	require.Equal(t, labels.Labels{
-		{Name: string(model.MetricNameLabel), Value: "testmetric"},
-		{Name: "a", Value: "b"},
-		{Name: "c", Value: "d"},
-		{Name: "e", Value: "f"},
-		{Name: "g", Value: "h"},
-	}, l)
+	require.Equal(t, labels.FromStrings(model.MetricNameLabel, "testmetric", "a", "b", "c", "d", "e", "f", "g", "h"), l)
 }

--- a/pkg/storage/tsdb/block/block_test.go
+++ b/pkg/storage/tsdb/block/block_test.go
@@ -33,6 +33,16 @@ import (
 	testutil "github.com/grafana/mimir/pkg/util/test"
 )
 
+var (
+	fiveLabels = []labels.Labels{
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
+		labels.FromStrings("a", "3"),
+		labels.FromStrings("a", "4"),
+		labels.FromStrings("b", "1"),
+	}
+)
+
 func TestIsBlockDir(t *testing.T) {
 	for _, tc := range []struct {
 		input string
@@ -88,13 +98,8 @@ func TestUpload(t *testing.T) {
 
 	bkt := objstore.NewInMemBucket()
 	rand.Seed(1) // hard-coded sizes later in this test depend on values created "randomly" by CreateBlock.
-	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
-		{{Name: "a", Value: "3"}},
-		{{Name: "a", Value: "4"}},
-		{{Name: "b", Value: "1"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+	b1, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+		100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path.Join(tmpDir, "test", b1.String()), os.ModePerm))
 
@@ -196,13 +201,8 @@ func TestUpload(t *testing.T) {
 	}
 	{
 		// Upload with no external labels should be blocked.
-		b2, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-			{{Name: "a", Value: "1"}},
-			{{Name: "a", Value: "2"}},
-			{{Name: "a", Value: "3"}},
-			{{Name: "a", Value: "4"}},
-			{{Name: "b", Value: "1"}},
-		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+		b2, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+			100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
 		require.NoError(t, err)
 		err = Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
 		require.Error(t, err)
@@ -211,13 +211,8 @@ func TestUpload(t *testing.T) {
 	}
 	{
 		// No external labels with UploadPromBlocks.
-		b2, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-			{{Name: "a", Value: "1"}},
-			{{Name: "a", Value: "2"}},
-			{{Name: "a", Value: "3"}},
-			{{Name: "a", Value: "4"}},
-			{{Name: "b", Value: "1"}},
-		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+		b2, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+			100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
 		require.NoError(t, err)
 		err = UploadPromBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc)
 		require.NoError(t, err)
@@ -236,13 +231,8 @@ func TestDelete(t *testing.T) {
 
 	bkt := objstore.NewInMemBucket()
 	{
-		b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-			{{Name: "a", Value: "1"}},
-			{{Name: "a", Value: "2"}},
-			{{Name: "a", Value: "3"}},
-			{{Name: "a", Value: "4"}},
-			{{Name: "b", Value: "1"}},
-		}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+		b1, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+			100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 		require.NoError(t, err)
 		require.NoError(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b1.String()), metadata.NoneFunc))
 		require.Equal(t, 3, len(bkt.Objects()))
@@ -255,13 +245,8 @@ func TestDelete(t *testing.T) {
 		require.Equal(t, 0, len(bkt.Objects()))
 	}
 	{
-		b2, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-			{{Name: "a", Value: "1"}},
-			{{Name: "a", Value: "2"}},
-			{{Name: "a", Value: "3"}},
-			{{Name: "a", Value: "4"}},
-			{{Name: "b", Value: "1"}},
-		}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+		b2, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+			100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 		require.NoError(t, err)
 		require.NoError(t, Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), metadata.NoneFunc))
 		require.Equal(t, 3, len(bkt.Objects()))
@@ -306,13 +291,8 @@ func TestMarkForDeletion(t *testing.T) {
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			bkt := objstore.NewInMemBucket()
-			id, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-				{{Name: "a", Value: "1"}},
-				{{Name: "a", Value: "2"}},
-				{{Name: "a", Value: "3"}},
-				{{Name: "a", Value: "4"}},
-				{{Name: "b", Value: "1"}},
-			}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+			id, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+				100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 			require.NoError(t, err)
 
 			tcase.preUpload(t, id, bkt)
@@ -360,13 +340,8 @@ func TestMarkForNoCompact(t *testing.T) {
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			bkt := objstore.NewInMemBucket()
-			id, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-				{{Name: "a", Value: "1"}},
-				{{Name: "a", Value: "2"}},
-				{{Name: "a", Value: "3"}},
-				{{Name: "a", Value: "4"}},
-				{{Name: "b", Value: "1"}},
-			}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+			id, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+				100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 			require.NoError(t, err)
 
 			tcase.preUpload(t, id, bkt)
@@ -396,8 +371,8 @@ func TestHashDownload(t *testing.T) {
 	instrumentedBkt := objstore.BucketWithMetrics("test", bkt, r)
 
 	b1, err := e2eutil.CreateBlockWithTombstone(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 42, metadata.SHA256Func)
+		labels.FromStrings("a", "1"),
+	}, 100, 0, 1000, labels.FromStrings("ext1", "val1"), 42, metadata.SHA256Func)
 	require.NoError(t, err)
 
 	require.NoError(t, Upload(ctx, log.NewNopLogger(), instrumentedBkt, path.Join(tmpDir, b1.String()), metadata.SHA256Func))
@@ -484,13 +459,8 @@ func TestUploadCleanup(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	bkt := objstore.NewInMemBucket()
-	b1, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
-		{{Name: "a", Value: "3"}},
-		{{Name: "a", Value: "4"}},
-		{{Name: "b", Value: "1"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+	b1, err := e2eutil.CreateBlock(ctx, tmpDir, fiveLabels,
+		100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 
 	{

--- a/pkg/storage/tsdb/block/index_test.go
+++ b/pkg/storage/tsdb/block/index_test.go
@@ -28,12 +28,12 @@ func TestRewrite(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	b, err := e2eutil.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
-		{{Name: "a", Value: "3"}},
-		{{Name: "a", Value: "4"}},
-		{{Name: "a", Value: "1"}, {Name: "b", Value: "1"}},
-	}, 150, 0, 1000, nil, 124, metadata.NoneFunc)
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
+		labels.FromStrings("a", "3"),
+		labels.FromStrings("a", "4"),
+		labels.FromStrings("a", "1", "b", "1"),
+	}, 150, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 
 	ir, err := index.NewFileReader(filepath.Join(tmpDir, b.String(), IndexFilename))

--- a/pkg/storage/tsdb/upload_test.go
+++ b/pkg/storage/tsdb/upload_test.go
@@ -30,12 +30,12 @@ func TestUploadBlock(t *testing.T) {
 
 	bkt := objstore.NewInMemBucket()
 	b1, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
-		{{Name: "a", Value: "3"}},
-		{{Name: "a", Value: "4"}},
-		{{Name: "b", Value: "1"}},
-	}, 100, 0, 1000, labels.Labels{{Name: "ext1", Value: "val1"}}, 124, metadata.NoneFunc)
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
+		labels.FromStrings("a", "3"),
+		labels.FromStrings("a", "4"),
+		labels.FromStrings("b", "1"),
+	}, 100, 0, 1000, labels.FromStrings("ext1", "val1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path.Join(tmpDir, "test", b1.String()), os.ModePerm))
 
@@ -140,12 +140,12 @@ func TestUploadBlock(t *testing.T) {
 	t.Run("upload with no external labels works just fine", func(t *testing.T) {
 		// Upload with no external labels should be blocked.
 		b2, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-			{{Name: "a", Value: "1"}},
-			{{Name: "a", Value: "2"}},
-			{{Name: "a", Value: "3"}},
-			{{Name: "a", Value: "4"}},
-			{{Name: "b", Value: "1"}},
-		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+			labels.FromStrings("a", "1"),
+			labels.FromStrings("a", "2"),
+			labels.FromStrings("a", "3"),
+			labels.FromStrings("a", "4"),
+			labels.FromStrings("b", "1"),
+		}, 100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
 		require.NoError(t, err)
 
 		err = UploadBlock(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, b2.String()), nil)
@@ -171,12 +171,12 @@ func TestUploadBlock(t *testing.T) {
 	t.Run("upload with supplied meta.json", func(t *testing.T) {
 		// Upload with no external labels should be blocked.
 		b3, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-			{{Name: "a", Value: "1"}},
-			{{Name: "a", Value: "2"}},
-			{{Name: "a", Value: "3"}},
-			{{Name: "a", Value: "4"}},
-			{{Name: "b", Value: "1"}},
-		}, 100, 0, 1000, nil, 124, metadata.NoneFunc)
+			labels.FromStrings("a", "1"),
+			labels.FromStrings("a", "2"),
+			labels.FromStrings("a", "3"),
+			labels.FromStrings("a", "4"),
+			labels.FromStrings("b", "1"),
+		}, 100, 0, 1000, labels.EmptyLabels(), 124, metadata.NoneFunc)
 		require.NoError(t, err)
 
 		// Prepare metadata that will be uploaded to the bucket.

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -399,8 +399,8 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 	cfg := prepareStorageConfig(t)
 
 	// Generate a single block with 1 series and a lot of samples.
-	seriesWithOutOfOrderChunks := labels.Labels{labels.Label{Name: "case", Value: "out_of_order"}, labels.Label{Name: labels.MetricName, Value: metricName}}
-	seriesWithOverlappingChunks := labels.Labels{labels.Label{Name: "case", Value: "overlapping"}, labels.Label{Name: labels.MetricName, Value: metricName}}
+	seriesWithOutOfOrderChunks := labels.FromStrings("case", "out_of_order", labels.MetricName, metricName)
+	seriesWithOverlappingChunks := labels.FromStrings("case", "overlapping", labels.MetricName, metricName)
 	specs := []*mimir_testutil.BlockSeriesSpec{
 		// Series with out of order chunks.
 		{
@@ -527,7 +527,7 @@ func generateStorageBlock(t *testing.T, storageDir, userID string, metricName st
 		require.NoError(t, db.Close())
 	}()
 
-	series := labels.Labels{labels.Label{Name: labels.MetricName, Value: metricName}}
+	series := labels.FromStrings(labels.MetricName, metricName)
 
 	app := db.Appender(context.Background())
 	for ts := minT; ts < maxT; ts += int64(step) {

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -45,21 +45,21 @@ func TestReaders(t *testing.T) {
 
 	// Create block index version 2.
 	id1, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
-		{{Name: "a", Value: "3"}},
-		{{Name: "a", Value: "4"}},
-		{{Name: "a", Value: "5"}},
-		{{Name: "a", Value: "6"}},
-		{{Name: "a", Value: "7"}},
-		{{Name: "a", Value: "8"}},
-		{{Name: "a", Value: "9"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
+		labels.FromStrings("a", "3"),
+		labels.FromStrings("a", "4"),
+		labels.FromStrings("a", "5"),
+		labels.FromStrings("a", "6"),
+		labels.FromStrings("a", "7"),
+		labels.FromStrings("a", "8"),
+		labels.FromStrings("a", "9"),
 		// Missing 10 on purpose.
-		{{Name: "a", Value: "11"}},
-		{{Name: "a", Value: "12"}},
-		{{Name: "a", Value: "13"}},
-		{{Name: "a", Value: "1"}, {Name: "longer-string", Value: "1"}},
-		{{Name: "a", Value: "1"}, {Name: "longer-string", Value: "2"}},
+		labels.FromStrings("a", "11"),
+		labels.FromStrings("a", "12"),
+		labels.FromStrings("a", "13"),
+		labels.FromStrings("a", "1", "longer-string", "1"),
+		labels.FromStrings("a", "1", "longer-string", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -55,8 +55,8 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
@@ -96,8 +96,8 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
@@ -136,8 +136,8 @@ func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
@@ -188,8 +188,8 @@ func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
@@ -239,8 +239,8 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -54,8 +54,8 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))
@@ -92,8 +92,8 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 
 	// Create block.
 	blockID, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
-		{{Name: "a", Value: "1"}},
-		{{Name: "a", Value: "2"}},
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
 	}, 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), metadata.NoneFunc))

--- a/pkg/storegateway/snappy_gob_codec_test.go
+++ b/pkg/storegateway/snappy_gob_codec_test.go
@@ -20,8 +20,8 @@ func TestSnappyGobSeriesCacheEntryCodec(t *testing.T) {
 
 	entry := testType{
 		LabelSets: []labels.Labels{
-			{{Name: "foo", Value: "bar"}},
-			{{Name: "baz", Value: "boo"}},
+			labels.FromStrings("foo", "bar"),
+			labels.FromStrings("baz", "boo"),
 		},
 		MatchersKey: indexcache.CanonicalLabelMatchersKey([]*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar")}),
 	}


### PR DESCRIPTION
Some more instances that were missed from #3303.

Instead of assuming `labels.Labels` is a slice that we can construct directly. This will allow flexibility in the implementation.

In a couple of places, use `labels.EmptyLabels` instead of `nil`, for the same reason.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-facing.
