### PR TITLE
Do not error when there is nothing to commit as part of a publish

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -48,6 +48,7 @@ jobs:
         github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_MIMIR }}"
         source_folder: "docs/sources/mimir"
         target_folder: "content/docs/mimir/next"
+        allow_no_changes: true
 
     - name: "Publish to website repository helm-charts/mimir-distributed (next)"
       uses: "./.github/actions/website-sync"
@@ -61,3 +62,4 @@ jobs:
         github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_MIMIR }}"
         source_folder: "docs/sources/helm-charts/mimir-distributed"
         target_folder: "content/docs/helm-charts/mimir-distributed/next"
+        allow_no_changes: true


### PR DESCRIPTION
Prevents errors such as those seen in https://github.com/grafana/mimir/actions/runs/3990037092/jobs/6843471055

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
