### PR TITLE
Adapt tsdb-index-health for native histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@
 
 ### Tools
 
+* [ENHANCEMENT] Adapt tsdb-index-health for blocks containing native histograms. #3948
+
 ## 2.5.0
 
 ### Grafana Mimir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adapts the tsdb-index-health tool for blocks containing native histograms.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/3947

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
