### PR TITLE
Implement no-op versions of Prometheus config and flags endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
 * [ENHANCEMENT] Query-frontend: added "fetched index bytes" to query statistics, so that the statistics contain the total bytes read by store-gateways from TSDB block indexes. #3206
 * [ENHANCEMENT] Distributor: push wrapper should only receive unforwarded samples. #2980
-* [ENHANCEMENT] Added the `/api/v1/status/config` API to maintain API compatibility with prometheus. #3596
+* [ENHANCEMENT] Added `/api/v1/status/config` and `/api/v1/status/flags` APIs to maintain compatibility with prometheus. #3596 #TBD
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 * [ENHANCEMENT] S3 bucket configuration now validates that the endpoint does not have the bucket name prefix. #3414
 * [ENHANCEMENT] Query-frontend: added "fetched index bytes" to query statistics, so that the statistics contain the total bytes read by store-gateways from TSDB block indexes. #3206
 * [ENHANCEMENT] Distributor: push wrapper should only receive unforwarded samples. #2980
-* [ENHANCEMENT] Added `/api/v1/status/config` and `/api/v1/status/flags` APIs to maintain compatibility with prometheus. #3596 #TBD
+* [ENHANCEMENT] Added `/api/v1/status/config` and `/api/v1/status/flags` APIs to maintain compatibility with prometheus. #3596 #3983
 * [BUGFIX] Flusher: Add `Overrides` as a dependency to prevent panics when starting with `-target=flusher`. #3151
 * [BUGFIX] Updated `golang.org/x/text` dependency to fix CVE-2022-32149. #3285
 * [BUGFIX] Query-frontend: properly close gRPC streams to the query-scheduler to stop memory and goroutines leak. #3302

--- a/docs/sources/mimir/operators-guide/reference-http-api/index.md
+++ b/docs/sources/mimir/operators-guide/reference-http-api/index.md
@@ -26,6 +26,7 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Index page](#index-page)                                                             | _All services_                 | `GET /`                                                                   |
 | [Configuration](#configuration)                                                       | _All services_                 | `GET /config`                                                             |
 | [Status Configuration](#status-configuration)                                         | _All services_                 | `GET /api/v1/status/config`                                               |
+| [Status Flags](#status-flags)                                                         | _All services_                 | `GET /api/v1/status/flags`                                                |
 | [Runtime Configuration](#runtime-configuration)                                       | _All services_                 | `GET /runtime_config`                                                     |
 | [Services' status](#services-status)                                                  | _All services_                 | `GET /services`                                                           |
 | [Readiness probe](#readiness-probe)                                                   | _All services_                 | `GET /ready`                                                              |
@@ -148,9 +149,15 @@ This endpoint displays the default configuration values.
 GET /api/v1/status/config
 ```
 
-This endpoint displays the configuration currently applied to Grafana Mimir including default values and settings via CLI flags. This endpoint provides the configuration in YAML format and masks sensitive data.
+This endpoint displays empty configuration settings, it exists only to be compatible with the Prometheus `/api/v1/status/config` API.
 
-It is a simplified wrapper for `/config` to be compatible with the prometheus `/api/v1/status/config` API.
+### Status Flags
+
+```
+GET /api/v1/status/flags
+```
+
+This endpoint displays empty configuration flags, it exists only to be compatible with the Prometheus `/api/v1/status/flags` API.
 
 ### Runtime Configuration
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -218,7 +218,8 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 	a.RegisterRoutesWithPrefix("/static/", http.StripPrefix(httpPathPrefix, http.FileServer(http.FS(staticFiles))), false, true, "GET")
 	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), false, true, "GET")
 	a.RegisterRoute("/api/v1/status/buildinfo", buildInfoHandler, false, true, "GET")
-	a.RegisterRoute("/api/v1/status/config", a.cfg.statusConfigHandler(actualCfg), false, true, "GET")
+	a.RegisterRoute("/api/v1/status/config", a.cfg.statusConfigHandler(), false, true, "GET")
+	a.RegisterRoute("/api/v1/status/flags", a.cfg.statusFlagsHandler(), false, true, "GET")
 }
 
 // RegisterRuntimeConfig registers the endpoints associates with the runtime configuration

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -157,7 +157,7 @@ func TestConfigDiffHandler(t *testing.T) {
 				actualCfg = newDefaultDiffConfigMock()
 			}
 
-			req := httptest.NewRequest("GET", "http://test.com/config?mode=diff", nil)
+			req := httptest.NewRequest("GET", "http://localhost/config?mode=diff", nil)
 			w := httptest.NewRecorder()
 
 			h := DefaultConfigHandler(actualCfg, defaultCfg)
@@ -182,7 +182,7 @@ func TestConfigOverrideHandler(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest("GET", "http://test.com/config", nil)
+	req := httptest.NewRequest("GET", "http://localhost/config", nil)
 	w := httptest.NewRecorder()
 
 	h := cfg.configHandler(
@@ -196,42 +196,4 @@ func TestConfigOverrideHandler(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("config"), body)
-}
-
-func TestStatusConfigHandler(t *testing.T) {
-	type testConfig struct {
-		Enabled bool `yaml:"enabled"`
-		MyInt   int  `yaml:"my_int"`
-	}
-
-	for _, tc := range []struct {
-		name               string
-		actualConfig       func() interface{}
-		expectedStatusCode int
-		expectedBody       string
-	}{
-		{
-			name: "normal config",
-			actualConfig: func() interface{} {
-				return &testConfig{Enabled: true, MyInt: 123}
-			},
-			expectedStatusCode: 200,
-			expectedBody:       "{\"status\":\"success\",\"data\":{\"yaml\":\"enabled: true\\nmy_int: 123\\n\"}}",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://test.com/api/v1/status/config", nil)
-			w := httptest.NewRecorder()
-
-			cfg := &Config{}
-			h := cfg.statusConfigHandler(tc.actualConfig())
-			h(w, req)
-			resp := w.Result()
-			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
-
-			body, err := io.ReadAll(resp.Body)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedBody, string(body))
-		})
-	}
 }


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Add `/api/v1/status/config` and `/api/v1/status/flags` endpoints for Prometheus compatibility but do not actually return Mimir configuration.

#### Which issue(s) this PR fixes or relates to

Fixes #3323

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
