### PR TITLE
Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 * [ENHANCEMENT] Update `rollout-operator` to `v0.2.0`. #3624
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
+* [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766
 
 ### Mimirtool
 

--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -35,9 +35,9 @@
       'query-scheduler.max-used-instances': 2,
     },
 
-  mimir_backend_zone_a_args:: {},
-  mimir_backend_zone_b_args:: {},
-  mimir_backend_zone_c_args:: {},
+  mimir_backend_zone_a_args:: $.store_gateway_zone_a_args {},
+  mimir_backend_zone_b_args:: $.store_gateway_zone_b_args {},
+  mimir_backend_zone_c_args:: $.store_gateway_zone_c_args {},
 
   local mimir_backend_data_pvc =
     pvc.new() +

--- a/operations/mimir/read-write-deployment/write.libsonnet
+++ b/operations/mimir/read-write-deployment/write.libsonnet
@@ -23,9 +23,9 @@
       'mem-ballast-size-bytes': null,
     },
 
-  mimir_write_zone_a_args:: {},
-  mimir_write_zone_b_args:: {},
-  mimir_write_zone_c_args:: {},
+  mimir_write_zone_a_args:: $.ingester_zone_a_args {},
+  mimir_write_zone_b_args:: $.ingester_zone_b_args {},
+  mimir_write_zone_c_args:: $.ingester_zone_c_args {},
 
   mimir_write_ports::
     std.uniq(


### PR DESCRIPTION
#### What this PR does
A tiny fix to read-write jsonnet to apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too.

_This PR is expected to be a no-op._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
