### PR TITLE
make it possible to inject memberlist kv codecs

### DIFF
--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -751,7 +751,7 @@ func (t *Mimir) initMemberlistKV() (services.Service, error) {
 	reg := t.Registerer
 	t.Cfg.MemberlistKV.MetricsRegisterer = reg
 
-	// Only append to the list of codecs, to allow third parties to inject their own codecs.
+	// Append to the list of codecs instead of overwriting the value to allow third parties to inject their own codecs.
 	t.Cfg.MemberlistKV.Codecs = append(t.Cfg.MemberlistKV.Codecs, ring.GetCodec())
 
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -750,6 +750,8 @@ func (t *Mimir) initStoreGateway() (serv services.Service, err error) {
 func (t *Mimir) initMemberlistKV() (services.Service, error) {
 	reg := t.Registerer
 	t.Cfg.MemberlistKV.MetricsRegisterer = reg
+
+	// Only append to the list of codecs, to allow third parties to inject their own codecs.
 	t.Cfg.MemberlistKV.Codecs = append(t.Cfg.MemberlistKV.Codecs, ring.GetCodec())
 
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/dns"
-	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/modules"
 	"github.com/grafana/dskit/ring"
@@ -751,9 +750,8 @@ func (t *Mimir) initStoreGateway() (serv services.Service, err error) {
 func (t *Mimir) initMemberlistKV() (services.Service, error) {
 	reg := t.Registerer
 	t.Cfg.MemberlistKV.MetricsRegisterer = reg
-	t.Cfg.MemberlistKV.Codecs = []codec.Codec{
-		ring.GetCodec(),
-	}
+	t.Cfg.MemberlistKV.Codecs = append(t.Cfg.MemberlistKV.Codecs, ring.GetCodec())
+
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(
 		"cortex_",
 		prometheus.WrapRegistererWith(


### PR DESCRIPTION
We want third parties to be able to inject their own memberlist kv codecs. 
Right now the codecs get set when the memberlist kv store is initialized, this changes the initialization method so that it only adds the codecs needed by Mimir but it doesn't overwrite codecs that are already configured.