### PR TITLE
Add flag to disable regenerating Go files from protobuf definitions during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,15 @@ $(EXES):
 protos: ## Generates protobuf files.
 protos: $(PROTO_GOS)
 
+GENERATE_FILES ?= true
+
 %.pb.go:
+ifeq ($(GENERATE_FILES),true)
 	protoc -I $(GOPATH)/src:./vendor/github.com/gogo/protobuf:./vendor:./$(@D):./pkg/storegateway/storepb --gogoslick_out=plugins=grpc,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,:./$(@D) ./$(patsubst %.pb.go,%.proto,$@)
+else
+	@echo "Warning: generating files has been disabled, but the following file needs to be regenerated: $@"
+	@echo "If this is unexpected, check if the last modified timestamps on $@ and $(patsubst %.pb.go,%.proto,$@) are correct."
+endif
 
 lint-packaging-scripts: packaging/deb/control/postinst packaging/deb/control/prerm packaging/rpm/control/post packaging/rpm/control/preun
 	shellcheck $?


### PR DESCRIPTION
#### What this PR does

This PR adds the ability to disable generating Go files from protobuf definitions during a build.

This is useful for scenarios where we want to build the source code as-is, such as the [`mimirtool` Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mimirtool.rb). 

(Homebrew's build process creates a fresh clone of the repository before building `mimirtool`. However, after a fresh Git clone of this repository, file timestamps will reflect when Git wrote the file to disk, not when each file was last modified, so `make` will regenerate files unnecessarily. This introduces additional dependencies such as `protoc` to the formula's build process, and risks introducing difficult-to-reproduce issues where some files are sometimes regenerated with different contents depending on which files get what timestamps.)

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
