### PR TITLE
Fixed helm gateway's checksum/config when using nginx

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.2.0`. #3624
 * [ENHANCEMENT] Add ability to manage PrometheusRule for metamonitoring with Prometheus operator from the Helm chart. The alerts are disabled by default but can be enabled with `prometheusRule.mimirAlerts` set to `true`. To enable the default rules, set `mimirRules` to `true`. #2134 #2609
 * [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary
+* [BUGFIX] Fixed gateway's checksum/config when using nginx #3780
 
 ## 4.0.0
 

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -27,8 +27,8 @@ spec:
         {{- include "mimir.podLabels" (dict "ctx" $ "component" "gateway") | nindent 8 }}
       annotations:
         {{- $annotations := include "mimir.podAnnotations" (dict "ctx" $ "component" "gateway") | fromYaml -}}
-        {{- if $isGEMGateway -}}
-        {{- $annotations = (dict "checksum/config" (include (print $.Template.BasePath "/gateway/nginx-configmap.yaml") $ | sha256sum )) | merge $annotations -}}
+        {{- if not $isGEMGateway -}}
+        {{- $annotations = (dict "checksum/config" (include (print $.Template.BasePath "/gateway/nginx-configmap.yaml") $ | sha256sum )) | mergeOverwrite $annotations -}}
         {{- end -}}
         {{- $annotations | toYaml | nindent 8 }}
       namespace: {{ $.Release.Namespace | quote }}


### PR DESCRIPTION
* use nginx-configmap.yaml's sha256sum when not isGEMGateway
* use mergeOverwrite instead of merge

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Gateway's `checksum/config` not change after `gateway.nginx.config.file` modified when `gateway.enabledNonEnterprise` is true.

1. `nginx-configmap.yaml` should be used when `$isGEMGateway` is false (like nginx container).
2. use [mergeOverwrite](https://helm.sh/docs/chart_template_guide/function_list/#mergeoverwrite-mustmergeoverwrite) instead of merge to merge the parameters correctly, which old `$annotations` as "dest" and the new dict as "source".

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
