### PR TITLE
Add Mimir 2.5.0 to compatibility test.

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -12,4 +12,5 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.2.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 	"grafana/mimir:2.3.1": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 	"grafana/mimir:2.4.0": e2emimir.NoopFlagMapper,
+	"grafana/mimir:2.5.0": e2emimir.NoopFlagMapper,
 }


### PR DESCRIPTION
This PR adds mimir-2.5.0 to backward compatibility test.

Part of release process: https://github.com/grafana/mimir/issues/3525