### PR TITLE
Optimize prefix matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,8 +229,8 @@ require (
 // Using our own fork to add custom dialer and improve perf.
 replace github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
 
-// Using a fork of Prometheus while we work on querysharding to avoid a dependency on the upstream.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230119151144-44904a663c20
+// Using a fork of Prometheus with Mimir-specific changes.
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230124093001-904bda33fdd4
 
 // Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
 replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f h1:ANwIMe7kOiMN
 github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230119151144-44904a663c20 h1:Vqdi1fp6sYiSaNNZO7pKKLpye430gE0XGyqV2zG4VAI=
-github.com/grafana/mimir-prometheus v0.0.0-20230119151144-44904a663c20/go.mod h1:jVWuK6kAKKW+G1Z5013SGMzOx3Cyek9s5nxZe1zCrdc=
+github.com/grafana/mimir-prometheus v0.0.0-20230124093001-904bda33fdd4 h1:tIyX60RiNDMVSnTFlM2oO3guDboRxYioXOuuEQoXAKA=
+github.com/grafana/mimir-prometheus v0.0.0-20230124093001-904bda33fdd4/go.mod h1:jVWuK6kAKKW+G1Z5013SGMzOx3Cyek9s5nxZe1zCrdc=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1463,7 +1463,7 @@ func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName 
 	}
 
 	// TODO: if matchers contains labelName, we could use it to filter out label values here.
-	allValues, err := indexr.block.indexHeaderReader.LabelValues(labelName, nil)
+	allValues, err := indexr.block.indexHeaderReader.LabelValues(labelName, "", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "index header label values")
 	}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -913,6 +913,11 @@ func benchmarkExpandedPostings(
 	series int,
 ) {
 	ctx := context.Background()
+	series = series / 5
+
+	iUniqueValues := series / 10      // The amount of unique values for "i" label prefix. See appendTestSeries.
+	iUniqueValue := iUniqueValues / 2 // There will be 50 series matching: 5 per each series, 10 for each n. See appendTestSeries.
+
 	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+labelLongSuffix)
 	nX := labels.MustNewMatcher(labels.MatchEqual, "n", "X"+labelLongSuffix)
 
@@ -922,6 +927,8 @@ func benchmarkExpandedPostings(
 	iStar := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")
 	iPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")
 	i1Plus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^1.+$")
+	iUniquePrefixPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", fmt.Sprintf("%d.+", iUniqueValue))
+	iNotUniquePrefixPlus := labels.MustNewMatcher(labels.MatchNotRegexp, "i", fmt.Sprintf("%d.+", iUniqueValue))
 	iEmptyRe := labels.MustNewMatcher(labels.MatchRegexp, "i", "^$")
 	iNotEmpty := labels.MustNewMatcher(labels.MatchNotEqual, "i", "")
 	iNot2 := labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+labelLongSuffix)
@@ -939,7 +946,6 @@ func benchmarkExpandedPostings(
 	// Just make sure that we're testing what we think we're testing.
 	require.NotEmpty(t, iRegexNotSetMatches.SetMatches(), "Should have non empty SetMatches to test the proper path.")
 
-	series = series / 5
 	cases := []struct {
 		name     string
 		matchers []*labels.Matcher
@@ -979,6 +985,9 @@ func benchmarkExpandedPostings(
 		{`i=~"[0-2]xxx"`, []*labels.Matcher{iRegexClass}, 150},                                  // 50 series for "1", 50 for "2" and 50 for "3".
 		{`i!~[0-2]xxx`, []*labels.Matcher{iRegexNotSetMatches}, 5*series - 150},                 // inverse of iRegexAlternateSuffix
 		{`i=~".*", i!~[0-2]xxx`, []*labels.Matcher{iStar, iRegexNotSetMatches}, 5*series - 150}, // inverse of iRegexAlternateSuffix
+		{`i=~"<unique_prefix>.+"`, []*labels.Matcher{iUniquePrefixPlus}, 50},
+		{`n="1",i=~"<unique_prefix>.+"`, []*labels.Matcher{n1, iUniquePrefixPlus}, 2},
+		{`n="1",i!~"<unique_prefix>.+"`, []*labels.Matcher{n1, iNotUniquePrefixPlus}, int(float64(series)*0.2) - 2},
 		{`p!=""`, []*labels.Matcher{pNotEmpty}, series},
 	}
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -757,13 +757,13 @@ func (iir *interceptedIndexReader) LabelNames() ([]string, error) {
 	return iir.Reader.LabelNames()
 }
 
-func (iir *interceptedIndexReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
+func (iir *interceptedIndexReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
 	if iir.onLabelValuesCalled != nil {
 		if err := iir.onLabelValuesCalled(name); err != nil {
 			return nil, err
 		}
 	}
-	return iir.Reader.LabelValues(name, filter)
+	return iir.Reader.LabelValues(name, prefix, filter)
 }
 
 type contextNotifyingOnDoneWaiting struct {

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -867,13 +867,40 @@ func (r *BinaryReader) LabelValues(name string, prefix string, filter func(strin
 	if len(e.offsets) == 0 {
 		return nil, nil
 	}
-	values := make([]string, 0, len(e.offsets)*r.postingOffsetsInMemSampling)
+
+	offsetIdx := 0
+	if prefix != "" {
+		// Find the first offset that is greater or equal to the prefix.
+		offsetIdx = sort.Search(len(e.offsets), func(i int) bool {
+			if prefix <= e.offsets[i].value {
+				return true
+			}
+			return false
+		})
+
+		// We always include the last value in the offsets,
+		// and given that prefix is always less or equal than the value,
+		// we can conclude that there are no values with this prefix.
+		if offsetIdx == len(e.offsets) {
+			return nil, nil
+		}
+
+		// If the value is not equal to the prefix, this value might have the prefix.
+		// But maybe the values in the previous offset also had the prefix,
+		// so we need to step back one offset to find all values with this prefix.
+		// Unless, of course, we are at the first offset.
+		if offsetIdx > 0 && e.offsets[offsetIdx].value != prefix {
+			offsetIdx--
+		}
+	}
 
 	d := encoding.NewDecbufAt(r.b, int(r.toc.PostingsOffsetTable), nil)
-	d.Skip(e.offsets[0].tableOff)
+	d.Skip(e.offsets[offsetIdx].tableOff)
 	lastVal := e.offsets[len(e.offsets)-1].value
 
+	seenPrefix := false
 	skip := 0
+	values := make([]string, 0, (len(e.offsets)-offsetIdx)*r.postingOffsetsInMemSampling)
 	for d.Err() == nil {
 		if skip == 0 {
 			// These are always the same number of bytes,
@@ -886,8 +913,14 @@ func (r *BinaryReader) LabelValues(name string, prefix string, filter func(strin
 			d.Skip(skip)
 		}
 		s := yoloString(d.UvarintBytes()) // Label value.
-		if strings.HasPrefix(s, prefix) && (filter == nil || filter(s)) {
-			values = append(values, s)
+		if strings.HasPrefix(s, prefix) {
+			if filter == nil || filter(s) {
+				values = append(values, s)
+			}
+			seenPrefix = true
+		} else if seenPrefix {
+			// We have seen all values with the prefix.
+			break
 		}
 		if s == lastVal {
 			break

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -425,21 +425,21 @@ func (e *postingValueOffsets) prefixOffset(prefix string) (int, bool) {
 	})
 
 	// We always include the last value in the offsets,
-	// and given that value is always less or equal than the value,
-	// we can conclude that there are no values with this value.
+	// and given that prefix is always less or equal than the value,
+	// we can conclude that there are no values with this prefix.
 	if offsetIdx == len(e.offsets) {
 		return 0, false
 	}
 
-	// Prefix is lower than the first value in the offsets, and that first value doesn't have this value.
-	// Next values won't have the value, so we can return early.
+	// Prefix is lower than the first value in the offsets, and that first value doesn't have this prefix.
+	// Next values won't have the prefix, so we can return early.
 	if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
 		return 0, false
 	}
 
-	// If the value is not equal to the value, this value might have the value.
-	// But maybe the values in the previous offset also had the value,
-	// so we need to step back one offset to find all values with this value.
+	// If the value is not equal to the prefix, this value might have the prefix.
+	// But maybe the values in the previous offset also had the prefix,
+	// so we need to step back one offset to find all values with this prefix.
 	// Unless, of course, we are at the first offset.
 	if offsetIdx > 0 && e.offsets[offsetIdx].value != prefix {
 		offsetIdx--

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -843,7 +844,7 @@ func (r *BinaryReader) LookupSymbol(o uint32) (string, error) {
 	return s, nil
 }
 
-func (r *BinaryReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
+func (r *BinaryReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
 	if r.indexVersion == index.FormatV1 {
 		e, ok := r.postingsV1[name]
 		if !ok {
@@ -851,7 +852,7 @@ func (r *BinaryReader) LabelValues(name string, filter func(string) bool) ([]str
 		}
 		values := make([]string, 0, len(e))
 		for k := range e {
-			if filter == nil || filter(k) {
+			if strings.HasPrefix(k, prefix) && (filter == nil || filter(k)) {
 				values = append(values, k)
 			}
 		}
@@ -885,7 +886,7 @@ func (r *BinaryReader) LabelValues(name string, filter func(string) bool) ([]str
 			d.Skip(skip)
 		}
 		s := yoloString(d.UvarintBytes()) // Label value.
-		if filter == nil || filter(s) {
+		if strings.HasPrefix(s, prefix) && (filter == nil || filter(s)) {
 			values = append(values, s)
 		}
 		if s == lastVal {

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -882,6 +882,12 @@ func (r *BinaryReader) LabelValues(name string, prefix string, filter func(strin
 			return nil, nil
 		}
 
+		// Prefix is lower than the first value in the offsets, and that first value doesn't have this prefix.
+		// Next values won't have the prefix, so we can return early.
+		if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
+			return nil, nil
+		}
+
 		// If the value is not equal to the prefix, this value might have the prefix.
 		// But maybe the values in the previous offset also had the prefix,
 		// so we need to step back one offset to find all values with this prefix.

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -872,10 +872,7 @@ func (r *BinaryReader) LabelValues(name string, prefix string, filter func(strin
 	if prefix != "" {
 		// Find the first offset that is greater or equal to the prefix.
 		offsetIdx = sort.Search(len(e.offsets), func(i int) bool {
-			if prefix <= e.offsets[i].value {
-				return true
-			}
-			return false
+			return prefix <= e.offsets[i].value
 		})
 
 		// We always include the last value in the offsets,

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -36,8 +36,9 @@ type Reader interface {
 	// LabelValues returns all label values for given label name or error.
 	// If no values are found for label name, or label name does not exists,
 	// then empty string is returned and no error.
+	// If non-empty prefix is provided, only values starting with the prefix are returned.
 	// If non-nil filter is provided, then only values for which filter returns true are returned.
-	LabelValues(name string, filter func(string) bool) ([]string, error)
+	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
 
 	// LabelNames returns all label names in sorted order.
 	LabelNames() ([]string, error)

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -311,7 +311,7 @@ func TestReadersLabelValues(t *testing.T) {
 		series = append(series, labels.FromStrings(lblStrings...))
 
 		for idx := range lblValues {
-			lblValues[idx] += 1
+			lblValues[idx]++
 			if idx < 2 {
 				continue
 			}

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -188,7 +188,7 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 		expectedLabelVals, err := indexReader.SortedLabelValues(lname)
 		require.NoError(t, err)
 
-		vals, err := headerReader.LabelValues(lname, nil)
+		vals, err := headerReader.LabelValues(lname, "", nil)
 		require.NoError(t, err)
 		require.Equal(t, expectedLabelVals, vals)
 

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -30,18 +30,62 @@ import (
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
-func TestReaders(t *testing.T) {
+var implementations = []struct {
+	name    string
+	factory func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader
+}{
+	{
+		name: "binary reader",
+		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
+			br, err := NewBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, Config{})
+			require.NoError(t, err)
+			requireCleanup(t, br.Close)
+			return br
+		},
+	},
+	{
+		name: "binary reader with map populate",
+		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
+			br, err := NewBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, Config{MapPopulateEnabled: true})
+			require.NoError(t, err)
+			requireCleanup(t, br.Close)
+			return br
+		},
+	},
+	{
+		name: "lazy binary reader",
+		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
+			readerFactory := func() (Reader, error) {
+				return NewBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, Config{})
+			}
+
+			br, err := NewLazyBinaryReader(ctx, readerFactory, log.NewNopLogger(), nil, dir, id, NewLazyBinaryReaderMetrics(nil), nil)
+			require.NoError(t, err)
+			requireCleanup(t, br.Close)
+			return br
+		},
+	},
+	{
+		name: "stream binary reader",
+		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
+			br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
+			require.NoError(t, err)
+			requireCleanup(t, br.Close)
+			return br
+		},
+	},
+}
+
+func TestReadersComparedToIndexHeader(t *testing.T) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
 	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, bkt.Close())
-	})
+	requireCleanup(t, bkt.Close)
 
 	// Create block index version 2.
-	idIndexV2, err := testhelper.CreateBlock(ctx, tmpDir, []labels.Labels{
+	series := []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
 		labels.FromStrings("a", "3"),
@@ -57,7 +101,9 @@ func TestReaders(t *testing.T) {
 		labels.FromStrings("a", "13"),
 		labels.FromStrings("a", "1", "longer-string", "1"),
 		labels.FromStrings("a", "1", "longer-string", "2"),
-	}, 100, 0, 1000, labels.FromStrings("ext1", "1"))
+	}
+
+	idIndexV2, err := testhelper.CreateBlock(ctx, tmpDir, series, 100, 0, 1000, labels.FromStrings("ext1", "1"))
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, idIndexV2.String()), nil))
 
@@ -73,62 +119,29 @@ func TestReaders(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, metaIndexV1.ULID.String()), nil))
 
-	for _, id := range []ulid.ULID{idIndexV2, metaIndexV1.ULID} {
-		t.Run(id.String(), func(t *testing.T) {
+	for _, testBlock := range []struct {
+		version string
+		id      ulid.ULID
+	}{
+		{version: "v2", id: idIndexV2},
+		{version: "v1", id: metaIndexV1.ULID},
+	} {
+		t.Run(testBlock.version, func(t *testing.T) {
+			id := testBlock.id
 			indexName := filepath.Join(tmpDir, id.String(), block.IndexHeaderFilename)
 			require.NoError(t, WriteBinary(ctx, bkt, id, indexName))
 
 			indexFile, err := fileutil.OpenMmapFile(filepath.Join(tmpDir, id.String(), block.IndexFilename))
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				require.NoError(t, indexFile.Close())
-			})
+			requireCleanup(t, indexFile.Close)
 
 			b := realByteSlice(indexFile.Bytes())
-
-			t.Run("binary reader", func(t *testing.T) {
-				br, err := NewBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, Config{})
-				require.NoError(t, err)
-				t.Cleanup(func() {
-					require.NoError(t, br.Close())
+			for _, impl := range implementations {
+				t.Run(impl.name, func(t *testing.T) {
+					r := impl.factory(t, ctx, tmpDir, id)
+					compareIndexToHeader(t, b, r)
 				})
-
-				compareIndexToHeader(t, b, br)
-			})
-
-			t.Run("binary reader with map populate", func(t *testing.T) {
-				br, err := NewBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, Config{MapPopulateEnabled: true})
-				require.NoError(t, err)
-				t.Cleanup(func() {
-					require.NoError(t, br.Close())
-				})
-
-				compareIndexToHeader(t, b, br)
-			})
-
-			t.Run("lazy binary reader", func(t *testing.T) {
-				factory := func() (Reader, error) {
-					return NewBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, Config{})
-				}
-
-				br, err := NewLazyBinaryReader(ctx, factory, log.NewNopLogger(), nil, tmpDir, id, NewLazyBinaryReaderMetrics(nil), nil)
-				require.NoError(t, err)
-				t.Cleanup(func() {
-					require.NoError(t, br.Close())
-				})
-
-				compareIndexToHeader(t, b, br)
-			})
-
-			t.Run("stream binary reader", func(t *testing.T) {
-				br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, tmpDir, id, 3, NewStreamBinaryReaderMetrics(nil), Config{})
-				require.NoError(t, err)
-				t.Cleanup(func() {
-					require.NoError(t, br.Close())
-				})
-
-				compareIndexToHeader(t, b, br)
-			})
+			}
 
 		})
 	}
@@ -274,6 +287,121 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *meta
 	require.NoError(t, block.Upload(context.Background(), log.NewNopLogger(), bkt, filepath.Join(tmpDir, m.ULID.String()), nil))
 
 	return m
+}
+
+func TestReadersLabelValues(t *testing.T) {
+	const testLabelCount = 32
+	const testSeriesCount = 512
+
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	require.NoError(t, err)
+	requireCleanup(t, bkt.Close)
+
+	series := make([]labels.Labels, 0, testSeriesCount)
+	lblValues := make([]int, testLabelCount)
+	for i := 0; i < testSeriesCount; i++ {
+		// add first, so we'll have the value_000.
+		lblStrings := make([]string, 0, testLabelCount*2)
+		for idx, val := range lblValues {
+			lblStrings = append(lblStrings, fmt.Sprintf("test_label_%d", idx), fmt.Sprintf("value_%03d", val))
+		}
+		series = append(series, labels.FromStrings(lblStrings...))
+
+		for idx := range lblValues {
+			lblValues[idx] += 1
+			if idx < 2 {
+				continue
+			}
+			lblValues[idx] %= idx
+		}
+	}
+
+	id, err := testhelper.CreateBlock(ctx, tmpDir, series, 100, 0, 1000, labels.FromStrings("ext1", "1"))
+	require.NoError(t, err)
+	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, id.String()), nil))
+
+	indexName := filepath.Join(tmpDir, id.String(), block.IndexHeaderFilename)
+	require.NoError(t, WriteBinary(ctx, bkt, id, indexName))
+
+	indexFile, err := fileutil.OpenMmapFile(filepath.Join(tmpDir, id.String(), block.IndexFilename))
+	require.NoError(t, err)
+	requireCleanup(t, indexFile.Close)
+
+	type testCase struct {
+		prefix   string
+		desc     string
+		filter   func(string) bool
+		expected int
+	}
+	tests := map[string][]testCase{
+		"test_label_0": {
+			{prefix: "", expected: 512},
+			{prefix: "value_", expected: 512},
+			{prefix: "value_0", expected: 100},
+			{prefix: "value_1", expected: 100},
+			{prefix: "value_2", expected: 100},
+			{prefix: "value_3", expected: 100},
+			{prefix: "value_4", expected: 100},
+			{prefix: "value_5", expected: 12},
+			{prefix: "value_00", expected: 10},
+			{prefix: "value_10", expected: 10},
+			{prefix: "value_20", expected: 10},
+			{prefix: "value_30", expected: 10},
+			{prefix: "value_40", expected: 10},
+			{prefix: "value_50", expected: 10},
+			{prefix: "value_000", expected: 1},
+			{prefix: "value_400", expected: 1},
+			{prefix: "value_511", expected: 1},
+			{prefix: "value_512", expected: 0},
+			{prefix: "value_600", expected: 0},
+			{prefix: "value_aaa", expected: 0},
+			{prefix: "value_aaa", expected: 0},
+			{
+				prefix:   "value_",
+				desc:     " only even",
+				filter:   labels.MustNewMatcher(labels.MatchRegexp, "test_label_0", "value_[0-9][0-9][02468]").Matches,
+				expected: 256,
+			},
+			{
+				prefix:   "",
+				desc:     " only even",
+				filter:   labels.MustNewMatcher(labels.MatchRegexp, "test_label_0", "value_[0-9][0-9][02468]").Matches,
+				expected: 256,
+			},
+		},
+	}
+
+	for lblIdx := 2; lblIdx < testLabelCount; lblIdx++ {
+		lbl := fmt.Sprintf("test_label_%d", lblIdx)
+		tests[lbl] = append(tests[lbl],
+			testCase{prefix: "", expected: lblIdx},
+			testCase{prefix: "value_", expected: lblIdx},
+			testCase{prefix: "value_000", expected: 1},
+			testCase{prefix: "value_001", expected: 1},
+			testCase{prefix: fmt.Sprintf("value_%03d", lblIdx-1), expected: 1},
+			testCase{prefix: fmt.Sprintf("value_%03d", lblIdx), expected: 0},
+		)
+	}
+
+	for _, impl := range implementations {
+		t.Run(impl.name, func(t *testing.T) {
+			r := impl.factory(t, ctx, tmpDir, id)
+			for lbl, tcs := range tests {
+				t.Run(lbl, func(t *testing.T) {
+					for _, tc := range tcs {
+						t.Run(fmt.Sprintf("prefix='%s'%s", tc.prefix, tc.desc), func(t *testing.T) {
+							values, err := r.LabelValues(lbl, tc.prefix, tc.filter)
+							require.NoError(t, err)
+							require.Equal(t, tc.expected, len(values))
+						})
+					}
+				})
+			}
+		})
+	}
 }
 
 func BenchmarkBinaryWrite(t *testing.B) {
@@ -467,4 +595,10 @@ func readSymbols(bs index.ByteSlice, version, off int) ([]string, map[uint32]str
 		cnt--
 	}
 	return symbolSlice, symbols, errors.Wrap(d.Err(), "read symbols")
+}
+
+func requireCleanup(t *testing.T, cleanupFun func() error) {
+	t.Cleanup(func() {
+		require.NoError(t, cleanupFun())
+	})
 }

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -358,7 +358,8 @@ func TestReadersLabelValues(t *testing.T) {
 			{prefix: "value_512", expected: 0},
 			{prefix: "value_600", expected: 0},
 			{prefix: "value_aaa", expected: 0},
-			{prefix: "value_aaa", expected: 0},
+			{prefix: "value_0000", expected: 0},
+			{prefix: "value_5110", expected: 0},
 			{
 				prefix:   "value_",
 				desc:     " only even",

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -386,10 +386,7 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 	if prefix != "" {
 		// Find the first offset that is greater or equal to the prefix.
 		offsetIdx = sort.Search(len(e.offsets), func(i int) bool {
-			if prefix <= e.offsets[i].value {
-				return true
-			}
-			return false
+			return prefix <= e.offsets[i].value
 		})
 
 		// We always include the last value in the offsets,

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -291,21 +291,21 @@ func (e *postingValueOffsets) prefixOffset(prefix string) (int, bool) {
 	})
 
 	// We always include the last value in the offsets,
-	// and given that value is always less or equal than the value,
-	// we can conclude that there are no values with this value.
+	// and given that prefix is always less or equal than the value,
+	// we can conclude that there are no values with this prefix.
 	if offsetIdx == len(e.offsets) {
 		return 0, false
 	}
 
-	// Prefix is lower than the first value in the offsets, and that first value doesn't have this value.
-	// Next values won't have the value, so we can return early.
+	// Prefix is lower than the first value in the offsets, and that first value doesn't have this prefix.
+	// Next values won't have the prefix, so we can return early.
 	if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
 		return 0, false
 	}
 
-	// If the value is not equal to the value, this value might have the value.
-	// But maybe the values in the previous offset also had the value,
-	// so we need to step back one offset to find all values with this value.
+	// If the value is not equal to the prefix, this value might have the prefix.
+	// But maybe the values in the previous offset also had the prefix,
+	// so we need to step back one offset to find all values with this prefix.
 	// Unless, of course, we are at the first offset.
 	if offsetIdx > 0 && e.offsets[offsetIdx].value != prefix {
 		offsetIdx--

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -396,6 +396,12 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 			return nil, nil
 		}
 
+		// Prefix is lower than the first value in the offsets, and that first value doesn't have this prefix.
+		// Next values won't have the prefix, so we can return early.
+		if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
+			return nil, nil
+		}
+
 		// If the value is not equal to the prefix, this value might have the prefix.
 		// But maybe the values in the previous offset also had the prefix,
 		// so we need to step back one offset to find all values with this prefix.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -284,6 +284,36 @@ type postingValueOffsets struct {
 	lastValOffset int64
 }
 
+func (e *postingValueOffsets) prefixOffset(prefix string) (int, bool) {
+	// Find the first offset that is greater or equal to the value.
+	offsetIdx := sort.Search(len(e.offsets), func(i int) bool {
+		return prefix <= e.offsets[i].value
+	})
+
+	// We always include the last value in the offsets,
+	// and given that value is always less or equal than the value,
+	// we can conclude that there are no values with this value.
+	if offsetIdx == len(e.offsets) {
+		return 0, false
+	}
+
+	// Prefix is lower than the first value in the offsets, and that first value doesn't have this value.
+	// Next values won't have the value, so we can return early.
+	if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
+		return 0, false
+	}
+
+	// If the value is not equal to the value, this value might have the value.
+	// But maybe the values in the previous offset also had the value,
+	// so we need to step back one offset to find all values with this value.
+	// Unless, of course, we are at the first offset.
+	if offsetIdx > 0 && e.offsets[offsetIdx].value != prefix {
+		offsetIdx--
+	}
+
+	return offsetIdx, true
+}
+
 type postingOffset struct {
 	// label value.
 	value string
@@ -384,30 +414,9 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 
 	offsetIdx := 0
 	if prefix != "" {
-		// Find the first offset that is greater or equal to the prefix.
-		offsetIdx = sort.Search(len(e.offsets), func(i int) bool {
-			return prefix <= e.offsets[i].value
-		})
-
-		// We always include the last value in the offsets,
-		// and given that prefix is always less or equal than the value,
-		// we can conclude that there are no values with this prefix.
-		if offsetIdx == len(e.offsets) {
+		offsetIdx, ok = e.prefixOffset(prefix)
+		if !ok {
 			return nil, nil
-		}
-
-		// Prefix is lower than the first value in the offsets, and that first value doesn't have this prefix.
-		// Next values won't have the prefix, so we can return early.
-		if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
-			return nil, nil
-		}
-
-		// If the value is not equal to the prefix, this value might have the prefix.
-		// But maybe the values in the previous offset also had the prefix,
-		// so we need to step back one offset to find all values with this prefix.
-		// Unless, of course, we are at the first offset.
-		if offsetIdx > 0 && e.offsets[offsetIdx].value != prefix {
-			offsetIdx--
 		}
 	}
 
@@ -419,7 +428,6 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 	d.ResetAt(e.offsets[offsetIdx].tableOff)
 	lastVal := e.offsets[len(e.offsets)-1].value
 
-	seenPrefix := false
 	skip := 0
 	values := make([]string, 0, len(e.offsets)*t.postingOffsetsInMemSampling)
 	for d.Err() == nil {
@@ -433,17 +441,29 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 		} else {
 			d.Skip(skip)
 		}
-		s := yoloString(d.UnsafeUvarintBytes()) // Label value.
-		if strings.HasPrefix(s, prefix) {
-			if filter == nil || filter(s) {
-				values = append(values, strings.Clone(s))
+
+		value := yoloString(d.UnsafeUvarintBytes())
+		if prefix == "" {
+			// Quick path for no prefix matching.
+			if filter == nil || filter(value) {
+				// Clone the yolo string since its bytes will be invalidated as soon as
+				// any other reads against the decoding buffer are performed.
+				values = append(values, strings.Clone(value))
 			}
-			seenPrefix = true
-		} else if seenPrefix {
-			// We have seen all values with the prefix.
-			break
+		} else {
+			if strings.HasPrefix(value, prefix) {
+				if filter == nil || filter(value) {
+					// Clone the yolo string since its bytes will be invalidated as soon as
+					// any other reads against the decoding buffer are performed.
+					values = append(values, strings.Clone(value))
+				}
+			} else if prefix < value {
+				// There will be no more values with the prefix.
+				break
+			}
 		}
-		if s == lastVal {
+
+		if value == lastVal {
 			break
 		}
 		d.Uvarint64() // Offset.

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -176,7 +176,7 @@ func (r *LazyBinaryReader) LookupSymbol(o uint32) (string, error) {
 }
 
 // LabelValues implements Reader.
-func (r *LazyBinaryReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
+func (r *LazyBinaryReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
 	r.readerMx.RLock()
 	defer r.readerMx.RUnlock()
 
@@ -185,7 +185,7 @@ func (r *LazyBinaryReader) LabelValues(name string, filter func(string) bool) ([
 	}
 
 	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.LabelValues(name, filter)
+	return r.reader.LabelValues(name, prefix, filter)
 }
 
 // LabelNames implements Reader.

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -179,7 +179,7 @@ func BenchmarkLabelValuesIndexV1(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := names[i%len(names)]
 
-			values, err := br.LabelValues(name, func(s string) bool {
+			values, err := br.LabelValues(name, "", func(s string) bool {
 				return true
 			})
 
@@ -223,7 +223,7 @@ func BenchmarkLabelValuesIndexV2(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := names[i%len(names)]
 
-			values, err := br.LabelValues(name, func(s string) bool {
+			values, err := br.LabelValues(name, "", func(s string) bool {
 				return true
 			})
 

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -216,8 +216,8 @@ func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
 	return s, nil
 }
 
-func (r *StreamBinaryReader) LabelValues(name string, filter func(string) bool) ([]string, error) {
-	return r.postingsOffsetTable.LabelValues(name, filter)
+func (r *StreamBinaryReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
+	return r.postingsOffsetTable.LabelValues(name, prefix, filter)
 }
 
 func (r *StreamBinaryReader) LabelNames() ([]string, error) {

--- a/vendor/github.com/prometheus/prometheus/model/labels/matcher.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/matcher.go
@@ -128,3 +128,12 @@ func (m *Matcher) SetMatches() []string {
 	}
 	return m.re.setMatches
 }
+
+// Prefix returns the required prefix of the value to match, if possible.
+// It will be empty if it's an equality matcher or if the prefix can't be determined.
+func (m *Matcher) Prefix() string {
+	if m.re == nil {
+		return ""
+	}
+	return m.re.prefix
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -784,7 +784,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230119151144-44904a663c20
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230124093001-904bda33fdd4
 ## explicit; go 1.18
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1369,7 +1369,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/bradfitz/gomemcache => github.com/grafana/gomemcache v0.0.0-20220812141943-44b6cde200bb
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230119151144-44904a663c20
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230124093001-904bda33fdd4
 # github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
 # github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe


### PR DESCRIPTION
#### What this PR does

When a label has lots of values (for example `__name__` can have tens of thousands of values) and a matcher is looking for a prefix (for example, `__name__=~"keda_.*"`) we were listing all the values and applying the match function to all of them.

However, we know the offset of each 32nd label, so we know more or less where we can start searching for that prefix, and we know that label values are sorted lexicographically, so we know we should stop looking if we stop seeing that prefix.

This implements that optimization, and also adds benchmark cases for it (label `i` has 500k values, each one matching 50 series).

```
name                                                                        old time/op    new time/op    delta
BucketIndexReader_ExpandedPostings/n="X"-16                                   1.92µs ±13%    1.76µs ±20%   -8.53%  (p=0.036 n=10+20)
BucketIndexReader_ExpandedPostings/n="X",j="foo"-16                           2.69µs ±11%    2.77µs ±16%     ~     (p=0.328 n=10+20)
BucketIndexReader_ExpandedPostings/n="X",j!="foo"-16                          2.74µs ±13%    2.71µs ±11%     ~     (p=0.507 n=10+20)
BucketIndexReader_ExpandedPostings/j=~"XXX|YYY"-16                            1.98µs ±20%    1.97µs ± 9%     ~     (p=0.542 n=10+19)
BucketIndexReader_ExpandedPostings/j=~"X.+"-16                                2.74µs ±12%    1.83µs ± 8%  -33.10%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~"X|Y|Z"-16                              2.24µs ± 9%    2.19µs ±12%     ~     (p=0.282 n=10+20)
BucketIndexReader_ExpandedPostings/n="1"-16                                   8.00ms ±13%    7.62ms ±18%     ~     (p=0.091 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-16                           27.5ms ± 2%    27.7ms ± 0%   +0.57%  (p=0.040 n=10+17)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-16                           27.5ms ± 1%    27.7ms ± 1%   +0.86%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-16                          23.3ms ± 1%    23.6ms ± 1%   +1.52%  (p=0.000 n=9+19)
BucketIndexReader_ExpandedPostings/i=~".*"-16                                  107ms ± 4%     108ms ± 3%     ~     (p=0.091 n=10+20)
BucketIndexReader_ExpandedPostings/i=~".+"-16                                  295ms ± 2%     299ms ± 3%   +1.41%  (p=0.002 n=10+19)
BucketIndexReader_ExpandedPostings/i=~"^.+$",j=~"X.+"-16                      4.41ms ± 6%    4.38ms ± 9%     ~     (p=0.694 n=9+20)
BucketIndexReader_ExpandedPostings/i=~""-16                                    330ms ± 1%     336ms ± 2%   +1.98%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/i!=""-16                                    297ms ± 1%     298ms ± 1%     ~     (p=0.243 n=9+19)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-16                   29.7ms ± 1%    30.1ms ± 0%   +1.35%  (p=0.000 n=10+17)
BucketIndexReader_ExpandedPostings/n="X",i=~"^.+$",j="foo"-16                 2.97µs ±12%    2.86µs ±16%     ~     (p=0.169 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-16            33.6ms ± 1%    34.0ms ± 1%   +1.23%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!=""-16                              149ms ± 2%     149ms ± 1%   +0.51%  (p=0.044 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-16                      154ms ± 2%     156ms ± 1%   +1.08%  (p=0.001 n=10+16)
BucketIndexReader_ExpandedPostings/n="1",i!="",j=~"X.+"-16                    3.90ms ±10%    3.72ms ± 9%   -4.57%  (p=0.031 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!="",j=~"XXX|YYY"-16                3.37µs ± 9%    3.49µs ± 9%     ~     (p=0.071 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",i=~"X|Y|Z",j="foo"-16                3.82µs ± 7%    3.83µs ±11%     ~     (p=0.854 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-16                    154ms ± 1%     156ms ± 1%   +1.69%  (p=0.000 n=8+19)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-16                  26.0ms ± 2%    24.4ms ± 1%   -6.14%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-16             160ms ± 2%     163ms ± 3%   +1.79%  (p=0.005 n=8+19)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-16           182ms ± 2%     183ms ± 2%     ~     (p=0.064 n=10+18)
BucketIndexReader_ExpandedPostings/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-16    3.26µs ± 8%    3.22µs ± 8%     ~     (p=0.388 n=10+18)
BucketIndexReader_ExpandedPostings/i=~"0xxx|1xxx|2xxx"-16                     29.1µs ± 6%    28.7µs ± 1%     ~     (p=0.308 n=9+19)
BucketIndexReader_ExpandedPostings/i=~"(0|1|2)xxx"-16                         29.6µs ± 6%    28.5µs ± 1%   -3.70%  (p=0.001 n=10+18)
BucketIndexReader_ExpandedPostings/i=~"[0-2]xxx"-16                           28.9µs ± 3%    28.4µs ± 1%   -1.64%  (p=0.007 n=9+20)
BucketIndexReader_ExpandedPostings/i!~[0-2]xxx-16                              124ms ± 2%     118ms ± 2%   -4.89%  (p=0.000 n=9+20)
BucketIndexReader_ExpandedPostings/i=~".*",_i!~[0-2]xxx-16                     129ms ± 4%     121ms ± 2%   -6.45%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/i=~"<unique_prefix>.+"-16                  2.66ms ± 7%    0.14ms ± 2%  -94.58%  (p=0.000 n=9+19)
BucketIndexReader_ExpandedPostings/n="1",i=~"<unique_prefix>.+"-16            4.19ms ±11%    2.25ms ±14%  -46.41%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",i!~"<unique_prefix>.+"-16            10.5ms ± 9%     9.1ms ±12%  -13.21%  (p=0.000 n=9+20)
BucketIndexReader_ExpandedPostings/p!=""-16                                   27.2ms ± 3%    26.9ms ± 6%     ~     (p=0.074 n=10+20)

name                                                                        old alloc/op   new alloc/op   delta
BucketIndexReader_ExpandedPostings/n="X"-16                                   1.01kB ± 0%    1.02kB ± 0%   +1.59%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="X",j="foo"-16                           1.34kB ± 0%    1.39kB ± 0%   +3.57%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="X",j!="foo"-16                          1.34kB ± 0%    1.39kB ± 0%   +3.57%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/j=~"XXX|YYY"-16                            1.02kB ± 0%    1.04kB ± 0%   +1.56%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/j=~"X.+"-16                                1.96kB ± 0%    0.95kB ± 0%  -51.43%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~"X|Y|Z"-16                              1.07kB ± 0%    1.09kB ± 0%   +1.49%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1"-16                                   12.7MB ± 0%    12.7MB ± 0%     ~     (p=0.787 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-16                           19.8MB ± 0%    19.8MB ± 0%     ~     (p=0.265 n=10+18)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-16                           19.8MB ± 0%    19.8MB ± 0%     ~     (p=0.422 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-16                          19.8MB ± 0%    19.8MB ± 0%     ~     (p=0.449 n=10+19)
BucketIndexReader_ExpandedPostings/i=~".*"-16                                  287MB ± 0%     287MB ± 0%     ~     (p=0.423 n=9+18)
BucketIndexReader_ExpandedPostings/i=~".+"-16                                  327MB ± 0%     327MB ± 0%     ~     (p=0.060 n=10+19)
BucketIndexReader_ExpandedPostings/i=~"^.+$",j=~"X.+"-16                      4.81MB ± 0%    4.81MB ± 0%   -0.02%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~""-16                                    113MB ± 0%     113MB ± 0%   +0.00%  (p=0.011 n=10+17)
BucketIndexReader_ExpandedPostings/i!=""-16                                    327MB ± 0%     327MB ± 0%   +0.00%  (p=0.002 n=9+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-16                   21.4MB ± 0%    21.4MB ± 0%   +0.00%  (p=0.000 n=8+17)
BucketIndexReader_ExpandedPostings/n="X",i=~"^.+$",j="foo"-16                 1.52kB ± 0%    1.58kB ± 0%   +4.21%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-16            22.7MB ± 0%    22.7MB ± 0%   +0.00%  (p=0.000 n=8+20)
BucketIndexReader_ExpandedPostings/n="1",i!=""-16                             86.4MB ± 0%    86.4MB ± 0%     ~     (p=0.087 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-16                     93.5MB ± 0%    93.5MB ± 0%   +0.00%  (p=0.000 n=10+18)
BucketIndexReader_ExpandedPostings/n="1",i!="",j=~"X.+"-16                    4.81MB ± 0%    4.81MB ± 0%   -0.02%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!="",j=~"XXX|YYY"-16                1.55kB ± 0%    1.62kB ± 0%   +4.12%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~"X|Y|Z",j="foo"-16                1.65kB ± 0%    1.71kB ± 0%   +3.88%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-16                   93.5MB ± 0%    93.5MB ± 0%   +0.00%  (p=0.000 n=10+18)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-16                  23.9MB ± 0%    23.9MB ± 0%   +0.00%  (p=0.000 n=9+18)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-16            94.8MB ± 0%    94.8MB ± 0%     ~     (p=0.422 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-16           100MB ± 0%      99MB ± 0%   -0.18%  (p=0.000 n=9+20)
BucketIndexReader_ExpandedPostings/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-16    1.70kB ± 0%    1.78kB ± 0%   +4.71%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~"0xxx|1xxx|2xxx"-16                     13.9kB ± 0%    13.9kB ± 0%   +0.12%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~"(0|1|2)xxx"-16                         13.8kB ± 0%    13.8kB ± 0%   +0.12%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~"[0-2]xxx"-16                           13.8kB ± 0%    13.8kB ± 0%   +0.12%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i!~[0-2]xxx-16                              285MB ± 0%     285MB ± 0%     ~     (p=0.088 n=10+20)
BucketIndexReader_ExpandedPostings/i=~".*",_i!~[0-2]xxx-16                     287MB ± 0%     287MB ± 0%   +0.00%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/i=~"<unique_prefix>.+"-16                  1.61MB ± 0%    0.90MB ± 0%  -44.25%  (p=0.000 n=10+19)
BucketIndexReader_ExpandedPostings/n="1",i=~"<unique_prefix>.+"-16            2.91MB ± 0%    2.19MB ± 0%  -24.53%  (p=0.000 n=8+20)
BucketIndexReader_ExpandedPostings/n="1",i!~"<unique_prefix>.+"-16            14.3MB ± 0%    13.6MB ± 0%   -4.98%  (p=0.000 n=10+18)
BucketIndexReader_ExpandedPostings/p!=""-16                                   58.8MB ± 0%    58.8MB ± 0%   +0.00%  (p=0.002 n=10+19)

name                                                                        old allocs/op  new allocs/op  delta
BucketIndexReader_ExpandedPostings/n="X"-16                                     23.0 ± 0%      23.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="X",j="foo"-16                             28.0 ± 0%      28.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="X",j!="foo"-16                            28.0 ± 0%      28.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/j=~"XXX|YYY"-16                              24.0 ± 0%      24.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/j=~"X.+"-16                                  23.0 ± 0%      22.0 ± 0%   -4.35%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~"X|Y|Z"-16                                25.0 ± 0%      25.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1"-16                                     93.0 ± 0%      93.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",j="foo"-16                              122 ± 1%       121 ± 0%     ~     (p=0.245 n=10+20)
BucketIndexReader_ExpandedPostings/j="foo",n="1"-16                              122 ± 1%       122 ± 0%     ~     (p=0.500 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",j!="foo"-16                             120 ± 1%       120 ± 1%     ~     (p=1.096 n=10+20)
BucketIndexReader_ExpandedPostings/i=~".*"-16                                    107 ± 0%       107 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~".+"-16                                   600k ± 0%      600k ± 0%     ~     (p=0.181 n=6+19)
BucketIndexReader_ExpandedPostings/i=~"^.+$",j=~"X.+"-16                        28.0 ± 0%      27.0 ± 0%   -3.57%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/i=~""-16                                     600k ± 0%      600k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i!=""-16                                     600k ± 0%      600k ± 0%   +0.00%  (p=0.001 n=9+14)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",j="foo"-16                      124 ± 0%       125 ± 0%     ~     (p=0.700 n=10+20)
BucketIndexReader_ExpandedPostings/n="X",i=~"^.+$",j="foo"-16                   30.0 ± 0%      30.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~".*",i!="2",j="foo"-16               150 ± 0%       150 ± 0%     ~     (p=1.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!=""-16                               600k ± 0%      600k ± 0%     ~     (p=1.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!="",j="foo"-16                       600k ± 0%      600k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i!="",j=~"X.+"-16                      31.0 ± 0%      30.0 ± 0%   -3.23%  (p=0.000 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i!="",j=~"XXX|YYY"-16                  30.0 ± 0%      30.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~"X|Y|Z",j="foo"-16                  33.0 ± 0%      33.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",j="foo"-16                     600k ± 0%      600k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~"1.+",j="foo"-16                   66.8k ± 0%     66.8k ± 0%     ~     (p=0.700 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!="2",j="foo"-16              600k ± 0%      600k ± 0%     ~     (p=0.131 n=10+20)
BucketIndexReader_ExpandedPostings/n="1",i=~".+",i!~"2.*",j="foo"-16            667k ± 0%      667k ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-16      31.0 ± 0%      31.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~"0xxx|1xxx|2xxx"-16                        118 ± 0%       118 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~"(0|1|2)xxx"-16                            118 ± 0%       118 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~"[0-2]xxx"-16                              118 ± 0%       118 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i!~[0-2]xxx-16                                165 ± 0%       165 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/i=~".*",_i!~[0-2]xxx-16                       170 ± 0%       170 ± 0%     ~     (p=0.099 n=9+20)
BucketIndexReader_ExpandedPostings/i=~"<unique_prefix>.+"-16                    66.0 ± 0%      66.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i=~"<unique_prefix>.+"-16              93.0 ± 0%      93.0 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/n="1",i!~"<unique_prefix>.+"-16               123 ± 0%       123 ± 0%     ~     (all equal)
BucketIndexReader_ExpandedPostings/p!=""-16                                     98.0 ± 0%      98.0 ± 0%     ~     (all equal)
```

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
