### PR TITLE
Build image: get skopeo from image instead of building from source

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -145,7 +145,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3973-3700ac406
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr3967-4691f3247
+LATEST_BUILD_IMAGE_TAG ?= pr3973-3700ac406
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -9,9 +9,7 @@ FROM quay.io/skopeo/stable:v1.10.0 as skopeo
 FROM golang:1.19.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev
-# skopeo dependencies
-RUN apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config && \
+RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,6 +5,7 @@
 
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.8.2 as helm
+FROM quay.io/skopeo/stable:v1.10.0 as skopeo
 FROM golang:1.19.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
@@ -38,10 +39,8 @@ RUN GOARCH=$(go env GOARCH) && \
 
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.49.0
 
-ENV SKOPEO_VERSION=v1.10.0
-RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
-    make -C $GOPATH/src/github.com/containers/skopeo bin/skopeo && \
-    mv $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/bin
+COPY --from=skopeo /usr/bin/skopeo /usr/bin/skopeo
+COPY --from=skopeo /etc/containers /etc/containers
 
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \


### PR DESCRIPTION
Follow-up of #3967

Building from source means that we don't get the /etc/containers
files that are usually installed when installing via a package manager.

`make install` has further dependencies. Instead, we can just use a
prebuilt image and copy what we need from it.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
