### PR TITLE
Distributor validation: stop checking series have sorted labels

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4271,6 +4271,19 @@ func TestDistributorValidation(t *testing.T) {
 			}},
 		},
 
+		// Test validation passes when labels are unsorted.
+		{
+			labels: []labels.Labels{mimirpb.FromLabelAdaptersToLabels(
+				[]mimirpb.LabelAdapter{
+					{Name: "foo", Value: "bar"},
+					{Name: labels.MetricName, Value: "testmetric"},
+				})},
+			samples: []mimirpb.Sample{{
+				TimestampMs: int64(now),
+				Value:       1,
+			}},
+		},
+
 		// Test validation fails for samples from the future.
 		{
 			labels: []labels.Labels{labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar")},
@@ -4405,7 +4418,7 @@ func TestRemoveReplicaLabel(t *testing.T) {
 	}
 }
 
-// This is not great, but we deal with unsorted labels when validating labels.
+// This is not great, but we deal with unsorted labels in prePushRelabelMiddleware.
 func TestShardByAllLabelsReturnsWrongResultsForUnsortedLabels(t *testing.T) {
 	val1 := shardByAllLabels("test", []mimirpb.LabelAdapter{
 		{Name: "__name__", Value: "foo"},

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4457,9 +4457,9 @@ func TestSortLabels(t *testing.T) {
 
 	sortLabelsIfNeeded(unsorted)
 
-	sort.SliceIsSorted(unsorted, func(i, j int) bool {
+	require.True(t, sort.SliceIsSorted(unsorted, func(i, j int) bool {
 		return unsorted[i].Name < unsorted[j].Name
-	})
+	}))
 }
 
 func TestDistributor_Push_Relabel(t *testing.T) {

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -87,17 +87,6 @@ func newDuplicatedLabelError(series []mimirpb.LabelAdapter, labelName string) Va
 	}
 }
 
-var labelsNotSortedMsgFormat = globalerror.SeriesLabelsNotSorted.Message(
-	"received a series where the label names are not alphabetically sorted, label: '%.200s' series: '%.200s'")
-
-func newLabelsNotSortedError(series []mimirpb.LabelAdapter, labelName string) ValidationError {
-	return genericValidationError{
-		message: labelsNotSortedMsgFormat,
-		cause:   labelName,
-		series:  series,
-	}
-}
-
 type tooManyLabelsError struct {
 	series []mimirpb.LabelAdapter
 	limit  int

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -296,9 +296,6 @@ func ValidateLabels(m *SampleValidationMetrics, cfg LabelValidationConfig, userI
 		} else if lastLabelName == l.Name {
 			m.duplicateLabelNames.WithLabelValues(userID).Inc()
 			return newDuplicatedLabelError(ls, l.Name)
-		} else if lastLabelName > l.Name {
-			m.labelsNotSorted.WithLabelValues(userID).Inc()
-			return newLabelsNotSortedError(ls, l.Name)
 		}
 
 		lastLabelName = l.Name

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -311,27 +311,6 @@ func TestValidateMetadata(t *testing.T) {
 	`), "cortex_discarded_metadata_total"))
 }
 
-func TestValidateLabelOrder(t *testing.T) {
-	var cfg validateLabelsCfg
-	cfg.maxLabelNameLength = 10
-	cfg.maxLabelNamesPerSeries = 10
-	cfg.maxLabelValueLength = 10
-
-	userID := "testUser"
-
-	actual := ValidateLabels(NewSampleValidationMetrics(nil), cfg, userID, []mimirpb.LabelAdapter{
-		{Name: model.MetricNameLabel, Value: "m"},
-		{Name: "b", Value: "b"},
-		{Name: "a", Value: "a"},
-	}, false)
-	expected := newLabelsNotSortedError([]mimirpb.LabelAdapter{
-		{Name: model.MetricNameLabel, Value: "m"},
-		{Name: "b", Value: "b"},
-		{Name: "a", Value: "a"},
-	}, "a")
-	assert.Equal(t, expected, actual)
-}
-
 func TestValidateLabelDuplication(t *testing.T) {
 	var cfg validateLabelsCfg
 	cfg.maxLabelNameLength = 10


### PR DESCRIPTION
Distributor always sorts labels at the relabeling stage, so this check would never have triggered an error.

Add a test to prove this.

Also fix another test which was nearly checking the sorting function.

And clarify a comment which mentions unsorted labels.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-visible.
