### PR TITLE
Refactoring: do not pass the chunks pool to newBucketChunkReader()

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/hashcache"
@@ -765,18 +764,6 @@ func storeCachedSeries(ctx context.Context, indexCache indexcache.IndexCache, us
 		return
 	}
 	indexCache.StoreSeries(ctx, userID, blockID, entry.MatchersKey, shard, data)
-}
-
-func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool *pool.BatchBytes, save func([]byte, *pool.BatchBytes) ([]byte, error)) error {
-	if in.Encoding() == chunkenc.EncXOR {
-		b, err := save(in.Bytes(), chunksPool)
-		if err != nil {
-			return err
-		}
-		out.Raw = &storepb.Chunk{Type: storepb.Chunk_XOR, Data: b}
-		return nil
-	}
-	return errors.Errorf("unsupported chunk encoding %d", in.Encoding())
 }
 
 // debugFoundBlockSetOverview logs on debug level what exactly blocks we used for query in terms of

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -32,16 +32,14 @@ type bucketChunkReader struct {
 
 	// Mutex protects access to following fields, when updated from chunks-loading goroutines.
 	// After chunks are loaded, mutex is no longer used.
-	mtx        sync.Mutex
-	chunkBytes *pool.BatchBytes
+	mtx sync.Mutex
 }
 
-func newBucketChunkReader(ctx context.Context, block *bucketBlock, chunkBytes *pool.BatchBytes) *bucketChunkReader {
+func newBucketChunkReader(ctx context.Context, block *bucketBlock) *bucketChunkReader {
 	return &bucketChunkReader{
-		ctx:        ctx,
-		block:      block,
-		toLoad:     make([][]loadIdx, len(block.chunkObjs)),
-		chunkBytes: chunkBytes,
+		ctx:    ctx,
+		block:  block,
+		toLoad: make([][]loadIdx, len(block.chunkObjs)),
 	}
 }
 
@@ -65,7 +63,7 @@ func (r *bucketChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) 
 }
 
 // load all added chunks and saves resulting chunks to res.
-func (r *bucketChunkReader) load(res []seriesEntry, stats *safeQueryStats) error {
+func (r *bucketChunkReader) load(res []seriesEntry, chunksPool *pool.BatchBytes, stats *safeQueryStats) error {
 	g, ctx := errgroup.WithContext(r.ctx)
 
 	for seq, pIdxs := range r.toLoad {
@@ -81,7 +79,7 @@ func (r *bucketChunkReader) load(res []seriesEntry, stats *safeQueryStats) error
 			p := p
 			indices := pIdxs[p.ElemRng[0]:p.ElemRng[1]]
 			g.Go(func() error {
-				return r.loadChunks(ctx, res, seq, p, indices, stats)
+				return r.loadChunks(ctx, res, seq, p, indices, chunksPool, stats)
 			})
 		}
 	}
@@ -90,7 +88,7 @@ func (r *bucketChunkReader) load(res []seriesEntry, stats *safeQueryStats) error
 
 // loadChunks will read range [start, end] from the segment file with sequence number seq.
 // This data range covers chunks starting at supplied offsets.
-func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, seq int, part Part, pIdxs []loadIdx, stats *safeQueryStats) error {
+func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, seq int, part Part, pIdxs []loadIdx, chunksPool *pool.BatchBytes, stats *safeQueryStats) error {
 	fetchBegin := time.Now()
 
 	// Get a reader for the required range.
@@ -167,7 +165,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, s
 		// There is also crc32 after the chunk, but we ignore that.
 		chunkLen = n + 1 + int(chunkDataLen)
 		if chunkLen <= len(cb) {
-			err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunk]), rawChunk(cb[n:chunkLen]), r.save)
+			err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunk]), rawChunk(cb[n:chunkLen]), chunksPool, r.save)
 			if err != nil {
 				return errors.Wrap(err, "populate chunk")
 			}
@@ -198,7 +196,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, s
 		localStats.chunksFetchCount++
 		localStats.chunksFetchDurationSum += time.Since(fetchBegin)
 		localStats.chunksFetchedSizeSum += len(*nb)
-		err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunk]), rawChunk((*nb)[n:]), r.save)
+		err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunk]), rawChunk((*nb)[n:]), chunksPool, r.save)
 		if err != nil {
 			r.block.chunkPool.Put(nb)
 			return errors.Wrap(err, "populate chunk")
@@ -211,10 +209,11 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, s
 	return nil
 }
 
-// save saves a copy of b's payload to a memory pool of its own and returns a new byte slice referencing said copy.
-// Returned slice becomes invalid once r.block.chunkPool.Put() is called.
-func (r *bucketChunkReader) save(b []byte) ([]byte, error) {
-	dst, err := r.chunkBytes.Get(len(b))
+// save a copy of b's payload to a buffer pulled from chunksPool.
+// The buffer containing the chunk data is returned.
+// The returned slice becomes invalid once chunksPool is released.
+func (r *bucketChunkReader) save(b []byte, chunksPool *pool.BatchBytes) ([]byte, error) {
+	dst, err := chunksPool.Get(len(b))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What this PR does
Currently `newBucketChunkReader()` requires the chunks pool in input. This complicates the implementation of the streaming store-gateway, so in this PR I'm proposing to remove it and just pass the chunks pool to `bucketChunkReader.load()` which is where is required. Keep in mind `pool.BatchBytes` is concurrency safe.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
