### PR TITLE
bucket/azure: Refactor NewBucketClient to not take a factory parameter

### DIFF
--- a/pkg/storage/bucket/azure/bucket_client.go
+++ b/pkg/storage/bucket/azure/bucket_client.go
@@ -13,7 +13,11 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-func NewBucketClient(cfg Config, name string, logger log.Logger, factory func(log.Logger, []byte, string) (*azure.Bucket, error)) (objstore.Bucket, error) {
+func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
+	return newBucketClient(cfg, name, logger, azure.NewBucket)
+}
+
+func newBucketClient(cfg Config, name string, logger log.Logger, factory func(log.Logger, []byte, string) (*azure.Bucket, error)) (objstore.Bucket, error) {
 	// Start with default config to make sure that all parameters are set to sensible values, especially
 	// HTTP Config field.
 	bucketConfig := azure.DefaultConfig

--- a/pkg/storage/bucket/azure/bucket_client_test.go
+++ b/pkg/storage/bucket/azure/bucket_client_test.go
@@ -21,7 +21,7 @@ func TestNewBucketClient(t *testing.T) {
 			ContainerName:      "test",
 			MaxRetries:         3,
 		}
-		bkt, err := NewBucketClient(cfg, "test", log.NewNopLogger(), fakeFactory(t, cfg))
+		bkt, err := newBucketClient(cfg, "test", log.NewNopLogger(), fakeFactory(t, cfg))
 		require.NoError(t, err)
 		require.NotNil(t, bkt)
 	})
@@ -34,7 +34,7 @@ func TestNewBucketClient(t *testing.T) {
 			MaxRetries:         3,
 			Endpoint:           "test-endpoint",
 		}
-		bkt, err := NewBucketClient(cfg, "test", log.NewNopLogger(), fakeFactory(t, cfg))
+		bkt, err := newBucketClient(cfg, "test", log.NewNopLogger(), fakeFactory(t, cfg))
 		require.NoError(t, err)
 		require.NotNil(t, bkt)
 	})

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
-	thazure "github.com/thanos-io/objstore/providers/azure"
 
 	"github.com/grafana/regexp"
 
@@ -165,7 +164,7 @@ func NewClient(ctx context.Context, cfg Config, name string, logger log.Logger, 
 	case GCS:
 		backendClient, err = gcs.NewBucketClient(ctx, cfg.GCS, name, logger)
 	case Azure:
-		backendClient, err = azure.NewBucketClient(cfg.Azure, name, logger, thazure.NewBucket)
+		backendClient, err = azure.NewBucketClient(cfg.Azure, name, logger)
 	case Swift:
 		backendClient, err = swift.NewBucketClient(cfg.Swift, name, logger)
 	case Filesystem:


### PR DESCRIPTION
#### What this PR does
In pkg/storage/bucket/azure, change NewBucketClient to not take a factory parameter, but leave this to a private implementation instead. Follows @pracucci's post-merge [advice](https://github.com/grafana/mimir/pull/3821#discussion_r1060010082) in #3821.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
