### PR TITLE
Streaming store-gateway: add iterators for loading series from index

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -11,8 +11,6 @@ import (
 )
 
 // seriesChunksSetIterator is the interface implemented by an iterator returning a sequence of seriesChunksSet.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunksSetIterator interface {
 	Next() bool
 	At() seriesChunksSet
@@ -20,8 +18,6 @@ type seriesChunksSetIterator interface {
 }
 
 // seriesChunksSet holds a set of series, each with its own chunks.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunksSet struct {
 	series []seriesEntry
 
@@ -29,13 +25,11 @@ type seriesChunksSet struct {
 	chunksReleaser chunksReleaser
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 type chunksReleaser interface {
 	// Release the memory used to allocate series chunks.
 	Release()
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (b *seriesChunksSet) release() {
 	if b.chunksReleaser != nil {
 		b.chunksReleaser.Release()
@@ -45,7 +39,6 @@ func (b *seriesChunksSet) release() {
 	b.series = nil
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (b seriesChunksSet) len() int {
 	return len(b.series)
 }

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -300,8 +300,6 @@ func TestPreloadingSeriesChunkSetIterator(t *testing.T) {
 
 // sliceSeriesChunksSetIterator implements seriesChunksSetIterator and
 // returns the provided err when the sets are exhausted
-//
-//nolint:unused // dead code while we are working on PR 3355
 type sliceSeriesChunksSetIterator struct {
 	current int
 	sets    []seriesChunksSet
@@ -310,7 +308,6 @@ type sliceSeriesChunksSetIterator struct {
 	errAt int
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func newSliceSeriesChunksSetIterator(sets ...seriesChunksSet) seriesChunksSetIterator {
 	return &sliceSeriesChunksSetIterator{
 		current: -1,
@@ -318,7 +315,6 @@ func newSliceSeriesChunksSetIterator(sets ...seriesChunksSet) seriesChunksSetIte
 	}
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func newSliceSeriesChunksSetIteratorWithError(err error, errAt int, sets ...seriesChunksSet) seriesChunksSetIterator {
 	return &sliceSeriesChunksSetIterator{
 		current: -1,
@@ -328,7 +324,6 @@ func newSliceSeriesChunksSetIteratorWithError(err error, errAt int, sets ...seri
 	}
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunksSetIterator) Next() bool {
 	s.current++
 
@@ -340,12 +335,10 @@ func (s *sliceSeriesChunksSetIterator) Next() bool {
 	return s.current < len(s.sets)
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunksSetIterator) At() seriesChunksSet {
 	return s.sets[s.current]
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunksSetIterator) Err() error {
 	if s.err != nil && s.current >= s.errAt {
 		return s.err

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -19,8 +19,6 @@ import (
 )
 
 // seriesChunkRefsSetIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefsSet.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunkRefsSetIterator interface {
 	Next() bool
 	At() seriesChunkRefsSet
@@ -28,8 +26,6 @@ type seriesChunkRefsSetIterator interface {
 }
 
 // seriesChunkRefsIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefs.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunkRefsIterator interface {
 	Next() bool
 	At() seriesChunkRefs
@@ -37,36 +33,28 @@ type seriesChunkRefsIterator interface {
 }
 
 // seriesChunkRefsSet holds a set of a set of series (sorted by labels) and their chunk references.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunkRefsSet struct {
 	// series sorted by labels.
 	series []seriesChunkRefs
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func newSeriesChunkRefsSet(capacity int) seriesChunkRefsSet {
 	return seriesChunkRefsSet{
 		series: make([]seriesChunkRefs, 0, capacity),
 	}
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (b seriesChunkRefsSet) len() int {
 	return len(b.series)
 }
 
 // seriesChunkRefs holds a series with a list of chunk references.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunkRefs struct {
 	lset   labels.Labels
 	chunks []seriesChunkRef
 }
 
 // seriesChunkRef holds the reference to a chunk in a given block.
-//
-//nolint:unused // dead code while we are working on PR 3355
 type seriesChunkRef struct {
 	blockID          ulid.ULID
 	ref              chunks.ChunkRef
@@ -75,8 +63,6 @@ type seriesChunkRef struct {
 
 // Compare returns > 0 if m should be before other when sorting seriesChunkRef,
 // 0 if they're equal or < 0 if m should be after other.
-//
-//nolint:unused // dead code while we are working on PR 3355
 func (m seriesChunkRef) Compare(other seriesChunkRef) int {
 	if m.minTime < other.minTime {
 		return 1
@@ -527,6 +513,7 @@ type loadingSeriesChunkRefsSetIterator struct {
 	currentSet seriesChunkRefsSet
 }
 
+//nolint:unused // dead code while we are working on PR 3355
 func openBlockSeriesChunkRefsSetsIterator(
 	ctx context.Context,
 	batchSize int,

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -3,10 +3,18 @@
 package storegateway
 
 import (
-	"github.com/oklog/ulid"
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/tsdb/chunks"
+	"context"
 
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/hashcache"
+
+	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/storage/tsdb/metadata"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 )
 
@@ -444,4 +452,315 @@ func (s *deduplicatingSeriesChunkRefsSetIterator) Next() bool {
 	}
 	s.current = nextSet
 	return true
+}
+
+type limitingSeriesChunkRefsSetIterator struct {
+	from          seriesChunkRefsSetIterator
+	chunksLimiter ChunksLimiter
+	seriesLimiter SeriesLimiter
+
+	err          error
+	currentBatch seriesChunkRefsSet
+}
+
+func newLimitingSeriesChunkRefsSetIterator(from seriesChunkRefsSetIterator, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter) *limitingSeriesChunkRefsSetIterator {
+	return &limitingSeriesChunkRefsSetIterator{
+		from:          from,
+		chunksLimiter: chunksLimiter,
+		seriesLimiter: seriesLimiter,
+	}
+}
+
+func (l *limitingSeriesChunkRefsSetIterator) Next() bool {
+	if l.err != nil {
+		return false
+	}
+
+	if !l.from.Next() {
+		l.err = l.from.Err()
+		return false
+	}
+
+	l.currentBatch = l.from.At()
+	err := l.seriesLimiter.Reserve(uint64(l.currentBatch.len()))
+	if err != nil {
+		l.err = errors.Wrap(err, "exceeded series limit")
+		return false
+	}
+
+	var totalChunks int
+	for _, s := range l.currentBatch.series {
+		totalChunks += len(s.chunks)
+	}
+
+	err = l.chunksLimiter.Reserve(uint64(totalChunks))
+	if err != nil {
+		l.err = errors.Wrap(err, "exceeded chunks limit")
+		return false
+	}
+	return true
+}
+
+func (l *limitingSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
+	return l.currentBatch
+}
+
+func (l *limitingSeriesChunkRefsSetIterator) Err() error {
+	return l.err
+}
+
+type loadingSeriesChunkRefsSetIterator struct {
+	ctx                 context.Context
+	postingsSetIterator *postingsSetsIterator
+	indexr              *bucketIndexReader
+	stats               *safeQueryStats
+	blockID             ulid.ULID
+	shard               *sharding.ShardSelector
+	seriesHasher        seriesHasher
+	skipChunks          bool
+	minTime, maxTime    int64
+
+	symbolizedLsetBuffer []symbolizedLabel
+	chksBuffer           []chunks.Meta
+
+	err        error
+	currentSet seriesChunkRefsSet
+}
+
+func openBlockSeriesChunkRefsSetsIterator(
+	ctx context.Context,
+	batchSize int,
+	indexr *bucketIndexReader, // Index reader for block.
+	blockMeta *metadata.Meta,
+	matchers []*labels.Matcher, // Series matchers.
+	shard *sharding.ShardSelector, // Shard selector.
+	seriesHashCache *hashcache.BlockSeriesHashCache, // Block-specific series hash cache (used only if shard selector is specified).
+	chunksLimiter ChunksLimiter, // Rate limiter for loading chunks.
+	seriesLimiter SeriesLimiter, // Rate limiter for loading series.
+	skipChunks bool, // If true chunks are not loaded and minTime/maxTime are ignored.
+	minTime, maxTime int64, // Series must have data in this time range to be returned (ignored if skipChunks=true).
+	stats *safeQueryStats,
+	logger log.Logger,
+) (seriesChunkRefsSetIterator, error) {
+	if batchSize <= 0 {
+		return nil, errors.New("set size must be a positive number")
+	}
+
+	ps, err := indexr.ExpandedPostings(ctx, matchers, stats)
+	if err != nil {
+		return nil, errors.Wrap(err, "expanded matching postings")
+	}
+
+	// We can't compute the series hash yet because we're still missing the series labels.
+	// However, if the hash is already in the cache, then we can remove all postings for series
+	// not belonging to the shard.
+	if shard != nil {
+		var unsafeStats queryStats
+		ps, unsafeStats = filterPostingsByCachedShardHash(ps, shard, seriesHashCache)
+		stats.merge(&unsafeStats)
+	}
+
+	postingsIterator := newPostingsSetsIterator(ps, batchSize)
+	loadingIterator := newLoadingSeriesChunkRefsSetIterator(
+		ctx,
+		postingsIterator,
+		indexr,
+		stats,
+		blockMeta,
+		shard,
+		cachedSeriesHasher{cache: seriesHashCache},
+		skipChunks,
+		minTime,
+		maxTime,
+	)
+
+	limitingIterator := newLimitingSeriesChunkRefsSetIterator(
+		loadingIterator,
+		chunksLimiter,
+		seriesLimiter,
+	)
+
+	return limitingIterator, nil
+}
+
+func newLoadingSeriesChunkRefsSetIterator(
+	ctx context.Context,
+	postingsSetIterator *postingsSetsIterator,
+	indexr *bucketIndexReader,
+	stats *safeQueryStats,
+	blockMeta *metadata.Meta,
+	shard *sharding.ShardSelector,
+	seriesHasher seriesHasher,
+	skipChunks bool,
+	minTime int64,
+	maxTime int64,
+) *loadingSeriesChunkRefsSetIterator {
+	if skipChunks {
+		minTime, maxTime = blockMeta.MinTime, blockMeta.MaxTime
+	}
+
+	return &loadingSeriesChunkRefsSetIterator{
+		ctx:                 ctx,
+		postingsSetIterator: postingsSetIterator,
+		indexr:              indexr,
+		stats:               stats,
+		blockID:             blockMeta.ULID,
+		shard:               shard,
+		seriesHasher:        seriesHasher,
+		skipChunks:          skipChunks,
+		minTime:             minTime,
+		maxTime:             maxTime,
+	}
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
+	if s.err != nil {
+		return false
+	}
+	if !s.postingsSetIterator.Next() {
+		return false
+	}
+	nextPostings := s.postingsSetIterator.At()
+	loadedSeries, err := s.indexr.preloadSeries(s.ctx, nextPostings, s.stats)
+	if err != nil {
+		s.err = errors.Wrap(err, "preload series")
+		return false
+	}
+
+	// Track the series loading statistics in a not synchronized data structure to avoid locking for each series
+	// and then merge before returning from the function.
+	loadStats := &queryStats{}
+	defer s.stats.merge(loadStats)
+
+	nextSet := newSeriesChunkRefsSet(len(nextPostings))
+
+	for _, id := range nextPostings {
+		lset, chks, err := s.loadSeriesForTime(id, loadedSeries, loadStats)
+		if err != nil {
+			s.err = errors.Wrap(err, "read series")
+			return false
+		}
+		if lset.Len() == 0 {
+			// No matching chunks for this time duration, skip series
+			continue
+		}
+
+		if !shardOwned(s.shard, s.seriesHasher, id, lset, loadStats) {
+			continue
+		}
+
+		nextSet.series = append(nextSet.series, seriesChunkRefs{
+			lset:   lset,
+			chunks: chks,
+		})
+	}
+	if nextSet.len() == 0 {
+		return s.Next() // we didn't find any suitable series in this set, try with the next one
+	}
+	s.currentSet = nextSet
+	return true
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
+	return s.currentSet
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) Err() error {
+	return s.err
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) loadSeriesForTime(ref storage.SeriesRef, loadedSeries *bucketIndexLoadedSeries, stats *queryStats) (labels.Labels, []seriesChunkRef, error) {
+	ok, err := loadedSeries.unsafeLoadSeriesForTime(ref, &s.symbolizedLsetBuffer, &s.chksBuffer, s.skipChunks, s.minTime, s.maxTime, stats)
+	if !ok || err != nil {
+		return labels.EmptyLabels(), nil, errors.Wrap(err, "inflateSeriesForTime")
+	}
+
+	lset, err := s.indexr.LookupLabelsSymbols(s.symbolizedLsetBuffer)
+	if err != nil {
+		return labels.EmptyLabels(), nil, errors.Wrap(err, "lookup labels symbols")
+	}
+
+	var chks []seriesChunkRef
+	if !s.skipChunks {
+		chks = metasToChunks(s.blockID, s.chksBuffer)
+	}
+
+	return lset, chks, nil
+}
+
+func metasToChunks(blockID ulid.ULID, metas []chunks.Meta) []seriesChunkRef {
+	chks := make([]seriesChunkRef, len(metas))
+	for i, meta := range metas {
+		chks[i] = seriesChunkRef{
+			minTime: meta.MinTime,
+			maxTime: meta.MaxTime,
+			ref:     meta.Ref,
+			blockID: blockID,
+		}
+	}
+	return chks
+}
+
+type seriesHasher interface {
+	Hash(seriesID storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64
+}
+
+type cachedSeriesHasher struct {
+	cache *hashcache.BlockSeriesHashCache
+}
+
+func (b cachedSeriesHasher) Hash(id storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64 {
+	stats.seriesHashCacheRequests++
+
+	hash, ok := b.cache.Fetch(id)
+	if !ok {
+		hash = lset.Hash()
+		b.cache.Store(id, hash)
+	} else {
+		stats.seriesHashCacheHits++
+	}
+	return hash
+}
+
+func shardOwned(shard *sharding.ShardSelector, hasher seriesHasher, id storage.SeriesRef, lset labels.Labels, stats *queryStats) bool {
+	if shard == nil {
+		return true
+	}
+	hash := hasher.Hash(id, lset, stats)
+
+	return hash%shard.ShardCount == shard.ShardIndex
+}
+
+type postingsSetsIterator struct {
+	postings []storage.SeriesRef
+
+	batchSize               int
+	nextBatchPostingsOffset int
+	currentBatch            []storage.SeriesRef
+}
+
+func newPostingsSetsIterator(postings []storage.SeriesRef, batchSize int) *postingsSetsIterator {
+	return &postingsSetsIterator{
+		postings:  postings,
+		batchSize: batchSize,
+	}
+}
+
+func (s *postingsSetsIterator) Next() bool {
+	if s.nextBatchPostingsOffset >= len(s.postings) {
+		return false
+	}
+
+	end := s.nextBatchPostingsOffset + s.batchSize
+	if end > len(s.postings) {
+		end = len(s.postings)
+	}
+	s.currentBatch = s.postings[s.nextBatchPostingsOffset:end]
+	s.nextBatchPostingsOffset += s.batchSize
+
+	return true
+}
+
+func (s *postingsSetsIterator) At() []storage.SeriesRef {
+	return s.currentBatch
 }

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1164,7 +1164,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			suite := prepareStoreWithTestBlocks(t, t.TempDir(), objstore.NewInMemBucket(), false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0))
+			suite := prepareStoreWithTestBlocks(t, objstore.NewInMemBucket(), defaultPrepareStoreConfig(t))
 			var firstBlock *bucketBlock
 			// Find the block with the smallest timestamp in its ULID.
 			// The test setup creates two blocks - each takes 4 different timeseries; each has
@@ -1181,7 +1181,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 					firstBlock = b
 				}
 			}
-			suite.cache.SwapWith(noopCache{})
 
 			indexReader := firstBlock.indexReader()
 			defer indexReader.Close()

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1290,14 +1290,13 @@ func (a mockSeriesHasher) Hash(seriesID storage.SeriesRef, lset labels.Labels, s
 // sliceSeriesChunkRefsSetIterator implements seriesChunkRefsSetIterator and
 // returns the provided err when the sets are exhausted.
 //
-//nolint:unused // dead code while we are working on PR 3355
+
 type sliceSeriesChunkRefsSetIterator struct {
 	current int
 	sets    []seriesChunkRefsSet
 	err     error
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func newSliceSeriesChunkRefsSetIterator(err error, sets ...seriesChunkRefsSet) seriesChunkRefsSetIterator {
 	return &sliceSeriesChunkRefsSetIterator{
 		current: -1,
@@ -1306,18 +1305,15 @@ func newSliceSeriesChunkRefsSetIterator(err error, sets ...seriesChunkRefsSet) s
 	}
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunkRefsSetIterator) Next() bool {
 	s.current++
 	return s.current < len(s.sets)
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
 	return s.sets[s.current]
 }
 
-//nolint:unused // dead code while we are working on PR 3355
 func (s *sliceSeriesChunkRefsSetIterator) Err() error {
 	if s.current >= len(s.sets) {
 		return s.err

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -3,15 +3,25 @@
 package storegateway
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestSeriesChunkRef_Compare(t *testing.T) {
@@ -759,6 +769,524 @@ func TestDeduplicatingSeriesChunkRefsSetIterator_PropagatesErrors(t *testing.T) 
 	assert.ErrorContains(t, chainedSet.Err(), "something went wrong")
 }
 
+func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
+	testCases := map[string]struct {
+		sets                     []seriesChunkRefsSet
+		seriesLimit, chunksLimit int
+		upstreamErr              error
+
+		expectedSetsCount int
+		expectedErr       string
+	}{
+		"doesn't exceed limits": {
+			seriesLimit:       5,
+			chunksLimit:       5,
+			expectedSetsCount: 1,
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+			},
+		},
+		"exceeds chunks limit": {
+			seriesLimit:       5,
+			chunksLimit:       9,
+			expectedSetsCount: 0,
+			expectedErr:       "exceeded chunks limit",
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 2)},
+					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 3)},
+					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 4)},
+				}},
+			},
+		},
+		"exceeds chunks limit on second set": {
+			seriesLimit:       5,
+			chunksLimit:       3,
+			expectedSetsCount: 1,
+			expectedErr:       "exceeded chunks limit",
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+			},
+		},
+		"exceeds series limit": {
+			seriesLimit:       3,
+			chunksLimit:       5,
+			expectedSetsCount: 0,
+			expectedErr:       "exceeded series limit",
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+			},
+		},
+		"exceeds series limit on second set": {
+			seriesLimit:       3,
+			chunksLimit:       5,
+			expectedSetsCount: 1,
+			expectedErr:       "exceeded series limit",
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+			},
+		},
+		"propagates error": {
+			seriesLimit:       5,
+			chunksLimit:       5,
+			upstreamErr:       errors.New("something went wrong"),
+			expectedSetsCount: 2,
+			expectedErr:       "something went wrong",
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+				}},
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testName, testCase := testName, testCase
+		t.Run(testName, func(t *testing.T) {
+			iterator := newLimitingSeriesChunkRefsSetIterator(
+				newSliceSeriesChunkRefsSetIterator(testCase.upstreamErr, testCase.sets...),
+				&limiter{limit: testCase.chunksLimit},
+				&limiter{limit: testCase.seriesLimit},
+			)
+
+			sets := readAllSeriesChunkRefsSet(iterator)
+			assert.Equal(t, testCase.expectedSetsCount, len(sets))
+			if testCase.expectedErr == "" {
+				assert.NoError(t, iterator.Err())
+			} else {
+				assert.ErrorContains(t, iterator.Err(), testCase.expectedErr)
+			}
+		})
+	}
+}
+
+func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
+	newTestBlock := prepareTestBlock(test.NewTB(t), func(t testing.TB, appender storage.Appender) {
+		for i := 0; i < 100; i++ {
+			_, err := appender.Append(0, labels.FromStrings("l1", fmt.Sprintf("v%d", i)), int64(i*10), 0)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, appender.Commit())
+	})
+
+	testCases := map[string]struct {
+		shard        *sharding.ShardSelector
+		matchers     []*labels.Matcher
+		seriesHasher mockSeriesHasher
+		skipChunks   bool
+		minT, maxT   int64
+		batchSize    int
+
+		expectedSets []seriesChunkRefsSet
+	}{
+		"loads one batch": {
+			minT:      0,
+			maxT:      10000,
+			batchSize: 100,
+			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{{minTime: 10, maxTime: 10, ref: 26}}},
+					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{{minTime: 20, maxTime: 20, ref: 234}}},
+					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
+					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{{minTime: 40, maxTime: 40, ref: 650}}},
+				}},
+			},
+		},
+		"loads multiple batches": {
+			minT:      0,
+			maxT:      10000,
+			batchSize: 2,
+			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{{minTime: 10, maxTime: 10, ref: 26}}},
+					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{{minTime: 20, maxTime: 20, ref: 234}}},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
+					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{{minTime: 40, maxTime: 40, ref: 650}}},
+				}},
+			},
+		},
+		"skips chunks": {
+			skipChunks: true,
+			minT:       0,
+			maxT:       40,
+			batchSize:  100,
+			matchers:   []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1")},
+					{lset: labels.FromStrings("l1", "v2")},
+					{lset: labels.FromStrings("l1", "v3")},
+					{lset: labels.FromStrings("l1", "v4")},
+				}},
+			},
+		},
+		"doesn't return series if they are outside of minT/maxT": {
+			minT:         20,
+			maxT:         30,
+			batchSize:    100,
+			matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v1")},
+			expectedSets: []seriesChunkRefsSet{},
+		},
+		"omits empty batches because they fall outside of minT/maxT": {
+			minT:      30,
+			maxT:      40,
+			batchSize: 2,
+			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
+					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{{minTime: 40, maxTime: 40, ref: 650}}},
+				}},
+			},
+		},
+		"returns no batches when no series are owned by shard": {
+			shard:        &sharding.ShardSelector{ShardIndex: 1, ShardCount: 2},
+			minT:         0,
+			maxT:         40,
+			batchSize:    2,
+			matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{},
+		},
+		"returns only series that are owned by shard": {
+			seriesHasher: mockSeriesHasher{
+				hashes: map[string]uint64{`{l1="v3"}`: 1},
+			},
+			shard:     &sharding.ShardSelector{ShardIndex: 1, ShardCount: 2},
+			minT:      0,
+			maxT:      40,
+			batchSize: 2,
+			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
+				}},
+			},
+		},
+		"ignores mixT/maxT when skipping chunks": {
+			minT:       0,
+			maxT:       10,
+			skipChunks: true,
+			batchSize:  4,
+			matchers:   []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
+			expectedSets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1")},
+					{lset: labels.FromStrings("l1", "v2")},
+					{lset: labels.FromStrings("l1", "v3")},
+					{lset: labels.FromStrings("l1", "v4")},
+				}},
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testName, testCase := testName, testCase
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			// Setup
+			block := newTestBlock()
+			indexr := block.indexReader()
+			postings, err := indexr.ExpandedPostings(context.Background(), testCase.matchers, newSafeQueryStats())
+			require.NoError(t, err)
+			postingsIterator := newPostingsSetsIterator(
+				postings,
+				testCase.batchSize,
+			)
+			loadingIterator := newLoadingSeriesChunkRefsSetIterator(
+				context.Background(),
+				postingsIterator,
+				indexr,
+				newSafeQueryStats(),
+				block.meta,
+				testCase.shard,
+				testCase.seriesHasher,
+				testCase.skipChunks,
+				testCase.minT,
+				testCase.maxT,
+			)
+
+			// Tests
+			sets := readAllSeriesChunkRefsSet(loadingIterator)
+			assert.NoError(t, loadingIterator.Err())
+			if !assert.Len(t, sets, len(testCase.expectedSets)) {
+				return
+			}
+
+			for i, actualSet := range sets {
+				expectedSet := testCase.expectedSets[i]
+				if !assert.Equalf(t, expectedSet.len(), actualSet.len(), "%d", i) {
+					continue
+				}
+				for j, actualSeries := range actualSet.series {
+					expectedSeries := expectedSet.series[j]
+					assert.Truef(t, labels.Equal(actualSeries.lset, expectedSeries.lset), "%d, %d: expected labels %s got %s", i, j, expectedSeries.lset, actualSeries.lset)
+					if !assert.Lenf(t, actualSeries.chunks, len(expectedSeries.chunks), "%d, %d", i, j) {
+						continue
+					}
+					for k, actualChunk := range actualSeries.chunks {
+						expectedChunk := expectedSeries.chunks[k]
+						assert.Equalf(t, expectedChunk.maxTime, actualChunk.maxTime, "%d, %d, %d", i, j, k)
+						assert.Equalf(t, expectedChunk.minTime, actualChunk.minTime, "%d, %d, %d", i, j, k)
+						assert.Equalf(t, int(expectedChunk.ref), int(actualChunk.ref), "%d, %d, %d", i, j, k)
+						assert.Equalf(t, block.meta.ULID, actualChunk.blockID, "%d, %d, %d", i, j, k)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	testCases := map[string]struct {
+		matcher        *labels.Matcher
+		batchSize      int
+		chunksLimit    int
+		seriesLimit    int
+		expectedErr    string
+		expectedSeries []seriesChunkRefsSet
+	}{
+		"chunks limits reached": {
+			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:   100,
+			chunksLimit: 1,
+			seriesLimit: 100,
+			expectedErr: "test limit exceeded",
+		},
+		"series limits reached": {
+			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:   100,
+			chunksLimit: 100,
+			seriesLimit: 1,
+			expectedErr: "test limit exceeded",
+		},
+		"selects all series in a single batch": {
+			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:   100,
+			chunksLimit: 100,
+			seriesLimit: 100,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "1")},
+					{lset: labels.FromStrings("a", "1", "b", "2")},
+					{lset: labels.FromStrings("a", "2", "b", "1")},
+					{lset: labels.FromStrings("a", "2", "b", "2")},
+				}},
+			},
+		},
+		"selects all series in multiple batches": {
+			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:   1,
+			chunksLimit: 100,
+			seriesLimit: 100,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "1")},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "2")},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "2", "b", "1")},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "2", "b", "2")},
+				}},
+			},
+		},
+		"selects some series in single batch": {
+			matcher:     labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
+			batchSize:   100,
+			chunksLimit: 100,
+			seriesLimit: 100,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "1")},
+					{lset: labels.FromStrings("a", "1", "b", "2")},
+				}},
+			},
+		},
+		"selects some series in multiple batches": {
+			matcher:     labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
+			batchSize:   1,
+			chunksLimit: 100,
+			seriesLimit: 100,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "1")},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "2")},
+				}},
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testName, testCase := testName, testCase
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			suite := prepareStoreWithTestBlocks(t, t.TempDir(), objstore.NewInMemBucket(), false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0))
+			var firstBlock *bucketBlock
+			// Find the block with the smallest timestamp in its ULID.
+			// The test setup creates two blocks - each takes 4 different timeseries; each has
+			// a timestamp of time.Now() when its being created.
+			// We want the first created block because we want to assert on the series inside it.
+			// The block created first contains a known set of 4 series.
+			// TODO dimitarvdimitrov change this setup to use prepareTestBlock() and assert on the chunks too
+			for _, b := range suite.store.blocks {
+				if firstBlock == nil {
+					firstBlock = b
+					continue
+				}
+				if b.meta.ULID.Time() < firstBlock.meta.ULID.Time() {
+					firstBlock = b
+				}
+			}
+			suite.cache.SwapWith(noopCache{})
+
+			indexReader := firstBlock.indexReader()
+			defer indexReader.Close()
+
+			iterator, err := openBlockSeriesChunkRefsSetsIterator(
+				ctx,
+				testCase.batchSize,
+				indexReader,
+				firstBlock.meta,
+				[]*labels.Matcher{testCase.matcher},
+				nil,
+				hashcache.NewSeriesHashCache(1024*1024).GetBlockCache(firstBlock.meta.ULID.String()),
+				&limiter{limit: testCase.chunksLimit},
+				&limiter{limit: testCase.seriesLimit},
+				false,
+				firstBlock.meta.MinTime,
+				firstBlock.meta.MaxTime,
+				newSafeQueryStats(),
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			actualSeriesSets := readAllSeriesChunkRefsSet(iterator)
+
+			require.Lenf(t, actualSeriesSets, len(testCase.expectedSeries), "expected %d sets, but got %d", len(testCase.expectedSeries), len(actualSeriesSets))
+			for i, actualSeriesSet := range actualSeriesSets {
+				expectedSeriesSet := testCase.expectedSeries[i]
+				require.Equal(t, expectedSeriesSet.len(), actualSeriesSet.len())
+				for j, actualSeries := range actualSeriesSet.series {
+					expectedSeries := testCase.expectedSeries[i].series[j]
+
+					actualLset := actualSeries.lset
+					expectedLset := expectedSeries.lset
+					assert.Truef(t, labels.Equal(actualLset, expectedLset), "%d, %d: expected labels %s got labels %s", i, j, expectedLset, actualLset)
+
+					// We can't test anything else from the chunk ref because it is generated on the go in each test case
+					assert.Len(t, actualSeries.chunks, 1)
+					assert.Equal(t, firstBlock.meta.ULID, actualSeries.chunks[0].blockID)
+				}
+			}
+			if testCase.expectedErr != "" {
+				assert.ErrorContains(t, iterator.Err(), "test limit exceeded")
+			} else {
+				assert.NoError(t, iterator.Err())
+			}
+		})
+	}
+}
+
+func TestPostingsSetsIterator(t *testing.T) {
+	testCases := map[string]struct {
+		postings        []storage.SeriesRef
+		batchSize       int
+		expectedBatches [][]storage.SeriesRef
+	}{
+		"single series": {
+			postings:        []storage.SeriesRef{1},
+			batchSize:       3,
+			expectedBatches: [][]storage.SeriesRef{{1}},
+		},
+		"single batch": {
+			postings:        []storage.SeriesRef{1, 2, 3},
+			batchSize:       3,
+			expectedBatches: [][]storage.SeriesRef{{1, 2, 3}},
+		},
+		"two batches, evenly split": {
+			postings:        []storage.SeriesRef{1, 2, 3, 4},
+			batchSize:       2,
+			expectedBatches: [][]storage.SeriesRef{{1, 2}, {3, 4}},
+		},
+		"two batches, last not full": {
+			postings:        []storage.SeriesRef{1, 2, 3, 4, 5},
+			batchSize:       3,
+			expectedBatches: [][]storage.SeriesRef{{1, 2, 3}, {4, 5}},
+		},
+		"empty postings": {
+			postings:        []storage.SeriesRef{},
+			batchSize:       2,
+			expectedBatches: [][]storage.SeriesRef{},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testName, testCase := testName, testCase
+		t.Run(testName, func(t *testing.T) {
+			iterator := newPostingsSetsIterator(testCase.postings, testCase.batchSize)
+
+			var actualBatches [][]storage.SeriesRef
+			for iterator.Next() {
+				actualBatches = append(actualBatches, iterator.At())
+			}
+
+			assert.ElementsMatch(t, testCase.expectedBatches, actualBatches)
+		})
+	}
+}
+
+type mockSeriesHasher struct {
+	hashes map[string]uint64
+}
+
+func (a mockSeriesHasher) Hash(seriesID storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64 {
+	return a.hashes[lset.String()]
+}
+
 // sliceSeriesChunkRefsSetIterator implements seriesChunkRefsSetIterator and
 // returns the provided err when the sets are exhausted.
 //
@@ -793,6 +1321,18 @@ func (s *sliceSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
 func (s *sliceSeriesChunkRefsSetIterator) Err() error {
 	if s.current >= len(s.sets) {
 		return s.err
+	}
+	return nil
+}
+
+type limiter struct {
+	limit   int
+	current atomic.Uint64
+}
+
+func (l *limiter) Reserve(num uint64) error {
+	if l.current.Add(num) > uint64(l.limit) {
+		return errors.New("test limit exceeded")
 	}
 	return nil
 }


### PR DESCRIPTION
We are adding three iterators:
* `loadingSeriesChunkRefsSetIterator` is responsible for loading chunks
from the index
* `postingsSetsIterator` is responsible for batching postings so loading
 series from the index doesn't load all labels and chunk refs from the
 index in one go
* `limitingSeriesChunkRefsSetIterator` is responsible for limiting
 series and chunks within a request

We are also adding a function to set up these three iterators for an
incoming Series() request for a block (`openBlockSeriesChunkRefsSetsIterator`).

> __Note to reviewers__: this PR uses the changes in https://github.com/grafana/mimir/pull/3644, so it's the base branch of this PR. After merging #3644, the base branch of this PR should change to `main` automatically

Co-authored-by: Marco Pracucci <marco@pracucci.com>
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>