### PR TITLE
Krajo/revert multitype batch

### DIFF
--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -93,14 +93,14 @@ func (a *iteratorAdapter) Seek(t int64) chunkenc.ValueType {
 		if t <= a.curr.Timestamps[a.curr.Index] {
 			//In this case, the interface's requirement is met, so state of this
 			//iterator does not need any change.
-			return a.curr.ValueTypes
+			return chunkenc.ValFloat
 		} else if t <= a.curr.Timestamps[a.curr.Length-1] {
 			//In this case, some timestamp between current sample and end of batch can fulfill
 			//the seek. Let's find it.
 			for a.curr.Index < a.curr.Length && t > a.curr.Timestamps[a.curr.Index] {
 				a.curr.Index++
 			}
-			return a.curr.ValueTypes
+			return chunkenc.ValFloat
 		}
 	}
 
@@ -127,33 +127,24 @@ func (a *iteratorAdapter) Next() chunkenc.ValueType {
 	}
 
 	if a.curr.Index < a.curr.Length {
-		return a.curr.ValueTypes
+		return chunkenc.ValFloat
 	}
 	return chunkenc.ValNone
 }
 
 // At implements chunkenc.Iterator.
 func (a *iteratorAdapter) At() (int64, float64) {
-	return a.curr.Timestamps[a.curr.Index], a.curr.SampleValues[a.curr.Index]
+	return a.curr.Timestamps[a.curr.Index], a.curr.Values[a.curr.Index]
 }
 
 // AtHistogram implements chunkenc.Iterator.
 func (a *iteratorAdapter) AtHistogram() (int64, *histogram.Histogram) {
-	return a.curr.Timestamps[a.curr.Index], a.curr.HistogramValues[a.curr.Index]
+	panic("iteratorAdapter.AtHistogram not yet implemented")
 }
 
 // AtFloatHistogram implements chunkenc.Iterator.
 func (a *iteratorAdapter) AtFloatHistogram() (int64, *histogram.FloatHistogram) {
-	// The promQL engine works on Float Histograms even if the underlying data is an integer histogram
-	// and will call AtFloatHistogram on a Histogram
-	var h *histogram.FloatHistogram
-	if a.curr.FloatHistogramValues != nil {
-		h = a.curr.FloatHistogramValues[a.curr.Index]
-	}
-	if h == nil {
-		h = a.curr.HistogramValues[a.curr.Index].ToFloat()
-	}
-	return a.curr.Timestamps[a.curr.Index], h
+	panic("iteratorAdapter.AtFloatHistogram not yet implemented")
 }
 
 // AtT implements chunkenc.Iterator.

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -44,7 +44,7 @@ func (i *chunkIterator) Seek(t int64, size int) chunkenc.ValueType {
 			i.batch.Index++
 		}
 		if i.batch.Index+size < i.batch.Length {
-			return i.batch.ValueTypes
+			return chunkenc.ValFloat
 		}
 	}
 

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -125,9 +125,11 @@ func (i *mockIterator) Value() model.SamplePair {
 }
 
 func (i *mockIterator) Batch(size int, valueType chunkenc.ValueType) chunk.Batch {
+	if valueType != chunkenc.ValFloat {
+		panic("mockIterator cannot handle non float chunks")
+	}
 	batch := chunk.Batch{
-		Length:     chunk.BatchSize,
-		ValueTypes: chunkenc.ValFloat,
+		Length: chunk.BatchSize,
 	}
 	for i := 0; i < chunk.BatchSize; i++ {
 		batch.Timestamps[i] = int64(i)

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -129,7 +129,7 @@ func (c *mergeIterator) buildNextBatch(size int) chunkenc.ValueType {
 	}
 
 	if len(c.batches) > 0 {
-		return c.batches[0].ValueTypes
+		return chunkenc.ValFloat
 	}
 	return chunkenc.ValNone
 }

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -6,9 +6,6 @@
 package batch
 
 import (
-	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
-
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
 
@@ -25,11 +22,8 @@ func (bs *batchStream) reset() {
 	}
 }
 
-func (bs *batchStream) hasNext() chunkenc.ValueType {
-	if len(*bs) > 0 {
-		return (*bs)[0].ValueTypes
-	}
-	return chunkenc.ValNone
+func (bs *batchStream) hasNext() bool {
+	return len(*bs) > 0
 }
 
 func (bs *batchStream) next() {
@@ -45,120 +39,64 @@ func (bs *batchStream) atTime() int64 {
 
 func (bs *batchStream) at() (int64, float64) {
 	b := &(*bs)[0]
-	return b.Timestamps[b.Index], b.SampleValues[b.Index]
+	return b.Timestamps[b.Index], b.Values[b.Index]
 }
 
-func (bs *batchStream) atHistogram() (int64, *histogram.Histogram) {
-	b := &(*bs)[0]
-	return b.Timestamps[b.Index], b.HistogramValues[b.Index]
-}
-
-func (bs *batchStream) atFloatHistogram() (int64, *histogram.FloatHistogram) {
-	b := &(*bs)[0]
-	return b.Timestamps[b.Index], b.FloatHistogramValues[b.Index]
-}
-
-// mergeStreams merges streams of Batches of the same series over time.
-// Samples are simply merged by time when they are the same type (float/histogram/...), with the left stream taking precedence if the timestamps are equal.
-// When sample are different type, batches are not merged. In case of equal timestamps, histograms take precedence since they have more information.
 func mergeStreams(left, right batchStream, result batchStream, size int) batchStream {
-
 	// Reset the Index and Length of existing batches.
 	for i := range result {
 		result[i].Index = 0
 		result[i].Length = 0
 	}
-
 	resultLen := 1 // Number of batches in the final result.
 	b := &result[0]
 
-	// Step to the next Batch in the result, create it if it does not exist
-	nextBatch := func(valueTypes chunkenc.ValueType) {
-		// The Index is the place at which new sample
-		// has to be appended, hence it tells the length.
-		b.Length = b.Index
-		resultLen++
-		if resultLen > len(result) {
-			// It is possible that result can grow longer
-			// then the one provided.
-			result = append(result, createBatch(valueTypes))
-		}
-		b = &result[resultLen-1]
-	}
-
-	ensureBatchType := func(valueTypes chunkenc.ValueType) {
-		for b.ValueTypes != valueTypes {
-			if b.ValueTypes == chunkenc.ValNone {
-				// Uninitialized Batch
-				initBatchType(b, valueTypes)
-				return
-			}
-			// These should be rare, means that we're merging into something where the chunk type changed
-			if b.Index == 0 {
-				// Batch not written yet
-				result[resultLen-1] = createBatch(valueTypes)
-				b = &result[resultLen-1]
-				return
-			}
-			// Batch already started, finish and start new
-			// We don't know its type so let the loop run one more time
-			nextBatch(valueTypes)
-		}
-	}
-
-	// Ensure that the batch we're writing to is not full and of the right type.
-	ensureBatch := func(valueTypes chunkenc.ValueType) {
+	// This function adds a new batch to the result
+	// if the current batch being appended is full.
+	checkForFullBatch := func() {
 		if b.Index == size {
-			// The batch reached its intended size.
+			// The batch reached it intended size.
 			// Add another batch the the result
 			// and use it for further appending.
-			nextBatch(valueTypes)
+
+			// The Index is the place at which new sample
+			// has to be appended, hence it tells the length.
+			b.Length = b.Index
+			resultLen++
+			if resultLen > len(result) {
+				// It is possible that result can grow longer
+				// then the one provided.
+				result = append(result, chunk.Batch{})
+			}
+			b = &result[resultLen-1]
 		}
-		ensureBatchType(valueTypes)
 	}
 
-	for {
-		if lt, rt := left.hasNext(), right.hasNext(); lt != chunkenc.ValNone && rt != chunkenc.ValNone {
-			t1, t2 := left.atTime(), right.atTime()
-			if t1 < t2 {
-				ensureBatch(lt)
-				populate(b, left, lt)
-				left.next()
-			} else if t1 > t2 {
-				ensureBatch(rt)
-				populate(b, right, rt)
-				right.next()
-			} else {
-				if (rt == chunkenc.ValHistogram || rt == chunkenc.ValFloatHistogram) && lt == chunkenc.ValFloat {
-					// Prefer historgrams over floats. Take left side if both has histograms.
-					ensureBatch(rt)
-					populate(b, right, rt)
-				} else {
-					ensureBatch(lt)
-					populate(b, left, lt)
-				}
-				left.next()
-				right.next()
-			}
-			b.Index++
+	for left.hasNext() && right.hasNext() {
+		checkForFullBatch()
+		t1, t2 := left.atTime(), right.atTime()
+		if t1 < t2 {
+			b.Timestamps[b.Index], b.Values[b.Index] = left.at()
+			left.next()
+		} else if t1 > t2 {
+			b.Timestamps[b.Index], b.Values[b.Index] = right.at()
+			right.next()
 		} else {
-			break
+			b.Timestamps[b.Index], b.Values[b.Index] = left.at()
+			left.next()
+			right.next()
 		}
+		b.Index++
 	}
 
 	// This function adds all the samples from the provided
 	// batchStream into the result in the same order.
 	addToResult := func(bs batchStream) {
-		for {
-			if t := bs.hasNext(); t != chunkenc.ValNone {
-				ensureBatch(t)
-				populate(b, bs, t)
-				b.Index++
-				b.Length++
-				bs.next()
-			} else {
-				break
-			}
+		for ; bs.hasNext(); bs.next() {
+			checkForFullBatch()
+			b.Timestamps[b.Index], b.Values[b.Index] = bs.at()
+			b.Index++
+			b.Length++
 		}
 	}
 
@@ -174,43 +112,4 @@ func mergeStreams(left, right batchStream, result batchStream, size int) batchSt
 	result = result[:resultLen]
 	result.reset()
 	return result
-}
-
-func createBatch(valueTypes chunkenc.ValueType) (batch chunk.Batch) {
-	switch valueTypes {
-	case chunkenc.ValFloat:
-		batch.ValueTypes = chunkenc.ValFloat
-		batch.SampleValues = &[chunk.BatchSize]float64{}
-	case chunkenc.ValHistogram:
-		batch.ValueTypes = chunkenc.ValHistogram
-		batch.HistogramValues = &[chunk.BatchSize]*histogram.Histogram{}
-	case chunkenc.ValFloatHistogram:
-		batch.ValueTypes = chunkenc.ValFloatHistogram
-		batch.FloatHistogramValues = &[chunk.BatchSize]*histogram.FloatHistogram{}
-	}
-	return
-}
-
-// Call on uninitialized Batch to allocate the correct valueType array
-func initBatchType(batch *chunk.Batch, valueTypes chunkenc.ValueType) {
-	batch.ValueTypes = valueTypes
-	switch valueTypes {
-	case chunkenc.ValFloat:
-		batch.SampleValues = &[chunk.BatchSize]float64{}
-	case chunkenc.ValHistogram:
-		batch.HistogramValues = &[chunk.BatchSize]*histogram.Histogram{}
-	case chunkenc.ValFloatHistogram:
-		batch.FloatHistogramValues = &[chunk.BatchSize]*histogram.FloatHistogram{}
-	}
-}
-
-func populate(b *chunk.Batch, s batchStream, valueTypes chunkenc.ValueType) {
-	switch valueTypes {
-	case chunkenc.ValFloat:
-		b.Timestamps[b.Index], b.SampleValues[b.Index] = s.at()
-	case chunkenc.ValHistogram:
-		b.Timestamps[b.Index], b.HistogramValues[b.Index] = s.atHistogram()
-	case chunkenc.ValFloatHistogram:
-		b.Timestamps[b.Index], b.FloatHistogramValues[b.Index] = s.atFloatHistogram()
-	}
 }

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
@@ -18,114 +16,52 @@ import (
 
 func TestStream(t *testing.T) {
 	for i, tc := range []struct {
-		testcase       string
 		input1, input2 []chunk.Batch
 		output         batchStream
 	}{
 		{
-			testcase: "One float input",
-			input1:   []chunk.Batch{mkBatch(0)},
-			output:   []chunk.Batch{mkBatch(0)},
+			input1: []chunk.Batch{mkBatch(0)},
+			output: []chunk.Batch{mkBatch(0)},
 		},
 
 		{
-			testcase: "Equal float inputs",
-			input1:   []chunk.Batch{mkBatch(0)},
-			input2:   []chunk.Batch{mkBatch(0)},
-			output:   []chunk.Batch{mkBatch(0)},
+			input1: []chunk.Batch{mkBatch(0)},
+			input2: []chunk.Batch{mkBatch(0)},
+			output: []chunk.Batch{mkBatch(0)},
 		},
 
 		{
-			testcase: "Non overlapping float inputs",
-			input1:   []chunk.Batch{mkBatch(0)},
-			input2:   []chunk.Batch{mkBatch(chunk.BatchSize)},
-			output:   []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize)},
+			input1: []chunk.Batch{mkBatch(0)},
+			input2: []chunk.Batch{mkBatch(chunk.BatchSize)},
+			output: []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize)},
 		},
 
 		{
-			testcase: "Overlapping and overhanging float inputs 0-11, 12-23 vs 6-17, 24-35",
-			input1:   []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize)},
-			input2:   []chunk.Batch{mkBatch(chunk.BatchSize / 2), mkBatch(2 * chunk.BatchSize)},
-			output:   []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize), mkBatch(2 * chunk.BatchSize)},
+			input1: []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize)},
+			input2: []chunk.Batch{mkBatch(chunk.BatchSize / 2), mkBatch(2 * chunk.BatchSize)},
+			output: []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize), mkBatch(2 * chunk.BatchSize)},
 		},
 
 		{
-			testcase: "Overlapping and overhanging float inputs 6-17, 18-29, 30-41 vs 0-11, 12-23, 24-35, 36-47",
-			input1:   []chunk.Batch{mkBatch(chunk.BatchSize / 2), mkBatch(3 * chunk.BatchSize / 2), mkBatch(5 * chunk.BatchSize / 2)},
-			input2:   []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize), mkBatch(3 * chunk.BatchSize)},
-			output:   []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize), mkBatch(2 * chunk.BatchSize), mkBatch(3 * chunk.BatchSize)},
-		},
-
-		{
-			testcase: "Equal histograms",
-			input1:   []chunk.Batch{mkHistogramBatch(0)},
-			output:   []chunk.Batch{mkHistogramBatch(0)},
-		},
-
-		{
-			testcase: "Histogram preferred over float",
-			input1:   []chunk.Batch{mkHistogramBatch(0), mkBatch(chunk.BatchSize)},
-			input2:   []chunk.Batch{mkBatch(0), mkHistogramBatch(chunk.BatchSize)},
-			output:   []chunk.Batch{mkHistogramBatch(0), mkHistogramBatch(chunk.BatchSize)},
-		},
-
-		{
-			testcase: "Non overlapping histograms and floats",
-			input1:   []chunk.Batch{mkBatch(0)},
-			input2:   []chunk.Batch{mkHistogramBatch(chunk.BatchSize)},
-			output:   []chunk.Batch{mkBatch(0), mkHistogramBatch(chunk.BatchSize)},
-		},
-
-		{
-			testcase: "Histogram splits floats 0-12 float vs histogram at 6",
-			input1:   []chunk.Batch{mkBatch(0)},
-			input2:   []chunk.Batch{mkGenericHistogramBatch(chunk.BatchSize/2, 1)},
-			output:   []chunk.Batch{mkGenericFloatBatch(0, 6), mkGenericHistogramBatch(chunk.BatchSize/2, 1), mkGenericFloatBatch(7, 5)},
+			input1: []chunk.Batch{mkBatch(chunk.BatchSize / 2), mkBatch(3 * chunk.BatchSize / 2), mkBatch(5 * chunk.BatchSize / 2)},
+			input2: []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize), mkBatch(3 * chunk.BatchSize)},
+			output: []chunk.Batch{mkBatch(0), mkBatch(chunk.BatchSize), mkBatch(2 * chunk.BatchSize), mkBatch(3 * chunk.BatchSize)},
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			result := make(batchStream, len(tc.input1)+len(tc.input2))
 			result = mergeStreams(tc.input1, tc.input2, result, chunk.BatchSize)
-			require.Equal(t, batchStream(tc.output), result, tc.testcase)
+			require.Equal(t, batchStream(tc.output), result)
 		})
 	}
 }
 
 func mkBatch(from int64) chunk.Batch {
-	return mkGenericFloatBatch(from, chunk.BatchSize)
-}
-
-func mkHistogramBatch(from int64) chunk.Batch {
-	return mkGenericHistogramBatch(from, chunk.BatchSize)
-}
-
-func mkGenericFloatBatch(from int64, size int) chunk.Batch {
-	result := createBatch(chunkenc.ValFloat)
-	for i := 0; i < size; i++ {
-		result.Timestamps[i] = from + int64(i)
-		result.SampleValues[i] = float64(from + int64(i))
+	var result chunk.Batch
+	for i := int64(0); i < chunk.BatchSize; i++ {
+		result.Timestamps[i] = from + i
+		result.Values[i] = float64(from + i)
 	}
-	result.Length = size
-	return result
-}
-
-func mkGenericHistogramBatch(from int64, size int) chunk.Batch {
-	result := createBatch(chunkenc.ValHistogram)
-	for i := 0; i < size; i++ {
-		result.Timestamps[i] = from + int64(i)
-		result.HistogramValues[i] = &histogram.Histogram{ // yes, this doesn't make much sense with the calculated Count
-			Schema:        3,
-			Count:         uint64(from + int64(i)),
-			Sum:           2.7,
-			ZeroThreshold: 0.1,
-			ZeroCount:     42,
-			PositiveSpans: []histogram.Span{
-				{Offset: 0, Length: 4},
-				{Offset: 10, Length: 3},
-			},
-			PositiveBuckets: []int64{1, 2, -2, 1, -1, 0, 0},
-		}
-	}
-	result.Length = size
+	result.Length = chunk.BatchSize
 	return result
 }

--- a/pkg/querier/iterators/chunk_merge_iterator.go
+++ b/pkg/querier/iterators/chunk_merge_iterator.go
@@ -224,14 +224,15 @@ func (it *nonOverlappingIterator) Seek(t int64) chunkenc.ValueType {
 }
 
 func (it *nonOverlappingIterator) Next() chunkenc.ValueType {
-	valType := it.chunks[it.curr].Next()
-	for ; it.curr < len(it.chunks) && valType == chunkenc.ValNone; valType = it.chunks[it.curr].Next() {
+	valType := chunkenc.ValNone
+	for it.curr < len(it.chunks) {
+		valType = it.chunks[it.curr].Next()
+		if valType != chunkenc.ValNone {
+			break
+		}
 		it.curr++
 	}
 
-	if it.curr >= len(it.chunks) {
-		return chunkenc.ValNone
-	}
 	return valType
 }
 

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -80,14 +80,9 @@ const BatchSize = 12
 // small, and passed by value.
 type Batch struct {
 	Timestamps [BatchSize]int64
-
-	ValueTypes           chunkenc.ValueType
-	SampleValues         *[BatchSize]float64
-	HistogramValues      *[BatchSize]*histogram.Histogram
-	FloatHistogramValues *[BatchSize]*histogram.FloatHistogram
-
-	Index  int
-	Length int
+	Values     [BatchSize]float64
+	Index      int
+	Length     int
 }
 
 // Chunk contains encoded timeseries data

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -190,7 +190,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 		batch := iter.Batch(BatchSize, chunkenc.ValFloat)
 		for j := 0; j < batch.Length; j++ {
 			require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
-			require.EqualValues(t, float64(i+j), batch.SampleValues[j])
+			require.EqualValues(t, float64(i+j), batch.Values[j])
 		}
 		i += batch.Length
 	}


### PR DESCRIPTION
WIP for testing revert, DO NOT PICK

This completely reverts the change to pkg/querier/batch/stream.go  and its test. Instead the Batch is not even created , because there would be a panic in pkg/storage/chunk/prometheus_chunk.go 
`func (p *prometheusChunkIterator) Batch(size int, valueType chunkenc.ValueType) Batch` 