### PR TITLE
ingester: Add `/ingester/tsdb_metrics` endpoint for returning tenant-specific TSDB metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] Alertmanager: Add additional template function `grafanaExploreURL` returning URL to grafana explore with range query. #3849
 * [ENHANCEMENT] Reduce overhead of debug logging when filtered out. #3875
 * [ENHANCEMENT] Update Docker base images from `alpine:3.16.2` to `alpine:3.17.1`. #3898
+* [ENHANCEMENT] Ingester: Add new `/ingester/tsdb_metrics` endpoint to return tenant-specific TSDB metrics. #3923
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675

--- a/docs/sources/mimir/operators-guide/reference-http-api/index.md
+++ b/docs/sources/mimir/operators-guide/reference-http-api/index.md
@@ -352,6 +352,18 @@ This endpoint unregisters the ingester from the ring even if you disable `-inges
 
 This API endpoint is usually used by scale down automations.
 
+### TSDB Metrics
+
+```
+GET /ingester/tsdb_metrics
+```
+
+This endpoint returns low-level metrics exposed by per-tenant TSDB. This can be useful for troubleshooting.
+Difference from `/metrics` is that metrics returned in `/metrics` are aggregated across all open TSDBs, while this
+endpoint returns TSDB metrics only for specific tenant.
+
+Requires [authentication](#authentication), authenticated tenant is one whose TSDB metrics are returned.
+
 ### Ingesters ring status
 
 ```

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -272,7 +272,7 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 	a.RegisterRoute("/ingester/flush", http.HandlerFunc(i.FlushHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/shutdown", http.HandlerFunc(i.ShutdownHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, i.PushWithCleanup), true, false, "POST") // For testing and debugging.
-	a.RegisterRoute("/ingester/tsdb_metrics", http.HandlerFunc(i.UserRegistryHandler), false, false, "GET")
+	a.RegisterRoute("/ingester/tsdb_metrics", http.HandlerFunc(i.UserRegistryHandler), true, false, "GET")
 }
 
 // RegisterRuler registers routes associated with the Ruler service.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -272,7 +272,7 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 	a.RegisterRoute("/ingester/flush", http.HandlerFunc(i.FlushHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/shutdown", http.HandlerFunc(i.ShutdownHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, i.PushWithCleanup), true, false, "POST") // For testing and debugging.
-	a.RegisterRoute("/ingester/tsdb_metrics", http.HandlerFunc(i.UserRegistryHandler), true, false, "GET")
+	a.RegisterRoute("/ingester/tsdb_metrics", http.HandlerFunc(i.UserRegistryHandler), true, true, "GET")
 }
 
 // RegisterRuler registers routes associated with the Ruler service.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -257,6 +257,7 @@ type Ingester interface {
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)
 	PushWithCleanup(context.Context, *push.Request) (*mimirpb.WriteResponse, error)
+	UserRegistryHandler(http.ResponseWriter, *http.Request)
 }
 
 // RegisterIngester registers the ingesters HTTP and GRPC service
@@ -271,6 +272,7 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 	a.RegisterRoute("/ingester/flush", http.HandlerFunc(i.FlushHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/shutdown", http.HandlerFunc(i.ShutdownHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, i.PushWithCleanup), true, false, "POST") // For testing and debugging.
+	a.RegisterRoute("/ingester/tsdb_metrics", http.HandlerFunc(i.UserRegistryHandler), false, false, "GET")
 }
 
 // RegisterRuler registers routes associated with the Ruler service.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2498,7 +2498,8 @@ func (i *Ingester) UserRegistryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	promhttp.HandlerFor(reg, promhttp.HandlerOpts{
-		ErrorHandling: promhttp.HTTPErrorOnError,
-		Timeout:       10 * time.Second,
+		DisableCompression: true,
+		ErrorHandling:      promhttp.HTTPErrorOnError,
+		Timeout:            10 * time.Second,
 	}).ServeHTTP(w, r)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
 	promcfg "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -2481,4 +2482,23 @@ func allOutOfBounds(samples []mimirpb.Sample, minValidTime int64) bool {
 		}
 	}
 	return true
+}
+
+func (i *Ingester) UserRegistryHandler(w http.ResponseWriter, r *http.Request) {
+	userID, err := tenant.TenantID(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	reg := i.tsdbMetrics.regs.GetRegistryForUser(userID)
+	if reg == nil {
+		http.Error(w, "user registry not found", http.StatusNotFound)
+		return
+	}
+
+	promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+		Timeout:       10 * time.Second,
+	}).ServeHTTP(w, r)
 }

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -149,6 +149,15 @@ func (i *ActivityTrackerWrapper) ShutdownHandler(w http.ResponseWriter, r *http.
 	i.ing.ShutdownHandler(w, r)
 }
 
+func (i *ActivityTrackerWrapper) UserRegistryHandler(writer http.ResponseWriter, request *http.Request) {
+	ix := i.tracker.Insert(func() string {
+		return requestActivity(request.Context(), "Ingester/UserRegistryHandler", nil)
+	})
+	defer i.tracker.Delete(ix)
+
+	i.ing.UserRegistryHandler(writer, request)
+}
+
 func requestActivity(ctx context.Context, name string, req interface{}) string {
 	userID, _ := tenant.TenantID(ctx)
 	traceID, _ := tracing.ExtractSampledTraceID(ctx)

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -675,6 +675,25 @@ func (r *UserRegistries) Registries() []UserRegistry {
 	return out
 }
 
+// GetRegistryForUser returns currently active registry for given user, or nil, if there is no such registry.
+func (r *UserRegistries) GetRegistryForUser(user string) *prometheus.Registry {
+	r.regsMu.Lock()
+	defer r.regsMu.Unlock()
+
+	for idx := 0; idx < len(r.regs); idx++ {
+		if user != r.regs[idx].user {
+			continue
+		}
+
+		if r.regs[idx].reg == nil {
+			continue
+		}
+
+		return r.regs[idx].reg
+	}
+	return nil
+}
+
 func (r *UserRegistries) BuildMetricFamiliesPerUser() MetricFamiliesPerUser {
 	data := MetricFamiliesPerUser{}
 	for _, entry := range r.Registries() {

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -685,10 +685,6 @@ func (r *UserRegistries) GetRegistryForUser(user string) *prometheus.Registry {
 			continue
 		}
 
-		if r.regs[idx].reg == nil {
-			continue
-		}
-
 		return r.regs[idx].reg
 	}
 	return nil


### PR DESCRIPTION
#### What this PR does
This PR adds `/ingester/tsdb_metrics` endpoint to ingester for returning tenant-specific TSDB metrics. This is not intended for generic metrics scraping, but can be used as a troubleshooting tool.

#### Checklist

- [na] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
