### PR TITLE
Install skopeo 1.10.0 into build image

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -145,7 +145,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3967-4691f3247
+      image: grafana/mimir-build-image:pr3976-e7cae18e3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -145,7 +145,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:pr3973-3700ac406
+      image: grafana/mimir-build-image:pr3967-4691f3247
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr3967-4691f3247
+LATEST_BUILD_IMAGE_TAG ?= pr3976-e7cae18e3
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr3973-3700ac406
+LATEST_BUILD_IMAGE_TAG ?= pr3967-4691f3247
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,11 +5,12 @@
 
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.8.2 as helm
-FROM quay.io/skopeo/stable:v1.10.0 as skopeo
 FROM golang:1.19.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev && \
+RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev
+# skopeo dependencies
+RUN apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
@@ -37,8 +38,10 @@ RUN GOARCH=$(go env GOARCH) && \
 
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.49.0
 
-COPY --from=skopeo /usr/bin/skopeo /usr/bin/skopeo
-COPY --from=skopeo /etc/containers /etc/containers
+ENV SKOPEO_VERSION=v1.10.0
+RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
+    make -C $GOPATH/src/github.com/containers/skopeo bin/skopeo && \
+    mv $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/bin
 
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -8,10 +8,9 @@ FROM alpine/helm:3.8.2 as helm
 FROM golang:1.19.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev
-# skopeo dependencies
-RUN apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
+RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -39,9 +38,9 @@ RUN GOARCH=$(go env GOARCH) && \
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.49.0
 
 ENV SKOPEO_VERSION=v1.10.0
-RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
-    make -C $GOPATH/src/github.com/containers/skopeo bin/skopeo && \
-    mv $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/bin
+RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \
+    DISABLE_DOCS=1 make -C /go/src/github.com/containers/skopeo install && \
+    rm -rf /go/pkg /go/src /root/.cache
 
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \


### PR DESCRIPTION
#### What this PR does

This PR updates skopeo to version 1.10.0 by building it from source and doing full make install.

Continuation of:
- https://github.com/grafana/mimir/pull/3967 (had missing config files)
- https://github.com/grafana/mimir/pull/3973 (missing libs)

#### Which issue(s) this PR fixes or relates to

Fixes pushing images from release branch. Image tested in this run: https://github.com/grafana/mimir/actions/runs/3940063316/jobs/6740797955 (r221-test branch)

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
