### PR TITLE
Update rollout-operator to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,23 @@
 # Changelog
 
-## Grafana Mimir - main / unreleased
+## main / unreleased
+
+### Grafana Mimir
 
 * [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
+
+### Mixin
+
+### Jsonnet
+
+* [ENHANCEMENT] Update `rollout-operator` to `v0.2.0`. #3624
+
+### Mimirtool
+
+### Documentation
+
+### Tools
 
 ## 2.5.0-rc.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Update the `rollout-operator` subchart to `0.2.0`. #3624
+
+## 4.0.0
+
 * [FEATURE] Support deploying NGINX via the `gateway` section. The `nginx` section will be removed in `7.0.0`. See
   [Migrate to using the unified proxy deployment for NGINX and GEM gateway](https://grafana.com/docs/mimir/latest/operators-guide/deploying-grafana-mimir/migrate-to-unified-gateway-deployment/)
 * [CHANGE] **breaking change** **Data loss without action.** Enables [zone-aware replication](https://grafana.com/docs/mimir/latest/operators-guide/configure/configure-zone-aware-replication/) for ingesters and store-gateways by default. #2778

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.2.8
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.1.2
-digest: sha256:bd2afb79872f86127981317d755ecee315670ffb5a314e3f388a9d4f69779e91
-generated: "2022-11-07T13:06:40.663397+01:00"
+  version: 0.2.0
+digest: sha256:7722b6a707f7990e41c6724bfdaa102e2a590d0f32faa1e3751f268e417ed4a1
+generated: "2022-12-01T17:11:57.722504-05:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.1.2
+    version: 0.2.0
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -22,7 +22,7 @@ Kubernetes: `^1.20.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.0.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.2.8 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.1.2 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.2.0 |
 
 ## Dependencies
 

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: gateway-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: gateway-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: gateway-nginx-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: gateway-nginx-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: large-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: large-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: scheduler-name-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: scheduler-name-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: small-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: small-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -34,7 +34,7 @@ spec:
         - name: rollout-operator
           securityContext:
             {}
-          image: "grafana/rollout-operator:v0.1.1"
+          image: "grafana/rollout-operator:v0.2.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.1.2
+    helm.sh/chart: rollout-operator-0.2.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.1.1"
+    app.kubernetes.io/version: "v0.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1227,7 +1227,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.1.1
+        image: grafana/rollout-operator:v0.2.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -872,7 +872,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.1.1
+        image: grafana/rollout-operator:v0.2.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -940,7 +940,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.1.1
+        image: grafana/rollout-operator:v0.2.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -509,7 +509,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.1.1
+        image: grafana/rollout-operator:v0.2.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -510,7 +510,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.1.1
+        image: grafana/rollout-operator:v0.2.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -28,6 +28,6 @@
     mimir_backend: self.mimir,
 
     // See: https://github.com/grafana/rollout-operator
-    rollout_operator: 'grafana/rollout-operator:v0.1.1',
+    rollout_operator: 'grafana/rollout-operator:v0.2.0',
   },
 }


### PR DESCRIPTION
#### What this PR does

Updates `rollout-operator` to `v0.2.0` in both Jsonnet and Helm, since it contains CVE fixes (see https://github.com/grafana/rollout-operator/pull/23 for details)

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/819

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
