### PR TITLE
Disable query sharding when tenant accepts native histograms

### DIFF
--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -67,6 +67,9 @@ type Limits interface {
 	// CreationGracePeriod returns the time interval to control how far into the future
 	// incoming samples are accepted compared to the wall clock.
 	CreationGracePeriod(userID string) time.Duration
+
+	// AcceptNativeHistograms returns whether to accept native histograms in the ingester
+	AcceptNativeHistograms(userID string) bool
 }
 
 type limitsMiddleware struct {

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -291,6 +291,7 @@ type mockLimits struct {
 	compactorBlocksRetentionPeriod time.Duration
 	outOfOrderTimeWindow           model.Duration
 	creationGracePeriod            time.Duration
+	acceptNativeHistograms         bool
 }
 
 func (m mockLimits) MaxQueryLookback(string) time.Duration {
@@ -345,6 +346,10 @@ func (m mockLimits) OutOfOrderTimeWindow(userID string) model.Duration {
 
 func (m mockLimits) CreationGracePeriod(userID string) time.Duration {
 	return m.creationGracePeriod
+}
+
+func (m mockLimits) AcceptNativeHistograms(userID string) bool {
+	return m.acceptNativeHistograms
 }
 
 type mockHandler struct {

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -256,6 +256,11 @@ func (s *querySharding) getShardsForQuery(ctx context.Context, tenantIDs []strin
 		return 1
 	}
 
+	// TODO: Remove when https://github.com/grafana/mimir/issues/3992 is solved. Also remove EnabledByAnyTenant (unless used elsewhere)
+	if validation.EnabledByAnyTenant(tenantIDs, s.limit.AcceptNativeHistograms) {
+		return 1
+	}
+
 	// Check the default number of shards configured for the given tenant.
 	totalShards := validation.SmallestPositiveIntPerTenant(tenantIDs, s.limit.QueryShardingTotalShards)
 	if totalShards <= 1 {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -866,3 +866,12 @@ func MaxDurationPerTenant(tenantIDs []string, f func(string) time.Duration) time
 	}
 	return result
 }
+
+func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
+	for _, tenantID := range tenantIDs {
+		if f(tenantID) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -646,3 +646,24 @@ metric_relabel_configs:
 		require.ErrorContains(t, err, "invalid metric_relabel_configs")
 	})
 }
+
+func TestEnabledByAnyTenant(t *testing.T) {
+	tenantLimits := map[string]*Limits{
+		"tenant1": {
+			AcceptNativeHistograms: false,
+		},
+		"tenant2": {
+			AcceptNativeHistograms: true,
+		},
+	}
+
+	defaults := Limits{
+		AcceptNativeHistograms: false,
+	}
+	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
+	require.NoError(t, err)
+
+	require.False(t, EnabledByAnyTenant([]string{"tenant1", "tenant3"}, ov.AcceptNativeHistograms))
+
+	require.True(t, EnabledByAnyTenant([]string{"tenant1", "tenant2", "tenant3"}, ov.AcceptNativeHistograms))
+}


### PR DESCRIPTION
#### What this PR does

Disables query sharding when tenant accepts native histograms.
It's not foolproof as disabling native histograms accept can introduce problems, but that's what #3971  is about.

#### Which issue(s) this PR fixes or relates to

Fixes #3981 

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
