### PR TITLE
autoscaling: Fix comment typo

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -67,7 +67,7 @@
             serverAddress: $._config.autoscaling_prometheus_url,
             query: trigger.query,
 
-            // The metric name uniquely identify a metric in the KEDA metrics server.
+            // The metric name uniquely identifies a metric in the KEDA metrics server.
             metricName: trigger.metric_name,
 
             // The threshold value is set to the HPA's targetAverageValue. The number of desired replicas is computed


### PR DESCRIPTION
#### What this PR does
Fix typo in autoscaling Jsonnet comment.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
