### PR TITLE
Disable helm gateway's serviceMonitor when using nginx

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add ability to manage PrometheusRule for metamonitoring with Prometheus operator from the Helm chart. The alerts are disabled by default but can be enabled with `prometheusRule.mimirAlerts` set to `true`. To enable the default rules, set `mimirRules` to `true`. #2134 #2609
 * [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary
 * [BUGFIX] Fixed gateway's checksum/config when using nginx #3780
+* [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781
 
 ## 4.0.0
 

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-servmon.yaml
@@ -1,3 +1,3 @@
-{{- if eq (include "mimir.gateway.isEnabled" .) "true" -}}
+{{- if and (eq (include "mimir.gateway.isEnabled" .) "true") (not .Values.gateway.enabledNonEnterprise) -}}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "gateway") }}
 {{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Gateway's nginx container not offer metrics for ServiceMonitor.
We should remove gateway's ServiceMonitor when using nginx ( as`.Values.gateway.enabledNonEnterprise` is true).

#### Which issue(s) this PR fixes or relates to

Fixes #3688

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
