### PR TITLE
Use authentication to download `yq` to avoid build failures due to GitHub API rate limiting

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -18,21 +18,24 @@ jobs:
       with:
         go-version: '1.19.3'
     - uses: helm/kind-action@v1.2.0
-    - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
+    - name: Download yq
+      uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
       with:
         repo: 'mikefarah/yq'
         version: 'tags/v4.30.6'
         file: 'yq_linux_amd64'
         target: 'bin/yq'
         token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
+    - name: Download tk
+      uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
       with:
         repo: 'grafana/tanka'
         version: 'tags/v0.22.1'
         file: 'tk-linux-amd64'
         target: 'bin/tk'
         token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
+    - name: Download jb
+      uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
       with:
         repo: 'jsonnet-bundler/jsonnet-bundler'
         version: 'tags/v0.5.1'

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -18,7 +18,13 @@ jobs:
       with:
         go-version: '1.19.3'
     - uses: helm/kind-action@v1.2.0
-    - uses: frenck/action-setup-yq@a2ad11c46c5d7ba576861216963c9365b53f35bc
+    - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
+      with:
+        repo: 'mikefarah/yq'
+        version: 'tags/v4.30.6'
+        file: 'yq_linux_amd64'
+        target: 'bin/yq'
+        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: dsaltares/fetch-gh-release-asset@d9376dacd30fd38f49238586cd2e9295a8307f4c
       with:
         repo: 'grafana/tanka'
@@ -36,6 +42,7 @@ jobs:
     - name: Configure dependencies
       run: |
         set -e
+        chmod +x $PWD/bin/yq
         chmod +x $PWD/bin/tk
         chmod +x $PWD/bin/jb
         echo $PWD/bin >> $GITHUB_PATH


### PR DESCRIPTION
#### What this PR does

The `compare-helm-with-jsonnet` CI job occasionally fails while trying to download `yq`. 

This is a known issue with the `action-setup-yq` action, so this PR replaces it with the `fetch-gh-release-asset` action which we're using to fetch other release binaries in the same job. This action does not suffer from rate limiting as it uses the job's token (`GITHUB_TOKEN`) to make requests to the GitHub API.

#### Which issue(s) this PR fixes or relates to

https://github.com/frenck/action-setup-yq/issues/35

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
