### PR TITLE
Fix "unsupported value type" logged when calling /ready and some services are not yet running.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
+* [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 
 ## 2.5.0-rc.0
 

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -856,7 +856,7 @@ func (t *Mimir) readyHandler(sm *services.Manager, shutdownRequested *atomic.Boo
 				}
 			}
 
-			level.Debug(util_log.Logger).Log("msg", "some services are not Running", "services", serviceNamesStates)
+			level.Debug(util_log.Logger).Log("msg", "some services are not Running", "services", strings.Join(serviceNamesStates, ", "))
 			httpResponse := "Some services are not Running:\n" + strings.Join(serviceNamesStates, "\n")
 			http.Error(w, httpResponse, http.StatusServiceUnavailable)
 			return


### PR DESCRIPTION
#### What this PR does

If `/ready` is called and some services are not yet running, we currently log a message like the following:

```
level=debug ts=2022-12-02T01:52:02.411627554Z caller=mimir.go:859 msg="some services are not Running" services="unsupported value type"
```

(note the `unsupported value type` for `services`)

This PR fixes this so that we instead log the names and states of the services that are not running, for example:

```
level=debug ts=2022-12-02T02:28:15.070733296Z caller=mimir.go:862 msg="some services are not Running" services="store-gateway: Starting, compactor: Starting"
```

It would also be great to have a linter that catches issues like these, but that seems out of scope for this PR.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
