### PR TITLE
Improve streaming store-gateway metrics

### DIFF
--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2506,7 +2506,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 6,
+                  "span": 4,
                   "stack": true,
                   "steppedLine": false,
                   "targets": [
@@ -2582,7 +2582,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 6,
+                  "span": 4,
                   "stack": true,
                   "steppedLine": false,
                   "targets": [
@@ -2630,6 +2630,83 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Series batch preloading efficiency\nThis panel shows the % of time reduced by preloading, for Series() requests which have been\nsplit to 2+ batches. If a Series() request is served within a single batch, then preloading\nis not triggered, and thus not counted in this measurement.\n\n",
+                  "fill": 1,
+                  "id": 31,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "(1 - (\n    sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n    /\n    sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n))\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "% of time reduced by preloading",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Series batch preloading efficiency (streaming enabled)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": 1,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -2650,7 +2727,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 31,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2729,7 +2806,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 32,
+                  "id": 33,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2816,7 +2893,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 33,
+                  "id": 34,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2912,7 +2989,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 34,
+                  "id": 35,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2988,7 +3065,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 35,
+                  "id": 36,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3092,7 +3169,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 36,
+                  "id": 37,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3168,7 +3245,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 37,
+                  "id": 38,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3244,7 +3321,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 38,
+                  "id": 39,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2229,7 +2229,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 10,
                   "id": 26,
                   "legend": {
                      "avg": false,
@@ -2241,7 +2241,7 @@
                      "values": false
                   },
                   "lines": true,
-                  "linewidth": 1,
+                  "linewidth": 0,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "percentage": false,
@@ -2251,38 +2251,30 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 4,
-                  "stack": false,
+                  "stack": true,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "histogram_quantile(0.99, sum(rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "sum(rate(cortex_bucket_store_series_get_all_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\nsum(rate(cortex_bucket_store_series_get_all_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "99th Percentile",
-                        "refId": "A",
+                        "legendFormat": "Fetch series and chunks",
+                        "legendLink": null,
                         "step": 10
                      },
                      {
-                        "expr": "histogram_quantile(0.50, sum(rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "sum(rate(cortex_bucket_store_series_merge_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\nsum(rate(cortex_bucket_store_series_merge_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "50th Percentile",
-                        "refId": "B",
-                        "step": 10
-                     },
-                     {
-                        "expr": "sum(rate(cortex_bucket_store_series_get_all_duration_seconds_sum{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) * 1e3 / sum(rate(cortex_bucket_store_series_get_all_duration_seconds_count{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Average",
-                        "refId": "C",
+                        "legendFormat": "Merge series and chunks",
+                        "legendLink": null,
                         "step": 10
                      }
                   ],
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series fetch duration (per request)",
+                  "title": "Series request average latency (streaming disabled)",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2298,7 +2290,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ms",
+                        "format": "s",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2321,7 +2313,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 10,
                   "id": 27,
                   "legend": {
                      "avg": false,
@@ -2333,7 +2325,7 @@
                      "values": false
                   },
                   "lines": true,
-                  "linewidth": 1,
+                  "linewidth": 0,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "percentage": false,
@@ -2343,38 +2335,30 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 4,
-                  "stack": false,
+                  "stack": true,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "histogram_quantile(0.99, sum(rate(cortex_bucket_store_series_merge_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "histogram_quantile(0.99, sum by(le) (rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "99th Percentile",
-                        "refId": "A",
+                        "legendFormat": "Fetch series and chunks",
+                        "legendLink": null,
                         "step": 10
                      },
                      {
-                        "expr": "histogram_quantile(0.50, sum(rate(cortex_bucket_store_series_merge_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "histogram_quantile(0.99, sum by(le) (rate(cortex_bucket_store_series_merge_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "50th Percentile",
-                        "refId": "B",
-                        "step": 10
-                     },
-                     {
-                        "expr": "sum(rate(cortex_bucket_store_series_merge_duration_seconds_sum{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) * 1e3 / sum(rate(cortex_bucket_store_series_merge_duration_seconds_count{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Average",
-                        "refId": "C",
+                        "legendFormat": "Merge series and chunks",
+                        "legendLink": null,
                         "step": 10
                      }
                   ],
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series merge duration (per request)",
+                  "title": "Series request 99th percentile latency (streaming disabled)",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2390,7 +2374,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ms",
+                        "format": "s",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2501,8 +2485,172 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 0,
+                  "fill": 10,
                   "id": 29,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\nsum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{stage}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Series request average latency (streaming enabled)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 30,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "histogram_quantile(0.99, sum by(stage, le) (rate(cortex_bucket_store_series_request_stage_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])))\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{stage}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Series request 99th percentile latency (streaming enabled)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 0,
+                  "id": 31,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2581,7 +2729,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 30,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2668,7 +2816,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 31,
+                  "id": 33,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2764,7 +2912,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 32,
+                  "id": 34,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2840,7 +2988,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 33,
+                  "id": 35,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2944,7 +3092,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 34,
+                  "id": 36,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3020,7 +3168,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 35,
+                  "id": 37,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3096,7 +3244,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 36,
+                  "id": 38,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2664,7 +2664,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "(1 - (\n    sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n    /\n    sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n))\n",
+                        "expr": "# Clamping min to 0 because if preloading not useful at all, then the actual value we get is\n# slightly negative because of the small overhead introduced by preloading.\nclamp_min(1 - (\n    sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n    /\n    sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n), 0)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "% of time reduced by preloading",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2506,7 +2506,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 6,
+                  "span": 4,
                   "stack": true,
                   "steppedLine": false,
                   "targets": [
@@ -2582,7 +2582,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 6,
+                  "span": 4,
                   "stack": true,
                   "steppedLine": false,
                   "targets": [
@@ -2630,6 +2630,83 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Series batch preloading efficiency\nThis panel shows the % of time reduced by preloading, for Series() requests which have been\nsplit to 2+ batches. If a Series() request is served within a single batch, then preloading\nis not triggered, and thus not counted in this measurement.\n\n",
+                  "fill": 1,
+                  "id": 31,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "(1 - (\n    sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n    /\n    sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n))\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "% of time reduced by preloading",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Series batch preloading efficiency (streaming enabled)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": 1,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -2650,7 +2727,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 31,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2729,7 +2806,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 32,
+                  "id": 33,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2816,7 +2893,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 33,
+                  "id": 34,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2912,7 +2989,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 34,
+                  "id": 35,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2988,7 +3065,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 35,
+                  "id": 36,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3092,7 +3169,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 36,
+                  "id": 37,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3168,7 +3245,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 37,
+                  "id": 38,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3244,7 +3321,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 38,
+                  "id": 39,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2229,7 +2229,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 10,
                   "id": 26,
                   "legend": {
                      "avg": false,
@@ -2241,7 +2241,7 @@
                      "values": false
                   },
                   "lines": true,
-                  "linewidth": 1,
+                  "linewidth": 0,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "percentage": false,
@@ -2251,38 +2251,30 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 4,
-                  "stack": false,
+                  "stack": true,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "histogram_quantile(0.99, sum(rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "sum(rate(cortex_bucket_store_series_get_all_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\nsum(rate(cortex_bucket_store_series_get_all_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "99th Percentile",
-                        "refId": "A",
+                        "legendFormat": "Fetch series and chunks",
+                        "legendLink": null,
                         "step": 10
                      },
                      {
-                        "expr": "histogram_quantile(0.50, sum(rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "sum(rate(cortex_bucket_store_series_merge_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\nsum(rate(cortex_bucket_store_series_merge_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "50th Percentile",
-                        "refId": "B",
-                        "step": 10
-                     },
-                     {
-                        "expr": "sum(rate(cortex_bucket_store_series_get_all_duration_seconds_sum{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) * 1e3 / sum(rate(cortex_bucket_store_series_get_all_duration_seconds_count{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Average",
-                        "refId": "C",
+                        "legendFormat": "Merge series and chunks",
+                        "legendLink": null,
                         "step": 10
                      }
                   ],
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series fetch duration (per request)",
+                  "title": "Series request average latency (streaming disabled)",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2298,7 +2290,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ms",
+                        "format": "s",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2321,7 +2313,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
+                  "fill": 10,
                   "id": 27,
                   "legend": {
                      "avg": false,
@@ -2333,7 +2325,7 @@
                      "values": false
                   },
                   "lines": true,
-                  "linewidth": 1,
+                  "linewidth": 0,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "percentage": false,
@@ -2343,38 +2335,30 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 4,
-                  "stack": false,
+                  "stack": true,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "histogram_quantile(0.99, sum(rate(cortex_bucket_store_series_merge_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "histogram_quantile(0.99, sum by(le) (rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "99th Percentile",
-                        "refId": "A",
+                        "legendFormat": "Fetch series and chunks",
+                        "legendLink": null,
                         "step": 10
                      },
                      {
-                        "expr": "histogram_quantile(0.50, sum(rate(cortex_bucket_store_series_merge_duration_seconds_bucket{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "histogram_quantile(0.99, sum by(le) (rate(cortex_bucket_store_series_merge_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "50th Percentile",
-                        "refId": "B",
-                        "step": 10
-                     },
-                     {
-                        "expr": "sum(rate(cortex_bucket_store_series_merge_duration_seconds_sum{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) * 1e3 / sum(rate(cortex_bucket_store_series_merge_duration_seconds_count{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Average",
-                        "refId": "C",
+                        "legendFormat": "Merge series and chunks",
+                        "legendLink": null,
                         "step": 10
                      }
                   ],
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series merge duration (per request)",
+                  "title": "Series request 99th percentile latency (streaming disabled)",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2390,7 +2374,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ms",
+                        "format": "s",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2501,8 +2485,172 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 0,
+                  "fill": 10,
                   "id": 29,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\nsum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{stage}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Series request average latency (streaming enabled)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 30,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "histogram_quantile(0.99, sum by(stage, le) (rate(cortex_bucket_store_series_request_stage_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])))\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{stage}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Series request 99th percentile latency (streaming enabled)",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 0,
+                  "id": 31,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2581,7 +2729,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 30,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2668,7 +2816,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 31,
+                  "id": 33,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2764,7 +2912,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 0,
-                  "id": 32,
+                  "id": 34,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2840,7 +2988,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 33,
+                  "id": 35,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2944,7 +3092,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 34,
+                  "id": 36,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3020,7 +3168,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 35,
+                  "id": 37,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -3096,7 +3244,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 36,
+                  "id": 38,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2664,7 +2664,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "(1 - (\n    sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n    /\n    sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n))\n",
+                        "expr": "# Clamping min to 0 because if preloading not useful at all, then the actual value we get is\n# slightly negative because of the small overhead introduced by preloading.\nclamp_min(1 - (\n    sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n    /\n    sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n), 0)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "% of time reduced by preloading",

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -309,7 +309,28 @@ local filename = 'mimir-queries.json';
         $.stack +
         { yaxes: $.yaxes('s') },
       )
-      // TODO preloading efficiency
+      .addPanel(
+        $.panel('Series batch preloading efficiency (streaming enabled)') +
+        $.queryPanel(
+          |||
+            (1 - (
+                sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{%s}[$__rate_interval]))
+                /
+                sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{%s}[$__rate_interval]))
+            ))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
+          '% of time reduced by preloading'
+        ) +
+        { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) } +
+        $.panelDescription(
+          'Series batch preloading efficiency',
+          |||
+            This panel shows the % of time reduced by preloading, for Series() requests which have been
+            split to 2+ batches. If a Series() request is served within a single batch, then preloading
+            is not triggered, and thus not counted in this measurement.
+          |||
+        ),
+      )
     )
     .addRow(
       $.row('')

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -313,11 +313,13 @@ local filename = 'mimir-queries.json';
         $.panel('Series batch preloading efficiency (streaming enabled)') +
         $.queryPanel(
           |||
-            (1 - (
+            # Clamping min to 0 because if preloading not useful at all, then the actual value we get is
+            # slightly negative because of the small overhead introduced by preloading.
+            clamp_min(1 - (
                 sum(rate(cortex_bucket_store_series_batch_preloading_wait_duration_seconds_sum{%s}[$__rate_interval]))
                 /
                 sum(rate(cortex_bucket_store_series_batch_preloading_load_duration_seconds_sum{%s}[$__rate_interval]))
-            ))
+            ), 0)
           ||| % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
           '% of time reduced by preloading'
         ) +

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -239,17 +239,77 @@ local filename = 'mimir-queries.json';
     .addRow(
       $.row('')
       .addPanel(
-        $.panel('Series fetch duration (per request)') +
-        $.latencyPanel('cortex_bucket_store_series_get_all_duration_seconds', '{component="store-gateway",%s}' % $.jobMatcher($._config.job_names.store_gateway)),
+        $.panel('Series request average latency (streaming disabled)') +
+        $.queryPanel([
+          // Fetch series and chunks.
+          |||
+            sum(rate(cortex_bucket_store_series_get_all_duration_seconds_sum{%s}[$__rate_interval]))
+            /
+            sum(rate(cortex_bucket_store_series_get_all_duration_seconds_count{%s}[$__rate_interval]))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
+          // Merge series and chunks.
+          |||
+            sum(rate(cortex_bucket_store_series_merge_duration_seconds_sum{%s}[$__rate_interval]))
+            /
+            sum(rate(cortex_bucket_store_series_merge_duration_seconds_count{%s}[$__rate_interval]))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
+        ], [
+          'Fetch series and chunks',
+          'Merge series and chunks',
+        ]) +
+        $.stack +
+        { yaxes: $.yaxes('s') },
       )
       .addPanel(
-        $.panel('Series merge duration (per request)') +
-        $.latencyPanel('cortex_bucket_store_series_merge_duration_seconds', '{component="store-gateway",%s}' % $.jobMatcher($._config.job_names.store_gateway)),
+        $.panel('Series request 99th percentile latency (streaming disabled)') +
+        $.queryPanel([
+          // Fetch series and chunks.
+          |||
+            histogram_quantile(0.99, sum by(le) (rate(cortex_bucket_store_series_get_all_duration_seconds_bucket{%s}[$__rate_interval])))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway)],
+          // Merge series and chunks.
+          |||
+            histogram_quantile(0.99, sum by(le) (rate(cortex_bucket_store_series_merge_duration_seconds_bucket{%s}[$__rate_interval])))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway)],
+        ], [
+          'Fetch series and chunks',
+          'Merge series and chunks',
+        ]) +
+        $.stack +
+        { yaxes: $.yaxes('s') },
       )
       .addPanel(
         $.panel('Series returned (per request)') +
         $.queryPanel('sum(rate(cortex_bucket_store_series_result_series_sum{component="store-gateway",%s}[$__rate_interval])) / sum(rate(cortex_bucket_store_series_result_series_count{component="store-gateway",%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)], 'avg series returned'),
       )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.panel('Series request average latency (streaming enabled)') +
+        $.queryPanel(
+          |||
+            sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_sum{%s}[$__rate_interval]))
+            /
+            sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_count{%s}[$__rate_interval]))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)],
+          '{{stage}}'
+        ) +
+        $.stack +
+        { yaxes: $.yaxes('s') },
+      )
+      .addPanel(
+        $.panel('Series request 99th percentile latency (streaming enabled)') +
+        $.queryPanel(
+          |||
+            histogram_quantile(0.99, sum by(stage, le) (rate(cortex_bucket_store_series_request_stage_duration_seconds_bucket{%s}[$__rate_interval])))
+          ||| % [$.jobMatcher($._config.job_names.store_gateway)],
+          '{{stage}}'
+        ) +
+        $.stack +
+        { yaxes: $.yaxes('s') },
+      )
+      // TODO preloading efficiency
     )
     .addRow(
       $.row('')

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1204,7 +1204,6 @@ func (s *BucketStore) recordSeriesCallResult(safeStats *safeQueryStats) {
 	s.metrics.cachedPostingsCompressedSizeBytes.Add(float64(stats.cachedPostingsCompressedSizeSum))
 	s.metrics.seriesHashCacheRequests.Add(float64(stats.seriesHashCacheRequests))
 	s.metrics.seriesHashCacheHits.Add(float64(stats.seriesHashCacheHits))
-	s.metrics.expandPostingsDuration.Observe(stats.expandedPostingsDuration.Seconds())
 
 	// Track the streaming store-gateway preloading effectiveness metrics only if the request had
 	// more than 1 batch. If the request only had 1 batch, then preloading is not triggered at all.

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -447,19 +447,17 @@ func testBucketStore_e2e(t *testing.T, ctx context.Context, s *storeSuite) {
 				assert.Equal(t, tcase.expected[i], s.Labels)
 				assert.Equal(t, tcase.expectedChunkLen, len(s.Chunks))
 			}
-			assertQueryStatsMetricsRecorded(t, len(tcase.expected), tcase.expectedChunkLen, s.metricsRegistry)
+			assertQueryStatsMetricsRecorded(t, len(tcase.expected), tcase.expectedChunkLen, s.store.maxSeriesPerBatch > 0, s.metricsRegistry)
 		}); !ok {
 			return
 		}
 	}
 }
 
-func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSeries int, registry *prometheus.Registry) {
+func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSeries int, streamingEnabled bool, registry *prometheus.Registry) {
 	t.Helper()
 
-	families, err := registry.Gather()
-	require.NoError(t, err, "couldn't gather metrics from BucketStore")
-	metrics, err := util.NewMetricFamilyMap(families)
+	metrics, err := util.NewMetricFamilyMapFromGatherer(registry)
 	require.NoError(t, err, "couldn't gather metrics from BucketStore")
 
 	toLabels := func(labelValuePairs []string) (result labels.Labels) {
@@ -500,8 +498,14 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "postings"))
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "series"))
 		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_expanded_postings_duration"))
-		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_get_all_duration_seconds"))
-		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_merge_duration_seconds"))
+
+		if streamingEnabled {
+			assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_request_stage_duration_seconds"))
+			assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_refs_fetch_duration_seconds"))
+		} else {
+			assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_get_all_duration_seconds"))
+			assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_merge_duration_seconds"))
+		}
 	}
 	if numChunksPerSeries > 0 {
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_touched", "data_type", "chunks"))

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -492,12 +492,10 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 
 	if numSeries > 0 {
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_result_series"))
-		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_expanded_postings_duration"))
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_touched", "data_type", "postings"))
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_touched", "data_type", "series"))
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "postings"))
 		assert.NotZero(t, numObservationsForSummaries("cortex_bucket_store_series_data_fetched", "data_type", "series"))
-		assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_expanded_postings_duration"))
 
 		if streamingEnabled {
 			assert.NotZero(t, numObservationsForHistogram("cortex_bucket_store_series_request_stage_duration_seconds"))

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -64,11 +64,7 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 	var (
 		loaded bool
 		cached bool
-		start  = time.Now()
 	)
-	defer stats.update(func(stats *queryStats) {
-		stats.expandedPostingsDuration += time.Since(start)
-	})
 	span, ctx := tracing.StartSpan(ctx, "ExpandedPostings()")
 	defer func() {
 		span.LogKV("returned postings", len(returnRefs), "cached", cached, "promise_loaded", loaded)

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -57,8 +57,6 @@ type BucketStoreMetrics struct {
 	postingsFetchDuration prometheus.Histogram
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
-
-	expandPostingsDuration prometheus.Histogram
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
@@ -205,12 +203,6 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	m.streamingSeriesRefsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_series_refs_fetch_duration_seconds",
 		Help:    "Time spent by store-gateway to fetch series labels and chunk references for a single request. This metric is tracked only if streaming store-gateway is enabled.",
-		Buckets: durationBuckets,
-	})
-
-	m.expandPostingsDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "cortex_bucket_store_expanded_postings_duration",
-		Help:    "The time it takes to get a list of all series that match the request matcher.",
 		Buckets: durationBuckets,
 	})
 

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -35,8 +35,8 @@ type BucketStoreMetrics struct {
 	seriesRefetches       prometheus.Counter
 
 	// Metrics tracked when streaming store-gateway is disabled.
-	seriesGetAllDuration prometheus.Histogram
-	seriesMergeDuration  prometheus.Histogram
+	synchronousSeriesGetAllDuration prometheus.Histogram
+	synchronousSeriesMergeDuration  prometheus.Histogram
 
 	// Metrics tracked when streaming store-gateway is enabled.
 	streamingSeriesRequestDurationByStage      *prometheus.HistogramVec
@@ -102,12 +102,12 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 		Name: "cortex_bucket_store_series_blocks_queried",
 		Help: "Number of blocks in a bucket store that were touched to satisfy a query.",
 	})
-	m.seriesGetAllDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+	m.synchronousSeriesGetAllDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_series_get_all_duration_seconds",
 		Help:    "Time it takes until all per-block prepares and loads for a query are finished. This metric is tracked only if streaming store-gateway is disabled.",
 		Buckets: durationBuckets,
 	})
-	m.seriesMergeDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+	m.synchronousSeriesMergeDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_series_merge_duration_seconds",
 		Help:    "Time it takes to merge sub-results from all queried blocks into a single result. This metric is tracked only if streaming store-gateway is disabled.",
 		Buckets: durationBuckets,

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -39,7 +39,10 @@ type BucketStoreMetrics struct {
 	seriesMergeDuration  prometheus.Histogram
 
 	// Metrics tracked when streaming store-gateway is enabled.
-	seriesRequestByStageDuration *prometheus.HistogramVec
+	streamingSeriesRequestDurationByStage      *prometheus.HistogramVec
+	streamingSeriesBatchPreloadingLoadDuration prometheus.Histogram
+	streamingSeriesBatchPreloadingWaitDuration prometheus.Histogram
+	streamingSeriesRefsFetchDuration           prometheus.Histogram
 
 	cachedPostingsCompressions           *prometheus.CounterVec
 	cachedPostingsCompressionErrors      *prometheus.CounterVec
@@ -55,12 +58,12 @@ type BucketStoreMetrics struct {
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
 
-	iteratorLoadDurations  *prometheus.HistogramVec
 	expandPostingsDuration prometheus.Histogram
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	var m BucketStoreMetrics
+	var durationBuckets = []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}
 
 	m.blockLoads = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_bucket_store_block_loads_total",
@@ -104,18 +107,13 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	m.seriesGetAllDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_series_get_all_duration_seconds",
 		Help:    "Time it takes until all per-block prepares and loads for a query are finished. This metric is tracked only if streaming store-gateway is disabled.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+		Buckets: durationBuckets,
 	})
 	m.seriesMergeDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_series_merge_duration_seconds",
 		Help:    "Time it takes to merge sub-results from all queried blocks into a single result. This metric is tracked only if streaming store-gateway is disabled.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+		Buckets: durationBuckets,
 	})
-	m.seriesRequestByStageDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "cortex_bucket_store_series_request_stage_duration_seconds",
-		Help:    "Time it takes to process a series request split by stages. This metric is tracked only if streaming store-gateway is enabled.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	}, []string{"stage"})
 	m.seriesRefetches = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_bucket_store_series_refetches_total",
 		Help: "Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.",
@@ -162,12 +160,12 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	m.seriesFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_cached_series_fetch_duration_seconds",
 		Help:    "Time it takes to fetch series to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+		Buckets: durationBuckets,
 	})
 	m.postingsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_cached_postings_fetch_duration_seconds",
 		Help:    "Time it takes to fetch postings to respond a request sent to store-gateway. It includes both the time to fetch it from cache and from storage in case of cache misses.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+		Buckets: durationBuckets,
 	})
 
 	m.seriesHashCacheRequests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -189,16 +187,31 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 
 	m.indexHeaderReaderMetrics = indexheader.NewReaderPoolMetrics(prometheus.WrapRegistererWithPrefix("cortex_bucket_store_", reg))
 
-	m.iteratorLoadDurations = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "cortex_bucket_store_iterator_load_duration",
-		Help:    "The time it takes an iterator to load the next item.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
-	}, []string{"iterator"})
+	m.streamingSeriesRequestDurationByStage = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_series_request_stage_duration_seconds",
+		Help:    "Time it takes to process a series request split by stages. This metric is tracked only if streaming store-gateway is enabled.",
+		Buckets: durationBuckets,
+	}, []string{"stage"})
+	m.streamingSeriesBatchPreloadingLoadDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_series_batch_preloading_load_duration_seconds",
+		Help:    "Time spent by store-gateway to load batches for a single request. This metric is tracked only if streaming store-gateway is enabled and if the request is split into 2+ batches.",
+		Buckets: durationBuckets,
+	})
+	m.streamingSeriesBatchPreloadingWaitDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_series_batch_preloading_wait_duration_seconds",
+		Help:    "Time spent by store-gateway waiting until the next batch is loaded, once the store-gateway is ready to send it. This metric is tracked only if streaming store-gateway is enabled and if the request is split into 2+ batches.",
+		Buckets: durationBuckets,
+	})
+	m.streamingSeriesRefsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_series_refs_fetch_duration_seconds",
+		Help:    "Time spent by store-gateway to fetch series labels and chunk references for a single request. This metric is tracked only if streaming store-gateway is enabled.",
+		Buckets: durationBuckets,
+	})
 
 	m.expandPostingsDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_expanded_postings_duration",
 		Help:    "The time it takes to get a list of all series that match the request matcher.",
-		Buckets: []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+		Buckets: durationBuckets,
 	})
 
 	return &m

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
@@ -169,15 +168,10 @@ func newSeriesChunksSeriesSet(from seriesChunksSetIterator) storepb.SeriesSet {
 	}
 }
 
-func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders, refsIterator seriesChunkRefsSetIterator, refsIteratorBatchSize int, stats *safeQueryStats, iteratorLoadDurations *prometheus.HistogramVec) storepb.SeriesSet {
+func newSeriesSetWithChunks(ctx context.Context, chunkReaders bucketChunkReaders, refsIterator seriesChunkRefsSetIterator, refsIteratorBatchSize int, stats *safeQueryStats) storepb.SeriesSet {
 	var iterator seriesChunksSetIterator
 	iterator = newLoadingSeriesChunksSetIterator(chunkReaders, refsIterator, refsIteratorBatchSize, stats)
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_load"))
-	iterator = newPreloadingSetIterator[seriesChunksSet](ctx, 1, iterator)
-	// We are measuring the time we wait for a preloaded batch. In an ideal world this is 0 because there's always a preloaded batch waiting.
-	// But realistically it will not be. Along with the duration of the chunks_load iterator,
-	// we can determine where is the bottleneck in the streaming pipeline.
-	iterator = newDurationMeasuringIterator[seriesChunksSet](iterator, iteratorLoadDurations.WithLabelValues("chunks_preloaded"))
+	iterator = newPreloadingAndStatsTrackingSetIterator[seriesChunksSet](ctx, 1, iterator, stats)
 	return newSeriesChunksSeriesSet(iterator)
 }
 
@@ -286,6 +280,28 @@ func (p *preloadingSetIterator[Set]) Err() error {
 	return p.err
 }
 
+func newPreloadingAndStatsTrackingSetIterator[Set any](ctx context.Context, preloadedSetsCount int, iterator genericIterator[Set], stats *safeQueryStats) genericIterator[Set] {
+	// Track the time spent loading batches (including preloading).
+	iterator = newNextDurationMeasuringIterator[Set](iterator, func(duration time.Duration) {
+		stats.update(func(stats *queryStats) {
+			stats.streamingSeriesBatchLoadDuration += duration
+
+			// This function is called for each Next() invocation, so we can use it to measure
+			// into how many batches the request has been split.
+			stats.streamingSeriesBatchCount++
+		})
+	})
+
+	iterator = newPreloadingSetIterator[Set](ctx, preloadedSetsCount, iterator)
+
+	// Track the time step waiting until the next batch is loaded once the "reader" is ready to get it.
+	return newNextDurationMeasuringIterator[Set](iterator, func(duration time.Duration) {
+		stats.update(func(stats *queryStats) {
+			stats.streamingSeriesWaitBatchLoadedDuration += duration
+		})
+	})
+}
+
 type loadingSeriesChunksSetIterator struct {
 	chunkReaders  bucketChunkReaders
 	from          seriesChunkRefsSetIterator
@@ -375,29 +391,29 @@ func (c *loadingSeriesChunksSetIterator) Err() error {
 	return c.err
 }
 
-type durationMeasuringIterator[Set any] struct {
+type nextDurationMeasuringIterator[Set any] struct {
 	from             genericIterator[Set]
-	durationObserver prometheus.Observer
+	durationObserver func(time.Duration)
 }
 
-func newDurationMeasuringIterator[Set any](from genericIterator[Set], durationObserver prometheus.Observer) genericIterator[Set] {
-	return &durationMeasuringIterator[Set]{
+func newNextDurationMeasuringIterator[Set any](from genericIterator[Set], durationObserver func(time.Duration)) genericIterator[Set] {
+	return &nextDurationMeasuringIterator[Set]{
 		from:             from,
 		durationObserver: durationObserver,
 	}
 }
 
-func (m *durationMeasuringIterator[Set]) Next() bool {
+func (m *nextDurationMeasuringIterator[Set]) Next() bool {
 	start := time.Now()
 	next := m.from.Next()
-	m.durationObserver.Observe(time.Since(start).Seconds())
+	m.durationObserver(time.Since(start))
 	return next
 }
 
-func (m *durationMeasuringIterator[Set]) At() Set {
+func (m *nextDurationMeasuringIterator[Set]) At() Set {
 	return m.from.At()
 }
 
-func (m *durationMeasuringIterator[Set]) Err() error {
+func (m *nextDurationMeasuringIterator[Set]) Err() error {
 	return m.from.Err()
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -672,7 +672,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 	)
 
 	// Track the time spent loading series and chunk refs.
-	iterator = newNextDurationMeasuringIterator[seriesChunkRefsSet](iterator, func(duration time.Duration) {
+	iterator = newNextDurationMeasuringIterator[seriesChunkRefsSet](iterator, func(duration time.Duration, _ bool) {
 		stats.update(func(stats *queryStats) {
 			stats.streamingSeriesFetchRefsDuration += duration
 		})

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -447,8 +448,9 @@ func newSeriesChunkRefsSeriesSet(from seriesChunkRefsSetIterator) storepb.Series
 	}
 }
 
-func newSeriesSetWithoutChunks(ctx context.Context, batches seriesChunkRefsSetIterator) storepb.SeriesSet {
-	return newSeriesChunkRefsSeriesSet(newPreloadingSetIterator[seriesChunkRefsSet](ctx, 1, batches))
+func newSeriesSetWithoutChunks(ctx context.Context, iterator seriesChunkRefsSetIterator, stats *safeQueryStats) storepb.SeriesSet {
+	iterator = newPreloadingAndStatsTrackingSetIterator[seriesChunkRefsSet](ctx, 1, iterator, stats)
+	return newSeriesChunkRefsSeriesSet(iterator)
 }
 
 func (s *seriesChunkRefsSeriesSet) Next() bool {
@@ -668,7 +670,14 @@ func openBlockSeriesChunkRefsSetsIterator(
 		tenantID,
 		logger,
 	)
-	iterator = newDurationMeasuringIterator[seriesChunkRefsSet](iterator, metrics.iteratorLoadDurations.WithLabelValues("series_load"))
+
+	// Track the time spent loading series and chunk refs.
+	iterator = newNextDurationMeasuringIterator[seriesChunkRefsSet](iterator, func(duration time.Duration) {
+		stats.update(func(stats *queryStats) {
+			stats.streamingSeriesFetchRefsDuration += duration
+		})
+	})
+
 	iterator = newLimitingSeriesChunkRefsSetIterator(iterator, chunksLimiter, seriesLimiter)
 	return iterator, nil
 }

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -63,6 +63,15 @@ type queryStats struct {
 	// The total time spent waiting until the next batch is loaded, once the store-gateway was
 	// ready to send it to the client.
 	streamingSeriesWaitBatchLoadedDuration time.Duration
+
+	// The Series() request timing breakdown when streaming store-gateway is enabled.
+	streamingSeriesExpandPostingsDuration       time.Duration
+	streamingSeriesFetchSeriesAndChunksDuration time.Duration
+	streamingSeriesSendResponseDuration         time.Duration
+
+	// The Series() request timing breakdown when streaming store-gateway is disabled.
+	synchronousSeriesGetAllDuration time.Duration
+	synchronousSeriesMergeDuration  time.Duration
 }
 
 func (s queryStats) merge(o *queryStats) *queryStats {
@@ -109,6 +118,12 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.streamingSeriesBatchCount += o.streamingSeriesBatchCount
 	s.streamingSeriesBatchLoadDuration += o.streamingSeriesBatchLoadDuration
 	s.streamingSeriesWaitBatchLoadedDuration += o.streamingSeriesWaitBatchLoadedDuration
+	s.streamingSeriesExpandPostingsDuration += o.streamingSeriesExpandPostingsDuration
+	s.streamingSeriesFetchSeriesAndChunksDuration += o.streamingSeriesFetchSeriesAndChunksDuration
+	s.streamingSeriesSendResponseDuration += o.streamingSeriesSendResponseDuration
+
+	s.synchronousSeriesGetAllDuration += o.synchronousSeriesGetAllDuration
+	s.synchronousSeriesMergeDuration += o.synchronousSeriesMergeDuration
 
 	return &s
 }

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -48,10 +48,8 @@ type queryStats struct {
 	chunksFetchCount       int
 	chunksFetchDurationSum time.Duration
 
-	getAllDuration    time.Duration
 	mergedSeriesCount int
 	mergedChunksCount int
-	mergeDuration     time.Duration
 
 	expandedPostingsDuration time.Duration
 }
@@ -93,10 +91,8 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.chunksFetchCount += o.chunksFetchCount
 	s.chunksFetchDurationSum += o.chunksFetchDurationSum
 
-	s.getAllDuration += o.getAllDuration
 	s.mergedSeriesCount += o.mergedSeriesCount
 	s.mergedChunksCount += o.mergedChunksCount
-	s.mergeDuration += o.mergeDuration
 
 	s.expandedPostingsDuration += o.expandedPostingsDuration
 

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -51,8 +51,6 @@ type queryStats struct {
 	mergedSeriesCount int
 	mergedChunksCount int
 
-	expandedPostingsDuration time.Duration
-
 	// The total time spent fetching series and chunk refs.
 	streamingSeriesFetchRefsDuration time.Duration
 
@@ -106,8 +104,6 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 
 	s.mergedSeriesCount += o.mergedSeriesCount
 	s.mergedChunksCount += o.mergedChunksCount
-
-	s.expandedPostingsDuration += o.expandedPostingsDuration
 
 	s.streamingSeriesFetchRefsDuration += o.streamingSeriesFetchRefsDuration
 	s.streamingSeriesBatchCount += o.streamingSeriesBatchCount

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -52,6 +52,19 @@ type queryStats struct {
 	mergedChunksCount int
 
 	expandedPostingsDuration time.Duration
+
+	// The total time spent fetching series and chunk refs.
+	streamingSeriesFetchRefsDuration time.Duration
+
+	// The number of batches the Series() request has been split into.
+	streamingSeriesBatchCount int
+
+	// The total time spent loading batches.
+	streamingSeriesBatchLoadDuration time.Duration
+
+	// The total time spent waiting until the next batch is loaded, once the store-gateway was
+	// ready to send it to the client.
+	streamingSeriesWaitBatchLoadedDuration time.Duration
 }
 
 func (s queryStats) merge(o *queryStats) *queryStats {
@@ -95,6 +108,11 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.mergedChunksCount += o.mergedChunksCount
 
 	s.expandedPostingsDuration += o.expandedPostingsDuration
+
+	s.streamingSeriesFetchRefsDuration += o.streamingSeriesFetchRefsDuration
+	s.streamingSeriesBatchCount += o.streamingSeriesBatchCount
+	s.streamingSeriesBatchLoadDuration += o.streamingSeriesBatchLoadDuration
+	s.streamingSeriesWaitBatchLoadedDuration += o.streamingSeriesWaitBatchLoadedDuration
 
 	return &s
 }

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -65,6 +65,17 @@ func (m singleValueWithLabelsMap) WriteToMetricChannel(out chan<- prometheus.Met
 // Keeping map of metric name to its family makes it easier to do searches later.
 type MetricFamilyMap map[string]*dto.MetricFamily
 
+// NewMetricFamilyMapFromGatherer is like NewMetricFamilyMap but gets metrics directly from a
+// prometheus.Gatherer instance.
+func NewMetricFamilyMapFromGatherer(gatherer prometheus.Gatherer) (MetricFamilyMap, error) {
+	metrics, err := gatherer.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewMetricFamilyMap(metrics)
+}
+
 // NewMetricFamilyMap sorts output from Gatherer.Gather method into a map.
 // Gatherer.Gather specifies that there metric families are uniquely named, and we use that fact here.
 // If they are not, this method returns error.
@@ -465,6 +476,11 @@ type HistogramData struct {
 	sampleCount uint64
 	sampleSum   float64
 	buckets     map[float64]uint64
+}
+
+// Count returns the histogram count value.
+func (d HistogramData) Count() uint64 {
+	return d.sampleCount
 }
 
 // AddHistogram adds histogram from gathered metrics to this histogram data.


### PR DESCRIPTION
#### What this PR does
While investigating https://github.com/grafana/mimir/issues/3940, I've realised there's room to improve metrics tracked by streaming store-gateway to better understand where `Series()` is actually spent. In this PR I'm proposing some changes to metrics. Since the streaming store-gateway is experimental, these are not breaking changes.

1. Introduce **`cortex_bucket_store_series_request_stage_duration_seconds`** to track how the time is spent in `Series()` when streaming store-gateway is enabled. Rationale:
   - This metric should be graphed as a stack, so the some of all stages should be the total (significant) time spent by `Series()`. It has 3 stages: `expand_postings`, `fetch_series_and_chunks` and `send`.
   - Do not track `cortex_bucket_store_series_get_all_duration_seconds` and `cortex_bucket_store_series_merge_duration_seconds` in streaming store-gateway because their naming doesn't make sense. Streaming store-gateway works differently. Since I want streaming store-gateway to be come default (and only supported method), but I also want to have clean metrics name, I prefer to start clean with the streaming store-gateway and have a new metric.
2. Remove **`cortex_bucket_store_iterator_load_duration`** (difficult to understand what it actually tracks) and introduce specific metrics (see below).
3. Introduce **`cortex_bucket_store_series_refs_fetch_duration_seconds`** to track the time spent fetching series and chunks refs.
4. Introduce **`cortex_bucket_store_series_batch_preloading_load_duration_seconds`** and **`cortex_bucket_store_series_batch_preloading_wait_duration_seconds`** to measure the preloading efficiency. These metrics are only tracked for requests with 2+ batches, where preloading triggers. If a request has only 1 batch, the preloading doesn't trigger (code is still executed, but there's no practical difference with or without preloading).
5. Remove `cortex_bucket_store_expanded_postings_duration` because replaced by `cortex_bucket_store_series_request_stage_duration_seconds{stage="expand_postings"}`

I've also changed the "Mimir / Queries" dashboard to add dedicated panels showing how Series() time is spent, both for the streaming and non-streaming mode. I tested it in a dev cluster and here you can see an example:

![Screenshot 2023-01-16 at 17 33 08](https://user-images.githubusercontent.com/1701904/212727147-e08cfb5a-f498-42cf-b5ab-67493c7396dc.png)


#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/3940

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
