### PR TITLE
Fix ruler-query-frontend and mimir-read gRPC server configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766
 * [BUGFIX] Apply overrides-exporter CLI flags to mimir-backend when running Mimir in read-write deployment mode. #3790
 * [BUGFIX] Fixed `mimir-write` Kubernetes service to correctly balance route requests among mimir-write pods. #3855
+* [BUGFIX] Fixed `ruler-query-frontend` and `mimir-read` gRPC server configuration to force clients to periodically re-resolve the backend addresses. #3862
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -970,6 +970,9 @@ spec:
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -909,6 +909,9 @@ spec:
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1021,6 +1021,9 @@ spec:
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -435,6 +435,9 @@ spec:
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -436,6 +436,9 @@ spec:
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -973,6 +973,9 @@ spec:
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -972,6 +972,9 @@ spec:
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -126,6 +126,17 @@
       'server.grpc.keepalive.ping-without-stream-allowed': true,
     },
 
+    // gRPC server configuration to apply to ingress services used by clients doing
+    // client-side load balancing in front of it. Since gRPC clients re-resolve the configured
+    // address when a connection fails or is closed, we do force the clients to reconnect
+    // periodically in order to have them re-resolve the configured address and eventually
+    // discover new replicas (e.g. after a scale up event).
+    grpcIngressConfig:: {
+      'server.grpc.keepalive.max-connection-age': '2m',
+      'server.grpc.keepalive.max-connection-age-grace': '5m',
+      'server.grpc.keepalive.max-connection-idle': '1m',
+    },
+
     storageConfig: {
       'common.storage.backend': $._config.storage_backend,
     } + (

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -5,6 +5,7 @@
   distributor_args::
     $._config.usageStatsConfig +
     $._config.grpcConfig +
+    $._config.grpcIngressConfig +
     $._config.ingesterRingClientConfig +
     $._config.distributorLimitsConfig +
     {
@@ -22,9 +23,6 @@
       'mem-ballast-size-bytes': 1 << 30,  // 1GB
 
       'server.http-listen-port': $._config.server_http_port,
-      'server.grpc.keepalive.max-connection-age': '2m',
-      'server.grpc.keepalive.max-connection-age-grace': '5m',
-      'server.grpc.keepalive.max-connection-idle': '1m',
 
       // The ingestion rate global limit requires the distributors to form a ring.
       'distributor.ring.store': 'consul',

--- a/operations/mimir/read-write-deployment/read.libsonnet
+++ b/operations/mimir/read-write-deployment/read.libsonnet
@@ -11,6 +11,8 @@
   //
 
   mimir_read_args::
+    // The ruler remote evaluation (running in mimir-backend) connects to mimir-read via gRPC.
+    $._config.grpcIngressConfig +
     $.query_frontend_args +
     $.querier_args + {
       target: 'read',

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -49,6 +49,8 @@
   //
 
   ruler_query_frontend_args+::
+    // The ruler remote evaluation connects to ruler-query-frontend via gRPC.
+    $._config.grpcIngressConfig +
     $.query_frontend_args +
     $.queryFrontendUseQuerySchedulerArgs(rulerQuerySchedulerName) +
     queryFrontendDisableCacheArgs,


### PR DESCRIPTION
#### What this PR does
Fixed `ruler-query-frontend` and `mimir-read` gRPC server configuration to force clients to periodically re-resolve the backend addresses.

See https://github.com/grafana/mimir/issues/3860 for more details.

#### Which issue(s) this PR fixes or relates to

Fixes #3860

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
