### PR TITLE
Limits and errors for ephemeral storage

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2782,6 +2782,17 @@
             },
             {
               "kind": "field",
+              "name": "max_ephemeral_series",
+              "required": false,
+              "desc": "Max ephemeral series that this ingester can hold (across all tenants). Requests to create additional ephemeral series will be rejected. 0 = unlimited.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "ingester.instance-limits.max-ephemeral-series",
+              "fieldType": "int",
+              "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
               "name": "max_inflight_push_requests",
               "required": false,
               "desc": "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.",
@@ -3031,6 +3042,17 @@
           "fieldDefaultValue": 0,
           "fieldFlag": "ingester.max-global-series-per-metric",
           "fieldType": "int"
+        },
+        {
+          "kind": "field",
+          "name": "max_global_ephemeral_series_per_user",
+          "required": false,
+          "desc": "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable.",
+          "fieldValue": null,
+          "fieldDefaultValue": 150000,
+          "fieldFlag": "ingester.max-global-ephemeral-series-per-user",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
         },
         {
           "kind": "field",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3045,12 +3045,12 @@
         },
         {
           "kind": "field",
-          "name": "max_global_ephemeral_series_per_user",
+          "name": "max_ephemeral_series_per_user",
           "required": false,
-          "desc": "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable.",
+          "desc": "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable ephemeral storage.",
           "fieldValue": null,
-          "fieldDefaultValue": 150000,
-          "fieldFlag": "ingester.max-global-ephemeral-series-per-user",
+          "fieldDefaultValue": 0,
+          "fieldFlag": "ingester.max-ephemeral-series-per-user",
           "fieldType": "int",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1025,6 +1025,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -ingester.ignore-series-limit-for-metric-names string
     	Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.
+  -ingester.instance-limits.max-ephemeral-series int
+    	[experimental] Max ephemeral series that this ingester can hold (across all tenants). Requests to create additional ephemeral series will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-inflight-push-requests int
     	Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited. (default 30000)
   -ingester.instance-limits.max-ingestion-rate float
@@ -1033,6 +1035,8 @@ Usage of ./cmd/mimir/mimir:
     	Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-tenants int
     	Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.
+  -ingester.max-global-ephemeral-series-per-user int
+    	[experimental] The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable. (default 150000)
   -ingester.max-global-exemplars-per-user int
     	[experimental] The maximum number of exemplars in memory, across the cluster. 0 to disable exemplars ingestion.
   -ingester.max-global-metadata-per-metric int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1035,8 +1035,8 @@ Usage of ./cmd/mimir/mimir:
     	Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-tenants int
     	Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.
-  -ingester.max-global-ephemeral-series-per-user int
-    	[experimental] The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable. (default 150000)
+  -ingester.max-ephemeral-series-per-user int
+    	[experimental] The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable ephemeral storage.
   -ingester.max-global-exemplars-per-user int
     	[experimental] The maximum number of exemplars in memory, across the cluster. 0 to disable exemplars ingestion.
   -ingester.max-global-metadata-per-metric int

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1367,7 +1367,18 @@ How to **fix** it:
 
 ### err-mimir-ingester-max-ephemeral-series
 
-This error refers to experimental ephemeral storage in ingesters. Documentation TBD.
+This critical error occurs when an ingester rejects a write request because it reached the maximum number of ephemeral series.
+
+How it **works**:
+
+- The ingester keeps all ephemeral series in memory.
+- The ingester has a per-instance limit on the number of ephemeral series, used to protect the ingester from overloading in case of high traffic.
+- When the limit on the number of ephemeral series is reached, new ephemeral series are rejected, while samples can still be appended to existing ones.
+- To configure the limit, set the `-ingester.instance-limits.max-ephemeral-series` option (or `max_ephemeral_series` in the runtime config).
+
+How to **fix** it:
+
+- Increase the limit, or reshard the tenants between ingesters. Please see [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit) runbook for more details (it describes persistent storage, but same principles apply to ephemeral storage).
 
 ### err-mimir-ingester-max-inflight-push-requests
 
@@ -1399,7 +1410,15 @@ How to **fix** it:
 
 ### err-mimir-max-ephemeral-series-per-user
 
-This error refers to experimental ephemeral storage in ingesters. Documentation TBD.
+This error occurs when the number of ephemeral series for a given tenant exceeds the configured limit.
+
+The limit is used to protect ingesters from overloading in case a tenant writes a high number of ephemeral series, as well as to protect the whole system’s stability from potential abuse or mistakes.
+To configure the limit on a per-tenant basis, use the `-ingester.max-ephemeral-series-per-user` option (or `max_ephemeral_series_per_user` in the runtime configuration).
+
+How to **fix** it:
+
+- Ensure the actual number of ephemeral series written by the affected tenant is legit.
+- Consider increasing the per-tenant limit by using the `-ingester.max-ephemeral-series-per-user` option (or `max_ephemeral_series_per_user` in the runtime configuration).
 
 ### err-mimir-max-series-per-metric
 
@@ -1568,7 +1587,11 @@ How it **works**:
 
 ### err-mimir-ephemeral-sample-timestamp-too-old
 
-This error refers to ingesting samples into experimental ephemeral storage in ingesters. Documentation TBD.
+This error occurs when the ingester rejects a sample because its timestamp older than configured retention of ephemeral storage.
+
+How it **works**:
+
+- Ephemeral storage in ingesters can only hold samples that not older than `-blocks-storage.ephemeral-tsdb.retention-period` value. If the incoming timestamp is older than "now - retention", it is rejected.
 
 ### err-mimir-sample-out-of-order
 
@@ -1591,7 +1614,11 @@ Common **causes**:
 
 ### err-mimir-ephemeral-sample-out-of-order
 
-This error refers to ingesting samples into experimental ephemeral storage in ingesters. Documentation TBD.
+This error occurs when the ingester rejects a sample because another sample with a more recent timestamp has already been ingested for the same series in the ephemeral storage.
+
+Please refer to [err-mimir-sample-out-of-order](#err-mimir-sample-out-of-order) for possible reasons. 
+
+> **Note**: It is not possible to enable out-of-order sample ingestion for ephemeral storage.
 
 ### err-mimir-sample-duplicate-timestamp
 
@@ -1604,7 +1631,12 @@ Common **causes**:
 
 ### err-mimir-ephemeral-sample-duplicate-timestamp
 
-This error refers to ingesting samples into experimental ephemeral storage in ingesters. Documentation TBD.
+This error occurs when the ingester rejects a sample because it is a duplicate of a previously received sample with the same timestamp but different value for the same ephemeral series.
+
+Common **causes**:
+
+- Multiple endpoints are exporting the same metrics, or multiple Prometheus instances are scraping different metrics with identical labels.
+- Prometheus relabelling has been configured and it causes series to clash after the relabelling. Check the error message for information about which series has received a duplicate sample.
 
 ### err-mimir-exemplar-series-missing
 
@@ -1663,7 +1695,15 @@ How to **fix** it:
 
 ### err-mimir-ephemeral-storage-not-enabled-for-user
 
-This error refers to experimental ephemeral storage in ingesters. Documentation TBD.
+Ingester returns this error when a write request contains ephemeral series, but ephemeral storage is disabled for user.
+
+Ephemeral storage is disabled when `-ingester.max-ephemeral-series-per-user` (or corresponding `max_ephemeral_series_per_user` limit in runtime configuration) is set to 0 for given tenant.
+
+How to **fix** it:
+
+- Disable support for ephemeral series in distributor by setting `-distributor.ephemeral-series-enabled` to `false`.
+- Remove rules for marking incoming series as ephemeral for given tenant by removing `-distributor.ephemeral-series-matchers` (or `ephemeral_series_matchers` in runtime configuration).
+- Enable ephemeral storage for tenant by setting the `-ingester.max-ephemeral-series-per-user` (or corresponding `max_ephemeral_series_per_user` limit in runtime configuration) to positive number.
 
 ## Mimir routes by path
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1365,6 +1365,10 @@ How to **fix** it:
 
 - See [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit) runbook.
 
+### err-mimir-ingester-max-ephemeral-series
+
+This error refers to experimental ephemeral storage in ingesters. Documentation TBD.
+
 ### err-mimir-ingester-max-inflight-push-requests
 
 This error occurs when an ingester rejects a write request because the maximum in-flight requests limit has been reached.
@@ -1392,6 +1396,10 @@ How to **fix** it:
 
 - Ensure the actual number of series written by the affected tenant is legit.
 - Consider increasing the per-tenant limit by using the `-ingester.max-global-series-per-user` option (or `max_global_series_per_user` in the runtime configuration).
+
+### err-mimir-max-ephemeral-series-per-user
+
+This error refers to experimental ephemeral storage in ingesters. Documentation TBD.
 
 ### err-mimir-max-series-per-metric
 
@@ -1558,6 +1566,10 @@ How it **works**:
 
 > **Note**: If the out-of-order sample ingestion is enabled, then this error is similar to `err-mimir-sample-out-of-order` below with a difference that the sample is older than the out-of-order time window as it relates to the latest sample for that particular time series or the TSDB.
 
+### err-mimir-ephemeral-sample-timestamp-too-old
+
+This error refers to ingesting samples into experimental ephemeral storage in ingesters. Documentation TBD.
+
 ### err-mimir-sample-out-of-order
 
 This error occurs when the ingester rejects a sample because another sample with a more recent timestamp has already been ingested.
@@ -1577,6 +1589,10 @@ Common **causes**:
 
 > **Note**: You can learn more about out of order samples in Prometheus, in the blog post [Debugging out of order samples](https://www.robustperception.io/debugging-out-of-order-samples/).
 
+### err-mimir-ephemeral-sample-out-of-order
+
+This error refers to ingesting samples into experimental ephemeral storage in ingesters. Documentation TBD.
+
 ### err-mimir-sample-duplicate-timestamp
 
 This error occurs when the ingester rejects a sample because it is a duplicate of a previously received sample with the same timestamp but different value in the same time series.
@@ -1585,6 +1601,10 @@ Common **causes**:
 
 - Multiple endpoints are exporting the same metrics, or multiple Prometheus instances are scraping different metrics with identical labels.
 - Prometheus relabelling has been configured and it causes series to clash after the relabelling. Check the error message for information about which series has received a duplicate sample.
+
+### err-mimir-ephemeral-sample-duplicate-timestamp
+
+This error refers to ingesting samples into experimental ephemeral storage in ingesters. Documentation TBD.
 
 ### err-mimir-exemplar-series-missing
 
@@ -1640,6 +1660,10 @@ How it **works**:
 How to **fix** it:
 
 - Increase the allowed limit by using the `-distributor.max-recv-msg-size` option.
+
+### err-mimir-ephemeral-storage-not-enabled-for-user
+
+This error refers to experimental ephemeral storage in ingesters. Documentation TBD.
 
 ## Mimir routes by path
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1616,7 +1616,7 @@ Common **causes**:
 
 This error occurs when the ingester rejects a sample because another sample with a more recent timestamp has already been ingested for the same series in the ephemeral storage.
 
-Please refer to [err-mimir-sample-out-of-order](#err-mimir-sample-out-of-order) for possible reasons. 
+Please refer to [err-mimir-sample-out-of-order](#err-mimir-sample-out-of-order) for possible reasons.
 
 > **Note**: It is not possible to enable out-of-order sample ingestion for ephemeral storage.
 

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -934,6 +934,12 @@ instance_limits:
   # CLI flag: -ingester.instance-limits.max-series
   [max_series: <int> | default = 0]
 
+  # (experimental) Max ephemeral series that this ingester can hold (across all
+  # tenants). Requests to create additional ephemeral series will be rejected. 0
+  # = unlimited.
+  # CLI flag: -ingester.instance-limits.max-ephemeral-series
+  [max_ephemeral_series: <int> | default = 0]
+
   # (advanced) Max inflight push requests that this ingester can handle (across
   # all tenants). Additional requests will be rejected. 0 = unlimited.
   # CLI flag: -ingester.instance-limits.max-inflight-push-requests
@@ -2538,6 +2544,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 # before replication. 0 to disable.
 # CLI flag: -ingester.max-global-series-per-metric
 [max_global_series_per_metric: <int> | default = 0]
+
+# (experimental) The maximum number of in-memory ephemeral series per tenant,
+# across the cluster before replication. 0 to disable.
+# CLI flag: -ingester.max-global-ephemeral-series-per-user
+[max_global_ephemeral_series_per_user: <int> | default = 150000]
 
 # The maximum number of in-memory metrics with metadata per tenant, across the
 # cluster. 0 to disable.

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -2546,9 +2546,9 @@ The `limits` block configures default and per-tenant limits imposed by component
 [max_global_series_per_metric: <int> | default = 0]
 
 # (experimental) The maximum number of in-memory ephemeral series per tenant,
-# across the cluster before replication. 0 to disable.
-# CLI flag: -ingester.max-global-ephemeral-series-per-user
-[max_global_ephemeral_series_per_user: <int> | default = 150000]
+# across the cluster before replication. 0 to disable ephemeral storage.
+# CLI flag: -ingester.max-ephemeral-series-per-user
+[max_ephemeral_series_per_user: <int> | default = 0]
 
 # The maximum number of in-memory metrics with metadata per tenant, across the
 # cluster. 0 to disable.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -98,10 +98,10 @@ const (
 	perUserSeriesLimit   = "per_user_series_limit"
 	perMetricSeriesLimit = "per_metric_series_limit"
 
-	ephemeralPerUserSeriesLimit = ephemeralDiscardPrefix + perUserSeriesLimit
-
 	// Prefix for discard reasons when ingesting ephemeral series.
 	ephemeralDiscardPrefix = "ephemeral-"
+
+	ephemeralPerUserSeriesLimit = "ephemeral_per_user_series_limit"
 
 	replicationFactorStatsName             = "ingester_replication_factor"
 	ringStoreStatsName                     = "ingester_ring_store"

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1824,7 +1824,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 
 	userDB.ephemeralSeriesRetentionPeriod = i.cfg.BlocksStorageConfig.EphemeralTSDB.Retention
 	userDB.ephemeralFactory = func() (*tsdb.Head, error) {
-		if i.limits.MaxGlobalEphemeralSeriesPerUser(userID) <= 0 {
+		if i.limits.MaxEphemeralSeriesPerUser(userID) <= 0 {
 			return nil, errEphemeralStorageDisabledForUser
 		}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -98,6 +98,8 @@ const (
 	perUserSeriesLimit   = "per_user_series_limit"
 	perMetricSeriesLimit = "per_metric_series_limit"
 
+	ephemeralPerUserSeriesLimit = ephemeralDiscardPrefix + perUserSeriesLimit
+
 	// Prefix for discard reasons when ingesting ephemeral series.
 	ephemeralDiscardPrefix = "ephemeral-"
 
@@ -1022,7 +1024,7 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 				stats.perUserSeriesLimitCount++
 				updateFirstPartial(func() error {
 					if ephemeral {
-						return makeLimitError(ephemeralDiscardPrefix+perUserSeriesLimit, i.limiter.FormatError(userID, cause))
+						return makeLimitError(ephemeralPerUserSeriesLimit, i.limiter.FormatError(userID, cause))
 					}
 					return makeLimitError(perUserSeriesLimit, i.limiter.FormatError(userID, cause))
 				})

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6097,6 +6097,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 	tests := map[string]struct {
 		reqs                       []*mimirpb.WriteRequest
 		additionalMetrics          []string
+		maxEphemeralSeriesLimit    int
 		expectedIngestedEphemeral  model.Matrix
 		expectedIngestedPersistent model.Matrix
 		expectedErr                error
@@ -6118,7 +6119,8 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					nil,
 					mimirpb.API),
 			},
-			expectedErr: nil,
+			maxEphemeralSeriesLimit: 10,
+			expectedErr:             nil,
 			expectedIngestedEphemeral: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: model.Time(now.UnixMilli() - 10)}, {Value: 2, Timestamp: model.Time(now.UnixMilli())}}},
 			},
@@ -6195,6 +6197,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					nil,
 					mimirpb.API),
 			},
+			maxEphemeralSeriesLimit:   10,
 			expectedErr:               httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(100), mimirpb.FromLabelsToLabelAdapters(metricLabels)), userID).Error()),
 			expectedIngestedEphemeral: nil, // No returned samples.
 			expectedMetrics: `
@@ -6283,7 +6286,8 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleOutOfOrder(model.Time(now.UnixMilli()-10), mimirpb.FromLabelsToLabelAdapters(metricLabels)), userID).Error()),
+			maxEphemeralSeriesLimit: 10,
+			expectedErr:             httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleOutOfOrder(model.Time(now.UnixMilli()-10), mimirpb.FromLabelsToLabelAdapters(metricLabels)), userID).Error()),
 			expectedIngestedEphemeral: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: model.Time(now.UnixMilli())}}},
 			},
@@ -6423,7 +6427,8 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 						},
 					}},
 				}},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(100), []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "eph_metric1"}}), userID).Error()),
+			maxEphemeralSeriesLimit: 10,
+			expectedErr:             httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(100), []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "eph_metric1"}}), userID).Error()),
 			expectedIngestedEphemeral: model.Matrix{
 				&model.SampleStream{
 					Metric: map[model.LabelName]model.LabelValue{labels.MetricName: "eph_metric2"},
@@ -6533,7 +6538,6 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					cortex_ingester_queries_ephemeral_total 1
 			`,
 		},
-
 		"only persistent series -- does not initialize ephemeral storage": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
@@ -6600,6 +6604,155 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					cortex_ingester_queries_ephemeral_total 1
 			`,
 		},
+		"ephemeral storage disabled": {
+			reqs: []*mimirpb.WriteRequest{
+				ToWriteRequestEphemeral(
+					[]labels.Labels{metricLabels},
+					[]mimirpb.Sample{{Value: 1, TimestampMs: now.UnixMilli() - 10}},
+					nil,
+					nil,
+					mimirpb.API),
+			},
+			maxEphemeralSeriesLimit: 0,
+			expectedErr:             httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(errors.New("ephemeral storage is not enabled for user (err-mimir-ephemeral-storage-not-enabled-for-user)"), userID).Error()),
+			expectedMetrics: `
+					# HELP cortex_ingester_memory_ephemeral_series The current number of ephemeral series in memory.
+        	        # TYPE cortex_ingester_memory_ephemeral_series gauge
+        	        cortex_ingester_memory_ephemeral_series 0
+
+					# HELP cortex_ingester_memory_series The current number of series in memory.
+        	        # TYPE cortex_ingester_memory_series gauge
+        	        cortex_ingester_memory_series 0
+
+					# HELP cortex_ingester_memory_users The current number of users in memory.
+					# TYPE cortex_ingester_memory_users gauge
+					cortex_ingester_memory_users 1
+
+					# HELP cortex_ingester_memory_ephemeral_users The current number of users with ephemeral storage in memory.
+					# TYPE cortex_ingester_memory_ephemeral_users gauge
+					cortex_ingester_memory_ephemeral_users 0
+
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
+					# TYPE cortex_ingester_queried_ephemeral_samples histogram
+					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="640"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="5120"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="40960"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="327680"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.62144e+06"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.097152e+07"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="+Inf"} 1
+					cortex_ingester_queried_ephemeral_samples_sum 0
+					cortex_ingester_queried_ephemeral_samples_count 1
+
+					# HELP cortex_ingester_queried_ephemeral_series The total number of ephemeral series returned from queries.
+					# TYPE cortex_ingester_queried_ephemeral_series histogram
+					cortex_ingester_queried_ephemeral_series_bucket{le="10"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="80"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="640"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="5120"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="40960"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="327680"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="+Inf"} 1
+					cortex_ingester_queried_ephemeral_series_sum 0
+					cortex_ingester_queried_ephemeral_series_count 1
+
+					# HELP cortex_ingester_queries_ephemeral_total The total number of queries the ingester has handled for ephemeral storage.
+					# TYPE cortex_ingester_queries_ephemeral_total counter
+					cortex_ingester_queries_ephemeral_total 1
+			`,
+		},
+
+		"only allow single ephemeral series": {
+			reqs: []*mimirpb.WriteRequest{
+				ToWriteRequestEphemeral(
+					[]labels.Labels{metricLabels},
+					[]mimirpb.Sample{{Value: 1, TimestampMs: now.UnixMilli()}},
+					nil,
+					nil,
+					mimirpb.API),
+
+				ToWriteRequestEphemeral(
+					[]labels.Labels{{{Name: labels.MetricName, Value: "second metric"}}},
+					[]mimirpb.Sample{{Value: 2, TimestampMs: now.UnixMilli()}},
+					nil,
+					nil,
+					mimirpb.API),
+			},
+			maxEphemeralSeriesLimit: 1,
+			expectedErr:             httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(errors.New("per-user ephemeral series limit of 1 exceeded (err-mimir-max-ephemeral-series-per-user). To adjust the related per-tenant limit, configure -ingester.max-global-ephemeral-series-per-user, or contact your service administrator."), userID).Error()),
+			expectedIngestedEphemeral: model.Matrix{
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: model.Time(now.UnixMilli())}}},
+			},
+			expectedMetrics: `
+					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
+					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
+					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 1
+
+					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
+					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
+					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 1
+
+					# HELP cortex_ingester_ephemeral_series_created_total The total number of series in ephemeral storage that were created per user.
+					# TYPE cortex_ingester_ephemeral_series_created_total counter
+					cortex_ingester_ephemeral_series_created_total{user="test"} 1
+
+					# HELP cortex_ingester_ephemeral_series_removed_total The total number of series in ephemeral storage that were removed per user.
+					# TYPE cortex_ingester_ephemeral_series_removed_total counter
+					cortex_ingester_ephemeral_series_removed_total{user="test"} 0
+
+					# HELP cortex_ingester_memory_ephemeral_series The current number of ephemeral series in memory.
+        	        # TYPE cortex_ingester_memory_ephemeral_series gauge
+        	        cortex_ingester_memory_ephemeral_series 1
+
+					# HELP cortex_ingester_memory_series The current number of series in memory.
+        	        # TYPE cortex_ingester_memory_series gauge
+        	        cortex_ingester_memory_series 0
+
+					# HELP cortex_ingester_memory_users The current number of users in memory.
+					# TYPE cortex_ingester_memory_users gauge
+					cortex_ingester_memory_users 1
+
+					# HELP cortex_ingester_memory_ephemeral_users The current number of users with ephemeral storage in memory.
+					# TYPE cortex_ingester_memory_ephemeral_users gauge
+					cortex_ingester_memory_ephemeral_users 1
+
+					# HELP cortex_ingester_queried_ephemeral_samples The total number of samples from ephemeral storage returned per query.
+					# TYPE cortex_ingester_queried_ephemeral_samples histogram
+					cortex_ingester_queried_ephemeral_samples_bucket{le="10"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="80"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="640"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="5120"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="40960"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="327680"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.62144e+06"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="2.097152e+07"} 1
+					cortex_ingester_queried_ephemeral_samples_bucket{le="+Inf"} 1
+					cortex_ingester_queried_ephemeral_samples_sum 1
+					cortex_ingester_queried_ephemeral_samples_count 1
+
+					# HELP cortex_ingester_queried_ephemeral_series The total number of ephemeral series returned from queries.
+					# TYPE cortex_ingester_queried_ephemeral_series histogram
+					cortex_ingester_queried_ephemeral_series_bucket{le="10"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="80"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="640"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="5120"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="40960"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="327680"} 1
+					cortex_ingester_queried_ephemeral_series_bucket{le="+Inf"} 1
+					cortex_ingester_queried_ephemeral_series_sum 1
+					cortex_ingester_queried_ephemeral_series_count 1
+
+					# HELP cortex_ingester_queries_ephemeral_total The total number of queries the ingester has handled for ephemeral storage.
+					# TYPE cortex_ingester_queries_ephemeral_total counter
+					cortex_ingester_queries_ephemeral_total 1
+
+					# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+					# TYPE cortex_discarded_samples_total counter
+					cortex_discarded_samples_total{group="",reason="per_user_ephemeral_series_limit",user="test"} 1
+			`,
+		},
 	}
 
 	for testName, testData := range tests {
@@ -6612,6 +6765,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			cfg.ActiveSeriesMetricsEnabled = false
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = 100
+			limits.MaxGlobalEphemeralSeriesPerUser = testData.maxEphemeralSeriesLimit
 			limits.OutOfOrderTimeWindow = model.Duration(time.Minute * 10)
 
 			i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, "", registry)
@@ -6691,10 +6845,13 @@ func ToWriteRequestEphemeral(lbls []labels.Labels, samples []mimirpb.Sample, exe
 func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.EphemeralTSDB.Retention = 10 * time.Minute
+	cfg.IngesterRing.ReplicationFactor = 1 // for computing limits.
 
-	// Create ingester
+	limits := defaultLimitsTestConfig()
+	limits.MaxGlobalEphemeralSeriesPerUser = 1
+
 	reg := prometheus.NewPedanticRegistry()
-	i, err := prepareIngesterWithBlocksStorage(t, cfg, reg)
+	i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, "", reg)
 	require.NoError(t, err)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
@@ -6707,14 +6864,12 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 		return i.lifecycler.HealthyInstancesCount()
 	})
 
-	metricLabels := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
-
 	now := time.Now()
 
 	// Push ephemeral series with good timestamps (in last 10 minutes)
 	ctx := user.InjectOrgID(context.Background(), userID)
 	req := ToWriteRequestEphemeral(
-		[]labels.Labels{mimirpb.FromLabelAdaptersToLabels(metricLabels)},
+		[]labels.Labels{{{Name: labels.MetricName, Value: "test"}}},
 		[]mimirpb.Sample{{Value: float64(100), TimestampMs: now.Add(-9 * time.Minute).UnixMilli()}},
 		nil,
 		nil,
@@ -6754,6 +6909,17 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 		},
 	})
 
+	// Pushing new series fails, because of limit of 1.
+	newReq := ToWriteRequestEphemeral(
+		[]labels.Labels{{{Name: labels.MetricName, Value: "new-metric"}}},
+		[]mimirpb.Sample{{Value: float64(500), TimestampMs: now.UnixMilli()}},
+		nil,
+		nil,
+		mimirpb.API,
+	)
+	_, err = i.Push(ctx, newReq)
+	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(i.limiter.FormatError(userID, errMaxEphemeralSeriesPerUserLimitExceeded), userID).Error()), err)
+
 	db := i.getTSDB(userID)
 	require.NotNil(t, db)
 
@@ -6765,7 +6931,20 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 
 	// Pushing the same request should now fail, because min valid time for ephemeral storage has moved on to (now + 5 minutes - ephemeral series retention = now - 5 minutes)
 	_, err = i.Push(ctx, req)
-	require.Equal(t, err, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(req.EphemeralTimeseries[0].Samples[0].TimestampMs), metricLabels), userID).Error()))
+	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(req.EphemeralTimeseries[0].Samples[0].TimestampMs), []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}), userID).Error()), err)
+
+	// Pushing new series now works.
+	_, err = i.Push(ctx, newReq)
+	require.NoError(t, err)
+
+	verifySamples(t, model.Matrix{
+		&model.SampleStream{
+			Metric: map[model.LabelName]model.LabelValue{labels.MetricName: "new-metric"},
+			Values: []model.SamplePair{
+				{Value: 500, Timestamp: model.Time(now.UnixMilli())},
+			},
+		},
+	})
 }
 
 func TestIngesterQueryingWithStorageLabelErrorHandling(t *testing.T) {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/grafana/mimir/pkg/usagestats"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/chunkcompat"
+	"github.com/grafana/mimir/pkg/util/globalerror"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/push"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -6711,7 +6712,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 					mimirpb.API),
 			},
 			maxEphemeralSeriesLimit: 1,
-			expectedErr:             httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(errors.New("per-user ephemeral series limit of 1 exceeded (err-mimir-max-ephemeral-series-per-user). To adjust the related per-tenant limit, configure -ingester.max-global-ephemeral-series-per-user, or contact your service administrator."), userID).Error()),
+			expectedErr:             httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(errors.New(globalerror.MaxEphemeralSeriesPerUser.MessageWithPerTenantLimitConfig(fmt.Sprintf("per-user ephemeral series limit of %d exceeded", 1), validation.MaxEphemeralSeriesPerUserFlag)), userID).Error()),
 			expectedIngestedEphemeral: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: model.Time(now.UnixMilli())}}},
 			},

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6795,7 +6795,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			cfg.ActiveSeriesMetricsEnabled = false
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = 100
-			limits.MaxGlobalEphemeralSeriesPerUser = testData.maxEphemeralSeriesLimit
+			limits.MaxEphemeralSeriesPerUser = testData.maxEphemeralSeriesLimit
 			limits.OutOfOrderTimeWindow = model.Duration(time.Minute * 10)
 
 			i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, "", registry)
@@ -6878,7 +6878,7 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 	cfg.IngesterRing.ReplicationFactor = 1 // for computing limits.
 
 	limits := defaultLimitsTestConfig()
-	limits.MaxGlobalEphemeralSeriesPerUser = 1
+	limits.MaxEphemeralSeriesPerUser = 1
 
 	reg := prometheus.NewPedanticRegistry()
 	i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, "", reg)

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -37,7 +37,7 @@ type InstanceLimits struct {
 	MaxIngestionRate           float64 `yaml:"max_ingestion_rate" category:"advanced"`
 	MaxInMemoryTenants         int64   `yaml:"max_tenants" category:"advanced"`
 	MaxInMemorySeries          int64   `yaml:"max_series" category:"advanced"`
-	MaxInMemoryEphemeralSeries int64   `yaml:"max_ephemeral_series" category:"advanced"`
+	MaxInMemoryEphemeralSeries int64   `yaml:"max_ephemeral_series" category:"experimental"`
 	MaxInflightPushRequests    int64   `yaml:"max_inflight_push_requests" category:"advanced"`
 }
 

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -15,33 +15,37 @@ import (
 )
 
 const (
-	maxIngestionRateFlag        = "ingester.instance-limits.max-ingestion-rate"
-	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
-	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
-	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
+	maxIngestionRateFlag           = "ingester.instance-limits.max-ingestion-rate"
+	maxInMemoryTenantsFlag         = "ingester.instance-limits.max-tenants"
+	maxInMemorySeriesFlag          = "ingester.instance-limits.max-series"
+	maxInMemoryEphemeralSeriesFlag = "ingester.instance-limits.max-ephemeral-series"
+	maxInflightPushRequestsFlag    = "ingester.instance-limits.max-inflight-push-requests"
 )
 
 var (
 	// We don't include values in the message to avoid leaking Mimir cluster configuration to users.
-	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
-	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
-	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
-	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached           = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
+	errMaxTenantsReached                 = errors.New(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
+	errMaxInMemorySeriesReached          = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
+	errMaxInMemoryEphemeralSeriesReached = errors.New(globalerror.IngesterMaxInMemoryEphemeralSeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of ephemeral in-memory series", maxInMemoryEphemeralSeriesFlag))
+	errMaxInflightRequestsReached        = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return
 // (internal) error.
 type InstanceLimits struct {
-	MaxIngestionRate        float64 `yaml:"max_ingestion_rate" category:"advanced"`
-	MaxInMemoryTenants      int64   `yaml:"max_tenants" category:"advanced"`
-	MaxInMemorySeries       int64   `yaml:"max_series" category:"advanced"`
-	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxIngestionRate           float64 `yaml:"max_ingestion_rate" category:"advanced"`
+	MaxInMemoryTenants         int64   `yaml:"max_tenants" category:"advanced"`
+	MaxInMemorySeries          int64   `yaml:"max_series" category:"advanced"`
+	MaxInMemoryEphemeralSeries int64   `yaml:"max_ephemeral_series" category:"advanced"`
+	MaxInflightPushRequests    int64   `yaml:"max_inflight_push_requests" category:"advanced"`
 }
 
 func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.MaxIngestionRate, maxIngestionRateFlag, 0, "Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.")
 	f.Int64Var(&l.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInMemoryEphemeralSeries, maxInMemoryEphemeralSeriesFlag, 0, "Max ephemeral series that this ingester can hold (across all tenants). Requests to create additional ephemeral series will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 }
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -116,10 +116,10 @@ func (l *Limiter) FormatError(userID string, err error) error {
 		return l.formatMaxSeriesPerUserError(userID)
 	case errMaxSeriesPerMetricLimitExceeded:
 		return l.formatMaxSeriesPerMetricError(userID)
-	case errMaxEphemeralSeriesPerUserLimitExceeded:
-		return l.formatMaxEphemeralSeriesPerUserError(userID)
 	case errMaxMetadataPerUserLimitExceeded:
 		return l.formatMaxMetadataPerUserError(userID)
+	case errMaxEphemeralSeriesPerUserLimitExceeded:
+		return l.formatMaxEphemeralSeriesPerUserError(userID)
 	case errMaxMetadataPerMetricLimitExceeded:
 		return l.formatMaxMetadataPerMetricError(userID)
 	default:

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -19,10 +19,11 @@ import (
 
 var (
 	// These errors are only internal, to change the API error messages, see Limiter's methods below.
-	errMaxSeriesPerMetricLimitExceeded   = errors.New("per-metric series limit exceeded")
-	errMaxMetadataPerMetricLimitExceeded = errors.New("per-metric metadata limit exceeded")
-	errMaxSeriesPerUserLimitExceeded     = errors.New("per-user series limit exceeded")
-	errMaxMetadataPerUserLimitExceeded   = errors.New("per-user metric metadata limit exceeded")
+	errMaxSeriesPerMetricLimitExceeded        = errors.New("per-metric series limit exceeded")
+	errMaxMetadataPerMetricLimitExceeded      = errors.New("per-metric metadata limit exceeded")
+	errMaxSeriesPerUserLimitExceeded          = errors.New("per-user series limit exceeded")
+	errMaxEphemeralSeriesPerUserLimitExceeded = errors.New("per-user ephemeral series limit exceeded")
+	errMaxMetadataPerUserLimitExceeded        = errors.New("per-user metric metadata limit exceeded")
 )
 
 // RingCount is the interface exposed by a ring implementation which allows
@@ -86,6 +87,16 @@ func (l *Limiter) AssertMaxSeriesPerUser(userID string, series int) error {
 	return errMaxSeriesPerUserLimitExceeded
 }
 
+// AssertMaxEphemeralSeriesPerUser limit has not been reached compared to the current
+// number of series in input and returns an error if so.
+func (l *Limiter) AssertMaxEphemeralSeriesPerUser(userID string, series int) error {
+	if actualLimit := l.maxEphemeralSeriesPerUser(userID); series < actualLimit {
+		return nil
+	}
+
+	return errMaxEphemeralSeriesPerUserLimitExceeded
+}
+
 // AssertMaxMetricsWithMetadataPerUser limit has not been reached compared to the current
 // number of metrics with metadata in input and returns an error if so.
 func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int) error {
@@ -105,6 +116,8 @@ func (l *Limiter) FormatError(userID string, err error) error {
 		return l.formatMaxSeriesPerUserError(userID)
 	case errMaxSeriesPerMetricLimitExceeded:
 		return l.formatMaxSeriesPerMetricError(userID)
+	case errMaxEphemeralSeriesPerUserLimitExceeded:
+		return l.formatMaxEphemeralSeriesPerUserError(userID)
 	case errMaxMetadataPerUserLimitExceeded:
 		return l.formatMaxMetadataPerUserError(userID)
 	case errMaxMetadataPerMetricLimitExceeded:
@@ -129,6 +142,15 @@ func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 	return errors.New(globalerror.MaxSeriesPerMetric.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-metric series limit of %d exceeded", globalLimit),
 		validation.MaxSeriesPerMetricFlag,
+	))
+}
+
+func (l *Limiter) formatMaxEphemeralSeriesPerUserError(userID string) error {
+	globalLimit := l.limits.MaxGlobalEphemeralSeriesPerUser(userID)
+
+	return errors.New(globalerror.MaxEphemeralSeriesPerUser.MessageWithPerTenantLimitConfig(
+		fmt.Sprintf("per-user ephemeral series limit of %d exceeded", globalLimit),
+		validation.MaxEphemeralSeriesPerUserFlag,
 	))
 }
 
@@ -160,6 +182,10 @@ func (l *Limiter) maxMetadataPerMetric(userID string) int {
 
 func (l *Limiter) maxSeriesPerUser(userID string) int {
 	return l.convertGlobalToLocalLimitOrUnlimited(userID, l.limits.MaxGlobalSeriesPerUser)
+}
+
+func (l *Limiter) maxEphemeralSeriesPerUser(userID string) int {
+	return l.convertGlobalToLocalLimitOrUnlimited(userID, l.limits.MaxGlobalEphemeralSeriesPerUser)
 }
 
 func (l *Limiter) maxMetadataPerUser(userID string) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -146,7 +146,7 @@ func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 }
 
 func (l *Limiter) formatMaxEphemeralSeriesPerUserError(userID string) error {
-	globalLimit := l.limits.MaxGlobalEphemeralSeriesPerUser(userID)
+	globalLimit := l.limits.MaxEphemeralSeriesPerUser(userID)
 
 	return errors.New(globalerror.MaxEphemeralSeriesPerUser.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-user ephemeral series limit of %d exceeded", globalLimit),
@@ -185,7 +185,7 @@ func (l *Limiter) maxSeriesPerUser(userID string) int {
 }
 
 func (l *Limiter) maxEphemeralSeriesPerUser(userID string) int {
-	return l.convertGlobalToLocalLimitOrUnlimited(userID, l.limits.MaxGlobalEphemeralSeriesPerUser)
+	return l.convertGlobalToLocalLimitOrUnlimited(userID, l.limits.MaxEphemeralSeriesPerUser)
 }
 
 func (l *Limiter) maxMetadataPerUser(userID string) int {

--- a/pkg/ingester/metric_counter.go
+++ b/pkg/ingester/metric_counter.go
@@ -12,13 +12,6 @@ import (
 	"github.com/segmentio/fasthash/fnv1a"
 )
 
-// DiscardedSamples metric labels
-const (
-	perUserSeriesLimit          = "per_user_series_limit"
-	perMetricSeriesLimit        = "per_metric_series_limit"
-	perUserEphemeralSeriesLimit = "per_user_ephemeral_series_limit"
-)
-
 const numMetricCounterShards = 128
 
 type metricCounterShard struct {

--- a/pkg/ingester/metric_counter.go
+++ b/pkg/ingester/metric_counter.go
@@ -14,8 +14,9 @@ import (
 
 // DiscardedSamples metric labels
 const (
-	perUserSeriesLimit   = "per_user_series_limit"
-	perMetricSeriesLimit = "per_metric_series_limit"
+	perUserSeriesLimit          = "per_user_series_limit"
+	perMetricSeriesLimit        = "per_metric_series_limit"
+	perUserEphemeralSeriesLimit = "per_user_ephemeral_series_limit"
 )
 
 const numMetricCounterShards = 128

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -48,6 +48,7 @@ type ingesterMetrics struct {
 	// Global limit metrics
 	maxUsersGauge           prometheus.GaugeFunc
 	maxSeriesGauge          prometheus.GaugeFunc
+	maxEphemeralSeriesGauge prometheus.GaugeFunc
 	maxIngestionRate        prometheus.GaugeFunc
 	ingestionRate           prometheus.GaugeFunc
 	maxInflightPushRequests prometheus.GaugeFunc
@@ -217,6 +218,17 @@ func newIngesterMetrics(
 		}, func() float64 {
 			if g := instanceLimitsFn(); g != nil {
 				return float64(g.MaxInMemorySeries)
+			}
+			return 0
+		}),
+
+		maxEphemeralSeriesGauge: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
+			Name:        instanceLimits,
+			Help:        instanceLimitsHelp,
+			ConstLabels: map[string]string{limitLabel: "max_ephemeral_series"},
+		}, func() float64 {
+			if g := instanceLimitsFn(); g != nil {
+				return float64(g.MaxInMemoryEphemeralSeries)
 			}
 			return 0
 		}),

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -63,12 +63,13 @@ type ingesterMetrics struct {
 	idleTsdbChecks         *prometheus.CounterVec
 
 	// Discarded samples
-	discardedSamplesSampleOutOfBounds    *prometheus.CounterVec
-	discardedSamplesSampleOutOfOrder     *prometheus.CounterVec
-	discardedSamplesSampleTooOld         *prometheus.CounterVec
-	discardedSamplesNewValueForTimestamp *prometheus.CounterVec
-	discardedSamplesPerUserSeriesLimit   *prometheus.CounterVec
-	discardedSamplesPerMetricSeriesLimit *prometheus.CounterVec
+	discardedSamplesSampleOutOfBounds           *prometheus.CounterVec
+	discardedSamplesSampleOutOfOrder            *prometheus.CounterVec
+	discardedSamplesSampleTooOld                *prometheus.CounterVec
+	discardedSamplesNewValueForTimestamp        *prometheus.CounterVec
+	discardedSamplesPerUserSeriesLimit          *prometheus.CounterVec
+	discardedSamplesPerMetricSeriesLimit        *prometheus.CounterVec
+	discardedSamplesPerUserEphemeralSeriesLimit *prometheus.CounterVec
 
 	// Discarded metadata
 	discardedMetadataPerUserMetadataLimit   *prometheus.CounterVec
@@ -320,12 +321,13 @@ func newIngesterMetrics(
 
 		idleTsdbChecks: idleTsdbChecks,
 
-		discardedSamplesSampleOutOfBounds:    validation.DiscardedSamplesCounter(r, sampleOutOfBounds),
-		discardedSamplesSampleOutOfOrder:     validation.DiscardedSamplesCounter(r, sampleOutOfOrder),
-		discardedSamplesSampleTooOld:         validation.DiscardedSamplesCounter(r, sampleTooOld),
-		discardedSamplesNewValueForTimestamp: validation.DiscardedSamplesCounter(r, newValueForTimestamp),
-		discardedSamplesPerUserSeriesLimit:   validation.DiscardedSamplesCounter(r, perUserSeriesLimit),
-		discardedSamplesPerMetricSeriesLimit: validation.DiscardedSamplesCounter(r, perMetricSeriesLimit),
+		discardedSamplesSampleOutOfBounds:           validation.DiscardedSamplesCounter(r, sampleOutOfBounds),
+		discardedSamplesSampleOutOfOrder:            validation.DiscardedSamplesCounter(r, sampleOutOfOrder),
+		discardedSamplesSampleTooOld:                validation.DiscardedSamplesCounter(r, sampleTooOld),
+		discardedSamplesNewValueForTimestamp:        validation.DiscardedSamplesCounter(r, newValueForTimestamp),
+		discardedSamplesPerUserSeriesLimit:          validation.DiscardedSamplesCounter(r, perUserSeriesLimit),
+		discardedSamplesPerMetricSeriesLimit:        validation.DiscardedSamplesCounter(r, perMetricSeriesLimit),
+		discardedSamplesPerUserEphemeralSeriesLimit: validation.DiscardedSamplesCounter(r, perUserEphemeralSeriesLimit),
 
 		discardedMetadataPerUserMetadataLimit:   validation.DiscardedMetadataCounter(r, perUserMetadataLimit),
 		discardedMetadataPerMetricMetadataLimit: validation.DiscardedMetadataCounter(r, perMetricMetadataLimit),
@@ -350,6 +352,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.discardedSamplesNewValueForTimestamp.DeletePartialMatch(filter)
 	m.discardedSamplesPerUserSeriesLimit.DeletePartialMatch(filter)
 	m.discardedSamplesPerMetricSeriesLimit.DeletePartialMatch(filter)
+	m.discardedSamplesPerUserEphemeralSeriesLimit.DeletePartialMatch(filter)
 
 	m.discardedMetadataPerUserMetadataLimit.DeleteLabelValues(userID)
 	m.discardedMetadataPerMetricMetadataLimit.DeleteLabelValues(userID)
@@ -362,6 +365,7 @@ func (m *ingesterMetrics) deletePerGroupMetricsForUser(userID, group string) {
 	m.discardedSamplesNewValueForTimestamp.DeleteLabelValues(userID, group)
 	m.discardedSamplesPerUserSeriesLimit.DeleteLabelValues(userID, group)
 	m.discardedSamplesPerMetricSeriesLimit.DeleteLabelValues(userID, group)
+	m.discardedSamplesPerUserEphemeralSeriesLimit.DeleteLabelValues(userID, group)
 }
 
 func (m *ingesterMetrics) deletePerUserCustomTrackerMetrics(userID string, customTrackerMetrics []string) {

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -68,8 +68,9 @@ type userTSDB struct {
 	ephemeralMtx     sync.RWMutex
 	ephemeralStorage *tsdb.Head
 
-	instanceSeriesCount *atomic.Int64 // Shared across all userTSDB instances created by ingester.
-	instanceLimitsFn    func() *InstanceLimits
+	instanceSeriesCount          *atomic.Int64 // Shared across all userTSDB instances created by ingester.
+	instanceEphemeralSeriesCount *atomic.Int64 // Shared across all userTSDB instances created by ingester.
+	instanceLimitsFn             func() *InstanceLimits
 
 	stateMtx       sync.RWMutex
 	state          tsdbState
@@ -267,8 +268,16 @@ func (u *userTSDB) compactHead(blockDuration int64) error {
 	return u.db.CompactHead(tsdb.NewRangeHead(h, minTime, maxTime))
 }
 
+func (u *userTSDB) persistentSeriesCallback() tsdb.SeriesLifecycleCallback {
+	return seriesLifecycleCallback{
+		preCreation:  u.persistentPreCreation,
+		postCreation: u.persistentPostCreation,
+		postDeletion: u.persistentPostDeletion,
+	}
+}
+
 // PreCreation implements SeriesLifecycleCallback interface.
-func (u *userTSDB) PreCreation(metric labels.Labels) error {
+func (u *userTSDB) persistentPreCreation(metric labels.Labels) error {
 	if u.limiter == nil {
 		return nil
 	}
@@ -299,7 +308,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 }
 
 // PostCreation implements SeriesLifecycleCallback interface.
-func (u *userTSDB) PostCreation(metric labels.Labels) {
+func (u *userTSDB) persistentPostCreation(metric labels.Labels) {
 	u.instanceSeriesCount.Inc()
 
 	metricName, err := extract.MetricNameFromLabels(metric)
@@ -311,7 +320,7 @@ func (u *userTSDB) PostCreation(metric labels.Labels) {
 }
 
 // PostDeletion implements SeriesLifecycleCallback interface.
-func (u *userTSDB) PostDeletion(metrics ...labels.Labels) {
+func (u *userTSDB) persistentPostDeletion(metrics ...labels.Labels) {
 	u.instanceSeriesCount.Sub(int64(len(metrics)))
 
 	for _, metric := range metrics {
@@ -322,6 +331,52 @@ func (u *userTSDB) PostDeletion(metrics ...labels.Labels) {
 		}
 		u.seriesInMetric.decreaseSeriesForMetric(metricName)
 	}
+}
+
+func (u *userTSDB) ephemeralSeriesCallback() tsdb.SeriesLifecycleCallback {
+	return seriesLifecycleCallback{
+		preCreation:  u.ephemeralPreCreation,
+		postCreation: u.ephemeralPostCreation,
+		postDeletion: u.ephemeralPostDeletion,
+	}
+}
+
+// PreCreation implements SeriesLifecycleCallback interface.
+func (u *userTSDB) ephemeralPreCreation(_ labels.Labels) error {
+	if u.limiter == nil {
+		return nil
+	}
+
+	// Verify ingester's global limit
+	gl := u.instanceLimitsFn()
+	if gl != nil && gl.MaxInMemoryEphemeralSeries > 0 {
+		if series := u.instanceEphemeralSeriesCount.Load(); series >= gl.MaxInMemoryEphemeralSeries {
+			return errMaxInMemoryEphemeralSeriesReached
+		}
+	}
+
+	eph := u.getEphemeralStorage()
+	if eph == nil {
+		// if ephemeralPreCreation is called, ephemeral storage should exist, but check here is better than panic.
+		return errors.New("ephemeral storage not created")
+	}
+
+	// Total series limit.
+	if err := u.limiter.AssertMaxEphemeralSeriesPerUser(u.userID, int(eph.NumSeries())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PostCreation implements SeriesLifecycleCallback interface.
+func (u *userTSDB) ephemeralPostCreation(_ labels.Labels) {
+	u.instanceEphemeralSeriesCount.Inc()
+}
+
+// PostDeletion implements SeriesLifecycleCallback interface.
+func (u *userTSDB) ephemeralPostDeletion(metrics ...labels.Labels) {
+	u.instanceEphemeralSeriesCount.Sub(int64(len(metrics)))
 }
 
 // blocksToDelete filters the input blocks and returns the blocks which are safe to be deleted from the ingester.
@@ -456,3 +511,13 @@ func (u *userTSDB) acquireAppendLock() error {
 func (u *userTSDB) releaseAppendLock() {
 	u.pushesInFlight.Done()
 }
+
+type seriesLifecycleCallback struct {
+	preCreation  func(metric labels.Labels) error
+	postCreation func(metric labels.Labels)
+	postDeletion func(metric ...labels.Labels)
+}
+
+func (s seriesLifecycleCallback) PreCreation(l labels.Labels) error { return s.preCreation(l) }
+func (s seriesLifecycleCallback) PostCreation(l labels.Labels)      { s.postCreation(l) }
+func (s seriesLifecycleCallback) PostDeletion(l ...labels.Labels)   { s.postDeletion(l...) }

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -276,7 +276,6 @@ func (u *userTSDB) persistentSeriesCallback() tsdb.SeriesLifecycleCallback {
 	}
 }
 
-// PreCreation implements SeriesLifecycleCallback interface.
 func (u *userTSDB) persistentPreCreation(metric labels.Labels) error {
 	if u.limiter == nil {
 		return nil
@@ -307,7 +306,6 @@ func (u *userTSDB) persistentPreCreation(metric labels.Labels) error {
 	return nil
 }
 
-// PostCreation implements SeriesLifecycleCallback interface.
 func (u *userTSDB) persistentPostCreation(metric labels.Labels) {
 	u.instanceSeriesCount.Inc()
 
@@ -319,7 +317,6 @@ func (u *userTSDB) persistentPostCreation(metric labels.Labels) {
 	u.seriesInMetric.increaseSeriesForMetric(metricName)
 }
 
-// PostDeletion implements SeriesLifecycleCallback interface.
 func (u *userTSDB) persistentPostDeletion(metrics ...labels.Labels) {
 	u.instanceSeriesCount.Sub(int64(len(metrics)))
 
@@ -341,7 +338,6 @@ func (u *userTSDB) ephemeralSeriesCallback() tsdb.SeriesLifecycleCallback {
 	}
 }
 
-// PreCreation implements SeriesLifecycleCallback interface.
 func (u *userTSDB) ephemeralPreCreation(_ labels.Labels) error {
 	if u.limiter == nil {
 		return nil
@@ -369,12 +365,10 @@ func (u *userTSDB) ephemeralPreCreation(_ labels.Labels) error {
 	return nil
 }
 
-// PostCreation implements SeriesLifecycleCallback interface.
 func (u *userTSDB) ephemeralPostCreation(_ labels.Labels) {
 	u.instanceEphemeralSeriesCount.Inc()
 }
 
-// PostDeletion implements SeriesLifecycleCallback interface.
 func (u *userTSDB) ephemeralPostDeletion(metrics ...labels.Labels) {
 	u.instanceEphemeralSeriesCount.Sub(int64(len(metrics)))
 }

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -26,6 +26,7 @@ const (
 	MaxSeriesPerMetric            ID = "max-series-per-metric"
 	MaxMetadataPerMetric          ID = "max-metadata-per-metric"
 	MaxSeriesPerUser              ID = "max-series-per-user"
+	MaxEphemeralSeriesPerUser     ID = "max-ephemeral-series-per-user"
 	MaxMetadataPerUser            ID = "max-metadata-per-user"
 	MaxChunksPerQuery             ID = "max-chunks-per-query"
 	MaxSeriesPerQuery             ID = "max-series-per-query"
@@ -35,10 +36,11 @@ const (
 	DistributorMaxInflightPushRequests      ID = "distributor-max-inflight-push-requests"
 	DistributorMaxInflightPushRequestsBytes ID = "distributor-max-inflight-push-requests-bytes"
 
-	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
-	IngesterMaxTenants              ID = "ingester-max-tenants"
-	IngesterMaxInMemorySeries       ID = "ingester-max-series"
-	IngesterMaxInflightPushRequests ID = "ingester-max-inflight-push-requests"
+	IngesterMaxIngestionRate           ID = "ingester-max-ingestion-rate"
+	IngesterMaxTenants                 ID = "ingester-max-tenants"
+	IngesterMaxInMemorySeries          ID = "ingester-max-series"
+	IngesterMaxInMemoryEphemeralSeries ID = "ingester-max-ephemeral-series"
+	IngesterMaxInflightPushRequests    ID = "ingester-max-inflight-push-requests"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"
@@ -64,6 +66,8 @@ const (
 	BucketIndexTooOld           ID = "bucket-index-too-old"
 
 	DistributorMaxWriteMessageSize ID = "distributor-max-write-message-size"
+
+	EphemeralStorageNotEnabledForUser ID = "ephemeral-storage-not-enabled-for-user"
 )
 
 // Message returns the provided msg, appending the error id.

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -62,6 +62,10 @@ const (
 	SampleDuplicateTimestamp ID = "sample-duplicate-timestamp"
 	ExemplarSeriesMissing    ID = "exemplar-series-missing"
 
+	EphemeralSampleTimestampTooOld    ID = "ephemeral-sample-timestamp-too-old"
+	EphemeralSampleOutOfOrder         ID = "ephemeral-sample-out-of-order"
+	EphemeralSampleDuplicateTimestamp ID = "ephemeral-sample-duplicate-timestamp"
+
 	StoreConsistencyCheckFailed ID = "store-consistency-check-failed"
 	BucketIndexTooOld           ID = "bucket-index-too-old"
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -30,7 +30,7 @@ const (
 	MaxSeriesPerMetricFlag        = "ingester.max-global-series-per-metric"
 	MaxMetadataPerMetricFlag      = "ingester.max-global-metadata-per-metric"
 	MaxSeriesPerUserFlag          = "ingester.max-global-series-per-user"
-	MaxEphemeralSeriesPerUserFlag = "ingester.max-global-ephemeral-series-per-user"
+	MaxEphemeralSeriesPerUserFlag = "ingester.max-ephemeral-series-per-user"
 	MaxMetadataPerUserFlag        = "ingester.max-global-metadata-per-user"
 	MaxChunksPerQueryFlag         = "querier.max-fetched-chunks-per-query"
 	MaxChunkBytesPerQueryFlag     = "querier.max-fetched-chunk-bytes-per-query"
@@ -95,7 +95,7 @@ type Limits struct {
 	MaxGlobalSeriesPerUser   int `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
 	MaxGlobalSeriesPerMetric int `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
 	// Ephemeral series
-	MaxGlobalEphemeralSeriesPerUser int `yaml:"max_global_ephemeral_series_per_user" json:"max_global_ephemeral_series_per_user" category:"experimental"`
+	MaxEphemeralSeriesPerUser int `yaml:"max_ephemeral_series_per_user" json:"max_ephemeral_series_per_user" category:"experimental"`
 	// Metadata
 	MaxGlobalMetricsWithMetadataPerUser int `yaml:"max_global_metadata_per_user" json:"max_global_metadata_per_user"`
 	MaxGlobalMetadataPerMetric          int `yaml:"max_global_metadata_per_metric" json:"max_global_metadata_per_metric"`
@@ -200,7 +200,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")
-	f.IntVar(&l.MaxGlobalEphemeralSeriesPerUser, MaxEphemeralSeriesPerUserFlag, 0, "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable ephemeral storage.")
+	f.IntVar(&l.MaxEphemeralSeriesPerUser, MaxEphemeralSeriesPerUserFlag, 0, "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable ephemeral storage.")
 
 	f.IntVar(&l.MaxGlobalMetricsWithMetadataPerUser, MaxMetadataPerUserFlag, 0, "The maximum number of in-memory metrics with metadata per tenant, across the cluster. 0 to disable.")
 	f.IntVar(&l.MaxGlobalMetadataPerMetric, MaxMetadataPerMetricFlag, 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")
@@ -460,9 +460,9 @@ func (o *Overrides) MaxGlobalSeriesPerMetric(userID string) int {
 	return o.getOverridesForUser(userID).MaxGlobalSeriesPerMetric
 }
 
-// MaxGlobalEphemeralSeriesPerUser returns the maximum number of ephemeral series a user is allowed to store across the cluster.
-func (o *Overrides) MaxGlobalEphemeralSeriesPerUser(userID string) int {
-	return o.getOverridesForUser(userID).MaxGlobalEphemeralSeriesPerUser
+// MaxEphemeralSeriesPerUser returns the maximum number of ephemeral series a user is allowed to store across the cluster.
+func (o *Overrides) MaxEphemeralSeriesPerUser(userID string) int {
+	return o.getOverridesForUser(userID).MaxEphemeralSeriesPerUser
 }
 
 func (o *Overrides) MaxChunksPerQuery(userID string) int {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -95,7 +95,7 @@ type Limits struct {
 	MaxGlobalSeriesPerUser   int `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
 	MaxGlobalSeriesPerMetric int `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
 	// Ephemeral series
-	MaxGlobalEphemeralSeriesPerUser int `yaml:"max_global_ephemeral_series_per_user" json:"max_global_ephemeral_series_per_user"`
+	MaxGlobalEphemeralSeriesPerUser int `yaml:"max_global_ephemeral_series_per_user" json:"max_global_ephemeral_series_per_user" category:"experimental"`
 	// Metadata
 	MaxGlobalMetricsWithMetadataPerUser int `yaml:"max_global_metadata_per_user" json:"max_global_metadata_per_user"`
 	MaxGlobalMetadataPerMetric          int `yaml:"max_global_metadata_per_metric" json:"max_global_metadata_per_metric"`

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -27,26 +27,27 @@ import (
 )
 
 const (
-	MaxSeriesPerMetricFlag     = "ingester.max-global-series-per-metric"
-	MaxMetadataPerMetricFlag   = "ingester.max-global-metadata-per-metric"
-	MaxSeriesPerUserFlag       = "ingester.max-global-series-per-user"
-	MaxMetadataPerUserFlag     = "ingester.max-global-metadata-per-user"
-	MaxChunksPerQueryFlag      = "querier.max-fetched-chunks-per-query"
-	MaxChunkBytesPerQueryFlag  = "querier.max-fetched-chunk-bytes-per-query"
-	MaxSeriesPerQueryFlag      = "querier.max-fetched-series-per-query"
-	maxLabelNamesPerSeriesFlag = "validation.max-label-names-per-series"
-	maxLabelNameLengthFlag     = "validation.max-length-label-name"
-	maxLabelValueLengthFlag    = "validation.max-length-label-value"
-	maxMetadataLengthFlag      = "validation.max-metadata-length"
-	creationGracePeriodFlag    = "validation.create-grace-period"
-	maxQueryLengthFlag         = "store.max-query-length"
-	maxPartialQueryLengthFlag  = "querier.max-partial-query-length"
-	maxTotalQueryLengthFlag    = "query-frontend.max-total-query-length"
-	requestRateFlag            = "distributor.request-rate-limit"
-	requestBurstSizeFlag       = "distributor.request-burst-size"
-	ingestionRateFlag          = "distributor.ingestion-rate-limit"
-	ingestionBurstSizeFlag     = "distributor.ingestion-burst-size"
-	HATrackerMaxClustersFlag   = "distributor.ha-tracker.max-clusters"
+	MaxSeriesPerMetricFlag        = "ingester.max-global-series-per-metric"
+	MaxMetadataPerMetricFlag      = "ingester.max-global-metadata-per-metric"
+	MaxSeriesPerUserFlag          = "ingester.max-global-series-per-user"
+	MaxEphemeralSeriesPerUserFlag = "ingester.max-global-ephemeral-series-per-user"
+	MaxMetadataPerUserFlag        = "ingester.max-global-metadata-per-user"
+	MaxChunksPerQueryFlag         = "querier.max-fetched-chunks-per-query"
+	MaxChunkBytesPerQueryFlag     = "querier.max-fetched-chunk-bytes-per-query"
+	MaxSeriesPerQueryFlag         = "querier.max-fetched-series-per-query"
+	maxLabelNamesPerSeriesFlag    = "validation.max-label-names-per-series"
+	maxLabelNameLengthFlag        = "validation.max-length-label-name"
+	maxLabelValueLengthFlag       = "validation.max-length-label-value"
+	maxMetadataLengthFlag         = "validation.max-metadata-length"
+	creationGracePeriodFlag       = "validation.create-grace-period"
+	maxQueryLengthFlag            = "store.max-query-length"
+	maxPartialQueryLengthFlag     = "querier.max-partial-query-length"
+	maxTotalQueryLengthFlag       = "query-frontend.max-total-query-length"
+	requestRateFlag               = "distributor.request-rate-limit"
+	requestBurstSizeFlag          = "distributor.request-burst-size"
+	ingestionRateFlag             = "distributor.ingestion-rate-limit"
+	ingestionBurstSizeFlag        = "distributor.ingestion-burst-size"
+	HATrackerMaxClustersFlag      = "distributor.ha-tracker.max-clusters"
 
 	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
@@ -93,6 +94,8 @@ type Limits struct {
 	// Series
 	MaxGlobalSeriesPerUser   int `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
 	MaxGlobalSeriesPerMetric int `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
+	// Ephemeral series
+	MaxGlobalEphemeralSeriesPerUser int `yaml:"max_global_ephemeral_series_per_user" json:"max_global_ephemeral_series_per_user"`
 	// Metadata
 	MaxGlobalMetricsWithMetadataPerUser int `yaml:"max_global_metadata_per_user" json:"max_global_metadata_per_user"`
 	MaxGlobalMetadataPerMetric          int `yaml:"max_global_metadata_per_metric" json:"max_global_metadata_per_metric"`
@@ -197,6 +200,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")
+
+	f.IntVar(&l.MaxGlobalEphemeralSeriesPerUser, MaxEphemeralSeriesPerUserFlag, 150000, "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable.")
 
 	f.IntVar(&l.MaxGlobalMetricsWithMetadataPerUser, MaxMetadataPerUserFlag, 0, "The maximum number of in-memory metrics with metadata per tenant, across the cluster. 0 to disable.")
 	f.IntVar(&l.MaxGlobalMetadataPerMetric, MaxMetadataPerMetricFlag, 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")
@@ -454,6 +459,11 @@ func (o *Overrides) MaxGlobalSeriesPerUser(userID string) int {
 // MaxGlobalSeriesPerMetric returns the maximum number of series allowed per metric across the cluster.
 func (o *Overrides) MaxGlobalSeriesPerMetric(userID string) int {
 	return o.getOverridesForUser(userID).MaxGlobalSeriesPerMetric
+}
+
+// MaxGlobalEphemeralSeriesPerUser returns the maximum number of ephemeral series a user is allowed to store across the cluster.
+func (o *Overrides) MaxGlobalEphemeralSeriesPerUser(userID string) int {
+	return o.getOverridesForUser(userID).MaxGlobalEphemeralSeriesPerUser
 }
 
 func (o *Overrides) MaxChunksPerQuery(userID string) int {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -200,8 +200,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")
-
-	f.IntVar(&l.MaxGlobalEphemeralSeriesPerUser, MaxEphemeralSeriesPerUserFlag, 150000, "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable.")
+	f.IntVar(&l.MaxGlobalEphemeralSeriesPerUser, MaxEphemeralSeriesPerUserFlag, 0, "The maximum number of in-memory ephemeral series per tenant, across the cluster before replication. 0 to disable ephemeral storage.")
 
 	f.IntVar(&l.MaxGlobalMetricsWithMetadataPerUser, MaxMetadataPerUserFlag, 0, "The maximum number of in-memory metrics with metadata per tenant, across the cluster. 0 to disable.")
 	f.IntVar(&l.MaxGlobalMetadataPerMetric, MaxMetadataPerMetricFlag, 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")


### PR DESCRIPTION
#### What this PR does
This PR
- introduces instance-limit for max number of ephemeral series in ingester (`-ingester.instance-limits.max-ephemeral-series`)
- introduces per-user series limit for ephemeral storage (`-ingester.max-ephemeral-series-per-user`)
- modifies "discard" reasons for discarded samples when ingesting ephemeral series (all reasons have "ephemeral-" prefix)
- introduces new error codes into error catalog:
  * `err-mimir-max-ephemeral-series-per-user`
  * `err-mimir-ingester-max-ephemeral-series`
  * `err-mimir-ephemeral-sample-timestamp-too-old`
  * `err-mimir-ephemeral-sample-out-of-order`
  * `err-mimir-ephemeral-sample-duplicate-timestamp`
  * `err-mimir-ephemeral-storage-not-enabled-for-user`

This PR does not update changelog, nor does it add documentation for newly introduced errors in the error catalog. This will be handled by subsequent PRs.

(If needed, I'm happy to split the PR into smaller PRs)

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/3884

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
