### PR TITLE
Alert when an ingester replica does not have any tenant assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Alerts: Added `MimirIngesterInstanceHasNoTenants` alert that fires when an ingester replica is not receiving write requests for any tenant. #3681
 * [BUGFIX] Alerts: Fixed `MemoryMapAreasTooHigh` alert when Mimir is deployed in read-write mode. #3626
 * [BUGFIX] Alerts: Fixed `MimirCompactorSkippedBlocksWithOutOfOrderChunks` matching on non-existent label. #3628
 

--- a/development/mimir-microservices-mode/config/grafana-agent.yaml
+++ b/development/mimir-microservices-mode/config/grafana-agent.yaml
@@ -11,54 +11,34 @@ prometheus:
     - name: local
       host_filter: false
       scrape_configs:
-        - job_name: mimir-microservices-mode/distributor
+        - job_name: mimir-microservices
           static_configs:
-            - targets: ['distributor-1:8000', 'distributor-2:8001']
+            - targets:
+                - 'distributor-1:8000'
+                - 'distributor-2:8001'
+                - 'ingester-1:8002'
+                - 'ingester-2:8003'
+                - 'querier:8004'
+                - 'ruler-1:8021'
+                - 'ruler-2:8022'
+                - 'compactor:8006'
+                - 'query-frontend:8007'
+                - 'store-gateway-1:8008'
+                - 'store-gateway-2:8009'
+                - 'query-scheduler:8011'
               labels:
                 cluster: 'docker-compose'
                 namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/ingester
-          static_configs:
-            - targets: ['ingester-1:8002', 'ingester-2:8003']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/querier
-          static_configs:
-            - targets: ['querier:8004']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/ruler
-          static_configs:
-            - targets: ['ruler-1:8021', 'ruler-2:8022']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/compactor
-          static_configs:
-            - targets: ['compactor:8006']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/query-frontend
-          static_configs:
-            - targets: ['query-frontend:8007']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/store-gateway
-          static_configs:
-            - targets: ['store-gateway-1:8008', 'store-gateway-2:8009']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
-        - job_name: mimir-microservices-mode/query-scheduler
-          static_configs:
-            - targets: ['query-scheduler:8011']
-              labels:
-                cluster: 'docker-compose'
-                namespace: 'mimir-microservices-mode'
+          relabel_configs:
+            - source_labels: ['__address__']
+              target_label: 'pod'
+              regex: '([^:]+)(:[0-9]+)?'
+              replacement: '${1}'
+            - source_labels: ['namespace', 'pod']
+              target_label: 'job'
+              separator: '/'
+              regex: '(.+?)(-\d+)?'
+              replacement: '${1}'
 
       remote_write:
         - url: http://distributor-1:8000/api/v1/push

--- a/development/mimir-microservices-mode/config/prometheus.yaml
+++ b/development/mimir-microservices-mode/config/prometheus.yaml
@@ -6,80 +6,52 @@ global:
 scrape_configs:
   - job_name: mimir-microservices-mode/distributor
     static_configs:
-      - targets: ['distributor-1:8000']
+      - targets: ['distributor-1:8000', 'distributor-2:8001']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'distributor-1'
-      - targets: ['distributor-2:8001']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-          pod: 'distributor-2'
   - job_name: mimir-microservices-mode/ingester
     static_configs:
-      - targets: ['ingester-1:8002']
+      - targets: ['ingester-1:8002', 'ingester-2:8003']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'ingester-1'
-      - targets: ['ingester-2:8003']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-          pod: 'ingester-2'
   - job_name: mimir-microservices-mode/querier
     static_configs:
       - targets: ['querier:8004']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'querier'
   - job_name: mimir-microservices-mode/ruler
     static_configs:
-      - targets: ['ruler-1:8021']
+      - targets: ['ruler-1:8021', 'ruler-2:8022']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'ruler-1'
-      - targets: ['ruler-2:8022']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-          pod: 'ruler-2'
   - job_name: mimir-microservices-mode/compactor
     static_configs:
       - targets: ['compactor:8006']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'compactor'
   - job_name: mimir-microservices-mode/query-frontend
     static_configs:
       - targets: ['query-frontend:8007']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'query-frontend'
   - job_name: mimir-microservices-mode/store-gateway
     static_configs:
-      - targets: ['store-gateway-1:8008']
+      - targets: ['store-gateway-1:8008', 'store-gateway-2:8009']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'store-gateway-1'
-      - targets: ['store-gateway-2:8009']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-          pod: 'store-gateway-2'
   - job_name: mimir-microservices-mode/query-scheduler
     static_configs:
       - targets: ['query-scheduler:8011']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-          pod: 'query-scheduler'
 
 remote_write:
   - url: http://distributor-1:8000/api/v1/push
@@ -87,3 +59,4 @@ remote_write:
 
 rule_files:
   - '/etc/alerts/alerts.yaml'
+

--- a/development/mimir-microservices-mode/config/prometheus.yaml
+++ b/development/mimir-microservices-mode/config/prometheus.yaml
@@ -6,53 +6,84 @@ global:
 scrape_configs:
   - job_name: mimir-microservices-mode/distributor
     static_configs:
-      - targets: ['distributor-1:8000', 'distributor-2:8001']
+      - targets: ['distributor-1:8000']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'distributor-1'
+      - targets: ['distributor-2:8001']
+        labels:
+          cluster: 'docker-compose'
+          namespace: 'mimir-microservices-mode'
+          pod: 'distributor-2'
   - job_name: mimir-microservices-mode/ingester
     static_configs:
-      - targets: ['ingester-1:8002', 'ingester-2:8003']
+      - targets: ['ingester-1:8002']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'ingester-1'
+      - targets: ['ingester-2:8003']
+        labels:
+          cluster: 'docker-compose'
+          namespace: 'mimir-microservices-mode'
+          pod: 'ingester-2'
   - job_name: mimir-microservices-mode/querier
     static_configs:
       - targets: ['querier:8004']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'querier'
   - job_name: mimir-microservices-mode/ruler
     static_configs:
-      - targets: ['ruler-1:8021', 'ruler-2:8022']
+      - targets: ['ruler-1:8021']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'ruler-1'
+      - targets: ['ruler-2:8022']
+        labels:
+          cluster: 'docker-compose'
+          namespace: 'mimir-microservices-mode'
+          pod: 'ruler-2'
   - job_name: mimir-microservices-mode/compactor
     static_configs:
       - targets: ['compactor:8006']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'compactor'
   - job_name: mimir-microservices-mode/query-frontend
     static_configs:
       - targets: ['query-frontend:8007']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'query-frontend'
   - job_name: mimir-microservices-mode/store-gateway
     static_configs:
-      - targets: ['store-gateway-1:8008', 'store-gateway-2:8009']
+      - targets: ['store-gateway-1:8008']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'store-gateway-1'
+      - targets: ['store-gateway-2:8009']
+        labels:
+          cluster: 'docker-compose'
+          namespace: 'mimir-microservices-mode'
+          pod: 'store-gateway-2'
   - job_name: mimir-microservices-mode/query-scheduler
     static_configs:
       - targets: ['query-scheduler:8011']
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
+          pod: 'query-scheduler'
 
 remote_write:
   - url: http://distributor-1:8000/api/v1/push
     send_exemplars: true
+
+rule_files:
+  - '/etc/alerts/alerts.yaml'

--- a/development/mimir-microservices-mode/config/prometheus.yaml
+++ b/development/mimir-microservices-mode/config/prometheus.yaml
@@ -4,54 +4,34 @@ global:
     scraped_by: prometheus
 
 scrape_configs:
-  - job_name: mimir-microservices-mode/distributor
+  - job_name: mimir-microservices
     static_configs:
-      - targets: ['distributor-1:8000', 'distributor-2:8001']
+      - targets:
+          - 'distributor-1:8000'
+          - 'distributor-2:8001'
+          - 'ingester-1:8002'
+          - 'ingester-2:8003'
+          - 'querier:8004'
+          - 'ruler-1:8021'
+          - 'ruler-2:8022'
+          - 'compactor:8006'
+          - 'query-frontend:8007'
+          - 'store-gateway-1:8008'
+          - 'store-gateway-2:8009'
+          - 'query-scheduler:8011'
         labels:
           cluster: 'docker-compose'
           namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/ingester
-    static_configs:
-      - targets: ['ingester-1:8002', 'ingester-2:8003']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/querier
-    static_configs:
-      - targets: ['querier:8004']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/ruler
-    static_configs:
-      - targets: ['ruler-1:8021', 'ruler-2:8022']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/compactor
-    static_configs:
-      - targets: ['compactor:8006']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/query-frontend
-    static_configs:
-      - targets: ['query-frontend:8007']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/store-gateway
-    static_configs:
-      - targets: ['store-gateway-1:8008', 'store-gateway-2:8009']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
-  - job_name: mimir-microservices-mode/query-scheduler
-    static_configs:
-      - targets: ['query-scheduler:8011']
-        labels:
-          cluster: 'docker-compose'
-          namespace: 'mimir-microservices-mode'
+    relabel_configs:
+      - source_labels: ['__address__']
+        target_label: 'pod'
+        regex: '([^:]+)(:[0-9]+)?'
+        replacement: '${1}'
+      - source_labels: ['namespace', 'pod']
+        target_label: 'job'
+        separator: '/'
+        regex: '(.+?)(-\d+)?'
+        replacement: '${1}'
 
 remote_write:
   - url: http://distributor-1:8000/api/v1/push

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -225,7 +225,7 @@ std.manifestYamlDoc({
         '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',
       ],
-      volumes: ['./config:/etc/prometheus'],
+      volumes: ['./config:/etc/prometheus', '../../operations/mimir-mixin-compiled/alerts.yaml:/etc/alerts/alerts.yaml'],
       ports: ['9090:9090'],
     },
   },

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -228,6 +228,7 @@
       - "9090:9090"
     "volumes":
       - "./config:/etc/prometheus"
+      - "../../operations/mimir-mixin-compiled/alerts.yaml:/etc/alerts/alerts.yaml"
   "querier":
     "build":
       "context": "."

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -483,7 +483,7 @@ This alert fires when an ingester instance doesn't own any tenants and is theref
 How it **works**:
 
 - Ingesters join a hash ring that facilitates per-tenant request sharding across ingester replicas.
-- Distributors shard requests belonging to an individual tenant across a subset of ingester replicas. The number of replicas used per tenant is determined by the `-distributor.ingestion-tenant-shard-size` or the `ingestion_tenant_shard_size` limit.
+- Distributors shard requests that belong to an individual tenant across a subset of ingester replicas. The number of replicas used per tenant is determined by the `-distributor.ingestion-tenant-shard-size` or the `ingestion_tenant_shard_size` limit.
 - When the tenant shard size is lower than the number of ingester replicas, some ingesters may not receive requests for any tenants.
 - This is more likely to happen in Mimir clusters with a lower number of tenants.
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -491,9 +491,9 @@ How to **fix** it:
 
 Choose one of three options:
 
-- Decrease the number of ingester replicas to match the highest number of shards per tenant.
 - Increase the shard size of one or more tenants to match the number of ingester replicas.
 - Set the shard size of one or more tenants to `0`; this will shard the given tenant’s requests across all ingesters.
+- [Decrease the number of ingester replicas]({{< relref "../operators-guide/run-production-environment/scaling-out.md#scaling-down-ingesters" >}}) to match the highest number of shards per tenant.
 
 ### MimirQuerierHasNotScanTheBucket
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -484,7 +484,7 @@ How it **works**:
 
 - Ingesters join a hash ring that facilitates per-tenant request sharding across ingester replicas.
 - Distributors shard requests that belong to an individual tenant across a subset of ingester replicas. The number of replicas used per tenant is determined by the `-distributor.ingestion-tenant-shard-size` or the `ingestion_tenant_shard_size` limit.
-- When the tenant shard size is lower than the number of ingester replicas, some ingesters may not receive requests for any tenants.
+- When the tenant shard size is lower than the number of ingester replicas, some ingesters might not receive requests for any tenants.
 - This is more likely to happen in Mimir clusters with a lower number of tenants.
 
 How to **fix** it:

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -476,6 +476,25 @@ How to **investigate**:
 
 - Look for details in the ingester logs
 
+### MimirIngesterInstanceHasNoTenants
+
+This alert fires when an ingester instance doesn't own any tenants and is therefore idling.
+
+How it **works**:
+
+- Ingesters join a hash ring that facilitates per-tenant request sharding across ingester replicas.
+- Distributors shard requests belonging to an individual tenant across a subset of ingester replicas. The number of replicas used per tenant is determined by the `-distributor.ingestion-tenant-shard-size` or the `ingestion_tenant_shard_size` limit.
+- When the tenant shard size is lower than the number of ingester replicas, some ingesters may not receive requests for any tenants.
+- This is more likely to happen in Mimir clusters with a lower number of tenants.
+
+How to **fix** it:
+
+There are three options:
+
+- Decrease the number of ingester replicas to match the highest number of shards per tenant or
+- Increase the shard size of one or more tenants to match the number of ingester replicas or
+- Set the shard size of one or more tenants to `0`; this will shard this tenant's requests across all ingesters.
+
 ### MimirQuerierHasNotScanTheBucket
 
 This alert fires when a Mimir querier is not successfully scanning blocks in the storage (bucket). A querier is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket since a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -489,11 +489,11 @@ How it **works**:
 
 How to **fix** it:
 
-There are three options:
+Choose one of three options:
 
-- Decrease the number of ingester replicas to match the highest number of shards per tenant or
-- Increase the shard size of one or more tenants to match the number of ingester replicas or
-- Set the shard size of one or more tenants to `0`; this will shard this tenant's requests across all ingesters.
+- Decrease the number of ingester replicas to match the highest number of shards per tenant.
+- Increase the shard size of one or more tenants to match the number of ingester replicas.
+- Set the shard size of one or more tenants to `0`; this will shard the given tenant’s requests across all ingesters.
 
 ### MimirQuerierHasNotScanTheBucket
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -493,7 +493,7 @@ Choose one of three options:
 
 - Increase the shard size of one or more tenants to match the number of ingester replicas.
 - Set the shard size of one or more tenants to `0`; this will shard the given tenant’s requests across all ingesters.
-- [Decrease the number of ingester replicas]({{< relref "../operators-guide/run-production-environment/scaling-out.md#scaling-down-ingesters" >}}) to match the highest number of shards per tenant.
+- [Decrease the number of ingester replicas]({{< relref "../../operators-guide/run-production-environment/scaling-out.md#scaling-down-ingesters" >}}) to match the highest number of shards per tenant.
 
 ### MimirQuerierHasNotScanTheBucket
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -164,7 +164,7 @@ spec:
         severity: critical
     - alert: MimirIngesterInstanceHasNoTenants
       annotations:
-        message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
           }} has no tenants assigned.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
       expr: |

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -162,6 +162,19 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: MimirIngesterInstanceHasNoTenants
+      annotations:
+        message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} has no tenants assigned.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
+      expr: |
+        (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
+        and on (cluster, namespace)
+        # Only if there's a least 1 tenant in Mimir.
+        (max by(cluster, namespace) (cortex_ingester_memory_users) > 0)
+      for: 1h
+      labels:
+        severity: warning
     - alert: MimirRingMembersMismatch
       annotations:
         message: |

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -150,6 +150,19 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirIngesterInstanceHasNoTenants
+    annotations:
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has no tenants assigned.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
+    expr: |
+      (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
+      and on (cluster, namespace)
+      # Only if there's a least 1 tenant in Mimir.
+      (max by(cluster, namespace) (cortex_ingester_memory_users) > 0)
+    for: 1h
+    labels:
+      severity: warning
   - alert: MimirRingMembersMismatch
     annotations:
       message: |

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -152,7 +152,7 @@ groups:
       severity: critical
   - alert: MimirIngesterInstanceHasNoTenants
     annotations:
-      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+      message: Mimir ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} has no tenants assigned.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
     expr: |

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -152,7 +152,7 @@ groups:
       severity: critical
   - alert: MimirIngesterInstanceHasNoTenants
     annotations:
-      message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+      message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
         }} has no tenants assigned.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
     expr: |

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -150,6 +150,19 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirIngesterInstanceHasNoTenants
+    annotations:
+      message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has no tenants assigned.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
+    expr: |
+      (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
+      and on (cluster, namespace)
+      # Only if there's a least 1 tenant in Mimir.
+      (max by(cluster, namespace) (cortex_ingester_memory_users) > 0)
+    for: 1h
+    labels:
+      severity: warning
   - alert: MimirRingMembersMismatch
     annotations:
       message: |

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -244,6 +244,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
             ||| % $._config,
           },
         },
+        {
+          // Alert if an ingester instance has no tenants assigned while other instances in the same cell do.
+          alert: $.alertName('IngesterInstanceHasNoTenants'),
+          'for': '1h',
+          expr: |||
+            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_memory_users) == 0)
+            and on (%(alert_aggregation_labels)s)
+            # Only if there's a least 1 tenant in Mimir.
+            (max by(%(alert_aggregation_labels)s) (cortex_ingester_memory_users) > 0)
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s Ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s has no tenants assigned.' % $._config,
+          },
+        },
       ] + [
         {
           alert: $.alertName('RingMembersMismatch'),

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -258,7 +258,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s Ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s has no tenants assigned.' % $._config,
+            message: '%(product)s ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s has no tenants assigned.' % $._config,
           },
         },
       ] + [


### PR DESCRIPTION
#### What this PR does

Under certain circumstances, it can happen that ingester replicas have no tenant assigned even after the cluster has started ingesting real customer data. This adds an alert that triggers in this situation.

It also adds the compiled alerts to the Prometheus configuration for docker-compose microservices development mode, which is helpful when developing/testing alerts manually and simplifies the scraping config a bit.

#### Which issue(s) this PR fixes or relates to

Relates to #1959

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
