### PR TITLE
Add an iterator which measures durations of Next calls

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1162,7 +1162,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	mergedBatches := mergedSeriesChunkRefsSetIterators(s.maxSeriesPerBatch, batches...)
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
-		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, stats, s.metrics)
+		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, stats, s.metrics.iteratorLoadDurations)
 	} else {
 		set = newSeriesSetWithoutChunks(ctx, mergedBatches)
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1131,6 +1131,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 				req.MinTime, req.MaxTime,
 				stats,
 				s.logger,
+				s.metrics,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "fetch series for block %s", b.meta.ULID)

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1161,7 +1161,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	mergedBatches := mergedSeriesChunkRefsSetIterators(s.maxSeriesPerBatch, batches...)
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
-		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, stats)
+		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, stats, s.metrics)
 	} else {
 		set = newSeriesSetWithoutChunks(ctx, mergedBatches)
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1194,6 +1194,7 @@ func (s *BucketStore) recordSeriesCallResult(safeStats *safeQueryStats) {
 	s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
 	s.metrics.seriesHashCacheRequests.Add(float64(stats.seriesHashCacheRequests))
 	s.metrics.seriesHashCacheHits.Add(float64(stats.seriesHashCacheHits))
+	s.metrics.expandPostingsDuration.Observe(float64(stats.expandedPostingsDuration))
 }
 
 func (s *BucketStore) openBlocksForReading(ctx context.Context, skipChunks bool, minT, maxT, maxResolutionMillis int64, blockMatchers []*labels.Matcher) ([]*bucketBlock, map[ulid.ULID]*bucketIndexReader, map[ulid.ULID]chunkReader) {

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"github.com/weaveworks/common/httpgrpc"
@@ -34,6 +36,7 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/indexheader"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	"github.com/grafana/mimir/pkg/storegateway/testhelper"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 var (
@@ -67,6 +70,7 @@ type storeSuite struct {
 	store            *BucketStore
 	minTime, maxTime int64
 	cache            *swappableCache
+	metricsRegistry  *prometheus.Registry
 
 	logger log.Logger
 }
@@ -137,6 +141,7 @@ type prepareStoreConfig struct {
 	series               []labels.Labels
 	indexCache           indexcache.IndexCache
 	bucketStoreOpts      []BucketStoreOption
+	metricsRegistry      *prometheus.Registry
 }
 
 func (c *prepareStoreConfig) apply(opts ...prepareStoreConfigOption) *prepareStoreConfig {
@@ -148,6 +153,7 @@ func (c *prepareStoreConfig) apply(opts ...prepareStoreConfigOption) *prepareSto
 
 func defaultPrepareStoreConfig(t testing.TB) *prepareStoreConfig {
 	return &prepareStoreConfig{
+		metricsRegistry:      prometheus.NewRegistry(),
 		tempDir:              t.TempDir(),
 		manyParts:            false,
 		seriesLimiterFactory: NewSeriesLimiterFactory(0),
@@ -186,10 +192,11 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 	minTime, maxTime := prepareTestBlocks(t, time.Now(), 3, cfg.tempDir, bkt, cfg.series, extLset)
 
 	s := &storeSuite{
-		logger:  log.NewNopLogger(),
-		cache:   &swappableCache{IndexCache: cfg.indexCache},
-		minTime: minTime,
-		maxTime: maxTime,
+		logger:          log.NewNopLogger(),
+		metricsRegistry: cfg.metricsRegistry,
+		cache:           &swappableCache{IndexCache: cfg.indexCache},
+		minTime:         minTime,
+		maxTime:         maxTime,
 	}
 
 	metaFetcher, err := block.NewMetaFetcher(s.logger, 20, objstore.WithNoopInstr(bkt), cfg.tempDir, nil, []block.MetadataFilter{})
@@ -212,7 +219,7 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 		true,
 		time.Minute,
 		hashcache.NewSeriesHashCache(1024*1024),
-		NewBucketStoreMetrics(nil),
+		NewBucketStoreMetrics(s.metricsRegistry),
 		storeOpts...,
 	)
 	assert.NoError(t, err)
@@ -440,10 +447,97 @@ func testBucketStore_e2e(t *testing.T, ctx context.Context, s *storeSuite) {
 				assert.Equal(t, tcase.expected[i], s.Labels)
 				assert.Equal(t, tcase.expectedChunkLen, len(s.Chunks))
 			}
+			assertSomeMetricsRecorded(t, len(tcase.expected), tcase.expectedChunkLen, s.metricsRegistry)
 		}); !ok {
 			return
 		}
 	}
+}
+
+func assertSomeMetricsRecorded(t *testing.T, numSeries int, numChunksPerSeries int, registry *prometheus.Registry) {
+	t.Helper()
+
+	families, err := registry.Gather()
+	require.NoError(t, err, "couldn't gather metrics from BucketStore")
+	metrics, err := util.NewMetricFamilyMap(families)
+	require.NoError(t, err, "couldn't gather metrics from BucketStore")
+
+	toLabels := func(labelValuePairs []string) (result labels.Labels) {
+		if len(labelValuePairs)%2 != 0 {
+			t.Fatalf("invalid label name-value pairs %s", strings.Join(labelValuePairs, ""))
+		}
+		for i := 0; i < len(labelValuePairs); i += 2 {
+			result = append(result, labels.Label{Name: labelValuePairs[i], Value: labelValuePairs[i+1]})
+		}
+		return
+	}
+
+	numObservationsForSummaries := func(summaryName string, labelValuePairs ...string) uint64 {
+		summaryData := &util.SummaryData{}
+		for _, metric := range getMetricsMatchingLabels(metrics[summaryName], toLabels(labelValuePairs)) {
+			summaryData.AddSummary(metric.GetSummary())
+		}
+		m := &dto.Metric{}
+		require.NoError(t, summaryData.Metric(&prometheus.Desc{}).Write(m))
+		return m.GetSummary().GetSampleCount()
+	}
+
+	numObservationsForHistogram := func(histogramName string, labelValuePairs ...string) uint64 {
+		histogramData := &util.HistogramData{}
+		for _, metric := range getMetricsMatchingLabels(metrics[histogramName], toLabels(labelValuePairs)) {
+			histogramData.AddHistogram(metric.GetHistogram())
+		}
+		m := &dto.Metric{}
+		require.NoError(t, histogramData.Metric(&prometheus.Desc{}).Write(m))
+		return m.GetHistogram().GetSampleCount()
+	}
+
+	if numSeries > 0 {
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_result_series"))
+		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_expanded_postings_duration"))
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_touched", "data_type", "postings"))
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_touched", "data_type", "series"))
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "postings"))
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "series"))
+		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_expanded_postings_duration"))
+		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_get_all_duration_seconds"))
+		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_merge_duration_seconds"))
+	}
+	if numChunksPerSeries > 0 {
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_touched", "data_type", "chunks"))
+		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "chunks"))
+	}
+}
+
+func getMetricsMatchingLabels(mf *dto.MetricFamily, selectors labels.Labels) []*dto.Metric {
+	var result []*dto.Metric
+	for _, m := range mf.GetMetric() {
+		if !matchesSelectors(m, selectors) {
+			continue
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func matchesSelectors(m *dto.Metric, selectors labels.Labels) bool {
+	for _, l := range selectors {
+		found := false
+		for _, lp := range m.GetLabel() {
+			if l.Name != lp.GetName() || l.Value != lp.GetValue() {
+				continue
+			}
+
+			found = true
+			break
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 func TestBucketStore_e2e(t *testing.T) {

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -447,14 +447,14 @@ func testBucketStore_e2e(t *testing.T, ctx context.Context, s *storeSuite) {
 				assert.Equal(t, tcase.expected[i], s.Labels)
 				assert.Equal(t, tcase.expectedChunkLen, len(s.Chunks))
 			}
-			assertSomeMetricsRecorded(t, len(tcase.expected), tcase.expectedChunkLen, s.metricsRegistry)
+			assertQueryStatsMetricsRecorded(t, len(tcase.expected), tcase.expectedChunkLen, s.metricsRegistry)
 		}); !ok {
 			return
 		}
 	}
 }
 
-func assertSomeMetricsRecorded(t *testing.T, numSeries int, numChunksPerSeries int, registry *prometheus.Registry) {
+func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSeries int, registry *prometheus.Registry) {
 	t.Helper()
 
 	families, err := registry.Gather()

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -64,7 +64,11 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 	var (
 		loaded bool
 		cached bool
+		start  = time.Now()
 	)
+	defer stats.update(func(stats *queryStats) {
+		stats.expandedPostingsDuration += time.Since(start)
+	})
 	span, ctx := tracing.StartSpan(ctx, "ExpandedPostings()")
 	defer func() {
 		span.LogKV("returned postings", len(returnRefs), "cached", cached, "promise_loaded", loaded)

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -50,8 +50,8 @@ type BucketStoreMetrics struct {
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
 
-	iteratorLoadDurations  *prometheus.SummaryVec
-	expandPostingsDuration prometheus.Summary
+	iteratorLoadDurations  *prometheus.HistogramVec
+	expandPostingsDuration prometheus.Histogram
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
@@ -179,16 +179,16 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 
 	m.indexHeaderReaderMetrics = indexheader.NewReaderPoolMetrics(prometheus.WrapRegistererWithPrefix("cortex_bucket_store_", reg))
 
-	m.iteratorLoadDurations = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "cortex_bucket_store_iterator_load_duration",
-		Help:       "The time it takes an iterator to load the next item.",
-		Objectives: map[float64]float64{0.99: 0.001},
+	m.iteratorLoadDurations = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_iterator_load_duration",
+		Help:    "The time it takes an iterator to load the next item.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	}, []string{"iterator"})
 
-	m.expandPostingsDuration = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
-		Name:       "cortex_bucket_store_expanded_postings_duration",
-		Help:       "The time it takes to get a list of all series that match the request matcher.",
-		Objectives: map[float64]float64{0.99: 0.001},
+	m.expandPostingsDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_expanded_postings_duration",
+		Help:    "The time it takes to get a list of all series that match the request matcher.",
+		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	})
 
 	return &m

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -49,6 +49,8 @@ type BucketStoreMetrics struct {
 	postingsFetchDuration prometheus.Histogram
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
+
+	batchLoadDurations *prometheus.SummaryVec
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
@@ -175,6 +177,12 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	})
 
 	m.indexHeaderReaderMetrics = indexheader.NewReaderPoolMetrics(prometheus.WrapRegistererWithPrefix("cortex_bucket_store_", reg))
+
+	m.batchLoadDurations = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "cortex_bucket_store_batch_load_duration",
+		Help:       "The time it takes to load a batch per stage.",
+		Objectives: map[float64]float64{0.99: 0.001},
+	}, []string{"stage"})
 
 	return &m
 }

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -50,7 +50,7 @@ type BucketStoreMetrics struct {
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
 
-	batchLoadDurations *prometheus.SummaryVec
+	iteratorLoadDurations *prometheus.SummaryVec
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
@@ -178,11 +178,11 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 
 	m.indexHeaderReaderMetrics = indexheader.NewReaderPoolMetrics(prometheus.WrapRegistererWithPrefix("cortex_bucket_store_", reg))
 
-	m.batchLoadDurations = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "cortex_bucket_store_batch_load_duration",
-		Help:       "The time it takes to load a batch per stage.",
+	m.iteratorLoadDurations = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "cortex_bucket_store_iterator_load_duration",
+		Help:       "The time it takes an iterator to load the next item.",
 		Objectives: map[float64]float64{0.99: 0.001},
-	}, []string{"stage"})
+	}, []string{"iterator"})
 
 	return &m
 }

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -50,7 +50,8 @@ type BucketStoreMetrics struct {
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
 
-	iteratorLoadDurations *prometheus.SummaryVec
+	iteratorLoadDurations  *prometheus.SummaryVec
+	expandPostingsDuration prometheus.Summary
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
@@ -183,6 +184,12 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 		Help:       "The time it takes an iterator to load the next item.",
 		Objectives: map[float64]float64{0.99: 0.001},
 	}, []string{"iterator"})
+
+	m.expandPostingsDuration = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
+		Name:       "cortex_bucket_store_expanded_postings_duration",
+		Help:       "The time it takes to get a list of all series that match the request matcher.",
+		Objectives: map[float64]float64{0.99: 0.001},
+	})
 
 	return &m
 }

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -65,7 +65,7 @@ func newSeriesSetWithChunks(ctx context.Context, chunkReaders chunkReaders, chun
 	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, chunksPool, batches, stats)
 	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunks_load"))
 	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunk_preloaded"))
+	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunks_preloaded"))
 	return newSeriesChunksSeriesSet(iterator)
 }
 

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -60,12 +60,12 @@ func newSeriesChunksSeriesSet(from seriesChunksSetIterator) storepb.SeriesSet {
 	}
 }
 
-func newSeriesSetWithChunks(ctx context.Context, chunkReaders chunkReaders, chunksPool pool.Bytes, batches seriesChunkRefsSetIterator, stats *safeQueryStats, metrics *BucketStoreMetrics) storepb.SeriesSet {
+func newSeriesSetWithChunks(ctx context.Context, chunkReaders chunkReaders, chunksPool pool.Bytes, batches seriesChunkRefsSetIterator, stats *safeQueryStats, iteratorLoadDurations *prometheus.HistogramVec) storepb.SeriesSet {
 	var iterator seriesChunksSetIterator
 	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, chunksPool, batches, stats)
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunks_load"))
+	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_load"))
 	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunks_preloaded"))
+	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_preloaded"))
 	return newSeriesChunksSeriesSet(iterator)
 }
 

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -65,6 +65,9 @@ func newSeriesSetWithChunks(ctx context.Context, chunkReaders chunkReaders, chun
 	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, chunksPool, batches, stats)
 	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_load"))
 	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
+	// We are measuring the time we wait for a preloaded batch. In an ideal world this is 0 because there's always a preloaded batch waiting.
+	// But realistically it will not be. Along with the duration of the chunks_load iterator,
+	// we can determine where is the bottleneck in the streaming pipeline.
 	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_preloaded"))
 	return newSeriesChunksSeriesSet(iterator)
 }

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -63,9 +63,9 @@ func newSeriesChunksSeriesSet(from seriesChunksSetIterator) storepb.SeriesSet {
 func newSeriesSetWithChunks(ctx context.Context, chunkReaders chunkReaders, chunksPool pool.Bytes, batches seriesChunkRefsSetIterator, stats *safeQueryStats, metrics *BucketStoreMetrics) storepb.SeriesSet {
 	var iterator seriesChunksSetIterator
 	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, chunksPool, batches, stats)
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.batchLoadDurations.WithLabelValues("chunks_load"))
+	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunks_load"))
 	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.batchLoadDurations.WithLabelValues("chunk_preloaded"))
+	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("chunk_preloaded"))
 	return newSeriesChunksSeriesSet(iterator)
 }
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -563,7 +563,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		minTime,
 		maxTime,
 	)
-	iterator = newDurationMeasuringIterator[seriesChunkRefsSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("index_load"))
+	iterator = newDurationMeasuringIterator[seriesChunkRefsSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("series_load"))
 	iterator = newLimitingSeriesChunkRefsSetIterator(iterator, chunksLimiter, seriesLimiter)
 	return iterator, nil
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -563,7 +563,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		minTime,
 		maxTime,
 	)
-	iterator = newDurationMeasuringIterator[seriesChunkRefsSet](iterator, metrics.batchLoadDurations.WithLabelValues("index_load"))
+	iterator = newDurationMeasuringIterator[seriesChunkRefsSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("index_load"))
 	iterator = newLimitingSeriesChunkRefsSetIterator(iterator, chunksLimiter, seriesLimiter)
 	return iterator, nil
 }

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -1211,6 +1212,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				block.meta.MaxTime,
 				newSafeQueryStats(),
 				log.NewNopLogger(),
+				NewBucketStoreMetrics(prometheus.DefaultRegisterer),
 			)
 			require.NoError(t, err)
 

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1212,7 +1212,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				block.meta.MaxTime,
 				newSafeQueryStats(),
 				log.NewNopLogger(),
-				NewBucketStoreMetrics(prometheus.DefaultRegisterer),
+				NewBucketStoreMetrics(prometheus.NewRegistry()),
 			)
 			require.NoError(t, err)
 

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -52,6 +52,8 @@ type queryStats struct {
 	mergedSeriesCount int
 	mergedChunksCount int
 	mergeDuration     time.Duration
+
+	expandedPostingsDuration time.Duration
 }
 
 func (s queryStats) merge(o *queryStats) *queryStats {
@@ -94,6 +96,8 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.mergedSeriesCount += o.mergedSeriesCount
 	s.mergedChunksCount += o.mergedChunksCount
 	s.mergeDuration += o.mergeDuration
+
+	s.expandedPostingsDuration += o.expandedPostingsDuration
 
 	return &s
 }

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -61,6 +61,7 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 
 	s.postingsTouched += o.postingsTouched
 	s.postingsTouchedSizeSum += o.postingsTouchedSizeSum
+	s.postingsToFetch += o.postingsToFetch
 	s.postingsFetched += o.postingsFetched
 	s.postingsFetchedSizeSum += o.postingsFetchedSizeSum
 	s.postingsFetchCount += o.postingsFetchCount


### PR DESCRIPTION
Starts measuring a few things (below). All are measured in p99 summaries.

* the time it takes to load the chunks for each batch (p99 summary)
	* we can see how this changes with changes batch size
* the time it takes to load the index for each batch (p99 summary)
	* we can see how this changes with changes batch size
* the time it takes to load the expanded postings at the beginning of the request (p99 summary)
	* we can see whether this is something we should split or parallelize
* the time it takes to wait for the next preloaded batch (p99 summary)
	* we can see how effective preloading is

also fixes a benign bug where postingsToFetch wasn't merged in queryStats