### PR TITLE
Read-write deployment mode integration tests: querying from long-term storage and alerting rules

### DIFF
--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -26,33 +26,33 @@ func TestReadWriteModeQueryingIngester(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	c, _, _ := startReadWriteModeCluster(t, s)
+	client, _ := startReadWriteModeCluster(t, s)
 
 	// Push some data to the cluster.
 	now := time.Now()
 	series, expectedVector, expectedMatrix := generateSeries("test_series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
-	res, err := c.Push(series)
+	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
 	// Verify we can read the data we just pushed, both with an instant query and a range query.
-	queryResult, err := c.Query("test_series_1", now)
+	queryResult, err := client.Query("test_series_1", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 	require.Equal(t, expectedVector, queryResult.(model.Vector))
 
-	rangeResult, err := c.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
+	rangeResult, err := client.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
+	labelValues, err := client.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
+	labelNames, err := client.LabelNames(prometheusMinTime, prometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }
@@ -62,7 +62,7 @@ func TestReadWriteModeQueryingStoreGateway(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	c, writeInstance, backendInstance := startReadWriteModeCluster(t, s, BlocksStorageFlags(), map[string]string{
+	client, cluster := startReadWriteModeCluster(t, s, BlocksStorageFlags(), map[string]string{
 		// Frequently compact and ship blocks to storage so we can query them through the store gateway.
 		"-blocks-storage.tsdb.block-ranges-period":          "2s",
 		"-blocks-storage.tsdb.ship-interval":                "1s",
@@ -74,33 +74,33 @@ func TestReadWriteModeQueryingStoreGateway(t *testing.T) {
 	now := time.Now()
 	series, expectedVector, expectedMatrix := generateSeries("test_series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
-	res, err := c.Push(series)
+	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
 	// Wait until the TSDB head is shipped to storage, removed from the ingester in the write instance, and loaded by the
 	// store-gateway in the backend instance to ensure we're querying the store-gateway (and not the ingester).
-	require.NoError(t, writeInstance.WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_ingester_shipper_uploads_total"))
-	require.NoError(t, writeInstance.WaitSumMetrics(e2e.Equals(0), "cortex_ingester_memory_series"))
-	require.NoError(t, backendInstance.WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_bucket_store_blocks_loaded"))
+	require.NoError(t, cluster.writeInstance.WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_ingester_shipper_uploads_total"))
+	require.NoError(t, cluster.writeInstance.WaitSumMetrics(e2e.Equals(0), "cortex_ingester_memory_series"))
+	require.NoError(t, cluster.backendInstance.WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_bucket_store_blocks_loaded"))
 
 	// Verify we can read the data we just pushed, both with an instant query and a range query.
-	queryResult, err := c.Query("test_series_1", now)
+	queryResult, err := client.Query("test_series_1", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 	require.Equal(t, expectedVector, queryResult.(model.Vector))
 
-	rangeResult, err := c.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
+	rangeResult, err := client.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
+	labelValues, err := client.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
+	labelNames, err := client.LabelNames(prometheusMinTime, prometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }
@@ -110,7 +110,7 @@ func TestReadWriteModeRecordingRule(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	c, _, backendInstance := startReadWriteModeCluster(
+	client, cluster := startReadWriteModeCluster(
 		t,
 		s,
 		map[string]string{
@@ -125,7 +125,7 @@ func TestReadWriteModeRecordingRule(t *testing.T) {
 	pushTime := time.Now()
 	series, _, _ := generateSeries("test_series", pushTime, prompb.Label{Name: "foo", Value: "bar"})
 
-	res, err := c.Push(series)
+	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
@@ -150,14 +150,14 @@ func TestReadWriteModeRecordingRule(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, c.SetRuleGroup(ruleGroup, "test_rule_group_namespace"))
+	require.NoError(t, client.SetRuleGroup(ruleGroup, "test_rule_group_namespace"))
 
 	// Wait for recording rule to evaluate
-	require.NoError(t, backendInstance.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
+	require.NoError(t, cluster.backendInstance.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
 
 	// Verify recorded series is as expected
 	queryTime := time.Now()
-	queryResult, err := c.Query(testRuleName, queryTime)
+	queryResult, err := client.Query(testRuleName, queryTime)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 
@@ -179,7 +179,7 @@ func TestReadWriteModeAlertingRule(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	c, _, backendInstance := startReadWriteModeCluster(
+	client, cluster := startReadWriteModeCluster(
 		t,
 		s,
 		map[string]string{
@@ -198,7 +198,7 @@ route:
 receivers:
   - name: test-receiver
 `
-	require.NoError(t, c.SetAlertmanagerConfig(context.Background(), alertmanagerConfig, map[string]string{}))
+	require.NoError(t, client.SetAlertmanagerConfig(context.Background(), alertmanagerConfig, map[string]string{}))
 
 	// Create alerting rule
 	alert := yaml.Node{}
@@ -220,26 +220,26 @@ receivers:
 		},
 	}
 
-	require.NoError(t, c.SetRuleGroup(ruleGroup, "test_rule_group_namespace"))
+	require.NoError(t, client.SetRuleGroup(ruleGroup, "test_rule_group_namespace"))
 
 	// Push data that should trigger the alerting rule
 	pushTime := time.Now()
 	series, _, _ := generateSeries("test_series", pushTime, prompb.Label{Name: "foo", Value: "bar"})
 
-	res, err := c.Push(series)
+	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
 	// Verify alert is firing
-	require.NoError(t, backendInstance.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_alertmanager_alerts_received_total"}, e2e.WaitMissingMetrics))
+	require.NoError(t, cluster.backendInstance.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_alertmanager_alerts_received_total"}, e2e.WaitMissingMetrics))
 
-	alerts, err := c.GetAlertsV1(context.Background())
+	alerts, err := client.GetAlertsV1(context.Background())
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
 	require.Equal(t, testAlertName, alerts[0].Name())
 }
 
-func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario, extraFlags ...map[string]string) (c *e2emimir.Client, writeInstance *e2emimir.MimirService, backendInstance *e2emimir.MimirService) {
+func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario, extraFlags ...map[string]string) (*e2emimir.Client, readWriteModeCluster) {
 	minio := e2edb.NewMinio(9000, mimirBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
@@ -254,20 +254,28 @@ func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario, extraFlags ...map[
 	commonFlags := mergeFlags(flagSets...)
 	backendFlags := mergeFlags(commonFlags, map[string]string{"-ruler.alertmanager-url": "http://localhost:8080/alertmanager"})
 
-	readInstance := e2emimir.NewReadInstance("mimir-read-1", commonFlags)
-	writeInstance = e2emimir.NewWriteInstance("mimir-write-1", commonFlags)
-	backendInstance = e2emimir.NewBackendInstance("mimir-backend-1", backendFlags)
-	require.NoError(t, s.StartAndWaitReady(readInstance, writeInstance, backendInstance))
+	cluster := readWriteModeCluster{
+		readInstance:    e2emimir.NewReadInstance("mimir-read-1", commonFlags),
+		writeInstance:   e2emimir.NewWriteInstance("mimir-write-1", commonFlags),
+		backendInstance: e2emimir.NewBackendInstance("mimir-backend-1", backendFlags),
+	}
+	require.NoError(t, s.StartAndWaitReady(cluster.readInstance, cluster.writeInstance, cluster.backendInstance))
 
-	c, err := e2emimir.NewClient(writeInstance.HTTPEndpoint(), readInstance.HTTPEndpoint(), backendInstance.HTTPEndpoint(), backendInstance.HTTPEndpoint(), "user-1")
+	client, err := e2emimir.NewClient(cluster.writeInstance.HTTPEndpoint(), cluster.readInstance.HTTPEndpoint(), cluster.backendInstance.HTTPEndpoint(), cluster.backendInstance.HTTPEndpoint(), "user-1")
 	require.NoError(t, err)
 
 	// Wait for the ingester to join the ring and become active - this prevents "empty ring" errors later when we try to query data.
-	require.NoError(t, readInstance.WaitSumMetricsWithOptions(
+	require.NoError(t, cluster.readInstance.WaitSumMetricsWithOptions(
 		e2e.Equals(1),
 		[]string{"cortex_ring_members"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"), labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
 	))
 
-	return
+	return client, cluster
+}
+
+type readWriteModeCluster struct {
+	readInstance    *e2emimir.MimirService
+	writeInstance   *e2emimir.MimirService
+	backendInstance *e2emimir.MimirService
 }


### PR DESCRIPTION
#### What this PR does

This PR adds two further integration tests for read-write deployment mode:
* querying from long-term storage
* alerting

One unexpected behaviour I ran into was that I needed to configure the Alertmanager URL in the alerting test. Should backend instances be configured to send alerts to themselves by default? (Is there any situation where this wouldn't be a reasonable default?)

On top of this, when no Alertmanager URL is configured, the alerts aren't sent anywhere and no warning is logged - should we perhaps log a warning when alerting rules are configured but the Alertmanager URL isn't set? 

#### Which issue(s) this PR fixes or relates to

#3363

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
