### PR TITLE
Enable adding dynamic manifests to the Mimir helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/extra-manifests.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3351,3 +3351,6 @@ continuous_test:
 
   tolerations: []
   terminationGracePeriodSeconds: 30
+
+# -- Add dynamic manifests via values:
+extraObjects: []

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3352,5 +3352,12 @@ continuous_test:
   tolerations: []
   terminationGracePeriodSeconds: 30
 
-# -- Add dynamic manifests via values:
+# -- Add dynamic manifests via values. Example:
+# extraObjects:
+# - kind: ConfigMap
+#   apiVersion: v1
+#   metadata:
+#     name: extra-cm-{{ .Release.Name }}
+#   data: |
+#     extra.yml: "does-my-install-need-extra-info: true"
 extraObjects: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Enable adding extra K8s manifests to the Mimir helm chart, similar to other Grafana helm charts ([example](https://github.com/grafana/helm-charts/blob/4b1c01f01da904528d282164aafca71062f7cf38/charts/grafana/templates/extra-manifests.yaml)).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
