### PR TITLE
Add default "time" param to parsed form (if any)

### DIFF
--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -251,7 +251,6 @@ func newQueryTripperware(
 		queryrange := newLimitedParallelismRoundTripper(next, codec, limits, queryRangeMiddleware...)
 		instant := defaultInstantQueryParamsRoundTripper(
 			newLimitedParallelismRoundTripper(next, codec, limits, queryInstantMiddleware...),
-			time.Now,
 		)
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			switch {
@@ -308,12 +307,19 @@ func isInstantQuery(path string) bool {
 	return strings.HasSuffix(path, instantQueryPathSuffix)
 }
 
-func defaultInstantQueryParamsRoundTripper(next http.RoundTripper, now func() time.Time) http.RoundTripper {
+func defaultInstantQueryParamsRoundTripper(next http.RoundTripper) http.RoundTripper {
 	return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		if isInstantQuery(r.URL.Path) && !r.URL.Query().Has("time") {
+			nowUnixStr := strconv.FormatInt(time.Now().Unix(), 10)
+
 			q := r.URL.Query()
-			q.Add("time", strconv.FormatInt(time.Now().Unix(), 10))
+			q.Add("time", nowUnixStr)
 			r.URL.RawQuery = q.Encode()
+
+			// If form was already parsed, add this param to the form too.
+			if r.Form != nil {
+				r.Form.Add("time", nowUnixStr)
+			}
 		}
 		return next.RoundTrip(r)
 	})

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -309,7 +309,7 @@ func isInstantQuery(path string) bool {
 
 func defaultInstantQueryParamsRoundTripper(next http.RoundTripper) http.RoundTripper {
 	return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
-		if isInstantQuery(r.URL.Path) && !r.URL.Query().Has("time") {
+		if isInstantQuery(r.URL.Path) && !r.Form.Has("time") && !r.URL.Query().Has("time") {
 			nowUnixStr := strconv.FormatInt(time.Now().Unix(), 10)
 
 			q := r.URL.Query()
@@ -317,8 +317,9 @@ func defaultInstantQueryParamsRoundTripper(next http.RoundTripper) http.RoundTri
 			r.URL.RawQuery = q.Encode()
 
 			// If form was already parsed, add this param to the form too.
+			// (The form doesn't have "time", otherwise we'd not be here)
 			if r.Form != nil {
-				r.Form.Add("time", nowUnixStr)
+				r.Form.Set("time", nowUnixStr)
 			}
 		}
 		return next.RoundTrip(r)

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -128,7 +128,6 @@ func TestInstantTripperware(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ts := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
 	rt := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// We will provide a sample exactly for the requested time,
 		// this way we'll also be able to tell which time was requested.
@@ -153,11 +152,14 @@ func TestInstantTripperware(t *testing.T) {
 		})
 	})
 
-	queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: tw(rt)})
-	require.NoError(t, err)
-	api := v1.NewAPI(queryClient)
+	tripper := tw(rt)
 
-	t.Run("happy case roundtrip", func(t *testing.T) {
+	t.Run("specific time happy case", func(t *testing.T) {
+		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: tripper})
+		require.NoError(t, err)
+		api := v1.NewAPI(queryClient)
+
+		ts := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
 		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, ts)
 		require.NoError(t, err)
 		require.Equal(t, model.Vector{
@@ -165,14 +167,59 @@ func TestInstantTripperware(t *testing.T) {
 		}, res)
 	})
 
-	t.Run("default time param", func(t *testing.T) {
-		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, time.Now())
+	t.Run("default time param happy case", func(t *testing.T) {
+		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: tripper})
+		require.NoError(t, err)
+		api := v1.NewAPI(queryClient)
+
+		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, time.Time{})
 		require.NoError(t, err)
 		require.IsType(t, model.Vector{}, res)
 		require.NotEmpty(t, res.(model.Vector))
 
 		resultTime := res.(model.Vector)[0].Timestamp.Time()
 		require.InDelta(t, time.Now().Unix(), resultTime.Unix(), 1)
+	})
+
+	t.Run("default time param with form being already parsed", func(t *testing.T) {
+		formParserRoundTripper := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			assert.NoError(t, r.ParseForm())
+			return tripper.RoundTrip(r)
+		})
+		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: formParserRoundTripper})
+		require.NoError(t, err)
+		api := v1.NewAPI(queryClient)
+
+		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, time.Time{})
+		require.NoError(t, err)
+		require.IsType(t, model.Vector{}, res)
+		require.NotEmpty(t, res.(model.Vector))
+
+		resultTime := res.(model.Vector)[0].Timestamp.Time()
+		require.InDelta(t, time.Now().Unix(), resultTime.Unix(), 1)
+	})
+
+	t.Run("post form time param takes precedence over query time param ", func(t *testing.T) {
+		postFormTimeParam := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
+
+		addQueryTimeParam := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			query := r.URL.Query()
+			// Set query's "time" param to something wrong, so that it would fail to be parsed if it's used.
+			query.Set("time", "query-time-param-should-not-be-used")
+			r.URL.RawQuery = query.Encode()
+			return tripper.RoundTrip(r)
+		})
+		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: addQueryTimeParam})
+		require.NoError(t, err)
+		api := v1.NewAPI(queryClient)
+
+		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, postFormTimeParam)
+		require.NoError(t, err)
+		require.IsType(t, model.Vector{}, res)
+		require.NotEmpty(t, res.(model.Vector))
+
+		resultTime := res.(model.Vector)[0].Timestamp.Time()
+		require.Equal(t, postFormTimeParam.Unix(), resultTime.Unix())
 	})
 }
 

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -167,6 +167,26 @@ func TestInstantTripperware(t *testing.T) {
 		}, res)
 	})
 
+	t.Run("specific time param with form being already parsed", func(t *testing.T) {
+		ts := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
+
+		formParserRoundTripper := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			assert.NoError(t, r.ParseForm())
+			return tripper.RoundTrip(r)
+		})
+		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: formParserRoundTripper})
+		require.NoError(t, err)
+		api := v1.NewAPI(queryClient)
+
+		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, ts)
+		require.NoError(t, err)
+		require.IsType(t, model.Vector{}, res)
+		require.NotEmpty(t, res.(model.Vector))
+
+		resultTime := res.(model.Vector)[0].Timestamp.Time()
+		require.Equal(t, ts.Unix(), resultTime.Unix())
+	})
+
 	t.Run("default time param happy case", func(t *testing.T) {
 		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: tripper})
 		require.NoError(t, err)


### PR DESCRIPTION
#### What this PR does

If the form was already parsed by a downstream middleware, we need to add it to that form too, otherwise it won't be available to upstream by just adding it to the url query.

This implement's @pstibrany's suggestion https://github.com/grafana/mimir/pull/3588#discussion_r1036930450 and copies all the tests from that PR.

#### Which issue(s) this PR fixes or relates to

Will make https://github.com/grafana/mimir/pull/3561 easier to review.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
