### PR TITLE
feat alertmanager: add new template function grafanaExploreURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   * `-blocks-storage.tsdb.head-postings-for-matchers-cache-force`
 * [ENHANCEMENT] Ingester: Improved series selection performance when some of the matchers do not match any series. #3827
 * [ENHANCEMENT] Alertmanager: Add new additional template function `tenantID` returning id of the tenant owning the alert. #3758
+* [ENHANCEMENT] Alertmanager: Add additional template function `grafanaExploreURL` returning URL to grafana explore with range query. #3849
 * [ENHANCEMENT] Reduce overhead of debug logging when filtered out. #3875
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604

--- a/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
@@ -97,9 +97,9 @@ When using a reverse proxy, use the following settings when you configure the HT
 
 The Mimir Alertmanager adds some custom template functions to the default ones of the Prometheus Alertmanager.
 
-| Function            | Params                                        | Description                                                                                                                                                 |
-| ------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tenantID`          | -                                             | Returns ID of the tenant the alert belongs to.                                                                                                              |
+| Function            | Params                                        | Description                                                                                                                                                                  |
+| ------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tenantID`          | -                                             | Returns ID of the tenant the alert belongs to.                                                                                                                               |
 | `grafanaExploreURL` | `grafana_URL`,`datasource`,`from`,`to`,`expr` | Returns link to Grafana explore with range query based on the input parameters. Example: `{{ grafanaExploreURL "https://foo.bar" "xyz" "now-12h" "now" "up{foo=\"bar\"}" }}` |
 
 ## Sharding and replication

--- a/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
@@ -97,9 +97,10 @@ When using a reverse proxy, use the following settings when you configure the HT
 
 The Mimir Alertmanager adds some custom template functions to the default ones of the Prometheus Alertmanager.
 
-| Function   | Params | Description                                    |
-| ---------- | ------ | ---------------------------------------------- |
-| `tenantID` | -      | Returns ID of the tenant the alert belongs to. |
+| Function            | Params                                        | Description                                                                |
+| ------------------- | --------------------------------------------- | -------------------------------------------------------------------------- |
+| `tenantID`          | -                                             | Returns ID of the tenant the alert belongs to.                             |
+| `grafanaExploreURL` | `grafana_URL`,`datasource`,`from`,`to`,`expr` | Returns link to Grafana explore based on the input parameters. Example: `{{ grafanaExploreURL "https://foo.bar" "xyz" "now-12h" "now" "up{foo=\"bar\"}" }}` |
 
 ## Sharding and replication
 

--- a/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
@@ -100,7 +100,7 @@ The Mimir Alertmanager adds some custom template functions to the default ones o
 | Function            | Params                                        | Description                                                                                                                                                 |
 | ------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tenantID`          | -                                             | Returns ID of the tenant the alert belongs to.                                                                                                              |
-| `grafanaExploreURL` | `grafana_URL`,`datasource`,`from`,`to`,`expr` | Returns link to Grafana explore based on the input parameters. Example: `{{ grafanaExploreURL "https://foo.bar" "xyz" "now-12h" "now" "up{foo=\"bar\"}" }}` |
+| `grafanaExploreURL` | `grafana_URL`,`datasource`,`from`,`to`,`expr` | Returns link to Grafana explore with range query based on the input parameters. Example: `{{ grafanaExploreURL "https://foo.bar" "xyz" "now-12h" "now" "up{foo=\"bar\"}" }}` |
 
 ## Sharding and replication
 

--- a/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/alertmanager.md
@@ -97,9 +97,9 @@ When using a reverse proxy, use the following settings when you configure the HT
 
 The Mimir Alertmanager adds some custom template functions to the default ones of the Prometheus Alertmanager.
 
-| Function            | Params                                        | Description                                                                |
-| ------------------- | --------------------------------------------- | -------------------------------------------------------------------------- |
-| `tenantID`          | -                                             | Returns ID of the tenant the alert belongs to.                             |
+| Function            | Params                                        | Description                                                                                                                                                 |
+| ------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tenantID`          | -                                             | Returns ID of the tenant the alert belongs to.                                                                                                              |
 | `grafanaExploreURL` | `grafana_URL`,`datasource`,`from`,`to`,`expr` | Returns link to Grafana explore based on the input parameters. Example: `{{ grafanaExploreURL "https://foo.bar" "xyz" "now-12h" "now" "up{foo=\"bar\"}" }}` |
 
 ## Sharding and replication

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -10,14 +10,12 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
-	tmplhtml "html/template"
 	"net/http"
 	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
-	tmpltext "text/template"
 	"time"
 
 	"github.com/go-kit/log"
@@ -303,16 +301,6 @@ func clusterWait(position func() int, timeout time.Duration) func() time.Duratio
 	}
 }
 
-// withTenantIDFunc returns template.Option which adds to the templates additional function tenantID
-// returning the userID of the alertmanager tenant.
-func withTenantIDFunc(userID string) template.Option {
-	funcs := tmpltext.FuncMap{"tenantID": func() string { return userID }}
-	return func(text *tmpltext.Template, html *tmplhtml.Template) {
-		text.Funcs(funcs)
-		html.Funcs(funcs)
-	}
-}
-
 // ApplyConfig applies a new configuration to an Alertmanager.
 func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, rawCfg string) error {
 	templateFiles := make([]string, len(conf.Templates))
@@ -325,7 +313,7 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, rawCfg s
 		templateFiles[i] = templateFilepath
 	}
 
-	tmpl, err := template.FromGlobs(templateFiles, withTenantIDFunc(userID))
+	tmpl, err := template.FromGlobs(templateFiles, withCustomFunctions(userID))
 	if err != nil {
 		return err
 	}

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package alertmanager
 
 import (

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -32,7 +32,7 @@ type grafanaExploreParams struct {
 }
 
 // grafanaURL is a template helper function to generate Grafana explore URL in the alert template.
-func grafanaURL(grafanaURL, datasource, from, to, expr string) string {
+func grafanaURL(grafanaURL, datasource, from, to, expr string) (string, error) {
 	res, err := json.Marshal(&grafanaExploreParams{
 		Datasource: datasource,
 		Range: grafanaExploreRange{
@@ -49,10 +49,7 @@ func grafanaURL(grafanaURL, datasource, from, to, expr string) string {
 			},
 		},
 	})
-	if err != nil {
-		panic(err)
-	}
-	return grafanaURL + "/explore?left=" + url.QueryEscape(string(res))
+	return grafanaURL + "/explore?left=" + url.QueryEscape(string(res)), err
 }
 
 // withCustomFunctions returns template.Option which adds additional template functions

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -11,40 +11,46 @@ import (
 	"github.com/prometheus/alertmanager/template"
 )
 
+type grafanaDatasource struct {
+	Type string `json:"type,omitempty"`
+	UID  string `json:"uid,omitempty"`
+}
+
 type grafanaExploreRange struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 }
 
 type grafanaExploreQuery struct {
-	Datasource string `json:"datasource"`
-	Expr       string `json:"expr"`
-	Instant    bool   `json:"instant"`
-	Range      bool   `json:"range"`
-	RefID      string `json:"refId"`
+	Datasource grafanaDatasource `json:"datasource"`
+	Expr       string            `json:"expr"`
+	Instant    bool              `json:"instant"`
+	Range      bool              `json:"range"`
+	RefID      string            `json:"refId"`
 }
 
 type grafanaExploreParams struct {
-	Datasource string                `json:"datasource"`
-	Range      grafanaExploreRange   `json:"range"`
-	Queries    []grafanaExploreQuery `json:"queries"`
+	Range   grafanaExploreRange   `json:"range"`
+	Queries []grafanaExploreQuery `json:"queries"`
 }
 
-// grafanaURL is a template helper function to generate Grafana explore URL in the alert template.
-func grafanaURL(grafanaURL, datasource, from, to, expr string) (string, error) {
+// grafanaExploreURL is a template helper function to generate Grafana range query explore URL in the alert template.
+func grafanaExploreURL(grafanaURL, datasource, from, to, expr string) (string, error) {
 	res, err := json.Marshal(&grafanaExploreParams{
-		Datasource: datasource,
 		Range: grafanaExploreRange{
 			From: from,
 			To:   to,
 		},
 		Queries: []grafanaExploreQuery{
 			{
-				Datasource: datasource,
-				Expr:       expr,
-				Instant:    false,
-				Range:      true,
-				RefID:      "A",
+				Datasource: grafanaDatasource{
+					Type: "prometheus",
+					UID:  datasource,
+				},
+				Expr:    expr,
+				Instant: false,
+				Range:   true,
+				RefID:   "A",
 			},
 		},
 	})
@@ -56,7 +62,7 @@ func grafanaURL(grafanaURL, datasource, from, to, expr string) (string, error) {
 func withCustomFunctions(userID string) template.Option {
 	funcs := tmpltext.FuncMap{
 		"tenantID":          func() string { return userID },
-		"grafanaExploreURL": grafanaURL,
+		"grafanaExploreURL": grafanaExploreURL,
 	}
 	return func(text *tmpltext.Template, html *tmplhtml.Template) {
 		text.Funcs(funcs)

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -4,10 +4,9 @@ package alertmanager
 
 import (
 	"encoding/json"
-	tmpltext "text/template"
-
 	tmplhtml "html/template"
 	"net/url"
+	tmpltext "text/template"
 
 	"github.com/prometheus/alertmanager/template"
 )

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -1,0 +1,67 @@
+package alertmanager
+
+import (
+	"encoding/json"
+	tmpltext "text/template"
+
+	tmplhtml "html/template"
+	"net/url"
+
+	"github.com/prometheus/alertmanager/template"
+)
+
+type grafanaExploreRange struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type grafanaExploreQuery struct {
+	Datasource string `json:"datasource"`
+	Expr       string `json:"expr"`
+	Instant    bool   `json:"instant"`
+	Range      bool   `json:"range"`
+	RefID      string `json:"refId"`
+}
+
+type grafanaExploreParams struct {
+	Datasource string                `json:"datasource"`
+	Range      grafanaExploreRange   `json:"range"`
+	Queries    []grafanaExploreQuery `json:"queries"`
+}
+
+// grafanaURL is a template helper function to generate Grafana explore URL in the alert template.
+func grafanaURL(grafanaURL, datasource, from, to, expr string) string {
+	res, err := json.Marshal(&grafanaExploreParams{
+		Datasource: datasource,
+		Range: grafanaExploreRange{
+			From: from,
+			To:   to,
+		},
+		Queries: []grafanaExploreQuery{
+			{
+				Datasource: datasource,
+				Expr:       expr,
+				Instant:    false,
+				Range:      true,
+				RefID:      "A",
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return grafanaURL + "/explore?left=" + url.QueryEscape(string(res))
+}
+
+// withCustomFunctions returns template.Option which adds additional template functions
+// to the default ones.
+func withCustomFunctions(userID string) template.Option {
+	funcs := tmpltext.FuncMap{
+		"tenantID":          func() string { return userID },
+		"grafanaExploreURL": grafanaURL,
+	}
+	return func(text *tmpltext.Template, html *tmplhtml.Template) {
+		text.Funcs(funcs)
+		html.Funcs(funcs)
+	}
+}

--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package alertmanager
 
 import (

--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -1,0 +1,49 @@
+package alertmanager
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/prometheus/alertmanager/template"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_withCustomFunctions(t *testing.T) {
+	type tc struct {
+		name        string
+		template    string
+		result      string
+		expectError bool
+	}
+	tmpl, err := template.FromGlobs([]string{}, withCustomFunctions("test"))
+	assert.NoError(t, err)
+	data := template.Data{}
+	cases := []tc{
+		{
+			name:     "template tenant ID",
+			template: "{{ tenantID }}",
+			result:   "test",
+		},
+		{
+			name:     "generate grafana explore URL",
+			template: `{{ grafanaExploreURL "https://foo.bar" "test_datasoruce" "now-12h" "now" "up{foo!=\"bar\"}" }}`,
+			result:   `https://foo.bar/explore?left=` + url.QueryEscape(`{"datasource":"test_datasoruce","range":{"from":"now-12h","to":"now"},"queries":[{"datasource":"test_datasoruce","expr":"up{foo!=\"bar\"}","instant":false,"range":true,"refId":"A"}]}`),
+		},
+		{
+			name:        "invalid params for grafanaExploreURL",
+			template:    `{{ grafanaExploreURL "https://foo.bar" 3 2 1 0 }}`,
+			expectError: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := tmpl.ExecuteTextString(c.template, data)
+			if c.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, c.result, res)
+		})
+	}
+}

--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -29,7 +29,7 @@ func Test_withCustomFunctions(t *testing.T) {
 		{
 			name:     "generate grafana explore URL",
 			template: `{{ grafanaExploreURL "https://foo.bar" "test_datasoruce" "now-12h" "now" "up{foo!=\"bar\"}" }}`,
-			result:   `https://foo.bar/explore?left=` + url.QueryEscape(`{"datasource":"test_datasoruce","range":{"from":"now-12h","to":"now"},"queries":[{"datasource":"test_datasoruce","expr":"up{foo!=\"bar\"}","instant":false,"range":true,"refId":"A"}]}`),
+			result:   `https://foo.bar/explore?left=` + url.QueryEscape(`{"range":{"from":"now-12h","to":"now"},"queries":[{"datasource":{"type":"prometheus","uid":"test_datasoruce"},"expr":"up{foo!=\"bar\"}","instant":false,"range":true,"refId":"A"}]}`),
 		},
 		{
 			name:        "invalid params for grafanaExploreURL",

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/dskit/test"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -320,12 +319,4 @@ func testLimiter(t *testing.T, limits Limits, ops []callbackOp) {
 		assert.Equal(t, op.expectedCount, count, "wrong count, op %d", ix)
 		assert.Equal(t, op.expectedTotalSize, totalSize, "wrong total size, op %d", ix)
 	}
-}
-
-func Test_withTenantIDFunc(t *testing.T) {
-	tmpl, err := template.FromGlobs([]string{}, withTenantIDFunc("test"))
-	assert.NoError(t, err)
-	res, err := tmpl.ExecuteTextString("{{ tenantID }}", template.Data{})
-	assert.NoError(t, err)
-	assert.Equal(t, "test", res)
 }

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -256,7 +256,7 @@ func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc, limits 
 		templateFiles[i] = filepath.Join(userTempDir, t)
 	}
 
-	_, err = template.FromGlobs(templateFiles, withTenantIDFunc(user))
+	_, err = template.FromGlobs(templateFiles, withCustomFunctions(user))
 	if err != nil {
 		return err
 	}

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -685,6 +685,22 @@ alertmanager_config: |
     receiver: 'default-receiver'
 `,
 		},
+		{
+			name: "Should pass if template uses the grafanaExploreURL custom function",
+			cfg: `
+alertmanager_config: |
+  receivers:
+    - name: default-receiver
+      slack_configs:
+        - api_url: http://localhost
+          channel: "test"
+          title: "Hello {{ grafanaExploreURL \"https://foo.bar\" \"xyz\" \"now-12h\" \"now\" \"up{foo='bar'}\" }}"
+          text: "Hello {{ grafanaExploreURL \"https://foo.bar\" \"xyz\" \"now-12h\" \"now\" \"up{foo='bar'}\" }}"
+
+  route:
+    receiver: 'default-receiver'
+`,
+		},
 	}
 
 	limits := &mockAlertManagerLimits{}


### PR DESCRIPTION
As discussed in https://github.com/grafana/mimir/issues/2997#issuecomment-1369857932

Not sure about the naming :shrug:
Moved the custom template functions to a separate file for more clarity, tests are passing and generated URL seems to be working. 