### PR TITLE
Remove internal use of store.max-query-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Querier: Introduce `-querier.max-partial-query-length` to limit the time range for partial queries at the querier level and deprecate `-store.max-query-length`. #3825
+* [CHANGE] Querier: Introduce `-querier.max-partial-query-length` to limit the time range for partial queries at the querier level and deprecate `-store.max-query-length`. #3825 #4017
 * [CHANGE] Store-gateway: Remove experimental `-blocks-storage.bucket-store.max-concurrent-reject-over-limit` flag. #3706
 * [CHANGE] Ingester: If shipping is enabled block retention will now be relative to the upload time to cloud storage. If shipping is disabled block retention will be relative to the creation time of the block instead of the mintime of the last block created. #3816
 * [CHANGE] Query-frontend: Deprecated CLI flag `-query-frontend.align-querier-with-step` has been removed. #3982

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2060,7 +2060,7 @@ Usage of ./cmd/mimir/mimir:
   -store.max-labels-query-length duration
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -store.max-query-length duration
-    	Limit the query time range (end - start time). This limit is enforced in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
+    	Deprecated: Limit the query time range (end - start time). This limit is enforced in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable. This option is deprecated, use -querier.max-partial-query-length or -query-frontend.max-total-query-length instead.
   -target comma-separated-list-of-strings
     	Comma-separated list of components to include in the instantiated process. The default value 'all' includes all components that are required to form a functional Grafana Mimir instance in single-binary mode. Use the '-modules' command line flag to get a list of available components, and to see which components are included with 'all'. (default all)
   -tenant-federation.enabled

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -594,7 +594,7 @@ Usage of ./cmd/mimir/mimir:
   -store.max-labels-query-length duration
     	Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.
   -store.max-query-length duration
-    	Limit the query time range (end - start time). This limit is enforced in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.
+    	Deprecated: Limit the query time range (end - start time). This limit is enforced in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable. This option is deprecated, use -querier.max-partial-query-length or -query-frontend.max-total-query-length instead.
   -target comma-separated-list-of-strings
     	Comma-separated list of components to include in the instantiated process. The default value 'all' includes all components that are required to form a functional Grafana Mimir instance in single-binary mode. Use the '-modules' command line flag to get a list of available components, and to see which components are included with 'all'. (default all)
   -tenant-federation.enabled

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -78,7 +78,7 @@ std.manifestYamlDoc({
         httpPort: 8007,
         jaegerApp: 'query-frontend',
         extraArguments:
-          '-store.max-query-length=8760h' +
+          '-query-frontend.max-total-query-length=8760h' +
           // Use of scheduler is activated by `-query-frontend.scheduler-address` option.
           (if $._config.use_query_scheduler then ' -query-frontend.scheduler-address=query-scheduler:9011' else ''),
       }),
@@ -87,7 +87,7 @@ std.manifestYamlDoc({
         'query-scheduler': mimirService({
           target: 'query-scheduler',
           httpPort: 8011,
-          extraArguments: '-store.max-query-length=8760h',
+          extraArguments: '-query-frontend.max-total-query-length=8760h',
         }),
       } else {}
     ),

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -259,7 +259,7 @@
     "command":
       - "sh"
       - "-c"
-      - "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007 -activity-tracker.filepath=/activity/query-frontend-8007 -store.max-query-length=8760h -query-frontend.scheduler-address=query-scheduler:9011 -memberlist.nodename=query-frontend -memberlist.bind-port=10007 -ingester.ring.store=memberlist -distributor.ring.store=memberlist -compactor.ring.store=memberlist -store-gateway.sharding-ring.store=memberlist -ruler.ring.store=memberlist -alertmanager.sharding-ring.store=memberlist"
+      - "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007 -activity-tracker.filepath=/activity/query-frontend-8007 -query-frontend.max-total-query-length=8760h -query-frontend.scheduler-address=query-scheduler:9011 -memberlist.nodename=query-frontend -memberlist.bind-port=10007 -ingester.ring.store=memberlist -distributor.ring.store=memberlist -compactor.ring.store=memberlist -store-gateway.sharding-ring.store=memberlist -ruler.ring.store=memberlist -alertmanager.sharding-ring.store=memberlist"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -282,7 +282,7 @@
     "command":
       - "sh"
       - "-c"
-      - "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=query-scheduler -server.http-listen-port=8011 -server.grpc-listen-port=9011 -activity-tracker.filepath=/activity/query-scheduler-8011 -store.max-query-length=8760h -memberlist.nodename=query-scheduler -memberlist.bind-port=10011 -ingester.ring.store=memberlist -distributor.ring.store=memberlist -compactor.ring.store=memberlist -store-gateway.sharding-ring.store=memberlist -ruler.ring.store=memberlist -alertmanager.sharding-ring.store=memberlist"
+      - "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=query-scheduler -server.http-listen-port=8011 -server.grpc-listen-port=9011 -activity-tracker.filepath=/activity/query-scheduler-8011 -query-frontend.max-total-query-length=8760h -memberlist.nodename=query-scheduler -memberlist.bind-port=10011 -ingester.ring.store=memberlist -distributor.ring.store=memberlist -compactor.ring.store=memberlist -store-gateway.sharding-ring.store=memberlist -ruler.ring.store=memberlist -alertmanager.sharding-ring.store=memberlist"
     "depends_on":
       - "minio"
       - "distributor-1"

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1494,7 +1494,7 @@ This time period is what Grafana Mimir calls the _query time range length_ (or _
 
 Mimir has a limit on the query length.
 This limit is applied to partial queries, after they've split (according to time) by the query-frontend. This limit protects the system’s stability from potential abuse or mistakes.
-To configure the limit on a per-tenant basis, use the `-store.max-query-length` option (or `max_query_length` in the runtime configuration).
+To configure the limit on a per-tenant basis, use the `-querier.max-partial-query-length` option (or `max_partial_query_length` in the runtime configuration).
 
 ### err-mimir-max-total-query-length
 

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -398,9 +398,9 @@ overrides:
 
 	flags = mergeFlags(flags, map[string]string{
 		"-querier.max-samples":                          "20",                                                 // Very low limit so that we can easily hit it, but high enough to test other features.
+		"-querier.max-partial-query-length":             "30d",                                                // To test too long query error (31d)
 		"-query-frontend.parallelize-shardable-queries": "true",                                               // Allow queries to be parallized (query-sharding)
 		"-query-frontend.query-sharding-total-shards":   "0",                                                  // Disable query-sharding by default
-		"-store.max-query-length":                       "30d",                                                // To test too long query error (31d)
 		"-runtime-config.file":                          filepath.Join(e2e.ContainerSharedDir, runtimeConfig), // Read per tenant runtime config
 	})
 	consul := e2edb.NewConsul()

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -570,6 +570,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -578,7 +579,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -796,6 +796,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -810,7 +811,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -891,6 +891,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -899,7 +900,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -862,6 +862,7 @@ spec:
         - -mem-ballast-size-bytes=268435456
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -871,7 +872,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1085,6 +1085,7 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1100,7 +1101,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1014,6 +1014,7 @@ spec:
         - -mem-ballast-size-bytes=268435456
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -1024,7 +1025,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1284,6 +1284,7 @@ spec:
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
         - -ingester.ring.zone-awareness-enabled=true
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1300,7 +1301,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -844,6 +844,7 @@ spec:
         - -mem-ballast-size-bytes=268435456
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -853,7 +854,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -441,6 +441,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -449,7 +450,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -920,6 +920,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-frontend.align-queries-with-step=false
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -942,7 +943,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=read
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1028,6 +1028,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.ring.prefix=
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
@@ -1039,7 +1040,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1318,6 +1318,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1332,7 +1333,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -2213,6 +2213,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -2237,7 +2238,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -2385,6 +2385,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -2409,7 +2410,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -2557,6 +2557,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -2581,7 +2582,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -495,6 +495,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -503,7 +504,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -721,6 +721,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -734,7 +735,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -507,6 +507,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml,/etc/another-config/runtimeconfig.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -515,7 +516,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -748,6 +748,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -761,7 +762,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-helm-parity.jsonnet
+++ b/operations/mimir-tests/test-helm-parity.jsonnet
@@ -29,16 +29,15 @@ mimir {
   // At that point there will likely be less deviation between components.
   // See the tracking issue: https://github.com/grafana/mimir/issues/2749
   querier_args+:: {
-    'store.max-query-length': null,
+    'querier.max-partial-query-length': null,
   },
 
   query_frontend_args+:: {
     'server.grpc-max-recv-msg-size-bytes': null,
-    'store.max-query-length': null,
     'query-frontend.query-sharding-total-shards': null,
   },
 
   ruler_args+:: {
-    'store.max-query-length': null,
+    'querier.max-partial-query-length': null,
   },
 }

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -494,6 +494,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -502,7 +503,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -720,6 +720,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -733,7 +734,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -496,6 +496,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -504,7 +505,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -723,6 +723,7 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.cluster-label-verification-disabled=true
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -736,7 +737,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -498,6 +498,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -506,7 +507,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -726,6 +726,7 @@ spec:
         - -memberlist.cluster-label=my-cluster-label
         - -memberlist.cluster-label-verification-disabled=true
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -739,7 +740,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -496,6 +496,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -504,7 +505,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -723,6 +723,7 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.cluster-label=my-cluster-label
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -736,7 +737,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -862,6 +862,7 @@ spec:
         - -mem-ballast-size-bytes=268435456
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -871,7 +872,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1085,6 +1085,7 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1100,7 +1101,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -912,6 +912,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -923,7 +924,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1144,6 +1144,7 @@ spec:
         - -ingester.ring.store=multi
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1163,7 +1164,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -912,6 +912,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -923,7 +924,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1144,6 +1144,7 @@ spec:
         - -ingester.ring.store=multi
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1163,7 +1164,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -912,6 +912,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -923,7 +924,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1144,6 +1144,7 @@ spec:
         - -ingester.ring.store=multi
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1163,7 +1164,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -912,6 +912,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -923,7 +924,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1144,6 +1144,7 @@ spec:
         - -ingester.ring.store=multi
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1163,7 +1164,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=multi
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -497,6 +497,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -505,7 +506,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -723,6 +723,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -736,7 +737,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -494,6 +494,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -502,7 +503,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -720,6 +720,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -733,7 +734,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -658,6 +658,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -667,7 +668,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -931,6 +931,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -945,7 +946,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -726,6 +726,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -735,7 +736,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -999,6 +999,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1013,7 +1014,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -862,6 +862,7 @@ spec:
         - -mem-ballast-size-bytes=268435456
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -query-scheduler.ring.prefix=
         - -query-scheduler.ring.store=consul
@@ -874,7 +875,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1095,6 +1095,7 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -1110,7 +1111,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=consul
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -594,6 +594,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.ring.prefix=
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
@@ -604,7 +605,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -838,6 +838,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -852,7 +853,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -935,6 +935,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.ring.prefix=ruler-query-scheduler/
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
@@ -945,7 +946,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -507,6 +507,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.ring.prefix=
         - -query-scheduler.ring.store=memberlist
         - -query-scheduler.service-discovery-mode=ring
@@ -517,7 +518,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -751,6 +751,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -764,7 +765,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -501,6 +501,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -509,7 +510,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -736,6 +736,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -749,7 +750,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -494,6 +494,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=419430400
         - -querier.max-concurrent=16
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -502,7 +503,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -725,6 +725,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -738,7 +739,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -446,6 +446,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-frontend.align-queries-with-step=false
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -468,7 +469,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=read
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -865,6 +865,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -889,7 +890,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -1038,6 +1038,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -1062,7 +1063,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -1211,6 +1211,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -1235,7 +1236,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -447,6 +447,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -query-frontend.align-queries-with-step=false
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -469,7 +470,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=read
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -866,6 +866,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -890,7 +891,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -1039,6 +1039,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -1063,7 +1064,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -1212,6 +1212,7 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -query-scheduler.max-outstanding-requests-per-tenant=100
         - -query-scheduler.max-used-instances=2
         - -query-scheduler.ring.prefix=
@@ -1236,7 +1237,6 @@ spec:
         - -store-gateway.sharding-ring.unregister-on-shutdown=false
         - -store-gateway.sharding-ring.wait-stability-min-duration=1m
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store.max-query-length=768h
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -572,6 +572,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -580,7 +581,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -798,6 +798,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -812,7 +813,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -894,6 +894,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -902,7 +903,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -572,6 +572,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -580,7 +581,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -798,6 +798,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -811,7 +812,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0
@@ -893,6 +893,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -901,7 +902,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -496,6 +496,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -505,7 +506,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.tenant-shard-size=3
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -726,6 +726,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -741,7 +742,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.tenant-shard-size=3
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -495,6 +495,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -querier.shuffle-sharding-ingesters-enabled=false
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -505,7 +506,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.tenant-shard-size=3
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -726,6 +726,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -querier.shuffle-sharding-ingesters-enabled=false
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
@@ -742,7 +743,6 @@ spec:
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.tenant-shard-size=3
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -496,6 +496,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -504,7 +505,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -724,6 +724,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.azure.container-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -737,7 +738,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -494,6 +494,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -502,7 +503,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -720,6 +720,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -733,7 +734,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -495,6 +495,7 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local:9095
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -503,7 +504,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -722,6 +722,7 @@ spec:
         - -ingester.ring.store=memberlist
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.max-partial-query-length=768h
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
         - -ruler.max-rule-groups-per-tenant=35
@@ -735,7 +736,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:2.5.0

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -404,6 +404,7 @@ spec:
         - -querier.frontend-address=query-frontend-discovery.default.svc.cluster.local:9095
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -411,7 +412,6 @@ spec:
         - -store-gateway.sharding-ring.prefix=
         - -store-gateway.sharding-ring.replication-factor=3
         - -store-gateway.sharding-ring.store=memberlist
-        - -store.max-query-length=768h
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -180,7 +180,7 @@
       // splitting in the frontend, the reality is this only limits rate(foo[32d])
       // type queries. 32 days to allow for comparision over the last month (31d) and
       // then some.
-      'store.max-query-length': '768h',
+      'querier.max-partial-query-length': '768h',
     } + $.mimirRuntimeConfigFile,
 
     // PromQL query engine config (shared between all services running PromQL engine, like the ruler and querier).

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -249,7 +249,7 @@ func newMetadataUnitTooLongError(metadata *mimirpb.MetricMetadata) ValidationErr
 func NewMaxQueryLengthError(actualQueryLen, maxQueryLength time.Duration) LimitError {
 	return LimitError(globalerror.MaxQueryLength.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("the query time range exceeds the limit (query length: %s, limit: %s)", actualQueryLen, maxQueryLength),
-		maxQueryLengthFlag))
+		maxPartialQueryLengthFlag))
 }
 
 func NewMaxTotalQueryLengthError(actualQueryLen, maxTotalQueryLength time.Duration) LimitError {

--- a/pkg/util/validation/errors_test.go
+++ b/pkg/util/validation/errors_test.go
@@ -28,7 +28,7 @@ func TestNewMetadataUnitTooLongError(t *testing.T) {
 
 func TestNewMaxQueryLengthError(t *testing.T) {
 	err := NewMaxQueryLengthError(time.Hour, time.Minute)
-	assert.Equal(t, "the query time range exceeds the limit (query length: 1h0m0s, limit: 1m0s) (err-mimir-max-query-length). To adjust the related per-tenant limit, configure -store.max-query-length, or contact your service administrator.", err.Error())
+	assert.Equal(t, "the query time range exceeds the limit (query length: 1h0m0s, limit: 1m0s) (err-mimir-max-query-length). To adjust the related per-tenant limit, configure -querier.max-partial-query-length, or contact your service administrator.", err.Error())
 }
 
 func TestNewTotalMaxQueryLengthError(t *testing.T) {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -40,6 +40,7 @@ const (
 	maxMetadataLengthFlag      = "validation.max-metadata-length"
 	creationGracePeriodFlag    = "validation.create-grace-period"
 	maxQueryLengthFlag         = "store.max-query-length"
+	maxPartialQueryLengthFlag  = "querier.max-partial-query-length"
 	maxTotalQueryLengthFlag    = "query-frontend.max-total-query-length"
 	requestRateFlag            = "distributor.request-rate-limit"
 	requestBurstSizeFlag       = "distributor.request-burst-size"
@@ -208,8 +209,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxChunksPerQuery, MaxChunksPerQueryFlag, 2e6, "Maximum number of chunks that can be fetched in a single query from ingesters and long-term storage. This limit is enforced in the querier, ruler and store-gateway. 0 to disable.")
 	f.IntVar(&l.MaxFetchedSeriesPerQuery, MaxSeriesPerQueryFlag, 0, "The maximum number of unique series for which a query can fetch samples from each ingesters and storage. This limit is enforced in the querier and ruler. 0 to disable")
 	f.IntVar(&l.MaxFetchedChunkBytesPerQuery, MaxChunkBytesPerQueryFlag, 0, "The maximum size of all chunks in bytes that a query can fetch from each ingester and storage. This limit is enforced in the querier and ruler. 0 to disable.")
-	f.Var(&l.MaxQueryLength, maxQueryLengthFlag, "Limit the query time range (end - start time). This limit is enforced in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable.")
-	f.Var(&l.MaxPartialQueryLength, "querier.max-partial-query-length", fmt.Sprintf("Limit the time range for partial queries at the querier level. Defaults to the value of -%s if set to 0.", maxQueryLengthFlag))
+	// TODO: Deprecated in Mimir 2.6, remove in Mimir 2.8
+	f.Var(&l.MaxQueryLength, maxQueryLengthFlag, fmt.Sprintf("Deprecated: Limit the query time range (end - start time). This limit is enforced in the querier (on the query possibly split by the query-frontend) and ruler. 0 to disable. This option is deprecated, use -%s or -%s instead.", maxPartialQueryLengthFlag, maxTotalQueryLengthFlag))
+	f.Var(&l.MaxPartialQueryLength, maxPartialQueryLengthFlag, fmt.Sprintf("Limit the time range for partial queries at the querier level. Defaults to the value of -%s if set to 0.", maxQueryLengthFlag))
 	f.Var(&l.MaxQueryLookback, "querier.max-query-lookback", "Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. This limit is enforced in the query-frontend, querier and ruler. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers.")
 	f.Var(&l.MaxLabelsQueryLength, "store.max-labels-query-length", "Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.")


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

#### What this PR does

Make deprecation of the option more obvious and attempt to remove any use of store.max-query-length in our documentation, jsonnet, helm, and integration tests.

#### Which issue(s) this PR fixes or relates to

See #2793
See #3825

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
