### PR TITLE
partitioner: report more accurate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Store-gateway: Remove experimental `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` flag. #3706
-* [FEATURE] Store-gateway: streaming of series. The store-gateway can now stream results back to the querier instead of buffering them. This is expected to greatly reduce peak memory consumption while keeping latency the same. You can enable this feature by setting `-blocks-storage.bucket-store.batch-series-size` to a value in the high thousands (5000-10000). This is still an experimental feature and is subject to a changing API and instability. #3540 #3546 #3587 #3606 #3611 #3620 #3645 #3355 #3697 #3666 #3687 #3728 #3739
+* [FEATURE] Store-gateway: streaming of series. The store-gateway can now stream results back to the querier instead of buffering them. This is expected to greatly reduce peak memory consumption while keeping latency the same. You can enable this feature by setting `-blocks-storage.bucket-store.batch-series-size` to a value in the high thousands (5000-10000). This is still an experimental feature and is subject to a changing API and instability. #3540 #3546 #3587 #3606 #3611 #3620 #3645 #3355 #3697 #3666 #3687 #3728 #3739 #3751
 * [ENHANCEMENT] Added new metric `thanos_shipper_last_successful_upload_time`: Unix timestamp (in seconds) of the last successful TSDB block uploaded to the bucket. #3627
 * [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
 * [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3691 #3703
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
+* [ENHANCEMENT] Store-gateway: add `cortex_bucket_store_partitioner_extended_ranges_total` metric to keep track of the ranges that the partitioner decided to overextend and merge in order to save API call to the object storage. #3769
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
 * [BUGFIX] Debian package: Fix post-install, environment file path and user creation. #3720
 * [BUGFIX] memberlist: Fix panic during Mimir startup when Mimir receives gossip message before it's ready. #3746
-* [BUGFIX] Store-gateway: make `cortex_bucket_store_partitioner_*` metrics are more accurate. #3769
+* [BUGFIX] Store-gateway: fix `cortex_bucket_store_partitioner_requested_bytes_total` metric to not double count overlapping ranges. #3769
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
 * [BUGFIX] Debian package: Fix post-install, environment file path and user creation. #3720
 * [BUGFIX] memberlist: Fix panic during Mimir startup when Mimir receives gossip message before it's ready. #3746
+* [BUGFIX] Store-gateway: make `cortex_bucket_store_partitioner_*` metrics are more accurate. #3769
 
 ### Mixin
 

--- a/pkg/storegateway/partitioner.go
+++ b/pkg/storegateway/partitioner.go
@@ -29,11 +29,11 @@ func newGapBasedPartitioner(maxGapBytes uint64, reg prometheus.Registerer) *gapB
 		maxGapBytes: maxGapBytes,
 		requestedBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_bucket_store_partitioner_requested_bytes_total",
-			Help: "Total size of byte ranges required to fetch from the storage before they are extended with maxGapBytes.",
+			Help: "Total size of byte ranges required to fetch from the storage before they are extended by the partitioner.",
 		}),
 		expandedBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_bucket_store_partitioner_expanded_bytes_total",
-			Help: "Total size of byte ranges required to fetch from the storage after they are extended with maxGapBytes.",
+			Help: "Total size of byte ranges required to fetch from the storage after they are extended by the partitioner.",
 		}),
 		requestedRanges: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_bucket_store_partitioner_requested_ranges_total",
@@ -45,7 +45,7 @@ func newGapBasedPartitioner(maxGapBytes uint64, reg prometheus.Registerer) *gapB
 		}),
 		extendedRanges: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_bucket_store_partitioner_extended_ranges_total",
-			Help: "Total number of byte ranges that were not overlapping but were joined because they were closer than maxGapBytes.",
+			Help: "Total number of byte ranges that were not overlapping but were joined because they were closer than the configured maximum gap.",
 		}),
 	}
 }

--- a/pkg/storegateway/partitioner.go
+++ b/pkg/storegateway/partitioner.go
@@ -45,7 +45,7 @@ func newGapBasedPartitioner(maxGapBytes uint64, reg prometheus.Registerer) *gapB
 		}),
 		extendedRanges: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_bucket_store_partitioner_extended_ranges_total",
-			Help: "Total number of byte ranges that were not overlapping but were joined because they were closer than the configured maximum gap.",
+			Help: "Total number of byte ranges that were not adjacent or overlapping but were joined because they were closer than the configured maximum gap.",
 		}),
 	}
 }

--- a/pkg/storegateway/partitioner.go
+++ b/pkg/storegateway/partitioner.go
@@ -94,8 +94,11 @@ func (g *gapBasedPartitioner) partition(length int, rng func(int) (uint64, uint6
 
 			if p.End >= s {
 				// The start of the next range overlaps with the current range's end, so we can merge them.
-				// We count the extra bytes between the current range's end and the next one's end - that's what's been requested.
-				stats.requestedBytesTotal += e - p.End
+				if p.End < e {
+					// If the next range extends after the current one,
+					// then we count the extra bytes between the current range's end and the next one's end.
+					stats.requestedBytesTotal += e - p.End
+				}
 			} else if p.End+g.maxGapBytes >= s {
 				// We can afford to fill a gap between the current range's end and the next range's start.
 				// We do so, but we also keep track of how much of it we do.

--- a/pkg/storegateway/partitioner_test.go
+++ b/pkg/storegateway/partitioner_test.go
@@ -22,18 +22,20 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	p := newGapBasedPartitioner(10, reg)
 
-	parts := p.Partition(5, func(i int) (uint64, uint64) {
+	parts := p.Partition(6, func(i int) (uint64, uint64) {
 		switch i {
 		case 0:
-			return 10, 12
+			return 10, 12 // 2B, extended to next range
 		case 1:
-			return 15, 18
+			return 15, 18 // 3B, extended to next range
 		case 2:
-			return 22, 27
+			return 22, 27 // 5B
 		case 3:
-			return 38, 41
+			return 38, 41 // 3B, extended to next range
 		case 4:
-			return 50, 52
+			return 50, 52 // 2B, extended to next range
+		case 5:
+			return 50, 54 // 4B, with 2B overlapping with the previous range
 		default:
 			return 0, 0
 		}
@@ -41,26 +43,30 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 
 	expected := []Part{
 		{Start: 10, End: 27, ElemRng: [2]int{0, 3}},
-		{Start: 38, End: 52, ElemRng: [2]int{3, 5}},
+		{Start: 38, End: 54, ElemRng: [2]int{3, 6}},
 	}
 	require.Equal(t, expected, parts)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_bucket_store_partitioner_requested_bytes_total Total size of byte ranges required to fetch from the storage before they are passed to the partitioner.
+		# HELP cortex_bucket_store_partitioner_requested_bytes_total Total size of byte ranges required to fetch from the storage before they are extended with maxGapBytes.
 		# TYPE cortex_bucket_store_partitioner_requested_bytes_total counter
-		cortex_bucket_store_partitioner_requested_bytes_total 15
+		cortex_bucket_store_partitioner_requested_bytes_total 17
 
 		# HELP cortex_bucket_store_partitioner_requested_ranges_total Total number of byte ranges required to fetch from the storage before they are passed to the partitioner.
 		# TYPE cortex_bucket_store_partitioner_requested_ranges_total counter
-		cortex_bucket_store_partitioner_requested_ranges_total 5
+		cortex_bucket_store_partitioner_requested_ranges_total 6
 
-		# HELP cortex_bucket_store_partitioner_expanded_bytes_total Total size of byte ranges returned by the partitioner after they've been combined together to reduce the number of bucket API calls.
+		# HELP cortex_bucket_store_partitioner_expanded_bytes_total Total size of byte ranges required to fetch from the storage after they are extended with maxGapBytes.
 		# TYPE cortex_bucket_store_partitioner_expanded_bytes_total counter
-		cortex_bucket_store_partitioner_expanded_bytes_total 31
+		cortex_bucket_store_partitioner_expanded_bytes_total 33
 
 		# HELP cortex_bucket_store_partitioner_expanded_ranges_total Total number of byte ranges returned by the partitioner after they've been combined together to reduce the number of bucket API calls.
 		# TYPE cortex_bucket_store_partitioner_expanded_ranges_total counter
 		cortex_bucket_store_partitioner_expanded_ranges_total 2
+
+		# HELP cortex_bucket_store_partitioner_extended_ranges_total Total number of byte ranges that were not overlapping but were joined because they were closer than maxGapBytes.
+		# TYPE cortex_bucket_store_partitioner_extended_ranges_total counter
+		cortex_bucket_store_partitioner_extended_ranges_total 3
 	`)))
 }
 

--- a/pkg/storegateway/partitioner_test.go
+++ b/pkg/storegateway/partitioner_test.go
@@ -22,7 +22,7 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	p := newGapBasedPartitioner(10, reg)
 
-	parts := p.Partition(6, func(i int) (uint64, uint64) {
+	parts := p.Partition(7, func(i int) (uint64, uint64) {
 		switch i {
 		case 0:
 			return 10, 12 // 2B, extended to next range
@@ -36,6 +36,8 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 			return 50, 52 // 2B, extended to next range
 		case 5:
 			return 50, 54 // 4B, with 2B overlapping with the previous range
+		case 6:
+			return 51, 53 // 2B, completely overlapping with the previous range
 		default:
 			return 0, 0
 		}
@@ -43,7 +45,7 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 
 	expected := []Part{
 		{Start: 10, End: 27, ElemRng: [2]int{0, 3}},
-		{Start: 38, End: 54, ElemRng: [2]int{3, 6}},
+		{Start: 38, End: 54, ElemRng: [2]int{3, 7}},
 	}
 	require.Equal(t, expected, parts)
 
@@ -54,7 +56,7 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 
 		# HELP cortex_bucket_store_partitioner_requested_ranges_total Total number of byte ranges required to fetch from the storage before they are passed to the partitioner.
 		# TYPE cortex_bucket_store_partitioner_requested_ranges_total counter
-		cortex_bucket_store_partitioner_requested_ranges_total 6
+		cortex_bucket_store_partitioner_requested_ranges_total 7
 
 		# HELP cortex_bucket_store_partitioner_expanded_bytes_total Total size of byte ranges required to fetch from the storage after they are extended by the partitioner.
 		# TYPE cortex_bucket_store_partitioner_expanded_bytes_total counter

--- a/pkg/storegateway/partitioner_test.go
+++ b/pkg/storegateway/partitioner_test.go
@@ -48,7 +48,7 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 	require.Equal(t, expected, parts)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_bucket_store_partitioner_requested_bytes_total Total size of byte ranges required to fetch from the storage before they are extended with maxGapBytes.
+		# HELP cortex_bucket_store_partitioner_requested_bytes_total Total size of byte ranges required to fetch from the storage before they are extended by the partitioner.
 		# TYPE cortex_bucket_store_partitioner_requested_bytes_total counter
 		cortex_bucket_store_partitioner_requested_bytes_total 17
 
@@ -56,7 +56,7 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 		# TYPE cortex_bucket_store_partitioner_requested_ranges_total counter
 		cortex_bucket_store_partitioner_requested_ranges_total 6
 
-		# HELP cortex_bucket_store_partitioner_expanded_bytes_total Total size of byte ranges required to fetch from the storage after they are extended with maxGapBytes.
+		# HELP cortex_bucket_store_partitioner_expanded_bytes_total Total size of byte ranges required to fetch from the storage after they are extended by the partitioner.
 		# TYPE cortex_bucket_store_partitioner_expanded_bytes_total counter
 		cortex_bucket_store_partitioner_expanded_bytes_total 33
 
@@ -64,7 +64,7 @@ func TestGapBasedPartitioner_Metrics(t *testing.T) {
 		# TYPE cortex_bucket_store_partitioner_expanded_ranges_total counter
 		cortex_bucket_store_partitioner_expanded_ranges_total 2
 
-		# HELP cortex_bucket_store_partitioner_extended_ranges_total Total number of byte ranges that were not overlapping but were joined because they were closer than maxGapBytes.
+		# HELP cortex_bucket_store_partitioner_extended_ranges_total Total number of byte ranges that were not overlapping but were joined because they were closer than the configured maximum gap.
 		# TYPE cortex_bucket_store_partitioner_extended_ranges_total counter
 		cortex_bucket_store_partitioner_extended_ranges_total 3
 	`)))


### PR DESCRIPTION
This commit fixes a partitioner metric and adds a new one

The partitioner currently exposes 4 counters
* `cortex_bucket_store_partitioner_requested_bytes_total`
* `cortex_bucket_store_partitioner_requested_ranges_total`
* `cortex_bucket_store_partitioner_expanded_bytes_total`
* `cortex_bucket_store_partitioner_expanded_ranges_total`

Currently, `cortex_bucket_store_partitioner_requested_bytes_total`
exposes the total sizes of all ranges independant of each other. This
represents their total size without merging any overlapping sizes.

This is not very useful information. This PR changes that metric to
report the number of bytes that would be fetched if the gap that the
partitioner fills is 0. This way you can use
`cortex_bucket_store_partitioner_requested_bytes_total` in combination
with `cortex_bucket_store_partitioner_expanded_bytes_total` to figure
out how much more data the partitioner is fetching that wasn't in the
original ranges.

This PR also adds `cortex_bucket_store_partitioner_extended_ranges_total`
This metric tracks the number of ranges that were merged together due to
 the gap that the partitioner fills. This metric will help determine
 whether the partitioner is mergning too many ranges and overfetching
 small gaps very often. Or whether it is overfetching a single very big
 range. This will help in tuning the default gap for the partitioner
 (currently at 512KB)

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>