### PR TITLE
usage-stats: Wrap bucket client error

### DIFF
--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -770,9 +770,9 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 		return nil, nil
 	}
 
-	bucketClient, err := bucket.NewClient(context.Background(), t.Cfg.BlocksStorage.Bucket, "usage-stats", util_log.Logger, t.Registerer)
+	bucketClient, err := bucket.NewClient(context.Background(), t.Cfg.BlocksStorage.Bucket, UsageStats, util_log.Logger, t.Registerer)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "create %s bucket client", UsageStats)
 	}
 
 	// Track anonymous usage statistics.


### PR DESCRIPTION
#### What this PR does
Wrap error from `bucket.NewClient` in usage-stats module. The motivation is dealing with an error from initializing the usage-stats module, most likely originating from `bucket.NewClient`, but not knowing the context for sure.

Also use `UsageStats` string constant consistently.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
