### PR TITLE
Add script for merging approved branch with merge commit

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -288,6 +288,7 @@ To merge a release branch `release-X.Y` into `main`:
 2. Once approved, merge the PR with a **Merge** commit through one of the following strategies:
    - Temporarily enable "Allow merge commits" option in "Settings > Options"
    - Locally merge the `merge-release-X.Y-to-main` branch into `main`, and push the changes to `main` back to GitHub. This doesn't break `main` branch protection, since the PR has been approved already, and it also doesn't require removing the protection.
+   - Using `tools/release/merge-approved-pr-branch-to-main.sh` script, which will do the merge and push automatically (in a safe way).
 
 **How to create the PR using the script:**
 

--- a/tools/release/create-pr-to-merge-release-branch-to-main.sh
+++ b/tools/release/create-pr-to-merge-release-branch-to-main.sh
@@ -77,4 +77,4 @@ done
 
 # Open the PR.
 git push -u origin "${BRANCH_NAME}"
-gh pr create --title "Merge ${LAST_RELEASE_BRANCH} to main" --body "In this PR I'm merging the ${LAST_RELEASE_BRANCH} branch to main branch. Please remember to merge it using **merge commit**."
+gh pr create --title "Merge ${LAST_RELEASE_BRANCH} to main" --body "In this PR I'm merging the ${LAST_RELEASE_BRANCH} branch to main branch. Please merge this PR using a **merge commit** or by using \`tools/release/merge-approved-pr-branch-to-main.sh\` script."

--- a/tools/release/merge-approved-pr-branch-to-main.sh
+++ b/tools/release/merge-approved-pr-branch-to-main.sh
@@ -50,8 +50,8 @@ git checkout main
 # (git pull could fail in that case.)
 git reset --hard "$FULL_MAIN_NAME"
 
-# We use origin/BRANCH_NAME here to make sure we merge the correct version of the branch.
-# Previous "git fetch origin" updated it.
+# We use $FULL_BRANCH_NAME here to make sure we merge the correct version of the branch
+# as found on server (updated via git fetch origin), and not possibly outdated local copy.
 git merge -n -m "Merge branch $BRANCH_NAME to main." "$FULL_BRANCH_NAME" || (echo; echo "Merge failed. This can happen if there are unresolved merge conflicts."; echo "Please update $BRANCH_NAME to fix conflicts and run this script again."; exit 1)
 
 echo

--- a/tools/release/merge-approved-pr-branch-to-main.sh
+++ b/tools/release/merge-approved-pr-branch-to-main.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -e
+
+BRANCH_NAME="$1"
+
+# Check input parameters.
+if [[ -z "$BRANCH_NAME" ]]; then
+  cat <<END
+Usage: $0 [branch]
+
+  branch    Branch that should be merged to main using merge commit.
+            This is typically the branch created by create-pr-to-merge-release-branch-to-main.sh script.
+            Merging of this branch needs to be approved by PR first, otherwise this script will fail.
+
+END
+  exit 1
+fi
+
+# Load common lib.
+CURR_DIR="$(dirname "$0")"
+. "${CURR_DIR}/common.sh"
+
+check_required_setup
+
+# Ensure there are not uncommitted changes.
+if [ -n "$(git status --porcelain=v1 2> /dev/null)" ]; then
+  echo "Please make sure there are no uncommitted changes."
+  exit 1
+fi
+
+# Get latest changes from origin, this includes both main and our merged branch.
+git fetch origin
+
+FULL_BRANCH_NAME="remotes/origin/$BRANCH_NAME"
+FULL_MAIN_NAME="remotes/origin/main"
+
+# Verify that merged branch exists.
+if ! git branch -a | grep -q "$FULL_BRANCH_NAME"; then
+  echo "Branch $BRANCH_NAME not found in this Git repository"
+  exit 1
+fi
+
+# Prepare the main branch for merging.
+git checkout main
+
+# Make sure that main is up-to-date wrt. origin/main. We use reset to avoid any weird
+# changes that one can have on the main branch (eg. from previous run of this script).
+# (git pull could fail in that case.)
+git reset --hard "$FULL_MAIN_NAME"
+
+# We use origin/BRANCH_NAME here to make sure we merge the correct version of the branch.
+# Previous "git fetch origin" updated it.
+git merge -n -m "Merge branch $BRANCH_NAME to main." "$FULL_BRANCH_NAME" || (echo; echo "Merge failed. This can happen if there are unresolved merge conflicts."; echo "Please update $BRANCH_NAME to fix conflicts and run this script again."; exit 1)
+
+echo
+echo "Merge successful, pushing to origin..."
+echo
+
+# Pushing to Github only succeeds if PR for $BRANCH_NAME was approved.
+# Successful push will also automatically close the PR.
+if ! git push origin HEAD:main; then
+  echo
+  echo "Push to Github failed. This can happen if PR was not approved yet"
+  echo "or if there was another commit pushed to main in the meantime."
+  echo "In that case, running this script again may succeed."
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a script for merging branch with approved PR to `main`, with a merge commit.

This is useful for merging release branch back to main. (But it should work for any branch with approved PR)

PR https://github.com/grafana/mimir/pull/3727 was merged using this script by calling `tools/release/merge-approved-pr-branch-to-main.sh merge-release-2.5-to-main`.

Benefit of this script is that it automates the task and doesn't require changing of repository permissions.