### PR TITLE
[release-2.4] Update publishing workflows to use PATs with fine-grained access control

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -25,7 +25,9 @@ jobs:
       uses: "actions/checkout@v3"
 
     - name: "Clone website-sync Action"
-      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+      # WEBSITE_SYNC_MIMIR is a fine-grained GitHub Personal Access Token that expires.
+      # It must be updated in the grafanabot GitHub account.
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_MIMIR }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
     - name: "Publish to website repository (next)"
       uses: "./.github/actions/website-sync"
@@ -34,6 +36,8 @@ jobs:
         repository: "grafana/website"
         branch: "master"
         host: "github.com"
-        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        # PUBLISH_TO_WEBSITE_MIMIR is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_MIMIR }}"
         source_folder: "docs/sources"
         target_folder: "content/docs/mimir/next"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -64,7 +64,9 @@ jobs:
         repository: "grafana/website"
         branch: "master"
         host: "github.com"
-        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        # PUBLISH_TO_WEBSITE_MIMIR is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_MIMIR }}"
         source_folder: "docs/sources"
         # Append ".x" to target to produce a v<major>.<minor>.x directory.
         target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}.x"


### PR DESCRIPTION
* Update publishing workflows to use PATs with fine-grained access control

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

* Fix typo

Co-authored-by: Ursula Kallio <ursula.kallio@grafana.com>

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
Co-authored-by: Ursula Kallio <ursula.kallio@grafana.com>
(cherry picked from commit b93ecbee90108a16ef4a18466c091738ff3e857a)
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
