### PR TITLE
Store gateway mmap removal: proof of concept: replace `bufio.Reader` with buffered reader optimised for our use case

### DIFF
--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -223,20 +223,15 @@ func (b *bufferingFileReader) fillIfRequired(minDesired int) error {
 		return nil
 	}
 
-	if _, err := b.f.Seek(int64(b.currentPositionInFile), io.SeekStart); err != nil {
-		return err
-	}
-
 	b.b = b.b[:cap(b.b)]
-	n, err := io.ReadFull(b.f, b.b)
+	n, err := b.f.ReadAt(b.b, int64(b.currentPositionInFile))
 	b.b = b.b[:n]
 	b.offsetFirstByteInB = b.currentPositionInFile
 
 	if err != nil {
-		if err == io.ErrUnexpectedEOF {
-			b.haveRead = true
-
+		if err == io.EOF {
 			if n == 0 {
+				b.haveRead = true
 				return io.EOF
 			}
 		} else {

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -177,6 +177,7 @@ func newBufferingFileReader(bufferSize int) *bufferingFileReader {
 	}
 }
 
+// Seek resets the position of this reader to off in f.
 func (b *bufferingFileReader) Seek(f *os.File, off int) {
 	b.currentPositionInFile = off
 
@@ -187,10 +188,15 @@ func (b *bufferingFileReader) Seek(f *os.File, off int) {
 	}
 }
 
+// Discard advances the position of this reader by n bytes.
 func (b *bufferingFileReader) Discard(n int) {
 	b.currentPositionInFile += n
 }
 
+// Peek returns the next n bytes of f without advancing the position of this reader.
+// The returned byte slice is only valid until the next Peek or Read call.
+// Peek guarantees that it will return exactly n bytes if there are n or more bytes remaining
+// to be read from f (ie. no short reads).
 func (b *bufferingFileReader) Peek(n int) ([]byte, error) {
 	if err := b.fillIfRequired(n); err != nil {
 		return nil, err
@@ -243,10 +249,12 @@ func (b *bufferingFileReader) fillIfRequired(minDesired int) error {
 	return nil
 }
 
+// Size returns the size of the underlying buffer used by this reader.
 func (b *bufferingFileReader) Size() int {
 	return cap(b.b)
 }
 
+// Read reads up to len(dest) bytes into dest and returns the number of bytes read.
 func (b *bufferingFileReader) Read(dest []byte) (int, error) {
 	// TODO: could potentially read directly into dest in some cases (eg. we have no available bytes buffered and we're doing a read larger than the capacity of the buffer)
 


### PR DESCRIPTION
#### What this PR does

The change in #3742 dramatically improved the performance of loading an index-header file from disk, but has a drawback: because we need to seek backwards after reading a previously-unread label name, we must reset the buffered reader each time we do this. This has a significant performance impact.

(Why does this have such a large impact? Because `bufio.Reader` is designed as a buffered reader for all kinds of streams (not just files), when we seek backwards, it must discard the entire buffer and fill it from disk again. This is very wasteful, as we're often seeking backwards a small distance and so the buffer likely contains the data we're interested in.)

This PR replaces our use of `bufio.Reader` with our own implementation optimised for this scenario, taking advantage of the fact that we only ever read an index-header from a file.

The performance impact is significant, with improvements anywhere from 2% to 75% depending on the ratio of unique names to labels:

<details><summary>Benchmark results running on my laptop with a SSD</summary>

```
name                                         old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-10          122µs ± 1%     120µs ± 3%     ~     (p=0.310 n=5+5)
NewStreamBinaryReader/1Names10Values-10         122µs ± 1%     119µs ± 1%   -2.27%  (p=0.016 n=5+5)
NewStreamBinaryReader/1Names100Values-10        132µs ± 2%     129µs ± 1%   -2.87%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names500Values-10        158µs ± 1%     155µs ± 2%   -1.85%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names1000Values-10       193µs ± 2%     183µs ± 2%   -5.27%  (p=0.008 n=5+5)
NewStreamBinaryReader/1Names5000Values-10       495µs ± 1%     471µs ± 0%   -4.81%  (p=0.016 n=5+4)
NewStreamBinaryReader/20Names1Values-10         169µs ± 2%     134µs ± 2%  -20.53%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-10        200µs ± 3%     145µs ± 2%  -27.64%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-10       353µs ± 0%     242µs ± 2%  -31.60%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names500Values-10       907µs ± 4%     724µs ± 4%  -20.17%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names1000Values-10     1.53ms ± 1%    1.43ms ± 4%   -6.88%  (p=0.016 n=4+5)
NewStreamBinaryReader/20Names5000Values-10     6.28ms ± 1%    5.86ms ± 1%   -6.64%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1Values-10         274µs ± 1%     162µs ± 1%  -41.09%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10        385µs ± 5%     191µs ± 1%  -50.39%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10       741µs ± 8%     457µs ± 4%  -38.30%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-10      2.09ms ± 3%    1.63ms ± 3%  -22.24%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-10     3.62ms ± 1%    3.30ms ± 2%   -9.01%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     15.5ms ± 1%    14.5ms ± 1%   -6.49%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1Values-10        537µs ± 1%     200µs ± 3%  -62.67%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-10       742µs ± 3%     254µs ± 2%  -65.70%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     1.38ms ± 6%    0.79ms ± 3%  -42.49%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-10     3.92ms ± 2%    3.12ms ± 2%  -20.37%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    6.93ms ± 1%    6.31ms ± 2%   -8.86%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-10    31.1ms ± 1%    28.8ms ± 1%   -7.46%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1Values-10       1.16ms ± 3%    0.28ms ± 7%  -75.88%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-10      1.51ms ± 1%    0.40ms ± 5%  -73.57%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names100Values-10     2.72ms ± 0%    1.48ms ± 6%  -45.44%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names500Values-10     7.60ms ± 1%    5.93ms ± 0%  -21.96%  (p=0.016 n=5+4)
NewStreamBinaryReader/200Names1000Values-10    13.7ms ± 1%    12.3ms ± 1%   -9.80%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-10    63.3ms ± 2%    57.7ms ± 0%   -8.93%  (p=0.016 n=5+4)

name                                         old alloc/op   new alloc/op   delta
NewStreamBinaryReader/1Names1Values-10         3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.040 n=5+5)
NewStreamBinaryReader/1Names10Values-10        3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.524 n=5+5)
NewStreamBinaryReader/1Names100Values-10       3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.270 n=5+5)
NewStreamBinaryReader/1Names500Values-10       3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.683 n=5+5)
NewStreamBinaryReader/1Names1000Values-10      3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.651 n=5+5)
NewStreamBinaryReader/1Names5000Values-10      3.20MB ± 0%    3.20MB ± 0%     ~     (p=0.302 n=5+4)
NewStreamBinaryReader/20Names1Values-10        3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.889 n=5+5)
NewStreamBinaryReader/20Names10Values-10       3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.032 n=5+5)
NewStreamBinaryReader/20Names100Values-10      3.19MB ± 0%    3.19MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-10      3.22MB ± 0%    3.22MB ± 0%     ~     (p=0.175 n=4+5)
NewStreamBinaryReader/20Names1000Values-10     3.27MB ± 0%    3.27MB ± 0%     ~     (p=0.200 n=4+4)
NewStreamBinaryReader/20Names5000Values-10     3.56MB ± 0%    3.56MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/50Names1Values-10        3.19MB ± 0%    3.19MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-10       3.19MB ± 0%    3.19MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-10      3.21MB ± 0%    3.21MB ± 0%     ~     (p=0.087 n=5+5)
NewStreamBinaryReader/50Names500Values-10      3.29MB ± 0%    3.29MB ± 0%   -0.00%  (p=0.016 n=5+4)
NewStreamBinaryReader/50Names1000Values-10     3.41MB ± 0%    3.41MB ± 0%     ~     (p=0.460 n=5+5)
NewStreamBinaryReader/50Names5000Values-10     4.13MB ± 0%    4.13MB ± 0%     ~     (p=0.421 n=5+5)
NewStreamBinaryReader/100Names1Values-10       3.20MB ± 0%    3.20MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-10      3.20MB ± 0%    3.20MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names100Values-10     3.25MB ± 0%    3.25MB ± 0%     ~     (p=0.111 n=4+5)
NewStreamBinaryReader/100Names500Values-10     3.41MB ± 0%    3.41MB ± 0%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/100Names1000Values-10    3.64MB ± 0%    3.64MB ± 0%     ~     (p=0.968 n=5+4)
NewStreamBinaryReader/100Names5000Values-10    5.08MB ± 0%    5.08MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/200Names1Values-10       3.22MB ± 0%    3.22MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-10      3.23MB ± 0%    3.23MB ± 0%   -0.00%  (p=0.016 n=4+5)
NewStreamBinaryReader/200Names100Values-10     3.32MB ± 0%    3.32MB ± 0%   -0.00%  (p=0.029 n=4+4)
NewStreamBinaryReader/200Names500Values-10     3.64MB ± 0%    3.64MB ± 0%     ~     (p=0.421 n=5+5)
NewStreamBinaryReader/200Names1000Values-10    4.10MB ± 0%    4.10MB ± 0%     ~     (p=0.421 n=5+5)
NewStreamBinaryReader/200Names5000Values-10    6.98MB ± 0%    6.98MB ± 0%     ~     (p=0.548 n=5+5)

name                                         old allocs/op  new allocs/op  delta
NewStreamBinaryReader/1Names1Values-10           76.0 ± 0%      76.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names10Values-10          78.0 ± 0%      78.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names100Values-10         84.0 ± 0%      84.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names500Values-10         98.0 ± 0%      98.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names1000Values-10         115 ± 0%       115 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names5000Values-10         242 ± 0%       242 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names1Values-10           154 ± 0%       154 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names10Values-10          194 ± 0%       194 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names100Values-10         314 ± 0%       314 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names500Values-10         594 ± 0%       594 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names1000Values-10        934 ± 0%       934 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names5000Values-10      3.47k ± 0%     3.47k ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/50Names1Values-10           278 ± 0%       278 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names10Values-10          378 ± 0%       378 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names100Values-10         678 ± 0%       678 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names500Values-10       1.38k ± 0%     1.38k ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names1000Values-10      2.23k ± 0%     2.23k ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names5000Values-10      8.58k ± 0%     8.58k ± 0%     ~     (p=1.000 n=4+5)
NewStreamBinaryReader/100Names1Values-10          481 ± 0%       481 ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names10Values-10         681 ± 0%       681 ± 0%     ~     (p=0.444 n=5+5)
NewStreamBinaryReader/100Names100Values-10      1.28k ± 0%     1.28k ± 0%     ~     (p=0.167 n=5+5)
NewStreamBinaryReader/100Names500Values-10      2.68k ± 0%     2.68k ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names1000Values-10     4.38k ± 0%     4.38k ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names5000Values-10     17.1k ± 0%     17.1k ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/200Names1Values-10          882 ± 0%       882 ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names10Values-10       1.28k ± 0%     1.28k ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names100Values-10      2.48k ± 0%     2.48k ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names500Values-10      5.28k ± 0%     5.28k ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names1000Values-10     8.68k ± 0%     8.68k ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names5000Values-10     34.1k ± 0%     34.1k ± 0%     ~     (p=0.333 n=5+4)
```

</details>

<details><summary>Benchmark results running on a VM with a spinning rust disk</summary>

```
name                                        old time/op    new time/op    delta
NewStreamBinaryReader/1Names1Values-2         1.29ms ± 3%    1.30ms ± 8%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/1Names10Values-2        1.26ms ± 4%    1.25ms ± 3%     ~     (p=0.548 n=5+5)
NewStreamBinaryReader/1Names100Values-2       1.30ms ± 3%    1.31ms ± 2%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/1Names500Values-2       1.41ms ± 3%    1.44ms ± 4%     ~     (p=0.222 n=5+5)
NewStreamBinaryReader/1Names1000Values-2      1.49ms ± 5%    1.50ms ± 4%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/1Names5000Values-2      2.30ms ± 2%    2.35ms ±11%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/20Names1Values-2        1.51ms ± 3%    1.41ms ± 4%   -6.89%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names10Values-2       1.65ms ± 5%    1.42ms ± 5%  -13.44%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names100Values-2      2.16ms ±15%    1.82ms ± 3%  -15.41%  (p=0.008 n=5+5)
NewStreamBinaryReader/20Names500Values-2      3.49ms ± 1%    3.21ms ±11%     ~     (p=0.190 n=4+5)
NewStreamBinaryReader/20Names1000Values-2     5.15ms ± 5%    5.01ms ± 5%     ~     (p=0.095 n=5+5)
NewStreamBinaryReader/20Names5000Values-2     17.0ms ± 3%    17.1ms ± 1%     ~     (p=0.310 n=5+5)
NewStreamBinaryReader/50Names1Values-2        1.98ms ± 1%    1.61ms ± 3%  -18.65%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names10Values-2       2.29ms ± 2%    1.70ms ± 3%  -25.72%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names100Values-2      3.19ms ± 8%    2.51ms ± 2%  -21.30%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names500Values-2      6.51ms ± 5%    5.65ms ± 4%  -13.11%  (p=0.008 n=5+5)
NewStreamBinaryReader/50Names1000Values-2     10.5ms ± 4%    10.4ms ± 4%     ~     (p=0.421 n=5+5)
NewStreamBinaryReader/50Names5000Values-2     38.4ms ± 1%    39.9ms ±11%     ~     (p=0.095 n=5+5)
NewStreamBinaryReader/100Names1Values-2       2.72ms ± 1%    1.85ms ± 4%  -31.99%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names10Values-2      3.29ms ± 2%    2.06ms ± 2%  -37.52%  (p=0.016 n=4+5)
NewStreamBinaryReader/100Names100Values-2     4.92ms ± 1%    3.60ms ± 2%  -26.82%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names500Values-2     11.5ms ± 2%     9.7ms ± 6%  -15.73%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names1000Values-2    18.8ms ± 2%    18.3ms ± 1%   -2.62%  (p=0.008 n=5+5)
NewStreamBinaryReader/100Names5000Values-2    74.2ms ± 1%    74.5ms ± 2%     ~     (p=0.548 n=5+5)
NewStreamBinaryReader/200Names1Values-2       4.52ms ± 5%    2.27ms ± 2%  -49.70%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-2      5.55ms ± 6%    2.71ms ± 4%  -51.18%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names100Values-2     8.58ms ± 3%    5.43ms ± 0%  -36.68%  (p=0.016 n=5+4)
NewStreamBinaryReader/200Names500Values-2     20.8ms ± 2%    17.5ms ± 1%  -15.71%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names1000Values-2    34.9ms ± 2%    33.7ms ± 2%   -3.29%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names5000Values-2     145ms ± 4%     148ms ± 2%     ~     (p=0.151 n=5+5)

name                                        old alloc/op   new alloc/op   delta
NewStreamBinaryReader/1Names1Values-2         3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.548 n=5+5)
NewStreamBinaryReader/1Names10Values-2        3.18MB ± 0%    3.18MB ± 0%   -0.00%  (p=0.016 n=5+4)
NewStreamBinaryReader/1Names100Values-2       3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.238 n=5+5)
NewStreamBinaryReader/1Names500Values-2       3.18MB ± 0%    3.18MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/1Names1000Values-2      3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.508 n=5+5)
NewStreamBinaryReader/1Names5000Values-2      3.20MB ± 0%    3.20MB ± 0%     ~     (p=0.889 n=5+5)
NewStreamBinaryReader/20Names1Values-2        3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.968 n=5+5)
NewStreamBinaryReader/20Names10Values-2       3.18MB ± 0%    3.18MB ± 0%     ~     (p=0.952 n=5+5)
NewStreamBinaryReader/20Names100Values-2      3.19MB ± 0%    3.19MB ± 0%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/20Names500Values-2      3.22MB ± 0%    3.22MB ± 0%     ~     (p=0.889 n=5+5)
NewStreamBinaryReader/20Names1000Values-2     3.27MB ± 0%    3.27MB ± 0%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/20Names5000Values-2     3.56MB ± 0%    3.56MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/50Names1Values-2        3.19MB ± 0%    3.19MB ± 0%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/50Names10Values-2       3.19MB ± 0%    3.19MB ± 0%     ~     (p=0.651 n=5+5)
NewStreamBinaryReader/50Names100Values-2      3.21MB ± 0%    3.21MB ± 0%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/50Names500Values-2      3.29MB ± 0%    3.29MB ± 0%     ~     (p=0.548 n=5+5)
NewStreamBinaryReader/50Names1000Values-2     3.41MB ± 0%    3.41MB ± 0%     ~     (p=0.278 n=5+5)
NewStreamBinaryReader/50Names5000Values-2     4.13MB ± 0%    4.13MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/100Names1Values-2       3.20MB ± 0%    3.20MB ± 0%   -0.00%  (p=0.040 n=5+5)
NewStreamBinaryReader/100Names10Values-2      3.20MB ± 0%    3.20MB ± 0%     ~     (p=0.151 n=5+5)
NewStreamBinaryReader/100Names100Values-2     3.25MB ± 0%    3.25MB ± 0%     ~     (p=0.841 n=5+5)
NewStreamBinaryReader/100Names500Values-2     3.41MB ± 0%    3.41MB ± 0%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/100Names1000Values-2    3.64MB ± 0%    3.64MB ± 0%     ~     (p=0.310 n=5+5)
NewStreamBinaryReader/100Names5000Values-2    5.08MB ± 0%    5.08MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/200Names1Values-2       3.22MB ± 0%    3.22MB ± 0%   -0.00%  (p=0.008 n=5+5)
NewStreamBinaryReader/200Names10Values-2      3.23MB ± 0%    3.23MB ± 0%     ~     (p=0.333 n=5+5)
NewStreamBinaryReader/200Names100Values-2     3.32MB ± 0%    3.32MB ± 0%     ~     (p=1.000 n=5+5)
NewStreamBinaryReader/200Names500Values-2     3.64MB ± 0%    3.64MB ± 0%     ~     (p=0.222 n=5+5)
NewStreamBinaryReader/200Names1000Values-2    4.10MB ± 0%    4.10MB ± 0%     ~     (p=0.690 n=5+5)
NewStreamBinaryReader/200Names5000Values-2    6.98MB ± 0%    6.98MB ± 0%     ~     (p=0.841 n=5+5)

name                                        old allocs/op  new allocs/op  delta
NewStreamBinaryReader/1Names1Values-2           76.0 ± 0%      76.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names10Values-2          78.0 ± 0%      78.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names100Values-2         84.0 ± 0%      84.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names500Values-2         98.0 ± 0%      98.0 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names1000Values-2         115 ± 0%       115 ± 0%     ~     (all equal)
NewStreamBinaryReader/1Names5000Values-2         242 ± 0%       242 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names1Values-2           155 ± 0%       154 ± 0%   -0.65%  (p=0.029 n=4+4)
NewStreamBinaryReader/20Names10Values-2          194 ± 0%       194 ± 0%     ~     (p=0.333 n=5+4)
NewStreamBinaryReader/20Names100Values-2         315 ± 0%       315 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names500Values-2         595 ± 0%       595 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names1000Values-2        935 ± 0%       935 ± 0%     ~     (all equal)
NewStreamBinaryReader/20Names5000Values-2      3.48k ± 0%     3.48k ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names1Values-2           279 ± 0%       279 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names10Values-2          379 ± 0%       379 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names100Values-2         679 ± 0%       679 ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names500Values-2       1.38k ± 0%     1.38k ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names1000Values-2      2.23k ± 0%     2.23k ± 0%     ~     (all equal)
NewStreamBinaryReader/50Names5000Values-2      8.58k ± 0%     8.58k ± 0%     ~     (p=0.952 n=5+5)
NewStreamBinaryReader/100Names1Values-2          483 ± 0%       483 ± 0%     ~     (p=0.333 n=4+5)
NewStreamBinaryReader/100Names10Values-2         683 ± 0%       683 ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names100Values-2      1.28k ± 0%     1.28k ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names500Values-2      2.68k ± 0%     2.68k ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names1000Values-2     4.38k ± 0%     4.38k ± 0%     ~     (all equal)
NewStreamBinaryReader/100Names5000Values-2     17.1k ± 0%     17.1k ± 0%     ~     (p=0.921 n=5+5)
NewStreamBinaryReader/200Names1Values-2          886 ± 0%       886 ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names10Values-2       1.29k ± 0%     1.29k ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names100Values-2      2.49k ± 0%     2.49k ± 0%     ~     (p=0.444 n=5+5)
NewStreamBinaryReader/200Names500Values-2      5.29k ± 0%     5.29k ± 0%     ~     (all equal)
NewStreamBinaryReader/200Names1000Values-2     8.69k ± 0%     8.69k ± 0%     ~     (p=0.952 n=5+5)
NewStreamBinaryReader/200Names5000Values-2     34.1k ± 0%     34.1k ± 0%     ~     (p=0.841 n=5+5)
```

</details>

---

I'm opening this as a draft for discussion because implementing something like this is tricky - we'd be replacing the battle-tested `bufio.Reader` with something new, with all of the inevitable hard-to-find bugs that entails.

If we do want to pursue this, I'd want to:
* add tests for `bufferingFileReader` (in addition the coverage provided by the existing tests that rely on it indirectly) before merging
* test in an environment with real data to catch any regressions + confirm the performance impact

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/3465, relates to https://github.com/grafana/mimir/pull/3742

#### Checklist

- [ ] Tests updated
- [n/a] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
