### PR TITLE
store-gateway: bucketStore tests with and without streaming

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -808,7 +808,10 @@ func foreachStore(t *testing.T, runTest func(t *testing.T, newSuite suiteFactory
 		b, err := filesystem.NewBucket(t.TempDir())
 		assert.NoError(t, err)
 		factory := func(opts ...prepareStoreConfigOption) *storeSuite {
-			opts = append(opts, withBucketStoreOptions(WithStreamingSeriesPerBatch(1000)))
+			// We want to force each Series() call to use more than one batch to catch some edge cases.
+			// This should make the implementation slightly slower, although test time
+			// should be dominated by the setup.
+			opts = append(opts, withBucketStoreOptions(WithStreamingSeriesPerBatch(10)))
 			return prepareStoreWithTestBlocks(t, b, defaultPrepareStoreConfig(t).apply(opts...))
 		}
 		runTest(t, factory)

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -136,6 +136,7 @@ type prepareStoreConfig struct {
 	seriesLimiterFactory SeriesLimiterFactory
 	series               []labels.Labels
 	indexCache           indexcache.IndexCache
+	bucketStoreOpts      []BucketStoreOption
 }
 
 func (c *prepareStoreConfig) apply(opts ...prepareStoreConfigOption) *prepareStoreConfig {
@@ -173,6 +174,12 @@ func withManyParts() prepareStoreConfigOption {
 	}
 }
 
+func withBucketStoreOptions(opts ...BucketStoreOption) prepareStoreConfigOption {
+	return func(config *prepareStoreConfig) {
+		config.bucketStoreOpts = opts
+	}
+}
+
 func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareStoreConfig) *storeSuite {
 	extLset := labels.FromStrings("ext1", "value1")
 
@@ -187,6 +194,9 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 
 	metaFetcher, err := block.NewMetaFetcher(s.logger, 20, objstore.WithNoopInstr(bkt), cfg.tempDir, nil, []block.MetadataFilter{})
 	assert.NoError(t, err)
+
+	// Have our options in the beginning so tests can override logger and index cache if they need to
+	storeOpts := append([]BucketStoreOption{WithLogger(s.logger), WithIndexCache(s.cache)}, cfg.bucketStoreOpts...)
 
 	store, err := NewBucketStore(
 		"tenant",
@@ -203,9 +213,7 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 		time.Minute,
 		hashcache.NewSeriesHashCache(1024*1024),
 		NewBucketStoreMetrics(nil),
-		WithLogger(s.logger),
-		WithIndexCache(s.cache),
-		WithStreamingSeriesPerBatch(65536),
+		storeOpts...,
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
@@ -786,11 +794,21 @@ func foreachStore(t *testing.T, runTest func(t *testing.T, newSuite suiteFactory
 	t.Run("filesystem", func(t *testing.T) {
 		t.Parallel()
 
-		dir := t.TempDir()
-
-		b, err := filesystem.NewBucket(dir)
+		b, err := filesystem.NewBucket(t.TempDir())
 		assert.NoError(t, err)
 		factory := func(opts ...prepareStoreConfigOption) *storeSuite {
+			return prepareStoreWithTestBlocks(t, b, defaultPrepareStoreConfig(t).apply(opts...))
+		}
+		runTest(t, factory)
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := filesystem.NewBucket(t.TempDir())
+		assert.NoError(t, err)
+		factory := func(opts ...prepareStoreConfigOption) *storeSuite {
+			opts = append(opts, withBucketStoreOptions(WithStreamingSeriesPerBatch(1000)))
 			return prepareStoreWithTestBlocks(t, b, defaultPrepareStoreConfig(t).apply(opts...))
 		}
 		runTest(t, factory)

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1092,8 +1092,8 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 	}
 
 	for testName, bucketStoreOpts := range map[string][]BucketStoreOption{
-		"run with default options": {WithLogger(logger), WithChunkPool(chunkPool)},
-		"with series streaming":    {WithLogger(logger), WithChunkPool(chunkPool), WithStreamingSeriesPerBatch(5000)},
+		"with default options":  {WithLogger(logger), WithChunkPool(chunkPool)},
+		"with series streaming": {WithLogger(logger), WithChunkPool(chunkPool), WithStreamingSeriesPerBatch(5000)},
 	} {
 		st, err := NewBucketStore(
 			"test",
@@ -1384,14 +1384,14 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 	tb, store, seriesSet1, seriesSet2, block1, block2, close := setupStoreForHintsTest(t)
 	tb.Cleanup(close)
 
-	tb.Run("with regular implementation", func(tb test.TB) {
+	tb.Run("with default options", func(tb test.TB) {
 		runTestServerSeries(tb, store, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 	})
 
 	tb, store, seriesSet1, seriesSet2, block1, block2, close = setupStoreForHintsTest(t, WithStreamingSeriesPerBatch(5000))
 	tb.Cleanup(close)
 
-	tb.Run("with streaming implementation", func(tb test.TB) {
+	tb.Run("with series streaming", func(tb test.TB) {
 		runTestServerSeries(tb, store, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 	})
 }

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1092,8 +1092,9 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 	}
 
 	for testName, bucketStoreOpts := range map[string][]BucketStoreOption{
-		"with default options":  {WithLogger(logger), WithChunkPool(chunkPool)},
-		"with series streaming": {WithLogger(logger), WithChunkPool(chunkPool), WithStreamingSeriesPerBatch(5000)},
+		"with default options":                  {WithLogger(logger), WithChunkPool(chunkPool)},
+		"with series streaming (1K per batch)":  {WithLogger(logger), WithChunkPool(chunkPool), WithStreamingSeriesPerBatch(1000)},
+		"with series streaming (10K per batch)": {WithLogger(logger), WithChunkPool(chunkPool), WithStreamingSeriesPerBatch(10000)},
 	} {
 		st, err := NewBucketStore(
 			"test",

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1383,16 +1383,16 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 	}
 
 	tb, store, seriesSet1, seriesSet2, block1, block2, close := setupStoreForHintsTest(t)
-	tb.Cleanup(close)
 
 	tb.Run("with default options", func(tb test.TB) {
+		tb.Cleanup(close)
 		runTestServerSeries(tb, store, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 	})
 
 	tb, store, seriesSet1, seriesSet2, block1, block2, close = setupStoreForHintsTest(t, WithStreamingSeriesPerBatch(5000))
-	tb.Cleanup(close)
 
 	tb.Run("with series streaming", func(tb test.TB) {
+		tb.Cleanup(close)
 		runTestServerSeries(tb, store, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 	})
 }

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1382,16 +1382,14 @@ func TestSeries_RequestAndResponseHints(t *testing.T) {
 		}
 	}
 
-	tb, store, seriesSet1, seriesSet2, block1, block2, close := setupStoreForHintsTest(t)
-
-	tb.Run("with default options", func(tb test.TB) {
+	t.Run("with default options", func(t *testing.T) {
+		tb, store, seriesSet1, seriesSet2, block1, block2, close := setupStoreForHintsTest(t)
 		tb.Cleanup(close)
 		runTestServerSeries(tb, store, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 	})
 
-	tb, store, seriesSet1, seriesSet2, block1, block2, close = setupStoreForHintsTest(t, WithStreamingSeriesPerBatch(5000))
-
-	tb.Run("with series streaming", func(tb test.TB) {
+	t.Run("with series streaming", func(t *testing.T) {
+		tb, store, seriesSet1, seriesSet2, block1, block2, close := setupStoreForHintsTest(t, WithStreamingSeriesPerBatch(5000))
 		tb.Cleanup(close)
 		runTestServerSeries(tb, store, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 	})


### PR DESCRIPTION
This PR also removes the streaming implementation from
* `TestSeries_BlockWithMultipleChunks`, which I think is ok because we
already have unit tests for multiple chunks in our units
* `TestLabelNamesAndValuesHints` label values aren't using streaming
still anyway
* `TestSeries_ErrorUnmarshallingRequestHints` this should be independent
 of how series are fetched (streaming or not)

pkg/storegateway now takes 109.121s to run on my machine compared to the
 94.677s it took before