### PR TITLE
Pool file handles used by StreamBinaryReader components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
-* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3703
+* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3691 #3703 
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
-* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use mmap. This reader is expected to improve stability of the store-gateway. This implementation can be enabled with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3703
+* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enabled this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3703
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
-* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3691 #3703 
+* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3691 #3703
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
-* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use mmap. This reader is expected to improve stability of the store-gateway. This implementation can be enabled with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639
+* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use mmap. This reader is expected to improve stability of the store-gateway. This implementation can be enabled with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3703
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
-* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enabled this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3703
+* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3703
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5694,7 +5694,7 @@
                   "kind": "field",
                   "name": "file_handle_pool_size",
                   "required": false,
-                  "desc": "Max number of file handles the store-gateway will keep open for each index-header file when using the streaming reader.",
+                  "desc": "Maximum number of file handles the store-gateway keeps open for each index-header file when using the streaming reader.",
                   "fieldValue": null,
                   "fieldDefaultValue": 1,
                   "fieldFlag": "blocks-storage.bucket-store.index-header.file-handle-pool-size",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5689,6 +5689,17 @@
                   "fieldFlag": "blocks-storage.bucket-store.index-header.stream-reader-enabled",
                   "fieldType": "boolean",
                   "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "file_handle_pool_size",
+                  "required": false,
+                  "desc": "Max number of file handles the store-gateway will keep open for each index-header file when using the streaming reader.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1,
+                  "fieldFlag": "blocks-storage.bucket-store.index-header.file-handle-pool-size",
+                  "fieldType": "int",
+                  "fieldCategory": "experimental"
                 }
               ],
               "fieldValue": null,

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5692,12 +5692,12 @@
                 },
                 {
                   "kind": "field",
-                  "name": "file_handle_pool_size",
+                  "name": "stream_reader_max_idle_file_handles",
                   "required": false,
-                  "desc": "Maximum number of file handles the store-gateway keeps open for each index-header file when using the streaming reader.",
+                  "desc": "Maximum number of idle file handles the store-gateway keeps open for each index-header file when using the streaming reader. This option is used only when the index-header streaming reader is enabled.",
                   "fieldValue": null,
                   "fieldDefaultValue": 1,
-                  "fieldFlag": "blocks-storage.bucket-store.index-header.file-handle-pool-size",
+                  "fieldFlag": "blocks-storage.bucket-store.index-header.stream-reader-max-idle-file-handles",
                   "fieldType": "int",
                   "fieldCategory": "experimental"
                 }

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -340,7 +340,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout duration
     	If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
   -blocks-storage.bucket-store.index-header.file-handle-pool-size uint
-    	[experimental] Max number of file handles the store-gateway will keep open for each index-header file when using the streaming reader. (default 1)
+    	[experimental] Maximum number of file handles the store-gateway keeps open for each index-header file when using the streaming reader. (default 1)
   -blocks-storage.bucket-store.index-header.map-populate-enabled
     	[experimental] If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.
   -blocks-storage.bucket-store.index-header.stream-reader-enabled

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -339,6 +339,8 @@ Usage of ./cmd/mimir/mimir:
     	If enabled, store-gateway will lazy load an index-header only once required by a query. (default true)
   -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout duration
     	If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
+  -blocks-storage.bucket-store.index-header.file-handle-pool-size uint
+    	[experimental] Max number of file handles the store-gateway will keep open for each index-header file when using the streaming reader. (default 1)
   -blocks-storage.bucket-store.index-header.map-populate-enabled
     	[experimental] If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.
   -blocks-storage.bucket-store.index-header.stream-reader-enabled

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -339,12 +339,12 @@ Usage of ./cmd/mimir/mimir:
     	If enabled, store-gateway will lazy load an index-header only once required by a query. (default true)
   -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout duration
     	If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
-  -blocks-storage.bucket-store.index-header.file-handle-pool-size uint
-    	[experimental] Maximum number of file handles the store-gateway keeps open for each index-header file when using the streaming reader. (default 1)
   -blocks-storage.bucket-store.index-header.map-populate-enabled
     	[experimental] If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.
   -blocks-storage.bucket-store.index-header.stream-reader-enabled
     	[experimental] If enabled, the store-gateway will use an experimental streaming reader to load and parse index-header files.
+  -blocks-storage.bucket-store.index-header.stream-reader-max-idle-file-handles uint
+    	[experimental] Maximum number of idle file handles the store-gateway keeps open for each index-header file when using the streaming reader. This option is used only when the index-header streaming reader is enabled. (default 1)
   -blocks-storage.bucket-store.max-chunk-pool-bytes uint
     	Max size - in bytes - of a chunks pool, used to reduce memory allocations. The pool is shared across all tenants. 0 to disable the limit. (default 2147483648)
   -blocks-storage.bucket-store.max-concurrent int

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -91,9 +91,9 @@ The following features are currently experimental:
   - Ring-based service discovery (`-query-scheduler.service-discovery-mode` and `-query-scheduler.ring.*`)
   - Max number of used instances (`-query-scheduler.max-used-instances`)
 - Store-gateway
-  - `-blocks-storage.bucket-store.index-header.file-handle-pool-size`
   - `-blocks-storage.bucket-store.index-header.map-populate-enabled`
   - `-blocks-storage.bucket-store.index-header.stream-reader-enabled`
+  - `-blocks-storage.bucket-store.index-header.stream-reader-max-idle-file-handles`
   - `-blocks-storage.bucket-store.batch-series-size`
 - Blocks Storage, Alertmanager, and Ruler support for partitioning access to the same storage bucket
   - `-alertmanager-storage.storage-prefix`

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -91,6 +91,7 @@ The following features are currently experimental:
   - Ring-based service discovery (`-query-scheduler.service-discovery-mode` and `-query-scheduler.ring.*`)
   - Max number of used instances (`-query-scheduler.max-used-instances`)
 - Store-gateway
+  - `-blocks-storage.bucket-store.index-header.file-handle-pool-size`
   - `-blocks-storage.bucket-store.index-header.map-populate-enabled`
   - `-blocks-storage.bucket-store.index-header.stream-reader-enabled`
   - `-blocks-storage.bucket-store.batch-series-size`

--- a/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
@@ -3021,7 +3021,7 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.stream-reader-enabled
     [stream_reader_enabled: <boolean> | default = false]
 
-    # (experimental) Max number of file handles the store-gateway will keep open
+    # (experimental) Maximum number of file handles the store-gateway keeps open
     # for each index-header file when using the streaming reader.
     # CLI flag: -blocks-storage.bucket-store.index-header.file-handle-pool-size
     [file_handle_pool_size: <int> | default = 1]

--- a/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
@@ -3021,10 +3021,11 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.stream-reader-enabled
     [stream_reader_enabled: <boolean> | default = false]
 
-    # (experimental) Maximum number of file handles the store-gateway keeps open
-    # for each index-header file when using the streaming reader.
-    # CLI flag: -blocks-storage.bucket-store.index-header.file-handle-pool-size
-    [file_handle_pool_size: <int> | default = 1]
+    # (experimental) Maximum number of idle file handles the store-gateway keeps
+    # open for each index-header file when using the streaming reader. This
+    # option is used only when the index-header streaming reader is enabled.
+    # CLI flag: -blocks-storage.bucket-store.index-header.stream-reader-max-idle-file-handles
+    [stream_reader_max_idle_file_handles: <int> | default = 1]
 
   # (experimental) If larger than 0, this option enables store-gateway series
   # streaming. The store-gateway will load series from the bucket in batches

--- a/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
@@ -3021,6 +3021,11 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.stream-reader-enabled
     [stream_reader_enabled: <boolean> | default = false]
 
+    # (experimental) Max number of file handles the store-gateway will keep open
+    # for each index-header file when using the streaming reader.
+    # CLI flag: -blocks-storage.bucket-store.index-header.file-handle-pool-size
+    [file_handle_pool_size: <int> | default = 1]
+
   # (experimental) If larger than 0, this option enables store-gateway series
   # streaming. The store-gateway will load series from the bucket in batches
   # instead of buffering them all in memory before returning to the querier.

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -261,14 +261,3 @@ func (d *Decbuf) Byte() byte {
 
 func (d *Decbuf) Err() error { return d.E }
 func (d *Decbuf) Len() int   { return d.r.Len() }
-
-// close cleans up any resources associated with this Decbuf. This method
-// is unexported to ensure that all resource management is handled by DecbufFactory
-// which pools resources.
-func (d *Decbuf) close() error {
-	if d.r != nil {
-		return d.r.close()
-	}
-
-	return nil
-}

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -261,3 +261,11 @@ func (d *Decbuf) Byte() byte {
 
 func (d *Decbuf) Err() error { return d.E }
 func (d *Decbuf) Len() int   { return d.r.len() }
+
+func (d *Decbuf) Close() error {
+	if d.r != nil {
+		return d.r.close()
+	}
+
+	return nil
+}

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -27,7 +27,7 @@ var (
 // Err() method must be checked. New file-backed Decbuf instances must be created
 // via DecbufFactory
 type Decbuf struct {
-	r *FileReader
+	r *fileReader
 	E error
 }
 
@@ -38,13 +38,13 @@ func (d *Decbuf) Be32int() int { return int(d.Be32()) }
 // comparing the contents with the CRC32 checksum stored in the last four bytes.
 // CheckCrc32 consumes the contents of this Decbuf.
 func (d *Decbuf) CheckCrc32(castagnoliTable *crc32.Table) {
-	if d.r.Len() <= 4 {
+	if d.r.len() <= 4 {
 		d.E = ErrInvalidSize
 		return
 	}
 
 	hash := crc32.New(castagnoliTable)
-	bytesToRead := d.r.Len() - 4
+	bytesToRead := d.r.len() - 4
 	maxChunkSize := 1024 * 1024
 	rawBuf := make([]byte, maxChunkSize)
 
@@ -52,7 +52,7 @@ func (d *Decbuf) CheckCrc32(castagnoliTable *crc32.Table) {
 		chunkSize := math.Min(bytesToRead, maxChunkSize)
 		chunkBuf := rawBuf[0:chunkSize]
 
-		err := d.r.ReadInto(chunkBuf)
+		err := d.r.readInto(chunkBuf)
 		if err != nil {
 			d.E = errors.Wrap(err, "read contents for CRC32 calculation")
 			return
@@ -77,28 +77,28 @@ func (d *Decbuf) CheckCrc32(castagnoliTable *crc32.Table) {
 	}
 }
 
-// Skip advances the pointer of the underlying FileReader by the given number
+// Skip advances the pointer of the underlying fileReader by the given number
 // of bytes. If E is non-nil, this method has no effect. Skip-ing beyond the
-// end of the underlying FileReader will set E to an error and not advance the
-// pointer of the FileReader.
+// end of the underlying fileReader will set E to an error and not advance the
+// pointer of the fileReader.
 func (d *Decbuf) Skip(l int) {
 	if d.E != nil {
 		return
 	}
 
-	d.E = d.r.Skip(l)
+	d.E = d.r.skip(l)
 }
 
-// ResetAt sets the pointer of the underlying FileReader to the absolute
+// ResetAt sets the pointer of the underlying fileReader to the absolute
 // offset and discards any buffered data. If E is non-nil, this method has
-// no effect. ResetAt-ing beyond the end of the underlying FileReader will set
-// E to an error and not advance the pointer of FileReader.
+// no effect. ResetAt-ing beyond the end of the underlying fileReader will set
+// E to an error and not advance the pointer of fileReader.
 func (d *Decbuf) ResetAt(off int) {
 	if d.E != nil {
 		return
 	}
 
-	d.E = d.r.ResetAt(off)
+	d.E = d.r.resetAt(off)
 }
 
 // UvarintStr reads varint prefixed bytes into a string and consumes them. The string
@@ -118,12 +118,12 @@ func (d *Decbuf) UvarintBytes() []byte {
 	}
 
 	// If the length of this uvarint slice is greater than the size of buffer used
-	// by our file reader, we can't Peek() it. Instead, we have to use the Read() method
-	// which will allocate its own slice to hold the results. We prefer to use Peek()
+	// by our file reader, we can't peek() it. Instead, we have to use the read() method
+	// which will allocate its own slice to hold the results. We prefer to use peek()
 	// when possible for performance but can't rely on slices always being less than
 	// the size of our buffer.
-	if l > uint64(d.r.Size()) {
-		b, err := d.r.Read(int(l))
+	if l > uint64(d.r.size()) {
+		b, err := d.r.read(int(l))
 		if err != nil {
 			d.E = err
 			return nil
@@ -132,7 +132,7 @@ func (d *Decbuf) UvarintBytes() []byte {
 		return b
 	}
 
-	b, err := d.r.Peek(int(l))
+	b, err := d.r.peek(int(l))
 	if err != nil {
 		d.E = err
 		return nil
@@ -147,7 +147,7 @@ func (d *Decbuf) UvarintBytes() []byte {
 		return nil
 	}
 
-	err = d.r.Skip(len(b))
+	err = d.r.skip(len(b))
 	if err != nil {
 		d.E = err
 		return nil
@@ -160,7 +160,7 @@ func (d *Decbuf) Uvarint64() uint64 {
 	if d.E != nil {
 		return 0
 	}
-	b, err := d.r.Peek(10)
+	b, err := d.r.peek(10)
 	if err != nil {
 		d.E = err
 		return 0
@@ -172,7 +172,7 @@ func (d *Decbuf) Uvarint64() uint64 {
 		return 0
 	}
 
-	err = d.r.Skip(n)
+	err = d.r.skip(n)
 	if err != nil {
 		d.E = err
 		return 0
@@ -186,7 +186,7 @@ func (d *Decbuf) Be64() uint64 {
 		return 0
 	}
 
-	b, err := d.r.Peek(8)
+	b, err := d.r.peek(8)
 	if err != nil {
 		d.E = err
 		return 0
@@ -198,7 +198,7 @@ func (d *Decbuf) Be64() uint64 {
 	}
 
 	v := binary.BigEndian.Uint64(b)
-	err = d.r.Skip(8)
+	err = d.r.skip(8)
 	if err != nil {
 		d.E = err
 		return 0
@@ -212,7 +212,7 @@ func (d *Decbuf) Be32() uint32 {
 		return 0
 	}
 
-	b, err := d.r.Peek(4)
+	b, err := d.r.peek(4)
 	if err != nil {
 		d.E = err
 		return 0
@@ -224,7 +224,7 @@ func (d *Decbuf) Be32() uint32 {
 	}
 
 	v := binary.BigEndian.Uint32(b)
-	err = d.r.Skip(4)
+	err = d.r.skip(4)
 	if err != nil {
 		d.E = err
 		return 0
@@ -238,7 +238,7 @@ func (d *Decbuf) Byte() byte {
 		return 0
 	}
 
-	b, err := d.r.Peek(1)
+	b, err := d.r.peek(1)
 	if err != nil {
 		d.E = err
 		return 0
@@ -250,7 +250,7 @@ func (d *Decbuf) Byte() byte {
 	}
 
 	v := b[0]
-	err = d.r.Skip(1)
+	err = d.r.skip(1)
 	if err != nil {
 		d.E = err
 		return 0
@@ -260,4 +260,4 @@ func (d *Decbuf) Byte() byte {
 }
 
 func (d *Decbuf) Err() error { return d.E }
-func (d *Decbuf) Len() int   { return d.r.Len() }
+func (d *Decbuf) Len() int   { return d.r.len() }

--- a/pkg/storegateway/indexheader/encoding/encoding_test.go
+++ b/pkg/storegateway/indexheader/encoding/encoding_test.go
@@ -626,7 +626,7 @@ func createDecbufWithBytes(t testing.TB, b []byte) Decbuf {
 	filePath := path.Join(dir, "test-file")
 	require.NoError(t, os.WriteFile(filePath, b, 0700))
 
-	factory := NewDecbufFactory(filePath)
+	factory := NewDecbufFactory(filePath, 0)
 	decbuf := factory.NewRawDecbuf()
 	t.Cleanup(func() {
 		require.NoError(t, factory.Close(decbuf))

--- a/pkg/storegateway/indexheader/encoding/encoding_test.go
+++ b/pkg/storegateway/indexheader/encoding/encoding_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
 
@@ -626,7 +627,8 @@ func createDecbufWithBytes(t testing.TB, b []byte) Decbuf {
 	filePath := path.Join(dir, "test-file")
 	require.NoError(t, os.WriteFile(filePath, b, 0700))
 
-	factory := NewDecbufFactory(filePath, 0)
+	reg := prometheus.NewPedanticRegistry()
+	factory := NewDecbufFactory(filePath, 0, NewDecbufFactoryMetrics(reg))
 	decbuf := factory.NewRawDecbuf()
 	t.Cleanup(func() {
 		require.NoError(t, factory.Close(decbuf))

--- a/pkg/storegateway/indexheader/encoding/encoding_test.go
+++ b/pkg/storegateway/indexheader/encoding/encoding_test.go
@@ -631,7 +631,7 @@ func createDecbufWithBytes(t testing.TB, b []byte) Decbuf {
 	factory := NewDecbufFactory(filePath, 0, NewDecbufFactoryMetrics(reg))
 	decbuf := factory.NewRawDecbuf()
 	t.Cleanup(func() {
-		require.NoError(t, factory.Close(decbuf))
+		require.NoError(t, decbuf.Close())
 	})
 
 	require.NoError(t, decbuf.Err())

--- a/pkg/storegateway/indexheader/encoding/encoding_test.go
+++ b/pkg/storegateway/indexheader/encoding/encoding_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
@@ -628,7 +629,7 @@ func createDecbufWithBytes(t testing.TB, b []byte) Decbuf {
 	require.NoError(t, os.WriteFile(filePath, b, 0700))
 
 	reg := prometheus.NewPedanticRegistry()
-	factory := NewDecbufFactory(filePath, 0, NewDecbufFactoryMetrics(reg))
+	factory := NewDecbufFactory(filePath, 0, log.NewNopLogger(), NewDecbufFactoryMetrics(reg))
 	decbuf := factory.NewRawDecbuf()
 	t.Cleanup(func() {
 		require.NoError(t, decbuf.Close())

--- a/pkg/storegateway/indexheader/encoding/encoding_test.go
+++ b/pkg/storegateway/indexheader/encoding/encoding_test.go
@@ -250,7 +250,7 @@ func TestDecbuf_SkipHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
-	// The underlying FileReader buffers the file 4k bytes at a time. Ensure
+	// The underlying fileReader buffers the file 4k bytes at a time. Ensure
 	// that we can skip multiple 4k chunks without ending up with a short read.
 	bytes := make([]byte, 4096*5)
 	for i := 0; i < len(bytes); i++ {
@@ -433,8 +433,8 @@ func TestDecbuf_UvarintBytesSkipDoesNotCauseBufferFill(t *testing.T) {
 		expectedBytes  = 983
 	)
 
-	// This test verifies that when bytes are read in UvarintBytes, the Peek(n) and
-	// subsequent Skip(len(b)) does not cause a read from disk that invalidates the slice
+	// This test verifies that when bytes are read in UvarintBytes, the peek(n) and
+	// subsequent skip(len(b)) does not cause a read from disk that invalidates the slice
 	// returned. It does this by creating multiple uvarint byte slices in the encoding
 	// buffer each with different content _and_ by ensuring there are more bytes written
 	// in total than the size of the underlying buffer (currently 4k).

--- a/pkg/storegateway/indexheader/encoding/factory.go
+++ b/pkg/storegateway/indexheader/encoding/factory.go
@@ -15,10 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// readerBufferSize is the size of the buffer used for reading index-header files. This
-// value is arbitrary and will likely change in the future based on profiling results.
-const readerBufferSize = 4096
-
 var ErrPoolStopped = errors.New("file handle pool is stopped")
 
 type DecbufFactoryMetrics struct {

--- a/pkg/storegateway/indexheader/encoding/factory.go
+++ b/pkg/storegateway/indexheader/encoding/factory.go
@@ -29,16 +29,16 @@ type DecbufFactoryMetrics struct {
 func NewDecbufFactoryMetrics(reg prometheus.Registerer) *DecbufFactoryMetrics {
 	return &DecbufFactoryMetrics{
 		openCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "indexheader_stream_open_total",
-			Help: "Total number of times index-header file has been opened.",
+			Name: "indexheader_stream_unpooled_open_total",
+			Help: "Total number of times index-header file has been opened instead of using a pooled handle.",
 		}),
 		pooledOpenCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "indexheader_stream_pooled_open_total",
 			Help: "Total number of times a pooled index-header file has been used instead of opened.",
 		}),
 		closeCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "indexheader_stream_close_total",
-			Help: "Total number of times index-header file has been closed.",
+			Name: "indexheader_stream_unpooled_close_total",
+			Help: "Total number of times index-header file has been closed instead of returning the handle to the pool.",
 		}),
 		pooledCloseCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "indexheader_stream_pooled_close_total",

--- a/pkg/storegateway/indexheader/encoding/factory.go
+++ b/pkg/storegateway/indexheader/encoding/factory.go
@@ -98,7 +98,7 @@ func (df *DecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decb
 
 	contentLength := int(binary.BigEndian.Uint32(lengthBytes))
 	bufferLength := len(lengthBytes) + contentLength + crc32.Size
-	r, err := NewFileReader(f, offset, bufferLength)
+	r, err := newFileReader(f, offset, bufferLength)
 	if err != nil {
 		return Decbuf{E: errors.Wrap(err, "create file reader")}
 	}
@@ -115,7 +115,7 @@ func (df *DecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decb
 			return d
 		}
 
-		// Reset to the beginning of the content after reading it all for the CRC.
+		// reset to the beginning of the content after reading it all for the CRC.
 		d.ResetAt(4)
 	}
 
@@ -155,7 +155,7 @@ func (df *DecbufFactory) NewRawDecbuf() Decbuf {
 	}
 
 	fileSize := stat.Size()
-	reader, err := NewFileReader(f, 0, int(fileSize))
+	reader, err := newFileReader(f, 0, int(fileSize))
 	if err != nil {
 		return Decbuf{E: errors.Wrap(err, "file reader for decbuf")}
 	}

--- a/pkg/storegateway/indexheader/encoding/factory.go
+++ b/pkg/storegateway/indexheader/encoding/factory.go
@@ -32,7 +32,7 @@ func NewDecbufFactoryMetrics(reg prometheus.Registerer) *DecbufFactoryMetrics {
 		}),
 		pooledOpenCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "indexheader_stream_pooled_open_total",
-			Help: "Total number of times a pooled index-header file has been used instead of opened.",
+			Help: "Total number of times a pooled index-header file handle has been used instead of opened.",
 		}),
 		closeCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "indexheader_stream_unpooled_close_total",
@@ -40,7 +40,7 @@ func NewDecbufFactoryMetrics(reg prometheus.Registerer) *DecbufFactoryMetrics {
 		}),
 		pooledCloseCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "indexheader_stream_pooled_close_total",
-			Help: "Total number of times pooled index-header file has been returned instead of closed.",
+			Help: "Total number of times pooled index-header file handle has been returned to the pool instead of closed.",
 		}),
 	}
 }

--- a/pkg/storegateway/indexheader/encoding/factory.go
+++ b/pkg/storegateway/indexheader/encoding/factory.go
@@ -17,12 +17,12 @@ const readerBufferSize = 4096
 
 // DecbufFactory creates new file-backed decoding buffer instances for a specific index-header file.
 type DecbufFactory struct {
-	path string
+	files   *filePool
 }
 
-func NewDecbufFactory(path string) *DecbufFactory {
+func NewDecbufFactory(path string, maxFileHandles uint) *DecbufFactory {
 	return &DecbufFactory{
-		path: path,
+		files: newFilePool(path, maxFileHandles),
 	}
 }
 
@@ -31,17 +31,17 @@ func NewDecbufFactory(path string) *DecbufFactory {
 // by the contents and the expected checksum. This method checks the CRC of the content and will
 // return an error Decbuf if it does not match the expected CRC.
 func (df *DecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decbuf {
-	f, err := os.Open(df.path)
+	f, err := df.files.get()
 	if err != nil {
 		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
 	}
 
 	// If we return early and don't include a Reader for our Decbuf, we are responsible
-	// for actually closing the file handle.
+	// for putting the file handle back in the pool.
 	closeFile := true
 	defer func() {
 		if closeFile {
-			_ = f.Close()
+			_ = df.files.put(f)
 		}
 	}()
 
@@ -96,17 +96,17 @@ func (df *DecbufFactory) NewDecbufAtUnchecked(offset int) Decbuf {
 // file, nor does it perform any form of integrity check. To create a decoding buffer for some subset
 // of the file or perform integrity checks use NewDecbufAtUnchecked or NewDecbufAtChecked.
 func (df *DecbufFactory) NewRawDecbuf() Decbuf {
-	f, err := os.Open(df.path)
+	f, err := df.files.get()
 	if err != nil {
 		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
 	}
 
 	// If we return early and don't include a Reader for our Decbuf, we are responsible
-	// for actually closing the file handle.
+	// for putting the file handle back in the pool.
 	closeFile := true
 	defer func() {
 		if closeFile {
-			_ = f.Close()
+			_ = df.files.put(f)
 		}
 	}()
 
@@ -125,9 +125,19 @@ func (df *DecbufFactory) NewRawDecbuf() Decbuf {
 	return Decbuf{r: reader}
 }
 
+// Stop cleans up resources associated with this DecbufFactory
+func (df *DecbufFactory) Stop() {
+	df.files.stop()
+}
+
 // Close cleans up any resources associated with the Decbuf
 func (df *DecbufFactory) Close(d Decbuf) error {
-	return d.close()
+	if d.r != nil {
+		d.close()
+		return df.files.put(d.r.file)
+	}
+
+	return nil
 }
 
 // CloseWithErrCapture cleans up any resources associated with d,
@@ -139,4 +149,59 @@ func (df *DecbufFactory) CloseWithErrCapture(err *error, d Decbuf, format string
 	merr.Add(errors.Wrapf(df.Close(d), format, a...))
 
 	*err = merr.Err()
+}
+
+// filePool maintains a pool of file handles up to a maximum number, creating
+// new handles and closing them when required. get and put operations on this
+// pool never block. If there are no available file handles, one will be created
+// on get. If the pool is full, the file handle is closed on put.
+type filePool struct {
+	path    string
+	handles chan *os.File
+}
+
+// newFilePool creates a new file pool for path with cap capacity. If cap is 0,
+// get always opens new file handles and put always closes them immediately.
+func newFilePool(path string, cap uint) *filePool {
+	return &filePool{
+		path: path,
+		// We don't care if cap is 0 which means the channel will be unbuffered. Because
+		// we have default cases for reads and writes to the channel, we will always open
+		// new files and close file handles immediately if the channel is unbuffered.
+		handles: make(chan *os.File, cap),
+	}
+}
+
+// get returns a pooled file handle if available or opens a new one if there
+// are no pooled handles available.
+func (p *filePool) get() (*os.File, error) {
+	select {
+	case f := <-p.handles:
+		return f, nil
+	default:
+		return os.Open(p.path)
+	}
+}
+
+// put returns a file handle to the pool if there is space available or closes
+// the file handle if there is not.
+func (p *filePool) put(f *os.File) error {
+	select {
+	case p.handles <- f:
+		return nil
+	default:
+		return f.Close()
+	}
+}
+
+// stop closes all pooled file handles.
+func (p *filePool) stop() {
+	for {
+		select {
+		case f := <-p.handles:
+			_ = f.Close()
+		default:
+			return
+		}
+	}
 }

--- a/pkg/storegateway/indexheader/encoding/factory.go
+++ b/pkg/storegateway/indexheader/encoding/factory.go
@@ -257,7 +257,7 @@ func (p *filePool) stop() {
 		select {
 		case f := <-p.handles:
 			if err := f.Close(); err != nil {
-				level.Warn(p.logger).Log("msg", "closing index-header files during pool stop", "path", p.path, "err", err)
+				level.Warn(p.logger).Log("msg", "closing index-header file during pool stop", "path", p.path, "err", err)
 			}
 		default:
 			return

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -81,6 +81,29 @@ func TestDecbufFactory_NewDecbufAtChecked_HappyPath(t *testing.T) {
 	})
 }
 
+func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
+		d1 := factory.NewDecbufAtChecked(0, table)
+		t.Cleanup(func() {
+			require.NoError(t, factory.Close(d1))
+		})
+
+		require.NoError(t, d1.Err())
+		require.Equal(t, testContentSize+crc32.Size, d1.Len())
+
+		d2 := factory.NewDecbufAtChecked(0, table)
+		t.Cleanup(func() {
+			require.NoError(t, factory.Close(d2))
+		})
+
+		require.NoError(t, d2.Err())
+		require.Equal(t, testContentSize+crc32.Size, d2.Len())
+	})
+}
+
 func TestDecbufFactory_NewDecbufAtUnchecked_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -110,6 +110,22 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	})
 }
 
+func TestDecbufFactory_Stop(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
+		factory.Stop()
+
+		d := factory.NewRawDecbuf()
+		t.Cleanup(func() {
+			require.NoError(t, factory.Close(d))
+		})
+
+		require.ErrorIs(t, d.Err(), ErrPoolStopped)
+	})
+}
+
 func testDecbufFactory(t *testing.T, len int, enc promencoding.Encbuf, test func(t *testing.T, factory *DecbufFactory)) {
 	t.Run("pooling file handles", func(t *testing.T) {
 		factory := createDecbufFactoryWithBytes(t, 1, len, enc)

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -90,20 +90,16 @@ func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
 
 	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
 		d1 := factory.NewDecbufAtChecked(0, table)
-		t.Cleanup(func() {
-			require.NoError(t, d1.Close())
-		})
-
 		require.NoError(t, d1.Err())
-		require.Equal(t, testContentSize+crc32.Size, d1.Len())
+		fd1 := d1.r.file.Fd()
+		require.NoError(t, d1.Close())
 
 		d2 := factory.NewDecbufAtChecked(0, table)
-		t.Cleanup(func() {
-			require.NoError(t, d2.Close())
-		})
+		require.NoError(t, d1.Err())
+		fd2 := d2.r.file.Fd()
+		require.NoError(t, d2.Close())
 
-		require.NoError(t, d2.Err())
-		require.Equal(t, testContentSize+crc32.Size, d2.Len())
+		require.Equal(t, fd1, fd2, "expected Decbuf instances to use the same file descriptor")
 	})
 }
 

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -32,7 +32,7 @@ func BenchmarkDecbufFactory_NewDecbufAtUnchecked(t *testing.B) {
 			require.NoError(t, err)
 		}
 
-		if err := factory.Close(d); err != nil {
+		if err := d.Close(); err != nil {
 			require.NoError(t, err)
 		}
 	}
@@ -45,7 +45,7 @@ func TestDecbufFactory_NewDecbufAtChecked_InvalidCRC(t *testing.T) {
 	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
 		d := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d))
+			require.NoError(t, d.Close())
 		})
 
 		require.ErrorIs(t, d.Err(), ErrInvalidChecksum)
@@ -59,7 +59,7 @@ func TestDecbufFactory_NewDecbufAtChecked_InvalidLength(t *testing.T) {
 	testDecbufFactory(t, testContentSize+1000, enc, func(t *testing.T, factory *DecbufFactory) {
 		d := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d))
+			require.NoError(t, d.Close())
 		})
 
 		require.ErrorIs(t, d.Err(), ErrInvalidSize)
@@ -73,7 +73,7 @@ func TestDecbufFactory_NewDecbufAtChecked_HappyPath(t *testing.T) {
 	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
 		d := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d))
+			require.NoError(t, d.Close())
 		})
 
 		require.NoError(t, d.Err())
@@ -88,7 +88,7 @@ func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
 	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
 		d1 := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d1))
+			require.NoError(t, d1.Close())
 		})
 
 		require.NoError(t, d1.Err())
@@ -96,7 +96,7 @@ func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
 
 		d2 := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d2))
+			require.NoError(t, d2.Close())
 		})
 
 		require.NoError(t, d2.Err())
@@ -111,7 +111,7 @@ func TestDecbufFactory_NewDecbufAtUnchecked_HappyPath(t *testing.T) {
 	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
 		d := factory.NewDecbufAtUnchecked(0)
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d))
+			require.NoError(t, d.Close())
 		})
 
 		require.NoError(t, d.Err())
@@ -126,7 +126,7 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory *DecbufFactory) {
 		d := factory.NewRawDecbuf()
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d))
+			require.NoError(t, d.Close())
 		})
 
 		require.NoError(t, d.Err())
@@ -143,7 +143,7 @@ func TestDecbufFactory_Stop(t *testing.T) {
 
 		d := factory.NewRawDecbuf()
 		t.Cleanup(func() {
-			require.NoError(t, factory.Close(d))
+			require.NoError(t, d.Close())
 		})
 
 		require.ErrorIs(t, d.Err(), ErrPoolStopped)

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -95,7 +95,7 @@ func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
 		require.NoError(t, d1.Close())
 
 		d2 := factory.NewDecbufAtChecked(0, table)
-		require.NoError(t, d1.Err())
+		require.NoError(t, d2.Err())
 		fd2 := d2.r.file.Fd()
 		require.NoError(t, d2.Close())
 

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
@@ -184,7 +185,7 @@ func createDecbufFactoryWithBytes(t testing.TB, filePoolSize uint, len int, enc 
 	require.NoError(t, os.WriteFile(filePath, bytes, 0700))
 
 	reg := prometheus.NewPedanticRegistry()
-	factory := NewDecbufFactory(filePath, filePoolSize, NewDecbufFactoryMetrics(reg))
+	factory := NewDecbufFactory(filePath, filePoolSize, log.NewNopLogger(), NewDecbufFactoryMetrics(reg))
 	t.Cleanup(func() {
 		factory.Stop()
 	})

--- a/pkg/storegateway/indexheader/encoding/factory_test.go
+++ b/pkg/storegateway/indexheader/encoding/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
 )
@@ -159,7 +160,8 @@ func createDecbufFactoryWithBytes(t testing.TB, filePoolSize uint, len int, enc 
 	filePath := path.Join(dir, "test-file")
 	require.NoError(t, os.WriteFile(filePath, bytes, 0700))
 
-	factory := NewDecbufFactory(filePath, filePoolSize)
+	reg := prometheus.NewPedanticRegistry()
+	factory := NewDecbufFactory(filePath, filePoolSize, NewDecbufFactoryMetrics(reg))
 	t.Cleanup(func() {
 		factory.Stop()
 	})

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -153,6 +153,5 @@ func (f *FileReader) close() error {
 	// Note that we don't do anything to clean up the buffer before returning it to the pool here:
 	// we reset the buffer when we retrieve it from the pool instead.
 	bufferPool.Put(f.buf)
-
-	return f.file.Close()
+	return nil
 }

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -11,6 +11,10 @@ import (
 	"sync"
 )
 
+// readerBufferSize is the size of the buffer used for reading index-header files. This
+// value is arbitrary and will likely change in the future based on profiling results.
+const readerBufferSize = 4096
+
 type poolCloser interface {
 	put(*os.File) error
 }

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -11,13 +11,14 @@ import (
 	"sync"
 )
 
-type FileReader struct {
+type fileReader struct {
 	file   *os.File
 	buf    *bufio.Reader
 	base   int
 	length int
 	pos    int
 }
+
 
 var bufferPool = sync.Pool{
 	New: func() any {
@@ -27,15 +28,15 @@ var bufferPool = sync.Pool{
 
 // NewFileReader creates a new FileReader for the segment of file beginning at base bytes
 // extending length bytes using the supplied buffered reader.
-func NewFileReader(file *os.File, base, length int) (*FileReader, error) {
-	f := &FileReader{
+func newFileReader(file *os.File, base, length int) (*fileReader, error) {
+	f := &fileReader{
 		file:   file,
 		buf:    bufferPool.Get().(*bufio.Reader),
 		base:   base,
 		length: length,
 	}
 
-	err := f.Reset()
+	err := f.reset()
 	if err != nil {
 		return nil, err
 	}
@@ -43,17 +44,17 @@ func NewFileReader(file *os.File, base, length int) (*FileReader, error) {
 	return f, nil
 }
 
-// Reset moves the cursor position to the beginning of the file segment including the
-// base set when the FileReader was created.
-func (f *FileReader) Reset() error {
-	return f.ResetAt(0)
+// reset moves the cursor position to the beginning of the file segment including the
+// base set when the fileReader was created.
+func (f *fileReader) reset() error {
+	return f.resetAt(0)
 }
 
-// ResetAt moves the cursor position to the given offset in the file segment including
-// the base set when the FileReader was created. Attempting to ResetAt to the end of the
-// file segment is valid. Attempting to ResetAt _beyond_ the end of the file segment will
+// resetAt moves the cursor position to the given offset in the file segment including
+// the base set when the fileReader was created. Attempting to resetAt to the end of the
+// file segment is valid. Attempting to resetAt _beyond_ the end of the file segment will
 // return an error.
-func (f *FileReader) ResetAt(off int) error {
+func (f *fileReader) resetAt(off int) error {
 	if off > f.length {
 		return ErrInvalidSize
 	}
@@ -69,11 +70,11 @@ func (f *FileReader) ResetAt(off int) error {
 	return nil
 }
 
-// Skip advances the cursor position by the given number of bytes in the file segment.
-// Attempting to Skip to the end of the file segment is valid. Attempting to Skip _beyond_
+// skip advances the cursor position by the given number of bytes in the file segment.
+// Attempting to skip to the end of the file segment is valid. Attempting to skip _beyond_
 // the end of the file segment will return an error.
-func (f *FileReader) Skip(l int) error {
-	if l > f.Len() {
+func (f *fileReader) skip(l int) error {
+	if l > f.len() {
 		return ErrInvalidSize
 	}
 
@@ -85,11 +86,11 @@ func (f *FileReader) Skip(l int) error {
 	return err
 }
 
-// Peek returns at most the given number of bytes from the file segment
+// peek returns at most the given number of bytes from the file segment
 // without consuming them. The bytes returned become invalid at the next
-// read. It is valid to Peek beyond the end of the file segment. In this
+// read. It is valid to peek beyond the end of the file segment. In this
 // case the available bytes are returned with a nil error.
-func (f *FileReader) Peek(n int) ([]byte, error) {
+func (f *fileReader) peek(n int) ([]byte, error) {
 	b, err := f.buf.Peek(n)
 	// bufio.Reader still returns what it read when it hits EOF and callers
 	// expect to be able to peek past the end of a file.
@@ -104,13 +105,13 @@ func (f *FileReader) Peek(n int) ([]byte, error) {
 	return nil, nil
 }
 
-// Read returns the given number of bytes from the file segment, consuming them. It is
-// NOT valid to Read beyond the end of the file segment. In this case, a nil byte slice
+// read returns the given number of bytes from the file segment, consuming them. It is
+// NOT valid to read beyond the end of the file segment. In this case, a nil byte slice
 // and ErrInvalidSize error will be returned, and the remaining bytes are consumed.
-func (f *FileReader) Read(n int) ([]byte, error) {
+func (f *fileReader) read(n int) ([]byte, error) {
 	b := make([]byte, n)
 
-	err := f.ReadInto(b)
+	err := f.readInto(b)
 	if err != nil {
 		return nil, err
 	}
@@ -118,10 +119,10 @@ func (f *FileReader) Read(n int) ([]byte, error) {
 	return b, nil
 }
 
-// ReadInto reads len(b) bytes from the file segment into b, consuming them. It is
-// NOT valid to ReadInto beyond the end of the file segment. In this case, an ErrInvalidSize
+// readInto reads len(b) bytes from the file segment into b, consuming them. It is
+// NOT valid to readInto beyond the end of the file segment. In this case, an ErrInvalidSize
 // error will be returned and the remaining bytes are consumed.
-func (f *FileReader) ReadInto(b []byte) error {
+func (f *fileReader) readInto(b []byte) error {
 	r, err := io.ReadFull(f.buf, b)
 	if r > 0 {
 		f.pos += r
@@ -136,13 +137,13 @@ func (f *FileReader) ReadInto(b []byte) error {
 	return nil
 }
 
-// Size returns the length of the underlying buffer in bytes.
-func (f *FileReader) Size() int {
+// size returns the length of the underlying buffer in bytes.
+func (f *fileReader) size() int {
 	return f.buf.Size()
 }
 
-// Len returns the remaining number of bytes in the file segment owned by this reader.
-func (f *FileReader) Len() int {
+// len returns the remaining number of bytes in the file segment owned by this reader.
+func (f *fileReader) len() int {
 	return f.length - f.pos
 }
 

--- a/pkg/storegateway/indexheader/encoding/reader_test.go
+++ b/pkg/storegateway/indexheader/encoding/reader_test.go
@@ -11,169 +11,169 @@ import (
 )
 
 func TestReaders_Read(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
-		firstRead, err := r.Read(5)
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		firstRead, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), firstRead, "first read")
 
-		secondRead, err := r.Read(5)
+		secondRead, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("fghij"), secondRead, "second read")
 
-		readBeyondEnd, err := r.Read(12)
+		readBeyondEnd, err := r.read(12)
 		require.ErrorIs(t, err, ErrInvalidSize)
 		require.Empty(t, readBeyondEnd, "read beyond end")
 
-		readAfterEnd, err := r.Read(1)
+		readAfterEnd, err := r.read(1)
 		require.ErrorIs(t, err, ErrInvalidSize)
 		require.Empty(t, readAfterEnd, "read after end")
 	})
 }
 
 func TestReaders_ReadInto(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
+	testReaders(t, func(t *testing.T, r *fileReader) {
 		firstBuf := make([]byte, 5)
-		err := r.ReadInto(firstBuf)
+		err := r.readInto(firstBuf)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), firstBuf, "first read")
 
 		secondBuf := make([]byte, 5)
-		err = r.ReadInto(secondBuf)
+		err = r.readInto(secondBuf)
 		require.NoError(t, err)
 		require.Equal(t, []byte("fghij"), secondBuf, "second read")
 
 		beyondEndBuf := make([]byte, 12)
-		err = r.ReadInto(beyondEndBuf)
+		err = r.readInto(beyondEndBuf)
 		require.ErrorIs(t, err, ErrInvalidSize)
 
 		afterEndBuf := make([]byte, 1)
-		err = r.ReadInto(afterEndBuf)
+		err = r.readInto(afterEndBuf)
 		require.ErrorIs(t, err, ErrInvalidSize)
 	})
 }
 
 func TestReaders_Peek(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
-		firstPeek, err := r.Peek(5)
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		firstPeek, err := r.peek(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), firstPeek, "peek (first call)")
 
-		secondPeek, err := r.Peek(5)
+		secondPeek, err := r.peek(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), secondPeek, "peek (second call)")
 
-		readAfterPeek, err := r.Read(5)
+		readAfterPeek, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), readAfterPeek, "first read call")
 
-		peekAfterRead, err := r.Peek(5)
+		peekAfterRead, err := r.peek(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("fghij"), peekAfterRead, "peek after read")
 
-		peekBeyondEnd, err := r.Peek(20)
+		peekBeyondEnd, err := r.peek(20)
 		require.NoError(t, err)
 		require.Equal(t, []byte("fghij1234567890"), peekBeyondEnd, "peek beyond end")
 
-		_, err = r.Read(15)
+		_, err = r.read(15)
 		require.NoError(t, err)
 
-		peekAfterEnd, err := r.Peek(1)
+		peekAfterEnd, err := r.peek(1)
 		require.NoError(t, err)
 		require.Empty(t, peekAfterEnd, "peek after end")
 	})
 }
 
 func TestReaders_Reset(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
-		_, err := r.Read(5)
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		_, err := r.read(5)
 		require.NoError(t, err)
-		require.NoError(t, r.Reset())
+		require.NoError(t, r.reset())
 
-		readAfterReset, err := r.Read(5)
+		readAfterReset, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), readAfterReset)
 	})
 }
 
 func TestReaders_ResetAt(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
-		require.NoError(t, r.ResetAt(5))
-		readAfterReset, err := r.Read(5)
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		require.NoError(t, r.resetAt(5))
+		readAfterReset, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("fghij"), readAfterReset, "read after reset to non-zero offset")
 
-		require.NoError(t, r.ResetAt(0))
-		readAfterResetToBeginning, err := r.Read(5)
+		require.NoError(t, r.resetAt(0))
+		readAfterResetToBeginning, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), readAfterResetToBeginning, "read after reset to zero offset")
 
-		require.NoError(t, r.ResetAt(19))
-		readAfterResetToLastByte, err := r.Read(1)
+		require.NoError(t, r.resetAt(19))
+		readAfterResetToLastByte, err := r.read(1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("0"), readAfterResetToLastByte, "read after reset to last byte")
 
-		require.NoError(t, r.ResetAt(20))
-		require.ErrorIs(t, r.ResetAt(21), ErrInvalidSize)
+		require.NoError(t, r.resetAt(20))
+		require.ErrorIs(t, r.resetAt(21), ErrInvalidSize)
 	})
 }
 
 func TestReaders_Skip(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
-		peek, err := r.Peek(5)
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		peek, err := r.peek(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("abcde"), peek, "peek before skip")
-		require.Equal(t, 20, r.Len())
+		require.Equal(t, 20, r.len())
 
-		require.NoError(t, r.Skip(5))
-		readAfterSkip, err := r.Read(5)
+		require.NoError(t, r.skip(5))
+		readAfterSkip, err := r.read(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("fghij"), readAfterSkip, "read after skip")
-		require.Equal(t, 10, r.Len())
+		require.Equal(t, 10, r.len())
 
-		require.NoError(t, r.Skip(5))
-		peekAfterSkip, err := r.Peek(5)
+		require.NoError(t, r.skip(5))
+		peekAfterSkip, err := r.peek(5)
 		require.NoError(t, err)
 		require.Equal(t, []byte("67890"), peekAfterSkip, "peek after skip")
-		require.Equal(t, 5, r.Len())
+		require.Equal(t, 5, r.len())
 
-		// Skip to exactly the end, then skip beyond it
-		require.NoError(t, r.Skip(5))
-		require.Equal(t, 0, r.Len())
-		require.ErrorIs(t, r.Skip(1), ErrInvalidSize)
+		// skip to exactly the end, then skip beyond it
+		require.NoError(t, r.skip(5))
+		require.Equal(t, 0, r.len())
+		require.ErrorIs(t, r.skip(1), ErrInvalidSize)
 
 	})
 }
 
 func TestReaders_Len(t *testing.T) {
-	testReaders(t, func(t *testing.T, r *FileReader) {
-		require.Equal(t, 20, r.Len(), "initial length")
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		require.Equal(t, 20, r.len(), "initial length")
 
-		_, err := r.Read(5)
+		_, err := r.read(5)
 		require.NoError(t, err)
-		require.Equal(t, 15, r.Len(), "after first read")
+		require.Equal(t, 15, r.len(), "after first read")
 
-		_, err = r.Read(2)
+		_, err = r.read(2)
 		require.NoError(t, err)
-		require.Equal(t, 13, r.Len(), "after second read")
+		require.Equal(t, 13, r.len(), "after second read")
 
-		_, err = r.Peek(3)
+		_, err = r.peek(3)
 		require.NoError(t, err)
-		require.Equal(t, 13, r.Len(), "after peek")
+		require.Equal(t, 13, r.len(), "after peek")
 
-		_, err = r.Read(14)
+		_, err = r.read(14)
 		require.ErrorIs(t, err, ErrInvalidSize)
-		require.Equal(t, 0, r.Len(), "after read beyond end")
+		require.Equal(t, 0, r.len(), "after read beyond end")
 
-		require.NoError(t, r.Reset())
-		require.Equal(t, 20, r.Len(), "after reset to beginning")
+		require.NoError(t, r.reset())
+		require.Equal(t, 20, r.len(), "after reset to beginning")
 
-		require.NoError(t, r.ResetAt(3))
-		require.Equal(t, 17, r.Len(), "after reset to offset")
+		require.NoError(t, r.resetAt(3))
+		require.Equal(t, 17, r.len(), "after reset to offset")
 	})
 }
 
 func TestReaders_CreationWithEmptyContents(t *testing.T) {
-	t.Run("FileReader", func(t *testing.T) {
+	t.Run("fileReader", func(t *testing.T) {
 		dir := t.TempDir()
 		filePath := path.Join(dir, "test-file")
 		require.NoError(t, os.WriteFile(filePath, nil, 0700))
@@ -184,14 +184,14 @@ func TestReaders_CreationWithEmptyContents(t *testing.T) {
 			require.NoError(t, f.Close())
 		})
 
-		r, err := NewFileReader(f, 0, 0)
+		r, err := newFileReader(f, 0, 0)
 		require.NoError(t, err)
-		require.ErrorIs(t, r.Skip(1), ErrInvalidSize)
-		require.ErrorIs(t, r.ResetAt(1), ErrInvalidSize)
+		require.ErrorIs(t, r.skip(1), ErrInvalidSize)
+		require.ErrorIs(t, r.resetAt(1), ErrInvalidSize)
 	})
 }
 
-func testReaders(t *testing.T, test func(t *testing.T, r *FileReader)) {
+func testReaders(t *testing.T, test func(t *testing.T, r *fileReader)) {
 	testReaderContents := []byte("abcdefghij1234567890")
 
 	t.Run("FileReaderWithZeroOffset", func(t *testing.T) {
@@ -205,7 +205,7 @@ func testReaders(t *testing.T, test func(t *testing.T, r *FileReader)) {
 			require.NoError(t, f.Close())
 		})
 
-		r, err := NewFileReader(f, 0, len(testReaderContents))
+		r, err := newFileReader(f, 0, len(testReaderContents))
 		require.NoError(t, err)
 
 		test(t, r)
@@ -225,7 +225,7 @@ func testReaders(t *testing.T, test func(t *testing.T, r *FileReader)) {
 			require.NoError(t, f.Close())
 		})
 
-		r, err := NewFileReader(f, len(offsetBytes), len(testReaderContents))
+		r, err := newFileReader(f, len(offsetBytes), len(testReaderContents))
 		require.NoError(t, err)
 
 		test(t, r)

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -46,9 +46,11 @@ type Reader interface {
 type Config struct {
 	MapPopulateEnabled  bool `yaml:"map_populate_enabled" category:"experimental"`
 	StreamReaderEnabled bool `yaml:"stream_reader_enabled" category:"experimental"`
+	FileHandlePoolSize  uint `yaml:"file_handle_pool_size" category:"experimental"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.MapPopulateEnabled, prefix+"map-populate-enabled", false, "If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.")
 	f.BoolVar(&cfg.StreamReaderEnabled, prefix+"stream-reader-enabled", false, "If enabled, the store-gateway will use an experimental streaming reader to load and parse index-header files.")
+	f.UintVar(&cfg.FileHandlePoolSize, prefix+"file-handle-pool-size", 1, "Max number of file handles the store-gateway will keep open for each index-header file when using the streaming reader.")
 }

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -52,5 +52,5 @@ type Config struct {
 func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.MapPopulateEnabled, prefix+"map-populate-enabled", false, "If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.")
 	f.BoolVar(&cfg.StreamReaderEnabled, prefix+"stream-reader-enabled", false, "If enabled, the store-gateway will use an experimental streaming reader to load and parse index-header files.")
-	f.UintVar(&cfg.FileHandlePoolSize, prefix+"file-handle-pool-size", 1, "Max number of file handles the store-gateway will keep open for each index-header file when using the streaming reader.")
+	f.UintVar(&cfg.FileHandlePoolSize, prefix+"file-handle-pool-size", 1, "Maximum number of file handles the store-gateway keeps open for each index-header file when using the streaming reader.")
 }

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -44,13 +44,13 @@ type Reader interface {
 }
 
 type Config struct {
-	MapPopulateEnabled  bool `yaml:"map_populate_enabled" category:"experimental"`
-	StreamReaderEnabled bool `yaml:"stream_reader_enabled" category:"experimental"`
-	FileHandlePoolSize  uint `yaml:"file_handle_pool_size" category:"experimental"`
+	MapPopulateEnabled             bool `yaml:"map_populate_enabled" category:"experimental"`
+	StreamReaderEnabled            bool `yaml:"stream_reader_enabled" category:"experimental"`
+	StreamReaderMaxIdleFileHandles uint `yaml:"stream_reader_max_idle_file_handles" category:"experimental"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.MapPopulateEnabled, prefix+"map-populate-enabled", false, "If enabled, the store-gateway will attempt to pre-populate the file system cache when memory-mapping index-header files.")
 	f.BoolVar(&cfg.StreamReaderEnabled, prefix+"stream-reader-enabled", false, "If enabled, the store-gateway will use an experimental streaming reader to load and parse index-header files.")
-	f.UintVar(&cfg.FileHandlePoolSize, prefix+"file-handle-pool-size", 1, "Maximum number of file handles the store-gateway keeps open for each index-header file when using the streaming reader.")
+	f.UintVar(&cfg.StreamReaderMaxIdleFileHandles, prefix+"stream-reader-max-idle-file-handles", 1, "Maximum number of idle file handles the store-gateway keeps open for each index-header file when using the streaming reader. This option is used only when the index-header streaming reader is enabled.")
 }

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -122,7 +122,7 @@ func TestReaders(t *testing.T) {
 			})
 
 			t.Run("stream binary reader", func(t *testing.T) {
-				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3)
+				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, Config{})
 				require.NoError(t, err)
 				t.Cleanup(func() {
 					require.NoError(t, br.Close())

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -122,7 +122,7 @@ func TestReaders(t *testing.T) {
 			})
 
 			t.Run("stream binary reader", func(t *testing.T) {
-				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, Config{})
+				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 				require.NoError(t, err)
 				t.Cleanup(func() {
 					require.NoError(t, br.Close())

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"unsafe"
 
+	"github.com/grafana/dskit/runutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 
 	streamencoding "github.com/grafana/mimir/pkg/storegateway/indexheader/encoding"
@@ -42,7 +43,7 @@ const symbolFactor = 32
 // NewSymbols returns a Symbols object for symbol lookups.
 func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *Symbols, err error) {
 	d := factory.NewDecbufAtChecked(offset, castagnoliTable)
-	defer factory.CloseWithErrCapture(&err, d, "read symbols")
+	defer runutil.CloseWithErrCapture(&err, &d, "read symbols")
 	if err := d.Err(); err != nil {
 		return nil, fmt.Errorf("decode symbol table: %w", d.Err())
 	}
@@ -75,7 +76,7 @@ func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *
 
 func (s *Symbols) Lookup(o uint32) (sym string, err error) {
 	d := s.factory.NewDecbufAtUnchecked(s.tableOffset)
-	defer s.factory.CloseWithErrCapture(&err, d, "lookup symbol")
+	defer runutil.CloseWithErrCapture(&err, &d, "lookup symbol")
 	if err := d.Err(); err != nil {
 		return "", err
 	}
@@ -109,7 +110,7 @@ func (s *Symbols) ReverseLookup(sym string) (o uint32, err error) {
 	}
 
 	d := s.factory.NewDecbufAtUnchecked(s.tableOffset)
-	defer s.factory.CloseWithErrCapture(&err, d, "reverse lookup symbol")
+	defer runutil.CloseWithErrCapture(&err, &d, "reverse lookup symbol")
 	if err := d.Err(); err != nil {
 		return 0, err
 	}
@@ -126,7 +127,7 @@ func (s *Symbols) ForEachSymbol(syms []string, f func(sym string, offset uint32)
 	}
 
 	d := s.factory.NewDecbufAtUnchecked(s.tableOffset)
-	defer s.factory.CloseWithErrCapture(&err, d, "iterate over symbols")
+	defer runutil.CloseWithErrCapture(&err, &d, "iterate over symbols")
 	if err := d.Err(); err != nil {
 		return err
 	}

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -44,7 +44,7 @@ func TestSymbols(t *testing.T) {
 	filePath := path.Join(dir, "index")
 	require.NoError(t, os.WriteFile(filePath, buf.Get(), 0700))
 
-	df := streamencoding.NewDecbufFactory(filePath)
+	df := streamencoding.NewDecbufFactory(filePath, 0)
 	s, err := NewSymbols(df, index.FormatV2, symbolsStart)
 	require.NoError(t, err)
 

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -45,7 +46,7 @@ func TestSymbols(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, buf.Get(), 0700))
 
 	reg := prometheus.NewPedanticRegistry()
-	df := streamencoding.NewDecbufFactory(filePath, 0, streamencoding.NewDecbufFactoryMetrics(reg))
+	df := streamencoding.NewDecbufFactory(filePath, 0, log.NewNopLogger(), streamencoding.NewDecbufFactoryMetrics(reg))
 	s, err := NewSymbols(df, index.FormatV2, symbolsStart)
 	require.NoError(t, err)
 

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -11,11 +11,11 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
-
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	streamencoding "github.com/grafana/mimir/pkg/storegateway/indexheader/encoding"
 )
@@ -44,7 +44,8 @@ func TestSymbols(t *testing.T) {
 	filePath := path.Join(dir, "index")
 	require.NoError(t, os.WriteFile(filePath, buf.Get(), 0700))
 
-	df := streamencoding.NewDecbufFactory(filePath, 0)
+	reg := prometheus.NewPedanticRegistry()
+	df := streamencoding.NewDecbufFactory(filePath, 0, streamencoding.NewDecbufFactoryMetrics(reg))
 	s, err := NewSymbols(df, index.FormatV2, symbolsStart)
 	require.NoError(t, err)
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -300,7 +300,7 @@ func testLazyBinaryReader(t *testing.T, bkt objstore.BucketReader, dir string, i
 		ctx := context.Background()
 		logger := log.NewNopLogger()
 		factory := func() (Reader, error) {
-			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, 3)
+			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, 3, Config{})
 		}
 
 		reader, err := NewLazyBinaryReader(ctx, factory, logger, bkt, dir, id, NewLazyBinaryReaderMetrics(nil), nil)

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -300,7 +300,7 @@ func testLazyBinaryReader(t *testing.T, bkt objstore.BucketReader, dir string, i
 		ctx := context.Background()
 		logger := log.NewNopLogger()
 		factory := func() (Reader, error) {
-			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, 3, Config{})
+			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 		}
 
 		reader, err := NewLazyBinaryReader(ctx, factory, logger, bkt, dir, id, NewLazyBinaryReaderMetrics(nil), nil)

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -89,7 +89,7 @@ func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt
 
 	if cfg.StreamReaderEnabled {
 		readerFactory = func() (Reader, error) {
-			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling)
+			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, cfg)
 		}
 	} else {
 		readerFactory = func() (Reader, error) {

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -21,13 +21,15 @@ import (
 
 // ReaderPoolMetrics holds metrics tracked by ReaderPool.
 type ReaderPoolMetrics struct {
-	lazyReader *LazyBinaryReaderMetrics
+	lazyReader   *LazyBinaryReaderMetrics
+	streamReader *StreamBinaryReaderMetrics
 }
 
 // NewReaderPoolMetrics makes new ReaderPoolMetrics.
 func NewReaderPoolMetrics(reg prometheus.Registerer) *ReaderPoolMetrics {
 	return &ReaderPoolMetrics{
-		lazyReader: NewLazyBinaryReaderMetrics(reg),
+		lazyReader:   NewLazyBinaryReaderMetrics(reg),
+		streamReader: NewStreamBinaryReaderMetrics(reg),
 	}
 }
 
@@ -89,7 +91,7 @@ func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt
 
 	if cfg.StreamReaderEnabled {
 		readerFactory = func() (Reader, error) {
-			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, cfg)
+			return NewStreamBinaryReader(ctx, logger, bkt, dir, id, postingOffsetsInMemSampling, p.metrics.streamReader, cfg)
 		}
 	} else {
 		readerFactory = func() (Reader, error) {

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/runutil"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -85,7 +86,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, met
 	// Create a new raw decoding buffer with access to the entire index-header file to
 	// read initial version information and the table of contents.
 	d := r.factory.NewRawDecbuf()
-	defer r.factory.CloseWithErrCapture(&err, d, "new file stream binary reader")
+	defer runutil.CloseWithErrCapture(&err, &d, "new file stream binary reader")
 	if err = d.Err(); err != nil {
 		return nil, fmt.Errorf("cannot create decoding buffer: %w", err)
 	}

--- a/pkg/storegateway/indexheader/stream_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader_test.go
@@ -54,7 +54,7 @@ func BenchmarkLookupSymbol(b *testing.B) {
 }
 
 func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bucketDir string, id ulid.ULID, parallelism int, percentageNameLookups int, nameSymbols []string, valueSymbols []string) {
-	br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, id, 3)
+	br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, id, 3, Config{})
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, br.Close())
@@ -124,7 +124,7 @@ func BenchmarkLabelNames(b *testing.B) {
 			require.NoError(b, WriteBinary(ctx, bkt, idIndexV2, indexName))
 
 			b.Run(fmt.Sprintf("%vNames%vValues", nameCount, valueCount), func(b *testing.B) {
-				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3)
+				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3, Config{})
 				require.NoError(b, err)
 				b.Cleanup(func() {
 					require.NoError(b, br.Close())
@@ -167,7 +167,7 @@ func BenchmarkNewStreamBinaryReader(b *testing.B) {
 
 			b.Run(fmt.Sprintf("%vNames%vValues", nameCount, valueCount), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3)
+					br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3, Config{})
 					require.NoError(b, err)
 					b.Cleanup(func() {
 						require.NoError(b, br.Close())

--- a/pkg/storegateway/indexheader/stream_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader_test.go
@@ -54,7 +54,7 @@ func BenchmarkLookupSymbol(b *testing.B) {
 }
 
 func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bucketDir string, id ulid.ULID, parallelism int, percentageNameLookups int, nameSymbols []string, valueSymbols []string) {
-	br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, id, 3, Config{})
+	br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, id, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, br.Close())
@@ -124,7 +124,7 @@ func BenchmarkLabelNames(b *testing.B) {
 			require.NoError(b, WriteBinary(ctx, bkt, idIndexV2, indexName))
 
 			b.Run(fmt.Sprintf("%vNames%vValues", nameCount, valueCount), func(b *testing.B) {
-				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3, Config{})
+				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 				require.NoError(b, err)
 				b.Cleanup(func() {
 					require.NoError(b, br.Close())
@@ -167,7 +167,7 @@ func BenchmarkNewStreamBinaryReader(b *testing.B) {
 
 			b.Run(fmt.Sprintf("%vNames%vValues", nameCount, valueCount), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3, Config{})
+					br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 					require.NoError(b, err)
 					b.Cleanup(func() {
 						require.NoError(b, br.Close())


### PR DESCRIPTION
#### What this PR does

Add a pool of file handles to avoid the cost of opening and closing files for each operation that needs access to the index-header file (symbols and posting offsets). The default number of handles to keep per index-header is `1` to maintain parity with the existing mmap implementation (which keeps a single file handle for the index-header open for the duration of the reader).

#### Which issue(s) this PR fixes or relates to

See #3465

#### Benchmark

```
$ benchstat -delta-test=none old.txt new.txt 
name                                   old time/op    new time/op    delta
DecbufFactory_NewDecbufAtUnchecked-16    2.98µs ± 0%    0.86µs ± 0%  -71.12%

name                                   old alloc/op   new alloc/op   delta
DecbufFactory_NewDecbufAtUnchecked-16      232B ± 0%       48B ± 0%  -79.31%

name                                   old allocs/op  new allocs/op  delta
DecbufFactory_NewDecbufAtUnchecked-16      4.00 ± 0%      1.00 ± 0%  -75.00%
```

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
