### PR TITLE
Tiny ingester improvements

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -13,33 +13,27 @@ import (
 )
 
 type validationError struct {
-	err       error // underlying error
-	errorType string
-	code      int
-	labels    labels.Labels
+	err    error // underlying error
+	code   int
+	labels labels.Labels
 }
 
-func makeLimitError(errorType string, err error) error {
+func makeLimitError(err error) error {
 	return &validationError{
-		errorType: errorType,
-		err:       err,
-		code:      http.StatusBadRequest,
+		err:  err,
+		code: http.StatusBadRequest,
 	}
 }
 
-func makeMetricLimitError(errorType string, labels labels.Labels, err error) error {
+func makeMetricLimitError(labels labels.Labels, err error) error {
 	return &validationError{
-		errorType: errorType,
-		err:       err,
-		code:      http.StatusBadRequest,
-		labels:    labels,
+		err:    err,
+		code:   http.StatusBadRequest,
+		labels: labels,
 	}
 }
 
 func (e *validationError) Error() string {
-	if e.err == nil {
-		return e.errorType
-	}
 	if e.labels == nil {
 		return e.err.Error()
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -101,8 +101,6 @@ const (
 	// Prefix for discard reasons when ingesting ephemeral series.
 	ephemeralDiscardPrefix = "ephemeral-"
 
-	ephemeralPerUserSeriesLimit = "ephemeral_per_user_series_limit"
-
 	replicationFactorStatsName             = "ingester_replication_factor"
 	ringStoreStatsName                     = "ingester_ring_store"
 	memorySeriesStatsName                  = "ingester_inmemory_series"
@@ -1028,9 +1026,9 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 				stats.perUserSeriesLimitCount++
 				updateFirstPartial(func() error {
 					if ephemeral {
-						return makeLimitError(ephemeralPerUserSeriesLimit, i.limiter.FormatError(userID, cause))
+						return makeLimitError(i.limiter.FormatError(userID, cause))
 					}
-					return makeLimitError(perUserSeriesLimit, i.limiter.FormatError(userID, cause))
+					return makeLimitError(i.limiter.FormatError(userID, cause))
 				})
 				continue
 
@@ -1038,7 +1036,7 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 				stats.perMetricSeriesLimitCount++
 				updateFirstPartial(func() error {
 					// Ephemeral storage doesn't have this limit.
-					return makeMetricLimitError(perMetricSeriesLimit, copiedLabels, i.limiter.FormatError(userID, cause))
+					return makeMetricLimitError(copiedLabels, i.limiter.FormatError(userID, cause))
 				})
 				continue
 			}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5135,7 +5135,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(makeLimitError(perUserSeriesLimit, ing.limiter.FormatError(userID, errMaxSeriesPerUserLimitExceeded)), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(makeLimitError(ing.limiter.FormatError(userID, errMaxSeriesPerUserLimitExceeded)), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata, expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))
@@ -5240,7 +5240,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(makeMetricLimitError(perMetricSeriesLimit, labels3, ing.limiter.FormatError(userID, errMaxSeriesPerMetricLimitExceeded)), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(makeMetricLimitError(labels3, ing.limiter.FormatError(userID, errMaxSeriesPerMetricLimitExceeded)), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -47,7 +47,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
 		if err := mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)); err != nil {
 			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
-			return makeLimitError(perUserMetadataLimit, mm.limiter.FormatError(mm.userID, err))
+			return makeLimitError(mm.limiter.FormatError(mm.userID, err))
 		}
 		set = metricMetadataSet{}
 		mm.metricToMetadata[metric] = set
@@ -55,7 +55,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 
 	if err := mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)); err != nil {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
-		return makeMetricLimitError(perMetricMetadataLimit, labels.FromStrings(labels.MetricName, metric), mm.limiter.FormatError(mm.userID, err))
+		return makeMetricLimitError(labels.FromStrings(labels.MetricName, metric), mm.limiter.FormatError(mm.userID, err))
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.


### PR DESCRIPTION
#### What this PR does
This PR simplifies how values for active series metrics are computed, and removes unused field in ingesters `validationError` struct.

No user-visible changes.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
