### PR TITLE
Remove Symbols.Size() method used only for tests.

### DIFF
--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -180,10 +180,6 @@ func (s *Symbols) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, er
 	return uint32(s.tableLength - lastLen), nil
 }
 
-func (s *Symbols) Size() int {
-	return len(s.offsets) * 8
-}
-
 func yoloString(b []byte) string {
 	return *((*string)(unsafe.Pointer(&b)))
 }

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -49,7 +49,7 @@ func TestSymbols(t *testing.T) {
 	require.NoError(t, err)
 
 	// We store only 4 offsets to symbols.
-	require.Equal(t, 4, len(s.offsets))
+	require.Len(t, s.offsets, 4)
 
 	for i := 99; i >= 0; i-- {
 		s, err := s.Lookup(uint32(i))

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -49,7 +49,7 @@ func TestSymbols(t *testing.T) {
 	require.NoError(t, err)
 
 	// We store only 4 offsets to symbols.
-	require.Equal(t, 32, s.Size())
+	require.Equal(t, 4, len(s.offsets))
 
 	for i := 99; i >= 0; i-- {
 		s, err := s.Lookup(uint32(i))


### PR DESCRIPTION
#### What this PR does

Removes a method used only by a single test.

#### Which issue(s) this PR fixes or relates to

Fixes a suggestion from the review of [#3639](https://github.com/grafana/mimir/pull/3639/files#r1042509225).

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
