### PR TITLE
Store-gateway: shortcut some cache and bucket ops when matching 0 series

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1836,10 +1836,6 @@ func (b *bucketBlock) Close() error {
 	return b.indexHeaderReader.Close()
 }
 
-type labelValuesReader interface {
-	LabelValues(name string, filter func(string) bool) ([]string, error)
-}
-
 type Part struct {
 	Start uint64
 	End   uint64

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -873,6 +873,7 @@ func benchmarkExpandedPostings(
 ) {
 	ctx := context.Background()
 	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+labelLongSuffix)
+	nX := labels.MustNewMatcher(labels.MatchEqual, "n", "X"+labelLongSuffix)
 
 	jFoo := labels.MustNewMatcher(labels.MatchEqual, "j", "foo")
 	jNotFoo := labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")
@@ -884,7 +885,11 @@ func benchmarkExpandedPostings(
 	iNotEmpty := labels.MustNewMatcher(labels.MatchNotEqual, "i", "")
 	iNot2 := labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+labelLongSuffix)
 	iNot2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")
+	iNotStar2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^.*2.*$")
+	jXXXYYY := labels.MustNewMatcher(labels.MatchRegexp, "j", "XXX|YYY")
+	jXplus := labels.MustNewMatcher(labels.MatchRegexp, "j", "X.+")
 	iRegexAlternate := labels.MustNewMatcher(labels.MatchRegexp, "i", "0"+labelLongSuffix+"|1"+labelLongSuffix+"|2"+labelLongSuffix)
+	iXYZ := labels.MustNewMatcher(labels.MatchRegexp, "i", "X|Y|Z")
 	iRegexAlternateSuffix := labels.MustNewMatcher(labels.MatchRegexp, "i", "(0|1|2)"+labelLongSuffix)
 	iRegexClass := labels.MustNewMatcher(labels.MatchRegexp, "i", "[0-2]"+labelLongSuffix)
 	iRegexNotSetMatches := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "(0|1|2)"+labelLongSuffix)
@@ -900,22 +905,34 @@ func benchmarkExpandedPostings(
 
 		expectedLen int
 	}{
+		{`n="X"`, []*labels.Matcher{nX}, 0},
+		{`n="X",j="foo"`, []*labels.Matcher{nX, jFoo}, 0},
+		{`n="X",j!="foo"`, []*labels.Matcher{nX, jNotFoo}, 0},
+		{`j=~"XXX|YYY"`, []*labels.Matcher{jXXXYYY}, 0},
+		{`j=~"X.+"`, []*labels.Matcher{jXplus}, 0},
+		{`i=~"X|Y|Z"`, []*labels.Matcher{iXYZ}, 0},
 		{`n="1"`, []*labels.Matcher{n1}, int(float64(series) * 0.2)},
 		{`n="1",j="foo"`, []*labels.Matcher{n1, jFoo}, int(float64(series) * 0.1)},
 		{`j="foo",n="1"`, []*labels.Matcher{jFoo, n1}, int(float64(series) * 0.1)},
 		{`n="1",j!="foo"`, []*labels.Matcher{n1, jNotFoo}, int(float64(series) * 0.1)},
 		{`i=~".*"`, []*labels.Matcher{iStar}, 5 * series},
 		{`i=~".+"`, []*labels.Matcher{iPlus}, 5 * series},
+		{`i=~"^.+$",j=~"X.+"`, []*labels.Matcher{iPlus, jXplus}, 0},
 		{`i=~""`, []*labels.Matcher{iEmptyRe}, 0},
 		{`i!=""`, []*labels.Matcher{iNotEmpty}, 5 * series},
 		{`n="1",i=~".*",j="foo"`, []*labels.Matcher{n1, iStar, jFoo}, int(float64(series) * 0.1)},
+		{`n="X",i=~"^.+$",j="foo"`, []*labels.Matcher{nX, iStar, jFoo}, 0},
 		{`n="1",i=~".*",i!="2",j="foo"`, []*labels.Matcher{n1, iStar, iNot2, jFoo}, int(float64(series) * 0.1)},
 		{`n="1",i!=""`, []*labels.Matcher{n1, iNotEmpty}, int(float64(series) * 0.2)},
 		{`n="1",i!="",j="foo"`, []*labels.Matcher{n1, iNotEmpty, jFoo}, int(float64(series) * 0.1)},
+		{`n="1",i!="",j=~"X.+"`, []*labels.Matcher{n1, iNotEmpty, jXplus}, 0},
+		{`n="1",i!="",j=~"XXX|YYY"`, []*labels.Matcher{n1, iNotEmpty, jXXXYYY}, 0},
+		{`n="1",i=~"X|Y|Z",j="foo"`, []*labels.Matcher{n1, iXYZ, jFoo}, 0},
 		{`n="1",i=~".+",j="foo"`, []*labels.Matcher{n1, iPlus, jFoo}, int(float64(series) * 0.1)},
 		{`n="1",i=~"1.+",j="foo"`, []*labels.Matcher{n1, i1Plus, jFoo}, int(float64(series) * 0.011111)},
 		{`n="1",i=~".+",i!="2",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2, jFoo}, int(float64(series) * 0.1)},
 		{`n="1",i=~".+",i!~"2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2Star, jFoo}, int(1 + float64(series)*0.088888)},
+		{`n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"`, []*labels.Matcher{nX, iPlus, iNotStar2Star, jFoo}, 0},
 		{`i=~"0xxx|1xxx|2xxx"`, []*labels.Matcher{iRegexAlternate}, 150},                        // 50 series for "1", 50 for "2" and 50 for "3".
 		{`i=~"(0|1|2)xxx"`, []*labels.Matcher{iRegexAlternateSuffix}, 150},                      // 50 series for "1", 50 for "2" and 50 for "3".
 		{`i=~"[0-2]xxx"`, []*labels.Matcher{iRegexClass}, 150},                                  // 50 series for "1", 50 for "2" and 50 for "3".

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1726,6 +1726,17 @@ func (c forbiddenFetchMultiSeriesForRefsIndexCache) FetchMultiSeriesForRefs(ctx 
 	return nil, nil
 }
 
+type forbiddenFetchMultiPostingsIndexCache struct {
+	indexcache.IndexCache
+
+	t *testing.T
+}
+
+func (c forbiddenFetchMultiPostingsIndexCache) FetchMultiPostings(ctx context.Context, userID string, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
+	assert.Fail(c.t, "index cache FetchMultiPostings should not be called")
+	return nil, nil
+}
+
 func extractLabelsFromSeriesChunkRefsSets(sets []seriesChunkRefsSet) (result []labels.Labels) {
 	for _, set := range sets {
 		for _, series := range set.series {


### PR DESCRIPTION
### Context

See https://github.com/grafana/mimir/issues/3847

### What this PR does

In the case __some matchers in the request try to select a non-existent label value__ this PR short-circuits the lookup in the cache and the bucket by using the index header first.

Why? Because sometimes the list of postings can be massive (up to 1MB of diff-encoded, snappy-compressed postings). Fetching and decoding these from the cache or the bucket takes a lot of effort for something we can tell by doing a lookup on the local disk.

This comes with the drawback that now we will do more lookups to disk. With the streaming binary reader this should not be a problem, but with the mmap binary reader this may lead to more frequent mmap page faults.

There is the detail that we also do a lookup in the index header on a cache miss ([here](https://github.com/grafana/mimir/blob/c44a07dd4c4e38a19ba01d676555c3c84d30b461/pkg/storegateway/bucket_index_reader.go#L337)), which is duplicated with 

### Tests

I ran this in a test cluster for a bit with requests that were almost exclusively selecting 0 series for this scenario.
* `zone-a` is running r219 with series streaming and streaming binary reader (without mmap)
* `zone-b` is running the same but with this PR cherry-picked on top
* `zone-c` is running r219 without any streaming 

#### Object store request rates dropped
![Screenshot 2023-01-04 at 13 27 27](https://user-images.githubusercontent.com/21020035/210554998-ea6a0ad7-7da2-4413-a3ea-34e8e278969c.png)

#### Receive and transmit bandwidth dropped
![Screenshot 2023-01-04 at 13 27 15](https://user-images.githubusercontent.com/21020035/210554953-56801ec0-5829-4bba-a068-fd2d090fb384.png)

#### CPU and memory utilization were also lower
![Screenshot 2023-01-04 at 13 26 12](https://user-images.githubusercontent.com/21020035/210554800-41f6adae-c563-45fe-a949-d492664129b4.png)

#### latency was also lower
![Screenshot 2023-01-04 at 13 26 31](https://user-images.githubusercontent.com/21020035/210554853-d543e6bc-5d05-419f-9cf9-c7addbf35b33.png)

#### correctness

I also ran this image with other test scenarios to make sure we returns the right series when there is something to return. TLDR: no negative impact on CPU, memory or latency for the other tests, also correctness passes on all tests.

[shortcut streaming store-gateway-2023-01-04.pdf](https://github.com/grafana/mimir/files/10344166/shortcut.streaming.store-gateway-2023-01-04.pdf)

