### PR TITLE
Document -modules=true as config validation cmd

### DIFF
--- a/docs/sources/mimir/operators-guide/configure/about-configurations.md
+++ b/docs/sources/mimir/operators-guide/configure/about-configurations.md
@@ -63,6 +63,6 @@ The most common use case for CLI flags is to use the `-target` flag to run Grafa
 ## Validate a configuration
 
 To validate your configuration, run the command `mimir -modules true -config.file <path-to-config-file>`.
-This is useful if you want to validate the configuration in a CI environment before deploying it.
+This is useful if you want to validate the configuration before deploying it. You can use the command locally or in a CI environment.
 - If the configuration file is valid, the command exits with a zero exit code and prints the available modules. 
 - If the configuration file is invalid, the command exits with a non-zero exit code and prints the error message to standard output.

--- a/docs/sources/mimir/operators-guide/configure/about-configurations.md
+++ b/docs/sources/mimir/operators-guide/configure/about-configurations.md
@@ -62,7 +62,7 @@ The most common use case for CLI flags is to use the `-target` flag to run Grafa
 
 ## Validate a configuration
 
-To validate your configuration, run the command `mimir -modules true -config.file <path-to-config-file>`.
+To validate your configuration, run the command `mimir -modules -config.file <path-to-config-file>`.
 This is useful if you want to validate the configuration before deploying it. You can use the command locally or in a CI environment.
 
 - If the configuration file is valid, the command exits with a zero exit code and prints the available modules.

--- a/docs/sources/mimir/operators-guide/configure/about-configurations.md
+++ b/docs/sources/mimir/operators-guide/configure/about-configurations.md
@@ -64,5 +64,6 @@ The most common use case for CLI flags is to use the `-target` flag to run Grafa
 
 To validate your configuration, run the command `mimir -modules true -config.file <path-to-config-file>`.
 This is useful if you want to validate the configuration before deploying it. You can use the command locally or in a CI environment.
-- If the configuration file is valid, the command exits with a zero exit code and prints the available modules. 
+
+- If the configuration file is valid, the command exits with a zero exit code and prints the available modules.
 - If the configuration file is invalid, the command exits with a non-zero exit code and prints the error message to standard output.

--- a/docs/sources/mimir/operators-guide/configure/about-configurations.md
+++ b/docs/sources/mimir/operators-guide/configure/about-configurations.md
@@ -60,9 +60,9 @@ If you need to, you can use advanced CLI flags to override specific values on a 
 
 The most common use case for CLI flags is to use the `-target` flag to run Grafana Mimir as microservices. By setting the `-target` CLI flag, all Grafana Mimir components share the same configuration file, but you can make them behave as a given component by specifying a `-target` command-line value, such as `-target=ingester` or `-target=querier`.
 
-## Validating configurations
+## Validate a configuration
 
-You can validate your configuration file by running the `mimir -modules true -config.file <path-to-config-file>` command. 
-This can be useful to validate the configuration in a CI environment before deploying it.
-- If the configuration file is valid, the command will exit with a zero exit code and will print the available modules. 
-- If the configuration file is invalid, the command will exit with a non-zero exit code and print the error message to the standard output.
+To validate your configuration, run the command `mimir -modules true -config.file <path-to-config-file>`.
+This is useful if you want to validate the configuration in a CI environment before deploying it.
+- If the configuration file is valid, the command exits with a zero exit code and prints the available modules. 
+- If the configuration file is invalid, the command exits with a non-zero exit code and prints the error message to standard output.

--- a/docs/sources/mimir/operators-guide/configure/about-configurations.md
+++ b/docs/sources/mimir/operators-guide/configure/about-configurations.md
@@ -59,3 +59,10 @@ There is no harm in passing a configuration that is specific to one component (s
 If you need to, you can use advanced CLI flags to override specific values on a particular Grafana Mimir component or replica. This can be helpful if you want to change a parameter that is specific to a certain component, without having to do a full restart of all other components.
 
 The most common use case for CLI flags is to use the `-target` flag to run Grafana Mimir as microservices. By setting the `-target` CLI flag, all Grafana Mimir components share the same configuration file, but you can make them behave as a given component by specifying a `-target` command-line value, such as `-target=ingester` or `-target=querier`.
+
+## Validating configurations
+
+You can validate your configuration file by running the `mimir -modules true -config.file <path-to-config-file>` command. 
+This can be useful to validate the configuration in a CI environment before deploying it.
+- If the configuration file is valid, the command will exit with a zero exit code and will print the available modules. 
+- If the configuration file is invalid, the command will exit with a non-zero exit code and print the error message to the standard output.


### PR DESCRIPTION
#### What this PR does

Document that running `mimir -modules=true -config.file <file>` can be used to validate a configuration.

#### Which issue(s) this PR fixes or relates to

Fixes #2588

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
