### PR TITLE
Check that metric_relabel_configs has non-nil configuration in runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Update `github.com/thanos-io/objstore` to address issue with Multipart PUT on s3-compatible Object Storage. #3802 #3821
 * [BUGFIX] Distributor, Query-scheduler: Make sure ring metrics include a `cortex_` prefix as expected by dashboards. #3809
 * [BUGFIX] Querier: canceled requests are no longer reported as "consistency check" failures. #3837
+* [BUGFIX] Distributor: don't panic when `metric_relabel_configs` in overrides contains null element. #3868
 
 ### Mixin
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -272,7 +272,7 @@ func (l *Limits) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 
-	return nil
+	return l.validate()
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -293,6 +293,16 @@ func (l *Limits) UnmarshalJSON(data []byte) error {
 	err := dec.Decode((*plain)(l))
 	if err != nil {
 		return err
+	}
+
+	return l.validate()
+}
+
+func (l *Limits) validate() error {
+	for _, cfg := range l.MetricRelabelConfigs {
+		if cfg == nil {
+			return fmt.Errorf("invalid metric_relabel_configs")
+		}
 	}
 
 	return nil

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -627,3 +627,22 @@ func TestCustomTrackerConfigDeserialize(t *testing.T) {
 	assert.False(t, overrides["user"].ActiveSeriesCustomTrackersConfig.Empty())
 	assert.Equal(t, expectedConfig.String(), overrides["user"].ActiveSeriesCustomTrackersConfig.String())
 }
+
+func TestUnmarshalInvalidMetricRelabelConfig(t *testing.T) {
+	t.Run("yaml", func(t *testing.T) {
+		limits := Limits{}
+		cfg := `
+metric_relabel_configs:
+  -
+`
+		err := yaml.Unmarshal([]byte(cfg), &limits)
+		require.ErrorContains(t, err, "invalid metric_relabel_configs")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		limits := Limits{}
+		cfg := `{"metric_relabel_configs": [null]}`
+		err := json.Unmarshal([]byte(cfg), &limits)
+		require.ErrorContains(t, err, "invalid metric_relabel_configs")
+	})
+}


### PR DESCRIPTION
#### What this PR does
This PR fixes panic in distributor which happens when user writes invalid `metric_relabel_configs` into overrides like this:

```
overrides:
  anonymous:
    metric_relabel_configs:
      -
```

This was accepted as valid runtime config file, but metric relabel configs translated to `[]*relabel.Config{nil}`. When distributor uses this, it panics (line numbers match main at ef085cdae5ae16413d6f3bd8af51811a7152b3c7):

```
2023/01/06 09:42:40 http: panic serving 172.18.0.5:42300: runtime error: invalid memory address or nil pointer dereference
goroutine 15715 [running]:
net/http.(*conn).serve.func1()
	/opt/homebrew/Cellar/go/1.19.2/libexec/src/net/http/server.go:1850 +0x120
panic({0x1fbfd80, 0x37a5770})
	/opt/homebrew/Cellar/go/1.19.2/libexec/src/runtime/panic.go:890 +0x264
github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5.1()
	/Users/peter/Grafana/mimir/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:150 +0x1a0
panic({0x1fbfd80, 0x37a5770})
	/opt/homebrew/Cellar/go/1.19.2/libexec/src/runtime/panic.go:890 +0x264
github.com/prometheus/prometheus/model/relabel.relabel({0x40019301c0, 0xb, 0xe}, 0x0, 0x400082f540)
	/Users/peter/Grafana/mimir/vendor/github.com/prometheus/prometheus/model/relabel/relabel.go:222 +0x7c
github.com/prometheus/prometheus/model/relabel.Process({0x40019301c0, 0xb, 0xe}, {0x4001fb40d8, 0x1, 0x1})
	/Users/peter/Grafana/mimir/vendor/github.com/prometheus/prometheus/model/relabel/relabel.go:211 +0xb0
github.com/grafana/mimir/pkg/distributor.(*Distributor).prePushRelabelMiddleware.func1({0x2945388, 0x40005c5ad0}, 0x4000f97680)
	/Users/peter/Grafana/mimir/pkg/distributor/distributor.go:801 +0x2ac
...
```

#### Which issue(s) this PR fixes or relates to

No issue created.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
