### PR TITLE
store-gateway: add iterators for seriesChunks and seriesChunkRefs

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -2,6 +2,14 @@
 
 package storegateway
 
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+)
+
 // seriesChunksSetIterator is the interface implemented by an iterator returning a sequence of seriesChunksSet.
 //
 //nolint:unused // dead code while we are working on PR 3355
@@ -17,26 +25,134 @@ type seriesChunksSetIterator interface {
 type seriesChunksSet struct {
 	series []seriesEntry
 
-	bytesReleaser releaser
+	// chunksReleaser releases the memory used to allocate series chunks.
+	chunksReleaser chunksReleaser
 }
 
 //nolint:unused // dead code while we are working on PR 3355
-type releaser interface{ Release() }
+type chunksReleaser interface {
+	// Release the memory used to allocate series chunks.
+	Release()
+}
 
 //nolint:unused // dead code while we are working on PR 3355
 func (b *seriesChunksSet) release() {
-	if len(b.series) == 0 {
-		// There's nothing to release, just return; this also allows to call release() on a zero-valued seriesChunksSet.
-		return
+	if b.chunksReleaser != nil {
+		b.chunksReleaser.Release()
+		b.chunksReleaser = nil
 	}
 
-	b.bytesReleaser.Release()
-
-	// Make it harder to do a "use after free".
 	b.series = nil
 }
 
 //nolint:unused // dead code while we are working on PR 3355
 func (b seriesChunksSet) len() int {
 	return len(b.series)
+}
+
+type seriesChunksSeriesSet struct {
+	from seriesChunksSetIterator
+
+	currSet    seriesChunksSet
+	currOffset int
+}
+
+func newSeriesChunksSeriesSet(from seriesChunksSetIterator) storepb.SeriesSet {
+	return &seriesChunksSeriesSet{
+		from: from,
+	}
+}
+
+// Next advances to the next item. Once the underlying seriesChunksSet has been fully consumed
+// (which means the call to Next moves to the next set), the seriesChunksSet is released. This
+// means that it's not safe to read from the values returned by At() after Next() is called again.
+func (b *seriesChunksSeriesSet) Next() bool {
+	b.currOffset++
+	if b.currOffset >= b.currSet.len() {
+		if !b.from.Next() {
+			b.currSet.release()
+			return false
+		}
+		b.currSet.release()
+		b.currSet = b.from.At()
+		b.currOffset = 0
+	}
+	return true
+}
+
+// At returns the current series. The result from At() MUST not be retained after calling Next()
+func (b *seriesChunksSeriesSet) At() (labels.Labels, []storepb.AggrChunk) {
+	if b.currOffset >= b.currSet.len() {
+		return nil, nil
+	}
+
+	return b.currSet.series[b.currOffset].lset, b.currSet.series[b.currOffset].chks
+}
+
+func (b *seriesChunksSeriesSet) Err() error {
+	return b.from.Err()
+}
+
+// preloadedSeriesChunksSet holds the result of preloading the next set. It can either contain
+// the preloaded set or an error, but not both.
+type preloadedSeriesChunksSet struct {
+	set seriesChunksSet
+	err error
+}
+
+type preloadingSeriesChunkSetIterator struct {
+	ctx     context.Context
+	from    seriesChunksSetIterator
+	current seriesChunksSet
+
+	preloaded chan preloadedSeriesChunksSet
+	err       error
+}
+
+func newPreloadingSeriesChunkSetIterator(ctx context.Context, preloadedSetsCount int, from seriesChunksSetIterator) *preloadingSeriesChunkSetIterator {
+	preloadedSet := &preloadingSeriesChunkSetIterator{
+		ctx:       ctx,
+		from:      from,
+		preloaded: make(chan preloadedSeriesChunksSet, preloadedSetsCount-1), // one will be kept outside the channel when the channel blocks
+	}
+	go preloadedSet.preload()
+	return preloadedSet
+}
+
+func (p *preloadingSeriesChunkSetIterator) preload() {
+	defer close(p.preloaded)
+
+	for p.from.Next() {
+		select {
+		case <-p.ctx.Done():
+			// If the context is done, we should just stop the preloading goroutine.
+			return
+		case p.preloaded <- preloadedSeriesChunksSet{set: p.from.At()}:
+		}
+	}
+
+	if p.from.Err() != nil {
+		p.preloaded <- preloadedSeriesChunksSet{err: p.from.Err()}
+	}
+}
+
+func (p *preloadingSeriesChunkSetIterator) Next() bool {
+	preloaded, ok := <-p.preloaded
+	if !ok {
+		// Iteration reached the end or context has been canceled.
+		return false
+	}
+
+	p.current = preloaded.set
+	p.err = preloaded.err
+
+	return p.err == nil
+}
+
+func (p *preloadingSeriesChunkSetIterator) At() seriesChunksSet {
+	return p.current
+}
+
+func (p *preloadingSeriesChunkSetIterator) Err() error {
+	return p.err
 }

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -2,6 +2,302 @@
 
 package storegateway
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util/test"
+)
+
+func TestSeriesChunksSeriesSet(t *testing.T) {
+	c := generateAggrChunk(6)
+
+	series1 := labels.FromStrings(labels.MetricName, "metric_1")
+	series2 := labels.FromStrings(labels.MetricName, "metric_2")
+	series3 := labels.FromStrings(labels.MetricName, "metric_3")
+	series4 := labels.FromStrings(labels.MetricName, "metric_4")
+	series5 := labels.FromStrings(labels.MetricName, "metric_4")
+
+	// Utility function to create sets, so that each test starts from a clean setup (e.g. releaser is not released).
+	createSets := func() (sets []seriesChunksSet, releasers []*releaserMock) {
+		for i := 0; i < 3; i++ {
+			releasers = append(releasers, newReleaserMock())
+		}
+
+		sets = append(sets,
+			seriesChunksSet{
+				chunksReleaser: releasers[0],
+				series: []seriesEntry{
+					{lset: series1, chks: []storepb.AggrChunk{c[1]}},
+					{lset: series2, chks: []storepb.AggrChunk{c[2]}},
+				}},
+			seriesChunksSet{
+				chunksReleaser: releasers[1],
+				series: []seriesEntry{
+					{lset: series3, chks: []storepb.AggrChunk{c[3]}},
+					{lset: series4, chks: []storepb.AggrChunk{c[4]}},
+				}},
+			seriesChunksSet{
+				chunksReleaser: releasers[2],
+				series: []seriesEntry{
+					{lset: series5, chks: []storepb.AggrChunk{c[5]}},
+				}},
+		)
+
+		return
+	}
+
+	t.Run("should iterate over a single set and release it once done", func(t *testing.T) {
+		sets, releasers := createSets()
+		source := newSliceSeriesChunksSetIterator(sets[0])
+		it := newSeriesChunksSeriesSet(source)
+
+		lbls, chks := it.At()
+		require.Zero(t, lbls)
+		require.Zero(t, chks)
+		require.NoError(t, it.Err())
+
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series1, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[1]}, chks)
+		require.NoError(t, it.Err())
+		require.False(t, releasers[0].isReleased())
+
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series2, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[2]}, chks)
+		require.NoError(t, it.Err())
+		require.False(t, releasers[0].isReleased())
+
+		require.False(t, it.Next())
+		lbls, chks = it.At()
+		require.Zero(t, lbls)
+		require.Zero(t, chks)
+		require.NoError(t, it.Err())
+		require.True(t, releasers[0].isReleased())
+	})
+
+	t.Run("should iterate over a multiple sets and release each set once we begin to iterate the next one", func(t *testing.T) {
+		sets, releasers := createSets()
+		source := newSliceSeriesChunksSetIterator(sets[0], sets[1])
+		it := newSeriesChunksSeriesSet(source)
+
+		lbls, chks := it.At()
+		require.Zero(t, lbls)
+		require.Zero(t, chks)
+		require.NoError(t, it.Err())
+
+		// Set 1.
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series1, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[1]}, chks)
+		require.NoError(t, it.Err())
+		require.False(t, releasers[0].isReleased())
+		require.False(t, releasers[1].isReleased())
+
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series2, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[2]}, chks)
+		require.NoError(t, it.Err())
+		require.False(t, releasers[0].isReleased())
+		require.False(t, releasers[1].isReleased())
+
+		// Set 2.
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series3, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[3]}, chks)
+		require.NoError(t, it.Err())
+		require.True(t, releasers[0].isReleased())
+		require.False(t, releasers[1].isReleased())
+
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series4, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[4]}, chks)
+		require.NoError(t, it.Err())
+		require.True(t, releasers[0].isReleased())
+		require.False(t, releasers[1].isReleased())
+
+		require.False(t, it.Next())
+		lbls, chks = it.At()
+		require.Zero(t, lbls)
+		require.Zero(t, chks)
+		require.NoError(t, it.Err())
+		require.True(t, releasers[0].isReleased())
+	})
+
+	t.Run("should release the current set on error", func(t *testing.T) {
+		expectedErr := errors.New("mocked error")
+
+		sets, releasers := createSets()
+		source := newSliceSeriesChunksSetIteratorWithError(expectedErr, 1, sets[0], sets[1], sets[2])
+		it := newSeriesChunksSeriesSet(source)
+
+		lbls, chks := it.At()
+		require.Zero(t, lbls)
+		require.Zero(t, chks)
+		require.NoError(t, it.Err())
+
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series1, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[1]}, chks)
+		require.NoError(t, it.Err())
+		require.False(t, releasers[0].isReleased())
+
+		require.True(t, it.Next())
+		lbls, chks = it.At()
+		require.Equal(t, series2, lbls)
+		require.Equal(t, []storepb.AggrChunk{c[2]}, chks)
+		require.NoError(t, it.Err())
+		require.False(t, releasers[0].isReleased())
+
+		require.False(t, it.Next())
+		lbls, chks = it.At()
+		require.Zero(t, lbls)
+		require.Zero(t, chks)
+		require.Equal(t, expectedErr, it.Err())
+
+		// The current set is released.
+		require.True(t, releasers[0].isReleased())
+
+		// Can't release the next ones because can't move forward with the iteration (due to the error).
+		require.False(t, releasers[1].isReleased())
+		require.False(t, releasers[2].isReleased())
+	})
+}
+
+func TestPreloadingSeriesChunkSetIterator(t *testing.T) {
+	test.VerifyNoLeak(t)
+
+	const delay = 10 * time.Millisecond
+
+	// Create some sets, each set containing 1 series.
+	sets := make([]seriesChunksSet, 0, 10)
+	for i := 0; i < 10; i++ {
+		sets = append(sets, seriesChunksSet{
+			series: []seriesEntry{{
+				lset: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
+				refs: []chunks.ChunkRef{chunks.ChunkRef(i)},
+			}},
+		})
+	}
+
+	t.Run("should iterate all sets if no error occurs", func(t *testing.T) {
+		for preloadSize := 1; preloadSize <= len(sets)+1; preloadSize++ {
+			preloadSize := preloadSize
+
+			t.Run(fmt.Sprintf("preload size: %d", preloadSize), func(t *testing.T) {
+				t.Parallel()
+
+				source := newSliceSeriesChunksSetIterator(sets...)
+				source = newDelayedSeriesChunksSetIterator(delay, source)
+
+				preloading := newPreloadingSeriesChunkSetIterator(context.Background(), preloadSize, source)
+
+				// Ensure expected sets are returned in order.
+				expectedIdx := 0
+				for preloading.Next() {
+					require.NoError(t, preloading.Err())
+					require.Equal(t, sets[expectedIdx], preloading.At())
+					expectedIdx++
+				}
+
+				// Ensure all sets have been returned.
+				require.NoError(t, preloading.Err())
+				require.Equal(t, len(sets), expectedIdx)
+			})
+		}
+	})
+
+	t.Run("should stop iterating once an error is found", func(t *testing.T) {
+		for preloadSize := 1; preloadSize <= len(sets)+1; preloadSize++ {
+			preloadSize := preloadSize
+
+			t.Run(fmt.Sprintf("preload size: %d", preloadSize), func(t *testing.T) {
+				t.Parallel()
+
+				source := newSliceSeriesChunksSetIteratorWithError(errors.New("mocked error"), len(sets), sets...)
+				source = newDelayedSeriesChunksSetIterator(delay, source)
+
+				preloading := newPreloadingSeriesChunkSetIterator(context.Background(), preloadSize, source)
+
+				// Ensure expected sets are returned in order.
+				expectedIdx := 0
+				for preloading.Next() {
+					require.NoError(t, preloading.Err())
+					require.Equal(t, sets[expectedIdx], preloading.At())
+					expectedIdx++
+				}
+
+				// Ensure an error is returned at the end.
+				require.Error(t, preloading.Err())
+				require.Equal(t, len(sets), expectedIdx)
+			})
+		}
+	})
+
+	t.Run("should not leak preloading goroutine if caller doesn't iterated until the end of sets but context is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancelCtx := context.WithCancel(context.Background())
+
+		source := newSliceSeriesChunksSetIteratorWithError(errors.New("mocked error"), len(sets), sets...)
+		source = newDelayedSeriesChunksSetIterator(delay, source)
+
+		preloading := newPreloadingSeriesChunkSetIterator(ctx, 1, source)
+
+		// Just call Next() once.
+		require.True(t, preloading.Next())
+		require.NoError(t, preloading.Err())
+		require.Equal(t, sets[0], preloading.At())
+
+		// Cancel the context.
+		cancelCtx()
+
+		// Give a short time to the preloader goroutine to react to the context cancellation.
+		// This is required to avoid a flaky test.
+		time.Sleep(100 * time.Millisecond)
+
+		// At this point we expect Next() to return false.
+		require.False(t, preloading.Next())
+		require.NoError(t, preloading.Err())
+	})
+
+	t.Run("should not leak preloading goroutine if caller doesn't call Next() until false but context is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancelCtx := context.WithCancel(context.Background())
+
+		source := newSliceSeriesChunksSetIteratorWithError(errors.New("mocked error"), len(sets), sets...)
+		source = newDelayedSeriesChunksSetIterator(delay, source)
+
+		preloading := newPreloadingSeriesChunkSetIterator(ctx, 1, source)
+
+		// Just call Next() once.
+		require.True(t, preloading.Next())
+		require.NoError(t, preloading.Err())
+		require.Equal(t, sets[0], preloading.At())
+
+		// Cancel the context. Do NOT call Next() after canceling the context.
+		cancelCtx()
+	})
+}
+
 // sliceSeriesChunksSetIterator implements seriesChunksSetIterator and
 // returns the provided err when the sets are exhausted
 //
@@ -10,21 +306,37 @@ type sliceSeriesChunksSetIterator struct {
 	current int
 	sets    []seriesChunksSet
 
-	err error
+	err   error
+	errAt int
 }
 
 //nolint:unused // dead code while we are working on PR 3355
-func newSliceSeriesChunksSetIterator(err error, sets ...seriesChunksSet) seriesChunksSetIterator {
+func newSliceSeriesChunksSetIterator(sets ...seriesChunksSet) seriesChunksSetIterator {
+	return &sliceSeriesChunksSetIterator{
+		current: -1,
+		sets:    sets,
+	}
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func newSliceSeriesChunksSetIteratorWithError(err error, errAt int, sets ...seriesChunksSet) seriesChunksSetIterator {
 	return &sliceSeriesChunksSetIterator{
 		current: -1,
 		sets:    sets,
 		err:     err,
+		errAt:   errAt,
 	}
 }
 
 //nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunksSetIterator) Next() bool {
 	s.current++
+
+	// If the next item should fail, we return false. The Err() function will return the error.
+	if s.err != nil && s.current >= s.errAt {
+		return false
+	}
+
 	return s.current < len(s.sets)
 }
 
@@ -35,8 +347,85 @@ func (s *sliceSeriesChunksSetIterator) At() seriesChunksSet {
 
 //nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunksSetIterator) Err() error {
-	if s.current >= len(s.sets) {
+	if s.err != nil && s.current >= s.errAt {
 		return s.err
 	}
 	return nil
+}
+
+// delayedSeriesChunksSetIterator implements seriesChunksSetIterator and
+// introduces an artificial delay before returning from Next() and At().
+type delayedSeriesChunksSetIterator struct {
+	wrapped seriesChunksSetIterator
+	delay   time.Duration
+}
+
+func newDelayedSeriesChunksSetIterator(delay time.Duration, wrapped seriesChunksSetIterator) seriesChunksSetIterator {
+	return &delayedSeriesChunksSetIterator{
+		wrapped: wrapped,
+		delay:   delay,
+	}
+}
+
+func (s *delayedSeriesChunksSetIterator) Next() bool {
+	time.Sleep(s.delay)
+	return s.wrapped.Next()
+}
+
+func (s *delayedSeriesChunksSetIterator) At() seriesChunksSet {
+	time.Sleep(s.delay)
+	return s.wrapped.At()
+}
+
+func (s *delayedSeriesChunksSetIterator) Err() error {
+	return s.wrapped.Err()
+}
+
+func generateAggrChunk(num int) []storepb.AggrChunk {
+	out := make([]storepb.AggrChunk, 0, num)
+
+	for i := 0; i < num; i++ {
+		out = append(out, storepb.AggrChunk{
+			MinTime: int64(i),
+			MaxTime: int64(i),
+		})
+	}
+
+	return out
+}
+
+type releaserMock struct {
+	released *atomic.Bool
+}
+
+func newReleaserMock() *releaserMock {
+	return &releaserMock{
+		released: atomic.NewBool(false),
+	}
+}
+
+func (r *releaserMock) Release() {
+	r.released.Store(true)
+}
+
+func (r *releaserMock) isReleased() bool {
+	return r.released.Load()
+}
+
+//nolint:unused // dead code while we are working on PR 3355
+func readAllSeriesChunksSets(it seriesChunksSetIterator) []seriesChunksSet {
+	var out []seriesChunksSet
+	for it.Next() {
+		out = append(out, it.At())
+	}
+	return out
+}
+
+func readAllSeriesLabels(it storepb.SeriesSet) []labels.Labels {
+	var out []labels.Labels
+	for it.Next() {
+		lbls, _ := it.At()
+		out = append(out, lbls)
+	}
+	return out
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -6,6 +6,8 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
+
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
 )
 
 // seriesChunkRefsSetIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefsSet.
@@ -127,4 +129,319 @@ func (c *seriesChunkRefsIteratorImpl) At() seriesChunkRefs {
 
 func (c *seriesChunkRefsIteratorImpl) Err() error {
 	return nil
+}
+
+type flattenedSeriesChunkRefsIterator struct {
+	from     seriesChunkRefsSetIterator
+	iterator *seriesChunkRefsIteratorImpl
+}
+
+func newFlattenedSeriesChunkRefsIterator(from seriesChunkRefsSetIterator) seriesChunkRefsIterator {
+	return &flattenedSeriesChunkRefsIterator{
+		from:     from,
+		iterator: newSeriesChunkRefsIterator(seriesChunkRefsSet{}), // start with an empty set and initialize on the first call to Next()
+	}
+}
+
+func (c flattenedSeriesChunkRefsIterator) Next() bool {
+	if c.iterator.Next() {
+		return true
+	}
+
+	// The current iterator has no more elements. We check if there's another
+	// iterator to fetch and then iterate on.
+	if !c.from.Next() {
+		return false
+	}
+
+	c.iterator.reset(c.from.At())
+
+	// We've replaced the current iterator, so can recursively call Next()
+	// to check if there's any item in the new iterator and further advance it if not.
+	return c.Next()
+}
+
+func (c flattenedSeriesChunkRefsIterator) At() seriesChunkRefs {
+	return c.iterator.At()
+}
+
+func (c flattenedSeriesChunkRefsIterator) Err() error {
+	return c.from.Err()
+}
+
+type emptySeriesChunkRefsSetIterator struct {
+}
+
+func (emptySeriesChunkRefsSetIterator) Next() bool             { return false }
+func (emptySeriesChunkRefsSetIterator) At() seriesChunkRefsSet { return seriesChunkRefsSet{} }
+func (emptySeriesChunkRefsSetIterator) Err() error             { return nil }
+
+//nolint:unused // dead code while we are working on PR 3355
+func mergedSeriesChunkRefsSetIterators(mergedSize int, all ...seriesChunkRefsSetIterator) seriesChunkRefsSetIterator {
+	switch len(all) {
+	case 0:
+		return emptySeriesChunkRefsSetIterator{}
+	case 1:
+		return newDeduplicatingSeriesChunkRefsSetIterator(mergedSize, all[0])
+	}
+	h := len(all) / 2
+
+	return newMergedSeriesChunkRefsSet(
+		mergedSize,
+		mergedSeriesChunkRefsSetIterators(mergedSize, all[:h]...),
+		mergedSeriesChunkRefsSetIterators(mergedSize, all[h:]...),
+	)
+}
+
+type mergedSeriesChunkRefsSet struct {
+	batchSize int
+
+	a, b     seriesChunkRefsSetIterator
+	aAt, bAt *seriesChunkRefsIteratorImpl
+	current  seriesChunkRefsSet
+}
+
+func newMergedSeriesChunkRefsSet(mergedBatchSize int, a, b seriesChunkRefsSetIterator) *mergedSeriesChunkRefsSet {
+	return &mergedSeriesChunkRefsSet{
+		batchSize: mergedBatchSize,
+		a:         a,
+		b:         b,
+		// start iterator on an empty set. It will be reset with a non-empty set when Next() is called
+		aAt: newSeriesChunkRefsIterator(seriesChunkRefsSet{}),
+		bAt: newSeriesChunkRefsIterator(seriesChunkRefsSet{}),
+	}
+}
+
+func (s *mergedSeriesChunkRefsSet) Err() error {
+	if err := s.a.Err(); err != nil {
+		return err
+	} else if err = s.b.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *mergedSeriesChunkRefsSet) Next() bool {
+	next := newSeriesChunkRefsSet(s.batchSize)
+
+	for i := 0; i < s.batchSize; i++ {
+		if err := s.ensureItemAvailableToRead(s.aAt, s.a); err != nil {
+			// Stop iterating on first error encountered.
+			return false
+		}
+
+		if err := s.ensureItemAvailableToRead(s.bAt, s.b); err != nil {
+			// Stop iterating on first error encountered.
+			return false
+		}
+
+		nextSeries, ok := s.nextUniqueEntry(s.aAt, s.bAt)
+		if !ok {
+			break
+		}
+		next.series = append(next.series, nextSeries)
+	}
+
+	s.current = next
+	return s.current.len() > 0
+}
+
+// ensureItemAvailableToRead ensures curr has an item available to read, unless we reached the
+// end of all sets. If curr has no item available to read, it will advance the iterator, eventually
+// picking the next one from the set.
+func (s *mergedSeriesChunkRefsSet) ensureItemAvailableToRead(curr *seriesChunkRefsIteratorImpl, set seriesChunkRefsSetIterator) error {
+	// Ensure curr has an item available, otherwise fetch the next set.
+	for curr.Done() {
+		if set.Next() {
+			curr.reset(set.At())
+
+			// Advance the iterator to the first element. If the iterator is empty,
+			// it will be detected and handled by the outer for loop.
+			curr.Next()
+			continue
+		}
+
+		if set.Err() != nil {
+			// Stop iterating on first error encountered.
+			return set.Err()
+		}
+
+		// No more sets.
+		return nil
+	}
+
+	return nil
+}
+
+// nextUniqueEntry returns the next unique entry from both a and b. If a.At() and b.At() have the same
+// label set, nextUniqueEntry merges their chunks. The merged chunks are sorted by their MinTime and then by MaxTIme.
+func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIteratorImpl) (toReturn seriesChunkRefs, _ bool) {
+	if a.Done() && b.Done() {
+		return toReturn, false
+	} else if a.Done() {
+		toReturn = b.At()
+		b.Next()
+		return toReturn, true
+	} else if b.Done() {
+		toReturn = a.At()
+		a.Next()
+		return toReturn, true
+	}
+
+	aAt := a.At()
+	lsetA, chksA := aAt.lset, aAt.chunks
+	bAt := b.At()
+	lsetB, chksB := bAt.lset, bAt.chunks
+
+	if d := labels.Compare(lsetA, lsetB); d > 0 {
+		toReturn = b.At()
+		b.Next()
+		return toReturn, true
+	} else if d < 0 {
+		toReturn = a.At()
+		a.Next()
+		return toReturn, true
+	}
+
+	// Both a and b contains the same series. Go through all chunk references and concatenate them from both
+	// series sets. We best effortly assume chunk references are sorted by min time, so that the sorting by min
+	// time is honored in the returned chunk references too.
+	toReturn.lset = lsetA
+
+	// Slice reuse is not generally safe with nested merge iterators.
+	// We err on the safe side and create a new slice.
+	toReturn.chunks = make([]seriesChunkRef, 0, len(chksA)+len(chksB))
+
+	bChunksOffset := 0
+Outer:
+	for aChunksOffset := range chksA {
+		for {
+			if bChunksOffset >= len(chksB) {
+				// No more b chunks.
+				toReturn.chunks = append(toReturn.chunks, chksA[aChunksOffset:]...)
+				break Outer
+			}
+
+			if chksA[aChunksOffset].Compare(chksB[bChunksOffset]) > 0 {
+				toReturn.chunks = append(toReturn.chunks, chksA[aChunksOffset])
+				break
+			} else {
+				toReturn.chunks = append(toReturn.chunks, chksB[bChunksOffset])
+				bChunksOffset++
+			}
+		}
+	}
+
+	if bChunksOffset < len(chksB) {
+		toReturn.chunks = append(toReturn.chunks, chksB[bChunksOffset:]...)
+	}
+
+	a.Next()
+	b.Next()
+	return toReturn, true
+}
+
+func (s *mergedSeriesChunkRefsSet) At() seriesChunkRefsSet {
+	return s.current
+}
+
+type seriesSetWithoutChunks struct {
+	from seriesChunkRefsSetIterator
+
+	currentIterator *seriesChunkRefsIteratorImpl
+}
+
+func newSeriesSetWithoutChunks(batches seriesChunkRefsSetIterator) storepb.SeriesSet {
+	return &seriesSetWithoutChunks{
+		from:            batches,
+		currentIterator: newSeriesChunkRefsIterator(seriesChunkRefsSet{}),
+	}
+}
+
+func (s *seriesSetWithoutChunks) Next() bool {
+	if s.currentIterator.Next() {
+		return true
+	}
+
+	// The current iterator has no more elements. We check if there's another
+	// iterator to fetch and then iterate on.
+	if !s.from.Next() {
+		return false
+	}
+
+	next := s.from.At()
+	s.currentIterator.reset(next)
+
+	// We've replaced the current iterator, so can recursively call Next()
+	// to check if there's any item in the new iterator and further advance it if not.
+	return s.Next()
+}
+
+func (s *seriesSetWithoutChunks) At() (labels.Labels, []storepb.AggrChunk) {
+	return s.currentIterator.At().lset, nil
+}
+
+func (s *seriesSetWithoutChunks) Err() error {
+	return s.from.Err()
+}
+
+// deduplicatingSeriesChunkRefsSetIterator implements seriesChunkRefsSetIterator, and merges together consecutive
+// series in an underlying seriesChunkRefsSetIterator.
+type deduplicatingSeriesChunkRefsSetIterator struct {
+	batchSize int
+
+	from    seriesChunkRefsIterator
+	peek    *seriesChunkRefs
+	current seriesChunkRefsSet
+}
+
+func newDeduplicatingSeriesChunkRefsSetIterator(batchSize int, wrapped seriesChunkRefsSetIterator) seriesChunkRefsSetIterator {
+	return &deduplicatingSeriesChunkRefsSetIterator{
+		batchSize: batchSize,
+		from:      newFlattenedSeriesChunkRefsIterator(wrapped),
+	}
+}
+
+func (s *deduplicatingSeriesChunkRefsSetIterator) Err() error {
+	return s.from.Err()
+}
+
+func (s *deduplicatingSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
+	return s.current
+}
+
+func (s *deduplicatingSeriesChunkRefsSetIterator) Next() bool {
+	var firstSeries seriesChunkRefs
+	if s.peek == nil {
+		if !s.from.Next() {
+			return false
+		}
+		firstSeries = s.from.At()
+	} else {
+		firstSeries = *s.peek
+		s.peek = nil
+	}
+	nextSet := newSeriesChunkRefsSet(s.batchSize)
+	nextSet.series = append(nextSet.series, firstSeries)
+
+	var nextSeries seriesChunkRefs
+	for i := 0; i < s.batchSize; {
+		if !s.from.Next() {
+			break
+		}
+		nextSeries = s.from.At()
+
+		if labels.Equal(nextSet.series[i].lset, nextSeries.lset) {
+			nextSet.series[i].chunks = append(nextSet.series[i].chunks, nextSeries.chunks...)
+		} else {
+			i++
+			if i >= s.batchSize {
+				s.peek = &nextSeries
+				break
+			}
+			nextSet.series = append(nextSet.series, nextSeries)
+		}
+	}
+	s.current = nextSet
+	return true
 }


### PR DESCRIPTION
This is the next step to introducing our changes from #3355. This
commit adds the iterators (and tests for them) used over the data
structures we added in #3587.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
