### PR TITLE
Ensure that ingesters use properly sized disks for capped-small.yaml

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -37,7 +37,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781
 * [BUGFIX] Expose OTLP ingestion in the `gateway` NGINX configuration. #3851
 * [BUGFIX] Use alertmanager headless service in `gateway` NGINX configuration. #3851
-* [BUGFIX] Use `50Gi` persistent volume for ingesters in `capped-small.yaml`. #TBD
+* [BUGFIX] Use `50Gi` persistent volume for ingesters in `capped-small.yaml`. #3919
 
 ## 4.0.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -37,6 +37,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781
 * [BUGFIX] Expose OTLP ingestion in the `gateway` NGINX configuration. #3851
 * [BUGFIX] Use alertmanager headless service in `gateway` NGINX configuration. #3851
+* [BUGFIX] Use `50Gi` persistent volume for ingesters in `capped-small.yaml`. #TBD
 
 ## 4.0.0
 

--- a/operations/helm/charts/mimir-distributed/capped-small.yaml
+++ b/operations/helm/charts/mimir-distributed/capped-small.yaml
@@ -60,7 +60,7 @@ distributor:
 
 ingester:
   persistentVolume:
-    size: 15Gi
+    size: 50Gi
   replicas: 3
   resources:
     limits:


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Each individual ingester should use the same size disk, regardless of which values file is being used.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
