### PR TITLE
Reduce memory allocations for seriesChunksSet.series and its chunks slices

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1156,7 +1156,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	mergedBatches := mergedSeriesChunkRefsSetIterators(s.maxSeriesPerBatch, batches...)
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
-		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, stats, s.metrics.iteratorLoadDurations)
+		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, s.maxSeriesPerBatch, stats, s.metrics.iteratorLoadDurations)
 	} else {
 		set = newSeriesSetWithoutChunks(ctx, mergedBatches)
 	}

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -4,6 +4,7 @@ package storegateway
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,22 +12,84 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/pool"
+)
+
+// Mimir compacts blocks up to 24h. Assuming a 5s scrape interval as worst case scenario,
+// and 120 samples per chunk, there could be 86400 * (1 / 5) * (1 / 120) = 144 chunks for
+// a series in the biggest block. Using a slab size of 1000 looks a good trade-off to support
+// high frequency scraping without wasting too much memory in case of queries hitting a low
+// number of chunks (across series).
+const seriesChunksSlabSize = 1000
+
+var (
+	seriesEntrySlicePool = pool.Interface(&sync.Pool{
+		// Intentionally return nil if the pool is empty, so that the caller can preallocate
+		// the slice with the right size.
+		New: nil,
+	})
+
+	seriesChunksSlicePool = pool.Interface(&sync.Pool{
+		// Intentionally return nil if the pool is empty, so that the caller can preallocate
+		// the slice with the right size.
+		New: nil,
+	})
 )
 
 // seriesChunksSetIterator is the interface implemented by an iterator returning a sequence of seriesChunksSet.
 type seriesChunksSetIterator interface {
 	Next() bool
+
+	// At returns the current seriesChunksSet. The caller should (but NOT must) invoke seriesChunksSet.release()
+	// on the returned set once it's guaranteed it will not be used anymore.
 	At() seriesChunksSet
+
 	Err() error
 }
 
 // seriesChunksSet holds a set of series, each with its own chunks.
 type seriesChunksSet struct {
-	series []seriesEntry
+	series           []seriesEntry
+	seriesReleasable bool
+
+	// It gets lazy initialized (only if required).
+	seriesChunksPool *pool.SlabPool[storepb.AggrChunk]
 
 	// chunksReleaser releases the memory used to allocate series chunks.
 	chunksReleaser chunksReleaser
+}
+
+// newSeriesChunksSet creates a new seriesChunksSet. The series slice is pre-allocated with
+// the provided seriesCapacity at least. This means this function GUARANTEES the series slice
+// will have a capacity of at least seriesCapacity.
+//
+// If seriesReleasable is true, then a subsequent call release() will put the internal
+// series slices to a memory pool for reusing.
+func newSeriesChunksSet(seriesCapacity int, seriesReleasable bool) seriesChunksSet {
+	var prealloc []seriesEntry
+
+	// If it's releasable then we try to reuse a slice from the pool.
+	if seriesReleasable {
+		if reused := seriesEntrySlicePool.Get(); reused != nil {
+			prealloc = *(reused.(*[]seriesEntry))
+
+			// The capacity MUST be guaranteed. If it's smaller, then we forget it and will be
+			// reallocated.
+			if cap(prealloc) < seriesCapacity {
+				prealloc = nil
+			}
+		}
+	}
+
+	if prealloc == nil {
+		prealloc = make([]seriesEntry, 0, seriesCapacity)
+	}
+
+	return seriesChunksSet{
+		series:           prealloc,
+		seriesReleasable: seriesReleasable,
+	}
 }
 
 type chunksReleaser interface {
@@ -34,16 +97,55 @@ type chunksReleaser interface {
 	Release()
 }
 
+// release the internal series and chunks slices to a memory pool, and call the chunksReleaser.Release().
+// The series and chunks slices won't be released to a memory pool if seriesChunksSet was created to be not releasable.
+//
+// This function is not idempotent. Calling it twice would introduce subtle bugs.
 func (b *seriesChunksSet) release() {
 	if b.chunksReleaser != nil {
 		b.chunksReleaser.Release()
-		b.chunksReleaser = nil
 	}
 
-	b.series = nil
+	if b.seriesReleasable {
+		// Reset series and chunk entries, before putting back to the pool.
+		for i := range b.series {
+			for c := range b.series[i].chks {
+				b.series[i].chks[c].MinTime = 0
+				b.series[i].chks[c].MaxTime = 0
+				b.series[i].chks[c].Raw = nil
+			}
+
+			b.series[i].lset = nil
+			b.series[i].refs = nil
+			b.series[i].chks = nil
+		}
+
+		if b.seriesChunksPool != nil {
+			b.seriesChunksPool.Release()
+		}
+
+		reuse := b.series[:0]
+		seriesEntrySlicePool.Put(&reuse)
+	}
 }
 
-func (b seriesChunksSet) len() int {
+// newSeriesAggrChunkSlice returns a []storepb.AggrChunk guaranteed to have length and capacity
+// equal to the provided size. The returned slice may be picked from a memory pool and then released
+// back once release() gets invoked.
+func (b *seriesChunksSet) newSeriesAggrChunkSlice(size int) []storepb.AggrChunk {
+	if !b.seriesReleasable {
+		return make([]storepb.AggrChunk, size)
+	}
+
+	// Lazy initialise the pool.
+	if b.seriesChunksPool == nil {
+		b.seriesChunksPool = pool.NewSlabPool[storepb.AggrChunk](seriesChunksSlicePool, seriesChunksSlabSize)
+	}
+
+	return b.seriesChunksPool.Get(size)
+}
+
+func (b *seriesChunksSet) len() int {
 	return len(b.series)
 }
 
@@ -60,9 +162,9 @@ func newSeriesChunksSeriesSet(from seriesChunksSetIterator) storepb.SeriesSet {
 	}
 }
 
-func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders, chunksPool pool.Bytes, batches seriesChunkRefsSetIterator, stats *safeQueryStats, iteratorLoadDurations *prometheus.HistogramVec) storepb.SeriesSet {
+func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders, chunksPool pool.Bytes, refsIterator seriesChunkRefsSetIterator, refsIteratorBatchSize int, stats *safeQueryStats, iteratorLoadDurations *prometheus.HistogramVec) storepb.SeriesSet {
 	var iterator seriesChunksSetIterator
-	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, chunksPool, batches, stats)
+	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, chunksPool, refsIterator, refsIteratorBatchSize, stats)
 	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_load"))
 	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
 	// We are measuring the time we wait for a preloaded batch. In an ideal world this is 0 because there's always a preloaded batch waiting.
@@ -78,11 +180,15 @@ func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders
 func (b *seriesChunksSeriesSet) Next() bool {
 	b.currOffset++
 	if b.currOffset >= b.currSet.len() {
+		// The current set won't be accessed anymore because the iterator is moving to the next one,
+		// so we can release it.
+		b.currSet.release()
+
 		if !b.from.Next() {
-			b.currSet.release()
+			b.currSet = seriesChunksSet{}
 			return false
 		}
-		b.currSet.release()
+
 		b.currSet = b.from.At()
 		b.currOffset = 0
 	}
@@ -174,25 +280,27 @@ func (p *preloadingSetIterator[Set]) Err() error {
 }
 
 type loadingSeriesChunksSetIterator struct {
-	chunkReaders bucketChunkReaders
-	from         seriesChunkRefsSetIterator
-	chunksPool   pool.Bytes
-	stats        *safeQueryStats
+	chunkReaders  bucketChunkReaders
+	from          seriesChunkRefsSetIterator
+	fromBatchSize int
+	chunksPool    pool.Bytes
+	stats         *safeQueryStats
 
 	current seriesChunksSet
 	err     error
 }
 
-func newLoadingSeriesChunksSetIterator(chunkReaders bucketChunkReaders, chunksPool pool.Bytes, from seriesChunkRefsSetIterator, stats *safeQueryStats) *loadingSeriesChunksSetIterator {
+func newLoadingSeriesChunksSetIterator(chunkReaders bucketChunkReaders, chunksPool pool.Bytes, from seriesChunkRefsSetIterator, fromBatchSize int, stats *safeQueryStats) *loadingSeriesChunksSetIterator {
 	return &loadingSeriesChunksSetIterator{
-		chunkReaders: chunkReaders,
-		from:         from,
-		chunksPool:   chunksPool,
-		stats:        stats,
+		chunkReaders:  chunkReaders,
+		from:          from,
+		fromBatchSize: fromBatchSize,
+		chunksPool:    chunksPool,
+		stats:         stats,
 	}
 }
 
-func (c *loadingSeriesChunksSetIterator) Next() bool {
+func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 	if c.err != nil {
 		return false
 	}
@@ -207,15 +315,30 @@ func (c *loadingSeriesChunksSetIterator) Next() bool {
 	// This data structure doesn't retain the seriesChunkRefsSet so it can be released once done.
 	defer nextUnloaded.release()
 
-	entries := make([]seriesEntry, nextUnloaded.len())
+	// Pre-allocate the series slice using the expected batchSize even if nextUnloaded has less elements,
+	// so that there's a higher chance the slice will be reused once released.
+	nextSet := newSeriesChunksSet(util_math.Max(c.fromBatchSize, nextUnloaded.len()), true)
+
+	// Release the set if an error occurred.
+	defer func() {
+		if !retHasNext && c.err != nil {
+			nextSet.release()
+		}
+	}()
+
+	// The series slice is guaranteed to have at least the requested capacity,
+	// so can safely expand it.
+	nextSet.series = nextSet.series[:nextUnloaded.len()]
+
 	c.chunkReaders.reset()
+
 	for i, s := range nextUnloaded.series {
-		entries[i].lset = s.lset
-		entries[i].chks = make([]storepb.AggrChunk, len(s.chunks))
+		nextSet.series[i].lset = s.lset
+		nextSet.series[i].chks = nextSet.newSeriesAggrChunkSlice(len(s.chunks))
 
 		for j, chunk := range s.chunks {
-			entries[i].chks[j].MinTime = chunk.minTime
-			entries[i].chks[j].MaxTime = chunk.maxTime
+			nextSet.series[i].chks[j].MinTime = chunk.minTime
+			nextSet.series[i].chks[j].MaxTime = chunk.maxTime
 
 			err := c.chunkReaders.addLoad(chunk.blockID, chunk.ref, i, j)
 			if err != nil {
@@ -228,15 +351,14 @@ func (c *loadingSeriesChunksSetIterator) Next() bool {
 	// Create a batched memory pool that can be released all at once.
 	chunksPool := &pool.BatchBytes{Delegate: c.chunksPool}
 
-	err := c.chunkReaders.load(entries, chunksPool, c.stats)
+	err := c.chunkReaders.load(nextSet.series, chunksPool, c.stats)
 	if err != nil {
 		c.err = errors.Wrap(err, "loading chunks")
 		return false
 	}
-	c.current = seriesChunksSet{
-		series:         entries,
-		chunksReleaser: chunksPool,
-	}
+
+	nextSet.chunksReleaser = chunksPool
+	c.current = nextSet
 	return true
 }
 

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -110,14 +110,10 @@ func (b *seriesChunksSet) release() {
 		// Reset series and chunk entries, before putting back to the pool.
 		for i := range b.series {
 			for c := range b.series[i].chks {
-				b.series[i].chks[c].MinTime = 0
-				b.series[i].chks[c].MaxTime = 0
-				b.series[i].chks[c].Raw = nil
+				b.series[i].chks[c].Reset()
 			}
 
-			b.series[i].lset = nil
-			b.series[i].refs = nil
-			b.series[i].chks = nil
+			b.series[i] = seriesEntry{}
 		}
 
 		if b.seriesChunksPool != nil {

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -22,6 +22,111 @@ import (
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
+func init() {
+	// Track the balance of gets/puts in pools in all tests.
+	seriesEntrySlicePool = &pool.TrackedPool{Parent: seriesEntrySlicePool}
+	seriesChunksSlicePool = &pool.TrackedPool{Parent: seriesChunksSlicePool}
+}
+
+func TestSeriesChunksSet(t *testing.T) {
+	t.Run("newSeriesChunksSet() should guarantee requested capacity", func(t *testing.T) {
+		const (
+			numRuns     = 1000
+			minCapacity = 10
+			maxCapacity = 1000
+		)
+
+		for r := 0; r < numRuns; r++ {
+			capacity := minCapacity + rand.Intn(maxCapacity-minCapacity)
+			set := newSeriesChunksSet(capacity, true)
+			require.GreaterOrEqual(t, cap(set.series), capacity)
+
+			set.release()
+		}
+	})
+
+	t.Run("release() should reset the series and chunk entries before putting them back to the pool", func(t *testing.T) {
+		const (
+			numRuns            = 1000
+			numSeries          = 10
+			numChunksPerSeries = 10
+		)
+
+		// Reset the memory pool tracker.
+		seriesEntrySlicePool.(*pool.TrackedPool).Reset()
+
+		for r := 0; r < numRuns; r++ {
+			set := newSeriesChunksSet(numSeries, true)
+
+			// Ensure the series slice is made of all zero values. Then write something inside before releasing it again.
+			// The slice is expected to be picked from the pool, at least in some runs (there's an assertion on it at
+			// the end of the test).
+			set.series = set.series[:numSeries]
+			for i := 0; i < numSeries; i++ {
+				require.Zero(t, set.series[i])
+
+				set.series[i].lset = labels.FromStrings(labels.MetricName, "metric")
+				set.series[i].refs = []chunks.ChunkRef{1, 2, 3}
+				set.series[i].chks = set.newSeriesAggrChunkSlice(numChunksPerSeries)
+			}
+
+			// Do the same with the chunks.
+			for i := 0; i < numSeries; i++ {
+				set.series[i].chks = set.newSeriesAggrChunkSlice(numChunksPerSeries)
+				for j := 0; j < numChunksPerSeries; j++ {
+					require.Equal(t, storepb.AggrChunk{}, set.series[i].chks[j])
+
+					set.series[i].chks[j].MinTime = 10
+					set.series[i].chks[j].MaxTime = 10
+					set.series[i].chks[j].Raw = &storepb.Chunk{Data: []byte{1, 2, 3}}
+				}
+			}
+
+			set.release()
+		}
+
+		// Ensure at least 1 series slice has been pulled from the pool.
+		assert.Greater(t, seriesEntrySlicePool.(*pool.TrackedPool).Gets.Load(), int64(0))
+		assert.Zero(t, seriesEntrySlicePool.(*pool.TrackedPool).Balance.Load())
+	})
+
+	t.Run("newSeriesAggrChunkSlice() should allocate slices from the pool and release() should put it back if the set is releasable", func(t *testing.T) {
+		seriesChunksSlicePool.(*pool.TrackedPool).Reset()
+
+		set := newSeriesChunksSet(1, true)
+
+		slice := set.newSeriesAggrChunkSlice(seriesChunksSlabSize - 1)
+		assert.Equal(t, seriesChunksSlabSize-1, len(slice))
+		assert.Equal(t, seriesChunksSlabSize-1, cap(slice))
+		assert.Equal(t, 1, int(seriesChunksSlicePool.(*pool.TrackedPool).Gets.Load()))
+
+		slice = set.newSeriesAggrChunkSlice(seriesChunksSlabSize)
+		assert.Equal(t, seriesChunksSlabSize, len(slice))
+		assert.Equal(t, seriesChunksSlabSize, cap(slice))
+		assert.Equal(t, 2, int(seriesChunksSlicePool.(*pool.TrackedPool).Gets.Load()))
+
+		set.release()
+		assert.Equal(t, 0, int(seriesChunksSlicePool.(*pool.TrackedPool).Balance.Load()))
+	})
+
+	t.Run("newSeriesAggrChunkSlice() should directly allocate a new slice and release() should not put back to the pool if the set is not releasable", func(t *testing.T) {
+		seriesChunksSlicePool.(*pool.TrackedPool).Reset()
+
+		set := newSeriesChunksSet(1, false)
+
+		slice := set.newSeriesAggrChunkSlice(seriesChunksSlabSize)
+		assert.Equal(t, seriesChunksSlabSize, len(slice))
+		assert.Equal(t, seriesChunksSlabSize, cap(slice))
+		assert.Equal(t, 0, int(seriesChunksSlicePool.(*pool.TrackedPool).Gets.Load()))
+		assert.Equal(t, 0, int(seriesChunksSlicePool.(*pool.TrackedPool).Balance.Load()))
+
+		set.release()
+
+		assert.Equal(t, 0, int(seriesChunksSlicePool.(*pool.TrackedPool).Gets.Load()))
+		assert.Equal(t, 0, int(seriesChunksSlicePool.(*pool.TrackedPool).Balance.Load()))
+	})
+}
+
 func TestSeriesChunksSeriesSet(t *testing.T) {
 	c := generateAggrChunk(6)
 
@@ -37,26 +142,27 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 			releasers = append(releasers, newReleaserMock())
 		}
 
-		sets = append(sets,
-			seriesChunksSet{
-				chunksReleaser: releasers[0],
-				series: []seriesEntry{
-					{lset: series1, chks: []storepb.AggrChunk{c[1]}},
-					{lset: series2, chks: []storepb.AggrChunk{c[2]}},
-				}},
-			seriesChunksSet{
-				chunksReleaser: releasers[1],
-				series: []seriesEntry{
-					{lset: series3, chks: []storepb.AggrChunk{c[3]}},
-					{lset: series4, chks: []storepb.AggrChunk{c[4]}},
-				}},
-			seriesChunksSet{
-				chunksReleaser: releasers[2],
-				series: []seriesEntry{
-					{lset: series5, chks: []storepb.AggrChunk{c[5]}},
-				}},
+		set1 := newSeriesChunksSet(2, true)
+		set1.chunksReleaser = releasers[0]
+		set1.series = append(set1.series,
+			seriesEntry{lset: series1, chks: []storepb.AggrChunk{c[1]}},
+			seriesEntry{lset: series2, chks: []storepb.AggrChunk{c[2]}},
 		)
 
+		set2 := newSeriesChunksSet(2, true)
+		set2.chunksReleaser = releasers[1]
+		set2.series = append(set2.series,
+			seriesEntry{lset: series3, chks: []storepb.AggrChunk{c[3]}},
+			seriesEntry{lset: series4, chks: []storepb.AggrChunk{c[4]}},
+		)
+
+		set3 := newSeriesChunksSet(1, true)
+		set3.chunksReleaser = releasers[2]
+		set3.series = append(set3.series,
+			seriesEntry{lset: series5, chks: []storepb.AggrChunk{c[5]}},
+		)
+
+		sets = append(sets, set1, set2, set3)
 		return
 	}
 
@@ -193,12 +299,14 @@ func TestPreloadingSetIterator(t *testing.T) {
 	// Create some sets, each set containing 1 series.
 	sets := make([]seriesChunksSet, 0, 10)
 	for i := 0; i < 10; i++ {
-		sets = append(sets, seriesChunksSet{
-			series: []seriesEntry{{
-				lset: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
-				refs: []chunks.ChunkRef{chunks.ChunkRef(i)},
-			}},
+		// The set is not releseable because will be reused by multiple tests.
+		set := newSeriesChunksSet(1, false)
+		set.series = append(set.series, seriesEntry{
+			lset: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
+			refs: []chunks.ChunkRef{chunks.ChunkRef(i)},
 		})
+
+		sets = append(sets, set)
 	}
 
 	t.Run("should iterate all sets if no error occurs", func(t *testing.T) {
@@ -309,19 +417,21 @@ func TestPreloadingSetIterator_Concurrency(t *testing.T) {
 		preloadSize = 10
 	)
 
-	// Create some batches.
-	batches := make([]seriesChunksSet, 0, numBatches)
+	// Create some sets.
+	sets := make([]seriesChunksSet, 0, numBatches)
 	for i := 0; i < numBatches; i++ {
-		batches = append(batches, seriesChunksSet{
-			series: []seriesEntry{{
-				lset: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
-			}},
+		// This set is unreleseable because reused by multiple test runs.
+		set := newSeriesChunksSet(1, false)
+		set.series = append(set.series, seriesEntry{
+			lset: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
 		})
+
+		sets = append(sets, set)
 	}
 
 	// Run many times to increase the likelihood to find a race (if any).
 	for i := 0; i < numRuns; i++ {
-		source := newSliceSeriesChunksSetIteratorWithError(errors.New("mocked error"), len(batches), batches...)
+		source := newSliceSeriesChunksSetIteratorWithError(errors.New("mocked error"), len(sets), sets...)
 		preloading := newPreloadingSetIterator[seriesChunksSet](context.Background(), preloadSize, source)
 
 		for preloading.Next() {
@@ -466,9 +576,11 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 	}
 
 	for testName, testCase := range testCases {
-		testName, testCase := testName, testCase
 		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
+			// Reset the memory pool tracker.
+			seriesEntrySlicePool.(*pool.TrackedPool).Reset()
+			seriesChunksSlicePool.(*pool.TrackedPool).Reset()
+
 			// Setup
 			bytesPool := &trackedBytesPool{parent: pool.NoopBytes{}}
 			readersMap := make(map[ulid.ULID]chunkReader, len(testCase.existingBlocks))
@@ -478,7 +590,7 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 			readers := newChunkReaders(readersMap)
 
 			// Run test
-			set := newLoadingSeriesChunksSetIterator(*readers, bytesPool, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), newSafeQueryStats())
+			set := newLoadingSeriesChunksSetIterator(*readers, bytesPool, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), 100, newSafeQueryStats())
 			loadedSets := readAllSeriesChunksSets(set)
 
 			// Assertions
@@ -515,7 +627,98 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 			for _, s := range loadedSets {
 				s.release()
 			}
+
 			assert.Zero(t, int(bytesPool.balance.Load()))
+			assert.Zero(t, seriesEntrySlicePool.(*pool.TrackedPool).Balance.Load())
+			assert.Greater(t, seriesEntrySlicePool.(*pool.TrackedPool).Gets.Load(), int64(0))
+			assert.Zero(t, seriesChunksSlicePool.(*pool.TrackedPool).Balance.Load())
+			assert.Greater(t, seriesChunksSlicePool.(*pool.TrackedPool).Gets.Load(), int64(0))
+		})
+	}
+}
+
+func BenchmarkLoadingSeriesChunksSetIterator(b *testing.B) {
+	for batchSize := 10; batchSize <= 10000; batchSize *= 10 {
+		b.Run(fmt.Sprintf("batch size: %d", batchSize), func(b *testing.B) {
+			var (
+				numSets            = 100
+				numSeriesPerSet    = batchSize
+				numChunksPerSeries = 10
+			)
+
+			// For simplicity all series have the same chunks. This doesn't affect the benchmark anyway.
+			blockID := ulid.MustNew(1, nil)
+			seriesEntries := make([]seriesEntry, 0, numChunksPerSeries)
+			for chunkIdx := 0; chunkIdx < numChunksPerSeries; chunkIdx++ {
+				seriesEntries = append(seriesEntries, seriesEntry{
+					refs: []chunks.ChunkRef{chunks.ChunkRef(chunkIdx)},
+					chks: []storepb.AggrChunk{{MinTime: int64(chunkIdx), MaxTime: int64(chunkIdx), Raw: &storepb.Chunk{}}},
+				})
+			}
+
+			// Creates the series sets, guaranteeing series sorted by labels.
+			sets := make([]seriesChunkRefsSet, 0, numSets)
+			for setIdx := 0; setIdx < numSets; setIdx++ {
+				minSeriesID := (numSets * numSeriesPerSet) + (setIdx * numSeriesPerSet)
+				maxSeriesID := minSeriesID + numSeriesPerSet - 1
+
+				// This set cannot be released because reused between multiple benchmark runs.
+				set := createSeriesChunkRefsSet(minSeriesID, maxSeriesID, false)
+
+				for seriesIdx := 0; seriesIdx < set.len(); seriesIdx++ {
+					set.series[seriesIdx].chunks = make([]seriesChunkRef, numChunksPerSeries)
+					for chunkIdx := 0; chunkIdx < numChunksPerSeries; chunkIdx++ {
+						set.series[seriesIdx].chunks[chunkIdx] = seriesChunkRef{
+							blockID: blockID,
+							ref:     chunks.ChunkRef(chunkIdx),
+						}
+					}
+				}
+
+				sets = append(sets, set)
+			}
+
+			// Mock the chunk reader.
+			readersMap := map[ulid.ULID]chunkReader{
+				blockID: newChunkReaderMockWithSeries(seriesEntries, nil, nil),
+			}
+
+			chunkReaders := newChunkReaders(readersMap)
+			chunksPool := &trackedBytesPool{parent: pool.NoopBytes{}}
+			stats := newSafeQueryStats()
+
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				batchSize := numSeriesPerSet
+				it := newLoadingSeriesChunksSetIterator(*chunkReaders, chunksPool, newSliceSeriesChunkRefsSetIterator(nil, sets...), batchSize, stats)
+
+				actualSeries := 0
+				actualChunks := 0
+
+				for it.Next() {
+					set := it.At()
+
+					for _, series := range set.series {
+						actualSeries++
+						actualChunks += len(series.chks)
+					}
+
+					set.release()
+				}
+
+				if err := it.Err(); err != nil {
+					b.Fatal(it.Err())
+				}
+
+				// Ensure each benchmark run go through the same data set.
+				if expectedSeries := numSets * numSeriesPerSet; actualSeries != expectedSeries {
+					b.Fatalf("benchmark iterated through an unexpected number of series (expected: %d got: %d)", expectedSeries, actualSeries)
+				}
+				if expectedChunks := numSets * numSeriesPerSet * numChunksPerSeries; actualChunks != expectedChunks {
+					b.Fatalf("benchmark iterated through an unexpected number of chunks (expected: %d got: %d)", expectedChunks, actualChunks)
+				}
+			}
 		})
 	}
 }

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -666,13 +666,7 @@ func BenchmarkLoadingSeriesChunksSetIterator(b *testing.B) {
 				set := createSeriesChunkRefsSet(minSeriesID, maxSeriesID, false)
 
 				for seriesIdx := 0; seriesIdx < set.len(); seriesIdx++ {
-					set.series[seriesIdx].chunks = make([]seriesChunkRef, numChunksPerSeries)
-					for chunkIdx := 0; chunkIdx < numChunksPerSeries; chunkIdx++ {
-						set.series[seriesIdx].chunks[chunkIdx] = seriesChunkRef{
-							blockID: blockID,
-							ref:     chunks.ChunkRef(chunkIdx),
-						}
-					}
+					set.series[seriesIdx].chunks = generateSeriesChunkRef(blockID, numChunksPerSeries)
 				}
 
 				sets = append(sets, set)

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -24,12 +24,13 @@ import (
 
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
+	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func init() {
 	// Track the balance of gets/puts to seriesChunkRefsSetPool in all tests.
-	seriesChunkRefsSetPool = &trackedPool{parent: seriesChunkRefsSetPool}
+	seriesChunkRefsSetPool = &pool.TrackedPool{Parent: seriesChunkRefsSetPool}
 }
 
 func TestSeriesChunkRef_Compare(t *testing.T) {
@@ -638,7 +639,7 @@ func TestMergedSeriesChunkRefsSet_Concurrency(t *testing.T) {
 	}
 
 	// Reset the memory pool tracker.
-	seriesChunkRefsSetPool.(*trackedPool).reset()
+	seriesChunkRefsSetPool.(*pool.TrackedPool).Reset()
 
 	g, _ := errgroup.WithContext(context.Background())
 	for c := 0; c < concurrency; c++ {
@@ -654,8 +655,8 @@ func TestMergedSeriesChunkRefsSet_Concurrency(t *testing.T) {
 
 	// Ensure the seriesChunkRefsSet memory pool has been used and all slices pulled from
 	// pool have put back.
-	assert.Greater(t, seriesChunkRefsSetPool.(*trackedPool).gets.Load(), int64(0))
-	assert.Equal(t, int64(0), seriesChunkRefsSetPool.(*trackedPool).balance.Load())
+	assert.Greater(t, seriesChunkRefsSetPool.(*pool.TrackedPool).Gets.Load(), int64(0))
+	assert.Equal(t, int64(0), seriesChunkRefsSetPool.(*pool.TrackedPool).Balance.Load())
 }
 
 func BenchmarkMergedSeriesChunkRefsSetIterators(b *testing.B) {

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -58,7 +58,7 @@ func TestSeriesChunkRef_Compare(t *testing.T) {
 }
 
 func TestSeriesChunkRefsIterator(t *testing.T) {
-	c := generateSeriesChunkRef(5)
+	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 5)
 	series1 := labels.FromStrings(labels.MetricName, "metric_1")
 	series2 := labels.FromStrings(labels.MetricName, "metric_2")
 	series3 := labels.FromStrings(labels.MetricName, "metric_3")
@@ -152,7 +152,7 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 
 func TestFlattenedSeriesChunkRefs(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are returned.
-	c := generateSeriesChunkRef(6)
+	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
 		input    seriesChunkRefsSetIterator
@@ -240,7 +240,7 @@ func TestFlattenedSeriesChunkRefs(t *testing.T) {
 
 func TestMergedSeriesChunkRefsSet(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are merged.
-	c := generateSeriesChunkRef(6)
+	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
 		batchSize    int
@@ -741,7 +741,7 @@ func BenchmarkMergedSeriesChunkRefsSetIterators(b *testing.B) {
 
 func TestSeriesSetWithoutChunks(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are returned.
-	c := generateSeriesChunkRef(6)
+	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
 		input    seriesChunkRefsSetIterator
@@ -832,7 +832,7 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 
 func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are returned.
-	c := generateSeriesChunkRef(8)
+	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 8)
 
 	series1 := labels.FromStrings("l1", "v1")
 	series2 := labels.FromStrings("l1", "v2")
@@ -1844,12 +1844,12 @@ func (l *limiter) Reserve(num uint64) error {
 	return nil
 }
 
-func generateSeriesChunkRef(num int) []seriesChunkRef {
+func generateSeriesChunkRef(blockID ulid.ULID, num int) []seriesChunkRef {
 	out := make([]seriesChunkRef, 0, num)
 
 	for i := 0; i < num; i++ {
 		out = append(out, seriesChunkRef{
-			blockID: ulid.MustNew(uint64(i), nil),
+			blockID: blockID,
 			ref:     chunks.ChunkRef(i),
 			minTime: int64(i),
 			maxTime: int64(i),

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -177,6 +177,12 @@ func (b *BatchBytes) Get(sz int) ([]byte, error) {
 	return (*slab)[len(*slab)-sz : len(*slab) : len(*slab)], nil
 }
 
+// SlabPool wraps Interface and adds support to get a sub-slice of the data type T
+// from the pool, trying to fit the slices picked from the pool as much as possible.
+//
+// The slices returned by SlabPool.Get() will be released back to the pool once
+// SlabPool.Release() is called.
+//
 // SlabPool is NOT concurrency safe.
 type SlabPool[T any] struct {
 	delegate Interface

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -176,3 +176,71 @@ func (b *BatchBytes) Get(sz int) ([]byte, error) {
 	*slab = (*slab)[:len(*slab)+sz]
 	return (*slab)[len(*slab)-sz : len(*slab) : len(*slab)], nil
 }
+
+// SlabPool is NOT concurrency safe.
+type SlabPool[T any] struct {
+	delegate Interface
+	slabSize int
+	slabs    []*[]T
+}
+
+func NewSlabPool[T any](delegate Interface, slabSize int) *SlabPool[T] {
+	return &SlabPool[T]{
+		delegate: delegate,
+		slabSize: slabSize,
+	}
+}
+
+// Release all slices returned by Get. It's unsafe to access slices previously returned by Get
+// after calling Release().
+func (b *SlabPool[T]) Release() {
+	for _, slab := range b.slabs {
+		// The slab length will be reset to 0 in the Get().
+		b.delegate.Put(slab)
+	}
+
+	b.slabs = b.slabs[:0]
+}
+
+// Get returns a slice of T with the given length and capacity (both matches).
+func (b *SlabPool[T]) Get(size int) []T {
+	const lookback = 3
+
+	if size <= 0 {
+		return nil
+	}
+
+	// If the requested size is bigger than the slab size, then the slice
+	// can't be handled by this pool and will be allocated outside it.
+	if size > b.slabSize {
+		return make([]T, size)
+	}
+
+	var slab *[]T
+
+	// Look in the last few slabs if there's any space left.
+	for i := len(b.slabs) - 1; i >= len(b.slabs)-lookback && i >= 0; i-- {
+		if cap(*b.slabs[i])-len(*b.slabs[i]) >= size {
+			slab = b.slabs[i]
+			break
+		}
+	}
+
+	// Get a new one if there's no space available in the last few slabs.
+	if slab == nil {
+		if reused := b.delegate.Get(); reused != nil {
+			slab = reused.(*[]T)
+			*slab = (*slab)[:0]
+		} else {
+			newSlab := make([]T, 0, b.slabSize)
+			slab = &newSlab
+		}
+
+		// Add the slab to the list of slabs.
+		b.slabs = append(b.slabs, slab)
+	}
+
+	// Resize the slab length and return a sub-slice.
+	*slab = (*slab)[:len(*slab)+size]
+	return (*slab)[len(*slab)-size : len(*slab) : len(*slab)]
+}

--- a/pkg/util/pool/pool_test.go
+++ b/pkg/util/pool/pool_test.go
@@ -6,6 +6,7 @@
 package pool
 
 import (
+	"math/rand"
 	"strings"
 	"sync"
 	"testing"
@@ -179,4 +180,145 @@ func TestBatchBytes(t *testing.T) {
 		batchBytes.Release()
 		assert.Zero(t, int(bytesPool.usedTotal))
 	})
+}
+
+func TestSlabPool(t *testing.T) {
+	t.Run("byte slices do not overlap when fit on the same slab", func(t *testing.T) {
+		delegatePool := &TrackedPool{Parent: &sync.Pool{}}
+		slabPool := NewSlabPool[byte](delegatePool, 10)
+
+		sliceA := slabPool.Get(5)
+		require.Len(t, sliceA, 5)
+		require.Equal(t, 5, cap(sliceA))
+		copy(sliceA, "12345")
+
+		sliceB := slabPool.Get(5)
+		require.Len(t, sliceB, 5)
+		require.Equal(t, 5, cap(sliceB))
+		copy(sliceB, "67890")
+
+		require.Equal(t, "12345", string(sliceA))
+		require.Equal(t, "67890", string(sliceB))
+
+		require.Equal(t, 1, len(slabPool.slabs))
+		require.Equal(t, 10, len(*(slabPool.slabs[0])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[0])))
+
+		slabPool.Release()
+		require.Zero(t, delegatePool.Balance.Load())
+		require.Greater(t, int(delegatePool.Gets.Load()), 0)
+	})
+
+	t.Run("a new slab is created when the new slice doesn't fit on an existing one", func(t *testing.T) {
+		delegatePool := &TrackedPool{Parent: &sync.Pool{}}
+		slabPool := NewSlabPool[byte](delegatePool, 10)
+
+		sliceA := slabPool.Get(5)
+		assert.Len(t, sliceA, 5)
+		assert.Equal(t, 5, cap(sliceA))
+		copy(sliceA, "12345")
+
+		require.Equal(t, 1, len(slabPool.slabs))
+		require.Equal(t, 5, len(*(slabPool.slabs[0])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[0])))
+
+		// Size doesn't fit the existing slab, so a new one will be created.
+		sliceB := slabPool.Get(6)
+		assert.Len(t, sliceB, 6)
+		assert.Equal(t, 6, cap(sliceB))
+		copy(sliceB, "67890-")
+
+		require.Equal(t, 2, len(slabPool.slabs))
+		require.Equal(t, 5, len(*(slabPool.slabs[0])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[0])))
+		require.Equal(t, 6, len(*(slabPool.slabs[1])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[1])))
+
+		// Size fits in the last slab.
+		sliceC := slabPool.Get(3)
+		assert.Len(t, sliceC, 3)
+		assert.Equal(t, 3, cap(sliceC))
+		copy(sliceC, "abc")
+
+		require.Equal(t, 2, len(slabPool.slabs))
+		require.Equal(t, 5, len(*(slabPool.slabs[0])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[0])))
+		require.Equal(t, 9, len(*(slabPool.slabs[1])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[1])))
+
+		// Size fits in the previous last slab.
+		sliceD := slabPool.Get(3)
+		assert.Len(t, sliceD, 3)
+		assert.Equal(t, 3, cap(sliceD))
+		copy(sliceD, "def")
+
+		require.Equal(t, 2, len(slabPool.slabs))
+		require.Equal(t, 8, len(*(slabPool.slabs[0])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[0])))
+		require.Equal(t, 9, len(*(slabPool.slabs[1])))
+		require.Equal(t, 10, cap(*(slabPool.slabs[1])))
+
+		assert.Equal(t, "12345", string(sliceA))
+		assert.Equal(t, "67890-", string(sliceB))
+		assert.Equal(t, "abc", string(sliceC))
+		assert.Equal(t, "def", string(sliceD))
+
+		slabPool.Release()
+		require.Zero(t, delegatePool.Balance.Load())
+		require.Greater(t, int(delegatePool.Gets.Load()), 0)
+	})
+}
+
+func TestSlabPool_Fuzzy(t *testing.T) {
+	const (
+		numRuns           = 100
+		numRequestsPerRun = 100
+		slabSize          = 100
+	)
+
+	type assertion struct {
+		expected []byte
+		actual   []byte
+	}
+
+	delegatePool := &TrackedPool{Parent: &sync.Pool{}}
+
+	// Randomise the seed but log it in case we need to reproduce the test on failure.
+	seed := time.Now().UnixNano()
+	rand.Seed(seed)
+	t.Log("random generator seed:", seed)
+
+	for r := 0; r < numRuns; r++ {
+		slabPool := NewSlabPool[byte](delegatePool, slabSize)
+		var assertions []assertion
+
+		for n := 0; n < numRequestsPerRun; n++ {
+			// Get a random size between 1 and (slabSize + 10)
+			size := 1 + rand.Intn(slabSize+9)
+
+			slice := slabPool.Get(size)
+
+			// Write some data to the slice.
+			expected := make([]byte, size)
+			_, err := rand.Read(expected)
+			require.NoError(t, err)
+
+			copy(slice, expected)
+
+			// Keep track of it, so we can check no data was overwritten later on.
+			assertions = append(assertions, assertion{
+				expected: expected,
+				actual:   slice,
+			})
+		}
+
+		// Ensure no data was overwritten.
+		for _, assertion := range assertions {
+			require.Equal(t, assertion.expected, assertion.actual)
+		}
+
+		slabPool.Release()
+		require.Zero(t, delegatePool.Balance.Load())
+		require.Greater(t, int(delegatePool.Gets.Load()), 0)
+	}
 }

--- a/pkg/util/pool/tracking.go
+++ b/pkg/util/pool/tracking.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package pool
+
+import "go.uber.org/atomic"
+
+type TrackedPool struct {
+	Parent  Interface
+	Balance atomic.Int64
+	Gets    atomic.Int64
+}
+
+func (p *TrackedPool) Get() any {
+	p.Balance.Inc()
+	p.Gets.Inc()
+	return p.Parent.Get()
+}
+
+func (p *TrackedPool) Put(x any) {
+	p.Balance.Dec()
+	p.Parent.Put(x)
+}
+
+func (p *TrackedPool) Reset() {
+	p.Balance.Store(0)
+	p.Gets.Store(0)
+}


### PR DESCRIPTION
#### What this PR does
Looking at streaming store-gateway profiles, I can see about 10% of memory allocated by `loadingSeriesChunksSetIterator.Next()`. There are two main memory allocations there:
- `make([]seriesEntry, nextUnloaded.len())`
- `make([]storepb.AggrChunk, len(s.chunks))`

In this PR I propose to use a memory pool for both of them (separate pools). To increase the chances the slice capacity is large enough to be reused, I've adopted the following strategies:
- `[]seriesEntry` allocate it based on the batch size (all real batches will have that size except the last one)
- `[]storepb.AggrChunk` use a slab (here the number of chunks is not predictable, so we can't use a good default)

I've introduced `pool.SlabPool` which is like `pool.BatchBytes` but works with generics and can never return `error` (so it's easier to use).

If this PR is accepted and once we feel comfortable with `pool.SlabPool`, I will replace `pool.BatchBytes` with `pool.SlabPool`.

**Benchmarks:**

Notes:
- LoadingSeriesChunksSetIterator is the micro benchmark
- Bucket_Series is the high level benchmark (we see a -10% improvement in some tests allocating a lot of memory, a downgrade is some tests on low cardinality queries, due to the higher pre-allocation done for reusing purposes)
- Bucket_Series_WithSkipChunks is not expected to be impacted, because this PR only affects chunks loading

I don't trust very much the worse performance reported by `BenchmarkBucket_Series`. Why? Because pooling is not effective if GC triggers continuously. The `BenchmarkBucket_Series` is even worse than the production scenario, because it runs both the store-gateway client and server, so a lot of memory is used to **unmarshal** the response and keep it in memory for assertions (which is not done by a real store-gateway server). For this reason, I will test it in a real Mimir cluster too.

```
name                                                                                                                 old time/op    new time/op    delta
Bucket_Series/1000000SeriesWith1Samples/with_default_options/1of1000000-12                                              110ms ± 1%     102ms ± 4%   -7.17%  (p=0.042 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_default_options/10of1000000-12                                             109ms ± 1%     101ms ± 3%   -7.24%  (p=0.029 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_default_options/1000000of1000000-12                                        1.65s ± 3%     1.67s ± 5%     ~     (p=0.683 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1of1000000-12                             82.0ms ± 3%    78.6ms ± 3%     ~     (p=0.117 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/10of1000000-12                            81.8ms ± 1%    80.1ms ± 3%     ~     (p=0.367 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1000000of1000000-12                        1.41s ± 1%     1.44s ± 2%     ~     (p=0.243 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1of1000000-12                            68.6ms ± 3%    64.4ms ± 2%     ~     (p=0.051 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/10of1000000-12                           67.3ms ± 1%    63.7ms ± 2%   -5.34%  (p=0.024 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1000000of1000000-12                       1.31s ± 1%     1.29s ± 3%     ~     (p=0.539 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/1of10000000-12                                           6.75ms ± 4%    5.80ms ± 0%  -14.09%  (p=0.019 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/100of10000000-12                                         6.99ms ± 1%    5.90ms ± 1%  -15.52%  (p=0.000 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/10000000of10000000-12                                     181ms ± 2%     172ms ± 2%   -5.21%  (p=0.023 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/1of10000000-12                           8.45ms ± 1%    7.82ms ± 2%   -7.49%  (p=0.017 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/100of10000000-12                         8.49ms ± 2%    7.87ms ± 2%   -7.25%  (p=0.012 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12                     149ms ± 1%     145ms ± 1%     ~     (p=0.056 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/1of10000000-12                          7.09ms ± 2%    6.25ms ± 3%  -11.80%  (p=0.005 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/100of10000000-12                        6.96ms ± 2%    6.16ms ± 2%  -11.53%  (p=0.001 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12                    180ms ± 2%     161ms ± 3%  -10.60%  (p=0.006 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/1of10000000-12                            250µs ± 2%     243µs ± 1%     ~     (p=0.065 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/100of10000000-12                          254µs ± 0%     242µs ± 1%   -4.53%  (p=0.005 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12                    86.2ms ± 1%    83.8ms ± 2%     ~     (p=0.089 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/1of10000000-12                           261µs ± 1%     246µs ± 1%   -5.91%  (p=0.002 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/100of10000000-12                         258µs ± 3%     245µs ± 1%     ~     (p=0.069 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12                   85.9ms ± 1%    84.2ms ± 1%   -2.00%  (p=0.019 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/1of10000000-12                                            238µs ± 2%     225µs ± 1%   -5.70%  (p=0.014 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/100of10000000-12                                          247µs ± 6%     229µs ± 2%     ~     (p=0.134 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/10000000of10000000-12                                    79.8ms ± 1%    76.0ms ± 1%   -4.76%  (p=0.005 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_default_options/1000000of1000000-12                         1.30s ± 4%     1.21s ± 1%     ~     (p=0.073 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1000000of1000000-12         1.37s ± 2%     1.27s ± 2%   -7.70%  (p=0.005 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1000000of1000000-12        1.34s ± 1%     1.27s ± 2%   -5.48%  (p=0.024 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_default_options/10000000of10000000-12                      124ms ± 3%     119ms ± 3%     ~     (p=0.101 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12      144ms ± 2%     131ms ± 1%   -9.16%  (p=0.010 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12     160ms ± 2%     145ms ± 1%   -9.22%  (p=0.003 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_default_options/10000000of10000000-12                      425µs ± 0%     385µs ± 2%   -9.25%  (p=0.005 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12      723µs ± 2%     685µs ± 5%     ~     (p=0.154 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12     697µs ± 2%     666µs ± 4%     ~     (p=0.141 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_10-12                                                                       1.03ms ± 2%    0.81ms ± 2%  -22.02%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_100-12                                                                      5.90ms ± 2%    4.05ms ± 4%  -31.40%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_1000-12                                                                     54.9ms ± 3%    36.0ms ± 2%  -34.33%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_10000-12                                                                     544ms ± 3%     362ms ± 5%  -33.33%  (p=0.000 n=3+3)

name                                                                                                                 old alloc/op   new alloc/op   delta
Bucket_Series/1000000SeriesWith1Samples/with_default_options/1of1000000-12                                             65.9MB ± 0%    65.9MB ± 0%     ~     (p=0.917 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_default_options/10of1000000-12                                            65.9MB ± 0%    65.9MB ± 0%     ~     (p=0.412 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_default_options/1000000of1000000-12                                       1.79GB ± 0%    1.79GB ± 0%     ~     (p=0.227 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1of1000000-12                             84.1MB ± 0%    84.1MB ± 0%   +0.06%  (p=0.050 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/10of1000000-12                            84.1MB ± 0%    84.1MB ± 0%     ~     (p=0.227 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1000000of1000000-12                       1.37GB ± 0%    1.23GB ± 0%   -9.90%  (p=0.000 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1of1000000-12                            59.1MB ± 0%    59.3MB ± 0%     ~     (p=0.115 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/10of1000000-12                           59.1MB ± 0%    59.3MB ± 0%     ~     (p=0.269 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1000000of1000000-12                      1.24GB ± 0%    1.11GB ± 0%  -10.49%  (p=0.000 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/1of10000000-12                                           5.04MB ± 0%    5.04MB ± 0%     ~     (p=0.638 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/100of10000000-12                                         5.04MB ± 0%    5.05MB ± 0%     ~     (p=0.127 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/10000000of10000000-12                                     204MB ± 1%     209MB ± 3%     ~     (p=0.239 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/1of10000000-12                           8.22MB ± 0%    8.25MB ± 0%   +0.36%  (p=0.025 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/100of10000000-12                         8.22MB ± 0%    8.25MB ± 0%   +0.34%  (p=0.018 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12                     173MB ± 0%     161MB ± 0%   -7.44%  (p=0.000 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/1of10000000-12                          5.77MB ± 0%    5.85MB ± 0%   +1.26%  (p=0.004 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/100of10000000-12                        5.77MB ± 0%    5.88MB ± 1%   +1.90%  (p=0.009 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12                    168MB ± 0%     156MB ± 0%   -7.39%  (p=0.000 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/1of10000000-12                            218kB ± 0%     225kB ± 0%   +3.00%  (p=0.004 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/100of10000000-12                          219kB ± 0%     224kB ± 0%   +2.72%  (p=0.000 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12                     226MB ± 0%     226MB ± 0%   +0.04%  (p=0.029 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/1of10000000-12                           242kB ± 1%     267kB ± 0%  +10.35%  (p=0.000 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/100of10000000-12                         242kB ± 0%     269kB ± 2%  +11.03%  (p=0.007 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12                    227MB ± 0%     228MB ± 0%   +0.35%  (p=0.005 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/1of10000000-12                                            217kB ± 0%     217kB ± 0%     ~     (p=0.098 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/100of10000000-12                                          217kB ± 0%     217kB ± 0%   +0.38%  (p=0.004 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/10000000of10000000-12                                     223MB ± 0%     223MB ± 0%     ~     (p=0.730 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_default_options/1000000of1000000-12                        1.95GB ± 0%    1.95GB ± 0%     ~     (p=0.168 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1000000of1000000-12        1.54GB ± 0%    1.54GB ± 0%     ~     (p=0.465 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1000000of1000000-12       1.46GB ± 0%    1.46GB ± 0%     ~     (p=0.870 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_default_options/10000000of10000000-12                      179MB ± 0%     179MB ± 0%   +0.00%  (p=0.038 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12      153MB ± 0%     153MB ± 0%     ~     (p=0.889 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12     149MB ± 0%     148MB ± 0%     ~     (p=0.083 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_default_options/10000000of10000000-12                      709kB ± 0%     710kB ± 0%   +0.16%  (p=0.000 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12      732kB ± 0%     732kB ± 0%     ~     (p=0.928 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12     883kB ± 1%     885kB ± 1%     ~     (p=0.875 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_10-12                                                                        869kB ± 0%     160kB ± 0%  -81.52%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_100-12                                                                      7.37MB ± 0%    0.16MB ± 0%  -97.83%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_1000-12                                                                     71.5MB ± 0%     0.2MB ± 1%  -99.71%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_10000-12                                                                     712MB ± 0%       3MB ± 0%  -99.61%  (p=0.000 n=3+3)

name                                                                                                                 old allocs/op  new allocs/op  delta
Bucket_Series/1000000SeriesWith1Samples/with_default_options/1of1000000-12                                              9.73k ± 0%     9.73k ± 0%     ~     (p=0.948 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_default_options/10of1000000-12                                             9.88k ± 0%     9.90k ± 0%     ~     (p=0.141 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_default_options/1000000of1000000-12                                        18.0M ± 0%     18.0M ± 0%     ~     (p=0.226 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1of1000000-12                              14.4k ± 0%     14.4k ± 0%     ~     (p=0.683 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/10of1000000-12                             14.5k ± 0%     14.5k ± 0%     ~     (p=0.961 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1000000of1000000-12                        17.1M ± 0%     16.1M ± 0%   -5.83%  (p=0.000 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1of1000000-12                             6.21k ± 0%     6.21k ± 0%     ~     (p=0.966 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/10of1000000-12                            6.35k ± 0%     6.35k ± 0%     ~     (p=0.720 n=3+3)
Bucket_Series/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1000000of1000000-12                       17.0M ± 0%     16.0M ± 0%   -5.87%  (p=0.000 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/1of10000000-12                                            1.14k ± 0%     1.14k ± 0%     ~     (p=0.621 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/100of10000000-12                                          1.20k ± 0%     1.20k ± 0%     ~     (p=0.138 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_default_options/10000000of10000000-12                                     1.80M ± 0%     1.81M ± 0%     ~     (p=0.236 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/1of10000000-12                            1.64k ± 0%     1.65k ± 0%   +0.20%  (p=0.013 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/100of10000000-12                          1.70k ± 0%     1.70k ± 0%     ~     (p=0.811 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12                     1.71M ± 0%     1.61M ± 0%   -5.82%  (p=0.000 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/1of10000000-12                             822 ± 0%       825 ± 0%     ~     (p=0.122 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/100of10000000-12                           877 ± 0%       874 ± 0%   -0.34%  (p=0.029 n=3+3)
Bucket_Series/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12                    1.70M ± 0%     1.60M ± 0%   -5.86%  (p=0.000 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/1of10000000-12                              250 ± 0%       252 ± 0%   +0.67%  (p=0.038 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/100of10000000-12                            250 ± 0%       252 ± 0%     ~     (zero variance)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12                      334k ± 0%      334k ± 0%     ~     (p=0.433 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/1of10000000-12                             250 ± 0%       251 ± 0%     ~     (zero variance)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/100of10000000-12                           250 ± 0%       251 ± 0%     ~     (zero variance)
Bucket_Series/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12                     334k ± 0%      334k ± 0%   +0.00%  (p=0.008 n=3+3)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/1of10000000-12                                              244 ± 0%       245 ± 0%     ~     (zero variance)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/100of10000000-12                                            244 ± 0%       245 ± 0%     ~     (zero variance)
Bucket_Series/1SeriesWith10000000Samples/with_default_options/10000000of10000000-12                                      334k ± 0%      334k ± 0%   +0.00%  (p=0.009 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_default_options/1000000of1000000-12                         11.0M ± 0%     11.0M ± 0%     ~     (p=0.441 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_series_streaming_(1K_per_batch)/1000000of1000000-12         10.1M ± 0%     10.1M ± 0%     ~     (p=0.892 n=3+3)
Bucket_Series_WithSkipChunks/1000000SeriesWith1Samples/with_series_streaming_(10K_per_batch)/1000000of1000000-12        10.0M ± 0%     10.0M ± 0%     ~     (p=0.528 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_default_options/10000000of10000000-12                      1.10M ± 0%     1.10M ± 0%   +0.00%  (p=0.039 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12      1.01M ± 0%     1.01M ± 0%     ~     (p=0.619 n=3+3)
Bucket_Series_WithSkipChunks/100000SeriesWith100Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12     1.00M ± 0%     1.00M ± 0%     ~     (p=0.234 n=3+3)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_default_options/10000000of10000000-12                        798 ± 0%       802 ± 0%     ~     (zero variance)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_series_streaming_(1K_per_batch)/10000000of10000000-12        816 ± 0%       816 ± 0%     ~     (zero variance)
Bucket_Series_WithSkipChunks/1SeriesWith10000000Samples/with_series_streaming_(10K_per_batch)/10000000of10000000-12       815 ± 0%       815 ± 0%     ~     (zero variance)
LoadingSeriesChunksSetIterator/batch_size:_10-12                                                                        3.21k ± 0%     2.40k ± 0%     ~     (zero variance)
LoadingSeriesChunksSetIterator/batch_size:_100-12                                                                       12.2k ± 0%      2.4k ± 0%     ~     (zero variance)
LoadingSeriesChunksSetIterator/batch_size:_1000-12                                                                       102k ± 0%        3k ± 0%  -97.26%  (p=0.000 n=3+3)
LoadingSeriesChunksSetIterator/batch_size:_10000-12                                                                     1.00M ± 0%     0.00M ± 0%  -99.68%  (p=0.000 n=3+3)
```

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
