### PR TITLE
Update skopeo version in build image

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -145,7 +145,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3702-cc811800b
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr3702-cc811800b
+LATEST_BUILD_IMAGE_TAG ?= pr3967-4691f3247
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -8,7 +8,9 @@ FROM alpine/helm:3.8.2 as helm
 FROM golang:1.19.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev skopeo && \
+RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev
+# skopeo dependencies
+RUN apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
@@ -35,6 +37,11 @@ RUN GOARCH=$(go env GOARCH) && \
     chmod a+x /usr/bin/tk
 
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.49.0
+
+ENV SKOPEO_VERSION=v1.10.0
+RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
+    make -C $GOPATH/src/github.com/containers/skopeo bin/skopeo && \
+    mv $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/bin
 
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \


### PR DESCRIPTION
The current skopeo version in the build image is 1.2.2, this PR updates
it to 1.10.0.

The problem with 1.2.0 is pushing images to docker hub is failing
([example failing action](https://github.com/grafana/mimir/actions/runs/3925907397/jobs/6722744206))

```
time="2023-01-16T14:43:18Z" level=fatal msg="Error creating an updated image manifest: Error preparing updated manifest, layer \"sha256:3ada1def0d50fd1ba32033c6b57ec2f292576d71ecc8be33f4207967a0508184\": unsupported MIME type for compression: application/vnd.in-toto+json"
```

This problem is gone after upgrading skopeo to 1.10.0.

A caveat is that the latest release for debian is 1.2.2. So in this PR
we are also building skopeo from source.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
