### PR TITLE
Query-frontend: Disambiguate logs for failed queries.

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -242,8 +242,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 		logStatus := "failed"
 		if errors.Is(queryErr, context.Canceled) {
 			logStatus = "canceled"
-		}
-		if errors.Is(queryErr, context.DeadlineExceeded) {
+		} else if errors.Is(queryErr, context.DeadlineExceeded) {
 			logStatus = "timeout"
 		}
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -239,8 +239,16 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 	}, formatQueryString(queryString)...)
 
 	if queryErr != nil {
+		logStatus := "failed"
+		if errors.Is(queryErr, context.Canceled) {
+			logStatus = "canceled"
+		}
+		if errors.Is(queryErr, context.DeadlineExceeded) {
+			logStatus = "timeout"
+		}
+
 		logMessage = append(logMessage,
-			"status", "failed",
+			"status", logStatus,
 			"err", queryErr)
 	} else {
 		logMessage = append(logMessage,

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -223,7 +223,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Contains(t, strings.TrimSpace(logs.String()), "sharded_queries")
-			assert.Contains(t, strings.TrimSpace(logs.String()), "status")
+			assert.Contains(t, strings.TrimSpace(logs.String()), "status=canceled")
 			if test.expectQueryParamLog {
 				assert.Contains(t, strings.TrimSpace(logs.String()), "param_query")
 			}


### PR DESCRIPTION
Instead of logging status=failed for all failed queries, disambiguate those
queries which failed for being canceled or being too slow. This makes analysis
of log files much easier, particularly when looking at trends in failed queries.
This can be achieved by grepping the `err` field of the log of course, but
I believe these two cases are significant enough to warrant special attention.

For example - when looking for logs of failed queries, we may not be interested
in queries cancelled by the user, or may only be interested in timeouts, etc.
