### PR TITLE
introduce ephemeral checker service and make distributor service depend on it

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -67,6 +67,7 @@ import (
 	"github.com/grafana/mimir/pkg/usagestats"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
+	"github.com/grafana/mimir/pkg/util/ephemeral"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/noauth"
 	"github.com/grafana/mimir/pkg/util/process"
@@ -667,6 +668,7 @@ type Mimir struct {
 	ActivityTracker          *activitytracker.ActivityTracker
 	UsageStatsReporter       *usagestats.Reporter
 	BuildInfoHandler         http.Handler
+	EphemeralChecker         ephemeral.SeriesCheckerByUser
 
 	// Queryables that the querier should use to query the long term storage.
 	StoreQueryables []querier.QueryableWithFilter

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -831,7 +831,7 @@ func (t *Mimir) setupModuleManager() error {
 	mm.RegisterModule(ActiveGroupsCleanupService, t.initActiveGroupsCleanupService, modules.UserInvisibleModule)
 	mm.RegisterModule(Distributor, t.initDistributor)
 	mm.RegisterModule(DistributorService, t.initDistributorService, modules.UserInvisibleModule)
-	mm.RegisterModule(EphemeralChecker, t.initEphemeralChecker)
+	mm.RegisterModule(EphemeralChecker, t.initEphemeralChecker, modules.UserInvisibleModule)
 	mm.RegisterModule(Ingester, t.initIngester)
 	mm.RegisterModule(IngesterService, t.initIngesterService, modules.UserInvisibleModule)
 	mm.RegisterModule(Flusher, t.initFlusher)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -73,6 +73,7 @@ const (
 	ActiveGroupsCleanupService string = "active-groups-cleanup-service"
 	Distributor                string = "distributor"
 	DistributorService         string = "distributor-service"
+	EphemeralChecker           string = "ephemeral-checker"
 	Ingester                   string = "ingester"
 	IngesterService            string = "ingester-service"
 	Flusher                    string = "flusher"
@@ -297,7 +298,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 	// ruler's dependency)
 	canJoinDistributorsRing := t.Cfg.isAnyModuleEnabled(Distributor, Write, All)
 
-	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.ActiveGroupsCleanup, t.Ring, t.Overrides, canJoinDistributorsRing, t.Registerer, util_log.Logger)
+	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.ActiveGroupsCleanup, t.Ring, t.EphemeralChecker, canJoinDistributorsRing, t.Registerer, util_log.Logger)
 	if err != nil {
 		return
 	}
@@ -307,6 +308,11 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 	}
 
 	return t.Distributor, nil
+}
+
+func (t *Mimir) initEphemeralChecker() (serv services.Service, err error) {
+	t.EphemeralChecker = t.Overrides
+	return nil, nil
 }
 
 func (t *Mimir) initDistributor() (serv services.Service, err error) {
@@ -825,6 +831,7 @@ func (t *Mimir) setupModuleManager() error {
 	mm.RegisterModule(ActiveGroupsCleanupService, t.initActiveGroupsCleanupService, modules.UserInvisibleModule)
 	mm.RegisterModule(Distributor, t.initDistributor)
 	mm.RegisterModule(DistributorService, t.initDistributorService, modules.UserInvisibleModule)
+	mm.RegisterModule(EphemeralChecker, t.initEphemeralChecker)
 	mm.RegisterModule(Ingester, t.initIngester)
 	mm.RegisterModule(IngesterService, t.initIngesterService, modules.UserInvisibleModule)
 	mm.RegisterModule(Flusher, t.initFlusher)
@@ -856,7 +863,7 @@ func (t *Mimir) setupModuleManager() error {
 		Overrides:                {RuntimeConfig},
 		OverridesExporter:        {Overrides, MemberlistKV},
 		Distributor:              {DistributorService, API, ActiveGroupsCleanupService},
-		DistributorService:       {Ring, Overrides},
+		DistributorService:       {Ring, Overrides, EphemeralChecker},
 		Ingester:                 {IngesterService, API, ActiveGroupsCleanupService},
 		IngesterService:          {Overrides, RuntimeConfig, MemberlistKV},
 		Flusher:                  {Overrides, API},

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -864,6 +864,7 @@ func (t *Mimir) setupModuleManager() error {
 		OverridesExporter:        {Overrides, MemberlistKV},
 		Distributor:              {DistributorService, API, ActiveGroupsCleanupService},
 		DistributorService:       {Ring, Overrides, EphemeralChecker},
+		EphemeralChecker:         {Overrides},
 		Ingester:                 {IngesterService, API, ActiveGroupsCleanupService},
 		IngesterService:          {Overrides, RuntimeConfig, MemberlistKV},
 		Flusher:                  {Overrides, API},


### PR DESCRIPTION
This introduces a new module named `ephemeral-checker`. 
It sets Mimir's `EphemeralChecker` property to the `Overrides` property, because we want that by default the overrides are used to configure ephemeral series.
Third parties can override that `EphemeralChecker` property to inject their own checkers. 

This PR implements what's described [in this comment](https://github.com/grafana/mimir/pull/3897#discussion_r1071331991)