### PR TITLE
Consitent Notes format in documentation

### DIFF
--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1181,49 +1181,49 @@ These error IDs allow you to read related details in the documentation that foll
 This non-critical error occurs when Mimir receives a write request that contains a series without a metric name.
 Each series must have a metric name. Rarely it does not, in which case there might be a bug in the sender client.
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-metric-name-invalid
 
 This non-critical error occurs when Mimir receives a write request that contains a series with an invalid metric name.
 A metric name can only contain characters as defined by Prometheus’ [Metric names and labels](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-max-label-names-per-series
 
 This non-critical error occurs when Mimir receives a write request that contains a series with a number of labels that exceed the configured limit.
 The limit protects the system’s stability from potential abuse or mistakes. To configure the limit on a per-tenant basis, use the `-validation.max-label-names-per-series` option.
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-label-invalid
 
 This non-critical error occurs when Mimir receives a write request that contains a series with an invalid label name.
 A label name name can only contain characters as defined by Prometheus’ [Metric names and labels](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-label-name-too-long
 
 This non-critical error occurs when Mimir receives a write request that contains a series with a label name whose length exceeds the configured limit.
 The limit protects the system’s stability from potential abuse or mistakes. To configure the limit on a per-tenant basis, use the `-validation.max-length-label-name` option.
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-label-value-too-long
 
 This non-critical error occurs when Mimir receives a write request that contains a series with a label value whose length exceeds the configured limit.
 The limit protects the system’s stability from potential abuse or mistakes. To configure the limit on a per-tenant basis, use the `-validation.max-length-label-value` option.
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-duplicate-label-names
 
 This non-critical error occurs when Mimir receives a write request that contains a series with the same label name two or more times.
 A series that contains a duplicated label name is invalid and gets skipped during the ingestion.
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-labels-not-sorted
 
@@ -1231,7 +1231,7 @@ This error occurs when Mimir receives a write request that contains a series who
 However, Mimir internally sorts labels for series that it receives, so this error should not occur in practice.
 If you experience this error, [open an issue in the Mimir repository](https://github.com/grafana/mimir/issues).
 
-> **Note**: Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
+> **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
 ### err-mimir-too-far-in-future
 
@@ -1239,49 +1239,49 @@ This non-critical error occurs when Mimir receives a write request that contains
 Mimir accepts timestamps that are slightly in the future, due to skewed clocks for example. It rejects timestamps that are too far in the future, based on the definition that you can set via the `-validation.create-grace-period` option.
 On a per-tenant basis, you can fine tune the tolerance by configuring the `-validation.max-length-label-value` option.
 
-> **Note**: Series with invalid samples are skipped during the ingestion, and series within the same request are ingested.
+> **Note:** Series with invalid samples are skipped during the ingestion, and series within the same request are ingested.
 
 ### err-mimir-exemplar-labels-missing
 
 This non-critical error occurs when Mimir receives a write request that contains an exemplar without a label that identifies the related metric.
 An exemplar must have at least one valid label pair, otherwise it cannot be associated with any metric.
 
-> **Note**: Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
+> **Note:** Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
 
 ### err-mimir-exemplar-labels-too-long
 
 This non-critical error occurs when Mimir receives a write request that contains an exemplar where the combined set size of its labels exceeds the limit.
 The limit is used to protect the system’s stability from potential abuse or mistakes, and it cannot be configured.
 
-> **Note**: Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
+> **Note:** Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
 
 ### err-mimir-exemplar-timestamp-invalid
 
 This non-critical error occurs when Mimir receives a write request that contains an exemplar without a timestamp.
 An exemplar must have a valid timestamp, otherwise it cannot be correlated to any point in time.
 
-> **Note**: Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
+> **Note:** Invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
 
 ### err-mimir-metadata-missing-metric-name
 
 This non-critical error occurs when Mimir receives a write request that contains a metric metadata without a metric name.
 Each metric metadata must have a metric name. Rarely it does not, in which case there might be a bug in the sender client.
 
-> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+> **Note:** Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
 
 ### err-mimir-metric-name-too-long
 
 This non-critical error occurs when Mimir receives a write request that contains a metric metadata with a metric name whose length exceeds the configured limit.
 The limit protects the system’s stability from potential abuse or mistakes. To configure the limit on a per-tenant basis, use the `-validation.max-metadata-length` option.
 
-> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+> **Note:** Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
 
 ### err-mimir-unit-too-long
 
 This non-critical error occurs when Mimir receives a write request that contains a metric metadata with unit name whose length exceeds the configured limit.
 The limit protects the system’s stability from potential abuse or mistakes. To configure the limit on a per-tenant basis, use the `-validation.max-metadata-length` option.
 
-> **Note**: Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
+> **Note:** Invalid metrics metadata are skipped during the ingestion, and valid metadata within the same request are ingested.
 
 ### err-mimir-distributor-max-ingestion-rate
 
@@ -1556,7 +1556,7 @@ How it **works**:
 
 - If the incoming timestamp is more than 1 hour older than the most recent timestamp ingested for the tenant, the sample will be rejected.
 
-> **Note**: If the out-of-order sample ingestion is enabled, then this error is similar to `err-mimir-sample-out-of-order` below with a difference that the sample is older than the out-of-order time window as it relates to the latest sample for that particular time series or the TSDB.
+> **Note:** If the out-of-order sample ingestion is enabled, then this error is similar to `err-mimir-sample-out-of-order` below with a difference that the sample is older than the out-of-order time window as it relates to the latest sample for that particular time series or the TSDB.
 
 ### err-mimir-sample-out-of-order
 
@@ -1575,7 +1575,7 @@ Common **causes**:
 - A Prometheus instance was restarted, and it pushed all data from its Write-Ahead Log to remote write upon restart, some of which has already been pushed and ingested. This is normal and can be ignored.
 - Prometheus and Mimir have the same recording rule, which generates the exact same series in both places and causes either the remote write or the rule evaluation to fail randomly, depending on timing.
 
-> **Note**: You can learn more about out of order samples in Prometheus, in the blog post [Debugging out of order samples](https://www.robustperception.io/debugging-out-of-order-samples/).
+> **Note:** You can learn more about out of order samples in Prometheus, in the blog post [Debugging out of order samples](https://www.robustperception.io/debugging-out-of-order-samples/).
 
 ### err-mimir-sample-duplicate-timestamp
 


### PR DESCRIPTION
#### What this PR does

This was a comment on native histograms, but it seems to be inconsistent in other places elsewhere, removing from histograms branch.

Zenador
Co-authored-by: Ursula Kallio <ursula.kallio@grafana.com>
Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [N/A] Tests updated
- [x] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
