### PR TITLE
Make tenants dashboard compatible with all deployment types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * [BUGFIX] Alerts: Fixed `MimirMemoryMapAreasTooHigh` alert when Mimir is deployed in read-write mode. #3626
 * [BUGFIX] Alerts: Fixed `MimirCompactorSkippedBlocksWithOutOfOrderChunks` matching on non-existent label. #3628
 * [BUGFIX] Dashboards: Fix `Rollout Progress` dashboard incorrectly using Gateway metrics when Gateway was not enabled. #3709
-* [BUGFIX] Tenants dashboard: Make it compatible with all deployment types. #xxxx
+* [BUGFIX] Tenants dashboard: Make it compatible with all deployment types. #3754
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [BUGFIX] Alerts: Fixed `MimirMemoryMapAreasTooHigh` alert when Mimir is deployed in read-write mode. #3626
 * [BUGFIX] Alerts: Fixed `MimirCompactorSkippedBlocksWithOutOfOrderChunks` matching on non-existent label. #3628
 * [BUGFIX] Dashboards: Fix `Rollout Progress` dashboard incorrectly using Gateway metrics when Gateway was not enabled. #3709
+* [BUGFIX] Tenants dashboard: Make it compatible with all deployment types. #xxxx
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -2202,7 +2202,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-frontend\", user=\"$user\"}[$__rate_interval]))",
+                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\", user=\"$user\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queries / Sec",
@@ -2278,7 +2278,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-scheduler\", user=\"$user\"})",
+                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((query-scheduler.*|mimir-backend.*))\", user=\"$user\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queue Length",
@@ -2366,7 +2366,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler-query-frontend\", user=\"$user\"}[$__rate_interval]))",
+                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", user=\"$user\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queries / Sec",
@@ -2442,7 +2442,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler-query-scheduler\", user=\"$user\"})",
+                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", user=\"$user\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queue Length",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -2202,7 +2202,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-frontend\", user=\"$user\"}[$__rate_interval]))",
+                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\", user=\"$user\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queries / Sec",
@@ -2278,7 +2278,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-scheduler\", user=\"$user\"})",
+                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((query-scheduler.*|mimir-backend.*))\", user=\"$user\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queue Length",
@@ -2366,7 +2366,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler-query-frontend\", user=\"$user\"}[$__rate_interval]))",
+                        "expr": "sum(rate(cortex_query_frontend_queries_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", user=\"$user\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queries / Sec",
@@ -2442,7 +2442,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler-query-scheduler\", user=\"$user\"})",
+                        "expr": "sum(cortex_query_scheduler_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", user=\"$user\"})",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "Queue Length",

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -538,7 +538,8 @@ local filename = 'mimir-tenants.json';
         local title = 'Rate of Read Requests - query-frontend';
         $.panel(title) +
         $.queryPanel(
-          'sum(rate(cortex_query_frontend_queries_total{%s, container="query-frontend", user="$user"}[$__rate_interval]))' % $.namespaceMatcher(),
+          'sum(rate(cortex_query_frontend_queries_total{%(job)s, user="$user"}[$__rate_interval]))'
+          % { job: $.jobMatcher($._config.job_names.query_frontend) },
           'Queries / Sec'
         )
       )
@@ -547,7 +548,8 @@ local filename = 'mimir-tenants.json';
         $.panel(title) +
         $.queryPanel(
           [
-            'sum(cortex_query_scheduler_queue_length{%s, container="query-scheduler", user="$user"})' % $.namespaceMatcher(),
+            'sum(cortex_query_scheduler_queue_length{%(job)s, user="$user"})'
+            % { job: $.jobMatcher($._config.job_names.query_scheduler) },
           ],
           [
             'Queue Length',
@@ -561,7 +563,8 @@ local filename = 'mimir-tenants.json';
         local title = 'Rate of Read Requests - ruler-query-frontend';
         $.panel(title) +
         $.queryPanel(
-          'sum(rate(cortex_query_frontend_queries_total{%s, container="ruler-query-frontend", user="$user"}[$__rate_interval]))' % $.namespaceMatcher(),
+          'sum(rate(cortex_query_frontend_queries_total{%(job)s, user="$user"}[$__rate_interval]))'
+          % { job: $.jobMatcher($._config.job_names.ruler_query_frontend) },
           'Queries / Sec'
         )
       )
@@ -570,7 +573,8 @@ local filename = 'mimir-tenants.json';
         $.panel(title) +
         $.queryPanel(
           [
-            'sum(cortex_query_scheduler_queue_length{%s, container="ruler-query-scheduler", user="$user"})' % $.namespaceMatcher(),
+            'sum(cortex_query_scheduler_queue_length{%(job)s, user="$user"})'
+            % { job: $.jobMatcher($._config.job_names.ruler_query_frontend) },
           ],
           [
             'Queue Length',


### PR DESCRIPTION
#### What this PR does

Some panels in tenants dashboard use a hardcoded label to select metrics to display.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
