### PR TITLE
Update AutoscalerNotActive for minReplicas=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [BUGFIX] Dashboards: Fix `Rollout Progress` dashboard incorrectly using Gateway metrics when Gateway was not enabled. #3709
 * [BUGFIX] Tenants dashboard: Make it compatible with all deployment types. #3754
 * [BUGFIX] Alerts: Fixed `MimirCompactorHasNotUploadedBlocks` to not fire if compactor has nothing to do. #3793
+* [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric is 0, to avoid false positives on scaled objects with 0 min replicas. #3999
 
 ### Jsonnet
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1042,7 +1042,8 @@ How to **investigate**:
 
 ### MimirAutoscalerNotActive
 
-This alert fires when any of Mimir's Kubernetes Horizontal Pod Autoscaler's (HPA) `ScalingActive` condition is `false`. When this happens, it's not able to calculate desired scale and generally indicates problems with fetching metrics.
+This alert fires when any of Mimir's Kubernetes Horizontal Pod Autoscaler's (HPA) `ScalingActive` condition is `false` and the related scaling metrics are not 0.
+When this happens, it's not able to calculate desired scale and generally indicates problems with fetching metrics.
 
 How it **works**:
 
@@ -1076,6 +1077,9 @@ How to **investigate**:
   # Assuming Prometheus is running in namespace "default":
   kubectl -n default get pod -lname=prometheus
   ```
+
+For scaled objects with 0 `minReplicas` it is expected for HPA to be inactive when the scaling metric exposed in `keda_metrics_adapter_scaler_metrics_value` is 0.
+When `keda_metrics_adapter_scaler_metrics_value` value is 0, the alert should not be firing.
 
 ### MimirContinuousTestNotRunningOnWrites
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -908,12 +908,14 @@ spec:
           }} in {{ $labels.namespace }} is not active.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
       expr: |
-        kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
-        # Match only Mimir namespaces.
-        * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
-        # Add "metric" label.
-        + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
-        > 0
+        (
+            kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+            # Match only Mimir namespaces.
+            * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
+            # Add "metric" label.
+            + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
+            > 0
+        )
         # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
         unless on (cluster, namespace, metric)
         (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -909,8 +909,14 @@ spec:
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
       expr: |
         kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+        # Match only Mimir namespaces.
         * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
+        # Add "metric" label.
+        + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
         > 0
+        # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
+        unless on (cluster, namespace, metric)
+        (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
       for: 1h
       labels:
         severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -889,12 +889,14 @@ groups:
         }} in {{ $labels.namespace }} is not active.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
     expr: |
-      kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
-      # Match only Mimir namespaces.
-      * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
-      # Add "metric" label.
-      + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
-      > 0
+      (
+          kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+          # Match only Mimir namespaces.
+          * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
+          # Add "metric" label.
+          + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
+          > 0
+      )
       # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
       unless on (cluster, namespace, metric)
       (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -890,8 +890,14 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
     expr: |
       kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+      # Match only Mimir namespaces.
       * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
+      # Add "metric" label.
+      + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
       > 0
+      # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
+      unless on (cluster, namespace, metric)
+      (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
     for: 1h
     labels:
       severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -897,8 +897,14 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
     expr: |
       kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+      # Match only Mimir namespaces.
       * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
+      # Add "metric" label.
+      + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
       > 0
+      # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
+      unless on (cluster, namespace, metric)
+      (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
     for: 1h
     labels:
       severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -896,12 +896,14 @@ groups:
         }} in {{ $labels.namespace }} is not active.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
     expr: |
-      kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
-      # Match only Mimir namespaces.
-      * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
-      # Add "metric" label.
-      + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
-      > 0
+      (
+          kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+          # Match only Mimir namespaces.
+          * on(cluster, namespace) group_left max by(cluster, namespace) (cortex_build_info)
+          # Add "metric" label.
+          + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
+          > 0
+      )
       # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
       unless on (cluster, namespace, metric)
       (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -7,12 +7,14 @@
           alert: $.alertName('AutoscalerNotActive'),
           'for': '1h',
           expr: |||
-            kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
-            # Match only Mimir namespaces.
-            * on(%(aggregation_labels)s) group_left max by(%(aggregation_labels)s) (cortex_build_info)
-            # Add "metric" label.
-            + on(%(aggregation_labels)s, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
-            > 0
+            (
+                kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+                # Match only Mimir namespaces.
+                * on(%(aggregation_labels)s) group_left max by(%(aggregation_labels)s) (cortex_build_info)
+                # Add "metric" label.
+                + on(%(aggregation_labels)s, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
+                > 0
+            )
             # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
             unless on (%(aggregation_labels)s, metric)
             (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -11,7 +11,7 @@
             # Match only Mimir namespaces.
             * on(%(aggregation_labels)s) group_left max by(%(aggregation_labels)s) (cortex_build_info)
             # Add "metric" label.
-            + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
+            + on(%(aggregation_labels)s, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
             > 0
             # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
             unless on (%(aggregation_labels)s, metric)

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -8,8 +8,14 @@
           'for': '1h',
           expr: |||
             kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"}
+            # Match only Mimir namespaces.
             * on(%(aggregation_labels)s) group_left max by(%(aggregation_labels)s) (cortex_build_info)
+            # Add "metric" label.
+            + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
             > 0
+            # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
+            unless on (%(aggregation_labels)s, metric)
+            (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
           ||| % {
             aggregation_labels: $._config.alert_aggregation_labels,
           },


### PR DESCRIPTION
#### What this PR does

When KEDA scales down to 0, the HPA autoscaler becomes not active, and the alert is fired.

This updates the alert to avoid being triggered when scaling metric is 0.

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
