### PR TITLE
Helm: use headless alertmanager,add OTLP endpoint in gateway NGINX

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary
 * [BUGFIX] Fixed gateway's checksum/config when using nginx #3780
 * [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781
+* [BUGFIX] Expose OTLP ingestion in the `gateway` NGINX configuration. #3851
+* [BUGFIX] Use alertmanager headless service in `gateway` NGINX configuration. #3851
 
 ## 4.0.0
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/gateway-enterprise-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/gateway-enterprise-values.yaml
@@ -1,7 +1,6 @@
 enterprise:
   enabled: true
 gateway:
-  enabled: true
   resources:
     requests:
       memory: 10Mi

--- a/operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml
@@ -1,7 +1,7 @@
 nginx:
   enabled: false
 gateway:
-  enabled: true
+  enabledNonEnterprise: true
   resources:
     requests:
       memory: 10Mi

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2493,16 +2493,19 @@ gateway:
             location = /api/v1/push {
               proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
+            location /otlp/v1/metrics {
+              proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            }
 
             # Alertmanager endpoints
             location {{ template "mimir.alertmanagerHttpPrefix" . }} {
-              proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+              proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /multitenant_alertmanager/status {
-              proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+              proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /api/v1/alerts {
-              proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+              proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
 
             # Ruler endpoints

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -1,0 +1,107 @@
+---
+# Source: mimir-distributed/templates/gateway/gateway-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/managed-by: Helm
+  name: gateway-nginx-values-mimir-gateway
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: gateway-nginx-values
+      app.kubernetes.io/component: gateway
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: gateway-nginx-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: gateway
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: gateway-nginx-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.22-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 10Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: mimir
+              app.kubernetes.io/instance: gateway-nginx-values
+              app.kubernetes.io/component: gateway
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: gateway-nginx-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: gateway-nginx-values-mimir-runtime
+        - name: nginx-config
+          configMap:
+            name: gateway-nginx-values-mimir-gateway-nginx
+        - name: docker-entrypoint-d-override
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-ingress.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-ingress.yaml
@@ -1,0 +1,28 @@
+---
+# Source: mimir-distributed/templates/gateway/gateway-ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway-nginx-values-mimir-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  tls:
+    - hosts:
+        - "mimir.example.com"
+      secretName: mimir-tls
+  rules:
+    - host: "mimir.example.com"
+      http:
+        paths:
+          - path: /
+            pathType: 
+            backend:
+              service:
+                name: gateway-nginx-values-mimir-gateway
+                port:
+                  number: 80

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/gateway/gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-nginx-values-mimir-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 8080
+      protocol: TCP
+      name: legacy-http-metrics
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/component: gateway

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -1,0 +1,114 @@
+---
+# Source: mimir-distributed/templates/gateway/nginx-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-nginx-values-mimir-gateway-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/component: gateway-nginx
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+    
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+    
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+    
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+    
+      sendfile     on;
+      tcp_nopush   on;
+      resolver kube-dns.kube-system.svc.cluster.local;
+    
+      # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.
+      map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        "" "anonymous";
+      }
+    
+      server {
+        listen 8080;
+    
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+    
+        location = /ready {
+          return 200 'OK';
+          auth_basic off;
+        }
+    
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+    
+        # Distributor endpoints
+        location /distributor {
+          proxy_pass      http://gateway-nginx-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+        }
+        location = /api/v1/push {
+          proxy_pass      http://gateway-nginx-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+        }
+        location /otlp/v1/metrics {
+          proxy_pass      http://gateway-nginx-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+        }
+    
+        # Alertmanager endpoints
+        location /alertmanager {
+          proxy_pass      http://gateway-nginx-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+        }
+        location = /multitenant_alertmanager/status {
+          proxy_pass      http://gateway-nginx-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+        }
+        location = /api/v1/alerts {
+          proxy_pass      http://gateway-nginx-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+        }
+    
+        # Ruler endpoints
+        location /prometheus/config/v1/rules {
+          proxy_pass      http://gateway-nginx-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+        }
+        location /prometheus/api/v1/rules {
+          proxy_pass      http://gateway-nginx-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+        }
+    
+        location /prometheus/api/v1/alerts {
+          proxy_pass      http://gateway-nginx-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+        }
+        location = /ruler/ring {
+          proxy_pass      http://gateway-nginx-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+        }
+    
+        # Rest of /prometheus goes to the query frontend
+        location /prometheus {
+          proxy_pass      http://gateway-nginx-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+        }
+    
+        # Buildinfo endpoint can go to any component
+        location = /api/v1/status/buildinfo {
+          proxy_pass      http://gateway-nginx-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+        }
+    
+        # Compactor endpoint for uploading blocks
+        location /api/v1/upload/block/ {
+          proxy_pass      http://gateway-nginx-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+        }
+      }
+    }

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -35,8 +35,8 @@ spec:
           imagePullPolicy: 
           args:
             - "-tests.smoke-test"
-            - "-tests.write-endpoint=http://gateway-nginx-values-mimir-nginx.citestns.svc:80"
-            - "-tests.read-endpoint=http://gateway-nginx-values-mimir-nginx.citestns.svc:80/prometheus"
+            - "-tests.write-endpoint=http://gateway-nginx-values-mimir-gateway.citestns.svc:80"
+            - "-tests.read-endpoint=http://gateway-nginx-values-mimir-gateway.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

* Forwards `/otlp/v1/metrics` to the distributor for the `gateway` NGINX deployment (different from the NGINX deployment that the `nginx` section creates)
* Changes the used service for the alertmanager from the regular service to the headless service. This is important because otherwise the NGINX doesn't work with the multi-zone alertmanager
* It also corrects the tests that generate the committed manifests to actually render the NGINX deployment.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/3830

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
