### PR TITLE
Update r220 with mimir prometheus bugfix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 replace github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20221229161652-98dee9f3843f
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230109080016-00b3237b8581
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb h1:CqfZjjd8iK3G
 github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20221229161652-98dee9f3843f h1:YfmwfTZHWj6ygGhDtSku7W8tzjlrs+PWzjWfQ0jmk+A=
-github.com/grafana/mimir-prometheus v0.0.0-20221229161652-98dee9f3843f/go.mod h1:keEiDdNH8SISDysiQeq1u1eMJSJth2yVc6duygWQir0=
+github.com/grafana/mimir-prometheus v0.0.0-20230109080016-00b3237b8581 h1:0B7hTWBx93/mUP6anjVcr/TozS3RbMIVf5/l/90ROkE=
+github.com/grafana/mimir-prometheus v0.0.0-20230109080016-00b3237b8581/go.mod h1:keEiDdNH8SISDysiQeq1u1eMJSJth2yVc6duygWQir0=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/vendor/github.com/prometheus/prometheus/tsdb/querier.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/querier.go
@@ -660,12 +660,7 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 	if valueType == chunkenc.ValNone {
 		if err := p.currDelIter.Err(); err != nil {
 			p.err = errors.Wrap(err, "iterate chunk while re-encoding")
-			return false
 		}
-
-		// Empty chunk, this should not happen, as we assume full
-		// deletions being filtered before this iterator.
-		p.err = errors.New("populateWithDelChunkSeriesIterator: unexpected empty chunk found while rewriting chunk")
 		return false
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -779,7 +779,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20221229161652-98dee9f3843f
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230109080016-00b3237b8581
 ## explicit; go 1.18
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1355,7 +1355,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20221229161652-98dee9f3843f
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230109080016-00b3237b8581
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe


### PR DESCRIPTION
This PR updates `r220` to use https://github.com/grafana/mimir-prometheus/tree/mimir-r219, which contains bugfix for https://github.com/prometheus/prometheus/issues/11585.