### PR TITLE
Return `Canceled` rather than `Aborted` when a `Series` request to a store-gateway is cancelled by the calling querier.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [BUGFIX] Distributor: don't panic when `metric_relabel_configs` in overrides contains null element. #3868
 * [BUGFIX] Distributor: don't panic when OTLP histograms don't have any buckets. #3853
 * [BUGFIX] Ingester, Compactor: fix panic that can occur when compaction fails. #3955
+* [BUGFIX] Store-gateway: return `Canceled` rather than `Aborted` error when the calling querier cancels the request. #4007
 
 ### Mixin
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -817,6 +817,8 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		code := codes.Aborted
 		if st, ok := status.FromError(errors.Cause(err)); ok {
 			code = st.Code()
+		} else if errors.Is(err, context.Canceled) {
+			code = codes.Canceled
 		}
 		err = status.Error(code, err.Error())
 	}()


### PR DESCRIPTION
#### What this PR does

Queriers make multiple requests to store-gateways simultaneously. If one of these requests fails, or if the querier decides to stop processing the request (eg. due to a query limit being reached, or an invalid query), the querier will cancel all in-flight store-gateway requests.

Previously, the store-gateway would return an `Aborted` gRPC error if the request is cancelled by the caller. However, this would then be recorded in logs and metrics with `status="error"`.

`Canceled` is the preferred error for this scenario (the caller cancelling the request). Requests returning `Canceled` are also recorded in our logs and metrics with `status="cancel"`, which more accurately reflects what happened. (I was confused while diagnosing an alert by a high number of requests logged with `status="error"` which were in fact the store-gateway handling an expected scenario in the desired way - `status="cancel"` is much clearer to me in this scenario.)

This PR changes the `Series` endpoint on store-gateways to return `Canceled` when the caller (eg. a querier) cancels the request.

This does not require any changes on the querier side, as we already have [special handling for the scenario where the querier cancels the request](https://github.com/grafana/mimir/blob/4141848b47c5c599c8a07d1477f0e882415aab0d/pkg/querier/blocks_store_queryable.go#L746).

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
