### PR TITLE
Align documentation with code

### DIFF
--- a/docs/sources/mimir/operators-guide/tools/mimirtool.md
+++ b/docs/sources/mimir/operators-guide/tools/mimirtool.md
@@ -557,7 +557,7 @@ mimirtool analyze dashboard <file>...
 
 | Environment variable | Flag       | Description                                                               |
 | -------------------- | ---------- | ------------------------------------------------------------------------- |
-| -                    | `--output` | Sets the output file path, which by default is `prometheus-metrics.json`. |
+| -                    | `--output` | Sets the output file path, which by default is `metrics-in-grafana.json`. |
 
 #### Rule-file
 
@@ -570,9 +570,9 @@ mimirtool analyze rule-file <file>
 
 ##### Configuration
 
-| Environment variable | Flag       | Description                                                               |
-| -------------------- | ---------- | ------------------------------------------------------------------------- |
-| -                    | `--output` | Sets the output file path, which by default is `prometheus-metrics.json`. |
+| Environment variable | Flag       | Description                                                             |
+| -------------------- | ---------- | ----------------------------------------------------------------------- |
+| -                    | `--output` | Sets the output file path, which by default is `metrics-in-ruler.json`. |
 
 #### Prometheus
 


### PR DESCRIPTION
mimirtool analyze rule-file and dashboard are incorrect. default output filename is wrong

Defaults values for output file are set here :
https://github.com/grafana/mimir/blob/main/pkg/mimirtool/commands/analyse.go#L93 https://github.com/grafana/mimir/blob/main/pkg/mimirtool/commands/analyse.go#L102

#### What this PR does

Fix documentation

#### Which issue(s) this PR fixes or relates to
N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
