### PR TITLE
Fix mimir-read Kubernetes service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766
 * [BUGFIX] Apply overrides-exporter CLI flags to mimir-backend when running Mimir in read-write deployment mode. #3790
-* [BUGFIX] Fixed `mimir-write` Kubernetes service to correctly balance route requests among mimir-write pods. #3855
+* [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864
 * [BUGFIX] Fixed `ruler-query-frontend` and `mimir-read` gRPC server configuration to force clients to periodically re-resolve the backend addresses. #3862
 
 ### Mimirtool

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -451,6 +451,7 @@ metadata:
   name: mimir-read
   namespace: default
 spec:
+  clusterIP: None
   ports:
   - name: mimir-read-gossip-ring
     port: 7946

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -277,6 +277,7 @@ metadata:
   name: mimir-read
   namespace: default
 spec:
+  clusterIP: None
   ports:
   - name: mimir-read-gossip-ring
     port: 7946

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -277,6 +277,7 @@ metadata:
   name: mimir-read
   namespace: default
 spec:
+  clusterIP: None
   ports:
   - name: mimir-read-gossip-ring
     port: 7946


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/3862 I forgot to upstream another change required to fix #3860 in the read-write mode, which is configuring `mimir-read` Kubernetes service as **headless**.

#### Which issue(s) this PR fixes or relates to

Fixes #3860

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
