### PR TITLE
Add IgnoreNativeHistogramsOnRead to storegateway

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3102,7 +3102,7 @@
           "required": false,
           "desc": "To stop processing native histograms as soon as possible, set to true",
           "fieldValue": null,
-          "fieldDefaultValue": false,
+          "fieldDefaultValue": true,
           "fieldFlag": "store-gateway.ignore-native-histograms-on-read",
           "fieldType": "boolean",
           "fieldCategory": "experimental"

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3098,6 +3098,17 @@
         },
         {
           "kind": "field",
+          "name": "ignore_native_histograms_on_read",
+          "required": false,
+          "desc": "To stop processing native histograms as soon as possible, set to true",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "store-gateway.ignore-native-histograms-on-read",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "active_series_custom_trackers",
           "required": false,
           "desc": "Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero).",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1983,6 +1983,8 @@ Usage of ./cmd/mimir/mimir:
     	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
   -shutdown-delay duration
     	[experimental] How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Mimir will report not-ready status via /ready endpoint.
+  -store-gateway.ignore-native-histograms-on-read
+    	[experimental] To stop processing native histograms as soon as possible, set to true
   -store-gateway.sharding-ring.consul.acl-token string
     	ACL Token used to interact with Consul.
   -store-gateway.sharding-ring.consul.cas-retry-delay duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1984,7 +1984,7 @@ Usage of ./cmd/mimir/mimir:
   -shutdown-delay duration
     	[experimental] How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Mimir will report not-ready status via /ready endpoint.
   -store-gateway.ignore-native-histograms-on-read
-    	[experimental] To stop processing native histograms as soon as possible, set to true
+    	[experimental] To stop processing native histograms as soon as possible, set to true (default true)
   -store-gateway.sharding-ring.consul.acl-token string
     	ACL Token used to interact with Consul.
   -store-gateway.sharding-ring.consul.cas-retry-delay duration

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -2581,7 +2581,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # (experimental) To stop processing native histograms as soon as possible, set
 # to true
 # CLI flag: -store-gateway.ignore-native-histograms-on-read
-[ignore_native_histograms_on_read: <boolean> | default = false]
+[ignore_native_histograms_on_read: <boolean> | default = true]
 
 # (advanced) Additional custom trackers for active metrics. If there are active
 # series matching a provided matcher (map value), the count will be exposed in

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -2578,6 +2578,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -ingester.native-histograms-ingestion-enabled
 [native_histograms_ingestion_enabled: <boolean> | default = false]
 
+# (experimental) To stop processing native histograms as soon as possible, set
+# to true
+# CLI flag: -store-gateway.ignore-native-histograms-on-read
+[ignore_native_histograms_on_read: <boolean> | default = false]
+
 # (advanced) Additional custom trackers for active metrics. If there are active
 # series matching a provided matcher (map value), the count will be exposed in
 # the custom trackers metric labeled using the tracker name (map key). Zero

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -159,6 +159,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 				"-store-gateway.tenant-shard-size":                             fmt.Sprintf("%d", testCfg.tenantShardSize),
 				"-query-frontend.query-stats-enabled":                          "true",
 				"-query-frontend.parallelize-shardable-queries":                strconv.FormatBool(testCfg.queryShardingEnabled),
+				"-store-gateway.ignore-native-histograms-on-read":              "false",
 			})
 
 			// Start store-gateways.

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -70,6 +70,9 @@ type Limits interface {
 
 	// NativeHistogramsIngestionEnabled returns whether to ingest native histograms in the ingester
 	NativeHistogramsIngestionEnabled(userID string) bool
+
+	// IgnoreNativeHistogramsOnRead returns whether to ignore native histograms in the ingester and store gateway.
+	IgnoreNativeHistogramsOnRead(userID string) bool
 }
 
 type limitsMiddleware struct {

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -292,6 +292,7 @@ type mockLimits struct {
 	outOfOrderTimeWindow             model.Duration
 	creationGracePeriod              time.Duration
 	nativeHistogramsIngestionEnabled bool
+	ignoreNativeHistogramsOnRead     bool
 }
 
 func (m mockLimits) MaxQueryLookback(string) time.Duration {
@@ -350,6 +351,10 @@ func (m mockLimits) CreationGracePeriod(userID string) time.Duration {
 
 func (m mockLimits) NativeHistogramsIngestionEnabled(userID string) bool {
 	return m.nativeHistogramsIngestionEnabled
+}
+
+func (m mockLimits) IgnoreNativeHistogramsOnRead(_ string) bool {
+	return m.ignoreNativeHistogramsOnRead
 }
 
 type mockHandler struct {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -736,31 +736,7 @@ func blockSeries(
 	}
 
 	if ignoreNativeHistograms {
-		seriesWriteIdx := 0
-		for _, series := range res {
-			chksWriteIdx := 0
-			for i := range series.chks {
-				ref := series.refs[i]
-				chk := series.chks[i]
-
-				if chk.Raw == nil {
-					continue
-				}
-
-				series.refs[chksWriteIdx] = ref
-				series.chks[chksWriteIdx] = chk
-				chksWriteIdx++
-			}
-			series.refs = series.refs[:chksWriteIdx]
-			series.chks = series.chks[:chksWriteIdx]
-
-			if len(series.chks) == 0 {
-				continue
-			}
-			res[seriesWriteIdx] = series
-			seriesWriteIdx++
-		}
-		res = res[:seriesWriteIdx]
+		res = filterNativeHistogramChunks(res)
 	}
 
 	reqStats.merge(&seriesCacheStats)

--- a/pkg/storegateway/bucket_chunk_reader_test.go
+++ b/pkg/storegateway/bucket_chunk_reader_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package storegateway
 
 import (

--- a/pkg/storegateway/bucket_chunk_reader_test.go
+++ b/pkg/storegateway/bucket_chunk_reader_test.go
@@ -1,0 +1,140 @@
+package storegateway
+
+import (
+	"context"
+	"path"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/log"
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore/providers/filesystem"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util/pool"
+)
+
+func TestLoad_IgnoreNativeHistogramChunks(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		chunks               []chunks.Meta
+		expectedNumNilChunks int
+	}{
+		{
+			name: "some chunks are histogram chunks",
+			chunks: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(10, 10, nil, nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(20, 20, nil, nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(30, 30, nil, nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(40, 0, tsdb.GenerateTestHistogram(1), nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(50, 50, nil, nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(60, 0, tsdb.GenerateTestHistogram(2), nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(70, 0, tsdb.GenerateTestHistogram(3), nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(80, 80, nil, nil),
+				}),
+			},
+			expectedNumNilChunks: 3,
+		},
+		{
+			name: "all chunks are histogram chunks",
+			chunks: []chunks.Meta{
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(10, 0, tsdb.GenerateTestHistogram(1), nil),
+				}),
+				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(20, 0, tsdb.GenerateTestHistogram(2), nil),
+				}),
+			},
+			expectedNumNilChunks: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := t.TempDir()
+
+			bkt, err := filesystem.NewBucket(d)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, bkt.Close()) }()
+
+			spec := testutil.BlockSeriesSpec{
+				Labels: labels.FromStrings("foo", "bar"),
+				Chunks: tc.chunks,
+			}
+
+			meta, err := testutil.GenerateBlockFromSpec("userID", d, []*testutil.BlockSeriesSpec{&spec})
+			require.NoError(t, err)
+
+			bb, err := newBucketBlock(
+				context.Background(),
+				"test",
+				log.NewNopLogger(),
+				NewBucketStoreMetrics(nil),
+				meta,
+				bkt,
+				path.Join(d, meta.ULID.String()),
+				nil,
+				nil,
+				nil,
+				newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
+				func() bool { return true },
+			)
+			require.NoError(t, err)
+
+			bktChkReader := bb.chunkReader(context.Background())
+			defer func() { require.NoError(t, bktChkReader.Close()) }()
+
+			res := []seriesEntry{
+				{
+					lset: spec.Labels,
+					refs: []chunks.ChunkRef{},
+					chks: make([]storepb.AggrChunk, len(spec.Chunks)),
+				},
+			}
+			for i, chkMeta := range spec.Chunks {
+				require.NoError(t, bktChkReader.addLoad(chkMeta.Ref, 0, i))
+				res[0].refs = append(res[0].refs, chkMeta.Ref)
+			}
+
+			chksPool := pool.NewSafeSlabPool[byte](pool.Interface(&sync.Pool{
+				New: nil,
+			}), 16384)
+
+			require.NoError(t, bktChkReader.load(res, chksPool, newSafeQueryStats()))
+
+			numNilChunks := 0
+			for _, chk := range res[0].chks {
+				if chk.Raw == nil {
+					numNilChunks++
+				}
+			}
+			require.Equal(t, tc.expectedNumNilChunks, numNilChunks)
+		})
+	}
+}
+
+func newSample(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) tsdbutil.Sample {
+	return sample{t, v, h, fh}
+}

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"google.golang.org/grpc/codes"
 
+	"github.com/grafana/mimir/pkg/util/validation"
+
 	"github.com/grafana/mimir/pkg/mimirpb"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
@@ -178,8 +180,11 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 	metaFetcher, err := block.NewMetaFetcher(s.logger, 20, objstore.WithNoopInstr(bkt), cfg.tempDir, nil, []block.MetadataFilter{})
 	assert.NoError(t, err)
 
+	overrides, err := validation.NewOverrides(validation.Limits{}, nil)
+	require.NoError(t, err)
+
 	// Have our options in the beginning so tests can override logger and index cache if they need to
-	storeOpts := append([]BucketStoreOption{WithLogger(s.logger), WithIndexCache(s.cache), WithChunksCache(s.cache)}, cfg.bucketStoreOpts...)
+	storeOpts := append([]BucketStoreOption{WithLogger(s.logger), WithIndexCache(s.cache), WithChunksCache(s.cache), WithIgnoreNativeHistogramChunks(overrides)}, cfg.bucketStoreOpts...)
 
 	store, err := NewBucketStore(
 		"tenant",

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -470,6 +470,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 		WithQueryGate(u.queryGate),
 		WithChunkPool(u.chunksPool),
 		WithStreamingSeriesPerBatch(u.cfg.BucketStore.StreamingBatchSize),
+		WithIgnoreNativeHistogramChunks(u.limits),
 	}
 
 	bs, err := NewBucketStore(

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2825,6 +2825,7 @@ func TestBlockSeries_IgnoreNativeHistograms(t *testing.T) {
 		_, chks := ss.At()
 		for _, chk := range chks {
 			require.Equal(t, storepb.Chunk_XOR, chk.Raw.Type)
+			require.NotNil(t, chk.Raw)
 		}
 	}
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -252,7 +252,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.")
-	f.BoolVar(&l.IgnoreNativeHistogramsOnRead, "store-gateway.ignore-native-histograms-on-read", false, "To stop processing native histograms as soon as possible, set to true")
+	f.BoolVar(&l.IgnoreNativeHistogramsOnRead, "store-gateway.ignore-native-histograms-on-read", true, "To stop processing native histograms as soon as possible, set to true")
 
 	// Alertmanager.
 	f.Var(&l.AlertmanagerReceiversBlockCIDRNetworks, "alertmanager.receivers-firewall-block-cidr-networks", "Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -103,6 +103,7 @@ type Limits struct {
 	MaxGlobalExemplarsPerUser int `yaml:"max_global_exemplars_per_user" json:"max_global_exemplars_per_user" category:"experimental"`
 	// Native histograms
 	NativeHistogramsIngestionEnabled bool `yaml:"native_histograms_ingestion_enabled" json:"native_histograms_ingestion_enabled" category:"experimental"`
+	IgnoreNativeHistogramsOnRead     bool `yaml:"ignore_native_histograms_on_read" json:"ignore_native_histograms_on_read" category:"experimental"`
 	// Active series custom trackers
 	ActiveSeriesCustomTrackersConfig activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
 	// Max allowed time window for out-of-order samples.
@@ -251,6 +252,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.")
+	f.BoolVar(&l.IgnoreNativeHistogramsOnRead, "store-gateway.ignore-native-histograms-on-read", false, "To stop processing native histograms as soon as possible, set to true")
 
 	// Alertmanager.
 	f.Var(&l.AlertmanagerReceiversBlockCIDRNetworks, "alertmanager.receivers-firewall-block-cidr-networks", "Comma-separated list of network CIDRs to block in Alertmanager receiver integrations.")
@@ -643,6 +645,11 @@ func (o *Overrides) MetricRelabelConfigs(userID string) []*relabel.Config {
 // NativeHistogramsIngestionEnabled returns whether to ingest native histograms in the ingester
 func (o *Overrides) NativeHistogramsIngestionEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).NativeHistogramsIngestionEnabled
+}
+
+// IgnoreNativeHistogramsOnRead returns whether to ignore native histograms in the ingester and store-gateway.
+func (o *Overrides) IgnoreNativeHistogramsOnRead(userID string) bool {
+	return o.getOverridesForUser(userID).IgnoreNativeHistogramsOnRead
 }
 
 // RulerTenantShardSize returns shard size (number of rulers) used by this tenant when using shuffle-sharding strategy.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds a per-tenant `IgnoreNativeHistogramsOnRead` override that stops native histogram chunks from being processed in the store gateway. 

#### Which issue(s) this PR fixes or relates to

Takes care of the store gateway half of https://github.com/grafana/mimir/issues/3971.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
