### PR TITLE
Store gateway mmap removal: introduce `Decbuf.Position()` to simplify logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Activity tracker logs now have `component=activity-tracker` label. #3556
 * [ENHANCEMENT] Distributor: remove labels with empty values #2439
 * [ENHANCEMENT] Query-frontend: track query HTTP requests in the Activity Tracker. #3561
-* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3691 #3703
+* [ENHANCEMENT] Store-gateway: Add experimental alternate implementation of index-header reader that does not use memory mapped files. The index-header reader is expected to improve stability of the store-gateway. You can enable this implementation with the flag `-blocks-storage.bucket-store.index-header.stream-reader-enabled`. #3639 #3691 #3703 #3785
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [ENHANCEMENT] Store-gateway: add `cortex_bucket_store_partitioner_extended_ranges_total` metric to keep track of the ranges that the partitioner decided to overextend and merge in order to save API call to the object storage. #3769
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -266,9 +266,14 @@ func (d *Decbuf) Byte() byte {
 	return v
 }
 
-func (d *Decbuf) Err() error    { return d.E }
-func (d *Decbuf) Len() int      { return d.r.len() }
-func (d *Decbuf) Position() int { return d.r.pos }
+func (d *Decbuf) Err() error { return d.E }
+
+// Len returns the remaining number of bytes in the underlying fileReader.
+func (d *Decbuf) Len() int { return d.r.len() }
+
+// Position returns the current position of the underlying fileReader.
+// Calling d.ResetAt(d.Position()) is effectively a no-op.
+func (d *Decbuf) Position() int { return d.r.position() }
 
 func (d *Decbuf) Close() error {
 	if d.r != nil {

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -266,8 +266,9 @@ func (d *Decbuf) Byte() byte {
 	return v
 }
 
-func (d *Decbuf) Err() error { return d.E }
-func (d *Decbuf) Len() int   { return d.r.len() }
+func (d *Decbuf) Err() error    { return d.E }
+func (d *Decbuf) Len() int      { return d.r.len() }
+func (d *Decbuf) Position() int { return d.r.pos }
 
 func (d *Decbuf) Close() error {
 	if d.r != nil {

--- a/pkg/storegateway/indexheader/encoding/encoding_test.go
+++ b/pkg/storegateway/indexheader/encoding/encoding_test.go
@@ -31,11 +31,13 @@ func TestDecbuf_Be32HappyPath(t *testing.T) {
 
 			dec := createDecbufWithBytes(t, enc.Get())
 			require.Equal(t, 4, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.Be32()
 			require.NoError(t, dec.Err())
 			require.Equal(t, c, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 4, dec.Position())
 		})
 	}
 }
@@ -61,11 +63,13 @@ func FuzzDecbuf_Be32(f *testing.F) {
 		dec := createDecbufWithBytes(t, enc.Get())
 		require.NoError(t, dec.Err())
 		require.Equal(t, 4, dec.Len())
+		require.Equal(t, 0, dec.Position())
 
 		actual := dec.Be32()
 		require.NoError(t, dec.Err())
 		require.Equal(t, n, actual)
 		require.Equal(t, 0, dec.Len())
+		require.Equal(t, 4, dec.Position())
 	})
 }
 
@@ -111,11 +115,13 @@ func TestDecbuf_Be32intHappyPath(t *testing.T) {
 
 			dec := createDecbufWithBytes(t, enc.Get())
 			require.Equal(t, 4, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.Be32int()
 			require.NoError(t, dec.Err())
 			require.Equal(t, c, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 4, dec.Position())
 		})
 	}
 }
@@ -145,11 +151,13 @@ func FuzzDecbuf_Be32int(f *testing.F) {
 		dec := createDecbufWithBytes(t, enc.Get())
 		require.NoError(t, dec.Err())
 		require.Equal(t, 4, dec.Len())
+		require.Equal(t, 0, dec.Position())
 
 		actual := dec.Be32int()
 		require.NoError(t, dec.Err())
 		require.Equal(t, n, actual)
 		require.Equal(t, 0, dec.Len())
+		require.Equal(t, 4, dec.Position())
 	})
 }
 
@@ -167,11 +175,13 @@ func TestDecbuf_Be64HappyPath(t *testing.T) {
 
 			dec := createDecbufWithBytes(t, enc.Get())
 			require.Equal(t, 8, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.Be64()
 			require.NoError(t, dec.Err())
 			require.Equal(t, c, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 8, dec.Position())
 		})
 	}
 }
@@ -194,11 +204,13 @@ func FuzzDecbuf_Be64(f *testing.F) {
 		dec := createDecbufWithBytes(t, enc.Get())
 		require.NoError(t, dec.Err())
 		require.Equal(t, 8, dec.Len())
+		require.Equal(t, 0, dec.Position())
 
 		actual := dec.Be64()
 		require.NoError(t, dec.Err())
 		require.Equal(t, n, actual)
 		require.Equal(t, 0, dec.Len())
+		require.Equal(t, 8, dec.Position())
 	})
 }
 
@@ -239,15 +251,18 @@ func TestDecbuf_SkipHappyPath(t *testing.T) {
 
 	dec := createDecbufWithBytes(t, enc.Get())
 	require.Equal(t, 8, dec.Len())
+	require.Equal(t, 0, dec.Position())
 
 	dec.Skip(4)
 	require.NoError(t, dec.Err())
 	require.Equal(t, 4, dec.Len())
+	require.Equal(t, 4, dec.Position())
 
 	actual := dec.Be32()
 	require.NoError(t, dec.Err())
 	require.Equal(t, expected, actual)
 	require.Equal(t, 0, dec.Len())
+	require.Equal(t, 8, dec.Position())
 }
 
 func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
@@ -263,6 +278,7 @@ func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
 
 	require.NoError(t, dec.Err())
 	require.Equal(t, dec.Len(), 4096)
+	require.Equal(t, 4096*4, dec.Position())
 	require.Equal(t, byte(0x01), dec.Byte())
 }
 
@@ -280,10 +296,12 @@ func TestDecbuf_SkipUvarintBytesHappyPath(t *testing.T) {
 
 	dec := createDecbufWithBytes(t, enc.Get())
 	require.Equal(t, 7, dec.Len())
+	require.Equal(t, 0, dec.Position())
 
 	dec.SkipUvarintBytes()
 	require.NoError(t, dec.Err())
 	require.Equal(t, 4, dec.Len())
+	require.Equal(t, 3, dec.Position())
 
 	actual := dec.Be32()
 	require.NoError(t, dec.Err())
@@ -298,6 +316,7 @@ func TestDecbuf_SkipUvarintBytesEndOfFile(t *testing.T) {
 	dec.Be32()
 	require.NoError(t, dec.Err())
 	require.Equal(t, 0, dec.Len())
+	require.Equal(t, 4, dec.Position())
 
 	dec.SkipUvarintBytes()
 	require.ErrorIs(t, dec.Err(), ErrInvalidSize)
@@ -310,6 +329,7 @@ func TestDecbuf_SkipUvarintBytesOnlyHaveLength(t *testing.T) {
 	bytes := enc.Get()
 	dec := createDecbufWithBytes(t, bytes[:len(bytes)-2])
 	require.Equal(t, 1, dec.Len())
+	require.Equal(t, 0, dec.Position())
 
 	dec.SkipUvarintBytes()
 	require.ErrorIs(t, dec.Err(), ErrInvalidSize)
@@ -322,6 +342,7 @@ func TestDecbuf_SkipUvarintBytesPartialValue(t *testing.T) {
 	bytes := enc.Get()
 	dec := createDecbufWithBytes(t, bytes[:len(bytes)-1])
 	require.Equal(t, 2, dec.Len())
+	require.Equal(t, 0, dec.Position())
 
 	dec.SkipUvarintBytes()
 	require.ErrorIs(t, dec.Err(), ErrInvalidSize)
@@ -346,11 +367,13 @@ func TestDecbuf_UvarintHappyPath(t *testing.T) {
 
 			dec := createDecbufWithBytes(t, enc.Get())
 			require.Equal(t, c.bytes, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.Uvarint()
 			require.NoError(t, dec.Err())
 			require.Equal(t, c.value, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, c.bytes, dec.Position())
 		})
 	}
 }
@@ -406,11 +429,13 @@ func TestDecbuf_Uvarint64HappyPath(t *testing.T) {
 
 			dec := createDecbufWithBytes(t, enc.Get())
 			require.Equal(t, c.bytes, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.Uvarint64()
 			require.NoError(t, dec.Err())
 			require.Equal(t, c.value, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, c.bytes, dec.Position())
 		})
 	}
 }
@@ -464,12 +489,15 @@ func TestDecbuf_UnsafeUvarintBytesHappyPath(t *testing.T) {
 			enc.PutUvarintBytes(c.value)
 
 			dec := createDecbufWithBytes(t, enc.Get())
-			require.Equal(t, dec.Len(), c.encodedSizeLength+len(c.value))
+			size := c.encodedSizeLength + len(c.value)
+			require.Equal(t, size, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.UnsafeUvarintBytes()
 			require.NoError(t, dec.Err())
 			require.Condition(t, test.EqualSlices(c.value, actual), "%#v != %#v", c.value, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, size, dec.Position())
 		})
 	}
 }
@@ -581,12 +609,15 @@ func TestDecbuf_UvarintStrHappyPath(t *testing.T) {
 			enc.PutUvarintStr(c.value)
 
 			dec := createDecbufWithBytes(t, enc.Get())
-			require.Equal(t, dec.Len(), c.encodedSizeLength+len(c.value))
+			size := c.encodedSizeLength + len(c.value)
+			require.Equal(t, size, dec.Len())
+			require.Equal(t, 0, dec.Position())
 
 			actual := dec.UvarintStr()
 			require.NoError(t, dec.Err())
 			require.Equal(t, c.value, actual)
 			require.Equal(t, 0, dec.Len())
+			require.Equal(t, size, dec.Position())
 		})
 	}
 }

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -156,7 +156,7 @@ func (f *fileReader) len() int {
 	return f.length - f.pos
 }
 
-// position returns the current position of this fileReader in f, relative to the beginning of f.
+// position returns the current position of this fileReader in f, relative to base.
 func (f *fileReader) position() int {
 	return f.pos
 }

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -156,6 +156,11 @@ func (f *fileReader) len() int {
 	return f.length - f.pos
 }
 
+// position returns the current position of this fileReader in f, relative to the beginning of f.
+func (f *fileReader) position() int {
+	return f.pos
+}
+
 // close cleans up the underlying resources used by this fileReader.
 func (f *fileReader) close() error {
 	// Note that we don't do anything to clean up the buffer before returning it to the pool here:

--- a/pkg/storegateway/indexheader/encoding/reader_test.go
+++ b/pkg/storegateway/indexheader/encoding/reader_test.go
@@ -178,6 +178,34 @@ func TestReaders_Len(t *testing.T) {
 	})
 }
 
+func TestReaders_Position(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *fileReader) {
+		require.Equal(t, 0, r.position(), "initial position")
+
+		_, err := r.read(5)
+		require.NoError(t, err)
+		require.Equal(t, 5, r.position(), "after first read")
+
+		_, err = r.read(2)
+		require.NoError(t, err)
+		require.Equal(t, 7, r.position(), "after second read")
+
+		_, err = r.peek(3)
+		require.NoError(t, err)
+		require.Equal(t, 7, r.position(), "after peek")
+
+		_, err = r.read(14)
+		require.ErrorIs(t, err, ErrInvalidSize)
+		require.Equal(t, 20, r.position(), "after read beyond end")
+
+		require.NoError(t, r.reset())
+		require.Equal(t, 0, r.position(), "after reset to beginning")
+
+		require.NoError(t, r.resetAt(3))
+		require.Equal(t, 3, r.position(), "after reset to offset")
+	})
+}
+
 func TestReaders_CreationWithEmptyContents(t *testing.T) {
 	t.Run("fileReader", func(t *testing.T) {
 		dir := t.TempDir()

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -184,10 +184,6 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 		t.postings[currentName].lastValOffset = int64(indexLastPostingEnd) - crc32.Size // Each posting offset table ends with a CRC32 checksum.
 	}
 
-	if d.Err() != nil {
-		return nil, errors.Wrap(d.Err(), "read last values for entries in postings table")
-	}
-
 	// Trim any extra space in the slices.
 	for k, v := range t.postings {
 		if len(v.offsets) == cap(v.offsets) {

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -469,7 +469,7 @@ func (t *PostingOffsetTableV2) LabelValues(name string, filter func(string) bool
 		d.Uvarint64() // Offset.
 	}
 	if d.Err() != nil {
-		return nil, errors.Wrap(d.Err(), "get postings offset entry")
+		return nil, errors.Wrap(d.Err(), "get label values")
 	}
 	return values, nil
 }

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -55,13 +55,11 @@ func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *
 		tableOffset: offset,
 	}
 
-	origLen := d.Len()
 	cnt := d.Be32int()
-	basePos := 4
 	s.offsets = make([]int, 0, 1+cnt/symbolFactor)
 	for d.Err() == nil && s.seen < cnt {
 		if s.seen%symbolFactor == 0 {
-			s.offsets = append(s.offsets, basePos+origLen-d.Len())
+			s.offsets = append(s.offsets, d.Position())
 		}
 		d.SkipUvarintBytes() // The symbol.
 		s.seen++

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -31,7 +31,6 @@ type Symbols struct {
 	factory *streamencoding.DecbufFactory
 
 	version     int
-	tableLength int
 	tableOffset int
 
 	offsets []int
@@ -51,7 +50,6 @@ func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *
 	s = &Symbols{
 		factory:     factory,
 		version:     version,
-		tableLength: d.Len() + 4, // NewDecbufAtChecked has already read the size of the table (4 bytes) by the time we get here.
 		tableOffset: offset,
 	}
 
@@ -157,10 +155,10 @@ func (s *Symbols) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, er
 
 	d.ResetAt(s.offsets[i])
 	res := i * symbolFactor
-	var lastLen int
+	var lastPosition int
 	var lastSymbol string
 	for d.Err() == nil && res <= s.seen {
-		lastLen = d.Len()
+		lastPosition = d.Position()
 		lastSymbol = yoloString(d.UnsafeUvarintBytes())
 		if lastSymbol >= sym {
 			break
@@ -176,7 +174,7 @@ func (s *Symbols) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, er
 	if s.version == index.FormatV2 {
 		return uint32(res), nil
 	}
-	return uint32(s.tableLength - lastLen), nil
+	return uint32(lastPosition), nil
 }
 
 func yoloString(b []byte) string {


### PR DESCRIPTION
#### What this PR does

This PR introduces a `Position()` method to `Decbuf`. This allows us to remove a number of confusing calculations involving the remaining length of a `Decbuf`. ([This](https://github.com/grafana/mimir/pull/3742#discussion_r1052108186) is one example of the confusion the current implementation can cause.)

I've tried to do this incrementally. I'd suggest reviewing each commit individually rather than trying to review the entire PR's changes in one go.

#### Which issue(s) this PR fixes or relates to

Relates to #3465, builds upon #3742.

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
