### PR TITLE
Alert on idle ingesters only after metric ingestion has started

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -170,8 +170,12 @@ spec:
       expr: |
         (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
         and on (cluster, namespace)
-        # Only if there's a least 1 tenant in Mimir.
-        (max by(cluster, namespace) (cortex_ingester_memory_users) > 0)
+        # Only if there are more time-series than would be expected due to continuous testing load
+        (
+          sum by(cluster, namespace) (cortex_ingester_memory_series)
+          /
+          max by(cluster, namespace) (cortex_distributor_replication_factor)
+        ) > 100000
       for: 1h
       labels:
         severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -158,8 +158,12 @@ groups:
     expr: |
       (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
       and on (cluster, namespace)
-      # Only if there's a least 1 tenant in Mimir.
-      (max by(cluster, namespace) (cortex_ingester_memory_users) > 0)
+      # Only if there are more time-series than would be expected due to continuous testing load
+      (
+        sum by(cluster, namespace) (cortex_ingester_memory_series)
+        /
+        max by(cluster, namespace) (cortex_distributor_replication_factor)
+      ) > 100000
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -158,8 +158,12 @@ groups:
     expr: |
       (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
       and on (cluster, namespace)
-      # Only if there's a least 1 tenant in Mimir.
-      (max by(cluster, namespace) (cortex_ingester_memory_users) > 0)
+      # Only if there are more time-series than would be expected due to continuous testing load
+      (
+        sum by(cluster, namespace) (cortex_ingester_memory_series)
+        /
+        max by(cluster, namespace) (cortex_distributor_replication_factor)
+      ) > 100000
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -251,8 +251,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_memory_users) == 0)
             and on (%(alert_aggregation_labels)s)
-            # Only if there's a least 1 tenant in Mimir.
-            (max by(%(alert_aggregation_labels)s) (cortex_ingester_memory_users) > 0)
+            # Only if there are more time-series than would be expected due to continuous testing load
+            (
+              sum by(%(alert_aggregation_labels)s) (cortex_ingester_memory_series)
+              /
+              max by(%(alert_aggregation_labels)s) (cortex_distributor_replication_factor)
+            ) > 100000
           ||| % $._config,
           labels: {
             severity: 'warning',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

In #3681, we added an alert for idle ingesters. @pracucci suggested that we make this alert conditional on a cluster having ingested a certain number of time series already, to avoid triggering it in newly commissioned clusters with a low number of time series.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
