### PR TITLE
Fix deb package post install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
+* [BUGFIX] Debian package: Fix post-install, environment file path and user creation. #3720 
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
-* [BUGFIX] Debian package: Fix post-install, environment file path and user creation. #3720 
+* [BUGFIX] Debian package: Fix post-install, environment file path and user creation. #3720
 
 ### Mixin
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -7,7 +7,7 @@
 set -e
 
 # shellcheck disable=1091
-[ -f /etc/sysconfig/mimir ] && . /etc/default/mimir
+[ -f /etc/default/mimir ] && . /etc/default/mimir
 
 case "$1" in
   configure)

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -9,24 +9,20 @@ set -e
 # shellcheck disable=1091
 [ -f /etc/default/mimir ] && . /etc/default/mimir
 
-case "$1" in
-  configure)
-    [ -z "$MIMIR_USER" ] && MIMIR_USER="mimir"
-    [ -z "$MIMIR_GROUP" ] && MIMIR_GROUP="mimir"
-    if ! getent group "$MIMIR_GROUP" >/dev/null 2>&1; then
-      groupadd -r "$MIMIR_GROUP"
-    fi
-    if ! getent passwd "$MIMIR_USER" >/dev/null 2>&1; then
-      useradd -m -r -g mimir -d /var/lib/mimir -s /sbin/nologin -c "mimir user" mimir
-    fi
+[ -z "$MIMIR_USER" ] && MIMIR_USER="mimir"
+[ -z "$MIMIR_GROUP" ] && MIMIR_GROUP="mimir"
+if ! getent group "$MIMIR_GROUP" >/dev/null 2>&1; then
+  groupadd -r "$MIMIR_GROUP"
+fi
+if ! getent passwd "$MIMIR_USER" >/dev/null 2>&1; then
+  useradd -m -r -g mimir -d /var/lib/mimir -s /sbin/nologin -c "mimir user" mimir
+fi
 
-    chmod 640 /etc/mimir/config.example.yaml
-    chown root:$MIMIR_GROUP /etc/mimir/config.example.yaml
+chmod 640 /etc/mimir/config.example.yaml
+chown root:$MIMIR_GROUP /etc/mimir/config.example.yaml
 
-    if [ -z ${2+x} ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
-      if command -v systemctl 2>/dev/null; then
-        systemctl daemon-reload
-      fi
-    fi
-    ;;
-esac
+if [ -z ${2+x} ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
+  if command -v systemctl 2>/dev/null; then
+    systemctl daemon-reload
+  fi
+fi


### PR DESCRIPTION
#### What this PR does
This pull request fix two things with the post-install of the Debian package:
- The environment path was wrong in one place
- The user creation was not working properly 

#### Which issue(s) this PR fixes or relates to
Fixes #3471 

#### More details

Here is the complete old post-install script (after fpm process):
```
#!/bin/sh


after_upgrade() {
    :

systemctl --system daemon-reload >/dev/null || true
debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
if ! systemctl is-enabled mimir >/dev/null 
then
  : # Ensure this if-clause is not empty. If it were empty, and we had an 'else', then it is an error in shell syntax
else
    $debsystemctl restart mimir >/dev/null || true
fi
}

after_install() {
    :
#!/bin/sh
# SPDX-License-Identifier: AGPL-3.0-only
# Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/packaging/deb/control/postinst
# Provenance-includes-license: Apache-2.0
# Provenance-includes-copyright: The Cortex Authors.

set -e

# shellcheck disable=1091
[ -f /etc/sysconfig/mimir ] && . /etc/default/mimir

case "$1" in
  configure)
    [ -z "$MIMIR_USER" ] && MIMIR_USER="mimir"
    [ -z "$MIMIR_GROUP" ] && MIMIR_GROUP="mimir"
    if ! getent group "$MIMIR_GROUP" >/dev/null 2>&1; then
      groupadd -r "$MIMIR_GROUP"
    fi
    if ! getent passwd "$MIMIR_USER" >/dev/null 2>&1; then
      useradd -m -r -g mimir -d /var/lib/mimir -s /sbin/nologin -c "mimir user" mimir
    fi

    chmod 640 /etc/mimir/config.example.yaml
    chown root:$MIMIR_GROUP /etc/mimir/config.example.yaml

    if [ -z ${2+x} ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
      if command -v systemctl 2>/dev/null; then
        systemctl daemon-reload
      fi
    fi
    ;;
esac


systemctl --system daemon-reload >/dev/null || true
debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
}

if [ "${1}" = "configure" -a -z "${2}" ] || \
   [ "${1}" = "abort-remove" ]
then
    # "after install" here
    # "abort-remove" happens when the pre-removal script failed.
    #   In that case, this script, which should be idemptoent, is run
    #   to ensure a clean roll-back of the removal.
    after_install
elif [ "${1}" = "configure" -a -n "${2}" ]
then
    upgradeFromVersion="${2}"
    # "after upgrade" here
    # NOTE: This slot is also used when deb packages are removed,
    # but their config files aren't, but a newer version of the
    # package is installed later, called "Config-Files" state.
    # basically, that still looks a _lot_ like an upgrade to me.
    after_upgrade "${2}"
elif echo "${1}" | grep -E -q "(abort|fail)"
then
    echo "Failed to install before the post-installation script was run." >&2
    exit 1
fi
```
Call to function `after_install` is made without any argument, therefore case statement can't work.

Here is the result of the `dpkg -i`command:
```
$ sudo dpkg -i mimir-2.4.0_amd64.deb
Selecting previously unselected package mimir.
(Reading database ... 21185 files and directories currently installed.)
Preparing to unpack mimir-2.4.0_amd64.deb ...
Unpacking mimir (2.4.0) ...
Setting up mimir (2.4.0) ...
/usr/bin/systemctl
```
User is now well created : 
```
$ cat /etc/passwd
***
mimir:x:997:997:mimir user:/var/lib/mimir:/sbin/nologin
```

You will find a package attached to this PR to test yourself.
[debian_packages.tar.gz](https://github.com/grafana/mimir/files/10219646/debian_packages.tar.gz)
