### PR TITLE
Only measure time taken to load an index-header once

### DIFF
--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -247,8 +247,10 @@ func (r *LazyBinaryReader) load() (returnErr error) {
 	}
 
 	r.reader = reader
-	level.Debug(r.logger).Log("msg", "lazy loaded index-header file", "path", r.filepath, "elapsed", time.Since(startTime))
-	r.metrics.loadDuration.Observe(time.Since(startTime).Seconds())
+	elapsed := time.Since(startTime)
+
+	level.Debug(r.logger).Log("msg", "lazy loaded index-header file", "path", r.filepath, "elapsed", elapsed)
+	r.metrics.loadDuration.Observe(elapsed.Seconds())
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does

Remove an extra unneeded `time.Now()` call. Probably not a measurable performance improvement but I noticed it while poking through some unrelated profiling.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
