### PR TITLE
Fix MimirAutoscalerNotActive alert to not fire if the scaling metric does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main / unreleased
 
+### Grafana Mimir
+
+### Mixin
+
+* [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric does not exist, to avoid false positives on scaled objects with 0 min replicas. #4045
+
 ## 2.6.0-rc.0
 
 ### Grafana Mimir

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -897,9 +897,11 @@ groups:
           + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
           > 0
       )
-      # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
-      unless on (cluster, namespace, metric)
-      (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
+      # Alert only if the scaling metric exists and is > 0. If the KEDA ScaledObject is configured to scale down 0,
+      # then HPA ScalingActive may be false when expected to run 0 replicas. In this case, the scaling metric exported
+      # by KEDA could not exist at all or being exposed with a value of 0.
+      and on (cluster, namespace, metric)
+      (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") > 0)
     for: 1h
     labels:
       severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -904,9 +904,11 @@ groups:
           + on(cluster, namespace, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
           > 0
       )
-      # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
-      unless on (cluster, namespace, metric)
-      (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
+      # Alert only if the scaling metric exists and is > 0. If the KEDA ScaledObject is configured to scale down 0,
+      # then HPA ScalingActive may be false when expected to run 0 replicas. In this case, the scaling metric exported
+      # by KEDA could not exist at all or being exposed with a value of 0.
+      and on (cluster, namespace, metric)
+      (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") > 0)
     for: 1h
     labels:
       severity: critical

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -15,9 +15,11 @@
                 + on(%(aggregation_labels)s, horizontalpodautoscaler) group_right label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
                 > 0
             )
-            # Do not alert if metric is 0, because in that case we expect the HPA to be inactive.
-            unless on (%(aggregation_labels)s, metric)
-            (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") == 0)
+            # Alert only if the scaling metric exists and is > 0. If the KEDA ScaledObject is configured to scale down 0,
+            # then HPA ScalingActive may be false when expected to run 0 replicas. In this case, the scaling metric exported
+            # by KEDA could not exist at all or being exposed with a value of 0.
+            and on (%(aggregation_labels)s, metric)
+            (label_replace(keda_metrics_adapter_scaler_metrics_value, "namespace", "$0", "exported_namespace", ".+") > 0)
           ||| % {
             aggregation_labels: $._config.alert_aggregation_labels,
           },


### PR DESCRIPTION
#### What this PR does
Fix MimirAutoscalerNotActive alert to not fire if the scaling metric does not exist.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
