### PR TITLE
Fix flaky test for overrides-exporter ring

### DIFF
--- a/pkg/util/validation/exporter/ring_test.go
+++ b/pkg/util/validation/exporter/ring_test.go
@@ -100,7 +100,7 @@ func TestOverridesExporterRing_scaleDown(t *testing.T) {
 
 	// Wait for the leader to have advertised its leaving state to the ring
 	test.Poll(t, 5*time.Second, ring.LEAVING, func() interface{} {
-		rs, _ := i1.client.GetAllHealthy(ringOp)
+		rs, _ := i2.client.GetAllHealthy(ringOp)
 		for _, instance := range rs.Instances {
 			if instance.Addr == l1.GetInstanceAddr() {
 				return instance.GetState()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This fixes a flaky test for the overrides-exporter ring. The flakiness arose from using the ring client of a service that was being stopped. The proposed fix is to use a ring client that is not in the process of being shut down.

#### Which issue(s) this PR fixes or relates to

Fixes #3994 

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
