### PR TITLE
Update memcached image to 1.6.17-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 * [ENHANCEMENT] Alertmanager: Add new additional template function `tenantID` returning id of the tenant owning the alert. #3758
 * [ENHANCEMENT] Reduce overhead of debug logging when filtered out. #3875
 * [ENHANCEMENT] Update Docker base images from `alpine:3.16.2` to `alpine:3.17.1`. #3898
-* [ENHANCEMENT] Update memcached image from `memcached:1.6.16-alpine` to `memcached:1.6.17-alpine`. #3914
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
@@ -63,6 +62,7 @@
 * [CHANGE] Changed default `mimir_backend_data_disk_size` from `100Gi` to `250Gi`. #3894
 * [ENHANCEMENT] Update `rollout-operator` to `v0.2.0`. #3624
 * [ENHANCEMENT] Add `user_24M` and `user_32M` classes to operations config. #3367
+* [ENHANCEMENT] Update memcached image from `memcached:1.6.16-alpine` to `memcached:1.6.17-alpine`. #3914
 * [BUGFIX] Apply ingesters and store-gateways per-zone CLI flags overrides to read-write deployment mode too. #3766
 * [BUGFIX] Apply overrides-exporter CLI flags to mimir-backend when running Mimir in read-write deployment mode. #3790
 * [BUGFIX] Fixed `mimir-write` and `mimir-read` Kubernetes service to correctly balance requests among pods. #3855 #3864 #3906

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Alertmanager: Add new additional template function `tenantID` returning id of the tenant owning the alert. #3758
 * [ENHANCEMENT] Reduce overhead of debug logging when filtered out. #3875
 * [ENHANCEMENT] Update Docker base images from `alpine:3.16.2` to `alpine:3.17.1`. #3898
+* [ENHANCEMENT] Update memcached image from `memcached:1.6.16-alpine` to `memcached:1.6.17-alpine`. #3914
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -214,7 +214,7 @@ std.manifestYamlDoc({
 
   memcached:: {
     memcached: {
-      image: 'memcached:1.6.16-alpine',
+      image: 'memcached:1.6.17-alpine',
     },
   },
 

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -198,7 +198,7 @@
       - "16686:16686"
       - "14268"
   "memcached":
-    "image": "memcached:1.6.16-alpine"
+    "image": "memcached:1.6.17-alpine"
   "minio":
     "command":
       - "server"

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -68,7 +68,7 @@ std.manifestYamlDoc({
 
   memcached:: {
     memcached: {
-      image: 'memcached:1.6',
+      image: 'memcached:1.6.17-alpine',
     },
   },
 

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -9,7 +9,7 @@
     "volumes":
       - "./config:/etc/agent-config"
   "memcached":
-    "image": "memcached:1.6"
+    "image": "memcached:1.6.17-alpine"
   "mimir-backend-1":
     "build":
       "context": "."

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Configured `max_total_query_length: 12000h` limit to match Mimir jsonnet-based deployment. #3879
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.2.0`. #3624
 * [ENHANCEMENT] Add ability to manage PrometheusRule for metamonitoring with Prometheus operator from the Helm chart. The alerts are disabled by default but can be enabled with `prometheusRule.mimirAlerts` set to `true`. To enable the default rules, set `mimirRules` to `true`. #2134 #2609
+* [ENHANCEMENT] Update memcached image to `memcached:1.6.17-alpine`. #3914
 * [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary
 * [BUGFIX] Fixed gateway's checksum/config when using nginx #3780
 * [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1555,7 +1555,7 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.6.16-alpine
+    tag: 1.6.17-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
 

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.16-alpine
+          image: memcached:1.6.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1395,7 +1395,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1448,7 +1448,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1501,7 +1501,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1554,7 +1554,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1445,7 +1445,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1498,7 +1498,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1551,7 +1551,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1604,7 +1604,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1882,7 +1882,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1935,7 +1935,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1988,7 +1988,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2041,7 +2041,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1335,7 +1335,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1388,7 +1388,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1441,7 +1441,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1494,7 +1494,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -857,7 +857,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -910,7 +910,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -963,7 +963,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1016,7 +1016,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1934,7 +1934,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1987,7 +1987,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2040,7 +2040,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2093,7 +2093,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -1091,7 +1091,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1144,7 +1144,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1197,7 +1197,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1250,7 +1250,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1138,7 +1138,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1191,7 +1191,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1244,7 +1244,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1297,7 +1297,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1180,7 +1180,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1233,7 +1233,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1286,7 +1286,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1339,7 +1339,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1090,7 +1090,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1143,7 +1143,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1196,7 +1196,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1249,7 +1249,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1096,7 +1096,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1149,7 +1149,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1202,7 +1202,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1255,7 +1255,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1102,7 +1102,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1155,7 +1155,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1208,7 +1208,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1261,7 +1261,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1096,7 +1096,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1149,7 +1149,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1202,7 +1202,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1255,7 +1255,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1445,7 +1445,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1498,7 +1498,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1551,7 +1551,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1604,7 +1604,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1529,7 +1529,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1582,7 +1582,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1635,7 +1635,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1688,7 +1688,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1529,7 +1529,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1582,7 +1582,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1635,7 +1635,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1688,7 +1688,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1529,7 +1529,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1582,7 +1582,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1635,7 +1635,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1688,7 +1688,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1529,7 +1529,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1582,7 +1582,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1635,7 +1635,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1688,7 +1688,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1093,7 +1093,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1146,7 +1146,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1199,7 +1199,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1252,7 +1252,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1090,7 +1090,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1143,7 +1143,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1196,7 +1196,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1249,7 +1249,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1547,7 +1547,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1600,7 +1600,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1653,7 +1653,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1706,7 +1706,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1718,7 +1718,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1771,7 +1771,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1824,7 +1824,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1877,7 +1877,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1455,7 +1455,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1508,7 +1508,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1561,7 +1561,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1614,7 +1614,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1459,7 +1459,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1512,7 +1512,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1565,7 +1565,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1618,7 +1618,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1124,7 +1124,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1177,7 +1177,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1230,7 +1230,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1283,7 +1283,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1109,7 +1109,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1162,7 +1162,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1215,7 +1215,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1268,7 +1268,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1095,7 +1095,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1201,7 +1201,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1254,7 +1254,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -585,7 +585,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -638,7 +638,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -691,7 +691,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -744,7 +744,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -586,7 +586,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -639,7 +639,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -692,7 +692,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -745,7 +745,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1398,7 +1398,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1451,7 +1451,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1504,7 +1504,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1557,7 +1557,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1397,7 +1397,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1450,7 +1450,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1503,7 +1503,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1556,7 +1556,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1099,7 +1099,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1152,7 +1152,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1205,7 +1205,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1258,7 +1258,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1100,7 +1100,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1153,7 +1153,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1206,7 +1206,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1259,7 +1259,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1100,7 +1100,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1153,7 +1153,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1206,7 +1206,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1259,7 +1259,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1090,7 +1090,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1143,7 +1143,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1196,7 +1196,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1249,7 +1249,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1095,7 +1095,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1201,7 +1201,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1254,7 +1254,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -754,7 +754,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -807,7 +807,7 @@ spec:
         - -I 5m
         - -c 1024
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -860,7 +860,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -913,7 +913,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.16-alpine
+        image: memcached:1.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.16-alpine',
+    memcached: 'memcached:1.6.17-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.


### PR DESCRIPTION
#### What this PR does
Updates memcached from `memcached:1.6.16-alpine` to `memcached:1.6.17-alpine`.

Two files in `development/mimir-read-write-mode/` were using `memcached:1.6` so I updated those as well for consistency.

[1.6.17 release notes](https://github.com/memcached/memcached/wiki/ReleaseNotes1617)
As I was looking into the changes, there was even a Grafana Labs sighting in the [mailing list](https://groups.google.com/g/memcached/c/h-m9S7wODBs/m/uLeDUm4XBQAJ)!

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
