### PR TITLE
ruler: set default of for-grace-period=2m and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_cancelled_requests_total` metric to track the number of requests that are already cancelled when dequeued. #3696
 * [ENHANCEMENT] Store-gateway: add `cortex_bucket_store_partitioner_extended_ranges_total` metric to keep track of the ranges that the partitioner decided to overextend and merge in order to save API call to the object storage. #3769
 * [ENHANCEMENT] Compactor: Auto-forget unhealthy compactors after ten failed ring heartbeats. #3771
+* [ENHANCEMENT] Ruler: change default value of `-ruler.for-grace-period` from `10m` to `2m` and update help text. The new default value reflects how we operate Mimir at Grafana Labs. #3817
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7549,9 +7549,9 @@
           "kind": "field",
           "name": "for_grace_period",
           "required": false,
-          "desc": "Minimum duration between alert and restored \"for\" state. This is maintained only for alerts with configured \"for\" time greater than grace period.",
+          "desc": "This grace period controls which alerts the ruler restores after a restart. Alerts with \"for\" duration lower than this grace period are not restored after a ruler restart. This means that if the alerts have been firing before the ruler restarted, they will now go to pending state and then to firing again after their \"for\" duration expires. Alerts with \"for\" duration greater than or equal to this grace period that have been pending before the ruler restart will remain in pending state for at least this grace period. Alerts with \"for\" duration greater than or equal to this grace period that have been firing before the ruler restart will continue to be firing after the restart.",
           "fieldValue": null,
-          "fieldDefaultValue": 600000000000,
+          "fieldDefaultValue": 120000000000,
           "fieldFlag": "ruler.for-grace-period",
           "fieldType": "duration",
           "fieldCategory": "advanced"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1670,7 +1670,7 @@ Usage of ./cmd/mimir/mimir:
   -ruler.external.url string
     	URL of alerts return path.
   -ruler.for-grace-period duration
-    	Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. (default 10m0s)
+    	This grace period controls which alerts the ruler restores after a restart. Alerts with "for" duration lower than this grace period are not restored after a ruler restart. This means that if the alerts have been firing before the ruler restarted, they will now go to pending state and then to firing again after their "for" duration expires. Alerts with "for" duration greater than or equal to this grace period that have been pending before the ruler restart will remain in pending state for at least this grace period. Alerts with "for" duration greater than or equal to this grace period that have been firing before the ruler restart will continue to be firing after the restart. (default 2m0s)
   -ruler.for-outage-tolerance duration
     	Max time to tolerate outage for restoring "for" state of alert. (default 1h0m0s)
   -ruler.max-rule-groups-per-tenant int

--- a/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
@@ -1344,11 +1344,18 @@ alertmanager_client:
 # CLI flag: -ruler.for-outage-tolerance
 [for_outage_tolerance: <duration> | default = 1h]
 
-# (advanced) Minimum duration between alert and restored "for" state. This is
-# maintained only for alerts with configured "for" time greater than grace
-# period.
+# (advanced) This grace period controls which alerts the ruler restores after a
+# restart. Alerts with "for" duration lower than this grace period are not
+# restored after a ruler restart. This means that if the alerts have been firing
+# before the ruler restarted, they will now go to pending state and then to
+# firing again after their "for" duration expires. Alerts with "for" duration
+# greater than or equal to this grace period that have been pending before the
+# ruler restart will remain in pending state for at least this grace period.
+# Alerts with "for" duration greater than or equal to this grace period that
+# have been firing before the ruler restart will continue to be firing after the
+# restart.
 # CLI flag: -ruler.for-grace-period
-[for_grace_period: <duration> | default = 10m]
+[for_grace_period: <duration> | default = 2m]
 
 # (advanced) Minimum amount of time to wait before resending an alert to
 # Alertmanager.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -149,7 +149,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.RulePath, "ruler.rule-path", "./data-ruler/", "Directory to store temporary rule files loaded by the Prometheus rule managers. This directory is not required to be persisted between restarts.")
 	f.BoolVar(&cfg.EnableAPI, "ruler.enable-api", true, "Enable the ruler config API.")
 	f.DurationVar(&cfg.OutageTolerance, "ruler.for-outage-tolerance", time.Hour, `Max time to tolerate outage for restoring "for" state of alert.`)
-	f.DurationVar(&cfg.ForGracePeriod, "ruler.for-grace-period", 10*time.Minute, `Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period.`)
+	f.DurationVar(&cfg.ForGracePeriod, "ruler.for-grace-period", 2*time.Minute, `This grace period controls which alerts the ruler restores after a restart. `+
+		`Alerts with "for" duration lower than this grace period are not restored after a ruler restart. `+
+		`This means that if the alerts have been firing before the ruler restarted, they will now go to pending state and then to firing again after their "for" duration expires. `+
+		`Alerts with "for" duration greater than or equal to this grace period that have been pending before the ruler restart will remain in pending state for at least this grace period. `+
+		`Alerts with "for" duration greater than or equal to this grace period that have been firing before the ruler restart will continue to be firing after the restart.`)
 	f.DurationVar(&cfg.ResendDelay, "ruler.resend-delay", time.Minute, `Minimum amount of time to wait before resending an alert to Alertmanager.`)
 
 	f.Var(&cfg.EnabledTenants, "ruler.enabled-tenants", "Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.")


### PR DESCRIPTION
This change reflects how we operate the ruler at Grafana Labs.

The benefit is that alerts no longer retrigger when a ruler starts when
their "for" period is longer than the for-grace-period.

A possible drawback of having a reduced grace period means that upon a
restart the ruler will send queries to the ingesters (or long-term
storage, depending on the value of `ruler.for-outage-tolerance`)to query
 the state of alerts. These queries are very light and do not show to be
  an issue.

This PR also updates the docs around this flag, because I found them to 
be too brief.

Related to #2888

Fixes #3814
