### PR TITLE
Make ephemeral storage queryable

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2706,7 +2706,8 @@ func findStorageLabelMatcher(matchers []*labels.Matcher) (string, int, error) {
 	return resultVal, resultIdx, nil
 }
 
-// removeStorageMatcher returns the value of storage label (or empty string, if not found), and input matchers without the storage label matcher.
+// removeStorageMatcher returns the value of storage label (or empty string, if not found),
+// and input matchers without the storage label matcher. When removing storage label matcher, original slice is reused.
 func removeStorageMatcher(matchers []*labels.Matcher) (val string, filtered []*labels.Matcher, _ error) {
 	val, idx, err := findStorageLabelMatcher(matchers)
 	if err != nil {
@@ -2716,10 +2717,8 @@ func removeStorageMatcher(matchers []*labels.Matcher) (val string, filtered []*l
 		return "", matchers, nil
 	}
 
-	// Create a new slice with the shard matcher removed.
-	filtered = make([]*labels.Matcher, 0, len(matchers)-1)
-	filtered = append(filtered, matchers[:idx]...)
-	filtered = append(filtered, matchers[idx+1:]...)
-
+	// Prepare slice without storage matcher.
+	copy(matchers[idx:], matchers[idx+1:])
+	filtered = matchers[:len(matchers)-1]
 	return val, filtered, nil
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -109,7 +109,7 @@ const (
 	ephemeralPrometheusMetricsPrefix = "ephemeral_"
 
 	// Label name used to select queried storage type.
-	StorageLabelName            = "__storage__"
+	StorageLabelName            = "__mimir_storage__"
 	EphemeralStorageLabelValue  = "ephemeral"
 	PersistentStorageLabelValue = "persistent"
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6155,7 +6155,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
 					cortex_ingester_memory_ephemeral_users 1
 
-					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
 					# TYPE cortex_ingester_queried_ephemeral_samples histogram
 					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
 					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
@@ -6234,7 +6234,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
 					cortex_ingester_memory_ephemeral_users 1
 
-					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
 					# TYPE cortex_ingester_queried_ephemeral_samples histogram
 					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
 					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
@@ -6324,7 +6324,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
 					cortex_ingester_memory_ephemeral_users 1
 
-					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
 					# TYPE cortex_ingester_queried_ephemeral_samples histogram
 					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
 					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
@@ -6502,7 +6502,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
 					cortex_ingester_memory_ephemeral_users 1
 
-					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
 					# TYPE cortex_ingester_queried_ephemeral_samples histogram
 					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
 					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
@@ -6569,7 +6569,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
 					cortex_ingester_memory_ephemeral_users 0
 
-					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
 					# TYPE cortex_ingester_queried_ephemeral_samples histogram
 					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
 					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6768,7 +6768,7 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 	require.Equal(t, err, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(req.EphemeralTimeseries[0].Samples[0].TimestampMs), metricLabels), userID).Error()))
 }
 
-func TestIngesterQueryingWithStorageLabel(t *testing.T) {
+func TestIngesterQueryingWithStorageLabelErrorHandling(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 
 	// Create ingester

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6097,7 +6097,6 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 	tests := map[string]struct {
 		reqs                       []*mimirpb.WriteRequest
 		additionalMetrics          []string
-		disableQueryingEphemeral   bool
 		expectedIngestedEphemeral  model.Matrix
 		expectedIngestedPersistent model.Matrix
 		expectedErr                error
@@ -6544,8 +6543,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					nil,
 					mimirpb.API),
 			},
-			disableQueryingEphemeral: true,
-			expectedErr:              nil,
+			expectedErr: nil,
 			expectedIngestedPersistent: model.Matrix{
 				&model.SampleStream{
 					Metric: metricLabelSet,
@@ -6573,33 +6571,33 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
 					# TYPE cortex_ingester_queried_ephemeral_samples histogram
-					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="640"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="5120"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="40960"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="327680"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="2.62144e+06"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="2.097152e+07"} 0
-					cortex_ingester_queried_ephemeral_samples_bucket{le="+Inf"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="640"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="5120"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="40960"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="327680"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.62144e+06"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.097152e+07"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="+Inf"} 1
 					cortex_ingester_queried_ephemeral_samples_sum 0
-					cortex_ingester_queried_ephemeral_samples_count 0
+					cortex_ingester_queried_ephemeral_samples_count 1
 
 					# HELP cortex_ingester_queried_ephemeral_series The total number of ephemeral series returned from queries.
 					# TYPE cortex_ingester_queried_ephemeral_series histogram
-					cortex_ingester_queried_ephemeral_series_bucket{le="10"} 0
-					cortex_ingester_queried_ephemeral_series_bucket{le="80"} 0
-					cortex_ingester_queried_ephemeral_series_bucket{le="640"} 0
-					cortex_ingester_queried_ephemeral_series_bucket{le="5120"} 0
-					cortex_ingester_queried_ephemeral_series_bucket{le="40960"} 0
-					cortex_ingester_queried_ephemeral_series_bucket{le="327680"} 0
-					cortex_ingester_queried_ephemeral_series_bucket{le="+Inf"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="10"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="80"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="640"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="5120"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="40960"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="327680"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="+Inf"} 1
 					cortex_ingester_queried_ephemeral_series_sum 0
-					cortex_ingester_queried_ephemeral_series_count 0
+					cortex_ingester_queried_ephemeral_series_count 1
 
 					# HELP cortex_ingester_queries_ephemeral_total The total number of queries the ingester has handled for ephemeral storage.
 					# TYPE cortex_ingester_queries_ephemeral_total counter
-					cortex_ingester_queries_ephemeral_total 0
+					cortex_ingester_queries_ephemeral_total 1
 			`,
 		},
 	}
@@ -6660,12 +6658,10 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			}
 
 			// Verify ephemeral samples.
-			if !testData.disableQueryingEphemeral {
-				verifyIngestedSamples(t, []*client.LabelMatcher{
-					{Type: client.REGEX_MATCH, Name: labels.MetricName, Value: ".*"},
-					{Type: client.EQUAL, Name: StorageLabelName, Value: EphemeralStorageLabelValue},
-				}, testData.expectedIngestedEphemeral)
-			}
+			verifyIngestedSamples(t, []*client.LabelMatcher{
+				{Type: client.REGEX_MATCH, Name: labels.MetricName, Value: ".*"},
+				{Type: client.EQUAL, Name: StorageLabelName, Value: EphemeralStorageLabelValue},
+			}, testData.expectedIngestedEphemeral)
 
 			// Verify persistent samples.
 			verifyIngestedSamples(t, []*client.LabelMatcher{

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6097,6 +6097,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 	tests := map[string]struct {
 		reqs                       []*mimirpb.WriteRequest
 		additionalMetrics          []string
+		disableQueryingEphemeral   bool
 		expectedIngestedEphemeral  model.Matrix
 		expectedIngestedPersistent model.Matrix
 		expectedErr                error
@@ -6533,6 +6534,74 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					cortex_ingester_queries_ephemeral_total 1
 			`,
 		},
+
+		"only persistent series -- does not initialize ephemeral storage": {
+			reqs: []*mimirpb.WriteRequest{
+				mimirpb.ToWriteRequest(
+					[]labels.Labels{metricLabels},
+					[]mimirpb.Sample{{Value: 1, TimestampMs: now.UnixMilli() - 10}},
+					nil,
+					nil,
+					mimirpb.API),
+			},
+			disableQueryingEphemeral: true,
+			expectedErr:              nil,
+			expectedIngestedPersistent: model.Matrix{
+				&model.SampleStream{
+					Metric: metricLabelSet,
+					Values: []model.SamplePair{
+						{Value: 1, Timestamp: model.Time(now.UnixMilli() - 10)},
+					},
+				},
+			},
+			expectedMetrics: `
+					# HELP cortex_ingester_memory_ephemeral_series The current number of ephemeral series in memory.
+        	        # TYPE cortex_ingester_memory_ephemeral_series gauge
+        	        cortex_ingester_memory_ephemeral_series 0
+
+					# HELP cortex_ingester_memory_series The current number of series in memory.
+        	        # TYPE cortex_ingester_memory_series gauge
+        	        cortex_ingester_memory_series 1
+
+					# HELP cortex_ingester_memory_users The current number of users in memory.
+					# TYPE cortex_ingester_memory_users gauge
+					cortex_ingester_memory_users 1
+
+					# HELP cortex_ingester_memory_ephemeral_users The current number of users with ephemeral storage in memory.
+					# TYPE cortex_ingester_memory_ephemeral_users gauge
+					cortex_ingester_memory_ephemeral_users 0
+
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned from queries.
+					# TYPE cortex_ingester_queried_ephemeral_samples histogram
+					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="640"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="5120"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="40960"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="327680"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.62144e+06"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.097152e+07"} 0
+					cortex_ingester_queried_ephemeral_samples_bucket{le="+Inf"} 0
+					cortex_ingester_queried_ephemeral_samples_sum 0
+					cortex_ingester_queried_ephemeral_samples_count 0
+
+					# HELP cortex_ingester_queried_ephemeral_series The total number of ephemeral series returned from queries.
+					# TYPE cortex_ingester_queried_ephemeral_series histogram
+					cortex_ingester_queried_ephemeral_series_bucket{le="10"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="80"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="640"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="5120"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="40960"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="327680"} 0
+					cortex_ingester_queried_ephemeral_series_bucket{le="+Inf"} 0
+					cortex_ingester_queried_ephemeral_series_sum 0
+					cortex_ingester_queried_ephemeral_series_count 0
+
+					# HELP cortex_ingester_queries_ephemeral_total The total number of queries the ingester has handled for ephemeral storage.
+					# TYPE cortex_ingester_queries_ephemeral_total counter
+					cortex_ingester_queries_ephemeral_total 0
+			`,
+		},
 	}
 
 	for testName, testData := range tests {
@@ -6591,10 +6660,12 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			}
 
 			// Verify ephemeral samples.
-			verifyIngestedSamples(t, []*client.LabelMatcher{
-				{Type: client.REGEX_MATCH, Name: labels.MetricName, Value: ".*"},
-				{Type: client.EQUAL, Name: StorageLabelName, Value: EphemeralStorageLabelValue},
-			}, testData.expectedIngestedEphemeral)
+			if !testData.disableQueryingEphemeral {
+				verifyIngestedSamples(t, []*client.LabelMatcher{
+					{Type: client.REGEX_MATCH, Name: labels.MetricName, Value: ".*"},
+					{Type: client.EQUAL, Name: StorageLabelName, Value: EphemeralStorageLabelValue},
+				}, testData.expectedIngestedEphemeral)
+			}
 
 			// Verify persistent samples.
 			verifyIngestedSamples(t, []*client.LabelMatcher{

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -170,7 +170,7 @@ func newIngesterMetrics(
 		}),
 		ephemeralQueriedSamples: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_queried_ephemeral_samples",
-			Help:    "The total number of samples from ephemeral storage returned from queries.",
+			Help:    "The total number of samples from ephemeral storage returned per query.",
 			Buckets: prometheus.ExponentialBuckets(10, 8, 8),
 		}),
 		ephemeralQueriedSeries: promauto.With(r).NewHistogram(prometheus.HistogramOpts{

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -26,10 +26,15 @@ type ingesterMetrics struct {
 	ephemeralIngestedSamples     *prometheus.CounterVec
 	ephemeralIngestedSamplesFail *prometheus.CounterVec
 
-	queries                 prometheus.Counter
-	queriedSamples          prometheus.Histogram
-	queriedExemplars        prometheus.Histogram
-	queriedSeries           prometheus.Histogram
+	queries          prometheus.Counter
+	queriedSamples   prometheus.Histogram
+	queriedExemplars prometheus.Histogram
+	queriedSeries    prometheus.Histogram
+
+	ephemeralQueries        prometheus.Counter
+	ephemeralQueriedSamples prometheus.Histogram
+	ephemeralQueriedSeries  prometheus.Histogram
+
 	memMetadata             prometheus.Gauge
 	memUsers                prometheus.Gauge
 	memEphemeralUsers       prometheus.Gauge
@@ -157,6 +162,20 @@ func newIngesterMetrics(
 			Name: "cortex_ingester_queried_series",
 			Help: "The total number of series returned from queries.",
 			// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
+			Buckets: prometheus.ExponentialBuckets(10, 8, 6),
+		}),
+		ephemeralQueries: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_queries_ephemeral_total",
+			Help: "The total number of queries the ingester has handled for ephemeral storage.",
+		}),
+		ephemeralQueriedSamples: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_queried_ephemeral_samples",
+			Help:    "The total number of samples from ephemeral storage returned from queries.",
+			Buckets: prometheus.ExponentialBuckets(10, 8, 8),
+		}),
+		ephemeralQueriedSeries: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_queried_ephemeral_series",
+			Help:    "The total number of ephemeral series returned from queries.",
 			Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 		}),
 		memMetadata: promauto.With(r).NewGauge(prometheus.GaugeOpts{

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -7,7 +7,6 @@ package ingester
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -156,7 +155,7 @@ func (u *userTSDB) Querier(ctx context.Context, mint, maxt int64, ephemeral bool
 	if ephemeral {
 		eph := u.getEphemeralStorage()
 		if eph == nil {
-			return nil, fmt.Errorf("ephemeral storage not available")
+			return storage.NoopQuerier(), nil
 		}
 
 		return tsdb.NewBlockQuerier(eph, mint, maxt)
@@ -169,7 +168,7 @@ func (u *userTSDB) ChunkQuerier(ctx context.Context, mint, maxt int64, ephemeral
 	if ephemeral {
 		eph := u.getEphemeralStorage()
 		if eph == nil {
-			return nil, fmt.Errorf("ephemeral storage not available")
+			return storage.NoopChunkedQuerier(), nil
 		}
 
 		return tsdb.NewBlockChunkQuerier(eph, mint, maxt)


### PR DESCRIPTION
#### What this PR does
This PR modifies ingester to allow querying of ephemeral storage. This is done by special label `__storage__` that ingester recognizes. It allows two values: `ephemeral` or `persistent`. If label is not in the matchers, ingester uses it as `persistent`. Any other values are rejected with error.

This PR also introduces new metrics:
* `cortex_ingester_queries_ephemeral_total` (based on existing `cortex_ingester_queries_total`)
* `cortex_ingester_queried_ephemeral_samples` (based on existing `cortex_ingester_queried_samples`)
* `cortex_ingester_queried_ephemeral_series` (based on existing `cortex_ingester_queried_series`)

#### Which issue(s) this PR fixes or relates to

This is part of https://github.com/grafana/mimir/issues/3884. Changelog entry will be added after feature is complete.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
