### PR TITLE
streaming store-gateway: avoid copying postings when hashing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Store-gateway: Remove experimental `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` flag. #3706
-* [FEATURE] Store-gateway: streaming of series. The store-gateway can now stream results back to the querier instead of buffering them. This is expected to greatly reduce peak memory consumption while keeping latency the same. You can enable this feature by setting `-blocks-storage.bucket-store.batch-series-size` to a value in the high thousands (5000-10000). This is still an experimental feature and is subject to a changing API and instability. #3540 #3546 #3587 #3606 #3611 #3620 #3645 #3355 #3697 #3666 #3687 #3728 #3739 #3751
+* [FEATURE] Store-gateway: streaming of series. The store-gateway can now stream results back to the querier instead of buffering them. This is expected to greatly reduce peak memory consumption while keeping latency the same. You can enable this feature by setting `-blocks-storage.bucket-store.batch-series-size` to a value in the high thousands (5000-10000). This is still an experimental feature and is subject to a changing API and instability. #3540 #3546 #3587 #3606 #3611 #3620 #3645 #3355 #3697 #3666 #3687 #3728 #3739 #3751 #3779
 * [ENHANCEMENT] Added new metric `thanos_shipper_last_successful_upload_time`: Unix timestamp (in seconds) of the last successful TSDB block uploaded to the bucket. #3627
 * [ENHANCEMENT] Ruler: Added `-ruler.alertmanager-client.tls-enabled` configuration for alertmanager client. #3432 #3597
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -97,7 +97,7 @@ func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
 	return PostingsKey(base64.RawURLEncoding.EncodeToString(checksum[:]))
 }
 
-var bytesPerPosting = int(unsafe.Sizeof(storage.SeriesRef(0)) / unsafe.Sizeof(byte(0)))
+const bytesPerPosting = int(unsafe.Sizeof(storage.SeriesRef(0)) / unsafe.Sizeof(byte(0)))
 
 // unsafeCastPostingsToBytes returns the postings as a slice of bytes with minimal allocations.
 // It casts the memory region of the underlying array to a slice of bytes.

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -7,10 +7,11 @@ package indexcache
 
 import (
 	"context"
-	"crypto/sha1"
 	"encoding/base64"
+	"reflect"
 	"sort"
 	"strings"
+	"unsafe"
 
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -91,23 +92,20 @@ type PostingsKey string
 
 // CanonicalPostingsKey creates a canonical version of PostingsKey
 func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
-	hashable := make([]byte, len(postings)*8)
-	for i, posting := range postings {
-		for octet := 0; octet < 8; octet++ {
-			hashable[i+octet] = byte(posting >> (octet * 8))
-		}
-	}
+	hashable := unsafeCastPostingsToBytes(postings)
+	checksum := blake2b.Sum256(hashable)
+	return PostingsKey(base64.RawURLEncoding.EncodeToString(checksum[:]))
+}
 
-	// We hash the postings list twice to minimize the chance of collisions
-	hasher1, _ := blake2b.New256(nil) // This will never return an error
-	hasher2 := sha1.New()
-
-	_, _ = hasher1.Write(hashable)
-	_, _ = hasher2.Write(hashable)
-
-	checksum := hasher2.Sum(hasher1.Sum(nil))
-
-	return PostingsKey(base64.RawURLEncoding.EncodeToString(checksum))
+// unsafeCastPostingsToBytes returns the postings as a slice of bytes with minimal allocations.
+// It casts the memory region of the underlying array to a slice of bytes.
+func unsafeCastPostingsToBytes(postings []storage.SeriesRef) []byte {
+	byteSlice := make([]byte, 0)
+	slicePtr := (*reflect.SliceHeader)(unsafe.Pointer(&byteSlice))
+	slicePtr.Data = (*reflect.SliceHeader)(unsafe.Pointer(&postings)).Data
+	slicePtr.Len = len(postings) * 8
+	slicePtr.Cap = slicePtr.Len
+	return byteSlice
 }
 
 // LabelMatchersKey represents a canonical key for a []*matchers.Matchers slice

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -97,7 +97,7 @@ func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
 	return PostingsKey(base64.RawURLEncoding.EncodeToString(checksum[:]))
 }
 
-const bytesPerPosting = int(unsafe.Sizeof(storage.SeriesRef(0)) / unsafe.Sizeof(byte(0)))
+const bytesPerPosting = int(unsafe.Sizeof(storage.SeriesRef(0)))
 
 // unsafeCastPostingsToBytes returns the postings as a slice of bytes with minimal allocations.
 // It casts the memory region of the underlying array to a slice of bytes.

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -100,7 +100,7 @@ func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
 const bytesPerPosting = int(unsafe.Sizeof(storage.SeriesRef(0)))
 
 // unsafeCastPostingsToBytes returns the postings as a slice of bytes with minimal allocations.
-// It casts the memory region of the underlying array to a slice of bytes.
+// It casts the memory region of the underlying array to a slice of bytes. The resulting byte slice is only valid as long as the postings slice exists and is unmodified.
 func unsafeCastPostingsToBytes(postings []storage.SeriesRef) []byte {
 	byteSlice := make([]byte, 0)
 	slicePtr := (*reflect.SliceHeader)(unsafe.Pointer(&byteSlice))

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -97,13 +97,15 @@ func CanonicalPostingsKey(postings []storage.SeriesRef) PostingsKey {
 	return PostingsKey(base64.RawURLEncoding.EncodeToString(checksum[:]))
 }
 
+var bytesPerPosting = int(unsafe.Sizeof(storage.SeriesRef(0)) / unsafe.Sizeof(byte(0)))
+
 // unsafeCastPostingsToBytes returns the postings as a slice of bytes with minimal allocations.
 // It casts the memory region of the underlying array to a slice of bytes.
 func unsafeCastPostingsToBytes(postings []storage.SeriesRef) []byte {
 	byteSlice := make([]byte, 0)
 	slicePtr := (*reflect.SliceHeader)(unsafe.Pointer(&byteSlice))
 	slicePtr.Data = (*reflect.SliceHeader)(unsafe.Pointer(&postings)).Data
-	slicePtr.Len = len(postings) * 8
+	slicePtr.Len = len(postings) * bytesPerPosting
 	slicePtr.Cap = slicePtr.Len
 	return byteSlice
 }

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -97,6 +97,13 @@ func TestCanonicalPostingsKey(t *testing.T) {
 		assert.NotEqual(t, CanonicalPostingsKey(postings1), CanonicalPostingsKey(postings2))
 	})
 
+	t.Run("when postings are a subset of each other, they still have different hashes", func(t *testing.T) {
+		postings1 := []storage.SeriesRef{1, 2, 3, 4}
+		postings2 := []storage.SeriesRef{1, 2, 3, 4, 5}
+
+		assert.NotEqual(t, CanonicalPostingsKey(postings1), CanonicalPostingsKey(postings2))
+	})
+
 	t.Run("same postings with different slice capacities have same hashes", func(t *testing.T) {
 		postings1 := []storage.SeriesRef{1, 2, 3, 4}
 		postings2 := make([]storage.SeriesRef, 4, 8)

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -49,6 +49,7 @@ func BenchmarkCanonicalPostingsKey(b *testing.B) {
 	}
 	for numPostings := 10; numPostings <= len(ms); numPostings *= 10 {
 		b.Run(fmt.Sprintf("%d postings", numPostings), func(b *testing.B) {
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				_ = CanonicalPostingsKey(ms[:numPostings])
 			}


### PR DESCRIPTION
This PR solves two problems:
* a bug I just discovered - when we previously constructed the byte slice of the postings we were incorrectly setting the byte position of the octet from the posting
	* it was 
	  ```go
      hashable[i+octet]   = byte(posting >> (octet * 8))
      ```
    * it should be 
      ```go
      hashable[i*8+octet] = byte(posting >> (octet * 8))
      ```
* avoids copying the postings into a byte slice altogether. Instead, it creates a new sliceHeader that it points to the data of the postings and adjusts the length and capacity.

It also changes the hashing functions from SHA1 (20B) + Blake2 (32B) to only Blake2 (32B). The memcached cache key is too small to fit both SHA1 and Blake2. In another change that will also remove the matchers hash from the key I will use Blake2 with 42B
