### PR TITLE
Add missing changelog entries for commits since Mimir 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] Reduce overhead of debug logging when filtered out. #3875
 * [ENHANCEMENT] Update Docker base images from `alpine:3.16.2` to `alpine:3.17.1`. #3898
 * [ENHANCEMENT] Ingester: Add new `/ingester/tsdb_metrics` endpoint to return tenant-specific TSDB metrics. #3923
+* [ENHANCEMENT] Query-frontend: CLI flag `-query-frontend.max-total-query-length` and its associated YAML configuration is now stable. #3882
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
@@ -44,6 +45,7 @@
 * [BUGFIX] Distributor, Query-scheduler: Make sure ring metrics include a `cortex_` prefix as expected by dashboards. #3809
 * [BUGFIX] Querier: canceled requests are no longer reported as "consistency check" failures. #3837 #3927
 * [BUGFIX] Distributor: don't panic when `metric_relabel_configs` in overrides contains null element. #3868
+* [BUGFIX] Distributor: don't panic when OTLP histograms don't have any buckets. #3853
 * [BUGFIX] Ingester, Compactor: fix panic that can occur when compaction fails. #3955
 
 ### Mixin
@@ -80,6 +82,7 @@
 
 ### Mimirtool
 
+* [ENHANCEMENT] Update `mimirtool config convert` to work with Mimir 2.4, 2.5, 2.6 changes. #3952
 * [ENHANCEMENT] Mimirtool is now available to install through Homebrew with `brew install mimirtool`. #3776
 * [BUGFIX] Fix summary output from `mimirtool rules sync` to display correct number of groups created and updated. #3918
 


### PR DESCRIPTION
All other commits weren't user-facing or were helm-chart specific.

See #3979

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>
