### PR TITLE
Store-gateway: apply limits on merged series

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1142,7 +1142,6 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 				req.SkipChunks,
 				req.MinTime, req.MaxTime,
 				stats,
-				s.metrics,
 				s.logger,
 			)
 			if err != nil {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1096,8 +1096,8 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	chunkReaders *bucketChunkReaders,
 	shardSelector *sharding.ShardSelector,
 	matchers []*labels.Matcher,
-	chunksLimiter ChunksLimiter,
-	seriesLimiter SeriesLimiter,
+	chunksLimiter ChunksLimiter, // Rate limiter for loading chunks.
+	seriesLimiter SeriesLimiter, // Rate limiter for loading series.
 	stats *safeQueryStats,
 ) (storepb.SeriesSet, *hintspb.SeriesResponseHints, error) {
 	var (
@@ -1137,8 +1137,6 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 				matchers,
 				shardSelector,
 				cachedSeriesHasher{blockSeriesHashCache},
-				chunksLimiter,
-				seriesLimiter,
 				req.SkipChunks,
 				req.MinTime, req.MaxTime,
 				stats,
@@ -1167,12 +1165,17 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 	})
 	s.metrics.seriesBlocksQueried.Observe(float64(len(batches)))
 
-	mergedBatches := mergedSeriesChunkRefsSetIterators(s.maxSeriesPerBatch, batches...)
+	mergedIterator := mergedSeriesChunkRefsSetIterators(s.maxSeriesPerBatch, batches...)
+
+	// Apply limits after the merging, so that if the same series is part of multiple blocks it just gets
+	// counted once towards the limit.
+	mergedIterator = newLimitingSeriesChunkRefsSetIterator(mergedIterator, chunksLimiter, seriesLimiter)
+
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
-		set = newSeriesSetWithChunks(ctx, *chunkReaders, mergedBatches, s.maxSeriesPerBatch, stats)
+		set = newSeriesSetWithChunks(ctx, *chunkReaders, mergedIterator, s.maxSeriesPerBatch, stats)
 	} else {
-		set = newSeriesSetWithoutChunks(ctx, mergedBatches, stats)
+		set = newSeriesSetWithoutChunks(ctx, mergedIterator, stats)
 	}
 	return set, resHints, nil
 }

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1297,7 +1297,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 		},
 		"should return error if the actual number of queried chunks is > limit": {
 			limit:       chunksQueried - 1,
-			expectedErr: status.Error(http.StatusUnprocessableEntity, fmt.Sprintf("exceeded chunks limit: rpc error: code = Code(422) desc = limit %d violated (got %d)", chunksQueried-1, chunksQueried)),
+			expectedErr: status.Error(http.StatusUnprocessableEntity, fmt.Sprintf("exceeded chunks limit: rpc error: code = Code(422) desc = limit %d exceeded", chunksQueried-1)),
 		},
 	}
 

--- a/pkg/storegateway/limiter.go
+++ b/pkg/storegateway/limiter.go
@@ -58,7 +58,7 @@ func (l *Limiter) Reserve(num uint64) error {
 		// We need to protect from the counter being incremented twice due to concurrency
 		// while calling Reserve().
 		l.failedOnce.Do(l.failedCounter.Inc)
-		return errors.Errorf("limit %v violated (got %v)", l.limit, reserved)
+		return errors.Errorf("limit %v exceeded", l.limit)
 	}
 	return nil
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -656,8 +656,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		return nil, errors.Wrap(err, "expanded matching postings")
 	}
 
-	var iterator seriesChunkRefsSetIterator
-	iterator = newLoadingSeriesChunkRefsSetIterator(
+	iterator := newLoadingSeriesChunkRefsSetIterator(
 		ctx,
 		newPostingsSetsIterator(ps, batchSize),
 		indexr,

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -37,6 +37,11 @@ var (
 	})
 )
 
+const (
+	errSeriesLimitMessage = "exceeded series limit"
+	errChunksLimitMessage = "exceeded chunks limit"
+)
+
 // seriesChunkRefsSetIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefsSet.
 type seriesChunkRefsSetIterator interface {
 	Next() bool
@@ -581,7 +586,7 @@ func (l *limitingSeriesChunkRefsSetIterator) Next() bool {
 	l.currentBatch = l.from.At()
 	err := l.seriesLimiter.Reserve(uint64(l.currentBatch.len()))
 	if err != nil {
-		l.err = errors.Wrap(err, "exceeded series limit")
+		l.err = errors.Wrap(err, errSeriesLimitMessage)
 		return false
 	}
 
@@ -592,7 +597,7 @@ func (l *limitingSeriesChunkRefsSetIterator) Next() bool {
 
 	err = l.chunksLimiter.Reserve(uint64(totalChunks))
 	if err != nil {
-		l.err = errors.Wrap(err, "exceeded chunks limit")
+		l.err = errors.Wrap(err, errChunksLimitMessage)
 		return false
 	}
 	return true
@@ -637,8 +642,6 @@ func openBlockSeriesChunkRefsSetsIterator(
 	matchers []*labels.Matcher, // Series matchers.
 	shard *sharding.ShardSelector, // Shard selector.
 	seriesHasher seriesHasher,
-	chunksLimiter ChunksLimiter, // Rate limiter for loading chunks.
-	seriesLimiter SeriesLimiter, // Rate limiter for loading series.
 	skipChunks bool, // If true chunks are not loaded and minTime/maxTime are ignored.
 	minTime, maxTime int64, // Series must have data in this time range to be returned (ignored if skipChunks=true).
 	stats *safeQueryStats,
@@ -671,14 +674,11 @@ func openBlockSeriesChunkRefsSetsIterator(
 	)
 
 	// Track the time spent loading series and chunk refs.
-	iterator = newNextDurationMeasuringIterator[seriesChunkRefsSet](iterator, func(duration time.Duration, _ bool) {
+	return newNextDurationMeasuringIterator[seriesChunkRefsSet](iterator, func(duration time.Duration, _ bool) {
 		stats.update(func(stats *queryStats) {
 			stats.streamingSeriesFetchRefsDuration += duration
 		})
-	})
-
-	iterator = newLimitingSeriesChunkRefsSetIterator(iterator, chunksLimiter, seriesLimiter)
-	return iterator, nil
+	}), nil
 }
 
 func newLoadingSeriesChunkRefsSetIterator(

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -642,7 +642,6 @@ func openBlockSeriesChunkRefsSetsIterator(
 	skipChunks bool, // If true chunks are not loaded and minTime/maxTime are ignored.
 	minTime, maxTime int64, // Series must have data in this time range to be returned (ignored if skipChunks=true).
 	stats *safeQueryStats,
-	metrics *BucketStoreMetrics,
 	logger log.Logger,
 ) (seriesChunkRefsSetIterator, error) {
 	if batchSize <= 0 {

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -1435,7 +1434,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				block.meta.MinTime,
 				block.meta.MaxTime,
 				newSafeQueryStats(),
-				NewBucketStoreMetrics(prometheus.NewRegistry()),
 				nil,
 			)
 			require.NoError(t, err)
@@ -1676,7 +1674,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 						b.meta.MinTime,
 						b.meta.MaxTime,
 						statsColdCache,
-						NewBucketStoreMetrics(nil),
 						log.NewNopLogger(),
 					)
 
@@ -1709,7 +1706,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 						b.meta.MinTime,
 						b.meta.MaxTime,
 						statsWarnCache,
-						NewBucketStoreMetrics(nil),
 						log.NewNopLogger(),
 					)
 					require.NoError(t, err)

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1286,34 +1286,16 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 	})
 
 	testCases := map[string]struct {
-		matcher     *labels.Matcher
-		batchSize   int
-		chunksLimit int
-		seriesLimit int
-		skipChunks  bool
+		matcher    *labels.Matcher
+		batchSize  int
+		skipChunks bool
 
 		expectedErr    string
 		expectedSeries []seriesChunkRefsSet
 	}{
-		"chunks limits reached": {
-			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
-			batchSize:   100,
-			chunksLimit: 1,
-			seriesLimit: 100,
-			expectedErr: "test limit exceeded",
-		},
-		"series limits reached": {
-			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
-			batchSize:   100,
-			chunksLimit: 100,
-			seriesLimit: 1,
-			expectedErr: "test limit exceeded",
-		},
 		"selects all series in a single batch": {
-			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
-			batchSize:   100,
-			chunksLimit: 100,
-			seriesLimit: 100,
+			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize: 100,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
@@ -1324,10 +1306,8 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			},
 		},
 		"selects all series in multiple batches": {
-			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
-			batchSize:   1,
-			chunksLimit: 100,
-			seriesLimit: 100,
+			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize: 1,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
@@ -1344,10 +1324,8 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			},
 		},
 		"selects some series in single batch": {
-			matcher:     labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
-			batchSize:   100,
-			chunksLimit: 100,
-			seriesLimit: 100,
+			matcher:   labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
+			batchSize: 100,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
@@ -1356,10 +1334,8 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			},
 		},
 		"selects some series in multiple batches": {
-			matcher:     labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
-			batchSize:   1,
-			chunksLimit: 100,
-			seriesLimit: 100,
+			matcher:   labels.MustNewMatcher(labels.MatchEqual, "a", "1"),
+			batchSize: 1,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
@@ -1370,11 +1346,9 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			},
 		},
 		"selects all series in a single batch with skipChunks": {
-			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
-			batchSize:   100,
-			skipChunks:  true,
-			chunksLimit: 100,
-			seriesLimit: 100,
+			matcher:    labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:  100,
+			skipChunks: true,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "1", "b", "1")},
@@ -1385,11 +1359,9 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			},
 		},
 		"selects all series in multiple batches with skipChunks": {
-			matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
-			batchSize:   1,
-			skipChunks:  true,
-			chunksLimit: 100,
-			seriesLimit: 100,
+			matcher:    labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			batchSize:  1,
+			skipChunks: true,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "1", "b", "1")},
@@ -1428,8 +1400,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				[]*labels.Matcher{testCase.matcher},
 				nil,
 				cachedSeriesHasher{hashCache},
-				&limiter{limit: testCase.chunksLimit},
-				&limiter{limit: testCase.seriesLimit},
 				testCase.skipChunks,
 				block.meta.MinTime,
 				block.meta.MaxTime,
@@ -1668,8 +1638,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 						testCase.matchers,
 						testCase.shard,
 						seriesHasher,
-						&limiter{limit: 1000},
-						&limiter{limit: 1000},
 						true,
 						b.meta.MinTime,
 						b.meta.MaxTime,
@@ -1700,8 +1668,6 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 						testCase.matchers,
 						testCase.shard,
 						seriesHasher,
-						&limiter{limit: 1000},
-						&limiter{limit: 1000},
 						true,
 						b.meta.MinTime,
 						b.meta.MaxTime,


### PR DESCRIPTION
#### What this PR does
I started working on #3878. Before addressing it, I would like to fix how series limit is applied (currently disabled, but Yuri is working on enabling it). Currently the series limit is applied on each block. If a series is included in two blocks, it gets counted twice, which is not correct. In this PR I propose to apply the limit after the merge.

This change shouldn't practically impact the chunks limit, because chunks are loaded later in the chain of iterators anyway.

#### Which issue(s) this PR fixes or relates to

Part of #3878

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
