### PR TITLE
Add container logs link in req/s description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [ENHANCEMENT] Alerts: Added `MimirRulerInstanceHasNoRuleGroups` alert that fires when a ruler replica is not assigned any rule group to evaluate. #3723
 * [ENHANCEMENT] Support for baremetal deployment for alerts and scaling recording rules. #3719
 * [ENHANCEMENT] Dashboards: querier autoscaling now supports multiple scaled objects (configurable via `$._config.autoscale.querier.hpa_name`). #3962
+* [ENHANCEMENT] Dashboards: "Requests per second" panels in the "Read", "Write" and "Remote ruler reads" dashboards now have a link to the container logs in the description. #3964
 * [BUGFIX] Alerts: Fixed `MimirIngesterRestarts` alert when Mimir is deployed in read-write mode. #3716
 * [BUGFIX] Alerts: Fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts for when Mimir is deployed in read-write or monolithic modes and updated them to use new `thanos_shipper_last_successful_upload_time` metric. #3627
 * [BUGFIX] Alerts: Fixed `MimirMemoryMapAreasTooHigh` alert when Mimir is deployed in read-write mode. #3626

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -391,7 +391,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for query-frontend in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -642,7 +642,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for query-scheduler in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {
@@ -1011,7 +1011,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for querier in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -1517,7 +1517,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ingester in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 20,
                   "legend": {
@@ -1757,7 +1757,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for store-gateway in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 23,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -391,6 +391,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -4712,6 +4713,15 @@
                "tagsQuery": "",
                "type": "query",
                "useTags": false
+            },
+            {
+               "hide": 0,
+               "includeAll": false,
+               "label": "Logs datasource",
+               "multi": false,
+               "name": "lokidatasource",
+               "query": "loki",
+               "type": "datasource"
             }
          ]
       },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -391,7 +391,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -642,7 +642,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {
@@ -1011,7 +1011,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -1517,7 +1517,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 20,
                   "legend": {
@@ -1757,7 +1757,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 23,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -642,6 +642,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {
@@ -1010,6 +1011,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -1515,6 +1517,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 20,
                   "legend": {
@@ -1754,6 +1757,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 23,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -160,7 +160,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ruler-query-frontend in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 3,
                   "legend": {
@@ -400,7 +400,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ruler-query-scheduler in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -589,7 +589,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ruler-querier in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 8,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -160,7 +160,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 3,
                   "legend": {
@@ -400,7 +400,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -589,7 +589,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 8,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -160,6 +160,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 3,
                   "legend": {
@@ -399,6 +400,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -587,6 +589,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 8,
                   "legend": {
@@ -1149,6 +1152,15 @@
                "tagsQuery": "",
                "type": "query",
                "useTags": false
+            },
+            {
+               "hide": 0,
+               "includeAll": false,
+               "label": "Logs datasource",
+               "multi": false,
+               "name": "lokidatasource",
+               "query": "loki",
+               "type": "datasource"
             }
          ]
       },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -466,7 +466,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for distributor in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 7,
                   "legend": {
@@ -1068,7 +1068,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ingester in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -466,7 +466,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 7,
                   "legend": {
@@ -1068,7 +1068,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -466,6 +466,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 7,
                   "legend": {
@@ -1067,6 +1068,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -2979,6 +2981,15 @@
                "tagsQuery": "",
                "type": "query",
                "useTags": false
+            },
+            {
+               "hide": 0,
+               "includeAll": false,
+               "label": "Logs datasource",
+               "multi": false,
+               "name": "lokidatasource",
+               "query": "loki",
+               "type": "datasource"
             }
          ]
       },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -391,7 +391,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for query-frontend in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -642,7 +642,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for query-scheduler in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {
@@ -1011,7 +1011,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for querier in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -1517,7 +1517,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ingester in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 20,
                   "legend": {
@@ -1757,7 +1757,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for store-gateway in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 23,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -391,6 +391,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -4712,6 +4713,15 @@
                "tagsQuery": "",
                "type": "query",
                "useTags": false
+            },
+            {
+               "hide": 0,
+               "includeAll": false,
+               "label": "Logs datasource",
+               "multi": false,
+               "name": "lokidatasource",
+               "query": "loki",
+               "type": "datasource"
             }
          ]
       },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -391,7 +391,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -642,7 +642,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {
@@ -1011,7 +1011,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -1517,7 +1517,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 20,
                   "legend": {
@@ -1757,7 +1757,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 23,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -642,6 +642,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22query%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {
@@ -1010,6 +1011,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22querier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -1515,6 +1517,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 20,
                   "legend": {
@@ -1754,6 +1757,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22store%2Dgateway%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 23,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -160,7 +160,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ruler-query-frontend in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 3,
                   "legend": {
@@ -400,7 +400,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ruler-query-scheduler in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -589,7 +589,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ruler-querier in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 8,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -160,7 +160,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 3,
                   "legend": {
@@ -400,7 +400,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -589,7 +589,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 8,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -160,6 +160,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dfrontend%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 3,
                   "legend": {
@@ -399,6 +400,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquery%2Dscheduler%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 6,
                   "legend": {
@@ -587,6 +589,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ruler%2Dquerier%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 8,
                   "legend": {
@@ -1149,6 +1152,15 @@
                "tagsQuery": "",
                "type": "query",
                "useTags": false
+            },
+            {
+               "hide": 0,
+               "includeAll": false,
+               "label": "Logs datasource",
+               "multi": false,
+               "name": "lokidatasource",
+               "query": "loki",
+               "type": "datasource"
             }
          ]
       },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -466,7 +466,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for distributor in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 7,
                   "legend": {
@@ -1068,7 +1068,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for ingester in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -466,7 +466,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 7,
                   "legend": {
@@ -1068,7 +1068,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](../../explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -466,6 +466,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22distributor%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 7,
                   "legend": {
@@ -1067,6 +1068,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\n[Explore logs for in ${lokidatasource}](/explore?left=%7B%0A%22datasource%22%3A%20%22${lokidatasource}%22%2C%0A%22queries%22%3A%20%5B%0A%7B%0A%22datasource%22%3A%20%7B%0A%22type%22%3A%20%22loki%22%2C%0A%22uid%22%3A%20%22${lokidatasource}%22%0A%7D%2C%0A%22editorMode%22%3A%20%22code%22%2C%0A%22expr%22%3A%20%22%7Bnamespace%3D%5C%22${namespace}%5C%22%2C%20container%3D%7E%5C%22ingester%5C%22%7D%22%2C%0A%22queryType%22%3A%20%22range%22%2C%0A%22refId%22%3A%20%22A%22%0A%7D%0A%5D%2C%0A%22range%22%3A%20%7B%0A%22from%22%3A%20%22now%2D1h%22%2C%0A%22to%22%3A%20%22now%22%0A%7D%0A%7D)\n\n",
                   "fill": 10,
                   "id": 14,
                   "legend": {
@@ -2979,6 +2981,15 @@
                "tagsQuery": "",
                "type": "query",
                "useTags": false
+            },
+            {
+               "hide": 0,
+               "includeAll": false,
+               "label": "Logs datasource",
+               "multi": false,
+               "name": "lokidatasource",
+               "query": "loki",
+               "type": "datasource"
             }
          ]
       },

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -6,9 +6,6 @@
     // The product name used when building dashboards.
     product: 'Mimir',
 
-    // The path on the server where Grafana is running (should end with a slash).
-    grafana_root_path: '/',
-
     // The prefix including product name used when building dashboards.
     dashboard_prefix: '%(product)s / ' % $._config.product,
     // Controls tooltip and hover highlight behavior across different panels

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -6,6 +6,9 @@
     // The product name used when building dashboards.
     product: 'Mimir',
 
+    // The path on the server where Grafana is running (should end with a slash).
+    grafana_root_path: '/',
+
     // The prefix including product name used when building dashboards.
     dashboard_prefix: '%(product)s / ' % $._config.product,
     // Controls tooltip and hover highlight behavior across different panels

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -907,7 +907,7 @@ local url = import 'xtd/url.libsonnet';
     };
 
     |||
-      [Explore logs for in ${lokidatasource}](%(link)s)
+      [Explore logs for %(container)s in ${lokidatasource}](%(link)s)
     ||| % {
       container: container,
       link: link,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -902,8 +902,7 @@ local url = import 'xtd/url.libsonnet';
     // We don't want to encode the ${...} vars, since they will be rendered by Grafana.
     local encodedExploreManifestWithVars = std.strReplace(std.strReplace(encodedExploreManifest, 'DOLLARLOKIDATASOURCE', '${lokidatasource}'), 'DOLLARNAMESPACE', '${namespace}');
 
-    local link = '%(grafana_root_path)sexplore?left=%(left_explore_urlencoded_json)s' % {
-      grafana_root_path: $._config.grafana_root_path,
+    local link = '../../explore?left=%(left_explore_urlencoded_json)s' % {
       left_explore_urlencoded_json: encodedExploreManifestWithVars,
     };
 

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -5,6 +5,7 @@ local filename = 'mimir-reads.json';
   [filename]:
     ($.dashboard('Reads') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
+    .addLogsDatasource()
     .addRowIf(
       $._config.show_dashboard_descriptions.reads,
       ($.row('Reads dashboard description') { height: '175px', showTitle: false })
@@ -105,6 +106,10 @@ local filename = 'mimir-reads.json';
       $.row('Gateway')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription(
+          'Requests / sec',
+          $.exploreContainerLogsLink($._config.container_names.gateway)
+        ) +
         $.qpsPanel($.queries.gateway.readRequestsPerSecond)
       )
       .addPanel(
@@ -122,6 +127,10 @@ local filename = 'mimir-reads.json';
       $.row('Query-frontend')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription(
+          'Requests / sec',
+          $.exploreContainerLogsLink($._config.container_names.query_frontend)
+        ) +
         $.qpsPanel($.queries.query_frontend.readRequestsPerSecond)
       )
       .addPanel(

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -106,10 +106,7 @@ local filename = 'mimir-reads.json';
       $.row('Gateway')
       .addPanel(
         $.panel('Requests / sec') +
-        $.panelDescription(
-          'Requests / sec',
-          $.exploreContainerLogsLink($._config.container_names.gateway)
-        ) +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.gateway)) +
         $.qpsPanel($.queries.gateway.readRequestsPerSecond)
       )
       .addPanel(
@@ -162,6 +159,7 @@ local filename = 'mimir-reads.json';
       )
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.query_scheduler)) +
         $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
       )
       .addPanel(
@@ -200,6 +198,7 @@ local filename = 'mimir-reads.json';
       $.row('Querier')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.querier)) +
         $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.querier), $.queries.read_http_routes_regex])
       )
       .addPanel(
@@ -319,6 +318,7 @@ local filename = 'mimir-reads.json';
       $.row('Ingester')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.ingester)) +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -336,6 +336,7 @@ local filename = 'mimir-reads.json';
       $.row('Store-gateway')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.store_gateway)) +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/gatewaypb.StoreGateway/.*"}' % $.jobMatcher($._config.job_names.store_gateway))
       )
       .addPanel(

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -9,6 +9,7 @@ local filename = 'mimir-remote-ruler-reads.json';
   [filename]:
     ($.dashboard('Remote ruler reads') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
+    .addLogsDatasource()
     .addRowIf(
       $._config.show_dashboard_descriptions.reads,
       ($.row('Remote ruler reads dashboard description') { height: '175px', showTitle: false })
@@ -56,6 +57,7 @@ local filename = 'mimir-remote-ruler-reads.json';
       $.row('Query-frontend (dedicated to ruler)')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.ruler_query_frontend)) +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.ruler_query_frontend), rulerRoutesRegex])
       )
       .addPanel(
@@ -73,6 +75,7 @@ local filename = 'mimir-remote-ruler-reads.json';
       $.row('Query-scheduler (dedicated to ruler)')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.ruler_query_scheduler)) +
         $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ruler_query_scheduler))
       )
       .addPanel(
@@ -84,6 +87,7 @@ local filename = 'mimir-remote-ruler-reads.json';
       $.row('Querier (dedicated to ruler)')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.ruler_querier)) +
         $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.ruler_querier), $.queries.read_http_routes_regex])
       )
       .addPanel(

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -6,6 +6,7 @@ local filename = 'mimir-writes.json';
   [filename]:
     ($.dashboard('Writes') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
+    .addLogsDatasource()
     .addRowIf(
       $._config.show_dashboard_descriptions.writes,
       ($.row('Writes dashboard description') { height: '125px', showTitle: false })
@@ -107,6 +108,7 @@ local filename = 'mimir-writes.json';
       $.row('Gateway')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.gateway)) +
         $.qpsPanel($.queries.gateway.writeRequestsPerSecond)
       )
       .addPanel(
@@ -124,6 +126,7 @@ local filename = 'mimir-writes.json';
       $.row('Distributor')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.distributor)) +
         $.qpsPanel($.queries.distributor.writeRequestsPerSecond)
       )
       .addPanel(
@@ -294,6 +297,7 @@ local filename = 'mimir-writes.json';
       $.row('Ingester')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription('Requests / sec', $.exploreContainerLogsLink($._config.container_names.ingester)) +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(

--- a/operations/mimir-mixin/jsonnetfile.json
+++ b/operations/mimir-mixin/jsonnetfile.json
@@ -18,6 +18,15 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -20,6 +20,16 @@
       },
       "version": "72c850dd4ca2a9bb7ee1c9fe17bb72d653df571a",
       "sum": "vzHAzFgkPo2hg4JJZb4dULQiFzhrqc3W2QUOHLSVQ9Q="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "55e3a45de3bb72cee76c879f09a7ad7a476cc13f",
+      "sum": "cAgY2tMVilrhpyTOcvZZGBfQJMUkJAhM4DdaL1RHKOM="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
#### What this PR does

This is a PoC (hence draft, pending to add to the rest of the panels), I'm looking for feedback on this before changing all panels.

It's quite usual to check the logs when you see errors in a container req/s panel (query-frontend, etc.), however that step is usually manual.

This adds a link to the Explore mode with namespace and container selectors populated in a Loki query. It looks like this:

![image](https://user-images.githubusercontent.com/1511481/212686943-eeffd8a2-d9b5-4b9b-801a-893c39abc425.png)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
