### PR TITLE
Fix MimirCompactorHasNotUploadedBlocks to not fire if compactor has nothing to do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Alerts: Fixed `MimirCompactorSkippedBlocksWithOutOfOrderChunks` matching on non-existent label. #3628
 * [BUGFIX] Dashboards: Fix `Rollout Progress` dashboard incorrectly using Gateway metrics when Gateway was not enabled. #3709
 * [BUGFIX] Tenants dashboard: Make it compatible with all deployment types. #3754
+* [BUGFIX] Alerts: Fixed `MimirCompactorHasNotUploadedBlocks` to not fire if compactor has nothing to do. #3793
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -785,6 +785,8 @@ spec:
           }} has not successfully cleaned up blocks in the last 6 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullycleanedupblocks
       expr: |
+        # The "last successful run" metric is updated even if the compactor owns no tenants,
+        # so this alert correctly doesn't fire if compactor has nothing to do.
         (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 6)
       for: 1h
       labels:
@@ -795,6 +797,8 @@ spec:
           }} has not run compaction in the last 24 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
       expr: |
+        # The "last successful run" metric is updated even if the compactor owns no tenants,
+        # so this alert correctly doesn't fire if compactor has nothing to do.
         (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
         and
         (cortex_compactor_last_successful_run_timestamp_seconds > 0)
@@ -808,6 +812,8 @@ spec:
           }} has not run compaction in the last 24 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
       expr: |
+        # The "last successful run" metric is updated even if the compactor owns no tenants,
+        # so this alert correctly doesn't fire if compactor has nothing to do.
         cortex_compactor_last_successful_run_timestamp_seconds == 0
       for: 24h
       labels:
@@ -829,9 +835,13 @@ spec:
           }} has not uploaded any block in the last 24 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
       expr: |
-        (time() - thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 60 * 60 * 24)
+        (time() - (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
         and
-        (thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 0)
+        (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) > 0)
+        and
+        # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+        # (e.g. there are more replicas than required because running as part of mimir-backend).
+        (sum by(cluster, namespace, pod) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
       for: 15m
       labels:
         severity: critical
@@ -841,7 +851,11 @@ spec:
           }} has not uploaded any block in the last 24 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
       expr: |
-        thanos_objstore_bucket_last_successful_upload_time{component="compactor"} == 0
+        (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
+        and
+        # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+        # (e.g. there are more replicas than required because running as part of mimir-backend).
+        (sum by(cluster, namespace, pod) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
       for: 24h
       labels:
         severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -774,6 +774,8 @@ groups:
         hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullycleanedupblocks
     expr: |
+      # The "last successful run" metric is updated even if the compactor owns no tenants,
+      # so this alert correctly doesn't fire if compactor has nothing to do.
       (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 6)
     for: 1h
     labels:
@@ -784,6 +786,8 @@ groups:
         $labels.namespace }} has not run compaction in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
     expr: |
+      # The "last successful run" metric is updated even if the compactor owns no tenants,
+      # so this alert correctly doesn't fire if compactor has nothing to do.
       (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
       and
       (cortex_compactor_last_successful_run_timestamp_seconds > 0)
@@ -797,6 +801,8 @@ groups:
         $labels.namespace }} has not run compaction in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
     expr: |
+      # The "last successful run" metric is updated even if the compactor owns no tenants,
+      # so this alert correctly doesn't fire if compactor has nothing to do.
       cortex_compactor_last_successful_run_timestamp_seconds == 0
     for: 24h
     labels:
@@ -818,9 +824,13 @@ groups:
         $labels.namespace }} has not uploaded any block in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
     expr: |
-      (time() - thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 60 * 60 * 24)
+      (time() - (max by(cluster, namespace, instance) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
       and
-      (thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 0)
+      (max by(cluster, namespace, instance) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) > 0)
+      and
+      # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+      # (e.g. there are more replicas than required because running as part of mimir-backend).
+      (sum by(cluster, namespace, instance) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
     for: 15m
     labels:
       severity: critical
@@ -830,7 +840,11 @@ groups:
         $labels.namespace }} has not uploaded any block in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
     expr: |
-      thanos_objstore_bucket_last_successful_upload_time{component="compactor"} == 0
+      (max by(cluster, namespace, instance) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
+      and
+      # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+      # (e.g. there are more replicas than required because running as part of mimir-backend).
+      (sum by(cluster, namespace, instance) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
     for: 24h
     labels:
       severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -773,6 +773,8 @@ groups:
         }} has not successfully cleaned up blocks in the last 6 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullycleanedupblocks
     expr: |
+      # The "last successful run" metric is updated even if the compactor owns no tenants,
+      # so this alert correctly doesn't fire if compactor has nothing to do.
       (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 6)
     for: 1h
     labels:
@@ -783,6 +785,8 @@ groups:
         }} has not run compaction in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
     expr: |
+      # The "last successful run" metric is updated even if the compactor owns no tenants,
+      # so this alert correctly doesn't fire if compactor has nothing to do.
       (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
       and
       (cortex_compactor_last_successful_run_timestamp_seconds > 0)
@@ -796,6 +800,8 @@ groups:
         }} has not run compaction in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
     expr: |
+      # The "last successful run" metric is updated even if the compactor owns no tenants,
+      # so this alert correctly doesn't fire if compactor has nothing to do.
       cortex_compactor_last_successful_run_timestamp_seconds == 0
     for: 24h
     labels:
@@ -817,9 +823,13 @@ groups:
         }} has not uploaded any block in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
     expr: |
-      (time() - thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 60 * 60 * 24)
+      (time() - (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
       and
-      (thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 0)
+      (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) > 0)
+      and
+      # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+      # (e.g. there are more replicas than required because running as part of mimir-backend).
+      (sum by(cluster, namespace, pod) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
     for: 15m
     labels:
       severity: critical
@@ -829,7 +839,11 @@ groups:
         }} has not uploaded any block in the last 24 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
     expr: |
-      thanos_objstore_bucket_last_successful_upload_time{component="compactor"} == 0
+      (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
+      and
+      # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+      # (e.g. there are more replicas than required because running as part of mimir-backend).
+      (sum by(cluster, namespace, pod) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
     for: 24h
     labels:
       severity: critical

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -8,6 +8,8 @@
           alert: $.alertName('CompactorHasNotSuccessfullyCleanedUpBlocks'),
           'for': '1h',
           expr: |||
+            # The "last successful run" metric is updated even if the compactor owns no tenants,
+            # so this alert correctly doesn't fire if compactor has nothing to do.
             (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 6)
           |||,
           labels: {
@@ -22,6 +24,8 @@
           alert: $.alertName('CompactorHasNotSuccessfullyRunCompaction'),
           'for': '1h',
           expr: |||
+            # The "last successful run" metric is updated even if the compactor owns no tenants,
+            # so this alert correctly doesn't fire if compactor has nothing to do.
             (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
             and
             (cortex_compactor_last_successful_run_timestamp_seconds > 0)
@@ -39,6 +43,8 @@
           alert: $.alertName('CompactorHasNotSuccessfullyRunCompaction'),
           'for': '24h',
           expr: |||
+            # The "last successful run" metric is updated even if the compactor owns no tenants,
+            # so this alert correctly doesn't fire if compactor has nothing to do.
             cortex_compactor_last_successful_run_timestamp_seconds == 0
           |||,
           labels: {
@@ -68,10 +74,14 @@
           alert: $.alertName('CompactorHasNotUploadedBlocks'),
           'for': '15m',
           expr: |||
-            (time() - thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 60 * 60 * 24)
+            (time() - (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
             and
-            (thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 0)
-          |||,
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) > 0)
+            and
+            # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+            # (e.g. there are more replicas than required because running as part of mimir-backend).
+            (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
+          ||| % $._config,
           labels: {
             severity: 'critical',
           },
@@ -84,8 +94,12 @@
           alert: $.alertName('CompactorHasNotUploadedBlocks'),
           'for': '24h',
           expr: |||
-            thanos_objstore_bucket_last_successful_upload_time{component="compactor"} == 0
-          |||,
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
+            and
+            # Only if some compactions have started. We don't want to fire this alert if the compactor has nothing to do
+            # (e.g. there are more replicas than required because running as part of mimir-backend).
+            (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_compactor_group_compaction_runs_started_total[24h])) > 0)
+          ||| % $._config,
           labels: {
             severity: 'critical',
           },


### PR DESCRIPTION
#### What this PR does
While testing the read-write deployment mode, we realised "MimirCompactorHasNotUploadedBlocks" alert may fire if a compactor replica has nothing to do. Since the compactor runs as part of the backend deployment, it's possible that not all replicas have a tenant assigned and so jobs to run.

In this PR I propose to fix the "MimirCompactorHasNotUploadedBlocks" alert checking whether the compactor replica has started some compactions in the last 24h (because this alert is designed to alert if no block is uploaded in the last 24h).

I've also checked other compactor alerts and they should be fine. I've added a comment to the query for the ones I've checked.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/3366

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
