### PR TITLE
streaming store-gateway: add tests for index cache with query sharding

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1130,6 +1130,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 				matchers,
 				shardSelector,
 				blockSeriesHashCache,
+				cachedSeriesHasher{blockSeriesHashCache},
 				chunksLimiter,
 				seriesLimiter,
 				req.SkipChunks,

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/encoding"
-	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/prometheus/prometheus/tsdb/index"
 
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -157,7 +156,7 @@ func (it *bigEndianPostings) length() int {
 // filterPostingsByCachedShardHash filters the input postings by the provided shard. It filters only
 // postings for which we have their series hash already in the cache; if a series is not in the cache,
 // postings will be kept in the output.
-func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache *hashcache.BlockSeriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
+func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache seriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
 	writeIdx := 0
 	stats.seriesHashCacheRequests = len(ps)
 

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -156,17 +156,11 @@ func (it *bigEndianPostings) length() int {
 // filterPostingsByCachedShardHash filters the input postings by the provided shard. It filters only
 // postings for which we have their series hash already in the cache; if a series is not in the cache,
 // postings will be kept in the output.
-func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache seriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
+func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache seriesHasher, stats *queryStats) []storage.SeriesRef {
 	writeIdx := 0
-	stats.seriesHashCacheRequests = len(ps)
-
 	for readIdx := 0; readIdx < len(ps); readIdx++ {
 		seriesID := ps[readIdx]
-		hash, ok := seriesHashCache.Fetch(seriesID)
-		if ok {
-			stats.seriesHashCacheHits++
-		}
-
+		hash, ok := seriesHashCache.CachedHash(seriesID, stats)
 		// Keep the posting if it's not in the cache, or it's in the cache and belongs to our shard.
 		if !ok || hash%uint64(shard.ShardCount) == uint64(shard.ShardIndex) {
 			ps[writeIdx] = seriesID
@@ -181,7 +175,7 @@ func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.Sha
 	// Shrink the size.
 	ps = ps[:writeIdx]
 
-	return ps, stats
+	return ps
 }
 
 // paddedPostings adds the v2 index padding to postings without expanding them

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/prometheus/prometheus/tsdb/index"
 
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -156,7 +157,7 @@ func (it *bigEndianPostings) length() int {
 // filterPostingsByCachedShardHash filters the input postings by the provided shard. It filters only
 // postings for which we have their series hash already in the cache; if a series is not in the cache,
 // postings will be kept in the output.
-func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache seriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
+func filterPostingsByCachedShardHash(ps []storage.SeriesRef, shard *sharding.ShardSelector, seriesHashCache *hashcache.BlockSeriesHashCache) (filteredPostings []storage.SeriesRef, stats queryStats) {
 	writeIdx := 0
 	stats.seriesHashCacheRequests = len(ps)
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2212,7 +2212,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 				chunkReader := blk.chunkReader(ctx)
 				chunksPool := &pool.BatchBytes{Delegate: pool.NoopBytes{}}
 
-				seriesSet, _, err := blockSeries(context.Background(), indexReader, chunkReader, chunksPool, matchers, shardSelector, seriesHashCache, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, log.NewNopLogger())
+				seriesSet, _, err := blockSeries(context.Background(), indexReader, chunkReader, chunksPool, matchers, shardSelector, cachedSeriesHasher{seriesHashCache}, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, log.NewNopLogger())
 				require.NoError(b, err)
 
 				// Ensure at least 1 series has been returned (as expected).
@@ -2312,7 +2312,7 @@ func TestBlockSeries_Cache(t *testing.T) {
 
 		indexr := b.indexReader()
 		for i, tc := range testCases {
-			ss, _, err := blockSeries(context.Background(), indexr, nil, nil, tc.matchers, tc.shard, shc, nil, sl, true, b.meta.MinTime, b.meta.MaxTime, log.NewNopLogger())
+			ss, _, err := blockSeries(context.Background(), indexr, nil, nil, tc.matchers, tc.shard, cachedSeriesHasher{shc}, nil, sl, true, b.meta.MinTime, b.meta.MaxTime, log.NewNopLogger())
 			require.NoError(t, err, "Unexpected error for test case %d", i)
 			lset := lsetFromSeriesSet(t, ss)
 			require.Equalf(t, tc.expectedLabelSet, lset, "Wrong label set for test case %d", i)
@@ -2322,7 +2322,7 @@ func TestBlockSeries_Cache(t *testing.T) {
 		// We break the index cache to not allow looking up series, so we know we don't look up series.
 		indexr.block.indexCache = forbiddenFetchMultiSeriesForRefsIndexCache{b.indexCache, t}
 		for i, tc := range testCases {
-			ss, _, err := blockSeries(context.Background(), indexr, nil, nil, tc.matchers, tc.shard, shc, nil, sl, true, b.meta.MinTime, b.meta.MaxTime, log.NewNopLogger())
+			ss, _, err := blockSeries(context.Background(), indexr, nil, nil, tc.matchers, tc.shard, cachedSeriesHasher{shc}, nil, sl, true, b.meta.MinTime, b.meta.MaxTime, log.NewNopLogger())
 			require.NoError(t, err, "Unexpected error for test case %d", i)
 			lset := lsetFromSeriesSet(t, ss)
 			require.Equalf(t, tc.expectedLabelSet, lset, "Wrong label set for test case %d", i)
@@ -2589,12 +2589,12 @@ func TestFilterPostingsByCachedShardHash(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			cache := hashcache.NewSeriesHashCache(1024 * 1024).GetBlockCache("test")
+			hasher := mockSeriesHasher{cached: make(map[storage.SeriesRef]uint64)}
 			for _, pair := range testData.cacheEntries {
-				cache.Store(storage.SeriesRef(pair[0]), pair[1])
+				hasher.cached[storage.SeriesRef(pair[0])] = pair[1]
 			}
 
-			actualPostings, _ := filterPostingsByCachedShardHash(testData.inputPostings, testData.shard, cache)
+			actualPostings := filterPostingsByCachedShardHash(testData.inputPostings, testData.shard, hasher, nil)
 			assert.Equal(t, testData.expectedPostings, actualPostings)
 		})
 	}
@@ -2609,9 +2609,10 @@ func TestFilterPostingsByCachedShardHash_NoAllocations(t *testing.T) {
 	for _, pair := range cacheEntries {
 		cache.Store(storage.SeriesRef(pair[0]), pair[1])
 	}
+	stats := &queryStats{}
 
 	assert.Equal(t, float64(0), testing.AllocsPerRun(1, func() {
-		filterPostingsByCachedShardHash(inputPostings, shard, cache)
+		filterPostingsByCachedShardHash(inputPostings, shard, cachedSeriesHasher{cache}, stats)
 	}))
 }
 
@@ -2638,7 +2639,7 @@ func BenchmarkFilterPostingsByCachedShardHash_AllPostingsShifted(b *testing.B) {
 		inputPostings = inputPostings[0:numPostings]
 		copy(inputPostings, originalPostings)
 
-		filterPostingsByCachedShardHash(inputPostings, shard, cache)
+		filterPostingsByCachedShardHash(inputPostings, shard, cachedSeriesHasher{cache}, nil)
 	}
 }
 
@@ -2657,6 +2658,6 @@ func BenchmarkFilterPostingsByCachedShardHash_NoPostingsShifted(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// We reuse the same postings slice because we expect this test to not
 		// modify it (cache is empty).
-		filterPostingsByCachedShardHash(ps, shard, cache)
+		filterPostingsByCachedShardHash(ps, shard, cachedSeriesHasher{cache}, nil)
 	}
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -604,7 +604,7 @@ type loadingSeriesChunkRefsSetIterator struct {
 	ctx                 context.Context
 	postingsSetIterator *postingsSetsIterator
 	indexr              *bucketIndexReader
-	seriesHashCache     *hashcache.BlockSeriesHashCache
+	seriesHashCache     seriesHashCache
 	indexCache          indexcache.IndexCache
 	stats               *safeQueryStats
 	blockID             ulid.ULID
@@ -905,8 +905,16 @@ type seriesHasher interface {
 	Hash(seriesID storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64
 }
 
+type seriesHashCache interface {
+	Fetch(seriesID storage.SeriesRef) (uint64, bool)
+}
+
 type cachedSeriesHasher struct {
 	cache *hashcache.BlockSeriesHashCache
+}
+
+func (b cachedSeriesHasher) Fetch(seriesID storage.SeriesRef) (uint64, bool) {
+	return b.cache.Fetch(seriesID)
 }
 
 func (b cachedSeriesHasher) Hash(id storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64 {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -604,7 +604,7 @@ type loadingSeriesChunkRefsSetIterator struct {
 	ctx                 context.Context
 	postingsSetIterator *postingsSetsIterator
 	indexr              *bucketIndexReader
-	seriesHashCache     seriesHashCache
+	seriesHashCache     *hashcache.BlockSeriesHashCache
 	indexCache          indexcache.IndexCache
 	stats               *safeQueryStats
 	blockID             ulid.ULID
@@ -905,16 +905,8 @@ type seriesHasher interface {
 	Hash(seriesID storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64
 }
 
-type seriesHashCache interface {
-	Fetch(seriesID storage.SeriesRef) (uint64, bool)
-}
-
 type cachedSeriesHasher struct {
 	cache *hashcache.BlockSeriesHashCache
-}
-
-func (b cachedSeriesHasher) Fetch(seriesID storage.SeriesRef) (uint64, bool) {
-	return b.cache.Fetch(seriesID)
 }
 
 func (b cachedSeriesHasher) Hash(id storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64 {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -749,11 +749,6 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 		loadStats.merge(&unsafeStats)
 	}
 
-	if len(nextPostings) == 0 {
-		// All postings were part of another shard, try with the next set.
-		return s.Next()
-	}
-
 	loadedSeries, err := s.indexr.preloadSeries(s.ctx, nextPostings, s.stats)
 	if err != nil {
 		s.err = errors.Wrap(err, "preload series")

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1453,6 +1453,8 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 	}
 }
 
+// TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching currently tests logic in loadingSeriesChunkRefsSetIterator.
+// If openBlockSeriesChunkRefsSetsIterator becomes more complex, consider making this a test for loadingSeriesChunkRefsSetIterator only.
 func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 	newTestBlock := prepareTestBlock(test.NewTB(t), func(tb testing.TB, appender storage.Appender) {
 		existingSeries := []labels.Labels{

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1397,6 +1397,8 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			indexReader := block.indexReader()
 			defer indexReader.Close()
 
+			hashCache := hashcache.NewSeriesHashCache(1024 * 1024).GetBlockCache(block.meta.ULID.String())
+
 			iterator, err := openBlockSeriesChunkRefsSetsIterator(
 				ctx,
 				testCase.batchSize,
@@ -1406,7 +1408,8 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				block.meta,
 				[]*labels.Matcher{testCase.matcher},
 				nil,
-				hashcache.NewSeriesHashCache(1024*1024).GetBlockCache(block.meta.ULID.String()),
+				hashCache,
+				cachedSeriesHasher{hashCache},
 				&limiter{limit: testCase.chunksLimit},
 				&limiter{limit: testCase.seriesLimit},
 				testCase.skipChunks,
@@ -1451,15 +1454,15 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 }
 
 func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
-	existingSeries := []labels.Labels{
-		labels.FromStrings("a", "1", "b", "1"),
-		labels.FromStrings("a", "1", "b", "2"),
-		labels.FromStrings("a", "2", "b", "1"),
-		labels.FromStrings("a", "2", "b", "2"),
-		labels.FromStrings("a", "3", "b", "1"),
-		labels.FromStrings("a", "3", "b", "2"),
-	}
 	newTestBlock := prepareTestBlock(test.NewTB(t), func(tb testing.TB, appender storage.Appender) {
+		existingSeries := []labels.Labels{
+			labels.FromStrings("a", "1", "b", "1"), // series ref 32
+			labels.FromStrings("a", "1", "b", "2"), // series ref 48
+			labels.FromStrings("a", "2", "b", "1"), // series ref 64
+			labels.FromStrings("a", "2", "b", "2"), // series ref 80
+			labels.FromStrings("a", "3", "b", "1"), // series ref 96
+			labels.FromStrings("a", "3", "b", "2"), // series ref 112
+		}
 		for ts := int64(0); ts < 10; ts++ {
 			for _, s := range existingSeries {
 				_, err := appender.Append(0, s, ts, 0)
@@ -1469,69 +1472,237 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 		assert.NoError(t, appender.Commit())
 	})
 
-	matchers := []*labels.Matcher{
-		labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+	mockedSeriesHashes := map[string]uint64{
+		`{a="1", b="1"}`: 1,
+		`{a="1", b="2"}`: 0,
+		`{a="2", b="1"}`: 1,
+		`{a="2", b="2"}`: 0,
+		`{a="3", b="1"}`: 1,
+		`{a="3", b="2"}`: 0,
 	}
 
-	for batchSize := 1; batchSize < len(existingSeries)+2; batchSize++ {
-		batchSize := batchSize
-		t.Run(fmt.Sprintf("batch size %d", batchSize), func(t *testing.T) {
-			t.Parallel()
-			b := newTestBlock()
-			b.indexCache = newInMemoryIndexCache(t)
+	testCases := map[string]struct {
+		batchSizes []int
+		shard      *sharding.ShardSelector
+		matchers   []*labels.Matcher
 
-			indexReader := b.indexReader()
-			ss, err := openBlockSeriesChunkRefsSetsIterator(
-				context.Background(),
-				batchSize,
-				"",
-				indexReader,
-				b.indexCache,
-				b.meta,
-				matchers,
-				nil,
-				nil,
-				&limiter{limit: 1000},
-				&limiter{limit: 1000},
-				true,
-				b.meta.MinTime, b.meta.MaxTime,
-				newSafeQueryStats(),
-				NewBucketStoreMetrics(nil),
-				log.NewNopLogger(),
-			)
+		cachedSeriesHashesWithColdCache map[storage.SeriesRef]uint64
+		cachedSeriesHashesWithWarmCache map[storage.SeriesRef]uint64
 
-			require.NoError(t, err)
-			lset := extractLabelsFromSeriesChunkRefsSets(readAllSeriesChunkRefsSet(ss))
-			require.NoError(t, ss.Err())
-			require.Equal(t, existingSeries, lset)
+		expectedLabelSets                        []labels.Labels
+		expectedSeriesReadFromBlockWithColdCache int
+		expectedSeriesReadFromBlockWithWarmCache int
+	}{
+		"without sharding, without series hash caches": {
+			matchers:                                 []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a", ".+")},
+			batchSizes:                               []int{1, 2, 3, 4, 5, 6, 7},
+			expectedSeriesReadFromBlockWithColdCache: 6,
+			expectedSeriesReadFromBlockWithWarmCache: 0,
+			expectedLabelSets: []labels.Labels{
+				labels.FromStrings("a", "1", "b", "1"),
+				labels.FromStrings("a", "1", "b", "2"),
+				labels.FromStrings("a", "2", "b", "1"),
+				labels.FromStrings("a", "2", "b", "2"),
+				labels.FromStrings("a", "3", "b", "1"),
+				labels.FromStrings("a", "3", "b", "2"),
+			},
+		},
+		"without sharding; series hash isn't looked at when request isn't sharded": {
+			matchers:   []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a", ".+")},
+			batchSizes: []int{1, 2, 3, 4, 5, 6, 7},
+			cachedSeriesHashesWithWarmCache: map[storage.SeriesRef]uint64{ // have some bogus series hash cache
+				32:  1,
+				48:  2,
+				64:  3,
+				80:  4,
+				96:  5,
+				112: 6,
+			},
+			expectedSeriesReadFromBlockWithColdCache: 6,
+			expectedSeriesReadFromBlockWithWarmCache: 0,
+			expectedLabelSets: []labels.Labels{
+				labels.FromStrings("a", "1", "b", "1"),
+				labels.FromStrings("a", "1", "b", "2"),
+				labels.FromStrings("a", "2", "b", "1"),
+				labels.FromStrings("a", "2", "b", "2"),
+				labels.FromStrings("a", "3", "b", "1"),
+				labels.FromStrings("a", "3", "b", "2"),
+			},
+		},
+		"with sharding, cached series hashes": {
+			batchSizes: []int{1, 2, 3, 4},
+			matchers:   []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a", ".+")},
+			shard:      &sharding.ShardSelector{ShardIndex: 1, ShardCount: 2},
+			cachedSeriesHashesWithColdCache: map[storage.SeriesRef]uint64{
+				32:  1,
+				48:  0,
+				64:  1,
+				80:  0,
+				96:  1,
+				112: 0,
+			},
+			cachedSeriesHashesWithWarmCache: map[storage.SeriesRef]uint64{
+				32:  1,
+				48:  0,
+				64:  1,
+				80:  0,
+				96:  1,
+				112: 0,
+			},
+			expectedSeriesReadFromBlockWithColdCache: 3, // we omit reading the block for series when know are outside of our shard
+			expectedSeriesReadFromBlockWithWarmCache: 0,
+			expectedLabelSets: []labels.Labels{
+				labels.FromStrings("a", "1", "b", "1"),
+				labels.FromStrings("a", "2", "b", "1"),
+				labels.FromStrings("a", "3", "b", "1"),
+			},
+		},
+		"with sharding without series hash cache": {
+			batchSizes:                               []int{1, 2, 3, 4},
+			matchers:                                 []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a", ".+")},
+			shard:                                    &sharding.ShardSelector{ShardIndex: 1, ShardCount: 2},
+			cachedSeriesHashesWithColdCache:          map[storage.SeriesRef]uint64{},
+			expectedSeriesReadFromBlockWithColdCache: 6,
+			expectedSeriesReadFromBlockWithWarmCache: 0,
+			expectedLabelSets: []labels.Labels{
+				labels.FromStrings("a", "1", "b", "1"),
+				labels.FromStrings("a", "2", "b", "1"),
+				labels.FromStrings("a", "3", "b", "1"),
+			},
+		},
+		// This case simulates having different series hash caches on different store-gateway replicas.
+		// Having a batch size of 1 means that some batches are entirely of series what don't fall in our shard.
+		// The series in such batches may end up being read from the block and then discarded.
+		"with sharding, with different series hash caches before and after caching, whole batches with unowned series": {
+			matchers:   []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a", ".+")},
+			batchSizes: []int{1},
+			shard:      &sharding.ShardSelector{ShardIndex: 1, ShardCount: 2},
+			cachedSeriesHashesWithColdCache: map[storage.SeriesRef]uint64{
+				32: 1,
+				48: 0,
+				64: 1,
+			},
+			cachedSeriesHashesWithWarmCache: map[storage.SeriesRef]uint64{
+				80:  0,
+				96:  1,
+				112: 0,
+			},
+			expectedSeriesReadFromBlockWithColdCache: 3 + 2, // 2 reads for the series on which we miss the hash cache, and 3 for series in our shard
+			expectedSeriesReadFromBlockWithWarmCache: 1,     // 1 read for the series on which we miss the hash cache and are not in our shard (so we also didn't cache them last time)
+			expectedLabelSets: []labels.Labels{
+				labels.FromStrings("a", "1", "b", "1"),
+				labels.FromStrings("a", "2", "b", "1"),
+				labels.FromStrings("a", "3", "b", "1"),
+			},
+		},
+		// This case simulates having different series hash caches on different store-gateway replicas.
+		// With batch size 2 at least one of the series in each batch is in our shard.
+		// This causes us to cache the result of the batch and not have to refresh the series even though we miss on the series hash cache.
+		"with sharding, with different series hash caches before and after caching, batches with some non-owned series": {
+			matchers:   []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a", ".+")},
+			batchSizes: []int{2},
+			shard:      &sharding.ShardSelector{ShardIndex: 1, ShardCount: 2},
+			cachedSeriesHashesWithColdCache: map[storage.SeriesRef]uint64{
+				32: 1,
+				48: 0,
+				64: 1,
+			},
+			cachedSeriesHashesWithWarmCache: map[storage.SeriesRef]uint64{
+				80:  0,
+				96:  1,
+				112: 0,
+			},
+			expectedSeriesReadFromBlockWithColdCache: 3 + 2, // 2 reads for the series on which we miss the hash cache, and 3 for series in our shard
+			expectedSeriesReadFromBlockWithWarmCache: 0,     // at least one series in each batch was in our shard, so we should've cached everything
+			expectedLabelSets: []labels.Labels{
+				labels.FromStrings("a", "1", "b", "1"),
+				labels.FromStrings("a", "2", "b", "1"),
+				labels.FromStrings("a", "3", "b", "1"),
+			},
+		},
+	}
 
-			// Cache should be filled by now. Pass an index cache that fails the test if you try to access the postings
-			b.indexCache = forbiddenFetchMultiSeriesForRefsIndexCache{b.indexCache, t}
+	for testName, testCase := range testCases {
+		testCase := testCase
+		t.Run(testName, func(t *testing.T) {
+			for _, batchSize := range testCase.batchSizes {
+				batchSize := batchSize
+				t.Run(fmt.Sprintf("batch size %d", batchSize), func(t *testing.T) {
+					b := newTestBlock()
+					b.indexCache = newInMemoryIndexCache(t)
 
-			ss, err = openBlockSeriesChunkRefsSetsIterator(
-				context.Background(),
-				batchSize,
-				"",
-				indexReader,
-				b.indexCache,
-				b.meta,
-				matchers,
-				nil,
-				nil,
-				&limiter{limit: 1000},
-				&limiter{limit: 1000},
-				true,
-				b.meta.MinTime, b.meta.MaxTime,
-				newSafeQueryStats(),
-				NewBucketStoreMetrics(nil),
-				log.NewNopLogger(),
-			)
-			require.NoError(t, err)
-			lset = extractLabelsFromSeriesChunkRefsSets(readAllSeriesChunkRefsSet(ss))
-			require.NoError(t, ss.Err())
-			require.Equal(t, existingSeries, lset)
+					// Run 1 with a cold cache
+					seriesHashCache := newSeriesHashCacheWithHashes(b.meta.ULID, testCase.cachedSeriesHashesWithColdCache)
+					seriesHasher := mockSeriesHasher{hashes: mockedSeriesHashes}
+
+					statsColdCache := newSafeQueryStats()
+					indexReader := b.indexReader()
+					ss, err := openBlockSeriesChunkRefsSetsIterator(
+						context.Background(),
+						batchSize,
+						"",
+						indexReader,
+						b.indexCache,
+						b.meta,
+						testCase.matchers,
+						testCase.shard,
+						seriesHashCache,
+						seriesHasher,
+						&limiter{limit: 1000},
+						&limiter{limit: 1000},
+						true,
+						b.meta.MinTime, b.meta.MaxTime,
+						statsColdCache,
+						NewBucketStoreMetrics(nil),
+						log.NewNopLogger(),
+					)
+
+					require.NoError(t, err)
+					lset := extractLabelsFromSeriesChunkRefsSets(readAllSeriesChunkRefsSet(ss))
+					require.NoError(t, ss.Err())
+					assert.Equal(t, testCase.expectedLabelSets, lset)
+					assert.Equal(t, testCase.expectedSeriesReadFromBlockWithColdCache, statsColdCache.export().seriesFetched)
+
+					// Run 2 with a warm cache
+					seriesHashCache = newSeriesHashCacheWithHashes(b.meta.ULID, testCase.cachedSeriesHashesWithWarmCache)
+
+					statsWarnCache := newSafeQueryStats()
+					ss, err = openBlockSeriesChunkRefsSetsIterator(
+						context.Background(),
+						batchSize,
+						"",
+						indexReader,
+						b.indexCache,
+						b.meta,
+						testCase.matchers,
+						testCase.shard,
+						seriesHashCache,
+						seriesHasher,
+						&limiter{limit: 1000},
+						&limiter{limit: 1000},
+						true,
+						b.meta.MinTime, b.meta.MaxTime,
+						statsWarnCache,
+						NewBucketStoreMetrics(nil),
+						log.NewNopLogger(),
+					)
+					require.NoError(t, err)
+					lset = extractLabelsFromSeriesChunkRefsSets(readAllSeriesChunkRefsSet(ss))
+					require.NoError(t, ss.Err())
+					assert.Equal(t, testCase.expectedLabelSets, lset)
+					assert.Equal(t, testCase.expectedSeriesReadFromBlockWithWarmCache, statsWarnCache.export().seriesFetched)
+				})
+			}
 		})
 	}
+}
+
+func newSeriesHashCacheWithHashes(blockID ulid.ULID, postings map[storage.SeriesRef]uint64) *hashcache.BlockSeriesHashCache {
+	cache := hashcache.NewSeriesHashCache(10000).GetBlockCache(blockID.String())
+	for p, h := range postings {
+		cache.Store(p, h)
+	}
+	return cache
 }
 
 type forbiddenFetchMultiSeriesForRefsIndexCache struct {


### PR DESCRIPTION
Adds tests for when running the streaming implementation with query
sharding and index cache. This is a follow-up of #3687

This PR also includes some changes to interfaces so that it's easier to mock the hash of a series.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>