### PR TITLE
Vendor update mimir-prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 replace github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230117132619-fa6d2a8edee7
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 replace github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
 
 // Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230110145420-eaeda077ed95
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f h1:ANwIMe7kOiMN
 github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230110145420-eaeda077ed95 h1:hdvXk568Gajf8Liaz+b/cRmqEMX4yIP4UKv4TdFujj4=
-github.com/grafana/mimir-prometheus v0.0.0-20230110145420-eaeda077ed95/go.mod h1:jVWuK6kAKKW+G1Z5013SGMzOx3Cyek9s5nxZe1zCrdc=
+github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826 h1:hyCEZhIH+jrIOAXGnx5e37JTKKo5DvrEN7bAOGP20pE=
+github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826/go.mod h1:jVWuK6kAKKW+G1Z5013SGMzOx3Cyek9s5nxZe1zCrdc=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f h1:ANwIMe7kOiMN
 github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826 h1:hyCEZhIH+jrIOAXGnx5e37JTKKo5DvrEN7bAOGP20pE=
-github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826/go.mod h1:jVWuK6kAKKW+G1Z5013SGMzOx3Cyek9s5nxZe1zCrdc=
+github.com/grafana/mimir-prometheus v0.0.0-20230117132619-fa6d2a8edee7 h1:roW6SA2xn9h8a9MLoxuzExdPe5AeeJLqA38lPDR1Dqk=
+github.com/grafana/mimir-prometheus v0.0.0-20230117132619-fa6d2a8edee7/go.mod h1:jVWuK6kAKKW+G1Z5013SGMzOx3Cyek9s5nxZe1zCrdc=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/vendor/github.com/prometheus/prometheus/discovery/manager.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/manager.go
@@ -428,11 +428,11 @@ func (m *Manager) registerProviders(cfgs Configs, setName string) int {
 		}
 		typ := cfg.Name()
 		d, err := cfg.NewDiscoverer(DiscovererOptions{
-			Logger:            log.With(m.logger, "discovery", typ),
+			Logger:            log.With(m.logger, "discovery", typ, "config", setName),
 			HTTPClientOptions: m.httpOpts,
 		})
 		if err != nil {
-			level.Error(m.logger).Log("msg", "Cannot create service discovery", "err", err, "type", typ)
+			level.Error(m.logger).Log("msg", "Cannot create service discovery", "err", err, "type", typ, "config", setName)
 			failed++
 			return
 		}

--- a/vendor/github.com/prometheus/prometheus/model/histogram/float_histogram.go
+++ b/vendor/github.com/prometheus/prometheus/model/histogram/float_histogram.go
@@ -27,6 +27,8 @@ import (
 // used to represent a histogram with integer counts and thus serves as a more
 // generalized representation.
 type FloatHistogram struct {
+	// Counter reset information.
+	CounterResetHint CounterResetHint
 	// Currently valid schema numbers are -4 <= n <= 8.  They are all for
 	// base-2 bucket schemas, where 1 is a bucket boundary in each case, and
 	// then each power of two is divided into 2^n logarithmic buckets.  Or

--- a/vendor/github.com/prometheus/prometheus/model/histogram/histogram.go
+++ b/vendor/github.com/prometheus/prometheus/model/histogram/histogram.go
@@ -19,6 +19,17 @@ import (
 	"strings"
 )
 
+// CounterResetHint contains the known information about a counter reset,
+// or alternatively that we are dealing with a gauge histogram, where counter resets do not apply.
+type CounterResetHint byte
+
+const (
+	UnknownCounterReset CounterResetHint = iota // UnknownCounterReset means we cannot say if this histogram signals a counter reset or not.
+	CounterReset                                // CounterReset means there was definitely a counter reset starting from this histogram.
+	NotCounterReset                             // NotCounterReset means there was definitely no counter reset with this histogram.
+	GaugeType                                   // GaugeType means this is a gauge histogram, where counter resets do not happen.
+)
+
 // Histogram encodes a sparse, high-resolution histogram. See the design
 // document for full details:
 // https://docs.google.com/document/d/1cLNv3aufPZb3fNfaJgdaRBZsInZKKIHo9E6HinJVbpM/edit#
@@ -35,6 +46,8 @@ import (
 //
 // Which bucket indices are actually used is determined by the spans.
 type Histogram struct {
+	// Counter reset information.
+	CounterResetHint CounterResetHint
 	// Currently valid schema numbers are -4 <= n <= 8.  They are all for
 	// base-2 bucket schemas, where 1 is a bucket boundary in each case, and
 	// then each power of two is divided into 2^n logarithmic buckets.  Or
@@ -295,15 +308,16 @@ func (h *Histogram) ToFloat() *FloatHistogram {
 	}
 
 	return &FloatHistogram{
-		Schema:          h.Schema,
-		ZeroThreshold:   h.ZeroThreshold,
-		ZeroCount:       float64(h.ZeroCount),
-		Count:           float64(h.Count),
-		Sum:             h.Sum,
-		PositiveSpans:   positiveSpans,
-		NegativeSpans:   negativeSpans,
-		PositiveBuckets: positiveBuckets,
-		NegativeBuckets: negativeBuckets,
+		CounterResetHint: h.CounterResetHint,
+		Schema:           h.Schema,
+		ZeroThreshold:    h.ZeroThreshold,
+		ZeroCount:        float64(h.ZeroCount),
+		Count:            float64(h.Count),
+		Sum:              h.Sum,
+		PositiveSpans:    positiveSpans,
+		NegativeSpans:    negativeSpans,
+		PositiveBuckets:  positiveBuckets,
+		NegativeBuckets:  negativeBuckets,
 	}
 }
 

--- a/vendor/github.com/prometheus/prometheus/model/textparse/openmetricsparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/openmetricsparse.go
@@ -113,8 +113,8 @@ func (p *OpenMetricsParser) Series() ([]byte, *int64, float64) {
 	return p.series, nil, p.val
 }
 
-// Histogram always returns (nil, nil, nil, nil) because OpenMetrics does not support
-// sparse histograms.
+// Histogram returns (nil, nil, nil, nil) for now because OpenMetrics does not
+// support sparse histograms yet.
 func (p *OpenMetricsParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
 	return nil, nil, nil, nil
 }

--- a/vendor/github.com/prometheus/prometheus/model/textparse/promparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/promparse.go
@@ -168,8 +168,8 @@ func (p *PromParser) Series() ([]byte, *int64, float64) {
 	return p.series, nil, p.val
 }
 
-// Histogram always returns (nil, nil, nil, nil) because the Prometheus text format
-// does not support sparse histograms.
+// Histogram returns (nil, nil, nil, nil) for now because the Prometheus text
+// format does not support sparse histograms yet.
 func (p *PromParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
 	return nil, nil, nil, nil
 }

--- a/vendor/github.com/prometheus/prometheus/model/textparse/protobufparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/protobufparse.go
@@ -105,7 +105,7 @@ func (p *ProtobufParser) Series() ([]byte, *int64, float64) {
 		default:
 			v = s.GetQuantile()[p.fieldPos].GetValue()
 		}
-	case dto.MetricType_HISTOGRAM:
+	case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
 		// This should only happen for a legacy histogram.
 		h := m.GetHistogram()
 		switch p.fieldPos {
@@ -170,6 +170,9 @@ func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *his
 			fh.NegativeSpans[i].Offset = span.GetOffset()
 			fh.NegativeSpans[i].Length = span.GetLength()
 		}
+		if p.mf.GetType() == dto.MetricType_GAUGE_HISTOGRAM {
+			fh.CounterResetHint = histogram.GaugeType
+		}
 		fh.Compact(0)
 		if ts != 0 {
 			return p.metricBytes.Bytes(), &ts, nil, &fh
@@ -199,6 +202,9 @@ func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *his
 		sh.NegativeSpans[i].Offset = span.GetOffset()
 		sh.NegativeSpans[i].Length = span.GetLength()
 	}
+	if p.mf.GetType() == dto.MetricType_GAUGE_HISTOGRAM {
+		sh.CounterResetHint = histogram.GaugeType
+	}
 	sh.Compact(0)
 	if ts != 0 {
 		return p.metricBytes.Bytes(), &ts, &sh, nil
@@ -225,6 +231,8 @@ func (p *ProtobufParser) Type() ([]byte, MetricType) {
 		return n, MetricTypeGauge
 	case dto.MetricType_HISTOGRAM:
 		return n, MetricTypeHistogram
+	case dto.MetricType_GAUGE_HISTOGRAM:
+		return n, MetricTypeGaugeHistogram
 	case dto.MetricType_SUMMARY:
 		return n, MetricTypeSummary
 	}
@@ -273,7 +281,7 @@ func (p *ProtobufParser) Exemplar(ex *exemplar.Exemplar) bool {
 	switch p.mf.GetType() {
 	case dto.MetricType_COUNTER:
 		exProto = m.GetCounter().GetExemplar()
-	case dto.MetricType_HISTOGRAM:
+	case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
 		bb := m.GetHistogram().GetBucket()
 		if p.fieldPos < 0 {
 			if p.state == EntrySeries {
@@ -331,13 +339,24 @@ func (p *ProtobufParser) Next() (Entry, error) {
 		}
 
 		// We are at the beginning of a metric family. Put only the name
-		// into metricBytes and validate only name and help for now.
+		// into metricBytes and validate only name, help, and type for now.
 		name := p.mf.GetName()
 		if !model.IsValidMetricName(model.LabelValue(name)) {
 			return EntryInvalid, errors.Errorf("invalid metric name: %s", name)
 		}
 		if help := p.mf.GetHelp(); !utf8.ValidString(help) {
 			return EntryInvalid, errors.Errorf("invalid help for metric %q: %s", name, help)
+		}
+		switch p.mf.GetType() {
+		case dto.MetricType_COUNTER,
+			dto.MetricType_GAUGE,
+			dto.MetricType_HISTOGRAM,
+			dto.MetricType_GAUGE_HISTOGRAM,
+			dto.MetricType_SUMMARY,
+			dto.MetricType_UNTYPED:
+			// All good.
+		default:
+			return EntryInvalid, errors.Errorf("unknown metric type for metric %q: %s", name, p.mf.GetType())
 		}
 		p.metricBytes.Reset()
 		p.metricBytes.WriteString(name)
@@ -346,7 +365,8 @@ func (p *ProtobufParser) Next() (Entry, error) {
 	case EntryHelp:
 		p.state = EntryType
 	case EntryType:
-		if p.mf.GetType() == dto.MetricType_HISTOGRAM &&
+		t := p.mf.GetType()
+		if (t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM) &&
 			isNativeHistogram(p.mf.GetMetric()[0].GetHistogram()) {
 			p.state = EntryHistogram
 		} else {
@@ -356,8 +376,11 @@ func (p *ProtobufParser) Next() (Entry, error) {
 			return EntryInvalid, err
 		}
 	case EntryHistogram, EntrySeries:
+		t := p.mf.GetType()
 		if p.state == EntrySeries && !p.fieldsDone &&
-			(p.mf.GetType() == dto.MetricType_SUMMARY || p.mf.GetType() == dto.MetricType_HISTOGRAM) {
+			(t == dto.MetricType_SUMMARY ||
+				t == dto.MetricType_HISTOGRAM ||
+				t == dto.MetricType_GAUGE_HISTOGRAM) {
 			p.fieldPos++
 		} else {
 			p.metricPos++
@@ -418,7 +441,7 @@ func (p *ProtobufParser) getMagicName() string {
 	if p.fieldPos == -1 {
 		return p.mf.GetName() + "_sum"
 	}
-	if t == dto.MetricType_HISTOGRAM {
+	if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM {
 		return p.mf.GetName() + "_bucket"
 	}
 	return p.mf.GetName()
@@ -436,7 +459,7 @@ func (p *ProtobufParser) getMagicLabel() (bool, string, string) {
 		q := qq[p.fieldPos]
 		p.fieldsDone = p.fieldPos == len(qq)-1
 		return true, model.QuantileLabel, formatOpenMetricsFloat(q.GetQuantile())
-	case dto.MetricType_HISTOGRAM:
+	case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
 		bb := p.mf.GetMetric()[p.metricPos].GetHistogram().GetBucket()
 		if p.fieldPos >= len(bb) {
 			p.fieldsDone = true

--- a/vendor/github.com/prometheus/prometheus/rules/manager.go
+++ b/vendor/github.com/prometheus/prometheus/rules/manager.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -681,7 +682,16 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}()
 
 			for _, s := range vector {
-				if _, err := app.Append(0, s.Metric, s.T, s.V); err != nil {
+				if s.H != nil {
+					// We assume that all native histogram results are gauge histograms.
+					// TODO(codesome): once PromQL can give the counter reset info, remove this assumption.
+					s.H.CounterResetHint = histogram.GaugeType
+					_, err = app.AppendHistogram(0, s.Metric, s.T, nil, s.H)
+				} else {
+					_, err = app.Append(0, s.Metric, s.T, s.V)
+				}
+
+				if err != nil {
 					rule.SetHealth(HealthBad)
 					rule.SetLastError(err)
 					sp.SetStatus(codes.Error, err.Error())

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -1544,7 +1544,7 @@ loop:
 			fh                       *histogram.FloatHistogram
 		)
 		if et, err = p.Next(); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = nil
 			}
 			break

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -917,8 +916,7 @@ type scrapeCache struct {
 	series map[string]*cacheEntry
 
 	// Cache of dropped metric strings and their iteration. The iteration must
-	// be a pointer so we can update it without setting a new entry with an unsafe
-	// string in addDropped().
+	// be a pointer so we can update it.
 	droppedSeries map[string]*uint64
 
 	// seriesCur and seriesPrev store the labels of series that were seen
@@ -1006,8 +1004,8 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	}
 }
 
-func (c *scrapeCache) get(met string) (*cacheEntry, bool) {
-	e, ok := c.series[met]
+func (c *scrapeCache) get(met []byte) (*cacheEntry, bool) {
+	e, ok := c.series[string(met)]
 	if !ok {
 		return nil, false
 	}
@@ -1015,20 +1013,20 @@ func (c *scrapeCache) get(met string) (*cacheEntry, bool) {
 	return e, true
 }
 
-func (c *scrapeCache) addRef(met string, ref storage.SeriesRef, lset labels.Labels, hash uint64) {
+func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labels, hash uint64) {
 	if ref == 0 {
 		return
 	}
-	c.series[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
+	c.series[string(met)] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
 }
 
-func (c *scrapeCache) addDropped(met string) {
+func (c *scrapeCache) addDropped(met []byte) {
 	iter := c.iter
-	c.droppedSeries[met] = &iter
+	c.droppedSeries[string(met)] = &iter
 }
 
-func (c *scrapeCache) getDropped(met string) bool {
-	iterp, ok := c.droppedSeries[met]
+func (c *scrapeCache) getDropped(met []byte) bool {
+	iterp, ok := c.droppedSeries[string(met)]
 	if ok {
 		*iterp = c.iter
 	}
@@ -1052,7 +1050,7 @@ func (c *scrapeCache) forEachStale(f func(labels.Labels) bool) {
 func (c *scrapeCache) setType(metric []byte, t textparse.MetricType) {
 	c.metaMtx.Lock()
 
-	e, ok := c.metadata[yoloString(metric)]
+	e, ok := c.metadata[string(metric)]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: textparse.MetricTypeUnknown}}
 		c.metadata[string(metric)] = e
@@ -1069,12 +1067,12 @@ func (c *scrapeCache) setType(metric []byte, t textparse.MetricType) {
 func (c *scrapeCache) setHelp(metric, help []byte) {
 	c.metaMtx.Lock()
 
-	e, ok := c.metadata[yoloString(metric)]
+	e, ok := c.metadata[string(metric)]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: textparse.MetricTypeUnknown}}
 		c.metadata[string(metric)] = e
 	}
-	if e.Help != yoloString(help) {
+	if e.Help != string(help) {
 		e.Help = string(help)
 		e.lastIterChange = c.iter
 	}
@@ -1086,12 +1084,12 @@ func (c *scrapeCache) setHelp(metric, help []byte) {
 func (c *scrapeCache) setUnit(metric, unit []byte) {
 	c.metaMtx.Lock()
 
-	e, ok := c.metadata[yoloString(metric)]
+	e, ok := c.metadata[string(metric)]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: textparse.MetricTypeUnknown}}
 		c.metadata[string(metric)] = e
 	}
-	if e.Unit != yoloString(unit) {
+	if e.Unit != string(unit) {
 		e.Unit = string(unit)
 		e.lastIterChange = c.iter
 	}
@@ -1509,7 +1507,7 @@ func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string,
 
 		sl.cache.metaMtx.Lock()
 		defer sl.cache.metaMtx.Unlock()
-		metaEntry, metaOk := sl.cache.metadata[yoloString([]byte(lset.Get(labels.MetricName)))]
+		metaEntry, metaOk := sl.cache.metadata[lset.Get(labels.MetricName)]
 		if metaOk && (isNewSeries || metaEntry.lastIterChange == sl.cache.iter) {
 			metadataChanged = true
 			meta.Type = metaEntry.Type
@@ -1584,14 +1582,13 @@ loop:
 		meta = metadata.Metadata{}
 		metadataChanged = false
 
-		if sl.cache.getDropped(yoloString(met)) {
+		if sl.cache.getDropped(met) {
 			continue
 		}
-		ce, ok := sl.cache.get(yoloString(met))
+		ce, ok := sl.cache.get(met)
 		var (
 			ref  storage.SeriesRef
 			lset labels.Labels
-			mets string
 			hash uint64
 		)
 
@@ -1602,7 +1599,7 @@ loop:
 			// Update metadata only if it changed in the current iteration.
 			updateMetadata(lset, false)
 		} else {
-			mets = p.Metric(&lset)
+			p.Metric(&lset)
 			hash = lset.Hash()
 
 			// Hash label set as it is seen local to the target. Then add target labels
@@ -1611,7 +1608,7 @@ loop:
 
 			// The label set may be set to empty to indicate dropping.
 			if lset.IsEmpty() {
-				sl.cache.addDropped(mets)
+				sl.cache.addDropped(met)
 				continue
 			}
 
@@ -1656,7 +1653,7 @@ loop:
 				// Bypass staleness logic if there is an explicit timestamp.
 				sl.cache.trackStaleness(hash, lset)
 			}
-			sl.cache.addRef(mets, ref, lset, hash)
+			sl.cache.addRef(met, ref, lset, hash)
 			if sampleAdded && sampleLimitErr == nil {
 				seriesAdded++
 			}
@@ -1721,10 +1718,6 @@ loop:
 	return
 }
 
-func yoloString(b []byte) string {
-	return *((*string)(unsafe.Pointer(&b)))
-}
-
 // Adds samples to the appender, checking the error, and then returns the # of samples added,
 // whether the caller should continue to process more samples, and any sample limit errors.
 func (sl *scrapeLoop) checkAddError(ce *cacheEntry, met []byte, tp *int64, err error, sampleLimitErr *error, appErrs *appendErrors) (bool, error) {
@@ -1777,15 +1770,15 @@ func (sl *scrapeLoop) checkAddExemplarError(err error, e exemplar.Exemplar, appE
 
 // The constants are suffixed with the invalid \xff unicode rune to avoid collisions
 // with scraped metrics in the cache.
-const (
-	scrapeHealthMetricName        = "up" + "\xff"
-	scrapeDurationMetricName      = "scrape_duration_seconds" + "\xff"
-	scrapeSamplesMetricName       = "scrape_samples_scraped" + "\xff"
-	samplesPostRelabelMetricName  = "scrape_samples_post_metric_relabeling" + "\xff"
-	scrapeSeriesAddedMetricName   = "scrape_series_added" + "\xff"
-	scrapeTimeoutMetricName       = "scrape_timeout_seconds" + "\xff"
-	scrapeSampleLimitMetricName   = "scrape_sample_limit" + "\xff"
-	scrapeBodySizeBytesMetricName = "scrape_body_size_bytes" + "\xff"
+var (
+	scrapeHealthMetricName        = []byte("up" + "\xff")
+	scrapeDurationMetricName      = []byte("scrape_duration_seconds" + "\xff")
+	scrapeSamplesMetricName       = []byte("scrape_samples_scraped" + "\xff")
+	samplesPostRelabelMetricName  = []byte("scrape_samples_post_metric_relabeling" + "\xff")
+	scrapeSeriesAddedMetricName   = []byte("scrape_series_added" + "\xff")
+	scrapeTimeoutMetricName       = []byte("scrape_timeout_seconds" + "\xff")
+	scrapeSampleLimitMetricName   = []byte("scrape_sample_limit" + "\xff")
+	scrapeBodySizeBytesMetricName = []byte("scrape_body_size_bytes" + "\xff")
 )
 
 func (sl *scrapeLoop) report(app storage.Appender, start time.Time, duration time.Duration, scraped, added, seriesAdded, bytes int, scrapeErr error) (err error) {
@@ -1861,7 +1854,7 @@ func (sl *scrapeLoop) reportStale(app storage.Appender, start time.Time) (err er
 	return
 }
 
-func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v float64) error {
+func (sl *scrapeLoop) addReportSample(app storage.Appender, s []byte, t int64, v float64) error {
 	ce, ok := sl.cache.get(s)
 	var ref storage.SeriesRef
 	var lset labels.Labels
@@ -1872,7 +1865,7 @@ func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v
 		// The constants are suffixed with the invalid \xff unicode rune to avoid collisions
 		// with scraped metrics in the cache.
 		// We have to drop it when building the actual metric.
-		lset = labels.FromStrings(labels.MetricName, s[:len(s)-1])
+		lset = labels.FromStrings(labels.MetricName, string(s[:len(s)-1]))
 		lset = sl.reportSampleMutator(lset)
 	}
 

--- a/vendor/github.com/prometheus/prometheus/storage/buffer.go
+++ b/vendor/github.com/prometheus/prometheus/storage/buffer.go
@@ -68,9 +68,11 @@ func (b *BufferedSeriesIterator) ReduceDelta(delta int64) bool {
 
 // PeekBack returns the nth previous element of the iterator. If there is none buffered,
 // ok is false.
-func (b *BufferedSeriesIterator) PeekBack(n int) (t int64, v float64, h *histogram.Histogram, ok bool) {
+func (b *BufferedSeriesIterator) PeekBack(n int) (
+	t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, ok bool,
+) {
 	s, ok := b.buf.nthLast(n)
-	return s.t, s.v, s.h, ok
+	return s.t, s.v, s.h, s.fh, ok
 }
 
 // Buffer returns an iterator over the buffered data. Invalidates previously

--- a/vendor/github.com/prometheus/prometheus/storage/remote/codec.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/codec.go
@@ -525,7 +525,7 @@ func exemplarProtoToExemplar(ep prompb.Exemplar) exemplar.Exemplar {
 
 // HistogramProtoToHistogram extracts a (normal integer) Histogram from the
 // provided proto message. The caller has to make sure that the proto message
-// represents an interger histogram and not a float histogram.
+// represents an integer histogram and not a float histogram.
 func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
 	return &histogram.Histogram{
 		Schema:          hp.Schema,
@@ -537,6 +537,23 @@ func HistogramProtoToHistogram(hp prompb.Histogram) *histogram.Histogram {
 		PositiveBuckets: hp.GetPositiveDeltas(),
 		NegativeSpans:   spansProtoToSpans(hp.GetNegativeSpans()),
 		NegativeBuckets: hp.GetNegativeDeltas(),
+	}
+}
+
+// HistogramProtoToFloatHistogram extracts a (normal integer) Histogram from the
+// provided proto message to a Float Histogram. The caller has to make sure that
+// the proto message represents an float histogram and not a integer histogram.
+func HistogramProtoToFloatHistogram(hp prompb.Histogram) *histogram.FloatHistogram {
+	return &histogram.FloatHistogram{
+		Schema:          hp.Schema,
+		ZeroThreshold:   hp.ZeroThreshold,
+		ZeroCount:       hp.GetZeroCountFloat(),
+		Count:           hp.GetCountFloat(),
+		Sum:             hp.Sum,
+		PositiveSpans:   spansProtoToSpans(hp.GetPositiveSpans()),
+		PositiveBuckets: hp.GetPositiveCounts(),
+		NegativeSpans:   spansProtoToSpans(hp.GetNegativeSpans()),
+		NegativeBuckets: hp.GetNegativeCounts(),
 	}
 }
 
@@ -560,6 +577,21 @@ func HistogramToHistogramProto(timestamp int64, h *histogram.Histogram) prompb.H
 		NegativeDeltas: h.NegativeBuckets,
 		PositiveSpans:  spansToSpansProto(h.PositiveSpans),
 		PositiveDeltas: h.PositiveBuckets,
+		Timestamp:      timestamp,
+	}
+}
+
+func FloatHistogramToHistogramProto(timestamp int64, fh *histogram.FloatHistogram) prompb.Histogram {
+	return prompb.Histogram{
+		Count:          &prompb.Histogram_CountFloat{CountFloat: fh.Count},
+		Sum:            fh.Sum,
+		Schema:         fh.Schema,
+		ZeroThreshold:  fh.ZeroThreshold,
+		ZeroCount:      &prompb.Histogram_ZeroCountFloat{ZeroCountFloat: fh.ZeroCount},
+		NegativeSpans:  spansToSpansProto(fh.NegativeSpans),
+		NegativeCounts: fh.NegativeBuckets,
+		PositiveSpans:  spansToSpansProto(fh.PositiveSpans),
+		PositiveCounts: fh.PositiveBuckets,
 		Timestamp:      timestamp,
 	}
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/block.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/block.go
@@ -72,7 +72,7 @@ type IndexReader interface {
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
 	// Found IDs are not strictly required to point to a valid Series, e.g.
-	// during background garbage collections. Input values must be sorted.
+	// during background garbage collections.
 	Postings(name string, values ...string) (index.Postings, error)
 
 	// PostingsForMatchers assembles a single postings iterator based on the given matchers.

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/float_histogram.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/float_histogram.go
@@ -174,6 +174,7 @@ func newFloatHistogramIterator(b []byte) *floatHistogramIterator {
 	// The first 3 bytes contain chunk headers.
 	// We skip that for actual samples.
 	_, _ = it.br.readBits(24)
+	it.counterResetHeader = CounterResetHeader(b[2] & 0b11000000)
 	return it
 }
 
@@ -196,6 +197,14 @@ type FloatHistogramAppender struct {
 	pBuckets, nBuckets []xorValue
 }
 
+func (a *FloatHistogramAppender) GetCounterResetHeader() CounterResetHeader {
+	return CounterResetHeader(a.b.bytes()[2] & 0b11000000)
+}
+
+func (a *FloatHistogramAppender) NumSamples() int {
+	return int(binary.BigEndian.Uint16(a.b.bytes()))
+}
+
 // Append implements Appender. This implementation panics because normal float
 // samples must never be appended to a histogram chunk.
 func (a *FloatHistogramAppender) Append(int64, float64) {
@@ -211,19 +220,14 @@ func (a *FloatHistogramAppender) AppendHistogram(int64, *histogram.Histogram) {
 // Appendable returns whether the chunk can be appended to, and if so
 // whether any recoding needs to happen using the provided interjections
 // (in case of any new buckets, positive or negative range, respectively).
+// If the sample is a gauge histogram, AppendableGauge must be used instead.
 //
 // The chunk is not appendable in the following cases:
-//
-// • The schema has changed.
-//
-// • The threshold for the zero bucket has changed.
-//
-// • Any buckets have disappeared.
-//
-// • There was a counter reset in the count of observations or in any bucket,
-// including the zero bucket.
-//
-// • The last sample in the chunk was stale while the current sample is not stale.
+//   - The schema has changed.
+//   - The threshold for the zero bucket has changed.
+//   - Any buckets have disappeared.
+//   - There was a counter reset in the count of observations or in any bucket, including the zero bucket.
+//   - The last sample in the chunk was stale while the current sample is not stale.
 //
 // The method returns an additional boolean set to true if it is not appendable
 // because of a counter reset. If the given sample is stale, it is always ok to
@@ -232,6 +236,9 @@ func (a *FloatHistogramAppender) Appendable(h *histogram.FloatHistogram) (
 	positiveInterjections, negativeInterjections []Interjection,
 	okToAppend, counterReset bool,
 ) {
+	if a.NumSamples() > 0 && a.GetCounterResetHeader() == GaugeType {
+		return
+	}
 	if value.IsStaleNaN(h.Sum) {
 		// This is a stale sample whose buckets and spans don't matter.
 		okToAppend = true
@@ -260,12 +267,12 @@ func (a *FloatHistogramAppender) Appendable(h *histogram.FloatHistogram) (
 	}
 
 	var ok bool
-	positiveInterjections, ok = compareSpans(a.pSpans, h.PositiveSpans)
+	positiveInterjections, ok = forwardCompareSpans(a.pSpans, h.PositiveSpans)
 	if !ok {
 		counterReset = true
 		return
 	}
-	negativeInterjections, ok = compareSpans(a.nSpans, h.NegativeSpans)
+	negativeInterjections, ok = forwardCompareSpans(a.nSpans, h.NegativeSpans)
 	if !ok {
 		counterReset = true
 		return
@@ -277,6 +284,49 @@ func (a *FloatHistogramAppender) Appendable(h *histogram.FloatHistogram) (
 		return
 	}
 
+	okToAppend = true
+	return
+}
+
+// AppendableGauge returns whether the chunk can be appended to, and if so
+// whether:
+//  1. Any recoding needs to happen to the chunk using the provided interjections
+//     (in case of any new buckets, positive or negative range, respectively).
+//  2. Any recoding needs to happen for the histogram being appended, using the backward interjections
+//     (in case of any missing buckets, positive or negative range, respectively).
+//
+// This method must be only used for gauge histograms.
+//
+// The chunk is not appendable in the following cases:
+//   - The schema has changed.
+//   - The threshold for the zero bucket has changed.
+//   - The last sample in the chunk was stale while the current sample is not stale.
+func (a *FloatHistogramAppender) AppendableGauge(h *histogram.FloatHistogram) (
+	positiveInterjections, negativeInterjections []Interjection,
+	backwardPositiveInterjections, backwardNegativeInterjections []Interjection,
+	positiveSpans, negativeSpans []histogram.Span,
+	okToAppend bool,
+) {
+	if a.NumSamples() > 0 && a.GetCounterResetHeader() != GaugeType {
+		return
+	}
+	if value.IsStaleNaN(h.Sum) {
+		// This is a stale sample whose buckets and spans don't matter.
+		okToAppend = true
+		return
+	}
+	if value.IsStaleNaN(a.sum.value) {
+		// If the last sample was stale, then we can only accept stale
+		// samples in this chunk.
+		return
+	}
+
+	if h.Schema != a.schema || h.ZeroThreshold != a.zThreshold {
+		return
+	}
+
+	positiveInterjections, backwardPositiveInterjections, positiveSpans = bidirectionalCompareSpans(a.pSpans, h.PositiveSpans)
+	negativeInterjections, backwardNegativeInterjections, negativeSpans = bidirectionalCompareSpans(a.nSpans, h.NegativeSpans)
 	okToAppend = true
 	return
 }
@@ -502,10 +552,28 @@ func (a *FloatHistogramAppender) Recode(
 	return hc, app
 }
 
+// RecodeHistogramm converts the current histogram (in-place) to accommodate an expansion of the set of
+// (positive and/or negative) buckets used.
+func (a *FloatHistogramAppender) RecodeHistogramm(
+	fh *histogram.FloatHistogram,
+	pBackwardInter, nBackwardInter []Interjection,
+) {
+	if len(pBackwardInter) > 0 {
+		numPositiveBuckets := countSpans(fh.PositiveSpans)
+		fh.PositiveBuckets = interject(fh.PositiveBuckets, make([]float64, numPositiveBuckets), pBackwardInter, false)
+	}
+	if len(nBackwardInter) > 0 {
+		numNegativeBuckets := countSpans(fh.NegativeSpans)
+		fh.NegativeBuckets = interject(fh.NegativeBuckets, make([]float64, numNegativeBuckets), nBackwardInter, false)
+	}
+}
+
 type floatHistogramIterator struct {
 	br       bstreamReader
 	numTotal uint16
 	numRead  uint16
+
+	counterResetHeader CounterResetHeader
 
 	// Layout:
 	schema         int32
@@ -559,16 +627,21 @@ func (it *floatHistogramIterator) AtFloatHistogram() (int64, *histogram.FloatHis
 		return it.t, &histogram.FloatHistogram{Sum: it.sum.value}
 	}
 	it.atFloatHistogramCalled = true
+	crHint := histogram.UnknownCounterReset
+	if it.counterResetHeader == GaugeType {
+		crHint = histogram.GaugeType
+	}
 	return it.t, &histogram.FloatHistogram{
-		Count:           it.cnt.value,
-		ZeroCount:       it.zCnt.value,
-		Sum:             it.sum.value,
-		ZeroThreshold:   it.zThreshold,
-		Schema:          it.schema,
-		PositiveSpans:   it.pSpans,
-		NegativeSpans:   it.nSpans,
-		PositiveBuckets: it.pBuckets,
-		NegativeBuckets: it.nBuckets,
+		CounterResetHint: crHint,
+		Count:            it.cnt.value,
+		ZeroCount:        it.zCnt.value,
+		Sum:              it.sum.value,
+		ZeroThreshold:    it.zThreshold,
+		Schema:           it.schema,
+		PositiveSpans:    it.pSpans,
+		NegativeSpans:    it.nSpans,
+		PositiveBuckets:  it.pBuckets,
+		NegativeBuckets:  it.nBuckets,
 	}
 }
 
@@ -586,6 +659,8 @@ func (it *floatHistogramIterator) Reset(b []byte) {
 	it.br = newBReader(b[3:])
 	it.numTotal = binary.BigEndian.Uint16(b)
 	it.numRead = 0
+
+	it.counterResetHeader = CounterResetHeader(b[2] & 0b11000000)
 
 	it.t, it.tDelta = 0, 0
 	it.cnt, it.zCnt, it.sum = xorValue{}, xorValue{}, xorValue{}

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/histogram.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/histogram.go
@@ -590,9 +590,9 @@ func (a *HistogramAppender) Recode(
 	return hc, app
 }
 
-// RecodeHistogramm converts the current histogram (in-place) to accommodate an expansion of the set of
+// RecodeHistogram converts the current histogram (in-place) to accommodate an expansion of the set of
 // (positive and/or negative) buckets used.
-func (a *HistogramAppender) RecodeHistogramm(
+func (a *HistogramAppender) RecodeHistogram(
 	h *histogram.Histogram,
 	pBackwardInter, nBackwardInter []Interjection,
 ) {

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"path/filepath"
 	"sync"
 	"time"
@@ -694,7 +695,7 @@ func (h *Head) Init(minValidTime int64) error {
 			offset = snapOffset
 		}
 		sr, err := wlog.NewSegmentBufReaderWithOffset(offset, s)
-		if errors.Cause(err) == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// File does not exist.
 			continue
 		}
@@ -789,7 +790,11 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			h.metrics.chunks.Inc()
 			h.metrics.chunksCreated.Inc()
 
-			ms.oooMmappedChunks = append(ms.oooMmappedChunks, &mmappedChunk{
+			if ms.ooo == nil {
+				ms.ooo = &memSeriesOOOFields{}
+			}
+
+			ms.ooo.oooMmappedChunks = append(ms.ooo.oooMmappedChunks, &mmappedChunk{
 				ref:        chunkRef,
 				minTime:    mint,
 				maxTime:    maxt,
@@ -1692,24 +1697,24 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 						minMmapFile = seq
 					}
 				}
-				if len(series.oooMmappedChunks) > 0 {
-					seq, _ := series.oooMmappedChunks[0].ref.Unpack()
+				if series.ooo != nil && len(series.ooo.oooMmappedChunks) > 0 {
+					seq, _ := series.ooo.oooMmappedChunks[0].ref.Unpack()
 					if seq < minMmapFile {
 						minMmapFile = seq
 					}
-					for _, ch := range series.oooMmappedChunks {
+					for _, ch := range series.ooo.oooMmappedChunks {
 						if ch.minTime < minOOOTime {
 							minOOOTime = ch.minTime
 						}
 					}
 				}
-				if series.oooHeadChunk != nil {
-					if series.oooHeadChunk.minTime < minOOOTime {
-						minOOOTime = series.oooHeadChunk.minTime
+				if series.ooo != nil && series.ooo.oooHeadChunk != nil {
+					if series.ooo.oooHeadChunk.minTime < minOOOTime {
+						minOOOTime = series.ooo.oooHeadChunk.minTime
 					}
 				}
-				if len(series.mmappedChunks) > 0 || len(series.oooMmappedChunks) > 0 ||
-					series.headChunk != nil || series.oooHeadChunk != nil || series.pendingCommit {
+				if len(series.mmappedChunks) > 0 || series.headChunk != nil || series.pendingCommit ||
+					(series.ooo != nil && (len(series.ooo.oooMmappedChunks) > 0 || series.ooo.oooHeadChunk != nil)) {
 					seriesMint := series.minTime()
 					if seriesMint < actualMint {
 						actualMint = seriesMint
@@ -1867,9 +1872,7 @@ type memSeries struct {
 	headChunk     *memChunk          // Most recent chunk in memory that's still being built.
 	firstChunkID  chunks.HeadChunkID // HeadChunkID for mmappedChunks[0]
 
-	oooMmappedChunks []*mmappedChunk    // Immutable chunks on disk containing OOO samples.
-	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
-	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0]
+	ooo *memSeriesOOOFields
 
 	mmMaxTime int64 // Max time of any mmapped chunk, only used during WAL replay.
 
@@ -1895,6 +1898,14 @@ type memSeries struct {
 	txs *txRing
 
 	pendingCommit bool // Whether there are samples waiting to be committed to this series.
+}
+
+// memSeriesOOOFields contains the fields required by memSeries
+// to handle out-of-order data.
+type memSeriesOOOFields struct {
+	oooMmappedChunks []*mmappedChunk    // Immutable chunks on disk containing OOO samples.
+	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
+	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0].
 }
 
 func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, hash uint64, chunkEndTimeVariance float64, isolationDisabled bool) *memSeries {
@@ -1957,15 +1968,19 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 	}
 
 	var removedOOO int
-	if len(s.oooMmappedChunks) > 0 {
-		for i, c := range s.oooMmappedChunks {
+	if s.ooo != nil && len(s.ooo.oooMmappedChunks) > 0 {
+		for i, c := range s.ooo.oooMmappedChunks {
 			if c.ref.GreaterThan(minOOOMmapRef) {
 				break
 			}
 			removedOOO = i + 1
 		}
-		s.oooMmappedChunks = append(s.oooMmappedChunks[:0], s.oooMmappedChunks[removedOOO:]...)
-		s.firstOOOChunkID += chunks.HeadChunkID(removedOOO)
+		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks[:0], s.ooo.oooMmappedChunks[removedOOO:]...)
+		s.ooo.firstOOOChunkID += chunks.HeadChunkID(removedOOO)
+
+		if len(s.ooo.oooMmappedChunks) == 0 && s.ooo.oooHeadChunk == nil {
+			s.ooo = nil
+		}
 	}
 
 	return removedInOrder + removedOOO
@@ -2060,7 +2075,7 @@ func (h *Head) updateWALReplayStatusRead(current int) {
 func GenerateTestHistograms(n int) (r []*histogram.Histogram) {
 	for i := 0; i < n; i++ {
 		r = append(r, &histogram.Histogram{
-			Count:         5 + uint64(i*4),
+			Count:         10 + uint64(i*8),
 			ZeroCount:     2 + uint64(i),
 			ZeroThreshold: 0.001,
 			Sum:           18.4 * float64(i+1),
@@ -2070,6 +2085,37 @@ func GenerateTestHistograms(n int) (r []*histogram.Histogram) {
 				{Offset: 1, Length: 2},
 			},
 			PositiveBuckets: []int64{int64(i + 1), 1, -1, 0},
+			NegativeSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			NegativeBuckets: []int64{int64(i + 1), 1, -1, 0},
+		})
+	}
+
+	return r
+}
+
+func GenerateTestGaugeHistograms(n int) (r []*histogram.Histogram) {
+	for x := 0; x < n; x++ {
+		i := rand.Intn(n)
+		r = append(r, &histogram.Histogram{
+			CounterResetHint: histogram.GaugeType,
+			Count:            10 + uint64(i*8),
+			ZeroCount:        2 + uint64(i),
+			ZeroThreshold:    0.001,
+			Sum:              18.4 * float64(i+1),
+			Schema:           1,
+			PositiveSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			PositiveBuckets: []int64{int64(i + 1), 1, -1, 0},
+			NegativeSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			NegativeBuckets: []int64{int64(i + 1), 1, -1, 0},
 		})
 	}
 
@@ -2079,7 +2125,7 @@ func GenerateTestHistograms(n int) (r []*histogram.Histogram) {
 func GenerateTestFloatHistograms(n int) (r []*histogram.FloatHistogram) {
 	for i := 0; i < n; i++ {
 		r = append(r, &histogram.FloatHistogram{
-			Count:         5 + float64(i*4),
+			Count:         10 + float64(i*8),
 			ZeroCount:     2 + float64(i),
 			ZeroThreshold: 0.001,
 			Sum:           18.4 * float64(i+1),
@@ -2089,6 +2135,37 @@ func GenerateTestFloatHistograms(n int) (r []*histogram.FloatHistogram) {
 				{Offset: 1, Length: 2},
 			},
 			PositiveBuckets: []float64{float64(i + 1), float64(i + 2), float64(i + 1), float64(i + 1)},
+			NegativeSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			NegativeBuckets: []float64{float64(i + 1), float64(i + 2), float64(i + 1), float64(i + 1)},
+		})
+	}
+
+	return r
+}
+
+func GenerateTestGaugeFloatHistograms(n int) (r []*histogram.FloatHistogram) {
+	for x := 0; x < n; x++ {
+		i := rand.Intn(n)
+		r = append(r, &histogram.FloatHistogram{
+			CounterResetHint: histogram.GaugeType,
+			Count:            10 + float64(i*8),
+			ZeroCount:        2 + float64(i),
+			ZeroThreshold:    0.001,
+			Sum:              18.4 * float64(i+1),
+			Schema:           1,
+			PositiveSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			PositiveBuckets: []float64{float64(i + 1), float64(i + 2), float64(i + 1), float64(i + 1)},
+			NegativeSpans: []histogram.Span{
+				{Offset: 0, Length: 2},
+				{Offset: 1, Length: 2},
+			},
+			NegativeBuckets: []float64{float64(i + 1), float64(i + 2), float64(i + 1), float64(i + 1)},
 		})
 	}
 

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
@@ -1179,7 +1179,7 @@ func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID ui
 		if len(pBackwardInter)+len(nBackwardInter) > 0 {
 			h.PositiveSpans = pMergedSpans
 			h.NegativeSpans = nMergedSpans
-			app.RecodeHistogramm(h, pBackwardInter, nBackwardInter)
+			app.RecodeHistogram(h, pBackwardInter, nBackwardInter)
 		}
 		// We have 3 cases here
 		// - !okToAppend -> We need to cut a new chunk.

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
@@ -499,7 +499,6 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	h.metrics.chunksRemoved.Add(float64(len(mSeries.mmappedChunks)))
 	h.metrics.chunks.Add(float64(len(mmc) + len(oooMmc) - len(mSeries.mmappedChunks)))
 	mSeries.mmappedChunks = mmc
-	mSeries.ooo = nil
 	if len(oooMmc) == 0 {
 		mSeries.ooo = nil
 	} else {

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
@@ -496,10 +496,18 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	}
 
 	h.metrics.chunksCreated.Add(float64(len(mmc) + len(oooMmc)))
-	h.metrics.chunksRemoved.Add(float64(len(mSeries.mmappedChunks) + len(mSeries.oooMmappedChunks)))
-	h.metrics.chunks.Add(float64(len(mmc) + len(oooMmc) - len(mSeries.mmappedChunks) - len(mSeries.oooMmappedChunks)))
+	h.metrics.chunksRemoved.Add(float64(len(mSeries.mmappedChunks)))
+	h.metrics.chunks.Add(float64(len(mmc) + len(oooMmc) - len(mSeries.mmappedChunks)))
 	mSeries.mmappedChunks = mmc
-	mSeries.oooMmappedChunks = oooMmc
+	mSeries.ooo = nil
+	if len(oooMmc) == 0 {
+		mSeries.ooo = nil
+	} else {
+		if mSeries.ooo == nil {
+			mSeries.ooo = &memSeriesOOOFields{}
+		}
+		*mSeries.ooo = memSeriesOOOFields{oooMmappedChunks: oooMmc}
+	}
 	// Cache the last mmapped chunk time, so we can skip calling append() for samples it will reject.
 	if len(mmc) == 0 {
 		mSeries.mmMaxTime = math.MinInt64
@@ -818,7 +826,9 @@ func (h *Head) loadWBL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				// chunk size parameters, we are not taking care of that here.
 				// TODO(codesome): see if there is a way to avoid duplicate m-map chunks if
 				// the size of ooo chunk was reduced between restart.
-				ms.oooHeadChunk = nil
+				if ms.ooo != nil {
+					ms.ooo.oooHeadChunk = nil
+				}
 
 				processors[idx].mx.Unlock()
 			}

--- a/vendor/github.com/prometheus/prometheus/tsdb/index/index.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/index/index.go
@@ -1662,6 +1662,7 @@ func (r *Reader) Postings(name string, values ...string) (Postings, error) {
 		return EmptyPostings(), nil
 	}
 
+	slices.Sort(values) // Values must be in order so we can step through the table on disk.
 	res := make([]Postings, 0, len(values))
 	skip := 0
 	valueIndex := 0
@@ -1906,7 +1907,7 @@ func (dec *Decoder) LabelValueFor(b []byte, label string) (string, error) {
 }
 
 // Series decodes a series entry from the given byte slice into builder and chks.
-// Previous contents of lbls can be overwritten - make sure you copy before retaining.
+// Previous contents of builder can be overwritten - make sure you copy before retaining.
 func (dec *Decoder) Series(b []byte, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
 	builder.Reset()
 	if chks != nil {

--- a/vendor/github.com/prometheus/prometheus/tsdb/record/record.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/record/record.go
@@ -441,6 +441,8 @@ func (d *Decoder) HistogramSamples(rec []byte, histograms []RefHistogramSample) 
 			H:   &histogram.Histogram{},
 		}
 
+		rh.H.CounterResetHint = histogram.CounterResetHint(dec.Byte())
+
 		rh.H.Schema = int32(dec.Varint64())
 		rh.H.ZeroThreshold = math.Float64frombits(dec.Be64())
 
@@ -516,6 +518,8 @@ func (d *Decoder) FloatHistogramSamples(rec []byte, histograms []RefFloatHistogr
 			T:   baseTime + dtime,
 			FH:  &histogram.FloatHistogram{},
 		}
+
+		rh.FH.CounterResetHint = histogram.CounterResetHint(dec.Byte())
 
 		rh.FH.Schema = int32(dec.Varint64())
 		rh.FH.ZeroThreshold = dec.Be64Float64()
@@ -715,6 +719,8 @@ func (e *Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) []
 		buf.PutVarint64(int64(h.Ref) - int64(first.Ref))
 		buf.PutVarint64(h.T - first.T)
 
+		buf.PutByte(byte(h.H.CounterResetHint))
+
 		buf.PutVarint64(int64(h.H.Schema))
 		buf.PutBE64(math.Float64bits(h.H.ZeroThreshold))
 
@@ -765,6 +771,8 @@ func (e *Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b 
 	for _, h := range histograms {
 		buf.PutVarint64(int64(h.Ref) - int64(first.Ref))
 		buf.PutVarint64(h.T - first.T)
+
+		buf.PutByte(byte(h.FH.CounterResetHint))
 
 		buf.PutVarint64(int64(h.FH.Schema))
 		buf.PutBEFloat64(h.FH.ZeroThreshold)

--- a/vendor/github.com/prometheus/prometheus/tsdb/wal.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wal.go
@@ -1018,7 +1018,7 @@ func (r *walReader) next() bool {
 	// If we reached the end of the reader, advance to the next one
 	// and close.
 	// Do not close on the last one as it will still be appended to.
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		if r.cur == len(r.files)-1 {
 			return false
 		}

--- a/vendor/github.com/prometheus/prometheus/tsdb/wlog/live_reader.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wlog/live_reader.go
@@ -96,7 +96,7 @@ type LiveReader struct {
 // not be used again.  It is up to the user to decide when to stop trying should
 // io.EOF be returned.
 func (r *LiveReader) Err() error {
-	if r.eofNonErr && r.err == io.EOF {
+	if r.eofNonErr && errors.Is(r.err, io.EOF) {
 		return nil
 	}
 	return r.err

--- a/vendor/github.com/prometheus/prometheus/tsdb/wlog/reader.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wlog/reader.go
@@ -43,7 +43,7 @@ func NewReader(r io.Reader) *Reader {
 // It must not be called again after it returned false.
 func (r *Reader) Next() bool {
 	err := r.next()
-	if errors.Cause(err) == io.EOF {
+	if errors.Is(err, io.EOF) {
 		// The last WAL segment record shouldn't be torn(should be full or last).
 		// The last record would be torn after a crash just before
 		// the last record part could be persisted to disk.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -784,7 +784,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230110145420-eaeda077ed95
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826
 ## explicit; go 1.18
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1363,7 +1363,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230110145420-eaeda077ed95
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -784,7 +784,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230117132619-fa6d2a8edee7
 ## explicit; go 1.18
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1363,7 +1363,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230117095202-d44f63ec4826
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230117132619-fa6d2a8edee7
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe


### PR DESCRIPTION
Update to https://github.com/grafana/mimir-prometheus/commit/d44f63ec48263c371d1e2d2bd2a36065bb14c6b6 Including https://github.com/prometheus/prometheus/commit/cb2be6e62ff80ba84b639e4251044214e185886f

Includes a breaking change in WAL record format in case native histograms are ingested: https://github.com/prometheus/prometheus/commit/57bcbf18880f7554ae34c5b341d52fc53f059a97. 

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
