### PR TITLE
Rollout operator psp

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.2.0`. #3624
 * [ENHANCEMENT] Add ability to manage PrometheusRule for metamonitoring with Prometheus operator from the Helm chart. The alerts are disabled by default but can be enabled with `prometheusRule.mimirAlerts` set to `true`. To enable the default rules, set `mimirRules` to `true`. #2134 #2609
+* [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary
 
 ## 4.0.0
 

--- a/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
@@ -15,4 +15,8 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "mimir.serviceAccountName" . }}
+{{- if .Values.rollout_operator.enabled }}
+- kind: ServiceAccount
+  name: {{ include "rollout-operator.serviceAccountName" . }}
+{{- end }}
 {{- end }}

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: gateway-enterprise-values-mimir
+- kind: ServiceAccount
+  name: gateway-enterprise-values-mimir-distributed

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: gateway-nginx-values-mimir
+- kind: ServiceAccount
+  name: gateway-nginx-values-mimir-distributed

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: large-values-mimir
+- kind: ServiceAccount
+  name: large-values-mimir-distributed

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: scheduler-name-values-mimir
+- kind: ServiceAccount
+  name: scheduler-name-values-mimir-distributed

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: small-values-mimir
+- kind: ServiceAccount
+  name: small-values-mimir-distributed

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: test-enterprise-legacy-label-values-enterprise-metrics
+- kind: ServiceAccount
+  name: test-enterprise-legacy-label-values-mimir-distributed

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: test-enterprise-values-mimir
+- kind: ServiceAccount
+  name: test-enterprise-values-mimir-distributed

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: test-oss-logical-multizone-values-mimir
+- kind: ServiceAccount
+  name: test-oss-logical-multizone-values-mimir-distributed

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -16,3 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: test-oss-multizone-values-mimir
+- kind: ServiceAccount
+  name: test-oss-multizone-values-mimir-distributed


### PR DESCRIPTION
#### What this PR does
This PR enables the rollout-operator serviceAccount to use podSecurityPolicies. 

#### Which issue(s) this PR fixes or relates to
Currently mimir has the possibility to use podSecurityPolicies for all components with the exception of the rollout-operator,
which makes the deployment of the rollout-operator impossible in an environment, where the use of podSecurityPolicies are active.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
