### PR TITLE
Fix mimir-read ingress service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766
 * [BUGFIX] Apply overrides-exporter CLI flags to mimir-backend when running Mimir in read-write deployment mode. #3790
-* [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864
+* [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864 #3905
 * [BUGFIX] Fixed `ruler-query-frontend` and `mimir-read` gRPC server configuration to force clients to periodically re-resolve the backend addresses. #3862
 * [BUGFIX] Fixed `mimir-read` CLI flags to ensure query-frontend configuration takes precedence over querier configuration. #3877
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766
 * [BUGFIX] Apply overrides-exporter CLI flags to mimir-backend when running Mimir in read-write deployment mode. #3790
-* [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864 #3905
+* [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864 #3906
 * [BUGFIX] Fixed `ruler-query-frontend` and `mimir-read` gRPC server configuration to force clients to periodically re-resolve the backend addresses. #3862
 * [BUGFIX] Fixed `mimir-read` CLI flags to ensure query-frontend configuration takes precedence over querier configuration. #3877
 

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -451,6 +451,27 @@ metadata:
   name: mimir-read
   namespace: default
 spec:
+  ports:
+  - name: mimir-read-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-read-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-read-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-read
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-read
+  name: mimir-read-headless
+  namespace: default
+spec:
   clusterIP: None
   ports:
   - name: mimir-read-gossip-ring
@@ -2201,7 +2222,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -2373,7 +2394,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -2545,7 +2566,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -277,6 +277,27 @@ metadata:
   name: mimir-read
   namespace: default
 spec:
+  ports:
+  - name: mimir-read-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-read-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-read-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-read
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-read
+  name: mimir-read-headless
+  namespace: default
+spec:
   clusterIP: None
   ports:
   - name: mimir-read-gossip-ring
@@ -853,7 +874,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -1026,7 +1047,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -1199,7 +1220,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -277,6 +277,27 @@ metadata:
   name: mimir-read
   namespace: default
 spec:
+  ports:
+  - name: mimir-read-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-read-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-read-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-read
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-read
+  name: mimir-read-headless
+  namespace: default
+spec:
   clusterIP: None
   ports:
   - name: mimir-read-gossip-ring
@@ -854,7 +875,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -1027,7 +1048,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -1200,7 +1221,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///mimir-read.default.svc.cluster.local:9095
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
         - -runtime-config.file=/etc/mimir/overrides.yaml

--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -30,7 +30,7 @@
 
       // Use ruler's remote evaluation mode.
       'querier.frontend-address': null,
-      'ruler.query-frontend.address': 'dns:///mimir-read.%s.svc.cluster.local:9095' % $._config.namespace,
+      'ruler.query-frontend.address': 'dns:///mimir-read-headless.%s.svc.cluster.local:9095' % $._config.namespace,
 
       // Restrict number of active query-schedulers.
       'query-scheduler.max-used-instances': 2,

--- a/operations/mimir/read-write-deployment/read.libsonnet
+++ b/operations/mimir/read-write-deployment/read.libsonnet
@@ -54,7 +54,11 @@
     (if $._config.memberlist_ring_enabled then gossipLabel else {}),
 
   mimir_read_service: if !$._config.is_read_write_deployment_mode then null else
+    $.util.serviceFor($.mimir_read_deployment, $._config.service_ignored_labels),
+
+  mimir_read_headless_service: if !$._config.is_read_write_deployment_mode then null else
     $.util.serviceFor($.mimir_read_deployment, $._config.service_ignored_labels) +
+    service.mixin.metadata.withName('mimir-read-headless') +
 
     // Must be an headless to ensure any gRPC client using it (ruler remote evaluations)
     // correctly balances requests across all mimir-read pods.


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/3864 I've changed mimir-read service to headless. This fixed rule evaluations balancing (gRPC) but I just realised HTTP balancing is imperfect, because it actually expects a non headless service. So, we need two services, and use the headless one for remote rule evaluation.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
