### PR TITLE
docs: update instructions for scaling down store-gateways

### DIFF
--- a/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
@@ -142,8 +142,9 @@ To guarantee no downtime when scaling down [store-gateways]({{< relref "../archi
    for store-gateways, you can in parallel scale down any number of store-gateway instances in one zone at a time.
    Zone-aware replication is enabled by default in the `mimir-distributed` Helm chart.
 1. Stop the store-gateway instances you want to scale down.
-1. Remove the stopped instances from the store-gateway ring. In your browser go to the `GET /store-gateway/ring` page that store-gateways expose on their HTTP port
-   and click "Forget" on the instances that you scaled down.
-   Alternatively, you can wait for 10 times the value of `-store-gateway.sharding-ring.heartbeat-timeout` (1m by default)
-   for the store-gateways to be automatically forgotten from the ring.
+1. If you have set the value of `-store-gateway.sharding-ring.unregister-on-shutdown` to `false`, then remove the stopped instances from the store-gateway ring:
+   1. In a browser, go to the `GET /store-gateway/ring` page that store-gateways expose on their HTTP port.
+   1. Click **Forget** on the instances that you scaled down.
+      Alternatively, wait for the duration of the value of `-store-gateway.sharding-ring.heartbeat-timeout` times 10.
+      The default value of  `-store-gateway.sharding-ring.heartbeat-timeout` is one minute.
 1. Proceed with the next two store-gateway replicas. If you are using zone-aware replication, the proceed with the next zone.

--- a/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
@@ -136,7 +136,12 @@ The required amount of time to wait depends on your configuration and it's the m
 
 To guarantee no downtime when scaling down [store-gateways]({{< relref "../architecture/components/store-gateway.md" >}}), complete the following steps:
 
-1. Scale down no more than two store-gateways at the same time.
 1. Ensure at least `-store-gateway.sharding-ring.replication-factor` store-gateway instances are running (three when running Grafana Mimir with the default configuration).
-
-> **Note:** If you enabled [zone-aware replication]({{< relref "../configure/configure-zone-aware-replication.md" >}}) for store-gateways, you can in parallel scale down any number of store-gateway instances in one zone at a time.
+1. Scale down no more than two store-gateways at the same time. If you enabled [zone-aware replication]({{< relref "../configure/configure-zone-aware-replication.md" >}})
+   for store-gateways, you can in parallel scale down any number of store-gateway instances in one zone at a time. Zone-aware replication is enabled by default in the `mimir-distributed` Helm chart.
+1. Stop the store-gateway instances you want to scale down.
+1. Remove the stopped instances from the store-gateway ring. In your browser go to the `GET /store-gateway/ring` page that store-gateways expose on their HTTP port
+   and click "Forget" on the instances that you scaled down.
+   Alternatively, you can wait for 10 times the value of `-store-gateway.sharding-ring.heartbeat-timeout` (1m by default)
+   for the store-gateways to be automatically forgotten from the ring.
+1. Proceed with the next two store-gateway replicas or the next zone when using zone-aware replication.

--- a/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
@@ -146,4 +146,4 @@ To guarantee no downtime when scaling down [store-gateways]({{< relref "../archi
    and click "Forget" on the instances that you scaled down.
    Alternatively, you can wait for 10 times the value of `-store-gateway.sharding-ring.heartbeat-timeout` (1m by default)
    for the store-gateways to be automatically forgotten from the ring.
-1. Proceed with the next two store-gateway replicas or the next zone when using zone-aware replication.
+1. Proceed with the next two store-gateway replicas. If you are using zone-aware replication, the proceed with the next zone.

--- a/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
@@ -137,8 +137,10 @@ The required amount of time to wait depends on your configuration and it's the m
 To guarantee no downtime when scaling down [store-gateways]({{< relref "../architecture/components/store-gateway.md" >}}), complete the following steps:
 
 1. Ensure at least `-store-gateway.sharding-ring.replication-factor` store-gateway instances are running (three when running Grafana Mimir with the default configuration).
-1. Scale down no more than two store-gateways at the same time. If you enabled [zone-aware replication]({{< relref "../configure/configure-zone-aware-replication.md" >}})
-   for store-gateways, you can in parallel scale down any number of store-gateway instances in one zone at a time. Zone-aware replication is enabled by default in the `mimir-distributed` Helm chart.
+1. Scale down no more than two store-gateways at the same time.
+   If you enabled [zone-aware replication]({{< relref "../configure/configure-zone-aware-replication.md" >}})
+   for store-gateways, you can in parallel scale down any number of store-gateway instances in one zone at a time.
+   Zone-aware replication is enabled by default in the `mimir-distributed` Helm chart.
 1. Stop the store-gateway instances you want to scale down.
 1. Remove the stopped instances from the store-gateway ring. In your browser go to the `GET /store-gateway/ring` page that store-gateways expose on their HTTP port
    and click "Forget" on the instances that you scaled down.

--- a/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
@@ -146,5 +146,5 @@ To guarantee no downtime when scaling down [store-gateways]({{< relref "../archi
    1. In a browser, go to the `GET /store-gateway/ring` page that store-gateways expose on their HTTP port.
    1. Click **Forget** on the instances that you scaled down.
       Alternatively, wait for the duration of the value of `-store-gateway.sharding-ring.heartbeat-timeout` times 10.
-      The default value of  `-store-gateway.sharding-ring.heartbeat-timeout` is one minute.
+      The default value of `-store-gateway.sharding-ring.heartbeat-timeout` is one minute.
 1. Proceed with the next two store-gateway replicas. If you are using zone-aware replication, the proceed with the next zone.


### PR DESCRIPTION
If we don't remove the instances form the ring before proceeding to the
next availability zone, then we risk losing redundancy for the blocks
that are replicated on these instances.

This PR updates the docs to mention forgetting the instances in the
store-gateway ring.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
