### PR TITLE
Add instructions for installing mimirtool with Homebrew.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Mimirtool
 
+* [ENHANCEMENT] Mimirtool is now available to install through Homebrew with `brew install mimirtool`. #3776
+
 ### Documentation
 
 * [BUGFIX] Querier: Remove assertion that the `-querier.max-concurrent` flag must also be set for the query-frontend. #3678

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -226,6 +226,10 @@ git checkout release-<version>
 > **Note:** Technical documentation is automatically published on release tags or release branches with a corresponding
 > release tag. The workflow that publishes documentation is defined in [`publish-technical-documentation-release.yml`](.github/workflows/publish-technical-documentation-release.yml).
 
+> **Note:** Homebrew's [autobump job](https://github.com/Homebrew/homebrew-core/actions/workflows/autobump.yml)
+> automatically updates the [`mimirtool` Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mimirtool.rb).
+> The autobump job runs once every 24 hours, so it may take a day or two for the updated formula to be created and published.
+
 To publish a stable release:
 
 1. Do not change the release branch directly; make a PR to the `release-X.Y` branch with VERSION and any CHANGELOG changes.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -228,7 +228,7 @@ git checkout release-<version>
 
 > **Note:** Homebrew's [autobump job](https://github.com/Homebrew/homebrew-core/actions/workflows/autobump.yml)
 > automatically updates the [`mimirtool` Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mimirtool.rb).
-> The autobump job runs once every 24 hours, so it may take a day or two for the updated formula to be created and published.
+> The autobump job runs once every 24 hours, so it might take a day or two for the updated formula to be created and published.
 
 To publish a stable release:
 

--- a/docs/sources/mimir/operators-guide/tools/mimirtool.md
+++ b/docs/sources/mimir/operators-guide/tools/mimirtool.md
@@ -51,7 +51,7 @@ Mimirtool interacts with:
 
 ## Installation
 
-To install Mimirtool with Homebrew on macOS, run `brew install mimirtool`. 
+To install Mimirtool with Homebrew on macOS, run `brew install mimirtool`.
 
 To install Mimirtool in other environments, download the appropriate binary from the [latest release](https://github.com/grafana/mimir/releases/latest) for your operating system and architecture and make it executable.
 

--- a/docs/sources/mimir/operators-guide/tools/mimirtool.md
+++ b/docs/sources/mimir/operators-guide/tools/mimirtool.md
@@ -51,7 +51,9 @@ Mimirtool interacts with:
 
 ## Installation
 
-To install Mimirtool, download the appropriate binary from the [latest release](https://github.com/grafana/mimir/releases/latest) for your operating system and architecture and make it executable.
+To install Mimirtool with Homebrew on macOS, run `brew install mimirtool`. 
+
+To install Mimirtool in other environments, download the appropriate binary from the [latest release](https://github.com/grafana/mimir/releases/latest) for your operating system and architecture and make it executable.
 
 Alternatively, use a command line tool such as `curl` to download `mimirtool`. For example, for Linux with the AMD64 architecture, use the following command:
 


### PR DESCRIPTION
#### What this PR does

`mimirtool` is now available through Homebrew. This PR adds instructions for how to install `mimirtool` with Homebrew on macOS, and adds a note to the release checklist.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
