### PR TITLE
mark `query-frontend.max-total-query-length` as stable

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3193,8 +3193,7 @@
           "fieldValue": null,
           "fieldDefaultValue": 0,
           "fieldFlag": "query-frontend.max-total-query-length",
-          "fieldType": "duration",
-          "fieldCategory": "experimental"
+          "fieldType": "duration"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1362,7 +1362,7 @@ Usage of ./cmd/mimir/mimir:
   -query-frontend.max-retries-per-request int
     	Maximum number of retries for a single request; beyond this, the downstream error is returned. (default 5)
   -query-frontend.max-total-query-length duration
-    	[experimental] Limit the total query time range (end - start time). This limit is enforced in the query-frontend on the received query. Defaults to the value of -store.max-query-length if set to 0.
+    	Limit the total query time range (end - start time). This limit is enforced in the query-frontend on the received query. Defaults to the value of -store.max-query-length if set to 0.
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
   -query-frontend.querier-forget-delay duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -411,6 +411,8 @@ Usage of ./cmd/mimir/mimir:
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.max-queriers-per-tenant int
     	Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.
+  -query-frontend.max-total-query-length duration
+    	Limit the total query time range (end - start time). This limit is enforced in the query-frontend on the received query. Defaults to the value of -store.max-query-length if set to 0.
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
   -query-frontend.query-sharding-max-sharded-queries int

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -86,7 +86,6 @@ The following features are currently experimental:
     - `-blocks-storage.tsdb.head-postings-for-matchers-cache-size`
     - `-blocks-storage.tsdb.head-postings-for-matchers-cache-force`
 - Query-frontend
-  - `-query-frontend.max-total-query-length`
   - `-query-frontend.querier-forget-delay`
   - Instant query splitting (`-query-frontend.split-instant-queries-by-interval`)
   - Lower TTL for cache entries overlapping the out-of-order samples ingestion window (re-using `-ingester.out-of-order-allowance` from ingesters)

--- a/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/operators-guide/configure/reference-configuration-parameters/index.md
@@ -2559,9 +2559,9 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.split-instant-queries-by-interval
 [split_instant_queries_by_interval: <duration> | default = 0s]
 
-# (experimental) Limit the total query time range (end - start time). This limit
-# is enforced in the query-frontend on the received query. Defaults to the value
-# of -store.max-query-length if set to 0.
+# Limit the total query time range (end - start time). This limit is enforced in
+# the query-frontend on the received query. Defaults to the value of
+# -store.max-query-length if set to 0.
 # CLI flag: -query-frontend.max-total-query-length
 [max_total_query_length: <duration> | default = 0s]
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -32,7 +32,6 @@ const (
 	MaxChunksPerQueryFlag      = "querier.max-fetched-chunks-per-query"
 	MaxChunkBytesPerQueryFlag  = "querier.max-fetched-chunk-bytes-per-query"
 	MaxSeriesPerQueryFlag      = "querier.max-fetched-series-per-query"
-	maxPartialQueryLengthFlag  = "querier.max-partial-query-length"
 	maxLabelNamesPerSeriesFlag = "validation.max-label-names-per-series"
 	maxLabelNameLengthFlag     = "validation.max-length-label-name"
 	maxLabelValueLengthFlag    = "validation.max-length-label-value"

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -117,7 +117,7 @@ type Limits struct {
 	SplitInstantQueriesByInterval  model.Duration `yaml:"split_instant_queries_by_interval" json:"split_instant_queries_by_interval" category:"experimental"`
 
 	// Query-frontend limits.
-	MaxTotalQueryLength model.Duration `yaml:"max_total_query_length" json:"max_total_query_length" category:"experimental"`
+	MaxTotalQueryLength model.Duration `yaml:"max_total_query_length" json:"max_total_query_length"`
 
 	// Cardinality
 	CardinalityAnalysisEnabled                    bool `yaml:"cardinality_analysis_enabled" json:"cardinality_analysis_enabled"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This marks the flag `query-frontend.max-total-query-length` as stable. This change is part of the transition away from the use of the ambiguous `store.max-query-length` flag to the dedicated flags `query-frontend.max-total-query-length` for the query-frontend and `querier.max-partial-query-length` for the querier, respectively.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
