### PR TITLE
Store gateway mmap removal: optimise index-header reader and symbol lookups

### DIFF
--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -112,13 +112,13 @@ func (d *Decbuf) ResetAt(off int) {
 // returned allocates its own memory may be used after subsequent reads from the Decbuf.
 // If E is non-nil, this method returns an empty string.
 func (d *Decbuf) UvarintStr() string {
-	return string(d.UvarintBytes())
+	return string(d.UnsafeUvarintBytes())
 }
 
-// UvarintBytes reads varint prefixed bytes into a byte slice consuming them but without
+// UnsafeUvarintBytes reads varint prefixed bytes into a byte slice consuming them but without
 // allocating. The bytes returned are NO LONGER VALID after subsequent reads from the Decbuf.
 // If E is non-nil, this method returns an empty byte slice.
-func (d *Decbuf) UvarintBytes() []byte {
+func (d *Decbuf) UnsafeUvarintBytes() []byte {
 	l := d.Uvarint64()
 	if d.E != nil {
 		return nil

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -89,6 +89,13 @@ func (d *Decbuf) Skip(l int) {
 	d.E = d.r.skip(l)
 }
 
+// SkipUvarintBytes advances the pointer of the underlying fileReader past the
+// next varint-prefixed bytes. If E is non-nil, this method has no effect.
+func (d *Decbuf) SkipUvarintBytes() {
+	l := d.Uvarint64()
+	d.Skip(int(l))
+}
+
 // ResetAt sets the pointer of the underlying fileReader to the absolute
 // offset and discards any buffered data. If E is non-nil, this method has
 // no effect. ResetAt-ing beyond the end of the underlying fileReader will set

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -116,7 +116,7 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 
 		// Important: this value is only valid as long as we don't perform any further reads from d.
 		// If we need to retain its value, we must copy it before performing another read.
-		unsafeName := d.UvarintBytes()
+		unsafeName := d.UnsafeUvarintBytes()
 
 		if len(t.postings) == 0 || currentName != string(unsafeName) {
 			newKey := string(unsafeName)
@@ -414,7 +414,7 @@ func (t *PostingOffsetTableV2) PostingsOffset(name string, values ...string) (r 
 				// We know it exists as we never go further in this loop than e.offsets[i, i+1].
 
 				skipNAndName(&d, &buf)
-				d.UvarintBytes() // Label value.
+				d.UnsafeUvarintBytes() // Label value.
 				postingOffset := int64(d.Uvarint64())
 
 				for j := range newSameRngs {
@@ -456,13 +456,13 @@ func (t *PostingOffsetTableV2) LabelValues(name string, filter func(string) bool
 			// These are always the same number of bytes,
 			// and it's faster to skip than parse.
 			skip = d.Len()
-			d.Uvarint()      // Keycount.
-			d.UvarintBytes() // Label name.
+			d.Uvarint()            // Keycount.
+			d.UnsafeUvarintBytes() // Label name.
 			skip -= d.Len()
 		} else {
 			d.Skip(skip)
 		}
-		s := yoloString(d.UvarintBytes()) // Label value.
+		s := yoloString(d.UnsafeUvarintBytes()) // Label value.
 		if filter == nil || filter(s) {
 			// Clone the yolo string since its bytes will be invalidated as soon as
 			// any other reads against the decoding buffer are performed.
@@ -501,8 +501,8 @@ func skipNAndName(d *streamencoding.Decbuf, buf *int) {
 		// Keycount+LabelName are always the same number of bytes,
 		// and it's faster to skip than parse.
 		*buf = d.Len()
-		d.Uvarint()      // Keycount.
-		d.UvarintBytes() // Label name.
+		d.Uvarint()            // Keycount.
+		d.UnsafeUvarintBytes() // Label name.
 		*buf -= d.Len()
 		return
 	}

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -140,6 +140,7 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 			valuesForCurrentKey = 0
 		}
 
+		// Retain every 1-in-postingOffsetsInMemSampling entries, starting with the first one.
 		if valuesForCurrentKey%postingOffsetsInMemSampling == 0 {
 			value := d.UvarintStr()
 			off := d.Uvarint64()

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -116,10 +116,10 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 
 		// Important: this value is only valid as long as we don't perform any further reads from d.
 		// If we need to retain its value, we must copy it before performing another read.
-		name := d.UvarintBytes()
+		unsafeName := d.UvarintBytes()
 
-		if len(t.postings) == 0 || currentName != string(name) {
-			newKey := string(name)
+		if len(t.postings) == 0 || currentName != string(unsafeName) {
+			newKey := string(unsafeName)
 
 			if lastEntryOffsetInTable != -1 {
 				// We haven't recorded the last offset for the last value of the previous name.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -137,7 +137,6 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 
 			currentKey = newKey
 			t.postings[currentKey] = &postingValueOffsets{}
-			lastEntryOffsetInTable = -1
 			valuesForCurrentKey = 0
 		}
 

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -116,9 +116,7 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 
 		// Important: this value is only valid as long as we don't perform any further reads from d.
 		// If we need to retain its value, we must copy it before performing another read.
-		unsafeName := d.UnsafeUvarintBytes()
-
-		if len(t.postings) == 0 || currentName != string(unsafeName) {
+		if unsafeName := d.UnsafeUvarintBytes(); len(t.postings) == 0 || currentName != string(unsafeName) {
 			newKey := string(unsafeName)
 
 			if lastEntryOffsetInTable != -1 {

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -166,9 +166,7 @@ func readOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, f f
 		offsetPos := startLen - d.Len()
 		keyCount := d.Uvarint()
 
-		// The Postings offset table takes only 2 keys per entry (name and value of label),
-		// and the LabelIndices offset table takes only 1 key per entry (a label name).
-		// Hence setting the size to max of both, i.e. 2.
+		// The Postings offset table takes only 2 keys per entry (name and value of label).
 		if keyCount != 2 {
 			return errors.Errorf("unexpected key length for posting table %d", keyCount)
 		}

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -63,7 +63,7 @@ func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *
 		if s.seen%symbolFactor == 0 {
 			s.offsets = append(s.offsets, basePos+origLen-d.Len())
 		}
-		d.UvarintBytes() // The symbol.
+		d.UnsafeUvarintBytes() // The symbol.
 		s.seen++
 	}
 
@@ -150,7 +150,7 @@ func (s *Symbols) ForEachSymbol(syms []string, f func(sym string, offset uint32)
 func (s *Symbols) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, error) {
 	i := sort.Search(len(s.offsets), func(i int) bool {
 		d.ResetAt(s.offsets[i])
-		return string(d.UvarintBytes()) > sym
+		return string(d.UnsafeUvarintBytes()) > sym
 	})
 
 	if i > 0 {
@@ -163,7 +163,7 @@ func (s *Symbols) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, er
 	var lastSymbol string
 	for d.Err() == nil && res <= s.seen {
 		lastLen = d.Len()
-		lastSymbol = yoloString(d.UvarintBytes())
+		lastSymbol = yoloString(d.UnsafeUvarintBytes())
 		if lastSymbol >= sym {
 			break
 		}

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -88,7 +88,7 @@ func (s *Symbols) Lookup(o uint32) (sym string, err error) {
 		d.ResetAt(s.offsets[int(o/symbolFactor)])
 		// Walk until we find the one we want.
 		for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
-			d.UvarintBytes()
+			d.SkipUvarintBytes()
 		}
 	} else {
 		// In v1, o is relative to the beginning of the whole index header file, so we

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -63,7 +63,7 @@ func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *
 		if s.seen%symbolFactor == 0 {
 			s.offsets = append(s.offsets, basePos+origLen-d.Len())
 		}
-		d.UnsafeUvarintBytes() // The symbol.
+		d.SkipUvarintBytes() // The symbol.
 		s.seen++
 	}
 

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -246,11 +246,11 @@ func BenchmarkNewStreamBinaryReader(b *testing.B) {
 	}
 }
 
-func generateSymbols(suffix string, count int) []string {
+func generateSymbols(prefix string, count int) []string {
 	s := make([]string, 0, count)
 
 	for idx := 0; idx < count; idx++ {
-		s = append(s, fmt.Sprintf("%v-%v", suffix, idx))
+		s = append(s, fmt.Sprintf("%v-%v", prefix, idx))
 	}
 
 	return s

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -222,8 +222,8 @@ func BenchmarkNewStreamBinaryReader(b *testing.B) {
 		require.NoError(b, bkt.Close())
 	})
 
-	for _, nameCount := range []int{20, 50, 100, 200} {
-		for _, valueCount := range []int{100, 500, 1000} {
+	for _, nameCount := range []int{1, 20, 50, 100, 200} {
+		for _, valueCount := range []int{1, 10, 100, 500, 1000, 5000} {
 			nameSymbols := generateSymbols("name", nameCount)
 			valueSymbols := generateSymbols("value", valueCount)
 			idIndexV2, err := testhelper.CreateBlock(ctx, bucketDir, generateLabels(nameSymbols, valueSymbols), 100, 0, 1000, labels.FromStrings("ext1", "1"), 124, metadata.NoneFunc)


### PR DESCRIPTION
#### What this PR does

Note to reviewers: this PR is made up of three main commits that build upon each other. I'd suggest reviewing each separately.

---

de7f5af improves the performance of loading index-headers with the mmap-less reader by 0-23%. This is due to removing an unnecessary allocation for every value of the postings offset table.

<details><summary>Benchmark results</summary>

```
name                                         old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-10          122µs ± 8%     122µs ± 5%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/1Names10Values-10         124µs ± 4%     131µs ± 9%     ~     (p=0.056 n=5+5)
NewStreamBinaryReader/1Names100Values-10        138µs ± 2%     135µs ± 3%     ~     (p=0.056 n=5+5)
NewStreamBinaryReader/1Names500Values-10        187µs ± 4%     177µs ± 2%   -5.31%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       262µs ± 2%     229µs ± 2%  -12.53%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       837µs ± 3%     689µs ± 1%  -17.62%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10         168µs ± 2%     169µs ± 3%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/20Names10Values-10        199µs ± 2%     194µs ± 2%   -2.56%  (p=0.032 n=5+5)
NewStreamBinaryReader/20Names100Values-10       505µs ± 1%     438µs ± 7%  -13.20%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names500Values-10      1.63ms ± 1%    1.31ms ± 0%  -19.49%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names1000Values-10     2.90ms ± 3%    2.28ms ± 2%  -21.30%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names5000Values-10     12.9ms ± 2%     9.9ms ± 2%  -22.69%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-10         276µs ± 0%     280µs ± 1%   +1.64%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names10Values-10        368µs ± 1%     347µs ± 2%   -5.82%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names100Values-10      1.10ms ± 4%    0.91ms ± 2%  -17.15%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      3.73ms ± 3%    2.97ms ± 2%  -20.32%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-10     6.74ms ± 2%    5.29ms ± 2%  -21.61%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     32.0ms ± 0%    24.9ms ± 1%  -22.30%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names1Values-10        547µs ± 1%     543µs ± 1%     ~     (p=0.286 n=4+5)
NewStreamBinaryReader/100Names10Values-10       728µs ± 4%     678µs ± 3%   -6.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     2.08ms ± 5%    1.73ms ± 5%  -16.87%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-10     7.13ms ± 1%    5.63ms ± 2%  -21.06%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    13.3ms ± 2%    10.2ms ± 2%  -23.17%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-10    64.9ms ± 2%    49.8ms ± 1%  -23.20%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       1.17ms ± 0%    1.16ms ± 2%     ~     (p=0.190 n=4+5)
NewStreamBinaryReader/200Names10Values-10      1.49ms ± 0%    1.39ms ± 1%   -6.68%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10     4.05ms ± 3%    3.35ms ± 3%  -17.32%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names500Values-10     14.4ms ± 2%    11.5ms ± 1%  -20.30%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-10    27.3ms ± 2%    21.1ms ± 3%  -22.79%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10     131ms ± 2%     100ms ± 2%  -23.35%  (p=0.008 n=5+5)

name                                         old alloc/op   new alloc/op   delta
NewStreamBinaryReader/1Names1Values-10         3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10        3.18MB ± 0%    3.18MB ± 0%   -0.01%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10       3.18MB ± 0%    3.18MB ± 0%   -0.10%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10       3.20MB ± 0%    3.19MB ± 0%   -0.50%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10      3.23MB ± 0%    3.20MB ± 0%   -0.99%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10      3.44MB ± 0%    3.28MB ± 0%   -4.66%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10        3.18MB ± 0%    3.18MB ± 0%   -0.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-10       3.19MB ± 0%    3.19MB ± 0%   -0.20%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10      3.29MB ± 0%    3.22MB ± 0%   -1.95%  (p=0.016 n=5+4)
NewStreamBinaryReader/20Names500Values-10      3.70MB ± 0%    3.38MB ± 0%   -8.65%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names1000Values-10     4.22MB ± 0%    3.58MB ± 0%  -15.17%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names5000Values-10     8.63MB ± 0%    5.43MB ± 0%  -37.09%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names1Values-10        3.19MB ± 0%    3.19MB ± 0%   -0.05%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10       3.21MB ± 0%    3.20MB ± 0%   -0.50%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names100Values-10      3.45MB ± 0%    3.29MB ± 0%   -4.64%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      4.48MB ± 0%    3.68MB ± 0%  -17.85%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-10     5.78MB ± 0%    4.18MB ± 0%  -27.67%  (p=0.016 n=5+4)
NewStreamBinaryReader/50Names5000Values-10     17.3MB ± 0%     9.3MB ± 0%  -46.28%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-10       3.20MB ± 0%    3.20MB ± 0%   -0.10%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-10      3.25MB ± 0%    3.22MB ± 0%   -0.99%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     3.72MB ± 0%    3.40MB ± 0%   -8.60%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names500Values-10     5.79MB ± 0%    4.19MB ± 0%  -27.65%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    8.39MB ± 0%    5.19MB ± 0%  -38.15%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names5000Values-10    31.7MB ± 0%    15.7MB ± 0%  -50.46%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       3.22MB ± 0%    3.22MB ± 0%   -0.20%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-10      3.32MB ± 0%    3.26MB ± 0%   -1.93%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10     4.27MB ± 0%    3.63MB ± 0%  -15.00%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names500Values-10     8.72MB ± 0%    5.52MB ± 0%  -36.72%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names1000Values-10    14.3MB ± 0%     7.9MB ± 0%  -44.70%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10    61.3MB ± 0%    29.3MB ± 0%  -52.22%  (p=0.008 n=5+5)

name                                         old allocs/op  new allocs/op  delta
NewStreamBinaryReader/1Names1Values-10           78.0 ± 0%      76.0 ± 0%   -2.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10           106 ± 0%        95 ± 0%  -10.38%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10          379 ± 0%       278 ± 0%  -26.65%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10        1.58k ± 0%     1.08k ± 0%  -31.69%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       3.08k ± 0%     2.08k ± 0%  -32.48%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       15.1k ± 0%     10.1k ± 0%  -33.15%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10           175 ± 0%       154 ± 0%  -12.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-10          735 ± 0%       534 ± 0%  -27.35%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       6.20k ± 0%     4.19k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/20Names500Values-10       30.2k ± 0%     20.2k ± 0%  -33.08%  (p=0.000 n=5+4)
NewStreamBinaryReader/20Names1000Values-10      60.3k ± 0%     40.3k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/20Names5000Values-10       300k ± 0%      200k ± 0%  -33.30%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names1Values-10           329 ± 0%       278 ± 0%  -15.50%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10        1.73k ± 0%     1.23k ± 0%  -28.98%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10       15.4k ± 0%     10.4k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/50Names500Values-10       75.5k ± 0%     50.5k ± 0%  -33.12%  (p=0.000 n=4+5)
NewStreamBinaryReader/50Names1000Values-10       151k ± 0%      101k ± 0%  -33.22%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names5000Values-10       751k ± 0%      501k ± 0%  -33.31%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names1Values-10          582 ± 0%       481 ± 0%  -17.35%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names10Values-10       3.38k ± 0%     2.38k ± 0%  -29.61%  (p=0.000 n=5+4)
NewStreamBinaryReader/100Names100Values-10      30.7k ± 0%     20.7k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/100Names500Values-10       151k ± 0%      101k ± 0%  -33.14%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names1000Values-10      301k ± 0%      201k ± 0%  -33.23%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names5000Values-10     1.50M ± 0%     1.00M ± 0%  -33.31%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10        1.08k ± 0%     0.88k ± 0%  -18.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-10       6.68k ± 0%     4.68k ± 0%  -29.94%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10      61.3k ± 0%     41.3k ± 0%  -32.64%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names500Values-10       302k ± 0%      202k ± 0%  -33.15%  (p=0.000 n=5+4)
NewStreamBinaryReader/200Names1000Values-10      602k ± 0%      402k ± 0%  -33.23%  (p=0.000 n=5+4)
NewStreamBinaryReader/200Names5000Values-10     3.00M ± 0%     2.00M ± 0%  -33.31%  (p=0.000 n=5+4)
```

</details>

---

40efcae improves the performance of `LookupSymbol` by skipping over unwanted symbols, saving ~2% in the best case scenario (all value symbol lookups, no name symbol lookups).

<details><summary>Benchmark results</summary>

```
name                                        old time/op    new time/op    delta
LookupSymbol/NameLookups0%-Parallelism1-10    8.57µs ± 0%    8.37µs ± 2%  -2.37%  (p=0.008 n=5+5)
```

</details>

2a119aa uses the same idea while reading the symbol table, resulting in anywhere up to a 2% improvement over 1d98754 for realistic index-headers:

<details><summary>Benchmark results (compared to <code>1d98754</code>)</summary>

```
name                                         old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-10          128µs ± 1%     123µs ± 2%  -4.25%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10         128µs ± 1%     122µs ± 1%  -4.95%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10        137µs ± 3%     133µs ± 1%  -2.84%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10        169µs ± 4%     161µs ± 1%  -4.87%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       201µs ± 3%     192µs ± 3%  -4.47%  (p=0.016 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       541µs ± 5%     494µs ± 2%  -8.64%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10         178µs ± 4%     169µs ± 1%  -4.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-10        216µs ± 4%     200µs ± 0%  -7.14%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       374µs ± 5%     360µs ± 5%    ~     (p=0.095 n=5+5)
NewStreamBinaryReader/20Names500Values-10       955µs ± 1%     907µs ± 4%  -5.05%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1000Values-10     1.60ms ± 0%    1.54ms ± 3%    ~     (p=0.063 n=4+5)
NewStreamBinaryReader/20Names5000Values-10     6.56ms ± 3%    6.26ms ± 1%  -4.64%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-10         297µs ± 4%     276µs ± 1%  -7.14%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10        401µs ± 6%     384µs ± 4%  -4.25%  (p=0.032 n=5+5)
NewStreamBinaryReader/50Names100Values-10       738µs ± 3%     716µs ± 2%  -2.97%  (p=0.032 n=5+5)
NewStreamBinaryReader/50Names500Values-10      2.10ms ± 3%    2.06ms ± 3%    ~     (p=0.151 n=5+5)
NewStreamBinaryReader/50Names1000Values-10     3.68ms ± 2%    3.59ms ± 2%    ~     (p=0.056 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     15.8ms ± 2%    15.4ms ± 1%  -2.77%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-10        556µs ± 6%     534µs ± 0%  -4.09%  (p=0.016 n=5+4)
NewStreamBinaryReader/100Names10Values-10       753µs ± 1%     736µs ± 2%  -2.18%  (p=0.032 n=5+5)
NewStreamBinaryReader/100Names100Values-10     1.40ms ± 4%    1.38ms ± 4%    ~     (p=0.222 n=5+5)
NewStreamBinaryReader/100Names500Values-10     3.95ms ± 3%    3.91ms ± 1%    ~     (p=0.310 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    6.92ms ± 1%    6.92ms ± 1%    ~     (p=1.000 n=5+5)
NewStreamBinaryReader/100Names5000Values-10    30.9ms ± 0%    30.8ms ± 1%    ~     (p=0.095 n=5+5)
NewStreamBinaryReader/200Names1Values-10       1.17ms ± 6%    1.14ms ± 0%  -2.33%  (p=0.032 n=5+4)
NewStreamBinaryReader/200Names10Values-10      1.54ms ± 6%    1.84ms ±43%    ~     (p=0.548 n=5+5)
NewStreamBinaryReader/200Names100Values-10     2.73ms ± 3%    2.74ms ± 3%    ~     (p=0.421 n=5+5)
NewStreamBinaryReader/200Names500Values-10     7.62ms ± 1%    7.58ms ± 1%    ~     (p=0.151 n=5+5)
NewStreamBinaryReader/200Names1000Values-10    13.7ms ± 1%    13.7ms ± 1%    ~     (p=0.222 n=5+5)
NewStreamBinaryReader/200Names5000Values-10    62.4ms ± 1%    61.9ms ± 0%  -0.79%  (p=0.029 n=4+4)
```

</details>

---

1d98754 is the more complex one. It is inspired by https://github.com/prometheus/prometheus/pull/11535.

On my machine (a M1 MacBook Pro with a fast SSD), this results in up to 37% better performance compared to de7f5af, and 52% better performance compared to `main`. I've also observed similar performance gains on machines with spinning rust disks (up to 62% better performance compared to `main`).

<details><summary>Explanation of changes</summary>

Unfortunately, we can't adopt https://github.com/prometheus/prometheus/pull/11535 as-is, as byte slices returned by our new `Decbuf.UvarintBytes()` implementation are not valid after subsequent reads because the underlying buffer may have been overwritten.

This means that we must decide whether or not to allocate a string for a label name or value before reading any further in the file. However, we want to store the last value for each name, but won't know if the value is the last one until we've read the next one.

To deal with this limitation, whenever we come to the beginning of a new label name's entries in the table, we seek backwards to read the last entry for the previous name and populate that before resuming with the new name.

</details>

This PR previously had a two-pass implementation for this change. Benchmarking of the final single-pass implementation included here showed the single-pass implementation saved another 3-7% (when using a SSD) or 5-12% (when using a spinning rust disk) for index headers with a small number of label names and a large number of values, which is what we'd expect in the real world.

I suspect this implementation could be improved even further: every seek operation requires us to call the `bufio.Reader`'s `Reset()` method, which discards its buffer and requires it to be refilled from disk. If we used a buffered reader that supported seeking backwards, we could avoid a number of unnecessary disk reads.

I haven't applied this optimisation to the v1 reader yet, but that case should be straightforward given we retain every name and value. This could be a follow-up PR.

<details><summary>Benchmark results: compared to de7f5af with SSD</summary>

```
name                                         old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-10          122µs ± 5%     136µs ± 4%  +11.59%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10         131µs ± 9%     129µs ± 7%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/1Names100Values-10        135µs ± 3%     135µs ± 1%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/1Names500Values-10        177µs ± 2%     164µs ± 2%   -7.43%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       229µs ± 2%     198µs ± 2%  -13.59%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       689µs ± 1%     518µs ± 2%  -24.80%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10         169µs ± 3%     171µs ± 1%     ~     (p=0.310 n=5+5)
NewStreamBinaryReader/20Names10Values-10        194µs ± 2%     208µs ± 2%   +6.99%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       438µs ± 7%     383µs ± 2%  -12.57%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-10      1.31ms ± 0%    0.93ms ± 3%  -28.94%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names1000Values-10     2.28ms ± 2%    1.57ms ± 3%  -31.19%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names5000Values-10     9.95ms ± 2%    6.33ms ± 1%  -36.32%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-10         280µs ± 1%     291µs ± 5%   +3.77%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10        347µs ± 2%     394µs ± 5%  +13.50%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10       910µs ± 2%     730µs ± 2%  -19.78%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      2.97ms ± 2%    2.08ms ± 3%  -30.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-10     5.29ms ± 2%    3.63ms ± 2%  -31.25%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     24.9ms ± 1%    15.5ms ± 0%  -37.81%  (p=0.016 n=5+4)
NewStreamBinaryReader/100Names1Values-10        543µs ± 1%     542µs ± 3%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/100Names10Values-10       678µs ± 3%     741µs ± 3%   +9.33%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     1.73ms ± 5%    1.40ms ± 5%  -19.31%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-10     5.63ms ± 2%    3.97ms ± 2%  -29.52%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    10.2ms ± 2%     7.0ms ± 1%  -32.03%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-10    49.8ms ± 1%    31.1ms ± 0%  -37.54%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       1.16ms ± 2%    1.16ms ± 3%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/200Names10Values-10      1.39ms ± 1%    1.57ms ± 4%  +13.04%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names100Values-10     3.35ms ± 3%    2.73ms ± 3%  -18.30%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names500Values-10     11.5ms ± 1%     7.6ms ± 1%  -33.61%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-10    21.1ms ± 3%    13.7ms ± 1%  -35.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10     100ms ± 2%      62ms ± 1%  -37.62%  (p=0.008 n=5+5)

name                                         old alloc/op   new alloc/op   delta
NewStreamBinaryReader/1Names1Values-10         3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.373 n=5+5)
NewStreamBinaryReader/1Names10Values-10        3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10       3.18MB ± 0%    3.18MB ± 0%   -0.05%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10       3.19MB ± 0%    3.18MB ± 0%   -0.24%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10      3.20MB ± 0%    3.18MB ± 0%   -0.48%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10      3.28MB ± 0%    3.20MB ± 0%   -2.37%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10        3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.357 n=5+5)
NewStreamBinaryReader/20Names10Values-10       3.19MB ± 0%    3.18MB ± 0%   -0.09%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10      3.22MB ± 0%    3.19MB ± 0%   -0.96%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names500Values-10      3.38MB ± 0%    3.22MB ± 0%   -4.59%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names1000Values-10     3.58MB ± 0%    3.27MB ± 0%   -8.66%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names5000Values-10     5.43MB ± 0%    3.56MB ± 0%  -34.45%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names1Values-10        3.19MB ± 0%    3.19MB ± 0%     ~     (p=0.921 n=5+5)
NewStreamBinaryReader/50Names10Values-10       3.20MB ± 0%    3.19MB ± 0%   -0.21%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10      3.29MB ± 0%    3.21MB ± 0%   -2.36%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      3.68MB ± 0%    3.29MB ± 0%  -10.54%  (p=0.016 n=5+4)
NewStreamBinaryReader/50Names1000Values-10     4.18MB ± 0%    3.41MB ± 0%  -18.53%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names5000Values-10     9.29MB ± 0%    4.13MB ± 0%  -55.53%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-10       3.20MB ± 0%    3.20MB ± 0%     ~     (p=0.254 n=5+5)
NewStreamBinaryReader/100Names10Values-10      3.22MB ± 0%    3.20MB ± 0%   -0.42%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     3.40MB ± 0%    3.25MB ± 0%   -4.56%  (p=0.016 n=5+4)
NewStreamBinaryReader/100Names500Values-10     4.19MB ± 0%    3.41MB ± 0%  -18.54%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    5.19MB ± 0%    3.64MB ± 0%  -29.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-10    15.7MB ± 0%     5.1MB ± 0%  -67.66%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       3.22MB ± 0%    3.22MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/200Names10Values-10      3.26MB ± 0%    3.23MB ± 0%   -0.84%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10     3.63MB ± 0%    3.32MB ± 0%   -8.56%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names500Values-10     5.52MB ± 0%    3.64MB ± 0%  -33.95%  (p=0.016 n=5+4)
NewStreamBinaryReader/200Names1000Values-10    7.92MB ± 0%    4.10MB ± 0%  -48.23%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10    29.3MB ± 0%     7.0MB ± 0%  -76.16%  (p=0.008 n=5+5)

name                                         old allocs/op  new allocs/op  delta
NewStreamBinaryReader/1Names1Values-10           76.0 ± 0%      76.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names10Values-10          95.0 ± 0%      78.0 ± 0%  -17.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10          278 ± 0%        84 ± 0%  -69.78%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10        1.08k ± 0%     0.10k ± 0%  -90.93%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       2.08k ± 0%     0.12k ± 0%  -94.47%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       10.1k ± 0%      0.2k ± 0%  -97.60%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10           154 ± 0%       154 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names10Values-10          534 ± 0%       194 ± 0%  -63.67%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       4.19k ± 0%     0.31k ± 0%  -92.51%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-10       20.2k ± 0%      0.6k ± 0%  -97.06%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names1000Values-10      40.3k ± 0%      0.9k ± 0%  -97.68%  (p=0.000 n=5+4)
NewStreamBinaryReader/20Names5000Values-10       200k ± 0%        3k ± 0%  -98.27%  (p=0.000 n=4+5)
NewStreamBinaryReader/50Names1Values-10           278 ± 0%       278 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names10Values-10        1.23k ± 0%     0.38k ± 0%  -69.22%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10       10.4k ± 0%      0.7k ± 0%  -93.47%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10       50.5k ± 0%      1.4k ± 0%  -97.27%  (p=0.000 n=5+4)
NewStreamBinaryReader/50Names1000Values-10       101k ± 0%        2k ± 0%  -97.78%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names5000Values-10       501k ± 0%        9k ± 0%  -98.29%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names1Values-10          481 ± 0%       481 ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names10Values-10       2.38k ± 0%     0.68k ± 0%  -71.38%  (p=0.000 n=4+5)
NewStreamBinaryReader/100Names100Values-10      20.7k ± 0%      1.3k ± 0%  -93.80%  (p=0.000 n=5+4)
NewStreamBinaryReader/100Names500Values-10       101k ± 0%        3k ± 0%  -97.34%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10      201k ± 0%        4k ± 0%  -97.82%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names5000Values-10     1.00M ± 0%     0.02M ± 0%  -98.29%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10          882 ± 0%       882 ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names10Values-10       4.68k ± 0%     1.28k ± 0%  -72.62%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10      41.3k ± 0%      2.5k ± 0%  -93.99%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names500Values-10       202k ± 0%        5k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/200Names1000Values-10      402k ± 0%        9k ± 0%  -97.84%  (p=0.000 n=4+5)
NewStreamBinaryReader/200Names5000Values-10     2.00M ± 0%     0.03M ± 0%  -98.30%  (p=0.029 n=4+4)
```

</details>

<details><summary>Benchmark results: compared to <code>main</code> with SSD</summary>

```
name                                         old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-10          122µs ± 8%     136µs ± 4%  +11.78%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10         124µs ± 4%     129µs ± 7%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/1Names100Values-10        138µs ± 2%     135µs ± 1%   -2.16%  (p=0.016 n=5+5)
NewStreamBinaryReader/1Names500Values-10        187µs ± 4%     164µs ± 2%  -12.35%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       262µs ± 2%     198µs ± 2%  -24.41%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       837µs ± 3%     518µs ± 2%  -38.05%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10         168µs ± 2%     171µs ± 1%   +1.56%  (p=0.032 n=5+5)
NewStreamBinaryReader/20Names10Values-10        199µs ± 2%     208µs ± 2%   +4.25%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       505µs ± 1%     383µs ± 2%  -24.11%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names500Values-10      1.63ms ± 1%    0.93ms ± 3%  -42.79%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names1000Values-10     2.90ms ± 3%    1.57ms ± 3%  -45.85%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names5000Values-10     12.9ms ± 2%     6.3ms ± 1%  -50.77%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-10         276µs ± 0%     291µs ± 5%   +5.48%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names10Values-10        368µs ± 1%     394µs ± 5%   +6.89%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names100Values-10      1.10ms ± 4%    0.73ms ± 2%  -33.54%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      3.73ms ± 3%    2.08ms ± 3%  -44.22%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-10     6.74ms ± 2%    3.63ms ± 2%  -46.11%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     32.0ms ± 0%    15.5ms ± 0%  -51.68%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names1Values-10        547µs ± 1%     542µs ± 3%     ~     (p=0.190 n=4+5)
NewStreamBinaryReader/100Names10Values-10       728µs ± 4%     741µs ± 3%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/100Names100Values-10     2.08ms ± 5%    1.40ms ± 5%  -32.92%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-10     7.13ms ± 1%    3.97ms ± 2%  -44.36%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    13.3ms ± 2%     7.0ms ± 1%  -47.78%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-10    64.9ms ± 2%    31.1ms ± 0%  -52.04%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       1.17ms ± 0%    1.16ms ± 3%     ~     (p=0.190 n=4+5)
NewStreamBinaryReader/200Names10Values-10      1.49ms ± 0%    1.57ms ± 4%   +5.49%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names100Values-10     4.05ms ± 3%    2.73ms ± 3%  -32.45%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names500Values-10     14.4ms ± 2%     7.6ms ± 1%  -47.09%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-10    27.3ms ± 2%    13.7ms ± 1%  -49.83%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10     131ms ± 2%      62ms ± 1%  -52.18%  (p=0.008 n=5+5)

name                                         old alloc/op   new alloc/op   delta
NewStreamBinaryReader/1Names1Values-10         3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10        3.18MB ± 0%    3.18MB ± 0%   -0.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10       3.18MB ± 0%    3.18MB ± 0%   -0.15%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10       3.20MB ± 0%    3.18MB ± 0%   -0.74%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10      3.23MB ± 0%    3.18MB ± 0%   -1.47%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10      3.44MB ± 0%    3.20MB ± 0%   -6.92%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10        3.18MB ± 0%    3.18MB ± 0%   -0.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-10       3.19MB ± 0%    3.18MB ± 0%   -0.29%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10      3.29MB ± 0%    3.19MB ± 0%   -2.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-10      3.70MB ± 0%    3.22MB ± 0%  -12.85%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names1000Values-10     4.22MB ± 0%    3.27MB ± 0%  -22.52%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names5000Values-10     8.63MB ± 0%    3.56MB ± 0%  -58.76%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names1Values-10        3.19MB ± 0%    3.19MB ± 0%   -0.05%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10       3.21MB ± 0%    3.19MB ± 0%   -0.71%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names100Values-10      3.45MB ± 0%    3.21MB ± 0%   -6.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      4.48MB ± 0%    3.29MB ± 0%  -26.51%  (p=0.016 n=5+4)
NewStreamBinaryReader/50Names1000Values-10     5.78MB ± 0%    3.41MB ± 0%  -41.08%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     17.3MB ± 0%     4.1MB ± 0%  -76.11%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-10       3.20MB ± 0%    3.20MB ± 0%   -0.10%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-10      3.25MB ± 0%    3.20MB ± 0%   -1.40%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     3.72MB ± 0%    3.25MB ± 0%  -12.77%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names500Values-10     5.79MB ± 0%    3.41MB ± 0%  -41.06%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    8.39MB ± 0%    3.64MB ± 0%  -56.63%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names5000Values-10    31.7MB ± 0%     5.1MB ± 0%  -83.98%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       3.22MB ± 0%    3.22MB ± 0%   -0.20%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-10      3.32MB ± 0%    3.23MB ± 0%   -2.75%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10     4.27MB ± 0%    3.32MB ± 0%  -22.27%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names500Values-10     8.72MB ± 0%    3.64MB ± 0%  -58.20%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names1000Values-10    14.3MB ± 0%     4.1MB ± 0%  -71.37%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10    61.3MB ± 0%     7.0MB ± 0%  -88.61%  (p=0.008 n=5+5)

name                                         old allocs/op  new allocs/op  delta
NewStreamBinaryReader/1Names1Values-10           78.0 ± 0%      76.0 ± 0%   -2.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-10           106 ± 0%        78 ± 0%  -26.42%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-10          379 ± 0%        84 ± 0%  -77.84%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10        1.58k ± 0%     0.10k ± 0%  -93.80%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       3.08k ± 0%     0.12k ± 0%  -96.27%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       15.1k ± 0%      0.2k ± 0%  -98.40%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-10           175 ± 0%       154 ± 0%  -12.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-10          735 ± 0%       194 ± 0%  -73.61%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       6.20k ± 0%     0.31k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/20Names500Values-10       30.2k ± 0%      0.6k ± 0%  -98.04%  (p=0.000 n=5+4)
NewStreamBinaryReader/20Names1000Values-10      60.3k ± 0%      0.9k ± 0%  -98.45%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names5000Values-10       300k ± 0%        3k ± 0%  -98.84%  (p=0.000 n=4+5)
NewStreamBinaryReader/50Names1Values-10           329 ± 0%       278 ± 0%  -15.50%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10        1.73k ± 0%     0.38k ± 0%  -78.14%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10       15.4k ± 0%      0.7k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/50Names500Values-10       75.5k ± 0%      1.4k ± 0%  -98.17%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names1000Values-10       151k ± 0%        2k ± 0%  -98.52%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names5000Values-10       751k ± 0%        9k ± 0%  -98.86%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names1Values-10          582 ± 0%       481 ± 0%  -17.35%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names10Values-10       3.38k ± 0%     0.68k ± 0%  -79.85%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10      30.7k ± 0%      1.3k ± 0%  -95.82%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names500Values-10       151k ± 0%        3k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/100Names1000Values-10      301k ± 0%        4k ± 0%  -98.54%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names5000Values-10     1.50M ± 0%     0.02M ± 0%  -98.86%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10        1.08k ± 0%     0.88k ± 0%  -18.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-10       6.68k ± 0%     1.28k ± 0%  -80.82%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-10      61.3k ± 0%      2.5k ± 0%  -95.95%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names500Values-10       302k ± 0%        5k ± 0%  -98.25%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-10      602k ± 0%        9k ± 0%  -98.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10     3.00M ± 0%     0.03M ± 0%  -98.86%  (p=0.000 n=5+4)

```

</details>


<details><summary>Benchmark results: compared to <code>main</code> with spinning rust disk</summary>

```
name                                        old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-2         1.56ms ±17%    1.67ms ±10%     ~     (p=0.548 n=5+5)
NewStreamBinaryReader/1Names10Values-2        1.62ms ±19%    1.77ms ±17%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/1Names100Values-2       1.66ms ±39%    1.62ms ±17%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/1Names500Values-2       2.30ms ±15%    2.19ms ±40%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/1Names1000Values-2      1.85ms ± 7%    2.01ms ±14%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/1Names5000Values-2      4.00ms ±10%    2.64ms ±11%  -33.86%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-2        1.89ms ±18%    2.01ms ± 6%     ~     (p=0.310 n=5+5)
NewStreamBinaryReader/20Names10Values-2       2.07ms ±10%    1.87ms ±18%     ~     (p=0.222 n=5+5)
NewStreamBinaryReader/20Names100Values-2      3.34ms ± 4%    2.47ms ±13%  -25.91%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-2      6.85ms ±10%    4.28ms ±13%  -37.59%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1000Values-2     10.7ms ± 6%     5.8ms ± 9%  -46.29%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names5000Values-2     42.5ms ± 8%    17.3ms ± 2%  -59.28%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-2        2.05ms ± 1%    2.33ms ±12%  +13.78%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names10Values-2       2.69ms ±16%    2.60ms ± 7%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/50Names100Values-2      5.06ms ± 9%    3.71ms ±13%  -26.66%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-2      14.2ms ± 6%     7.2ms ±10%  -49.34%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-2     22.9ms ± 4%    11.4ms ± 7%  -50.06%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-2      103ms ± 2%      41ms ± 2%  -60.12%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-2       3.12ms ± 9%    3.36ms ±17%     ~     (p=0.548 n=5+5)
NewStreamBinaryReader/100Names10Values-2      4.05ms ±12%    3.85ms ±17%     ~     (p=0.421 n=5+5)
NewStreamBinaryReader/100Names100Values-2     8.04ms ±10%    5.65ms ± 4%  -29.78%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-2     23.1ms ± 2%    12.5ms ± 2%  -45.90%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-2    42.7ms ± 5%    20.0ms ± 5%  -53.26%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-2     200ms ± 4%      79ms ± 2%  -60.60%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-2       5.10ms ±11%    5.11ms ± 9%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/200Names10Values-2      6.25ms ± 9%    6.09ms ± 5%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/200Names100Values-2     14.6ms ± 5%     9.6ms ±10%  -34.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names500Values-2     46.1ms ± 5%    21.9ms ± 3%  -52.61%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-2    85.3ms ± 4%    36.9ms ± 4%  -56.77%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-2     407ms ± 3%     152ms ± 3%  -62.57%  (p=0.008 n=5+5)

name                                        old alloc/op   new alloc/op   delta
NewStreamBinaryReader/1Names1Values-2         3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.032 n=5+5)
NewStreamBinaryReader/1Names10Values-2        3.18MB ± 0%    3.18MB ± 0%   -0.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-2       3.18MB ± 0%    3.18MB ± 0%   -0.15%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-2       3.20MB ± 0%    3.18MB ± 0%   -0.74%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-2      3.23MB ± 0%    3.18MB ± 0%   -1.47%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-2      3.44MB ± 0%    3.20MB ± 0%   -6.92%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1Values-2        3.18MB ± 0%    3.18MB ± 0%   -0.02%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-2       3.19MB ± 0%    3.18MB ± 0%   -0.29%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names100Values-2      3.29MB ± 0%    3.19MB ± 0%   -2.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-2      3.70MB ± 0%    3.22MB ± 0%  -12.85%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names1000Values-2     4.22MB ± 0%    3.27MB ± 0%  -22.52%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names5000Values-2     8.63MB ± 0%    3.56MB ± 0%  -58.76%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-2        3.19MB ± 0%    3.19MB ± 0%   -0.05%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-2       3.21MB ± 0%    3.19MB ± 0%   -0.71%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-2      3.45MB ± 0%    3.21MB ± 0%   -6.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-2      4.48MB ± 0%    3.29MB ± 0%  -26.51%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-2     5.78MB ± 0%    3.41MB ± 0%  -41.08%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-2     17.3MB ± 0%     4.1MB ± 0%  -76.11%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-2       3.20MB ± 0%    3.20MB ± 0%   -0.10%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-2      3.25MB ± 0%    3.20MB ± 0%   -1.41%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-2     3.72MB ± 0%    3.25MB ± 0%  -12.77%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-2     5.79MB ± 0%    3.41MB ± 0%  -41.07%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-2    8.39MB ± 0%    3.64MB ± 0%  -56.63%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-2    31.7MB ± 0%     5.1MB ± 0%  -83.98%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-2       3.22MB ± 0%    3.22MB ± 0%   -0.20%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names10Values-2      3.32MB ± 0%    3.23MB ± 0%   -2.75%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names100Values-2     4.27MB ± 0%    3.32MB ± 0%  -22.27%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names500Values-2     8.72MB ± 0%    3.64MB ± 0%  -58.20%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-2    14.3MB ± 0%     4.1MB ± 0%  -71.37%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-2    61.3MB ± 0%     7.0MB ± 0%  -88.61%  (p=0.008 n=5+5)

name                                        old allocs/op  new allocs/op  delta
NewStreamBinaryReader/1Names1Values-2           78.0 ± 0%      76.0 ± 0%   -2.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names10Values-2           106 ± 0%        78 ± 0%  -26.42%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names100Values-2          379 ± 0%        84 ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/1Names500Values-2        1.58k ± 0%     0.10k ± 0%  -93.80%  (p=0.029 n=4+4)
NewStreamBinaryReader/1Names1000Values-2       3.08k ± 0%     0.12k ± 0%  -96.27%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-2       15.1k ± 0%      0.2k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/20Names1Values-2           176 ± 0%       155 ± 0%  -11.93%  (p=0.000 n=5+4)
NewStreamBinaryReader/20Names10Values-2          736 ± 0%       195 ± 0%  -73.49%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-2       6.20k ± 0%     0.32k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/20Names500Values-2       30.2k ± 0%      0.6k ± 0%  -98.03%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names1000Values-2      60.3k ± 0%      0.9k ± 0%  -98.45%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names5000Values-2       300k ± 0%        3k ± 0%  -98.84%  (p=0.000 n=5+4)
NewStreamBinaryReader/50Names1Values-2           330 ± 0%       279 ± 0%  -15.45%  (p=0.000 n=5+4)
NewStreamBinaryReader/50Names10Values-2        1.73k ± 0%     0.38k ± 0%  -78.09%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-2       15.4k ± 0%      0.7k ± 0%  -95.59%  (p=0.029 n=4+4)
NewStreamBinaryReader/50Names500Values-2       75.5k ± 0%      1.4k ± 0%  -98.17%  (p=0.000 n=5+4)
NewStreamBinaryReader/50Names1000Values-2       151k ± 0%        2k ± 0%  -98.52%  (p=0.016 n=4+5)
NewStreamBinaryReader/50Names5000Values-2       751k ± 0%        9k ± 0%  -98.86%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-2          584 ± 0%       483 ± 0%  -17.24%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-2       3.38k ± 0%     0.68k ± 0%  -79.82%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names100Values-2      30.7k ± 0%      1.3k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/100Names500Values-2       151k ± 0%        3k ± 0%  -98.22%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names1000Values-2      301k ± 0%        4k ± 0%  -98.54%  (p=0.029 n=4+4)
NewStreamBinaryReader/100Names5000Values-2     1.50M ± 0%     0.02M ± 0%  -98.86%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-2        1.09k ± 0%     0.89k ± 0%     ~     (p=0.079 n=4+5)
NewStreamBinaryReader/200Names10Values-2       6.69k ± 0%     1.29k ± 0%  -80.77%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names100Values-2      61.3k ± 0%      2.5k ± 0%  -95.94%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names500Values-2       302k ± 0%        5k ± 0%  -98.25%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names1000Values-2      602k ± 0%        9k ± 0%  -98.56%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-2     3.00M ± 0%     0.03M ± 0%  -98.86%  (p=0.008 n=5+5)

```

</details>

---


Overall impact: reading the index header from disk is now 50-60% faster for realistic scenarios 🎉 

#### Which issue(s) this PR fixes or relates to

#3465

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
