### PR TITLE
Use SafeSlabPool as memory pool for individual chunks' data

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -907,7 +907,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 			readers = newChunkReaders(chunkReaders)
 		}
 
-		seriesSet, resHints, err = s.streamingSeriesSetForBlocks(ctx, req, blocks, indexReaders, readers, s.chunkPool, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
+		seriesSet, resHints, err = s.streamingSeriesSetForBlocks(ctx, req, blocks, indexReaders, readers, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
 	}
 
 	if err != nil {
@@ -1076,7 +1076,6 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	blocks []*bucketBlock,
 	indexReaders map[ulid.ULID]*bucketIndexReader,
 	chunkReaders *bucketChunkReaders,
-	chunksPool pool.Bytes,
 	shardSelector *sharding.ShardSelector,
 	matchers []*labels.Matcher,
 	chunksLimiter ChunksLimiter,
@@ -1156,7 +1155,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	mergedBatches := mergedSeriesChunkRefsSetIterators(s.maxSeriesPerBatch, batches...)
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
-		set = newSeriesSetWithChunks(ctx, *chunkReaders, chunksPool, mergedBatches, s.maxSeriesPerBatch, stats, s.metrics.iteratorLoadDurations)
+		set = newSeriesSetWithChunks(ctx, *chunkReaders, mergedBatches, s.maxSeriesPerBatch, stats, s.metrics.iteratorLoadDurations)
 	} else {
 		set = newSeriesSetWithoutChunks(ctx, mergedBatches)
 	}

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -68,7 +68,7 @@ func (r *bucketChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) 
 }
 
 // load all added chunks and saves resulting chunks to res.
-func (r *bucketChunkReader) load(res []seriesEntry, chunksPool *pool.BatchBytes, stats *safeQueryStats) error {
+func (r *bucketChunkReader) load(res []seriesEntry, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error {
 	g, ctx := errgroup.WithContext(r.ctx)
 
 	for seq, pIdxs := range r.toLoad {
@@ -98,7 +98,7 @@ func (r *bucketChunkReader) load(res []seriesEntry, chunksPool *pool.BatchBytes,
 // passed to multiple concurrent invocations. However, this shouldn't require a mutex
 // because part and pIdxs is only read, and different calls are expected to write to
 // different chunks in the res.
-func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, seq int, part Part, pIdxs []loadIdx, chunksPool *pool.BatchBytes, stats *safeQueryStats) error {
+func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, seq int, part Part, pIdxs []loadIdx, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error {
 	fetchBegin := time.Now()
 
 	// Get a reader for the required range.
@@ -202,12 +202,9 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, s
 	return nil
 }
 
-func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool *pool.BatchBytes) error {
+func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool *pool.SafeSlabPool[byte]) error {
 	if in.Encoding() == chunkenc.EncXOR {
-		b, err := saveChunk(in.Bytes(), chunksPool)
-		if err != nil {
-			return err
-		}
+		b := saveChunk(in.Bytes(), chunksPool)
 		out.Raw = &storepb.Chunk{Type: storepb.Chunk_XOR, Data: b}
 		return nil
 	}
@@ -217,13 +214,10 @@ func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool *pool.B
 // saveChunk saves a copy of b's payload to a buffer pulled from chunksPool.
 // The buffer containing the chunk data is returned.
 // The returned slice becomes invalid once chunksPool is released.
-func saveChunk(b []byte, chunksPool *pool.BatchBytes) ([]byte, error) {
-	dst, err := chunksPool.Get(len(b))
-	if err != nil {
-		return nil, err
-	}
+func saveChunk(b []byte, chunksPool *pool.SafeSlabPool[byte]) []byte {
+	dst := chunksPool.Get(len(b))
 	copy(dst, b)
-	return dst, nil
+	return dst
 }
 
 type loadIdx struct {
@@ -269,7 +263,7 @@ type chunkReader interface {
 	io.Closer
 
 	addLoad(id chunks.ChunkRef, seriesEntry, chunk int) error
-	load(result []seriesEntry, chunksPool *pool.BatchBytes, stats *safeQueryStats) error
+	load(result []seriesEntry, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error
 	reset()
 }
 
@@ -283,7 +277,7 @@ func (r bucketChunkReaders) addLoad(blockID ulid.ULID, id chunks.ChunkRef, serie
 	return r.readers[blockID].addLoad(id, seriesEntry, chunk)
 }
 
-func (r bucketChunkReaders) load(entries []seriesEntry, chunksPool *pool.BatchBytes, stats *safeQueryStats) error {
+func (r bucketChunkReaders) load(entries []seriesEntry, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error {
 	g := &errgroup.Group{}
 	for _, reader := range r.readers {
 		reader := reader

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -46,7 +46,6 @@ func (r *bucketChunkReader) Close() error {
 }
 
 // reset resets the chunks scheduled for loading. It does not release any loaded chunks.
-// Use the injected pool.BatchBytes to release the bytes.
 func (r *bucketChunkReader) reset() {
 	for i := range r.toLoad {
 		r.toLoad[i] = r.toLoad[i][:0]

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -68,7 +68,7 @@ func (r *bucketChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) 
 }
 
 // load all added chunks and saves resulting chunks to res.
-func (r *bucketChunkReader) load(res []seriesEntry, chunksPool pool.BatchReleasable[byte], stats *safeQueryStats) error {
+func (r *bucketChunkReader) load(res []seriesEntry, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error {
 	g, ctx := errgroup.WithContext(r.ctx)
 
 	for seq, pIdxs := range r.toLoad {
@@ -98,7 +98,7 @@ func (r *bucketChunkReader) load(res []seriesEntry, chunksPool pool.BatchReleasa
 // passed to multiple concurrent invocations. However, this shouldn't require a mutex
 // because part and pIdxs is only read, and different calls are expected to write to
 // different chunks in the res.
-func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, seq int, part Part, pIdxs []loadIdx, chunksPool pool.BatchReleasable[byte], stats *safeQueryStats) error {
+func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, seq int, part Part, pIdxs []loadIdx, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error {
 	fetchBegin := time.Now()
 
 	// Get a reader for the required range.
@@ -202,7 +202,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, s
 	return nil
 }
 
-func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool pool.BatchReleasable[byte]) error {
+func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool *pool.SafeSlabPool[byte]) error {
 	if in.Encoding() == chunkenc.EncXOR {
 		b := saveChunk(in.Bytes(), chunksPool)
 		out.Raw = &storepb.Chunk{Type: storepb.Chunk_XOR, Data: b}
@@ -214,7 +214,7 @@ func populateChunk(out *storepb.AggrChunk, in chunkenc.Chunk, chunksPool pool.Ba
 // saveChunk saves a copy of b's payload to a buffer pulled from chunksPool.
 // The buffer containing the chunk data is returned.
 // The returned slice becomes invalid once chunksPool is released.
-func saveChunk(b []byte, chunksPool pool.BatchReleasable[byte]) []byte {
+func saveChunk(b []byte, chunksPool *pool.SafeSlabPool[byte]) []byte {
 	dst := chunksPool.Get(len(b))
 	copy(dst, b)
 	return dst
@@ -263,7 +263,7 @@ type chunkReader interface {
 	io.Closer
 
 	addLoad(id chunks.ChunkRef, seriesEntry, chunk int) error
-	load(result []seriesEntry, chunksPool pool.BatchReleasable[byte], stats *safeQueryStats) error
+	load(result []seriesEntry, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error
 	reset()
 }
 
@@ -277,7 +277,7 @@ func (r bucketChunkReaders) addLoad(blockID ulid.ULID, id chunks.ChunkRef, serie
 	return r.readers[blockID].addLoad(id, seriesEntry, chunk)
 }
 
-func (r bucketChunkReaders) load(entries []seriesEntry, chunksPool pool.BatchReleasable[byte], stats *safeQueryStats) error {
+func (r bucketChunkReaders) load(entries []seriesEntry, chunksPool *pool.SafeSlabPool[byte], stats *safeQueryStats) error {
 	g := &errgroup.Group{}
 	for _, reader := range r.readers {
 		reader := reader

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2204,7 +2204,7 @@ func benchmarkBlockSeriesWithConcurrency(b *testing.B, concurrency int, blockMet
 
 				indexReader := blk.indexReader()
 				chunkReader := blk.chunkReader(ctx)
-				chunksPool := &pool.BatchBytes{Delegate: pool.NoopBytes{}}
+				chunksPool := pool.NewSafeSlabPool[byte](chunkBytesSlicePool, chunkBytesSlabSize)
 
 				seriesSet, _, err := blockSeries(context.Background(), indexReader, chunkReader, chunksPool, matchers, shardSelector, cachedSeriesHasher{seriesHashCache}, chunksLimiter, seriesLimiter, req.SkipChunks, req.MinTime, req.MaxTime, log.NewNopLogger())
 				require.NoError(b, err)

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -358,6 +358,7 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 
 	err := c.chunkReaders.load(nextSet.series, chunksPool, c.stats)
 	if err != nil {
+		chunksPool.Release()
 		c.err = errors.Wrap(err, "loading chunks")
 		return false
 	}

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -172,15 +172,7 @@ func newSeriesChunksSeriesSet(from seriesChunksSetIterator) storepb.SeriesSet {
 
 func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders, refsIterator seriesChunkRefsSetIterator, refsIteratorBatchSize int, stats *safeQueryStats, iteratorLoadDurations *prometheus.HistogramVec) storepb.SeriesSet {
 	var iterator seriesChunksSetIterator
-	iterator = newLoadingSeriesChunksSetIterator(
-		chunkReaders,
-		refsIterator,
-		refsIteratorBatchSize,
-		stats,
-		func() pool.BatchReleasable[byte] {
-			return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, chunkBytesSlabSize)
-		},
-	)
+	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, refsIterator, refsIteratorBatchSize, stats)
 	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_load"))
 	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
 	// We are measuring the time we wait for a preloaded batch. In an ideal world this is 0 because there's always a preloaded batch waiting.
@@ -296,29 +288,21 @@ func (p *preloadingSetIterator[Set]) Err() error {
 }
 
 type loadingSeriesChunksSetIterator struct {
-	chunkReaders     bucketChunkReaders
-	from             seriesChunkRefsSetIterator
-	fromBatchSize    int
-	stats            *safeQueryStats
-	chunkPoolFactory func() pool.BatchReleasable[byte]
+	chunkReaders  bucketChunkReaders
+	from          seriesChunkRefsSetIterator
+	fromBatchSize int
+	stats         *safeQueryStats
 
 	current seriesChunksSet
 	err     error
 }
 
-func newLoadingSeriesChunksSetIterator(
-	chunkReaders bucketChunkReaders,
-	from seriesChunkRefsSetIterator,
-	fromBatchSize int,
-	stats *safeQueryStats,
-	chunkPoolFactory func() pool.BatchReleasable[byte],
-) *loadingSeriesChunksSetIterator {
+func newLoadingSeriesChunksSetIterator(chunkReaders bucketChunkReaders, from seriesChunkRefsSetIterator, fromBatchSize int, stats *safeQueryStats) *loadingSeriesChunksSetIterator {
 	return &loadingSeriesChunksSetIterator{
-		chunkReaders:     chunkReaders,
-		from:             from,
-		fromBatchSize:    fromBatchSize,
-		stats:            stats,
-		chunkPoolFactory: chunkPoolFactory,
+		chunkReaders:  chunkReaders,
+		from:          from,
+		fromBatchSize: fromBatchSize,
+		stats:         stats,
 	}
 }
 
@@ -371,7 +355,7 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 	}
 
 	// Create a batched memory pool that can be released all at once.
-	chunksPool := c.chunkPoolFactory()
+	chunksPool := pool.NewSafeSlabPool[byte](chunkBytesSlicePool, chunkBytesSlabSize)
 
 	err := c.chunkReaders.load(nextSet.series, chunksPool, c.stats)
 	if err != nil {

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -24,8 +24,8 @@ const (
 	// number of chunks (across series).
 	seriesChunksSlabSize = 1000
 
-	// Selected so that an individual chunk's data typically fits within the slab size
-	chunkBytesSlabSize = 32_000
+	// Selected so that an individual chunk's data typically fits within the slab size (16 KiB)
+	chunkBytesSlabSize = 16_384
 )
 
 var (

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -177,7 +177,7 @@ func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders
 		refsIterator,
 		refsIteratorBatchSize,
 		stats,
-		func() *pool.SafeSlabPool[byte] {
+		func() pool.BatchReleasable[byte] {
 			return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, tsdb.EstimatedMaxChunkSize)
 		},
 	)
@@ -300,7 +300,7 @@ type loadingSeriesChunksSetIterator struct {
 	from             seriesChunkRefsSetIterator
 	fromBatchSize    int
 	stats            *safeQueryStats
-	chunkPoolFactory func() *pool.SafeSlabPool[byte]
+	chunkPoolFactory func() pool.BatchReleasable[byte]
 
 	current seriesChunksSet
 	err     error
@@ -311,7 +311,7 @@ func newLoadingSeriesChunksSetIterator(
 	from seriesChunkRefsSetIterator,
 	fromBatchSize int,
 	stats *safeQueryStats,
-	chunkPoolFactory func() *pool.SafeSlabPool[byte],
+	chunkPoolFactory func() pool.BatchReleasable[byte],
 ) *loadingSeriesChunksSetIterator {
 	return &loadingSeriesChunksSetIterator{
 		chunkReaders:     chunkReaders,

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -25,8 +25,8 @@ const (
 	// number of chunks (across series).
 	seriesChunksSlabSize = 1000
 
-	// Selected so that the largest common-use-case chunk of 16k bytes can be served from the pool
-	chunkBytesSlabSize = tsdb.EstimatedMaxChunkSize
+	// Selected so that an individual chunk's data typically fits within the slab size
+	chunkBytesSlabSize = 10 * tsdb.EstimatedMaxChunkSize
 )
 
 var (
@@ -178,7 +178,7 @@ func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders
 		refsIteratorBatchSize,
 		stats,
 		func() pool.BatchReleasable[byte] {
-			return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, tsdb.EstimatedMaxChunkSize)
+			return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, chunkBytesSlabSize)
 		},
 	)
 	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_load"))

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/pool"
@@ -26,7 +25,7 @@ const (
 	seriesChunksSlabSize = 1000
 
 	// Selected so that an individual chunk's data typically fits within the slab size
-	chunkBytesSlabSize = 10 * tsdb.EstimatedMaxChunkSize
+	chunkBytesSlabSize = 32_000
 )
 
 var (

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -358,7 +358,6 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 
 	err := c.chunkReaders.load(nextSet.series, chunksPool, c.stats)
 	if err != nil {
-		chunksPool.Release()
 		c.err = errors.Wrap(err, "loading chunks")
 		return false
 	}

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -619,6 +619,11 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 				s.release()
 			}
 
+			if testCase.expectedErr != "" {
+				assert.Zero(t, chunkBytesSlicePool.(*pool.TrackedPool).Gets.Load())
+			} else {
+				assert.Greater(t, chunkBytesSlicePool.(*pool.TrackedPool).Gets.Load(), int64(0))
+			}
 			assert.Zero(t, chunkBytesSlicePool.(*pool.TrackedPool).Balance.Load())
 			assert.Zero(t, seriesEntrySlicePool.(*pool.TrackedPool).Balance.Load())
 			assert.Greater(t, seriesEntrySlicePool.(*pool.TrackedPool).Gets.Load(), int64(0))

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -591,12 +591,7 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 			readers := newChunkReaders(readersMap)
 
 			// Run test
-			set := newLoadingSeriesChunksSetIterator(
-				*readers,
-				newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...),
-				100,
-				newSafeQueryStats(),
-			)
+			set := newLoadingSeriesChunksSetIterator(*readers, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), 100, newSafeQueryStats())
 			loadedSets := readAllSeriesChunksSets(set)
 
 			// Assertions
@@ -746,7 +741,7 @@ func (f *chunkReaderMock) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) er
 	return nil
 }
 
-func (f *chunkReaderMock) load(result []seriesEntry, chunksPool pool.BatchReleasable[byte], _ *safeQueryStats) error {
+func (f *chunkReaderMock) load(result []seriesEntry, chunksPool *pool.SafeSlabPool[byte], _ *safeQueryStats) error {
 	if f.loadErr != nil {
 		return f.loadErr
 	}

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -709,7 +709,6 @@ func BenchmarkLoadingSeriesChunksSetIterator(b *testing.B) {
 			}
 
 			chunkReaders := newChunkReaders(readersMap)
-			//chunksPool := &trackedBytesPool{parent: pool.NoopBytes{}}
 			stats := newSafeQueryStats()
 
 			b.ResetTimer()

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -595,7 +595,7 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 				newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...),
 				100,
 				newSafeQueryStats(),
-				func() *pool.SafeSlabPool[byte] { return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, 0) },
+				func() pool.BatchReleasable[byte] { return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, 0) },
 			)
 			loadedSets := readAllSeriesChunksSets(set)
 
@@ -696,7 +696,7 @@ func BenchmarkLoadingSeriesChunksSetIterator(b *testing.B) {
 					newSliceSeriesChunkRefsSetIterator(nil, sets...),
 					batchSize,
 					stats,
-					func() *pool.SafeSlabPool[byte] {
+					func() pool.BatchReleasable[byte] {
 						return pool.NewSafeSlabPool[byte](chunkBytesSlicePool, 0)
 					},
 				)
@@ -765,7 +765,7 @@ func (f *chunkReaderMock) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) er
 	return nil
 }
 
-func (f *chunkReaderMock) load(result []seriesEntry, chunksPool *pool.SafeSlabPool[byte], _ *safeQueryStats) error {
+func (f *chunkReaderMock) load(result []seriesEntry, chunksPool pool.BatchReleasable[byte], _ *safeQueryStats) error {
 	if f.loadErr != nil {
 		return f.loadErr
 	}

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -590,7 +590,7 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 			readers := newChunkReaders(readersMap)
 
 			// Run test
-			set := newLoadingSeriesChunksSetIterator(*readers, bytesPool, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), 100, newSafeQueryStats())
+			set := newLoadingSeriesChunksSetIterator(*readers, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), 100, newSafeQueryStats())
 			loadedSets := readAllSeriesChunksSets(set)
 
 			// Assertions
@@ -685,7 +685,7 @@ func BenchmarkLoadingSeriesChunksSetIterator(b *testing.B) {
 
 			for n := 0; n < b.N; n++ {
 				batchSize := numSeriesPerSet
-				it := newLoadingSeriesChunksSetIterator(*chunkReaders, chunksPool, newSliceSeriesChunkRefsSetIterator(nil, sets...), batchSize, stats)
+				it := newLoadingSeriesChunksSetIterator(*chunkReaders, newSliceSeriesChunkRefsSetIterator(nil, sets...), batchSize, stats)
 
 				actualSeries := 0
 				actualChunks := 0

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -177,6 +177,11 @@ func (b *BatchBytes) Get(sz int) ([]byte, error) {
 	return (*slab)[len(*slab)-sz : len(*slab) : len(*slab)], nil
 }
 
+type BatchReleasable[T any] interface {
+	Get(size int) []T
+	Release()
+}
+
 // SlabPool wraps Interface and adds support to get a sub-slice of the data type T
 // from the pool, trying to fit the slices picked from the pool as much as possible.
 //

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -138,45 +138,6 @@ func (p *BucketedBytes) Put(b *[]byte) {
 	}
 }
 
-// BatchBytes uses a Bytes pool to hand out byte slices, but they don't need to be
-// individually put back into the pool. Instead, they can be all released at once.
-// Additionally, BatchBytes combines results from the other two.
-// BatchBytes is concurrency safe.
-type BatchBytes struct {
-	Delegate Bytes
-
-	mtx   sync.Mutex
-	slabs []*[]byte
-}
-
-func (b *BatchBytes) Release() {
-	b.mtx.Lock()
-	defer b.mtx.Unlock()
-
-	for _, slab := range b.slabs {
-		b.Delegate.Put(slab)
-	}
-	b.slabs = b.slabs[:0]
-}
-
-func (b *BatchBytes) Get(sz int) ([]byte, error) {
-	b.mtx.Lock()
-	defer b.mtx.Unlock()
-
-	if len(b.slabs) == 0 ||
-		// Ensure we never grow slab beyond original capacity.
-		cap(*b.slabs[len(b.slabs)-1])-len(*b.slabs[len(b.slabs)-1]) < sz {
-		s, err := b.Delegate.Get(sz)
-		if err != nil {
-			return nil, errors.Wrap(err, "allocate chunk bytes")
-		}
-		b.slabs = append(b.slabs, s)
-	}
-	slab := b.slabs[len(b.slabs)-1]
-	*slab = (*slab)[:len(*slab)+sz]
-	return (*slab)[len(*slab)-sz : len(*slab) : len(*slab)], nil
-}
-
 // SlabPool wraps Interface and adds support to get a sub-slice of the data type T
 // from the pool, trying to fit the slices picked from the pool as much as possible.
 //

--- a/pkg/util/pool/pool.go
+++ b/pkg/util/pool/pool.go
@@ -177,11 +177,6 @@ func (b *BatchBytes) Get(sz int) ([]byte, error) {
 	return (*slab)[len(*slab)-sz : len(*slab) : len(*slab)], nil
 }
 
-type BatchReleasable[T any] interface {
-	Get(size int) []T
-	Release()
-}
-
 // SlabPool wraps Interface and adds support to get a sub-slice of the data type T
 // from the pool, trying to fit the slices picked from the pool as much as possible.
 //

--- a/pkg/util/pool/pool_test.go
+++ b/pkg/util/pool/pool_test.go
@@ -132,56 +132,6 @@ func TestRacePutGet(t *testing.T) {
 	}
 }
 
-func TestBatchBytes(t *testing.T) {
-	t.Run("byte slices do not overlap when fit on the same slab", func(t *testing.T) {
-		bytesPool, err := NewBucketedBytes(10, 100, 2, 1000)
-		require.NoError(t, err)
-		batchBytes := BatchBytes{Delegate: bytesPool}
-		bytesA, err := batchBytes.Get(5)
-		assert.NoError(t, err)
-		assert.Len(t, bytesA, 5)
-		assert.Equal(t, 5, cap(bytesA))
-		copy(bytesA, "12345")
-
-		bytesB, err := batchBytes.Get(5)
-		assert.NoError(t, err)
-		assert.Len(t, bytesB, 5)
-		assert.Equal(t, 5, cap(bytesB))
-		copy(bytesB, "67890")
-
-		assert.Equal(t, 10, int(bytesPool.usedTotal))
-		assert.Equal(t, "12345", string(bytesA))
-		assert.Equal(t, "67890", string(bytesB))
-
-		batchBytes.Release()
-		assert.Zero(t, int(bytesPool.usedTotal))
-	})
-
-	t.Run("a new slab is created when the new slice doesn't fit on an existing one", func(t *testing.T) {
-		bytesPool, err := NewBucketedBytes(10, 100, 2, 1000)
-		require.NoError(t, err)
-		batchBytes := BatchBytes{Delegate: bytesPool}
-		bytesA, err := batchBytes.Get(5)
-		assert.NoError(t, err)
-		assert.Len(t, bytesA, 5)
-		assert.Equal(t, 5, cap(bytesA))
-		copy(bytesA, "12345")
-
-		bytesB, err := batchBytes.Get(6)
-		assert.NoError(t, err)
-		assert.Len(t, bytesB, 6)
-		assert.Equal(t, 6, cap(bytesB))
-		copy(bytesB, "67890-")
-
-		assert.Equal(t, 20, int(bytesPool.usedTotal))
-		assert.Equal(t, "12345", string(bytesA))
-		assert.Equal(t, "67890-", string(bytesB))
-
-		batchBytes.Release()
-		assert.Zero(t, int(bytesPool.usedTotal))
-	})
-}
-
 func TestSlabPool(t *testing.T) {
 	t.Run("byte slices do not overlap when fit on the same slab", func(t *testing.T) {
 		delegatePool := &TrackedPool{Parent: &sync.Pool{}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR introduces a new global memory pool wrapped by `SlabPool` to replace the `BatchBytes`-wrapped pool that  `storegateway.chunkReader`s currently use. 


Benchmark results for
```
go test -run '^$' -bench 'BenchmarkBucket_Series|BenchmarkLoadingSeriesChunksSetIterator' -benchmem -count=3
```
are here: [benchmark_differences.txt](https://github.com/grafana/mimir/files/10293767/benchmark_differences.txt)


#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
