### PR TITLE
Fix flaky test TestIngesterNotDeleteShippedBlocksUntilRetentionExpires

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4322,7 +4322,7 @@ func TestIngesterNotDeleteShippedBlocksUntilRetentionExpires(t *testing.T) {
 		# HELP cortex_ingester_oldest_unshipped_block_timestamp_seconds Unix timestamp of the oldest TSDB block not shipped to the storage yet. 0 if ingester has no blocks or all blocks have been shipped.
 		# TYPE cortex_ingester_oldest_unshipped_block_timestamp_seconds gauge
 		cortex_ingester_oldest_unshipped_block_timestamp_seconds %d
-	`, newBlocks[0].Meta().ULID.Time()/1000)), "cortex_ingester_oldest_unshipped_block_timestamp_seconds"))
+	`, newBlocks[1].Meta().ULID.Time()/1000)), "cortex_ingester_oldest_unshipped_block_timestamp_seconds")) // Note it has to be newBlocks[1] because newBlocks[0] was already shipped, it is just kept due to the retention.
 }
 
 func TestIngesterWithShippingDisabledDeletesBlocksOnlyAfterRetentionExpires(t *testing.T) {


### PR DESCRIPTION
Attempts to fix https://github.com/grafana/mimir/issues/3977

After diving into the code I realized that newBlock[0] is shipped but kept until retention expires so the oldest unshipped block is always newBlock[1]. 

My confusion came from thinking "what is the oldest block" and that was newBlock[0] but I had to question "what is the oldest unshipped block". After all I'm only human.

I ran this test locally hundreds of times and I think it was flakky because of the float64 notation in the prometheus metrics test. In cases like this it would always pass:
```
1674041474621 // newblock[0]
1674041474722 // newblock[1]
1674041474826 // newblock[2]
1.674041474e+09 // oldest unshipped block timestamp in float64 notation
```  

But in cases like this it would fail, thus the flakyness
```
1674041477911 // newblock[0]
1674041478008 // newblock[1]
1674041478103 // newblock[2]
1.674041478e+09--- // oldest unshipped block timestamp in float64 notation
``` 
