### PR TITLE
Add top-level jsonnet containers for mimir-write and mimir-backend

### DIFF
--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -40,12 +40,7 @@
   mimir_backend_zone_b_args:: $.store_gateway_zone_b_args {},
   mimir_backend_zone_c_args:: $.store_gateway_zone_c_args {},
 
-  local mimir_backend_data_pvc =
-    pvc.new() +
-    pvc.mixin.spec.resources.withRequests({ storage: $._config.mimir_backend_data_disk_size }) +
-    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName($._config.mimir_backend_data_disk_class) +
-    pvc.mixin.metadata.withName('mimir-backend-data'),
+
 
   mimir_backend_ports::
     std.uniq(
@@ -56,10 +51,25 @@
       ), byContainerPort
     ),
 
-  newMimirBackendZoneContainer(zone, zone_args)::
+  mimir_backend_container::
     container.new('mimir-backend', $._images.mimir_backend) +
     container.withPorts($.mimir_backend_ports) +
-    container.withArgsMixin($.util.mapToFlags(
+    container.withVolumeMountsMixin([volumeMount.new('mimir-backend-data', '/data')]) +
+    $.util.resourcesRequests(1, '12Gi') +
+    $.util.resourcesLimits(null, '18Gi') +
+    $.util.readinessProbe +
+    $.jaeger_mixin,
+
+  local mimir_backend_data_pvc =
+    pvc.new() +
+    pvc.mixin.spec.resources.withRequests({ storage: $._config.mimir_backend_data_disk_size }) +
+    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
+    pvc.mixin.spec.withStorageClassName($._config.mimir_backend_data_disk_class) +
+    pvc.mixin.metadata.withName('mimir-backend-data'),
+
+  newMimirBackendZoneContainer(zone, zone_args)::
+    $.mimir_backend_container +
+    container.withArgs($.util.mapToFlags(
       // This first block contains flags that can be overridden.
       {
         // Do not unregister from ring at shutdown, so that no blocks re-shuffling occurs during rollouts.
@@ -71,12 +81,7 @@
         // Use a different prefix so that both single-zone and multi-zone store-gateway rings can co-exists.
         'store-gateway.sharding-ring.prefix': 'multi-zone/',
       }
-    )) +
-    container.withVolumeMountsMixin([volumeMount.new('mimir-backend-data', '/data')]) +
-    $.util.resourcesRequests(1, '12Gi') +
-    $.util.resourcesLimits(null, '18Gi') +
-    $.util.readinessProbe +
-    $.jaeger_mixin,
+    )),
 
   newMimirBackendZoneStatefulset(zone, container)::
     local name = 'mimir-backend-zone-%s' % zone;

--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -40,8 +40,6 @@
   mimir_backend_zone_b_args:: $.store_gateway_zone_b_args {},
   mimir_backend_zone_c_args:: $.store_gateway_zone_c_args {},
 
-
-
   mimir_backend_ports::
     std.uniq(
       std.sort(


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

This adds top-level container objects for mimir-write and mimir-backend components much like ingesters and store-gateways have top-level objects even though they are optionally run in multi-zone mode. This allows settings that apply to all zones to be easily applied.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
