### PR TITLE
autoscaling.libsonnet: Fix typo in comment

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -36,8 +36,8 @@
       },
 
       // The min/max replica count settings are reflected to HPA too.
-      maxReplicaCount: config.max_replica_count,
       minReplicaCount: config.min_replica_count,
+      maxReplicaCount: config.max_replica_count,
 
       // The pollingInterval defines how frequently KEDA will run the queries defined in triggers.
       // This setting is only effective when scaling from 0->N because the scale up from 0 is managed
@@ -49,7 +49,7 @@
           behavior: {
             scaleDown: {
               policies: [{
-                // Allow to scale down up to 10% of pods every 1m. This prevents from suddenly scaling to minRepliacs
+                // Allow to scale down up to 10% of pods every 1m. This prevents from suddenly scaling to minReplicas
                 // when Prometheus comes back up after a long outage (longer than stabilizationWindowSeconds=300s)
                 type: 'Percent',
                 value: 10,


### PR DESCRIPTION
#### What this PR does
In operations/mimir/autoscaling.libsonnet, fix typo in comment. Also move `minReplicaCount` before `maxReplicaCount` to be consistent with min/max comment, improving readability a tad.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
