### PR TITLE
streaming store-gateway: Add caching of series when skipChunks

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -145,15 +145,15 @@ func (c noopCache) FetchExpandedPostings(_ context.Context, _ string, _ ulid.ULI
 	return nil, false
 }
 
-func (noopCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+func (noopCache) StoreSeries(_ context.Context, _ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ *sharding.ShardSelector, _ []byte) {
 }
-func (noopCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
+func (noopCache) FetchSeries(_ context.Context, _ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ *sharding.ShardSelector) ([]byte, bool) {
 	return nil, false
 }
 
-func (noopCache) StoreSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, v []byte) {
+func (noopCache) StoreSeriesForPostings(_ context.Context, _ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ *sharding.ShardSelector, _ indexcache.PostingsKey, _ []byte) {
 }
-func (noopCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey) ([]byte, bool) {
+func (noopCache) FetchSeriesForPostings(_ context.Context, _ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ *sharding.ShardSelector, _ indexcache.PostingsKey) ([]byte, bool) {
 	return nil, false
 }
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2345,12 +2345,12 @@ type cacheNotExpectingToStoreSeries struct {
 	t *testing.T
 }
 
-func (c cacheNotExpectingToStoreSeries) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, v []byte) {
+func (c cacheNotExpectingToStoreSeries) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
 	c.t.Fatalf("StoreSeries should not be called")
 }
 
-func (c cacheNotExpectingToStoreSeries) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	c.t.Fatalf("StoreSeriesParts should not be called")
+func (c cacheNotExpectingToStoreSeries) StoreSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, v []byte) {
+	c.t.Fatalf("StoreSeriesForPostings should not be called")
 }
 
 type headGenOptions struct {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2319,8 +2319,8 @@ func TestBlockSeries_Cache(t *testing.T) {
 		}
 
 		// Cache should be filled by now.
-		// We break the LookupSymbol so we know for sure we'll be using the cache in the next calls.
-		indexr.dec.LookupSymbol = nil
+		// We break the index cache to not allow looking up series, so we know we don't look up series.
+		indexr.block.indexCache = forbiddenFetchMultiSeriesForRefsIndexCache{b.indexCache, t}
 		for i, tc := range testCases {
 			ss, _, err := blockSeries(context.Background(), indexr, nil, nil, tc.matchers, tc.shard, shc, nil, sl, true, b.meta.MinTime, b.meta.MaxTime, log.NewNopLogger())
 			require.NoError(t, err, "Unexpected error for test case %d", i)
@@ -2345,7 +2345,7 @@ type cacheNotExpectingToStoreSeries struct {
 	t *testing.T
 }
 
-func (c cacheNotExpectingToStoreSeries) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
+func (c cacheNotExpectingToStoreSeries) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, v []byte) {
 	c.t.Fatalf("StoreSeries should not be called")
 }
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2345,8 +2345,12 @@ type cacheNotExpectingToStoreSeries struct {
 	t *testing.T
 }
 
-func (c cacheNotExpectingToStoreSeries) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+func (c cacheNotExpectingToStoreSeries) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
 	c.t.Fatalf("StoreSeries should not be called")
+}
+
+func (c cacheNotExpectingToStoreSeries) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey indexcache.LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+	c.t.Fatalf("StoreSeriesParts should not be called")
 }
 
 type headGenOptions struct {

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -23,6 +23,7 @@ const (
 	cacheTypeSeriesForRef     = "SeriesForRef"
 	cacheTypeExpandedPostings = "ExpandedPostings"
 	cacheTypeSeries           = "Series"
+	cacheTypeSeriesParts      = "SeriesParts"
 	cacheTypeLabelNames       = "LabelNames"
 	cacheTypeLabelValues      = "LabelValues"
 )
@@ -33,6 +34,7 @@ var (
 		cacheTypeSeriesForRef,
 		cacheTypeExpandedPostings,
 		cacheTypeSeries,
+		cacheTypeSeriesParts,
 		cacheTypeLabelNames,
 		cacheTypeLabelValues,
 	}

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -97,7 +97,7 @@ func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
 	})
 
 	// We hash the postings list twice to minimize the chance of collisions
-	hasher1 := fnv.New64a()
+	hasher1, _ := blake2b.New256(nil) // This will never return an error
 	hasher2 := sha1.New()
 
 	_, _ = hasher1.Write(sorted)

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -60,10 +60,14 @@ type IndexCache interface {
 	// FetchExpandedPostings fetches the result of ExpandedPostings, encoded with an unspecified codec.
 	FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey) ([]byte, bool)
 
+	// StoreSeriesParts stores the number of parts in which this series was cached
+	StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte)
 	// StoreSeries stores the result of a Series() call.
-	StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte)
+	StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte)
+	// FetchSeriesParts stores the number of parts in which this series was cached
+	FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool)
 	// FetchSeries fetches the result of a Series() call.
-	FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool)
+	FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool)
 
 	// StoreLabelNames stores the result of a LabelNames() call.
 	StoreLabelNames(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, v []byte)

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -91,22 +91,19 @@ type PostingsKey string
 
 // CanonicalPostingsKey creates a canonical version of PostingsKey
 func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
-	sorted := make([]byte, len(postings)*8)
+	hashable := make([]byte, len(postings)*8)
 	for i, posting := range postings {
 		for octet := 0; octet < 8; octet++ {
-			sorted[i+octet] = byte(posting >> (octet * 8))
+			hashable[i+octet] = byte(posting >> (octet * 8))
 		}
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i] < sorted[j]
-	})
 
 	// We hash the postings list twice to minimize the chance of collisions
 	hasher1, _ := blake2b.New256(nil) // This will never return an error
 	hasher2 := sha1.New()
 
-	_, _ = hasher1.Write(sorted)
-	_, _ = hasher2.Write(sorted)
+	_, _ = hasher1.Write(hashable)
+	_, _ = hasher2.Write(hashable)
 
 	checksum := hasher2.Sum(hasher1.Sum(nil))
 

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -49,7 +49,6 @@ func BenchmarkCanonicalPostingsKey(b *testing.B) {
 	}
 	for numPostings := 10; numPostings <= len(ms); numPostings *= 10 {
 		b.Run(fmt.Sprintf("%d postings", numPostings), func(b *testing.B) {
-			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = CanonicalPostingsKey(ms[:numPostings])
 			}

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/mimir/pkg/util/test"
@@ -36,6 +37,21 @@ func BenchmarkCanonicalLabelMatchersKey(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = CanonicalLabelMatchersKey(ms[:l])
+			}
+		})
+	}
+}
+
+func BenchmarkCanonicalPostingsKey(b *testing.B) {
+	ms := make([]storage.SeriesRef, 1_000_000)
+	for i := range ms {
+		ms[i] = storage.SeriesRef(i)
+	}
+	for numPostings := 10; numPostings <= len(ms); numPostings *= 10 {
+		b.Run(fmt.Sprintf("%d postings", numPostings), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = CanonicalPostingsKey(ms[:numPostings])
 			}
 		})
 	}

--- a/pkg/storegateway/indexcache/inmemory.go
+++ b/pkg/storegateway/indexcache/inmemory.go
@@ -346,7 +346,7 @@ func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, userID str
 }
 
 func (c *InMemoryIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	// TODO dimitarvdimitrov
+	c.set(cacheKeySeriesParts{userID, blockID, matchersKey, shardKey(shard)}, v)
 }
 
 // StoreSeries stores the result of a Series() call.
@@ -355,8 +355,7 @@ func (c *InMemoryIndexCache) StoreSeries(ctx context.Context, userID string, blo
 }
 
 func (c *InMemoryIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
-	// TODO dimitarvdimitrov
-	return nil, false
+	return c.get(cacheKeySeriesParts{userID, blockID, matchersKey, shardKey(shard)})
 }
 
 // FetchSeries fetches the result of a Series() call.
@@ -445,6 +444,21 @@ func (c cacheKeySeries) typ() string {
 }
 
 func (c cacheKeySeries) size() uint64 {
+	return stringSize(c.userID) + ulidSize + stringSize(string(c.matchersKey)) + stringSize(c.shard) + 8
+}
+
+type cacheKeySeriesParts struct {
+	userID      string
+	block       ulid.ULID
+	matchersKey LabelMatchersKey
+	shard       string
+}
+
+func (c cacheKeySeriesParts) typ() string {
+	return cacheTypeSeriesParts
+}
+
+func (c cacheKeySeriesParts) size() uint64 {
 	return stringSize(c.userID) + ulidSize + stringSize(string(c.matchersKey)) + stringSize(c.shard)
 }
 

--- a/pkg/storegateway/indexcache/inmemory.go
+++ b/pkg/storegateway/indexcache/inmemory.go
@@ -346,22 +346,22 @@ func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, userID str
 }
 
 // StoreSeries stores the result of a Series() call.
-func (c *InMemoryIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+func (c *InMemoryIndexCache) StoreSeries(_ context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
 	c.set(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard)}, v)
 }
 
 // FetchSeries fetches the result of a Series() call.
-func (c *InMemoryIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
+func (c *InMemoryIndexCache) FetchSeries(_ context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
 	return c.get(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard)})
 }
 
 // StoreSeriesForPostings stores a series set for the provided postings.
-func (c *InMemoryIndexCache) StoreSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
+func (c *InMemoryIndexCache) StoreSeriesForPostings(_ context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
 	c.set(cacheKeySeriesForPostings{userID, blockID, matchersKey, shardKey(shard), postingsKey}, v)
 }
 
 // FetchSeriesForPostings fetches a series set for the provided postings.
-func (c *InMemoryIndexCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
+func (c *InMemoryIndexCache) FetchSeriesForPostings(_ context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
 	return c.get(cacheKeySeriesForPostings{userID, blockID, matchersKey, shardKey(shard), postingsKey})
 }
 

--- a/pkg/storegateway/indexcache/inmemory.go
+++ b/pkg/storegateway/indexcache/inmemory.go
@@ -346,13 +346,23 @@ func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, userID str
 }
 
 // StoreSeries stores the result of a Series() call.
-func (c *InMemoryIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
-	c.set(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard), postingsKey}, v)
+func (c *InMemoryIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+	c.set(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard)}, v)
 }
 
 // FetchSeries fetches the result of a Series() call.
-func (c *InMemoryIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
-	return c.get(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard), postingsKey})
+func (c *InMemoryIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
+	return c.get(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard)})
+}
+
+// StoreSeriesForPostings stores a series set for the provided postings.
+func (c *InMemoryIndexCache) StoreSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
+	c.set(cacheKeySeriesForPostings{userID, blockID, matchersKey, shardKey(shard), postingsKey}, v)
+}
+
+// FetchSeriesForPostings fetches a series set for the provided postings.
+func (c *InMemoryIndexCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
+	return c.get(cacheKeySeriesForPostings{userID, blockID, matchersKey, shardKey(shard), postingsKey})
 }
 
 // StoreLabelNames stores the result of a LabelNames() call.
@@ -428,7 +438,6 @@ type cacheKeySeries struct {
 	block       ulid.ULID
 	matchersKey LabelMatchersKey
 	shard       string
-	postingsKey PostingsKey
 }
 
 func (c cacheKeySeries) typ() string {
@@ -436,6 +445,22 @@ func (c cacheKeySeries) typ() string {
 }
 
 func (c cacheKeySeries) size() uint64 {
+	return stringSize(c.userID) + ulidSize + stringSize(string(c.matchersKey)) + stringSize(c.shard)
+}
+
+type cacheKeySeriesForPostings struct {
+	userID      string
+	block       ulid.ULID
+	matchersKey LabelMatchersKey
+	shard       string
+	postingsKey PostingsKey
+}
+
+func (c cacheKeySeriesForPostings) typ() string {
+	return cacheTypeSeriesForPostings
+}
+
+func (c cacheKeySeriesForPostings) size() uint64 {
 	return stringSize(c.userID) + ulidSize + stringSize(string(c.matchersKey)) + stringSize(c.shard) + stringSize(string(c.postingsKey))
 }
 

--- a/pkg/storegateway/indexcache/inmemory.go
+++ b/pkg/storegateway/indexcache/inmemory.go
@@ -345,14 +345,23 @@ func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, userID str
 	return c.get(cacheKeyExpandedPostings{userID, blockID, key})
 }
 
+func (c *InMemoryIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+	// TODO dimitarvdimitrov
+}
+
 // StoreSeries stores the result of a Series() call.
-func (c *InMemoryIndexCache) StoreSeries(_ context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	c.set(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard)}, v)
+func (c *InMemoryIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
+	c.set(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard), part}, v)
+}
+
+func (c *InMemoryIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
+	// TODO dimitarvdimitrov
+	return nil, false
 }
 
 // FetchSeries fetches the result of a Series() call.
-func (c *InMemoryIndexCache) FetchSeries(_ context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
-	return c.get(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard)})
+func (c *InMemoryIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool) {
+	return c.get(cacheKeySeries{userID, blockID, matchersKey, shardKey(shard), part})
 }
 
 // StoreLabelNames stores the result of a LabelNames() call.
@@ -428,6 +437,7 @@ type cacheKeySeries struct {
 	block       ulid.ULID
 	matchersKey LabelMatchersKey
 	shard       string
+	part        int
 }
 
 func (c cacheKeySeries) typ() string {

--- a/pkg/storegateway/indexcache/inmemory_test.go
+++ b/pkg/storegateway/indexcache/inmemory_test.go
@@ -172,10 +172,10 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		{
 			typ: cacheTypeSeries,
 			set: func(id uint64, b []byte) {
-				cache.StoreSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, b)
+				cache.StoreSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, 0, b)
 			},
 			get: func(id uint64) ([]byte, bool) {
-				return cache.FetchSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard)
+				return cache.FetchSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, 0)
 			},
 		},
 		{

--- a/pkg/storegateway/indexcache/inmemory_test.go
+++ b/pkg/storegateway/indexcache/inmemory_test.go
@@ -172,19 +172,10 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		{
 			typ: cacheTypeSeries,
 			set: func(id uint64, b []byte) {
-				cache.StoreSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, 0, b)
+				cache.StoreSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, CanonicalPostingsKey([]storage.SeriesRef{1}), b)
 			},
 			get: func(id uint64) ([]byte, bool) {
-				return cache.FetchSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, 0)
-			},
-		},
-		{
-			typ: cacheTypeSeriesParts,
-			set: func(id uint64, b []byte) {
-				cache.StoreSeriesParts(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, b)
-			},
-			get: func(id uint64) ([]byte, bool) {
-				return cache.FetchSeriesParts(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard)
+				return cache.FetchSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, CanonicalPostingsKey([]storage.SeriesRef{1}))
 			},
 		},
 		{

--- a/pkg/storegateway/indexcache/inmemory_test.go
+++ b/pkg/storegateway/indexcache/inmemory_test.go
@@ -179,6 +179,15 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 			},
 		},
 		{
+			typ: cacheTypeSeriesParts,
+			set: func(id uint64, b []byte) {
+				cache.StoreSeriesParts(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, b)
+			},
+			get: func(id uint64) ([]byte, bool) {
+				return cache.FetchSeriesParts(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard)
+			},
+		},
+		{
 			typ: cacheTypeLabelNames,
 			set: func(id uint64, b []byte) {
 				cache.StoreLabelNames(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), b)

--- a/pkg/storegateway/indexcache/inmemory_test.go
+++ b/pkg/storegateway/indexcache/inmemory_test.go
@@ -172,10 +172,19 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		{
 			typ: cacheTypeSeries,
 			set: func(id uint64, b []byte) {
-				cache.StoreSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, CanonicalPostingsKey([]storage.SeriesRef{1}), b)
+				cache.StoreSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, b)
 			},
 			get: func(id uint64) ([]byte, bool) {
-				return cache.FetchSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, CanonicalPostingsKey([]storage.SeriesRef{1}))
+				return cache.FetchSeries(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard)
+			},
+		},
+		{
+			typ: cacheTypeSeriesForPostings,
+			set: func(id uint64, b []byte) {
+				cache.StoreSeriesForPostings(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, CanonicalPostingsKey([]storage.SeriesRef{1}), b)
+			},
+			get: func(id uint64) ([]byte, bool) {
+				return cache.FetchSeriesForPostings(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), shard, CanonicalPostingsKey([]storage.SeriesRef{1}))
 			},
 		},
 		{

--- a/pkg/storegateway/indexcache/memcached.go
+++ b/pkg/storegateway/indexcache/memcached.go
@@ -248,8 +248,8 @@ func (c *MemcachedIndexCache) FetchSeriesForPostings(ctx context.Context, userID
 
 func seriesForPostingsCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) string {
 	hash := blake2b.Sum256([]byte(matchersKey))
-	// We use SS: as S: is already used for SeriesForRef
-	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + string(postingsKey) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
+	// We use SP: as S: is already used for SeriesForRef and SS: is already used for Series
+	return "SP:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + string(postingsKey) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
 }
 
 // StoreLabelNames stores the result of a LabelNames() call.

--- a/pkg/storegateway/indexcache/memcached.go
+++ b/pkg/storegateway/indexcache/memcached.go
@@ -220,34 +220,20 @@ func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatch
 	return "E:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
 }
 
-func (c *MemcachedIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	c.set(ctx, cacheTypeSeries, seriesPartsCacheKey(userID, blockID, matchersKey, shard), v)
-}
-
 // StoreSeries stores the result of a Series() call.
-func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
-	c.set(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard, part), v)
-}
-
-func (c *MemcachedIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
-	return c.get(ctx, cacheTypeSeriesParts, seriesPartsCacheKey(userID, blockID, matchersKey, shard))
+func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
+	c.set(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard, postingsKey), v)
 }
 
 // FetchSeries fetches the result of a Series() call.
-func (c *MemcachedIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool) {
-	return c.get(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard, part))
+func (c *MemcachedIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
+	return c.get(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard, postingsKey))
 }
 
-func seriesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) string {
+func seriesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) string {
 	hash := blake2b.Sum256([]byte(matchersKey))
 	// We use SS: as S: is already used for SeriesForRef
-	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + strconv.Itoa(part) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
-}
-
-func seriesPartsCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) string {
-	hash := blake2b.Sum256([]byte(matchersKey))
-	// We use SS: as S: is already used for SeriesForRef
-	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":parts:" + base64.RawURLEncoding.EncodeToString(hash[0:])
+	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + string(postingsKey) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
 }
 
 // StoreLabelNames stores the result of a LabelNames() call.

--- a/pkg/storegateway/indexcache/memcached.go
+++ b/pkg/storegateway/indexcache/memcached.go
@@ -221,7 +221,7 @@ func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatch
 }
 
 func (c *MemcachedIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	// TODO dimitarvdimitrov
+	c.set(ctx, cacheTypeSeries, seriesPartsCacheKey(userID, blockID, matchersKey, shard), v)
 }
 
 // StoreSeries stores the result of a Series() call.
@@ -230,8 +230,7 @@ func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, userID string, bl
 }
 
 func (c *MemcachedIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
-	// TODO dimitarvdimitrov
-	return nil, false
+	return c.get(ctx, cacheTypeSeriesParts, seriesPartsCacheKey(userID, blockID, matchersKey, shard))
 }
 
 // FetchSeries fetches the result of a Series() call.
@@ -243,6 +242,12 @@ func seriesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersK
 	hash := blake2b.Sum256([]byte(matchersKey))
 	// We use SS: as S: is already used for SeriesForRef
 	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + strconv.Itoa(part) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
+}
+
+func seriesPartsCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) string {
+	hash := blake2b.Sum256([]byte(matchersKey))
+	// We use SS: as S: is already used for SeriesForRef
+	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":parts:" + base64.RawURLEncoding.EncodeToString(hash[0:])
 }
 
 // StoreLabelNames stores the result of a LabelNames() call.

--- a/pkg/storegateway/indexcache/memcached.go
+++ b/pkg/storegateway/indexcache/memcached.go
@@ -220,20 +220,29 @@ func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatch
 	return "E:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
 }
 
+func (c *MemcachedIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+	// TODO dimitarvdimitrov
+}
+
 // StoreSeries stores the result of a Series() call.
-func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	c.set(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard), v)
+func (c *MemcachedIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
+	c.set(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard, part), v)
+}
+
+func (c *MemcachedIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
+	// TODO dimitarvdimitrov
+	return nil, false
 }
 
 // FetchSeries fetches the result of a Series() call.
-func (c *MemcachedIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
-	return c.get(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard))
+func (c *MemcachedIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool) {
+	return c.get(ctx, cacheTypeSeries, seriesCacheKey(userID, blockID, matchersKey, shard, part))
 }
 
-func seriesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) string {
+func seriesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) string {
 	hash := blake2b.Sum256([]byte(matchersKey))
 	// We use SS: as S: is already used for SeriesForRef
-	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
+	return "SS:" + userID + ":" + blockID.String() + ":" + shardKey(shard) + ":" + strconv.Itoa(part) + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
 }
 
 // StoreLabelNames stores the result of a LabelNames() call.

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -393,11 +393,11 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			// Store the postings expected before running the test.
 			ctx := context.Background()
 			for _, p := range testData.setup {
-				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, p.value)
+				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, 0, p.value)
 			}
 
 			// Fetch postings from cached and assert on it.
-			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard)
+			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, 0)
 			assert.Equal(t, testData.expectedData, data)
 			assert.Equal(t, testData.expectedOk, ok)
 

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -333,6 +333,8 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 	value3 := []byte{3}
 	shard1 := (*sharding.ShardSelector)(nil)
 	shard2 := &sharding.ShardSelector{ShardIndex: 1, ShardCount: 16}
+	postings1 := []storage.SeriesRef{1, 2}
+	postings2 := []storage.SeriesRef{2, 3}
 
 	tests := map[string]struct {
 		setup        []mockedSeries
@@ -341,7 +343,7 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 		fetchBlockID ulid.ULID
 		fetchKey     LabelMatchersKey
 		fetchShard   *sharding.ShardSelector
-		part         int
+		postings     []storage.SeriesRef
 		expectedData []byte
 		expectedOk   bool
 	}{
@@ -351,54 +353,41 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			fetchBlockID: block1,
 			fetchKey:     CanonicalLabelMatchersKey(matchers1),
 			fetchShard:   shard1,
-			part:         1,
+			postings:     postings1,
 			expectedData: nil,
 			expectedOk:   false,
 		},
 		"should return no miss on hit": {
 			setup: []mockedSeries{
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value1},
-				{userID: user2, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value2}, // different user
-				{userID: user1, block: block1, matchers: matchers1, shard: shard2, part: 1, value: value2}, // different shard
-				{userID: user1, block: block1, matchers: matchers2, shard: shard1, part: 1, value: value2}, // different matchers
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 1, value: value3}, // different block
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 2, value: value3}, // different part
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, postings: postings1, value: value1},
+				{userID: user2, block: block1, matchers: matchers1, shard: shard1, postings: postings1, value: value2}, // different user
+				{userID: user1, block: block1, matchers: matchers1, shard: shard2, postings: postings1, value: value2}, // different shard
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, postings: postings1, value: value2}, // different matchers
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, postings: postings1, value: value3}, // different block
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, postings: postings2, value: value3}, // different postings
 			},
 			fetchUserID:  user1,
 			fetchBlockID: block1,
 			fetchKey:     CanonicalLabelMatchersKey(matchers1),
 			fetchShard:   shard1,
-			part:         1,
+			postings:     postings1,
 			expectedData: value1,
 			expectedOk:   true,
 		},
 		"should return no hit on memcached error": {
 			setup: []mockedSeries{
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, value: value1},
-				{userID: user1, block: block1, matchers: matchers2, shard: shard1, value: value2},
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, value: value3},
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, postings: postings1, value: value1},
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, postings: postings1, value: value2},
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, postings: postings1, value: value3},
 			},
 			mockedErr:    context.DeadlineExceeded,
 			fetchUserID:  user1,
 			fetchBlockID: block1,
 			fetchKey:     CanonicalLabelMatchersKey(matchers1),
 			fetchShard:   shard1,
-			part:         1,
+			postings:     postings1,
 			expectedData: nil,
 			expectedOk:   false,
-		},
-		"should accept negative part": {
-			setup: []mockedSeries{
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: -1, value: value1},
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value2},
-			},
-			fetchUserID:  user1,
-			fetchBlockID: block1,
-			fetchKey:     CanonicalLabelMatchersKey(matchers1),
-			fetchShard:   shard1,
-			part:         -1,
-			expectedData: value1,
-			expectedOk:   true,
 		},
 	}
 
@@ -411,11 +400,11 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			// Store the postings expected before running the test.
 			ctx := context.Background()
 			for _, p := range testData.setup {
-				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, p.part, p.value)
+				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, CanonicalPostingsKey(p.postings), p.value)
 			}
 
 			// Fetch postings from cached and assert on it.
-			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, testData.part)
+			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, CanonicalPostingsKey(testData.postings))
 			assert.Equal(t, testData.expectedData, data)
 			assert.Equal(t, testData.expectedOk, ok)
 
@@ -427,109 +416,6 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			assert.Equal(t, float64(1), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeries)))
 			assert.Equal(t, expectedHits, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeries)))
 			for _, typ := range remove(allCacheTypes, cacheTypeSeries) {
-				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(typ)))
-				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(typ)))
-			}
-		})
-	}
-}
-
-func TestMemcachedIndexCache_FetchSeriesParts(t *testing.T) {
-	t.Parallel()
-
-	// Init some data to conveniently define test cases later one.
-	user1 := "tenant1"
-	user2 := "tenant2"
-	block1 := ulid.MustNew(1, nil)
-	block2 := ulid.MustNew(2, nil)
-	matchers1 := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
-	matchers2 := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "baz", "boo")}
-	value1 := []byte{1}
-	value2 := []byte{2}
-	value3 := []byte{3}
-	shard1 := (*sharding.ShardSelector)(nil)
-	shard2 := &sharding.ShardSelector{ShardIndex: 1, ShardCount: 16}
-
-	tests := map[string]struct {
-		setup        []mockedSeries
-		mockedErr    error
-		fetchUserID  string
-		fetchBlockID ulid.ULID
-		fetchKey     LabelMatchersKey
-		fetchShard   *sharding.ShardSelector
-		part         int
-		expectedData []byte
-		expectedOk   bool
-	}{
-		"should return no hit on empty cache": {
-			setup:        []mockedSeries{},
-			fetchUserID:  user1,
-			fetchBlockID: block1,
-			fetchKey:     CanonicalLabelMatchersKey(matchers1),
-			fetchShard:   shard1,
-			part:         1,
-			expectedData: nil,
-			expectedOk:   false,
-		},
-		"should return no miss on hit": {
-			setup: []mockedSeries{
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value1},
-				{userID: user2, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value2}, // different user
-				{userID: user1, block: block1, matchers: matchers1, shard: shard2, part: 1, value: value2}, // different shard
-				{userID: user1, block: block1, matchers: matchers2, shard: shard1, part: 1, value: value2}, // different matchers
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 1, value: value3}, // different block
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 2, value: value3}, // different part
-			},
-			fetchUserID:  user1,
-			fetchBlockID: block1,
-			fetchKey:     CanonicalLabelMatchersKey(matchers1),
-			fetchShard:   shard1,
-			part:         1,
-			expectedData: value1,
-			expectedOk:   true,
-		},
-		"should return no hit on memcached error": {
-			setup: []mockedSeries{
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, value: value1},
-				{userID: user1, block: block1, matchers: matchers2, shard: shard1, value: value2},
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, value: value3},
-			},
-			mockedErr:    context.DeadlineExceeded,
-			fetchUserID:  user1,
-			fetchBlockID: block1,
-			fetchKey:     CanonicalLabelMatchersKey(matchers1),
-			fetchShard:   shard1,
-			part:         1,
-			expectedData: nil,
-			expectedOk:   false,
-		},
-	}
-
-	for testName, testData := range tests {
-		t.Run(testName, func(t *testing.T) {
-			memcached := newMockedMemcachedClient(testData.mockedErr)
-			c, err := NewMemcachedIndexCache(log.NewNopLogger(), memcached, nil)
-			assert.NoError(t, err)
-
-			// Store the postings expected before running the test.
-			ctx := context.Background()
-			for _, p := range testData.setup {
-				c.StoreSeriesParts(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, p.value)
-			}
-
-			// Fetch postings from cached and assert on it.
-			data, ok := c.FetchSeriesParts(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard)
-			assert.Equal(t, testData.expectedData, data)
-			assert.Equal(t, testData.expectedOk, ok)
-
-			// Assert on metrics.
-			expectedHits := 0.0
-			if testData.expectedOk {
-				expectedHits = 1.0
-			}
-			assert.Equal(t, float64(1), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeriesParts)))
-			assert.Equal(t, expectedHits, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeriesParts)))
-			for _, typ := range remove(allCacheTypes, cacheTypeSeriesParts) {
 				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(typ)))
 				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(typ)))
 			}
@@ -852,7 +738,7 @@ type mockedSeries struct {
 	block    ulid.ULID
 	matchers []*labels.Matcher
 	shard    *sharding.ShardSelector
-	part     int
+	postings []storage.SeriesRef
 	value    []byte
 }
 

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -318,7 +318,7 @@ func TestMemcachedIndexCache_FetchExpandedPostings(t *testing.T) {
 	}
 }
 
-func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
+func TestMemcachedIndexCache_FetchSeriesForPostings(t *testing.T) {
 	t.Parallel()
 
 	// Init some data to conveniently define test cases later one.
@@ -400,11 +400,110 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			// Store the postings expected before running the test.
 			ctx := context.Background()
 			for _, p := range testData.setup {
-				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, CanonicalPostingsKey(p.postings), p.value)
+				c.StoreSeriesForPostings(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, CanonicalPostingsKey(p.postings), p.value)
 			}
 
 			// Fetch postings from cached and assert on it.
-			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, CanonicalPostingsKey(testData.postings))
+			data, ok := c.FetchSeriesForPostings(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, CanonicalPostingsKey(testData.postings))
+			assert.Equal(t, testData.expectedData, data)
+			assert.Equal(t, testData.expectedOk, ok)
+
+			// Assert on metrics.
+			expectedHits := 0.0
+			if testData.expectedOk {
+				expectedHits = 1.0
+			}
+			assert.Equal(t, float64(1), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeriesForPostings)))
+			assert.Equal(t, expectedHits, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeriesForPostings)))
+			for _, typ := range remove(allCacheTypes, cacheTypeSeriesForPostings) {
+				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(typ)))
+				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(typ)))
+			}
+		})
+	}
+}
+
+func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
+	t.Parallel()
+
+	// Init some data to conveniently define test cases later one.
+	user1 := "tenant1"
+	user2 := "tenant2"
+	block1 := ulid.MustNew(1, nil)
+	block2 := ulid.MustNew(2, nil)
+	matchers1 := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
+	matchers2 := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "baz", "boo")}
+	value1 := []byte{1}
+	value2 := []byte{2}
+	value3 := []byte{3}
+	shard1 := (*sharding.ShardSelector)(nil)
+	shard2 := &sharding.ShardSelector{ShardIndex: 1, ShardCount: 16}
+
+	tests := map[string]struct {
+		setup        []mockedSeries
+		mockedErr    error
+		fetchUserID  string
+		fetchBlockID ulid.ULID
+		fetchKey     LabelMatchersKey
+		fetchShard   *sharding.ShardSelector
+		postings     []storage.SeriesRef
+		expectedData []byte
+		expectedOk   bool
+	}{
+		"should return no hit on empty cache": {
+			setup:        []mockedSeries{},
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			expectedData: nil,
+			expectedOk:   false,
+		},
+		"should return no miss on hit": {
+			setup: []mockedSeries{
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, value: value1},
+				{userID: user2, block: block1, matchers: matchers1, shard: shard1, value: value2}, // different user
+				{userID: user1, block: block1, matchers: matchers1, shard: shard2, value: value2}, // different shard
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, value: value2}, // different matchers
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, value: value3}, // different block
+			},
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			expectedData: value1,
+			expectedOk:   true,
+		},
+		"should return no hit on memcached error": {
+			setup: []mockedSeries{
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, value: value1},
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, value: value2},
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, value: value3},
+			},
+			mockedErr:    context.DeadlineExceeded,
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			expectedData: nil,
+			expectedOk:   false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			memcached := newMockedMemcachedClient(testData.mockedErr)
+			c, err := NewMemcachedIndexCache(log.NewNopLogger(), memcached, nil)
+			assert.NoError(t, err)
+
+			// Store the postings expected before running the test.
+			ctx := context.Background()
+			for _, p := range testData.setup {
+				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, p.value)
+			}
+
+			// Fetch postings from cached and assert on it.
+			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard)
 			assert.Equal(t, testData.expectedData, data)
 			assert.Equal(t, testData.expectedOk, ok)
 

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -341,6 +341,7 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 		fetchBlockID ulid.ULID
 		fetchKey     LabelMatchersKey
 		fetchShard   *sharding.ShardSelector
+		part         int
 		expectedData []byte
 		expectedOk   bool
 	}{
@@ -350,21 +351,24 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			fetchBlockID: block1,
 			fetchKey:     CanonicalLabelMatchersKey(matchers1),
 			fetchShard:   shard1,
+			part:         1,
 			expectedData: nil,
 			expectedOk:   false,
 		},
 		"should return no miss on hit": {
 			setup: []mockedSeries{
-				{userID: user1, block: block1, matchers: matchers1, shard: shard1, value: value1},
-				{userID: user2, block: block1, matchers: matchers1, shard: shard1, value: value2}, // different user
-				{userID: user1, block: block1, matchers: matchers1, shard: shard2, value: value2}, // different shard
-				{userID: user1, block: block1, matchers: matchers2, shard: shard1, value: value2}, // different matchers
-				{userID: user1, block: block2, matchers: matchers1, shard: shard1, value: value3}, // different block
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value1},
+				{userID: user2, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value2}, // different user
+				{userID: user1, block: block1, matchers: matchers1, shard: shard2, part: 1, value: value2}, // different shard
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, part: 1, value: value2}, // different matchers
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 1, value: value3}, // different block
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 2, value: value3}, // different part
 			},
 			fetchUserID:  user1,
 			fetchBlockID: block1,
 			fetchKey:     CanonicalLabelMatchersKey(matchers1),
 			fetchShard:   shard1,
+			part:         1,
 			expectedData: value1,
 			expectedOk:   true,
 		},
@@ -379,6 +383,123 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			fetchBlockID: block1,
 			fetchKey:     CanonicalLabelMatchersKey(matchers1),
 			fetchShard:   shard1,
+			part:         1,
+			expectedData: nil,
+			expectedOk:   false,
+		},
+		"should accept negative part": {
+			setup: []mockedSeries{
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: -1, value: value1},
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value2},
+			},
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			part:         -1,
+			expectedData: value1,
+			expectedOk:   true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			memcached := newMockedMemcachedClient(testData.mockedErr)
+			c, err := NewMemcachedIndexCache(log.NewNopLogger(), memcached, nil)
+			assert.NoError(t, err)
+
+			// Store the postings expected before running the test.
+			ctx := context.Background()
+			for _, p := range testData.setup {
+				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, p.part, p.value)
+			}
+
+			// Fetch postings from cached and assert on it.
+			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, testData.part)
+			assert.Equal(t, testData.expectedData, data)
+			assert.Equal(t, testData.expectedOk, ok)
+
+			// Assert on metrics.
+			expectedHits := 0.0
+			if testData.expectedOk {
+				expectedHits = 1.0
+			}
+			assert.Equal(t, float64(1), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeries)))
+			assert.Equal(t, expectedHits, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeries)))
+			for _, typ := range remove(allCacheTypes, cacheTypeSeries) {
+				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(typ)))
+				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(typ)))
+			}
+		})
+	}
+}
+
+func TestMemcachedIndexCache_FetchSeriesParts(t *testing.T) {
+	t.Parallel()
+
+	// Init some data to conveniently define test cases later one.
+	user1 := "tenant1"
+	user2 := "tenant2"
+	block1 := ulid.MustNew(1, nil)
+	block2 := ulid.MustNew(2, nil)
+	matchers1 := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
+	matchers2 := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "baz", "boo")}
+	value1 := []byte{1}
+	value2 := []byte{2}
+	value3 := []byte{3}
+	shard1 := (*sharding.ShardSelector)(nil)
+	shard2 := &sharding.ShardSelector{ShardIndex: 1, ShardCount: 16}
+
+	tests := map[string]struct {
+		setup        []mockedSeries
+		mockedErr    error
+		fetchUserID  string
+		fetchBlockID ulid.ULID
+		fetchKey     LabelMatchersKey
+		fetchShard   *sharding.ShardSelector
+		part         int
+		expectedData []byte
+		expectedOk   bool
+	}{
+		"should return no hit on empty cache": {
+			setup:        []mockedSeries{},
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			part:         1,
+			expectedData: nil,
+			expectedOk:   false,
+		},
+		"should return no miss on hit": {
+			setup: []mockedSeries{
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value1},
+				{userID: user2, block: block1, matchers: matchers1, shard: shard1, part: 1, value: value2}, // different user
+				{userID: user1, block: block1, matchers: matchers1, shard: shard2, part: 1, value: value2}, // different shard
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, part: 1, value: value2}, // different matchers
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 1, value: value3}, // different block
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, part: 2, value: value3}, // different part
+			},
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			part:         1,
+			expectedData: value1,
+			expectedOk:   true,
+		},
+		"should return no hit on memcached error": {
+			setup: []mockedSeries{
+				{userID: user1, block: block1, matchers: matchers1, shard: shard1, value: value1},
+				{userID: user1, block: block1, matchers: matchers2, shard: shard1, value: value2},
+				{userID: user1, block: block2, matchers: matchers1, shard: shard1, value: value3},
+			},
+			mockedErr:    context.DeadlineExceeded,
+			fetchUserID:  user1,
+			fetchBlockID: block1,
+			fetchKey:     CanonicalLabelMatchersKey(matchers1),
+			fetchShard:   shard1,
+			part:         1,
 			expectedData: nil,
 			expectedOk:   false,
 		},
@@ -393,11 +514,11 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			// Store the postings expected before running the test.
 			ctx := context.Background()
 			for _, p := range testData.setup {
-				c.StoreSeries(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, 0, p.value)
+				c.StoreSeriesParts(ctx, p.userID, p.block, CanonicalLabelMatchersKey(p.matchers), p.shard, p.value)
 			}
 
 			// Fetch postings from cached and assert on it.
-			data, ok := c.FetchSeries(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard, 0)
+			data, ok := c.FetchSeriesParts(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchKey, testData.fetchShard)
 			assert.Equal(t, testData.expectedData, data)
 			assert.Equal(t, testData.expectedOk, ok)
 
@@ -406,9 +527,9 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 			if testData.expectedOk {
 				expectedHits = 1.0
 			}
-			assert.Equal(t, float64(1), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeries)))
-			assert.Equal(t, expectedHits, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeries)))
-			for _, typ := range remove(allCacheTypes, cacheTypeSeries) {
+			assert.Equal(t, float64(1), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeriesParts)))
+			assert.Equal(t, expectedHits, prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeriesParts)))
+			for _, typ := range remove(allCacheTypes, cacheTypeSeriesParts) {
 				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(typ)))
 				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.hits.WithLabelValues(typ)))
 			}
@@ -731,6 +852,7 @@ type mockedSeries struct {
 	block    ulid.ULID
 	matchers []*labels.Matcher
 	shard    *sharding.ShardSelector
+	part     int
 	value    []byte
 }
 

--- a/pkg/storegateway/indexcache/memcached_test.go
+++ b/pkg/storegateway/indexcache/memcached_test.go
@@ -446,7 +446,6 @@ func TestMemcachedIndexCache_FetchSeries(t *testing.T) {
 		fetchBlockID ulid.ULID
 		fetchKey     LabelMatchersKey
 		fetchShard   *sharding.ShardSelector
-		postings     []storage.SeriesRef
 		expectedData []byte
 		expectedOk   bool
 	}{

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -124,11 +124,11 @@ func (t *TracingIndexCache) FetchSeriesForPostings(ctx context.Context, userID s
 	spanLogger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(spanLogger).Log(
 		"msg", "IndexCache.FetchSeriesForPostings",
-		"requested key", matchersKey,
+		"matchers_key", matchersKey,
 		"shard", shardKey(shard),
 		"found", found,
-		"time elapsed", time.Since(t0),
-		"returned bytes", len(data),
+		"time_elapsed", time.Since(t0),
+		"returned_bytes", len(data),
 		"user_id", userID,
 		"postings_key", postingsKey,
 	)

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -91,13 +91,21 @@ func (t *TracingIndexCache) FetchExpandedPostings(ctx context.Context, userID st
 	return data, found
 }
 
-func (t *TracingIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	t.c.StoreSeries(ctx, userID, blockID, matchersKey, shard, v)
+func (t *TracingIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+	t.c.StoreSeriesParts(ctx, userID, blockID, matchersKey, shard, v)
 }
 
-func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
+func (t *TracingIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
+	t.c.StoreSeries(ctx, userID, blockID, matchersKey, shard, part, v)
+}
+
+func (t *TracingIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
+	return t.c.FetchSeriesParts(ctx, userID, blockID, matchersKey, shard)
+}
+
+func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool) {
 	t0 := time.Now()
-	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard)
+	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard, 0)
 
 	spanLogger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(spanLogger).Log(

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -105,7 +105,7 @@ func (t *TracingIndexCache) FetchSeriesParts(ctx context.Context, userID string,
 
 func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool) {
 	t0 := time.Now()
-	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard, 0)
+	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard, part)
 
 	spanLogger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(spanLogger).Log(

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -91,21 +91,13 @@ func (t *TracingIndexCache) FetchExpandedPostings(ctx context.Context, userID st
 	return data, found
 }
 
-func (t *TracingIndexCache) StoreSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
-	t.c.StoreSeriesParts(ctx, userID, blockID, matchersKey, shard, v)
+func (t *TracingIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
+	t.c.StoreSeries(ctx, userID, blockID, matchersKey, shard, postingsKey, v)
 }
 
-func (t *TracingIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int, v []byte) {
-	t.c.StoreSeries(ctx, userID, blockID, matchersKey, shard, part, v)
-}
-
-func (t *TracingIndexCache) FetchSeriesParts(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) (parts []byte, b bool) {
-	return t.c.FetchSeriesParts(ctx, userID, blockID, matchersKey, shard)
-}
-
-func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, part int) ([]byte, bool) {
+func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
 	t0 := time.Now()
-	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard, part)
+	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard, postingsKey)
 
 	spanLogger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(spanLogger).Log(

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -91,13 +91,13 @@ func (t *TracingIndexCache) FetchExpandedPostings(ctx context.Context, userID st
 	return data, found
 }
 
-func (t *TracingIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
-	t.c.StoreSeries(ctx, userID, blockID, matchersKey, shard, postingsKey, v)
+func (t *TracingIndexCache) StoreSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, v []byte) {
+	t.c.StoreSeries(ctx, userID, blockID, matchersKey, shard, v)
 }
 
-func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
+func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector) ([]byte, bool) {
 	t0 := time.Now()
-	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard, postingsKey)
+	data, found := t.c.FetchSeries(ctx, userID, blockID, matchersKey, shard)
 
 	spanLogger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(spanLogger).Log(
@@ -108,6 +108,29 @@ func (t *TracingIndexCache) FetchSeries(ctx context.Context, userID string, bloc
 		"time elapsed", time.Since(t0),
 		"returned bytes", len(data),
 		"user_id", userID,
+	)
+
+	return data, found
+}
+
+func (t *TracingIndexCache) StoreSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
+	t.c.StoreSeriesForPostings(ctx, userID, blockID, matchersKey, shard, postingsKey, v)
+}
+
+func (t *TracingIndexCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, shard *sharding.ShardSelector, postingsKey PostingsKey) ([]byte, bool) {
+	t0 := time.Now()
+	data, found := t.c.FetchSeriesForPostings(ctx, userID, blockID, matchersKey, shard, postingsKey)
+
+	spanLogger := spanlogger.FromContext(ctx, t.logger)
+	level.Debug(spanLogger).Log(
+		"msg", "IndexCache.FetchSeriesForPostings",
+		"requested key", matchersKey,
+		"shard", shardKey(shard),
+		"found", found,
+		"time elapsed", time.Since(t0),
+		"returned bytes", len(data),
+		"user_id", userID,
+		"postings_key", postingsKey,
 	)
 
 	return data, found

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -849,15 +849,15 @@ func fetchCachedSeriesForPostings(ctx context.Context, userID string, indexCache
 
 	var entry seriesForPostingsCacheEntry
 	if err := decodeSnappyGob(data, &entry); err != nil {
-		logSeiresForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "can't decode series cache", "err", err)
+		logSeriesForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "can't decode series cache", "err", err)
 		return seriesChunkRefsSet{}, false
 	}
 	if entry.MatchersKey != matchersKey {
-		logSeiresForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "cached series entry key doesn't match, possible collision", "cached_matchers", entry.MatchersKey)
+		logSeriesForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "cached series entry key doesn't match, possible collision", "cached_matchers", entry.MatchersKey)
 		return seriesChunkRefsSet{}, false
 	}
 	if entry.Shard != maybeNilShard(shard) {
-		logSeiresForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "cached series shard doesn't match, possible collision", "cached_shard", entry.Shard)
+		logSeriesForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "cached series shard doesn't match, possible collision", "cached_shard", entry.Shard)
 		return seriesChunkRefsSet{}, false
 	}
 
@@ -884,13 +884,13 @@ func storeCachedSeriesForPostings(ctx context.Context, indexCache indexcache.Ind
 
 	data, err := encodeSnappyGob(entry)
 	if err != nil {
-		logSeiresForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "can't encode series for caching", "err", err)
+		logSeriesForPostingsCacheEvent(ctx, logger, userID, blockID, matchers, shard, postingsKey, "msg", "can't encode series for caching", "err", err)
 		return
 	}
 	indexCache.StoreSeriesForPostings(ctx, userID, blockID, entry.MatchersKey, shard, postingsKey, data)
 }
 
-func logSeiresForPostingsCacheEvent(ctx context.Context, logger log.Logger, userID string, blockID ulid.ULID, matchers []*labels.Matcher, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, msgAndArgs ...any) {
+func logSeriesForPostingsCacheEvent(ctx context.Context, logger log.Logger, userID string, blockID ulid.ULID, matchers []*labels.Matcher, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, msgAndArgs ...any) {
 	var matchersStr strings.Builder
 	for _, m := range matchers {
 		matchersStr.WriteString(m.String())

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -861,7 +861,7 @@ func fetchCachedSeriesForPostings(ctx context.Context, userID string, indexCache
 		return seriesChunkRefsSet{}, false
 	}
 
-	// This can be released by the caller because loadingSeriesChunkRefsSetIterator (this function's called) doesn't retain it
+	// This can be released by the caller because loadingSeriesChunkRefsSetIterator (where this function is called) doesn't retain it
 	// after Next() will be called again.
 	res := newSeriesChunkRefsSet(len(entry.LabelSets), true)
 	for _, lset := range entry.LabelSets {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	"github.com/grafana/mimir/pkg/util/pool"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 var (
@@ -829,6 +831,61 @@ func metasToChunks(blockID ulid.ULID, metas []chunks.Meta) []seriesChunkRef {
 		}
 	}
 	return chks
+}
+
+type seriesForPostingsCacheEntry struct {
+	LabelSets   []labels.Labels
+	MatchersKey indexcache.LabelMatchersKey
+	Shard       sharding.ShardSelector
+}
+
+func fetchCachedSeriesForPostings(ctx context.Context, userID string, indexCache indexcache.IndexCache, blockID ulid.ULID, matchers []*labels.Matcher, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, logger log.Logger) (seriesChunkRefsSet, bool) {
+	matchersKey := indexcache.CanonicalLabelMatchersKey(matchers)
+	data, ok := indexCache.FetchSeriesForPostings(ctx, userID, blockID, matchersKey, shard, postingsKey)
+	if !ok {
+		return seriesChunkRefsSet{}, false
+	}
+	var entry seriesForPostingsCacheEntry
+	if err := decodeSnappyGob(data, &entry); err != nil {
+		level.Warn(spanlogger.FromContext(ctx, logger)).Log("msg", "can't decode series cache", "err", err)
+		return seriesChunkRefsSet{}, false
+	}
+	if entry.MatchersKey != matchersKey {
+		level.Debug(spanlogger.FromContext(ctx, logger)).Log("msg", "cached series entry key doesn't match, possible collision", "cached_key", entry.MatchersKey, "requested_key", matchersKey)
+		return seriesChunkRefsSet{}, false
+	}
+	if entry.Shard != maybeNilShard(shard) {
+		level.Debug(spanlogger.FromContext(ctx, logger)).Log("msg", "cached series shard doesn't match, possible collision", "cached_shard", entry.Shard, "requested_shard", maybeNilShard(shard))
+		return seriesChunkRefsSet{}, false
+	}
+
+	// This can be released by the caller because loadingSeriesChunkRefsSetIterator (this function's called) doesn't retain it
+	// after Next() will be called again.
+	res := newSeriesChunkRefsSet(len(entry.LabelSets), true)
+	for _, lset := range entry.LabelSets {
+		res.series = append(res.series, seriesChunkRefs{
+			lset: lset,
+		})
+	}
+	return res, true
+}
+
+func storeCachedSeriesForPostings(ctx context.Context, indexCache indexcache.IndexCache, userID string, blockID ulid.ULID, matchers []*labels.Matcher, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, set seriesChunkRefsSet, logger log.Logger) {
+	entry := seriesForPostingsCacheEntry{
+		LabelSets:   make([]labels.Labels, set.len()),
+		MatchersKey: indexcache.CanonicalLabelMatchersKey(matchers),
+		Shard:       maybeNilShard(shard),
+	}
+	for i, s := range set.series {
+		entry.LabelSets[i] = s.lset
+	}
+
+	data, err := encodeSnappyGob(entry)
+	if err != nil {
+		level.Error(spanlogger.FromContext(ctx, logger)).Log("msg", "can't encode series for caching", "err", err)
+		return
+	}
+	indexCache.StoreSeriesForPostings(ctx, userID, blockID, entry.MatchersKey, shard, postingsKey, data)
 }
 
 type seriesHasher interface {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -227,22 +227,6 @@ func (c flattenedSeriesChunkRefsIterator) Err() error {
 	return c.from.Err()
 }
 
-type seriesChunkRefsIteratorSeriesSetAdaptor struct {
-	from seriesChunkRefsIterator
-}
-
-func (s seriesChunkRefsIteratorSeriesSetAdaptor) Next() bool {
-	return s.from.Next()
-}
-
-func (s seriesChunkRefsIteratorSeriesSetAdaptor) At() (labels.Labels, []storepb.AggrChunk) {
-	return s.from.At().lset, nil
-}
-
-func (s seriesChunkRefsIteratorSeriesSetAdaptor) Err() error {
-	return s.from.Err()
-}
-
 type emptySeriesChunkRefsSetIterator struct {
 }
 
@@ -458,14 +442,6 @@ func newSeriesChunkRefsSeriesSet(from seriesChunkRefsSetIterator) storepb.Series
 
 func newSeriesSetWithoutChunks(ctx context.Context, batches seriesChunkRefsSetIterator) storepb.SeriesSet {
 	return newSeriesChunkRefsSeriesSet(newPreloadingSetIterator[seriesChunkRefsSet](ctx, 1, batches))
-}
-
-func extractLabelsFromSeriesChunkRefs(entries []seriesChunkRefs) (result []labels.Labels) {
-	result = make([]labels.Labels, len(entries))
-	for i := range result {
-		result[i] = entries[i].lset
-	}
-	return
 }
 
 func (s *seriesChunkRefsSeriesSet) Next() bool {

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1350,6 +1350,21 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				}},
 			},
 		},
+		"selects all series in a single batch with skipChunks": {
+			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:   100,
+			skipChunks:  true,
+			chunksLimit: 100,
+			seriesLimit: 100,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "1", "b", "1")},
+					{lset: labels.FromStrings("a", "1", "b", "2")},
+					{lset: labels.FromStrings("a", "2", "b", "1")},
+					{lset: labels.FromStrings("a", "2", "b", "2")},
+				}},
+			},
+		},
 		"selects all series in multiple batches with skipChunks": {
 			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
 			batchSize:   1,

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1451,11 +1451,13 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 	b.indexCache = newInMemoryIndexCache(t)
 
 	matchers := []*labels.Matcher{
-		labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
+		labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
 	}
 	expectedLabelSet := []labels.Labels{
 		labels.FromStrings("a", "1", "b", "1"),
 		labels.FromStrings("a", "1", "b", "2"),
+		labels.FromStrings("a", "2", "b", "1"),
+		labels.FromStrings("a", "2", "b", "2"),
 	}
 
 	indexReader := b.indexReader()
@@ -1480,6 +1482,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 
 	require.NoError(t, err)
 	lset := extractLabelsFromSeriesChunkRefsSets(readAllSeriesChunkRefsSet(ss))
+	require.NoError(t, ss.Err())
 	require.Equal(t, expectedLabelSet, lset)
 
 	// Cache should be filled by now. We pass a nil index reader to make sure.
@@ -1504,6 +1507,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 	)
 	require.NoError(t, err)
 	lset = extractLabelsFromSeriesChunkRefsSets(readAllSeriesChunkRefsSet(ss))
+	require.NoError(t, ss.Err())
 	require.Equal(t, expectedLabelSet, lset)
 }
 

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1352,7 +1352,25 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			indexReader := block.indexReader()
 			defer indexReader.Close()
 
-			iterator, err := openBlockSeriesChunkRefsSetsIterator(ctx, testCase.batchSize, indexReader, block.meta, []*labels.Matcher{testCase.matcher}, nil, hashcache.NewSeriesHashCache(1024*1024).GetBlockCache(block.meta.ULID.String()), &limiter{limit: testCase.chunksLimit}, &limiter{limit: testCase.seriesLimit}, false, block.meta.MinTime, block.meta.MaxTime, newSafeQueryStats(), NewBucketStoreMetrics(prometheus.NewRegistry()))
+			iterator, err := openBlockSeriesChunkRefsSetsIterator(
+				ctx,
+				testCase.batchSize,
+				"",
+				indexReader,
+				nil,
+				block.meta,
+				[]*labels.Matcher{testCase.matcher},
+				nil,
+				hashcache.NewSeriesHashCache(1024*1024).GetBlockCache(block.meta.ULID.String()),
+				&limiter{limit: testCase.chunksLimit},
+				&limiter{limit: testCase.seriesLimit},
+				false,
+				block.meta.MinTime,
+				block.meta.MaxTime,
+				newSafeQueryStats(),
+				NewBucketStoreMetrics(prometheus.NewRegistry()),
+				nil,
+			)
 			require.NoError(t, err)
 
 			actualSeriesSets := readAllSeriesChunkRefsSet(iterator)

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1497,13 +1497,15 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 	require.NoError(t, ss.Err())
 	require.Equal(t, expectedLabelSet, lset)
 
+	b.indexCache = forbiddenFetchMultiSeriesForRefsIndexCache{b.indexCache, t}
+
 	// Cache should be filled by now. Pass an index cache that fails the test if you try to access the postings
 	ss, err = openBlockSeriesChunkRefsSetsIterator(
 		context.Background(),
 		batchSize,
 		"",
 		indexReader,
-		forbiddenFetchMultiSeriesForRefsIndexCache{b.indexCache, t},
+		b.indexCache,
 		b.meta,
 		matchers,
 		nil,

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1473,7 +1473,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
 	}
 
-	for batchSize := 1; batchSize < len(existingSeries)*2; batchSize++ {
+	for batchSize := 1; batchSize < len(existingSeries)+2; batchSize++ {
 		batchSize := batchSize
 		t.Run(fmt.Sprintf("batch size %d", batchSize), func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

* doesn't change how the default implementation caches series
* adds caching to the streaming implementation
 	* the streaming implementation caches the series for each batch
	* part of the hash key is a reproducible hash of the postings list 
	* each different set can be cached or not, so eviction from the cache of single batches doesn't affect the cacheability of the whole request by more than necessary

__possible problems:__
* default and streaming implementations cannot reuse each other's caches because they use different keys
