### PR TITLE
Remove Mimir implementations of "Fingerprint" functions.

### DIFF
--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -216,23 +216,6 @@ func FromLabelMatchers(matchers []*LabelMatcher) ([]*labels.Matcher, error) {
 	return result, nil
 }
 
-// FastFingerprint runs the same algorithm as Prometheus labelSetToFastFingerprint()
-func FastFingerprint(ls []mimirpb.LabelAdapter) model.Fingerprint {
-	if len(ls) == 0 {
-		return model.Metric(nil).FastFingerprint()
-	}
-
-	var result uint64
-	for _, l := range ls {
-		sum := hashNew()
-		sum = hashAdd(sum, l.Name)
-		sum = hashAddByte(sum, model.SeparatorByte)
-		sum = hashAdd(sum, l.Value)
-		result ^= sum
-	}
-	return model.Fingerprint(result)
-}
-
 // LabelsToKeyString is used to form a string to be used as
 // the hashKey. Don't print, use l.String() for printing.
 func LabelsToKeyString(l labels.Labels) string {

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -233,18 +233,6 @@ func FastFingerprint(ls []mimirpb.LabelAdapter) model.Fingerprint {
 	return model.Fingerprint(result)
 }
 
-// Fingerprint runs the same algorithm as Prometheus labelSetToFingerprint()
-func Fingerprint(labels labels.Labels) model.Fingerprint {
-	sum := hashNew()
-	for _, label := range labels {
-		sum = hashAddString(sum, label.Name)
-		sum = hashAddByte(sum, model.SeparatorByte)
-		sum = hashAddString(sum, label.Value)
-		sum = hashAddByte(sum, model.SeparatorByte)
-	}
-	return model.Fingerprint(sum)
-}
-
 // LabelsToKeyString is used to form a string to be used as
 // the hashKey. Don't print, use l.String() for printing.
 func LabelsToKeyString(l labels.Labels) string {

--- a/pkg/ingester/client/compat_test.go
+++ b/pkg/ingester/client/compat_test.go
@@ -83,65 +83,6 @@ func TestLabelNamesRequest(t *testing.T) {
 	assert.Equal(t, matchers, actualMatchers)
 }
 
-// This test shows label sets with same fingerprints, and also shows how to easily create new collisions
-// (by adding "_" or "A" label with specific values, see below).
-func TestFingerprintCollisions(t *testing.T) {
-	// "8yn0iYCKYHlIj4-BwPqk" and "GReLUrM4wMqfg9yzV3KQ" have same FNV-1a hash.
-	// If we use it as a single label name (for labels that have same value), we get colliding labels.
-	c1 := labels.FromStrings("8yn0iYCKYHlIj4-BwPqk", "hello")
-	c2 := labels.FromStrings("GReLUrM4wMqfg9yzV3KQ", "hello")
-	verifyCollision(t, true, c1, c2)
-
-	// Adding _="ypfajYg2lsv" or _="KiqbryhzUpn" respectively to most metrics will produce collision.
-	// It's because "_\xffypfajYg2lsv" and "_\xffKiqbryhzUpn" have same FNV-1a hash, and "_" label is sorted before
-	// most other labels (except labels starting with upper-case letter)
-
-	const _label1 = "ypfajYg2lsv"
-	const _label2 = "KiqbryhzUpn"
-
-	metric := labels.NewBuilder(labels.FromStrings("__name__", "logs"))
-	c1 = metric.Set("_", _label1).Labels(nil)
-	c2 = metric.Set("_", _label2).Labels(nil)
-	verifyCollision(t, true, c1, c2)
-
-	metric = labels.NewBuilder(labels.FromStrings("__name__", "up", "instance", "hello"))
-	c1 = metric.Set("_", _label1).Labels(nil)
-	c2 = metric.Set("_", _label2).Labels(nil)
-	verifyCollision(t, true, c1, c2)
-
-	// here it breaks, because "Z" label is sorted before "_" label.
-	metric = labels.NewBuilder(labels.FromStrings("__name__", "up", "Z", "hello"))
-	c1 = metric.Set("_", _label1).Labels(nil)
-	c2 = metric.Set("_", _label2).Labels(nil)
-	verifyCollision(t, false, c1, c2)
-
-	// A="K6sjsNNczPl" and A="cswpLMIZpwt" label has similar property.
-	// (Again, because "A\xffK6sjsNNczPl" and "A\xffcswpLMIZpwt" have same FNV-1a hash)
-	// This time, "A" is the smallest possible label name, and is always sorted first.
-
-	const Alabel1 = "K6sjsNNczPl"
-	const Alabel2 = "cswpLMIZpwt"
-
-	metric = labels.NewBuilder(labels.FromStrings("__name__", "up", "Z", "hello"))
-	c1 = metric.Set("A", Alabel1).Labels(nil)
-	c2 = metric.Set("A", Alabel2).Labels(nil)
-	verifyCollision(t, true, c1, c2)
-
-	// Adding the same suffix to the "A" label also works.
-	metric = labels.NewBuilder(labels.FromStrings("__name__", "up", "Z", "hello"))
-	c1 = metric.Set("A", Alabel1+"suffix").Labels(nil)
-	c2 = metric.Set("A", Alabel2+"suffix").Labels(nil)
-	verifyCollision(t, true, c1, c2)
-}
-
-func verifyCollision(t *testing.T, collision bool, ls1 labels.Labels, ls2 labels.Labels) {
-	if collision && Fingerprint(ls1) != Fingerprint(ls2) {
-		t.Errorf("expected same fingerprints for %v (%016x) and %v (%016x)", ls1.String(), Fingerprint(ls1), ls2.String(), Fingerprint(ls2))
-	} else if !collision && Fingerprint(ls1) == Fingerprint(ls2) {
-		t.Errorf("expected different fingerprints for %v (%016x) and %v (%016x)", ls1.String(), Fingerprint(ls1), ls2.String(), Fingerprint(ls2))
-	}
-}
-
 // The main usecase for `LabelsToKeyString` is to generate hashKeys
 // for maps. We are benchmarking that here.
 func BenchmarkSeriesMap(b *testing.B) {

--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -8,42 +8,9 @@ package client
 // Inline and byte-free variant of hash/fnv's fnv64a.
 
 const (
-	offset64 = 14695981039346656037
-	prime64  = 1099511628211
 	offset32 = 2166136261
 	prime32  = 16777619
 )
-
-// hashNew initializes a new fnv64a hash value.
-func hashNew() uint64 {
-	return offset64
-}
-
-// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
-// Note this is the same algorithm as Go stdlib `sum64a.Write()`
-func hashAdd(h uint64, s string) uint64 {
-	for i := 0; i < len(s); i++ {
-		h ^= uint64(s[i])
-		h *= prime64
-	}
-	return h
-}
-
-// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
-func hashAddString(h uint64, s string) uint64 {
-	for i := 0; i < len(s); i++ {
-		h ^= uint64(s[i])
-		h *= prime64
-	}
-	return h
-}
-
-// hashAddByte adds a byte to a fnv64a hash value, returning the updated hash.
-func hashAddByte(h uint64, b byte) uint64 {
-	h ^= uint64(b)
-	h *= prime64
-	return h
-}
 
 // HashNew32 initializies a new fnv32 hash value.
 func HashNew32() uint32 {

--- a/pkg/util/limiter/query_limiter.go
+++ b/pkg/util/limiter/query_limiter.go
@@ -10,10 +10,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
 
-	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -39,7 +37,7 @@ var (
 
 type QueryLimiter struct {
 	uniqueSeriesMx sync.Mutex
-	uniqueSeries   map[model.Fingerprint]struct{}
+	uniqueSeries   map[uint64]struct{}
 
 	chunkBytesCount atomic.Int64
 	chunkCount      atomic.Int64
@@ -54,7 +52,7 @@ type QueryLimiter struct {
 func NewQueryLimiter(maxSeriesPerQuery, maxChunkBytesPerQuery int, maxChunksPerQuery int) *QueryLimiter {
 	return &QueryLimiter{
 		uniqueSeriesMx: sync.Mutex{},
-		uniqueSeries:   map[model.Fingerprint]struct{}{},
+		uniqueSeries:   map[uint64]struct{}{},
 
 		maxSeriesPerQuery:     maxSeriesPerQuery,
 		maxChunkBytesPerQuery: maxChunkBytesPerQuery,
@@ -83,7 +81,7 @@ func (ql *QueryLimiter) AddSeries(seriesLabels []mimirpb.LabelAdapter) error {
 	if ql.maxSeriesPerQuery == 0 {
 		return nil
 	}
-	fingerprint := client.FastFingerprint(seriesLabels)
+	fingerprint := mimirpb.FromLabelAdaptersToLabels(seriesLabels).Hash()
 
 	ql.uniqueSeriesMx.Lock()
 	defer ql.uniqueSeriesMx.Unlock()


### PR DESCRIPTION
#### What this PR does

Remove the `Fingerprint()` function, which was only called in tests.
Replace attempt to check collision with values that actually do collide with the `Hash()` function used by the feature under test (in `active_series.go` `findOrCreateEntryForSeries()`).
 
The `FastFingerprint()` function was only used in `QueryLimiter`; replace it with `Labels.Hash()`, which is a better hash algorithm and avoids us maintaining extra code.

There are a couple of references to `FastFingerprint` collisions remaining in ingester and distributor tests; I didn't get to the bottom of what they should be doing.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-visible.
