### PR TITLE
Use stable `v1` PodDisruptionBudget rather than deprecated `v1beta1` when deploying read-write deployment mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Mixin
 
+* [CHANGE] Replaced the deprecated `policy/v1beta1` with `policy/v1` when configuring a PodDisruptionBudget for read-write deployment mode. #3811
 * [ENHANCEMENT] Alerts: Added `MimirIngesterInstanceHasNoTenants` alert that fires when an ingester replica is not receiving write requests for any tenant. #3681
 * [ENHANCEMENT] Alerts: Extended `MimirAllocatingTooMuchMemory` to check read-write deployment containers. #3710
 * [BUGFIX] Alerts: Fixed `MimirIngesterRestarts` alert when Mimir is deployed in read-write mode. #3716

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 
 ### Mixin
 
-* [CHANGE] Replaced the deprecated `policy/v1beta1` with `policy/v1` when configuring a PodDisruptionBudget for read-write deployment mode. #3811
 * [ENHANCEMENT] Alerts: Added `MimirIngesterInstanceHasNoTenants` alert that fires when an ingester replica is not receiving write requests for any tenant. #3681
 * [ENHANCEMENT] Alerts: Extended `MimirAllocatingTooMuchMemory` to check read-write deployment containers. #3710
 * [BUGFIX] Alerts: Fixed `MimirIngesterRestarts` alert when Mimir is deployed in read-write mode. #3716
@@ -39,6 +38,7 @@
 
 ### Jsonnet
 
+* [CHANGE] Replaced the deprecated `policy/v1beta1` with `policy/v1` when configuring a PodDisruptionBudget for read-write deployment mode. #3811
 * [ENHANCEMENT] Update `rollout-operator` to `v0.2.0`. #3624
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -29,7 +29,7 @@ spec:
     matchLabels:
       rollout-group: ingester
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
@@ -42,7 +42,7 @@ spec:
     matchLabels:
       rollout-group: mimir-backend
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: default
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       rollout-group: mimir-backend
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: default
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       rollout-group: mimir-backend
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/operations/mimir/read-write-deployment/utils.libsonnet
+++ b/operations/mimir/read-write-deployment/utils.libsonnet
@@ -1,10 +1,9 @@
 {
   local service = $.core.v1.service,
-  local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
+  local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
 
   newMimirRolloutGroupPDB(rolloutGroup, maxUnavailable)::
-    podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName('%s-rollout-pdb' % rolloutGroup) +
+    podDisruptionBudget.new('%s-rollout-pdb' % rolloutGroup) +
     podDisruptionBudget.mixin.metadata.withLabels({ name: '%s-rollout-pdb' % rolloutGroup }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ 'rollout-group': rolloutGroup }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(maxUnavailable),


### PR DESCRIPTION
#### What this PR does

We migrated from the deprecated `v1beta1` PodDisruptionBudget in #3284, but we've since added Jsonnet support for read-write deployment mode, which is still using `v1beta1`. 

This PR switches the PodDisruptionBudgets in read-write deployment mode to use `v1` as well.

This fixes warnings like these:

```
Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

#### Which issue(s) this PR fixes or relates to

Relates to #3284 and #937.

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
