### PR TITLE
Remove always-nil error return value from distributor method

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4984,9 +4984,7 @@ func TestSeriesAreShardedToCorrectIngesters(t *testing.T) {
 		totalMetadata += len(ing[ix].metadata)
 
 		for _, ts := range ing[ix].timeseries {
-			token, err := distrib.tokenForLabels(userName, ts.Labels)
-			require.NoError(t, err)
-
+			token := distrib.tokenForLabels(userName, ts.Labels)
 			ingIx := getIngesterIndexForToken(token, ing)
 			assert.Equal(t, ix, ingIx)
 		}


### PR DESCRIPTION
#### What this PR does
This tiny PR removes unnecessary error return value (which was always `nil`) from `tokenForLabels` method in distributor. No user-visible change.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
