### PR TITLE
Changed default mimir_backend_data_disk_size from 100Gi to 250Gi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [CHANGE] Replaced the deprecated `policy/v1beta1` with `policy/v1` when configuring a PodDisruptionBudget for read-write deployment mode. #3811
 * [CHANGE] Removed `-server.http-write-timeout` default option value from querier and query-frontend, as it defaults to a higher value in the code now, and cannot be lower than `-querier.timeout`. #3836
 * [CHANGE] Replaced `-store.max-query-length` with `-query-frontend.max-total-query-length` in the query-frontend config. #3879
+* [CHANGE] Changed default `mimir_backend_data_disk_size` from `100Gi` to `250Gi`. #3894
 * [ENHANCEMENT] Update `rollout-operator` to `v0.2.0`. #3624
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2265,7 +2265,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1
@@ -2437,7 +2437,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1
@@ -2609,7 +2609,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -917,7 +917,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1
@@ -1090,7 +1090,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1
@@ -1263,7 +1263,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -918,7 +918,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1
@@ -1091,7 +1091,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1
@@ -1264,7 +1264,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 250Gi
       storageClassName: fast-dont-retain
 ---
 apiVersion: apps/v1

--- a/operations/mimir/read-write-deployment/config.libsonnet
+++ b/operations/mimir/read-write-deployment/config.libsonnet
@@ -9,7 +9,7 @@
     mimir_read_topology_spread_max_skew: 1,
     mimir_backend_replicas: 3,
     mimir_backend_max_unavailable: 10,
-    mimir_backend_data_disk_size: '100Gi',
+    mimir_backend_data_disk_size: '250Gi',
     mimir_backend_data_disk_class: 'fast-dont-retain',
     mimir_backend_allow_multiple_replicas_on_same_node: false,
 


### PR DESCRIPTION
#### What this PR does
In this PR I'm changing the default mimir_backend_data_disk_size from 100Gi to 250Gi, to match the default compactor disk size.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
