### PR TITLE
Fix ExampleInitLogger to work in UTC

### DIFF
--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -21,7 +21,7 @@ func ExampleInitLogger() {
 	os.Stderr = os.Stdout
 	saveTimestamp := gokitlog.DefaultTimestampUTC
 	gokitlog.DefaultTimestampUTC = gokitlog.TimestampFormat(
-		func() time.Time { return time.Unix(0, 0) },
+		func() time.Time { return time.Unix(0, 0).UTC() },
 		time.RFC3339Nano,
 	)
 


### PR DESCRIPTION
#### What this PR does

The test didn't pass in my time zone (tm), this should fix it.

```
--- FAIL: ExampleInitLogger (0.00s)
got:
ts=1970-01-01T01:00:00+01:00 caller=log_test.go:31 level=info test=1
ts=1970-01-01T01:00:00+01:00 caller=log_test.go:33 level=info msg="test 3"
want:
ts=1970-01-01T00:00:00Z caller=log_test.go:31 level=info test=1
ts=1970-01-01T00:00:00Z caller=log_test.go:33 level=info msg="test 3"
```

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
