### PR TITLE
Alerts: Add alert that triggers for idle alertmanager instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 ### Mixin
 
 * [ENHANCEMENT] Alerts: Added `MimirIngesterInstanceHasNoTenants` alert that fires when an ingester replica is not receiving write requests for any tenant. #3681
-* [ENHANCEMENT] Alerts: Added `MimirAlertmanagerInstanceHasNoTenants` alert that fires when an alertmanager instance ows no tenants. #3826
 * [ENHANCEMENT] Alerts: Extended `MimirAllocatingTooMuchMemory` to check read-write deployment containers. #3710
+* [ENHANCEMENT] Alerts: Added `MimirAlertmanagerInstanceHasNoTenants` alert that fires when an alertmanager instance ows no tenants. #3826
 * [BUGFIX] Alerts: Fixed `MimirIngesterRestarts` alert when Mimir is deployed in read-write mode. #3716
 * [BUGFIX] Alerts: Fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts for when Mimir is deployed in read-write or monolithic modes and updated them to use new `thanos_shipper_last_successful_upload_time` metric. #3627
 * [BUGFIX] Alerts: Fixed `MimirMemoryMapAreasTooHigh` alert when Mimir is deployed in read-write mode. #3626

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Alerts: Added `MimirIngesterInstanceHasNoTenants` alert that fires when an ingester replica is not receiving write requests for any tenant. #3681
+* [ENHANCEMENT] Alerts: Added `MimirAlertmanagerInstanceHasNoTenants` alert that fires when an alertmanager instance ows no tenants. #3826
 * [ENHANCEMENT] Alerts: Extended `MimirAllocatingTooMuchMemory` to check read-write deployment containers. #3710
 * [BUGFIX] Alerts: Fixed `MimirIngesterRestarts` alert when Mimir is deployed in read-write mode. #3716
 * [BUGFIX] Alerts: Fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts for when Mimir is deployed in read-write or monolithic modes and updated them to use new `thanos_shipper_last_successful_upload_time` metric. #3627

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -968,11 +968,8 @@ How it **works**:
 
 How to **fix** it:
 
-Choose one of three options:
-
 - Decrease the number of alertmanager replicas
-- Increase the shard size of one or more tenants to match the number of alertmanager replicas.
-- Set the shard size of one or more tenants to `0`; this will shard the given tenant’s alerts across all instances.
+- Increase the value for `-alertmanager.sharding-ring.replication-factor` to match the number of replicas
 
 ### MimirRolloutStuck
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -969,7 +969,6 @@ How it **works**:
 How to **fix** it:
 
 - Decrease the number of alertmanager replicas
-- Increase the value for `-alertmanager.sharding-ring.replication-factor` to match the number of replicas
 
 ### MimirRolloutStuck
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -956,6 +956,24 @@ How to **fix** it:
 
 - Scale up alertmanager replicas; you can use e.g. the `Mimir / Scaling` dashboard for reference, in order to determine the needed amount of alertmanagers.
 
+### MimirAlertmanagerInstanceHasNoTenants
+
+This alert fires when an alertmanager instance doesn't own any tenants and is therefore idling.
+
+How it **works**:
+
+- Alerts handled by alertmanagers are sharded by tenant.
+- When the tenant shard size is lower than the number of alertmanager replicas, some replicas will not own any tenant and therefore idle.
+- This is more likely to happen in Mimir clusters with a lower number of tenants.
+
+How to **fix** it:
+
+Choose one of three options:
+
+- Decrease the number of alertmanager replicas
+- Increase the shard size of one or more tenants to match the number of alertmanager replicas.
+- Set the shard size of one or more tenants to `0`; this will shard the given tenant’s alerts across all instances.
+
 ### MimirRolloutStuck
 
 This alert fires when a Mimir service rollout is stuck, which means the number of updated replicas doesn't match the expected one and looks there's no progress in the rollout. The alert monitors services deployed as Kubernetes `StatefulSet` and `Deployment`.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -588,6 +588,20 @@ spec:
       for: 15m
       labels:
         severity: critical
+    - alert: MimirAlertmanagerInstanceHasNoTenants
+      annotations:
+        message: Mimir alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} owns no tenants.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
+      expr: |
+        # Alert on alertmanager instances in microservices mode that own no tenants,
+        min by(cluster, namespace, pod) (cortex_alertmanager_tenants_owned{pod=~"(.*-mimir-)?alertmanager.*"}) == 0
+        # but only if other instances of the same cell do have tenants assigned.
+        and on (cluster, namespace)
+        max by(cluster, namespace) (cortex_alertmanager_tenants_owned) > 0
+      for: 1h
+      labels:
+        severity: warning
   - name: mimir_blocks_alerts
     rules:
     - alert: MimirIngesterHasNotShippedBlocks

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -576,6 +576,20 @@ groups:
     for: 15m
     labels:
       severity: critical
+  - alert: MimirAlertmanagerInstanceHasNoTenants
+    annotations:
+      message: Mimir alertmanager {{ $labels.instance }} in {{ $labels.cluster }}/{{
+        $labels.namespace }} owns no tenants.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
+    expr: |
+      # Alert on alertmanager instances in microservices mode that own no tenants,
+      min by(cluster, namespace, instance) (cortex_alertmanager_tenants_owned{instance=~".*alertmanager.*"}) == 0
+      # but only if other instances of the same cell do have tenants assigned.
+      and on (cluster, namespace)
+      max by(cluster, namespace) (cortex_alertmanager_tenants_owned) > 0
+    for: 1h
+    labels:
+      severity: warning
 - name: mimir_blocks_alerts
   rules:
   - alert: MimirIngesterHasNotShippedBlocks

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -576,6 +576,20 @@ groups:
     for: 15m
     labels:
       severity: critical
+  - alert: MimirAlertmanagerInstanceHasNoTenants
+    annotations:
+      message: Mimir alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} owns no tenants.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
+    expr: |
+      # Alert on alertmanager instances in microservices mode that own no tenants,
+      min by(cluster, namespace, pod) (cortex_alertmanager_tenants_owned{pod=~"(.*-mimir-)?alertmanager.*"}) == 0
+      # but only if other instances of the same cell do have tenants assigned.
+      and on (cluster, namespace)
+      max by(cluster, namespace) (cortex_alertmanager_tenants_owned) > 0
+    for: 1h
+    labels:
+      severity: warning
 - name: mimir_blocks_alerts
   rules:
   - alert: MimirIngesterHasNotShippedBlocks

--- a/operations/mimir-mixin/alerts/alertmanager.libsonnet
+++ b/operations/mimir-mixin/alerts/alertmanager.libsonnet
@@ -126,6 +126,27 @@
             ||| % $._config,
           },
         },
+        {
+          alert: $.alertName('AlertmanagerInstanceHasNoTenants'),
+          expr: |||
+            # Alert on alertmanager instances in microservices mode that own no tenants,
+            min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_alertmanager_tenants_owned{%(per_instance_label)s=~"%(alertmanagerInstanceName)s"}) == 0
+            # but only if other instances of the same cell do have tenants assigned.
+            and on (%(alert_aggregation_labels)s)
+            max by(%(alert_aggregation_labels)s) (cortex_alertmanager_tenants_owned) > 0
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+            per_instance_label: $._config.per_instance_label,
+            alertmanagerInstanceName: $._config.instance_names.alertmanager,
+          },
+          'for': '1h',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s alertmanager %(alert_instance_variable)s in %(alert_aggregation_variables)s owns no tenants.' % $._config,
+          },
+        },
       ],
     },
   ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This adds an alert to detect alertmanager instances that don't own any tenants.

#### Which issue(s) this PR fixes or relates to

Fixes #1959 

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
