### PR TITLE
Rename -ruler.tls-enabled to -ruler.alertmanager-client.tls-enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Grafana Mimir - main / unreleased
 
-* [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432
+* [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 
 ## 2.5.0-rc.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Grafana Mimir - main / unreleased
 
-* [ENHANCEMENT] Ruler: Added `ruler.tls-enabled` configuration for alertmanager client. #3432
+* [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 
 ## 2.5.0-rc.0

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7407,7 +7407,7 @@
               "desc": "Enable TLS for gRPC client connecting to alertmanager.",
               "fieldValue": null,
               "fieldDefaultValue": true,
-              "fieldFlag": "ruler.tls-enabled",
+              "fieldFlag": "ruler.alertmanager-client.tls-enabled",
               "fieldType": "boolean",
               "fieldCategory": "advanced"
             },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1605,6 +1605,8 @@ Usage of ./cmd/mimir/mimir:
     	Path to the client certificate file, which will be used for authenticating with the server. Also requires the key path to be configured.
   -ruler.alertmanager-client.tls-cipher-suites string
     	Override the default cipher suite list (separated by commas).
+  -ruler.alertmanager-client.tls-enabled
+    	Enable TLS for gRPC client connecting to alertmanager. (default true)
   -ruler.alertmanager-client.tls-insecure-skip-verify
     	Skip validating server certificate.
   -ruler.alertmanager-client.tls-key-path string
@@ -1791,8 +1793,6 @@ Usage of ./cmd/mimir/mimir:
     	Enable running rule groups against multiple tenants. The tenant IDs involved need to be in the rule group's 'source_tenants' field. If this flag is set to 'false' when there are already created federated rule groups, then these rules groups will be skipped during evaluations.
   -ruler.tenant-shard-size int
     	The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.
-  -ruler.tls-enabled
-    	Enable TLS for gRPC client connecting to alertmanager. (default true)
   -runtime-config.file comma-separated-list-of-strings
     	Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.
   -runtime-config.reload-period duration

--- a/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
@@ -1265,7 +1265,7 @@ The `ruler` block configures the ruler.
 
 alertmanager_client:
   # (advanced) Enable TLS for gRPC client connecting to alertmanager.
-  # CLI flag: -ruler.tls-enabled
+  # CLI flag: -ruler.alertmanager-client.tls-enabled
   [tls_enabled: <boolean> | default = true]
 
   # (advanced) Path to the client certificate file, which will be used for

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -32,7 +32,7 @@ type NotifierConfig struct {
 }
 
 func (cfg *NotifierConfig) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.TLSEnabled, "ruler.tls-enabled", true, "Enable TLS for gRPC client connecting to alertmanager.")
+	f.BoolVar(&cfg.TLSEnabled, "ruler.alertmanager-client.tls-enabled", true, "Enable TLS for gRPC client connecting to alertmanager.")
 	cfg.TLS.RegisterFlagsWithPrefix("ruler.alertmanager-client", f)
 	cfg.BasicAuth.RegisterFlagsWithPrefix("ruler.alertmanager-client.", f)
 }


### PR DESCRIPTION
This PR addressed this comment https://github.com/grafana/mimir/pull/3432#discussion_r1036792258

This makes the flag consistent with the existing ruler alertmanager client flags. It is ok to merge this change because `-ruler.tls-enabled` is still not part of any release