### PR TITLE
Add --concurrency support to 'mimirtool rules sync' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] Mimirtool is now available to install through Homebrew with `brew install mimirtool`. #3776
+* [ENHANCEMENT] Added `--concurrency` to `mimirtool rules sync` command. #3996
 * [BUGFIX] Fix summary output from `mimirtool rules sync` to display correct number of groups created and updated. #3918
 
 ### Documentation

--- a/pkg/mimirtool/client/alerts.go
+++ b/pkg/mimirtool/client/alerts.go
@@ -32,7 +32,7 @@ func (r *MimirClient) CreateAlertmanagerConfig(ctx context.Context, cfg string, 
 		return err
 	}
 
-	res, err := r.doRequest(alertmanagerAPIPath, "POST", bytes.NewBuffer(payload), int64(len(payload)))
+	res, err := r.doRequest(ctx, alertmanagerAPIPath, "POST", bytes.NewBuffer(payload), int64(len(payload)))
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (r *MimirClient) CreateAlertmanagerConfig(ctx context.Context, cfg string, 
 
 // DeleteAlermanagerConfig deletes the users alertmanagerconfig
 func (r *MimirClient) DeleteAlermanagerConfig(ctx context.Context) error {
-	res, err := r.doRequest(alertmanagerAPIPath, "DELETE", nil, -1)
+	res, err := r.doRequest(ctx, alertmanagerAPIPath, "DELETE", nil, -1)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (r *MimirClient) DeleteAlermanagerConfig(ctx context.Context) error {
 
 // GetAlertmanagerConfig retrieves a Mimir cluster's Alertmanager config.
 func (r *MimirClient) GetAlertmanagerConfig(ctx context.Context) (string, map[string]string, error) {
-	res, err := r.doRequest(alertmanagerAPIPath, "GET", nil, -1)
+	res, err := r.doRequest(ctx, alertmanagerAPIPath, "GET", nil, -1)
 	if err != nil {
 		log.Debugln("no alert config present in response")
 		return "", nil, err

--- a/pkg/mimirtool/client/client_test.go
+++ b/pkg/mimirtool/client/client_test.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -92,7 +93,7 @@ func TestBuildURL(t *testing.T) {
 			url, err := url.Parse(tt.url)
 			require.NoError(t, err)
 
-			req, err := buildRequest(tt.path, tt.method, *url, bytes.NewBuffer(nil), 0)
+			req, err := buildRequest(context.Background(), tt.path, tt.method, *url, bytes.NewBuffer(nil), 0)
 			require.NoError(t, err)
 			require.Equal(t, tt.resultURL, req.URL.String())
 		})

--- a/pkg/mimirtool/client/rules.go
+++ b/pkg/mimirtool/client/rules.go
@@ -29,7 +29,7 @@ func (r *MimirClient) CreateRuleGroup(ctx context.Context, namespace string, rg 
 	escapedNamespace := url.PathEscape(namespace)
 	path := r.apiPath + "/" + escapedNamespace
 
-	res, err := r.doRequest(path, "POST", bytes.NewBuffer(payload), int64(len(payload)))
+	res, err := r.doRequest(ctx, path, "POST", bytes.NewBuffer(payload), int64(len(payload)))
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (r *MimirClient) DeleteRuleGroup(ctx context.Context, namespace, groupName 
 	escapedGroupName := url.PathEscape(groupName)
 	path := r.apiPath + "/" + escapedNamespace + "/" + escapedGroupName
 
-	res, err := r.doRequest(path, "DELETE", nil, -1)
+	res, err := r.doRequest(ctx, path, "DELETE", nil, -1)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (r *MimirClient) GetRuleGroup(ctx context.Context, namespace, groupName str
 	path := r.apiPath + "/" + escapedNamespace + "/" + escapedGroupName
 
 	fmt.Println(path)
-	res, err := r.doRequest(path, "GET", nil, -1)
+	res, err := r.doRequest(ctx, path, "GET", nil, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[stri
 		path = path + "/" + namespace
 	}
 
-	res, err := r.doRequest(path, "GET", nil, -1)
+	res, err := r.doRequest(ctx, path, "GET", nil, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (r *MimirClient) DeleteNamespace(ctx context.Context, namespace string) err
 	escapedNamespace := url.PathEscape(namespace)
 	path := r.apiPath + "/" + escapedNamespace
 
-	res, err := r.doRequest(path, "DELETE", nil, -1)
+	res, err := r.doRequest(ctx, path, "DELETE", nil, -1)
 	if err != nil {
 		return err
 	}

--- a/pkg/mimirtool/commands/backfill.go
+++ b/pkg/mimirtool/commands/backfill.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -99,5 +100,5 @@ func (c *BackfillCommand) backfill(k *kingpin.ParseContext) error {
 		return err
 	}
 
-	return cli.Backfill(c.blocks, c.sleepTime)
+	return cli.Backfill(context.Background(), c.blocks, c.sleepTime)
 }

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/grafana/dskit/concurrency"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -29,6 +30,9 @@ import (
 
 const (
 	defaultPrepareAggregationLabel = "cluster"
+
+	// maxSyncConcurrency is the upper bound limit on the concurrency value that can be set.
+	maxSyncConcurrency = 32
 )
 
 var (
@@ -36,11 +40,30 @@ var (
 	formats  = []string{"json", "yaml", "table"} // list of supported formats for the list command
 )
 
+// ruleCommandClient defines the interface that should be implemented by the API client used by
+// the RuleCommand. This is useful for testing purposes.
+type ruleCommandClient interface {
+	// CreateRuleGroup creates a new rule group.
+	CreateRuleGroup(ctx context.Context, namespace string, rg rwrulefmt.RuleGroup) error
+
+	// DeleteRuleGroup deletes a rule group.
+	DeleteRuleGroup(ctx context.Context, namespace, groupName string) error
+
+	// GetRuleGroup retrieves a rule group.
+	GetRuleGroup(ctx context.Context, namespace, groupName string) (*rwrulefmt.RuleGroup, error)
+
+	// ListRules retrieves a rule group.
+	ListRules(ctx context.Context, namespace string) (map[string][]rwrulefmt.RuleGroup, error)
+
+	// DeleteNamespace delete all the rule groups in a namespace including the namespace itself.
+	DeleteNamespace(ctx context.Context, namespace string) error
+}
+
 // RuleCommand configures and executes rule related mimir operations
 type RuleCommand struct {
 	ClientConfig client.Config
 
-	cli *client.MimirClient
+	cli ruleCommandClient
 
 	// Backend type (cortex | loki)
 	Backend string
@@ -59,6 +82,9 @@ type RuleCommand struct {
 	namespacesMap        map[string]struct{}
 	IgnoredNamespaces    string
 	ignoredNamespacesMap map[string]struct{}
+
+	// Sync Rules Config
+	SyncConcurrency int
 
 	// Prepare Rules Config
 	InPlaceEdit                            bool
@@ -198,6 +224,10 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 		"rule-dirs",
 		"Comma separated list of paths to directories containing rules yaml files. Each file in a directory with a .yml or .yaml suffix will be parsed.",
 	).StringVar(&r.RuleFilesPath)
+	syncRulesCmd.Flag(
+		"concurrency",
+		fmt.Sprintf("How many concurrent rule groups to sync. The maximum accepted value is %d.", maxSyncConcurrency),
+	).Default("8").IntVar(&r.SyncConcurrency)
 
 	// Prepare Command
 	prepareCmd.Arg("rule-files", "The rule files to check.").ExistingFilesVar(&r.RuleFilesList)
@@ -504,6 +534,11 @@ func (r *RuleCommand) diffRules(k *kingpin.ParseContext) error {
 }
 
 func (r *RuleCommand) syncRules(k *kingpin.ParseContext) error {
+	// Check the configuration.
+	if r.SyncConcurrency < 1 || r.SyncConcurrency > maxSyncConcurrency {
+		return fmt.Errorf("the configured concurrency (%d) must be a value between 1 and %d", r.SyncConcurrency, maxSyncConcurrency)
+	}
+
 	err := r.setupFiles()
 	if err != nil {
 		return errors.Wrap(err, "sync operation unsuccessful, unable to load rules files")
@@ -562,7 +597,7 @@ func (r *RuleCommand) syncRules(k *kingpin.ParseContext) error {
 		})
 	}
 
-	err = r.executeChanges(context.Background(), changes)
+	err = r.executeChanges(context.Background(), changes, r.SyncConcurrency)
 	if err != nil {
 		return errors.Wrap(err, "sync operation unsuccessful, unable to complete executing changes")
 	}
@@ -570,53 +605,39 @@ func (r *RuleCommand) syncRules(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.NamespaceChange) error {
-	var err error
+func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.NamespaceChange, concurrencyLimit int) error {
+	// Prepare operations to run, so that we can easily parallelize them.
+	var ops []rules.NamespaceChangeOperation
 	for _, ch := range changes {
-		for _, g := range ch.GroupsCreated {
-			if !r.shouldCheckNamespace(ch.Namespace) {
-				continue
-			}
+		ops = append(ops, ch.ToOperations()...)
+	}
 
-			log.WithFields(log.Fields{
-				"group":     g.Name,
-				"namespace": ch.Namespace,
-			}).Infof("creating group")
-			err = r.cli.CreateRuleGroup(ctx, ch.Namespace, g)
-			if err != nil {
-				return err
-			}
+	// The execution breaks on first error encountered.
+	err := concurrency.ForEachJob(ctx, len(ops), concurrencyLimit, func(ctx context.Context, idx int) error {
+		op := ops[idx]
+
+		log.WithFields(log.Fields{
+			"group":     op.RuleGroup.Name,
+			"namespace": op.Namespace,
+		}).Infof("synching %s group", op.State.String())
+
+		switch op.State {
+		case rules.Created:
+			return r.cli.CreateRuleGroup(ctx, op.Namespace, op.RuleGroup)
+
+		case rules.Updated:
+			return r.cli.CreateRuleGroup(ctx, op.Namespace, op.RuleGroup)
+
+		case rules.Deleted:
+			return r.cli.DeleteRuleGroup(ctx, op.Namespace, op.RuleGroup.Name)
+
+		default:
+			return fmt.Errorf("unsupported operation %q", op.State)
 		}
+	})
 
-		for _, g := range ch.GroupsUpdated {
-			if !r.shouldCheckNamespace(ch.Namespace) {
-				continue
-			}
-
-			log.WithFields(log.Fields{
-				"group":     g.New.Name,
-				"namespace": ch.Namespace,
-			}).Infof("updating group")
-			err = r.cli.CreateRuleGroup(ctx, ch.Namespace, g.New)
-			if err != nil {
-				return err
-			}
-		}
-
-		for _, g := range ch.GroupsDeleted {
-			if !r.shouldCheckNamespace(ch.Namespace) {
-				continue
-			}
-
-			log.WithFields(log.Fields{
-				"group":     g.Name,
-				"namespace": ch.Namespace,
-			}).Infof("deleting group")
-			err = r.cli.DeleteRuleGroup(ctx, ch.Namespace, g.Name)
-			if err != nil && !errors.Is(err, client.ErrResourceNotFound) {
-				return err
-			}
-		}
+	if err != nil {
+		return err
 	}
 
 	created, updated, deleted := rules.SummarizeChanges(changes)

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -632,7 +632,7 @@ func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.Namesp
 			return r.cli.DeleteRuleGroup(ctx, op.Namespace, op.RuleGroup.Name)
 
 		default:
-			return fmt.Errorf("unsupported operation %q", op.State)
+			return fmt.Errorf("internal error: unexpected operation %q", op.State)
 		}
 	})
 

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -6,14 +6,61 @@
 package commands
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/grafana/mimir/pkg/mimirtool/rules"
 	"github.com/grafana/mimir/pkg/mimirtool/rules/rwrulefmt"
 )
+
+func TestRuleCommand_executeChanges(t *testing.T) {
+	group1 := rwrulefmt.RuleGroup{RuleGroup: rulefmt.RuleGroup{Name: "group-1"}}
+	group2 := rwrulefmt.RuleGroup{RuleGroup: rulefmt.RuleGroup{Name: "group-2"}}
+	group3 := rwrulefmt.RuleGroup{RuleGroup: rulefmt.RuleGroup{Name: "group-3"}}
+	group4 := rwrulefmt.RuleGroup{RuleGroup: rulefmt.RuleGroup{Name: "group-4"}}
+	group5 := rwrulefmt.RuleGroup{RuleGroup: rulefmt.RuleGroup{Name: "group-5"}}
+	group6 := rwrulefmt.RuleGroup{RuleGroup: rulefmt.RuleGroup{Name: "group-6"}}
+
+	changes := []rules.NamespaceChange{
+		{Namespace: "namespace-1", State: rules.Created, GroupsCreated: []rwrulefmt.RuleGroup{group1}},
+		{Namespace: "namespace-2", State: rules.Created, GroupsCreated: []rwrulefmt.RuleGroup{group2}},
+		{Namespace: "namespace-3", State: rules.Updated, GroupsUpdated: []rules.UpdatedRuleGroup{{New: group3}}},
+		{Namespace: "namespace-4", State: rules.Updated, GroupsUpdated: []rules.UpdatedRuleGroup{{New: group4}}},
+		{Namespace: "namespace-5", State: rules.Deleted, GroupsDeleted: []rwrulefmt.RuleGroup{group5}},
+		{Namespace: "namespace-6", State: rules.Deleted, GroupsDeleted: []rwrulefmt.RuleGroup{group6}},
+	}
+
+	for _, concurrencyLimit := range []int{1, len(changes)} {
+		t.Run(fmt.Sprintf("concurrency limit = %d", concurrencyLimit), func(t *testing.T) {
+			client := newRuleCommandClientMock()
+			client.On("CreateRuleGroup", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			client.On("DeleteRuleGroup", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+			cmd := &RuleCommand{cli: client}
+			err := cmd.executeChanges(context.Background(), changes, concurrencyLimit)
+			require.NoError(t, err)
+
+			// Ensure all correct APIs have been called.
+			client.AssertNumberOfCalls(t, "CreateRuleGroup", 4)
+			client.AssertNumberOfCalls(t, "DeleteRuleGroup", 2)
+
+			client.AssertCalled(t, "CreateRuleGroup", mock.Anything, "namespace-1", group1)
+			client.AssertCalled(t, "CreateRuleGroup", mock.Anything, "namespace-2", group2)
+			client.AssertCalled(t, "CreateRuleGroup", mock.Anything, "namespace-3", group3)
+			client.AssertCalled(t, "CreateRuleGroup", mock.Anything, "namespace-4", group4)
+
+			client.AssertCalled(t, "DeleteRuleGroup", mock.Anything, "namespace-5", "group-5")
+			client.AssertCalled(t, "DeleteRuleGroup", mock.Anything, "namespace-6", "group-6")
+		})
+	}
+}
 
 func TestCheckDuplicates(t *testing.T) {
 	for _, tc := range []struct {
@@ -66,4 +113,37 @@ func TestCheckDuplicates(t *testing.T) {
 			assert.Equal(t, tc.want, checkDuplicates(tc.in))
 		})
 	}
+}
+
+type ruleCommandClientMock struct {
+	mock.Mock
+}
+
+func newRuleCommandClientMock() *ruleCommandClientMock {
+	return &ruleCommandClientMock{}
+}
+
+func (m *ruleCommandClientMock) CreateRuleGroup(ctx context.Context, namespace string, rg rwrulefmt.RuleGroup) error {
+	args := m.Called(ctx, namespace, rg)
+	return args.Error(0)
+}
+
+func (m *ruleCommandClientMock) DeleteRuleGroup(ctx context.Context, namespace, groupName string) error {
+	args := m.Called(ctx, namespace, groupName)
+	return args.Error(0)
+}
+
+func (m *ruleCommandClientMock) GetRuleGroup(ctx context.Context, namespace, groupName string) (*rwrulefmt.RuleGroup, error) {
+	args := m.Called(ctx, namespace, groupName)
+	return args.Get(0).(*rwrulefmt.RuleGroup), args.Error(1)
+}
+
+func (m *ruleCommandClientMock) ListRules(ctx context.Context, namespace string) (map[string][]rwrulefmt.RuleGroup, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(map[string][]rwrulefmt.RuleGroup), args.Error(1)
+}
+
+func (m *ruleCommandClientMock) DeleteNamespace(ctx context.Context, namespace string) error {
+	args := m.Called(ctx, namespace)
+	return args.Error(0)
 }


### PR DESCRIPTION
#### What this PR does
We have a customer reporting that synching 500+ rule groups is slow. They're right, given the synching operations are sequential. Even if each API call takes 500ms, synching 500 rule groups will take few minutes.

In this PR I'm adding `--concurrency` support to `mimirtool rules sync`. The new default concurrency is 8. The max configurable is 32.

I've manually tested it and speeds up the synching significantly.

#### Which issue(s) this PR fixes or relates to

Fixes #3990

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
