### PR TITLE
store-gateway: more flexible e2e testing setup (pt.2)

### DIFF
--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -738,7 +738,11 @@ func BenchmarkBucketStoreLabelValues(tb *testing.B) {
 	series := generateSeries(card)
 	tb.Logf("Total %d series generated", len(series))
 
-	s := prepareStoreWithTestBlocksForSeries(tb, dir, bkt, false, NewChunksLimiterFactory(0), NewSeriesLimiterFactory(0), series)
+	prepareCfg := defaultPrepareStoreConfig(tb)
+	prepareCfg.tempDir = dir
+	prepareCfg.series = series
+
+	s := prepareStoreWithTestBlocks(tb, bkt, prepareCfg)
 	mint, maxt := s.store.TimeRange()
 	assert.Equal(tb, s.minTime, mint)
 	assert.Equal(tb, s.maxTime, maxt)


### PR DESCRIPTION
The current e2e testing framework allows to inject a bucket
implementation. Each end-to-end test then repeats mostly the same code
to set up the testing suite.

This PR moves the testing setup further up and allows each test to
either immediately get a ready test suite with sensible defaults _or_
to customize the test suite with the testing config.

This change will be needed for the streaming store-gateway work where we
want to run the whole e2e test suite also for the streaming
implementation.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
