### PR TITLE
Return slice with ephemeral series back to pool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric does not exist, to avoid false positives on scaled objects with 0 min replicas. #4045
 * [BUGFIX] Alerts: `MimirCompactorHasNotSuccessfullyRunCompaction` is no longer triggered by frequent compactor restarts. #4012
 * [BUGFIX] Ingester: remove series from ephemeral storage even if there are no persistent series. #4052
+* [BUGFIX] Ingester: reuse memory when ingesting ephemeral series. #4072
 
 ### Jsonnet
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2530,7 +2530,10 @@ func (i *Ingester) checkRunning() error {
 // Push implements client.IngesterServer
 func (i *Ingester) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
 	pushReq := push.NewParsedRequest(req)
-	pushReq.AddCleanup(func() { mimirpb.ReuseSlice(req.Timeseries) })
+	pushReq.AddCleanup(func() {
+		mimirpb.ReuseSlice(req.Timeseries)
+		mimirpb.ReuseSlice(req.EphemeralTimeseries)
+	})
 	return i.PushWithCleanup(ctx, pushReq)
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6952,7 +6952,7 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 		},
 	})
 
-	// Pushing new series fails, because of limit of 1. This is a function because i.Push cleans up the request, but we want to reuse it.
+	// This is a function because i.Push cleans up the request, but we want to reuse it.
 	newReq := func() *mimirpb.WriteRequest {
 		return ToWriteRequestEphemeral(
 			[]labels.Labels{{{Name: labels.MetricName, Value: "new-metric"}}},
@@ -6962,6 +6962,7 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 			mimirpb.API,
 		)
 	}
+	// Pushing new series fails, because of limit of 1.
 	_, err = i.Push(ctx, newReq())
 	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(i.limiter.FormatError(userID, errMaxEphemeralSeriesPerUserLimitExceeded), userID).Error()), err)
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6899,15 +6899,27 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 
 	// Push ephemeral series with good timestamps (in last 10 minutes)
 	ctx := user.InjectOrgID(context.Background(), userID)
-	req := ToWriteRequestEphemeral(
-		[]labels.Labels{{{Name: labels.MetricName, Value: "test"}}},
-		[]mimirpb.Sample{{Value: float64(100), TimestampMs: now.Add(-9 * time.Minute).UnixMilli()}},
-		nil,
-		nil,
-		mimirpb.API,
-	)
-	_, err = i.Push(ctx, req)
-	require.NoError(t, err)
+	oldTS := now.Add(-9 * time.Minute).UnixMilli()
+	// This is a function, because i.Push() cleans up the passed request, but we want to reuse it.
+	oldReq := func() *mimirpb.WriteRequest {
+		return ToWriteRequestEphemeral(
+			[]labels.Labels{{{Name: labels.MetricName, Value: "test"}}},
+			[]mimirpb.Sample{{Value: float64(100), TimestampMs: oldTS}},
+			nil,
+			nil,
+			mimirpb.API,
+		)
+	}
+	{
+		r := oldReq()
+		require.NotEmpty(t, r.EphemeralTimeseries[0].Labels[0].Name)
+
+		_, err = i.Push(ctx, r)
+		require.NoError(t, err)
+
+		// Verify that ephemeral timeseries were cleaned in Push.
+		require.Empty(t, r.EphemeralTimeseries[0].Labels)
+	}
 
 	// Query back the series and verify that sample exists.
 	verifySamples := func(t *testing.T, expected model.Matrix) {
@@ -6940,15 +6952,17 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 		},
 	})
 
-	// Pushing new series fails, because of limit of 1.
-	newReq := ToWriteRequestEphemeral(
-		[]labels.Labels{{{Name: labels.MetricName, Value: "new-metric"}}},
-		[]mimirpb.Sample{{Value: float64(500), TimestampMs: now.UnixMilli()}},
-		nil,
-		nil,
-		mimirpb.API,
-	)
-	_, err = i.Push(ctx, newReq)
+	// Pushing new series fails, because of limit of 1. This is a function because i.Push cleans up the request, but we want to reuse it.
+	newReq := func() *mimirpb.WriteRequest {
+		return ToWriteRequestEphemeral(
+			[]labels.Labels{{{Name: labels.MetricName, Value: "new-metric"}}},
+			[]mimirpb.Sample{{Value: float64(500), TimestampMs: now.UnixMilli()}},
+			nil,
+			nil,
+			mimirpb.API,
+		)
+	}
+	_, err = i.Push(ctx, newReq())
 	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(i.limiter.FormatError(userID, errMaxEphemeralSeriesPerUserLimitExceeded), userID).Error()), err)
 
 	db := i.getTSDB(userID)
@@ -6961,11 +6975,11 @@ func TestIngesterTruncationOfEphemeralSeries(t *testing.T) {
 	verifySamples(t, nil)
 
 	// Pushing the same request should now fail, because min valid time for ephemeral storage has moved on to (now + 5 minutes - ephemeral series retention = now - 5 minutes)
-	_, err = i.Push(ctx, req)
-	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newEphemeralIngestErrSampleTimestampTooOld(model.Time(req.EphemeralTimeseries[0].Samples[0].TimestampMs), []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}), userID).Error()), err)
+	_, err = i.Push(ctx, oldReq())
+	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newEphemeralIngestErrSampleTimestampTooOld(model.Time(oldTS), []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}), userID).Error()), err)
 
 	// Pushing new series now works.
-	_, err = i.Push(ctx, newReq)
+	_, err = i.Push(ctx, newReq())
 	require.NoError(t, err)
 
 	verifySamples(t, model.Matrix{


### PR DESCRIPTION
#### What this PR does
This PR fixes omission when slice of ephemeral series was not returned to the pool.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
