### PR TITLE
Fix makefiles in development folder to properly check yml in CI/CD

### DIFF
--- a/development/mimir-microservices-mode/Makefile
+++ b/development/mimir-microservices-mode/Makefile
@@ -5,7 +5,7 @@
 # Or follow instructions on https://github.com/google/go-jsonnet
 
 .DEFAULT_GOAL := docker-compose.yml
-.PHONY: docker-compose.yml
+.PHONY: docker-compose.yml check
 
 docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml

--- a/development/mimir-microservices-mode/Makefile
+++ b/development/mimir-microservices-mode/Makefile
@@ -4,10 +4,10 @@
 #
 # Or follow instructions on https://github.com/google/go-jsonnet
 
-.DEFAULT_GOAL := docker-compose-yml
+.DEFAULT_GOAL := docker-compose.yml
 
-docker-compose-yml: docker-compose.jsonnet
+docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
-check: docker-compose-yml
+check: docker-compose.yml
 	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)

--- a/development/mimir-microservices-mode/Makefile
+++ b/development/mimir-microservices-mode/Makefile
@@ -5,6 +5,7 @@
 # Or follow instructions on https://github.com/google/go-jsonnet
 
 .DEFAULT_GOAL := docker-compose.yml
+.PHONY: docker-compose.yml
 
 docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml

--- a/development/mimir-microservices-mode/Makefile
+++ b/development/mimir-microservices-mode/Makefile
@@ -5,10 +5,15 @@
 # Or follow instructions on https://github.com/google/go-jsonnet
 
 .DEFAULT_GOAL := docker-compose.yml
-.PHONY: docker-compose.yml check
 
+# intended to update new changes from jsonnet to yml, but not to overwrite if yml is newer
 docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
-check: docker-compose.yml
+.PHONY: check
+check: clean docker-compose.yml
 	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)
+
+.PHONY: clean
+clean:
+	rm -f docker-compose.yml

--- a/development/mimir-microservices-mode/Makefile
+++ b/development/mimir-microservices-mode/Makefile
@@ -4,10 +4,10 @@
 #
 # Or follow instructions on https://github.com/google/go-jsonnet
 
-.DEFAULT_GOAL := docker-compose.yml
+.DEFAULT_GOAL := docker-compose-yml
 
-docker-compose.yml: docker-compose.jsonnet
+docker-compose-yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
-check: docker-compose.yml
+check: docker-compose-yml
 	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)

--- a/development/mimir-read-write-mode/Makefile
+++ b/development/mimir-read-write-mode/Makefile
@@ -5,7 +5,7 @@
 # Or follow instructions on https://github.com/google/go-jsonnet
 
 .DEFAULT_GOAL := docker-compose.yml
-.PHONY: docker-compose.yml
+.PHONY: docker-compose.yml check
 
 docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml

--- a/development/mimir-read-write-mode/Makefile
+++ b/development/mimir-read-write-mode/Makefile
@@ -4,10 +4,10 @@
 #
 # Or follow instructions on https://github.com/google/go-jsonnet
 
-.DEFAULT_GOAL := docker-compose-yml
+.DEFAULT_GOAL := docker-compose.yml
 
-docker-compose-yml: docker-compose.jsonnet
+docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
-check: docker-compose-yml
+check: docker-compose.yml
 	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)

--- a/development/mimir-read-write-mode/Makefile
+++ b/development/mimir-read-write-mode/Makefile
@@ -5,6 +5,7 @@
 # Or follow instructions on https://github.com/google/go-jsonnet
 
 .DEFAULT_GOAL := docker-compose.yml
+.PHONY: docker-compose.yml
 
 docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml

--- a/development/mimir-read-write-mode/Makefile
+++ b/development/mimir-read-write-mode/Makefile
@@ -5,10 +5,15 @@
 # Or follow instructions on https://github.com/google/go-jsonnet
 
 .DEFAULT_GOAL := docker-compose.yml
-.PHONY: docker-compose.yml check
 
+# intended to update new changes from jsonnet to yml, but not to overwrite if yml is newer
 docker-compose.yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
-check: docker-compose.yml
+.PHONY: check
+check: clean docker-compose.yml
 	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)
+
+.PHONY: clean
+clean:
+	rm -f docker-compose.yml

--- a/development/mimir-read-write-mode/Makefile
+++ b/development/mimir-read-write-mode/Makefile
@@ -4,10 +4,10 @@
 #
 # Or follow instructions on https://github.com/google/go-jsonnet
 
-.DEFAULT_GOAL := docker-compose.yml
+.DEFAULT_GOAL := docker-compose-yml
 
-docker-compose.yml: docker-compose.jsonnet
+docker-compose-yml: docker-compose.jsonnet
 	jsonnet -S docker-compose.jsonnet -o docker-compose.yml
 
-check: docker-compose.yml
+check: docker-compose-yml
 	@git diff --exit-code -- 'docker-compose.yml' || (echo "docker-compose.jsonnet and docker-compose.yml don't match in ${PWD}" && false)


### PR DESCRIPTION
#### What this PR does

Fixes this problem: currently, you can modify the docker-compose.yml directly (which is supposed to be generated) without modifying the docker-compose.jsonnet template and have it still pass the CI/CD tests, which doesn't seem to be intended, because of this issue https://stackoverflow.com/questions/3931741/why-does-make-think-the-target-is-up-to-date where if the make command name is the same as the name of a file in that folder that already exists, it does not regenerate it and hence does not notice that the file has changed. So we use `.PHONY` to ensure that `make check` in our CI/CD will actually regenerate the file properly.

#### Which issue(s) this PR fixes or relates to

N/A. CI/CD issue only, doesn't affect users

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
