### PR TITLE
Alerts: Add an alert to detect idling ruler instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [ENHANCEMENT] Alerts: Added `MimirIngesterInstanceHasNoTenants` alert that fires when an ingester replica is not receiving write requests for any tenant. #3681
 * [ENHANCEMENT] Alerts: Extended `MimirAllocatingTooMuchMemory` to check read-write deployment containers. #3710
 * [ENHANCEMENT] Alerts: Added `MimirAlertmanagerInstanceHasNoTenants` alert that fires when an alertmanager instance ows no tenants. #3826
+* [ENHANCEMENT] Alerts: Added `MimirRulerInstanceHasNoRuleGroups` alert that fires when a ruler replica is not assigned any rule group to evaluate. #3723
 * [BUGFIX] Alerts: Fixed `MimirIngesterRestarts` alert when Mimir is deployed in read-write mode. #3716
 * [BUGFIX] Alerts: Fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts for when Mimir is deployed in read-write or monolithic modes and updated them to use new `thanos_shipper_last_successful_upload_time` metric. #3627
 * [BUGFIX] Alerts: Fixed `MimirMemoryMapAreasTooHigh` alert when Mimir is deployed in read-write mode. #3626

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -507,7 +507,7 @@ How it **works**:
 
 How to **fix** it:
 
-- Increase the shard size of one or more tenants to match the number of ingester replicas.
+- Increase the shard size of one or more tenants to match the number of ruler replicas.
 - Set the shard size of one or more tenants to `0`; this will shard the given tenant's rule groups across all ingesters.
 - Decrease the total number of ruler replicas by the number of idle replicas.
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -495,6 +495,22 @@ Choose one of three options:
 - Set the shard size of one or more tenants to `0`; this will shard the given tenant’s requests across all ingesters.
 - [Decrease the number of ingester replicas]({{< relref "../../operators-guide/run-production-environment/scaling-out.md#scaling-down-ingesters" >}}) to match the highest number of shards per tenant.
 
+### MimirRulerInstanceHasNoRuleGroups
+
+This alert fires when a ruler instance doesn't own any rule groups and is therefore idling.
+
+How it **works**:
+
+- When [ruler shuffle sharding]({{< relref "../../operators-guide/configure/configure-shuffle-sharding/index.md#ruler-shuffle-sharding" >}}) is enabled, a single tenant's rule groups are sharded across a subset of ruler instances, with a given rule group always being evaluated on a single ruler.
+- The parameters `-ruler.tenant-shard-size` or `ruler_tenant_shard_size` control how many ruler instances a tenant's rule groups are sharded across.
+- When the overall number of rule groups or the tenant's shard size is lower than the number of ruler replicas, some replicas might not be assigned any rule group to evaluate and remain idle.
+
+How to **fix** it:
+
+- Increase the shard size of one or more tenants to match the number of ingester replicas.
+- Set the shard size of one or more tenants to `0`; this will shard the given tenant's rule groups across all ingesters.
+- Decrease the total number of ruler replicas by the number of idle replicas.
+
 ### MimirQuerierHasNotScanTheBucket
 
 This alert fires when a Mimir querier is not successfully scanning blocks in the storage (bucket). A querier is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket since a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -185,20 +185,14 @@ spec:
           }} has no rule groups assigned.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
       expr: |
-        # Alert on ruler instances that have no rule groups assigned,
-        (min by(cluster, namespace, pod) (cortex_ruler_managers_total) == 0)
+        # Alert on ruler instances in microservices mode that have no rule groups assigned,
+        min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*-mimir-)?ruler.*"}) == 0
         # but only if other ruler instances of the same cell do have rule groups assigned
         and on (cluster, namespace)
-        (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-        # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
-        # We never want to scale to less than 2 instances because of availability concerns,
-        # and in these cases, it's likely that rule groups aren't sharded across both instances.
-        unless on (cluster, namespace)
-        (
-            count by (cluster, namespace) (cortex_ruler_managers_total) == 2
-            and on (cluster, namespace)
-            count by (cluster, namespace) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
-        )
+        max by(cluster, namespace) (cortex_ruler_managers_total) > 0
+        # and there are more than two instances overall
+        and on (cluster, namespace)
+        count by (cluster, namespace) (cortex_ruler_managers_total) > 2
       for: 1h
       labels:
         severity: warning

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -189,10 +189,10 @@ spec:
         min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*-mimir-)?ruler.*"}) == 0
         # but only if other ruler instances of the same cell do have rule groups assigned
         and on (cluster, namespace)
-        max by(cluster, namespace) (cortex_ruler_managers_total) > 0
+        (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
         # and there are more than two instances overall
         and on (cluster, namespace)
-        count by (cluster, namespace) (cortex_ruler_managers_total) > 2
+        (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
       for: 1h
       labels:
         severity: warning

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -179,6 +179,19 @@ spec:
       for: 1h
       labels:
         severity: warning
+    - alert: MimirRulerInstanceHasNoRuleGroups
+      annotations:
+        message: Mimir ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} has no rule groups assigned.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
+      expr: |
+        (min by(cluster, namespace, pod) (cortex_ruler_managers_total) == 0)
+        and on (cluster, namespace)
+        # Only if other ruler instances of the same cell have rule groups assigned
+        (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+      for: 1h
+      labels:
+        severity: warning
     - alert: MimirRingMembersMismatch
       annotations:
         message: |

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -185,10 +185,20 @@ spec:
           }} has no rule groups assigned.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
       expr: |
+        # Alert on ruler instances that have no rule groups assigned,
         (min by(cluster, namespace, pod) (cortex_ruler_managers_total) == 0)
+        # but only if other ruler instances of the same cell do have rule groups assigned
         and on (cluster, namespace)
-        # Only if other ruler instances of the same cell have rule groups assigned
         (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+        # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
+        # We never want to scale to less than 2 instances because of availability concerns,
+        # and in these cases, it's likely that rule groups aren't sharded across both instances.
+        unless on (cluster, namespace)
+        (
+            count by (cluster, namespace) (cortex_ruler_managers_total) == 2
+            and on (cluster, namespace)
+            count by (cluster, namespace) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
+        )
       for: 1h
       labels:
         severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -173,20 +173,14 @@ groups:
         }} has no rule groups assigned.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
     expr: |
-      # Alert on ruler instances that have no rule groups assigned,
-      (min by(cluster, namespace, instance) (cortex_ruler_managers_total) == 0)
+      # Alert on ruler instances in microservices mode that have no rule groups assigned,
+      min by(cluster, namespace, instance) (cortex_ruler_managers_total{instance=~".*ruler.*"}) == 0
       # but only if other ruler instances of the same cell do have rule groups assigned
       and on (cluster, namespace)
-      (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-      # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
-      # We never want to scale to less than 2 instances because of availability concerns,
-      # and in these cases, it's likely that rule groups aren't sharded across both instances.
-      unless on (cluster, namespace)
-      (
-          count by (cluster, namespace) (cortex_ruler_managers_total) == 2
-          and on (cluster, namespace)
-          count by (cluster, namespace) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
-      )
+      max by(cluster, namespace) (cortex_ruler_managers_total) > 0
+      # and there are more than two instances overall
+      and on (cluster, namespace)
+      count by (cluster, namespace) (cortex_ruler_managers_total) > 2
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -167,6 +167,19 @@ groups:
     for: 1h
     labels:
       severity: warning
+  - alert: MimirRulerInstanceHasNoRuleGroups
+    annotations:
+      message: Mimir ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has no rule groups assigned.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
+    expr: |
+      (min by(cluster, namespace, instance) (cortex_ruler_managers_total) == 0)
+      and on (cluster, namespace)
+      # Only if other ruler instances of the same cell have rule groups assigned
+      (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+    for: 1h
+    labels:
+      severity: warning
   - alert: MimirRingMembersMismatch
     annotations:
       message: |

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -177,10 +177,10 @@ groups:
       min by(cluster, namespace, instance) (cortex_ruler_managers_total{instance=~".*ruler.*"}) == 0
       # but only if other ruler instances of the same cell do have rule groups assigned
       and on (cluster, namespace)
-      max by(cluster, namespace) (cortex_ruler_managers_total) > 0
+      (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
       # and there are more than two instances overall
       and on (cluster, namespace)
-      count by (cluster, namespace) (cortex_ruler_managers_total) > 2
+      (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -173,10 +173,20 @@ groups:
         }} has no rule groups assigned.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
     expr: |
+      # Alert on ruler instances that have no rule groups assigned,
       (min by(cluster, namespace, instance) (cortex_ruler_managers_total) == 0)
+      # but only if other ruler instances of the same cell do have rule groups assigned
       and on (cluster, namespace)
-      # Only if other ruler instances of the same cell have rule groups assigned
       (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+      # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
+      # We never want to scale to less than 2 instances because of availability concerns,
+      # and in these cases, it's likely that rule groups aren't sharded across both instances.
+      unless on (cluster, namespace)
+      (
+          count by (cluster, namespace) (cortex_ruler_managers_total) == 2
+          and on (cluster, namespace)
+          count by (cluster, namespace) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
+      )
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -173,10 +173,20 @@ groups:
         }} has no rule groups assigned.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
     expr: |
+      # Alert on ruler instances that have no rule groups assigned,
       (min by(cluster, namespace, pod) (cortex_ruler_managers_total) == 0)
+      # but only if other ruler instances of the same cell do have rule groups assigned
       and on (cluster, namespace)
-      # Only if other ruler instances of the same cell have rule groups assigned
       (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+      # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
+      # We never want to scale to less than 2 instances because of availability concerns,
+      # and in these cases, it's likely that rule groups aren't sharded across both instances.
+      unless on (cluster, namespace)
+      (
+          count by (cluster, namespace) (cortex_ruler_managers_total) == 2
+          and on (cluster, namespace)
+          count by (cluster, namespace) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
+      )
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -177,10 +177,10 @@ groups:
       min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*-mimir-)?ruler.*"}) == 0
       # but only if other ruler instances of the same cell do have rule groups assigned
       and on (cluster, namespace)
-      max by(cluster, namespace) (cortex_ruler_managers_total) > 0
+      (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
       # and there are more than two instances overall
       and on (cluster, namespace)
-      count by (cluster, namespace) (cortex_ruler_managers_total) > 2
+      (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -167,6 +167,19 @@ groups:
     for: 1h
     labels:
       severity: warning
+  - alert: MimirRulerInstanceHasNoRuleGroups
+    annotations:
+      message: Mimir ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has no rule groups assigned.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
+    expr: |
+      (min by(cluster, namespace, pod) (cortex_ruler_managers_total) == 0)
+      and on (cluster, namespace)
+      # Only if other ruler instances of the same cell have rule groups assigned
+      (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+    for: 1h
+    labels:
+      severity: warning
   - alert: MimirRingMembersMismatch
     annotations:
       message: |

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -173,20 +173,14 @@ groups:
         }} has no rule groups assigned.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
     expr: |
-      # Alert on ruler instances that have no rule groups assigned,
-      (min by(cluster, namespace, pod) (cortex_ruler_managers_total) == 0)
+      # Alert on ruler instances in microservices mode that have no rule groups assigned,
+      min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*-mimir-)?ruler.*"}) == 0
       # but only if other ruler instances of the same cell do have rule groups assigned
       and on (cluster, namespace)
-      (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-      # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
-      # We never want to scale to less than 2 instances because of availability concerns,
-      # and in these cases, it's likely that rule groups aren't sharded across both instances.
-      unless on (cluster, namespace)
-      (
-          count by (cluster, namespace) (cortex_ruler_managers_total) == 2
-          and on (cluster, namespace)
-          count by (cluster, namespace) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
-      )
+      max by(cluster, namespace) (cortex_ruler_managers_total) > 0
+      # and there are more than two instances overall
+      and on (cluster, namespace)
+      count by (cluster, namespace) (cortex_ruler_managers_total) > 2
     for: 1h
     labels:
       severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -265,6 +265,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
             message: '%(product)s ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s has no tenants assigned.' % $._config,
           },
         },
+        {
+          // Alert if a ruler instance has no rule groups assigned while other instances in the same cell do.
+          alert: $.alertName('RulerInstanceHasNoRuleGroups'),
+          'for': '1h',
+          expr: |||
+            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ruler_managers_total) == 0)
+            and on (%(alert_aggregation_labels)s)
+            # Only if other ruler instances of the same cell have rule groups assigned
+            (max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0)
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s has no rule groups assigned.' % $._config,
+          },
+        },
       ] + [
         {
           alert: $.alertName('RingMembersMismatch'),

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -270,21 +270,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerInstanceHasNoRuleGroups'),
           'for': '1h',
           expr: |||
-            # Alert on ruler instances that have no rule groups assigned,
-            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ruler_managers_total) == 0)
+            # Alert on ruler instances in microservices mode that have no rule groups assigned,
+            min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ruler_managers_total{%(per_instance_label)s=~"%(rulerInstanceName)s"}) == 0
             # but only if other ruler instances of the same cell do have rule groups assigned
             and on (%(alert_aggregation_labels)s)
-            (max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0)
-            # but not if we have exactly 2 instances and the cell has less than 5 rule groups.
-            # We never want to scale to less than 2 instances because of availability concerns,
-            # and in these cases, it's likely that rule groups aren't sharded across both instances.
-            unless on (%(alert_aggregation_labels)s)
-            (
-                count by (%(alert_aggregation_labels)s) (cortex_ruler_managers_total) == 2
-                and on (%(alert_aggregation_labels)s)
-                count by (%(alert_aggregation_labels)s) (cortex_prometheus_rule_group_rules{job=~".+?((ruler|cortex|mimir|mimir-backend.*))"}) < 5
-            )
-          ||| % $._config,
+            max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0
+            # and there are more than two instances overall
+            and on (%(alert_aggregation_labels)s)
+            count by (%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 2
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+            per_instance_label: $._config.per_instance_label,
+            rulerInstanceName: $._config.instance_names.ruler,
+          },
           labels: {
             severity: 'warning',
           },

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -274,10 +274,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
             min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ruler_managers_total{%(per_instance_label)s=~"%(rulerInstanceName)s"}) == 0
             # but only if other ruler instances of the same cell do have rule groups assigned
             and on (%(alert_aggregation_labels)s)
-            max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0
+            (max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0)
             # and there are more than two instances overall
             and on (%(alert_aggregation_labels)s)
-            count by (%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 2
+            (count by (%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 2)
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds an alert to help detect idling ruler instances in microservices mode that aren't evaluating any rule groups.

Note: The unrelated change in `CHANGELOG.md` recovers a line that I believe got lost in a previous merge.

#### Which issue(s) this PR fixes or relates to

Partially fixes #1959 

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
