### PR TITLE
Mark query-scheduler ring-based service discovery as stable and document migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] Ingester: Add new `/ingester/tsdb_metrics` endpoint to return tenant-specific TSDB metrics. #3923
 * [ENHANCEMENT] Query-frontend: CLI flag `-query-frontend.max-total-query-length` and its associated YAML configuration is now stable. #3882
 * [ENHANCEMENT] Ruler: rule groups now support optional and experimental `align_evaluation_time_on_interval` field, which causes all evaluations to happen on interval-aligned timestamp. #4013
+* [ENHANCEMENT] Query-scheduler: ring-based service discovery is now stable. #4028
 * [BUGFIX] Log the names of services that are not yet running rather than `unsupported value type` when calling `/ready` and some services are not running. #3625
 * [BUGFIX] Alertmanager: Fix template spurious deletion with relative data dir. #3604
 * [BUGFIX] Security: update prometheus/exporter-toolkit for CVE-2022-46146. #3675
@@ -93,6 +94,7 @@
 
 * [BUGFIX] Querier: Remove assertion that the `-querier.max-concurrent` flag must also be set for the query-frontend. #3678
 * [ENHANCEMENT] Update migration from cortex documentation. #3662
+* [ENHANCEMENT] Query-scheduler: documented how to migrate from DNS-based to ring-based service discovery. #4028
 
 ### Tools
 

--- a/docs/sources/mimir/operators-guide/architecture/components/query-scheduler/index.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/query-scheduler/index.md
@@ -37,7 +37,7 @@ To use the query-scheduler, query-frontends and queriers need to discover the ad
 The query-scheduler supports two service discovery mechanisms:
 
 - DNS-based service discovery
-- Ring-based service discovery (experimental)
+- Ring-based service discovery
 
 ### DNS-based service discovery
 
@@ -50,13 +50,56 @@ To use the query-scheduler with DNS-based service discovery, configure the query
 
 > **Note:** The querier pulls queries only from the query-frontend or the query-scheduler, but not both. `-querier.frontend-address` and `-querier.scheduler-address` options are mutually exclusive, and only one option can be set.
 
-### Ring-based service discovery (experimental)
+### Ring-based service discovery
 
 To use the query-scheduler with ring-based service discovery, configure the query-schedulers to join their hash ring, and the query-frontends and queriers to discover query-scheduler instances via the ring:
 
 1. [Configure the hash ring]({{< relref "../../../configure/configure-hash-rings.md" >}}) for the query-scheduler.
 1. Set `-query-scheduler.service-discovery-mode=ring` (or its respective YAML configuration parameter) to query-scheduler, query-frontend and querier.
 1. Set the `-query-scheduler.ring.*` flags (or their respective YAML configuration parameters) to query-scheduler, query-frontend and querier.
+
+#### Migrate from DNS-based to ring-based service discovery
+
+To migrate the query-scheduler from [DNS-based service discovery](#dns-based-service-discovery) to [ring-based service discovery](#ring-based-service-discovery) you can follow these steps:
+
+1. Configure the **query-scheduler** instances to join a ring:
+   ```
+   -query-scheduler.service-discovery-mode=ring
+
+   # Configure the query-scheduler ring backend (e.g. "memberlist").
+   -query-scheduler.ring.store=<backend>
+
+   # If the configured <backend> is "memberlist", then ensure memberlist is configured for the query-scheduler.
+   -memberlist.join=<same as other Mimir components>
+
+   # If the configured <backend> is "consul" or "etcd", then ensure their backend configuration is set
+   # for the query-scheduler ring:
+   # - Consul: -query-scheduler.ring.consul.*
+   # - Ecd:    -query-scheduler.ring.etcd.*
+   ```
+1. Wait until query-scheduler instances rolled out. Then ensure the changes have been successfully applied:
+   - Open the [query-scheduler ring status]({{< relref "../../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
+   - At this point, queriers and query-frontend are still discovering query-schedulers via DNS.
+1. Configure **query-frontend** and **querier** instances to discover query-schedulers via the ring:
+   ```
+   -query-scheduler.service-discovery-mode=ring
+
+   # Remove the DNS-based service discovery configuration:
+   # -query-frontend.scheduler-address
+
+   # Configure the query-scheduler ring backend (e.g. "memberlist").
+   -query-scheduler.ring.store=<backend>
+
+   # If the configured <backend> is "memberlist", then ensure memberlist is configured for the query-scheduler.
+   -memberlist.join=<same as other Mimir components>
+
+   # If the configured <backend> is "consul" or "etcd", then ensure their backend configuration is set
+   # for the query-scheduler ring:
+   # - Consul: -query-scheduler.ring.consul.*
+   # - Ecd:    -query-scheduler.ring.etcd.*
+   ```
+
+> **Note**: see [Migrate query-scheduler from DNS-based to ring-based service discovery]({{< relref "../../../deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md" >}}) if your Mimir cluster is deployed using Jsonnet.
 
 ## Operational considerations
 

--- a/docs/sources/mimir/operators-guide/architecture/components/query-scheduler/index.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/query-scheduler/index.md
@@ -60,7 +60,7 @@ To use the query-scheduler with ring-based service discovery, configure the quer
 
 #### Migrate from DNS-based to ring-based service discovery
 
-To migrate the query-scheduler from [DNS-based service discovery](#dns-based-service-discovery) to [ring-based service discovery](#ring-based-service-discovery) you can follow these steps:
+To migrate the query-scheduler from [DNS-based service discovery](#dns-based-service-discovery) to [ring-based service discovery](#ring-based-service-discovery), perform the following steps:
 
 1. Configure the **query-scheduler** instances to join a ring:
 
@@ -73,15 +73,15 @@ To migrate the query-scheduler from [DNS-based service discovery](#dns-based-ser
    # If the configured <backend> is "memberlist", then ensure memberlist is configured for the query-scheduler.
    -memberlist.join=<same as other Mimir components>
 
-   # If the configured <backend> is "consul" or "etcd", then ensure their backend configuration is set
+   # If the configured <backend> is "consul" or "etcd", then set their backend configuration
    # for the query-scheduler ring:
    # - Consul: -query-scheduler.ring.consul.*
    # - Ecd:    -query-scheduler.ring.etcd.*
    ```
 
-1. Wait until query-scheduler instances rolled out. Then ensure the changes have been successfully applied:
-   - Open the [query-scheduler ring status]({{< relref "../../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
-   - At this point, queriers and query-frontend are still discovering query-schedulers via DNS.
+1. Wait until the query-scheduler instances have completed rolling out.
+1. Ensure the changes have been successfully applied; open the [query-scheduler ring status]({{< relref "../../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
+   At this point, queriers and query-frontend are still discovering query-schedulers via DNS.
 1. Configure **query-frontend** and **querier** instances to discover query-schedulers via the ring:
 
    ```
@@ -96,13 +96,13 @@ To migrate the query-scheduler from [DNS-based service discovery](#dns-based-ser
    # If the configured <backend> is "memberlist", then ensure memberlist is configured for the query-scheduler.
    -memberlist.join=<same as other Mimir components>
 
-   # If the configured <backend> is "consul" or "etcd", then ensure their backend configuration is set
+   # If the configured <backend> is "consul" or "etcd", then set their backend configuration
    # for the query-scheduler ring:
    # - Consul: -query-scheduler.ring.consul.*
    # - Ecd:    -query-scheduler.ring.etcd.*
    ```
 
-> **Note**: see [Migrate query-scheduler from DNS-based to ring-based service discovery]({{< relref "../../../deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md" >}}) if your Mimir cluster is deployed using Jsonnet.
+> **Note:** If your Mimir cluster is deployed using Jsonnet, see [Migrate query-scheduler from DNS-based to ring-based service discovery]({{< relref "../../../deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md" >}}).
 
 ## Operational considerations
 

--- a/docs/sources/mimir/operators-guide/architecture/components/query-scheduler/index.md
+++ b/docs/sources/mimir/operators-guide/architecture/components/query-scheduler/index.md
@@ -63,6 +63,7 @@ To use the query-scheduler with ring-based service discovery, configure the quer
 To migrate the query-scheduler from [DNS-based service discovery](#dns-based-service-discovery) to [ring-based service discovery](#ring-based-service-discovery) you can follow these steps:
 
 1. Configure the **query-scheduler** instances to join a ring:
+
    ```
    -query-scheduler.service-discovery-mode=ring
 
@@ -77,10 +78,12 @@ To migrate the query-scheduler from [DNS-based service discovery](#dns-based-ser
    # - Consul: -query-scheduler.ring.consul.*
    # - Ecd:    -query-scheduler.ring.etcd.*
    ```
+
 1. Wait until query-scheduler instances rolled out. Then ensure the changes have been successfully applied:
    - Open the [query-scheduler ring status]({{< relref "../../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
    - At this point, queriers and query-frontend are still discovering query-schedulers via DNS.
 1. Configure **query-frontend** and **querier** instances to discover query-schedulers via the ring:
+
    ```
    -query-scheduler.service-discovery-mode=ring
 

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -87,7 +87,6 @@ The following features are currently experimental:
   - Lower TTL for cache entries overlapping the out-of-order samples ingestion window (re-using `-ingester.out-of-order-allowance` from ingesters)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
-  - Ring-based service discovery (`-query-scheduler.service-discovery-mode` and `-query-scheduler.ring.*`)
   - Max number of used instances (`-query-scheduler.max-used-instances`)
 - Store-gateway
   - `-blocks-storage.bucket-store.index-header.map-populate-enabled`

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to migrate query-scheduler from DNS-based to ring-based service discovery
-menuTitle: Migrate query-scheduler from DNS-based to ring-based service discovery
+menuTitle: Migrate query-scheduler to ring-based service discovery
 title: Migrate query-scheduler from DNS-based to ring-based service discovery
 weight: 50
 ---

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
@@ -12,11 +12,9 @@ The query-scheduler supports two service discovery mechanisms:
 - [DNS-based service discovery]({{< relref "../../architecture/components/query-scheduler/index.md#dns-based-service-discovery" >}})
 - [Ring-based service discovery]({{< relref "../../architecture/components/query-scheduler/index.md#ring-based-service-discovery" >}})
 
-In this guide you can learn how to migrate query-scheduler from DNS-based to ring-based service discovery when your Mimir cluster is deployed using Jsonnet.
+To migrate the query-scheduler from DNS-based to ring-based service discovery when your Mimir cluster is deployed using Jsonnet:
 
-## Step 1: Configure the query-scheduler instances to join a ring
-
-Configure the query-scheduler instances to join a ring, but keep querier and query-frontend instances discovering query-schedulers via DNS:
+1. Configure the query-scheduler instances to join a ring, but keep the querier and query-frontend instances discovering query-schedulers via DNS:
 
 ```jsonnet
 {
@@ -27,10 +25,8 @@ Configure the query-scheduler instances to join a ring, but keep querier and que
 }
 ```
 
-## Step 2: Wait until query-scheduler changes have been applied
-
-Wait until query-scheduler instances rolled out.
-Then open the [query-scheduler ring status]({{< relref "../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
+1. Wait until query-scheduler changes have been applied.
+1. Open the [query-scheduler ring status]({{< relref "../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
 
 ## Step 3: Configure query-frontend and querier instances to discover query-schedulers via the ring
 

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
@@ -15,28 +15,22 @@ The query-scheduler supports two service discovery mechanisms:
 To migrate the query-scheduler from DNS-based to ring-based service discovery when your Mimir cluster is deployed using Jsonnet:
 
 1. Configure the query-scheduler instances to join a ring, but keep the querier and query-frontend instances discovering query-schedulers via DNS:
-
-```jsonnet
-{
-  _config+:: {
-    query_scheduler_service_discovery_mode: 'ring',
-    query_scheduler_service_discovery_ring_read_path_enabled: false,
-  }
-}
-```
-
+   ```jsonnet
+   {
+     _config+:: {
+       query_scheduler_service_discovery_mode: 'ring',
+       query_scheduler_service_discovery_ring_read_path_enabled: false,
+     }
+   }
+   ```
 1. Wait until query-scheduler changes have been applied.
 1. Open the [query-scheduler ring status]({{< relref "../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
-
-## Step 3: Configure query-frontend and querier instances to discover query-schedulers via the ring
-
-Configure query-frontend and querier instances to discover query-schedulers via the ring:
-
-```jsonnet
-{
-  _config+:: {
-    query_scheduler_service_discovery_mode: 'ring',
-    query_scheduler_service_discovery_ring_read_path_enabled: true,
-  }
-}
-```
+1. Configure query-frontend and querier instances to discover query-schedulers via the ring:
+   ```jsonnet
+   {
+     _config+:: {
+       query_scheduler_service_discovery_mode: 'ring',
+       query_scheduler_service_discovery_ring_read_path_enabled: true,
+     }
+   }
+   ```

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-query-scheduler-from-dns-to-ring-based-service-discovery.md
@@ -1,0 +1,46 @@
+---
+description: Learn how to migrate query-scheduler from DNS-based to ring-based service discovery
+menuTitle: Migrate query-scheduler from DNS-based to ring-based service discovery
+title: Migrate query-scheduler from DNS-based to ring-based service discovery
+weight: 50
+---
+
+# Migrate query-scheduler from DNS-based to ring-based service discovery
+
+The query-scheduler supports two service discovery mechanisms:
+
+- [DNS-based service discovery]({{< relref "../../architecture/components/query-scheduler/index.md#dns-based-service-discovery" >}})
+- [Ring-based service discovery]({{< relref "../../architecture/components/query-scheduler/index.md#ring-based-service-discovery" >}})
+
+In this guide you can learn how to migrate query-scheduler from DNS-based to ring-based service discovery when your Mimir cluster is deployed using Jsonnet.
+
+## Step 1: Configure the query-scheduler instances to join a ring
+
+Configure the query-scheduler instances to join a ring, but keep querier and query-frontend instances discovering query-schedulers via DNS:
+
+```jsonnet
+{
+  _config+:: {
+    query_scheduler_service_discovery_mode: 'ring',
+    query_scheduler_service_discovery_ring_read_path_enabled: false,
+  }
+}
+```
+
+## Step 2: Wait until query-scheduler changes have been applied
+
+Wait until query-scheduler instances rolled out.
+Then open the [query-scheduler ring status]({{< relref "../../reference-http-api/index.md#query-scheduler-ring-status" >}}) page and ensure all query-scheduler instances are registered to the ring.
+
+## Step 3: Configure query-frontend and querier instances to discover query-schedulers via the ring
+
+Configure query-frontend and querier instances to discover query-schedulers via the ring:
+
+```jsonnet
+{
+  _config+:: {
+    query_scheduler_service_discovery_mode: 'ring',
+    query_scheduler_service_discovery_ring_read_path_enabled: true,
+  }
+}
+```


### PR DESCRIPTION
#### What this PR does
In this PR:
- Mark query-scheduler ring-based service discovery as stable
- Document how to migrate from DNS-based to ring-based service discovery

#### Which issue(s) this PR fixes or relates to

Fixes #3473

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
