### PR TITLE
[WIP PROPOSAL] Add helm values flag for using existing minio endpoint during cortex to mimir migration

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -87,6 +87,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Update grafana-agent-operator subchart to 0.2.8. Notable changes are being able to configure Pod's SecurityContext and Container's SecurityContext. #3350
 * [ENHANCEMENT] Add possibility to configure fallbackConfig for alertmanager and set it by default. Now tenants without an alertmanager config will not see errors accessing the alertmanager UI or when using the alertmanager API. #3360
 * [ENHANCEMENT] Add ability to set a `schedulerName` for alertmanager, compactor, ingester and store-gateway. This is needed for example for some storage providers. #3140
+* [ENHANCEMENT] Add new configuration `minio.existingEndpoint` to use existing minio endpoint outside subchart provided by mimir-distributed helm chart. #3646
 * [BUGFIX] Fix an issue that caused metamonitoring secrets to be created incorrectly #3170
 * [BUGFIX] Nginx: fixed `imagePullSecret` value reference inconsistency. #3208
 * [BUGFIX] Move the activity tracker log from /data to /active-query-tracker to remove ignore log messages. #3169

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -104,7 +104,7 @@ mimir:
           bucket_name: enterprise-metrics-admin
           {{- if  (.Values.minio.existingEndpoint) }}
           endpoint: {{ .Values.minio.existingEndpoint }}
-          {{- else -}}
+          {{- else }}
           endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
           {{- end }}
           insecure: true
@@ -132,7 +132,7 @@ mimir:
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-ruler
         {{- if  (.Values.minio.existingEndpoint) }}
         endpoint: {{ .Values.minio.existingEndpoint }}
-        {{- else -}}
+        {{- else }}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
         {{- end }}
         insecure: true
@@ -178,7 +178,7 @@ mimir:
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-tsdb
         {{- if  (.Values.minio.existingEndpoint) }}
         endpoint: {{ .Values.minio.existingEndpoint }}
-        {{- else -}}
+        {{- else }}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
         {{- end }}
         insecure: true
@@ -314,7 +314,7 @@ mimir:
       s3:
         {{- if  (.Values.minio.existingEndpoint) }}
         endpoint: {{ .Values.minio.existingEndpoint }}
-        {{- else -}}
+        {{- else }}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
         {{- end }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-ruler

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -95,7 +95,7 @@ mimir:
           kvstore:
             store: "memberlist"
 
-      {{- if .Values.minio.enabled }}
+      {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
     admin_client:
       storage:
         type: s3
@@ -120,7 +120,7 @@ mimir:
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
       {{- end }}
 
-    {{- if .Values.minio.enabled }}
+    {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
     alertmanager_storage:
       backend: s3
       s3:
@@ -164,7 +164,7 @@ mimir:
             max_item_size: {{ mul (index .Values "metadata-cache").maxItemMemory 1024 1024 }}
         {{- end }}
         sync_dir: /data/tsdb-sync
-      {{- if .Values.minio.enabled }}
+      {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-tsdb
@@ -296,7 +296,7 @@ mimir:
       enable_api: true
       rule_path: /data
 
-    {{- if .Values.minio.enabled }}
+    {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
     ruler_storage:
       backend: s3
       s3:
@@ -1861,6 +1861,7 @@ rollout_operator:
 
 minio:
   enabled: true
+  useExisting: false
   mode: standalone
   rootUser: grafana-mimir
   buckets:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -95,7 +95,7 @@ mimir:
           kvstore:
             store: "memberlist"
 
-      {{- if .Values.minio.enabled }}
+      {{- if  or (.Values.minio.enabled) (.Values.minio.existingEndpoint) }}
     admin_client:
       storage:
         type: s3

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -95,14 +95,18 @@ mimir:
           kvstore:
             store: "memberlist"
 
-      {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
+      {{- if .Values.minio.enabled }}
     admin_client:
       storage:
         type: s3
         s3:
           access_key_id: {{ .Values.minio.rootUser }}
           bucket_name: enterprise-metrics-admin
+          {{- if  (.Values.minio.existingEndpoint) }}
+          endpoint: {{ .Values.minio.existingEndpoint }}
+          {{- else -}}
           endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+          {{- end }}
           insecure: true
           secret_access_key: {{ .Values.minio.rootPassword }}
       {{- end }}
@@ -120,13 +124,17 @@ mimir:
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
       {{- end }}
 
-    {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
+    {{- if  or (.Values.minio.enabled) (.Values.minio.existingEndpoint) }}
     alertmanager_storage:
       backend: s3
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-ruler
+        {{- if  (.Values.minio.existingEndpoint) }}
+        endpoint: {{ .Values.minio.existingEndpoint }}
+        {{- else -}}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+        {{- end }}
         insecure: true
         secret_access_key: {{ .Values.minio.rootPassword }}
     {{- end }}
@@ -164,11 +172,15 @@ mimir:
             max_item_size: {{ mul (index .Values "metadata-cache").maxItemMemory 1024 1024 }}
         {{- end }}
         sync_dir: /data/tsdb-sync
-      {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
+      {{- if  or (.Values.minio.enabled) (.Values.minio.existingEndpoint) }}
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-tsdb
+        {{- if  (.Values.minio.existingEndpoint) }}
+        endpoint: {{ .Values.minio.existingEndpoint }}
+        {{- else -}}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+        {{- end }}
         insecure: true
         secret_access_key: {{ .Values.minio.rootPassword }}
       {{- end }}
@@ -296,11 +308,15 @@ mimir:
       enable_api: true
       rule_path: /data
 
-    {{- if or (eq .Values.minio.enabled true) (eq .Values.minio.useExisting true) }}
+    {{- if  or (.Values.minio.enabled) (.Values.minio.existingEndpoint) }}
     ruler_storage:
       backend: s3
       s3:
+        {{- if  (.Values.minio.existingEndpoint) }}
+        endpoint: {{ .Values.minio.existingEndpoint }}
+        {{- else -}}
         endpoint: {{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000
+        {{- end }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-ruler
         access_key_id: {{ .Values.minio.rootUser }}
         secret_access_key: {{ .Values.minio.rootPassword }}
@@ -1861,7 +1877,7 @@ rollout_operator:
 
 minio:
   enabled: true
-  useExisting: false
+  existingEndpoint: ""
   mode: standalone
   rootUser: grafana-mimir
   buckets:


### PR DESCRIPTION
#### What this PR does
Add `minio.existingEndpoint` to simplify [migration from Cortex to Mimir](https://grafana.com/docs/mimir/latest/migration-guide/migrating-from-cortex/) (documentation update is WIP).

This change is a proposal. We can drop this if this is considered complicated things or deemed unnecessary.

#### Which issue(s) this PR fixes or relates to
NA

This PR is created as a way to simplify the migration process from Cortex to Mimir. Now the migration still needs to add manual adjustment to `mimir.config` field in helm values. mimir-distributed v3.0.0 introduces `mimir.structuredConfig` which should drop the need for `mimir.config` manual adjustment. We just need to add an updated config in the `mimir.structuredConfig`.

To make it clearer, we can go from this

```
...
mimir:
  config: |
    blocks_storage:
      {{- if index .Values "memcached-chunks" "enabled" }}
      chunks_cache:
        backend: "memcached"
        memcached:
          addresses: dns+{{ template "mimir.fullname" . }}-memcached-chunks.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-chunks").port }}
          max_item_size: {{ mul (index .Values "memcached-chunks").maxItemMemory 1024 1024 }}
      {{- end }}
      {{- if index .Values "memcached-metadata" "enabled" }}
      metadata_cache:
        backend: "memcached"
        memcached:
          addresses: dns+{{ template "mimir.fullname" . }}-memcached-metadata.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-metadata").port }}
          max_item_size: {{ mul (index .Values "memcached-metadata").maxItemMemory 1024 1024 }}
      {{- end }}
      {{- if index .Values "memcached-queries" "enabled" }}
      index_cache:
        backend: "memcached"
        memcached:
          addresses: dns+{{ template "mimir.fullname" . }}-memcached-index-queries.{{ .Release.Namespace }}.svc:{{ (index .Values "memcached-index-queries").port }}
          max_item_size: {{ mul (index .Values "memcached-index-queries").maxItemMemory 1024 1024 }}
      {{- end }}
    frontend_worker:
      frontend_address: "{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}"
    ingester:
      ring:
        num_tokens: 512
    memberlist:
      join_members: ["{{ include "mimir.fullname" . }}-gossip-ring"]
    ruler:
      alertmanager_url: "dnssrvnoa+http://_http-metrics._tcp.{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.cluster.local/alertmanager"
....
```
to
```
...
mimir:
  structuredConfig:
    no_auth_tenant: "fake"
    ingester:
      ring:
        num_tokens: 512
    # other override
...
```

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
