### PR TITLE
Fix mimir-read CLI flags precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [BUGFIX] Apply overrides-exporter CLI flags to mimir-backend when running Mimir in read-write deployment mode. #3790
 * [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864
 * [BUGFIX] Fixed `ruler-query-frontend` and `mimir-read` gRPC server configuration to force clients to periodically re-resolve the backend addresses. #3862
+* [BUGFIX] Fixed `mimir-read` CLI flags to ensure query-frontend configuration takes precedence over querier configuration. #3877
 
 ### Mimirtool
 

--- a/operations/mimir/read-write-deployment/read.libsonnet
+++ b/operations/mimir/read-write-deployment/read.libsonnet
@@ -14,8 +14,10 @@
   mimir_read_args::
     // The ruler remote evaluation (running in mimir-backend) connects to mimir-read via gRPC.
     $._config.grpcIngressConfig +
-    $.query_frontend_args +
-    $.querier_args + {
+    $.querier_args +
+    // Query-frontend configuration takes precedence over querier configuration (e.g. HTTP / gRPC settings) because
+    // the query-frontend is the ingress service.
+    $.query_frontend_args {
       target: 'read',
       // Restrict number of active query-schedulers.
       'query-scheduler.max-used-instances': 2,


### PR DESCRIPTION
#### What this PR does
Fix mimir-read CLI flags precedence to have query-frontend overriding any flag conflicting with querier.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
