### PR TITLE
Store-gateway: Make e2e test setup more flexible

### DIFF
--- a/pkg/storegateway/postings_codec_test.go
+++ b/pkg/storegateway/postings_codec_test.go
@@ -36,7 +36,7 @@ func TestDiffVarintCodec(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(chunksDir))
 	})
 
-	appendTestData(t, h.Appender(context.Background()), 1e4)
+	appendTestSeries(1e4)(t, h.Appender(context.Background()))
 
 	idx, err := h.Index()
 	assert.NoError(t, err)


### PR DESCRIPTION
in the streaming store-gateway work we need more control over what
series and samples are written to a test block. This PR makes it
possible for each test that creates a test block to write arbitrary
series and samples.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
