### PR TITLE
Store gateway spends most of the time waiting to load series and chun…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [BUGFIX] Store-gateway: fix `cortex_bucket_store_partitioner_requested_bytes_total` metric to not double count overlapping ranges. #3769
 * [BUGFIX] Update `github.com/thanos-io/objstore` to address issue with Multipart PUT on s3-compatible Object Storage. #3802 #3821
 * [BUGFIX] Distributor, Query-scheduler: Make sure ring metrics include a `cortex_` prefix as expected by dashboards. #3809
-* [BUGFIX] Querier: canceled requests are no longer reported as "consistency check" failures. #3837
+* [BUGFIX] Querier: canceled requests are no longer reported as "consistency check" failures. #3837 #3927
 * [BUGFIX] Distributor: don't panic when `metric_relabel_configs` in overrides contains null element. #3868
 
 ### Mixin

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -743,6 +743,10 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 					break
 				}
 				if err != nil {
+					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+						return err
+					}
+
 					level.Warn(spanLog).Log("msg", "failed to receive series", "remote", c.RemoteAddress(), "err", err)
 					return nil
 				}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2016,10 +2016,9 @@ func (m *cancelerStoreGatewayClientMock) Series(ctx context.Context, in *storepb
 			cancel: m.cancel,
 		}
 		return series, nil
-	} else {
-		m.cancel()
-		return nil, ctx.Err()
 	}
+	m.cancel()
+	return nil, ctx.Err()
 }
 
 func (m *cancelerStoreGatewayClientMock) LabelNames(ctx context.Context, _ *storepb.LabelNamesRequest, _ ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {


### PR DESCRIPTION
#### What this PR does
Store gateway spends most of the time waiting to load series and chunks. During that waiting time, a context.Canceled error might occur. The latter must not be handled as a consistency check, but should be propagated as context.Canceled.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
