### PR TITLE
Update base images to alpine:3.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Ingester: Improved series selection performance when some of the matchers do not match any series. #3827
 * [ENHANCEMENT] Alertmanager: Add new additional template function `tenantID` returning id of the tenant owning the alert. #3758
 * [ENHANCEMENT] Reduce overhead of debug logging when filtered out. #3875
+* [ENHANCEMENT] Update Docker base images from `alpine:3.16.2` to `alpine:3.17.1`. #3898
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.16.2
+FROM       alpine:3.17.1
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimir-continuous-test/Dockerfile
+++ b/cmd/mimir-continuous-test/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.16.2
+FROM       alpine:3.17.1
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.16.2
+FROM       alpine:3.17.1
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM       alpine:3.16.2
+FROM       alpine:3.17.1
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.16.2
+FROM       alpine:3.17.1
 RUN        apk add --no-cache ca-certificates
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19.3
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 
-FROM alpine:3.16.2
+FROM alpine:3.17.1
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-monolithic-mode-with-swift-storage/dev.dockerfile
+++ b/development/mimir-monolithic-mode-with-swift-storage/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.17.1
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-monolithic-mode/dev.dockerfile
+++ b/development/mimir-monolithic-mode/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.17.1
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.18.4
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.7.3
 
-FROM alpine:3.16.2
+FROM alpine:3.17.1
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/packaging/fpm/Dockerfile
+++ b/packaging/fpm/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM alpine:3.16.2
+FROM alpine:3.17.1
 
 RUN apk add --no-cache \
         bash \


### PR DESCRIPTION
#### What this PR does

Updates base images to [alpine 3.17.1](https://alpinelinux.org/posts/Alpine-3.17.1-released.html) which was recently released.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
