### PR TITLE
Add per tenant limit whether to accept native histograms or not

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2794,17 +2794,6 @@
           "fieldFlag": "ingester.ignore-series-limit-for-metric-names",
           "fieldType": "string",
           "fieldCategory": "advanced"
-        },
-        {
-          "kind": "field",
-          "name": "native_histograms_enabled",
-          "required": false,
-          "desc": "Enable native histograms from prometheus.",
-          "fieldValue": null,
-          "fieldDefaultValue": false,
-          "fieldFlag": "ingester.native-histograms-enabled",
-          "fieldType": "boolean",
-          "fieldCategory": "advanced"
         }
       ],
       "fieldValue": null,
@@ -3061,6 +3050,17 @@
           "fieldDefaultValue": 0,
           "fieldFlag": "ingester.max-global-exemplars-per-user",
           "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "accept_native_histograms",
+          "required": false,
+          "desc": "Flag to enable the ingestion of native histogram samples.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.accept-native-histograms",
+          "fieldType": "boolean",
           "fieldCategory": "experimental"
         },
         {

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -977,6 +977,8 @@ Usage of ./cmd/mimir/mimir:
     	HTTP URL path under which the Alertmanager ui and api will be served. (default "/alertmanager")
   -http.prometheus-http-prefix string
     	HTTP URL path under which the Prometheus api will be served. (default "/prometheus")
+  -ingester.accept-native-histograms
+    	[experimental] Flag to enable the ingestion of native histogram samples.
   -ingester.active-series-custom-trackers value
     	Additional active series metrics, matching the provided matchers. Matchers should be in form <name>:<matcher>, like 'foobar:{foo="bar"}'. Multiple matchers can be provided either providing the flag multiple times or providing multiple semicolon-separated values to a single flag.
   -ingester.active-series-metrics-enabled
@@ -1041,8 +1043,6 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable. (default 150000)
   -ingester.metadata-retain-period duration
     	Period at which metadata we have not seen will remain in memory before being deleted. (default 10m0s)
-  -ingester.native-histograms-enabled
-    	Enable native histograms from prometheus.
   -ingester.out-of-order-time-window duration
     	[experimental] Non-zero value enables out-of-order support for most recent samples that are within the time window in relation to the TSDB's maximum time, i.e., within [db.maxTime-timeWindow, db.maxTime]). The ingester will need more memory as a factor of rate of out-of-order samples being ingested and the number of series that are getting out-of-order samples. A lower TTL of 10 minutes will be set for the query cache entries that overlap with this window.
   -ingester.rate-update-period duration

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -928,10 +928,6 @@ instance_limits:
 # the -ingester.max-global-series-per-user limit.
 # CLI flag: -ingester.ignore-series-limit-for-metric-names
 [ignore_series_limit_for_metric_names: <string> | default = ""]
-
-# (advanced) Enable native histograms from prometheus.
-# CLI flag: -ingester.native-histograms-enabled
-[native_histograms_enabled: <boolean> | default = false]
 ```
 
 ### querier
@@ -2540,6 +2536,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # 0 to disable exemplars ingestion.
 # CLI flag: -ingester.max-global-exemplars-per-user
 [max_global_exemplars_per_user: <int> | default = 0]
+
+# (experimental) Flag to enable the ingestion of native histogram samples.
+# CLI flag: -ingester.accept-native-histograms
+[accept_native_histograms: <boolean> | default = false]
 
 # (advanced) Additional custom trackers for active metrics. If there are active
 # series matching a provided matcher (map value), the count will be exposed in

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,10 +7,10 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.0.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.native-histograms-enabled": ""}),
-	"grafana/mimir:2.1.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.native-histograms-enabled": ""}),
-	"grafana/mimir:2.2.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.native-histograms-enabled": ""}),
-	"grafana/mimir:2.3.1": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.native-histograms-enabled": ""}),
-	"grafana/mimir:2.4.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.native-histograms-enabled": ""}),
-	"grafana/mimir:2.5.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.native-histograms-enabled": ""}),
+	"grafana/mimir:2.0.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.accept-native-histograms": ""}),
+	"grafana/mimir:2.1.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.accept-native-histograms": ""}),
+	"grafana/mimir:2.2.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.accept-native-histograms": ""}),
+	"grafana/mimir:2.3.1": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false", "-ingester.accept-native-histograms": ""}),
+	"grafana/mimir:2.4.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.accept-native-histograms": ""}),
+	"grafana/mimir:2.5.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.accept-native-histograms": ""}),
 }

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -143,7 +143,7 @@ func NewIngester(name string, consulAddress string, flags map[string]string, opt
 			// Speed up the startup.
 			"-ingester.ring.min-ready-duration": "0s",
 			// Enable native histograms
-			"-ingester.native-histograms-enabled": "true",
+			"-ingester.accept-native-histograms": "true",
 		},
 		flags,
 		options...,
@@ -209,7 +209,7 @@ func NewSingleBinary(name string, flags map[string]string, options ...Option) *M
 			// Speed up the startup.
 			"-ingester.ring.min-ready-duration": "0s",
 			// Enable native histograms
-			"-ingester.native-histograms-enabled": "true",
+			"-ingester.accept-native-histograms": "true",
 		},
 		flags,
 		options...,
@@ -239,7 +239,7 @@ func NewWriteInstance(name string, flags map[string]string, options ...Option) *
 			// Speed up startup.
 			"-ingester.ring.min-ready-duration": "0s",
 			// Enable native histograms
-			"-ingester.native-histograms-enabled": "true",
+			"-ingester.accept-native-histograms": "true",
 		},
 		flags,
 		options...,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2034,7 +2034,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 			b.ResetTimer()
 
 			for n := 0; n < b.N; n++ {
-				_, err := distributor.Push(ctx, mimirpb.ToWriteRequest(metrics, samples, nil, nil, mimirpb.API))
+				_, err := distributor.Push(ctx, mimirpb.ToWriteRequest(metrics, samples, nil, nil, nil, mimirpb.API))
 
 				if testData.expectedErr == "" && err != nil {
 					b.Fatalf("no error expected but got %v", err)
@@ -3550,7 +3550,7 @@ func mockWriteRequest(lbls labels.Labels, value float64, timestampMs int64) *mim
 		},
 	}
 
-	return mimirpb.ToWriteRequest([]labels.Labels{lbls}, samples, nil, nil, mimirpb.API)
+	return mimirpb.ToWriteRequest([]labels.Labels{lbls}, samples, nil, nil, nil, mimirpb.API)
 }
 
 type prepConfig struct {
@@ -4618,7 +4618,7 @@ func TestDistributorValidation(t *testing.T) {
 				limits:          &limits,
 			})
 
-			_, err := ds[0].Push(ctx, mimirpb.ToWriteRequest(tc.labels, tc.samples, tc.exemplars, tc.metadata, mimirpb.API))
+			_, err := ds[0].Push(ctx, mimirpb.ToWriteRequest(tc.labels, tc.samples, nil, tc.exemplars, tc.metadata, mimirpb.API))
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -74,7 +74,7 @@ func (a *PusherAppender) Commit() error {
 
 	// Since a.pusher is distributor, client.ReuseSlice will be called in a.pusher.Push.
 	// We shouldn't call client.ReuseSlice here.
-	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), mimirpb.ToWriteRequest(a.labels, a.samples, nil, nil, mimirpb.RULE))
+	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), mimirpb.ToWriteRequest(a.labels, a.samples, nil, nil, nil, mimirpb.RULE))
 
 	if err != nil {
 		// Don't report errors that ended with 4xx HTTP status code (series limits, duplicate samples, out of order, etc.)


### PR DESCRIPTION
#### What this PR does

Do not reject non histogram samples, rather just silently ignore histograms and increase the failed histograms counter. Remove previous global configuration.
Add unit tests to ingester_test to test silent ignore and also query of histograms.
Fix a bug in ruler/compat.go - slide index panic.

#### Which issue(s) this PR fixes or relates to

Fixes #3958 

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
