### PR TITLE
Fix marshalling of `ephemeral_series_matchers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [BUGFIX] Alerts: `MimirCompactorHasNotSuccessfullyRunCompaction` is no longer triggered by frequent compactor restarts. #4012
 * [BUGFIX] Ingester: remove series from ephemeral storage even if there are no persistent series. #4052
 * [BUGFIX] Ingester: reuse memory when ingesting ephemeral series. #4072
+* [BUGFIX] Fix JSON and YAML marshalling of `ephemeral_series_matchers` field in `/runtime_config`. #4091
 
 ### Jsonnet
 

--- a/pkg/util/ephemeral/label_matchers.go
+++ b/pkg/util/ephemeral/label_matchers.go
@@ -220,9 +220,6 @@ func matchersConfigString(matchers map[Source][]string) string {
 	return sb.String()
 }
 
-// MarshalYAML implements yaml.Marshaler.
-//
-//goland:noinspection GoMixedReceiverTypes // We need MarshalYAML to be on non-pointer as validation.Limits doesn't use pointer to this struct.
 func (c LabelMatchers) MarshalYAML() (interface{}, error) {
 	return c.getMap(), nil
 }

--- a/pkg/util/ephemeral/label_matchers.go
+++ b/pkg/util/ephemeral/label_matchers.go
@@ -209,7 +209,9 @@ func matchersConfigString(matchers map[Source][]string) string {
 }
 
 // MarshalYAML implements yaml.Marshaler.
-func (c *LabelMatchers) MarshalYAML() (interface{}, error) {
+//
+//goland:noinspection GoMixedReceiverTypes // We need MarshalYAML to be on non-pointer as validation.Limits doesn't use pointer to this struct.
+func (c LabelMatchers) MarshalYAML() (interface{}, error) {
 	res := map[Source][]string{}
 
 	for _, source := range ValidSources {

--- a/pkg/util/ephemeral/label_matchers.go
+++ b/pkg/util/ephemeral/label_matchers.go
@@ -3,6 +3,7 @@
 package ephemeral
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -104,6 +105,17 @@ func (c *LabelMatchers) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	*c, err = parseLabelMatchers(rawMatchers)
+	return err
+}
+
+func (c *LabelMatchers) UnmarshalJSON(data []byte) error {
+	m := map[Source][]string{}
+	err := json.Unmarshal(data, &m)
+	if err != nil {
+		return err
+	}
+
+	*c, err = parseLabelMatchers(m)
 	return err
 }
 
@@ -212,6 +224,14 @@ func matchersConfigString(matchers map[Source][]string) string {
 //
 //goland:noinspection GoMixedReceiverTypes // We need MarshalYAML to be on non-pointer as validation.Limits doesn't use pointer to this struct.
 func (c LabelMatchers) MarshalYAML() (interface{}, error) {
+	return c.getMap(), nil
+}
+
+func (c LabelMatchers) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.getMap())
+}
+
+func (c LabelMatchers) getMap() map[Source][]string {
 	res := map[Source][]string{}
 
 	for _, source := range ValidSources {
@@ -222,5 +242,5 @@ func (c LabelMatchers) MarshalYAML() (interface{}, error) {
 		res[source] = c.raw[source]
 	}
 
-	return res, nil
+	return res
 }

--- a/pkg/util/ephemeral/label_matchers_test.go
+++ b/pkg/util/ephemeral/label_matchers_test.go
@@ -18,7 +18,7 @@ func TestParseLabelMatchers(t *testing.T) {
 		name           string
 		inputStringArg string
 		inputYamlBlob  string
-		inputJsonBlob  string
+		inputJSONBlob  string
 		expect         LabelMatchers
 		expectErr      bool
 	}
@@ -30,7 +30,7 @@ func TestParseLabelMatchers(t *testing.T) {
 			inputYamlBlob: `api:
     - '{__name__="foo"}'
 `,
-			inputJsonBlob: `{"api":["{__name__=\"foo\"}"]}`,
+			inputJSONBlob: `{"api":["{__name__=\"foo\"}"]}`,
 			expect: LabelMatchers{
 				raw: map[Source][]string{API: {`{__name__="foo"}`}},
 				bySource: map[Source]MatcherSetsForSource{
@@ -61,7 +61,7 @@ rule:
     - '{__name__="foo_rule", testLabel1="testValue1"}'
     - '{__name__="bar_rule", testLabel2="testValue2"}'
 `,
-			inputJsonBlob: `{"any":["{__name__=\"foo_any\", testLabel1=\"testValue1\"}","{__name__=\"bar_any\", testLabel2=\"testValue2\"}"],"api":["{__name__=\"bar_api\", testLabel2=\"testValue2\"}","{__name__=\"foo_api\", testLabel1=\"testValue1\"}"],"rule":["{__name__=\"foo_rule\", testLabel1=\"testValue1\"}","{__name__=\"bar_rule\", testLabel2=\"testValue2\"}"]}`,
+			inputJSONBlob: `{"any":["{__name__=\"foo_any\", testLabel1=\"testValue1\"}","{__name__=\"bar_any\", testLabel2=\"testValue2\"}"],"api":["{__name__=\"bar_api\", testLabel2=\"testValue2\"}","{__name__=\"foo_api\", testLabel1=\"testValue1\"}"],"rule":["{__name__=\"foo_rule\", testLabel1=\"testValue1\"}","{__name__=\"bar_rule\", testLabel2=\"testValue2\"}"]}`,
 			expect: LabelMatchers{
 				raw: map[Source][]string{
 					API:  {`{__name__="bar_api", testLabel2="testValue2"}`, `{__name__="foo_api", testLabel1="testValue1"}`},
@@ -162,20 +162,20 @@ api:
 
 			t.Run("unmarshal json", func(t *testing.T) {
 				got := LabelMatchers{}
-				gotErr := json.Unmarshal([]byte(tc.inputJsonBlob), &got)
+				gotErr := json.Unmarshal([]byte(tc.inputJSONBlob), &got)
 				check(t, tc.expect, got, tc.expectErr, gotErr)
 
 				if !tc.expectErr {
 					t.Run("marshal json", func(t *testing.T) {
-						gotJson, err := json.Marshal(&got)
+						gotJSON, err := json.Marshal(&got)
 						require.NoError(t, err)
-						require.Equal(t, tc.inputJsonBlob, string(gotJson))
+						require.Equal(t, tc.inputJSONBlob, string(gotJSON))
 					})
 
 					t.Run("marshal json (non-pointer)", func(t *testing.T) {
-						gotJson, err := json.Marshal(got)
+						gotJSON, err := json.Marshal(got)
 						require.NoError(t, err)
-						require.Equal(t, tc.inputJsonBlob, string(gotJson))
+						require.Equal(t, tc.inputJSONBlob, string(gotJSON))
 					})
 				}
 			})

--- a/pkg/util/ephemeral/label_matchers_test.go
+++ b/pkg/util/ephemeral/label_matchers_test.go
@@ -249,7 +249,12 @@ api:
 					t.Run("marshal yaml", func(t *testing.T) {
 						gotYaml, err := yaml.Marshal(&got)
 						require.NoError(t, err)
+						require.Equal(t, tc.inputYamlBlob, string(gotYaml))
+					})
 
+					t.Run("marshal yaml (non-pointer)", func(t *testing.T) {
+						gotYaml, err := yaml.Marshal(got)
+						require.NoError(t, err)
 						require.Equal(t, tc.inputYamlBlob, string(gotYaml))
 					})
 				}

--- a/pkg/util/ephemeral/label_matchers_test.go
+++ b/pkg/util/ephemeral/label_matchers_test.go
@@ -3,6 +3,7 @@
 package ephemeral
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -17,6 +18,7 @@ func TestParseLabelMatchers(t *testing.T) {
 		name           string
 		inputStringArg string
 		inputYamlBlob  string
+		inputJsonBlob  string
 		expect         LabelMatchers
 		expectErr      bool
 	}
@@ -28,6 +30,7 @@ func TestParseLabelMatchers(t *testing.T) {
 			inputYamlBlob: `api:
     - '{__name__="foo"}'
 `,
+			inputJsonBlob: `{"api":["{__name__=\"foo\"}"]}`,
 			expect: LabelMatchers{
 				raw: map[Source][]string{API: {`{__name__="foo"}`}},
 				bySource: map[Source]MatcherSetsForSource{
@@ -58,6 +61,7 @@ rule:
     - '{__name__="foo_rule", testLabel1="testValue1"}'
     - '{__name__="bar_rule", testLabel2="testValue2"}'
 `,
+			inputJsonBlob: `{"any":["{__name__=\"foo_any\", testLabel1=\"testValue1\"}","{__name__=\"bar_any\", testLabel2=\"testValue2\"}"],"api":["{__name__=\"bar_api\", testLabel2=\"testValue2\"}","{__name__=\"foo_api\", testLabel1=\"testValue1\"}"],"rule":["{__name__=\"foo_rule\", testLabel1=\"testValue1\"}","{__name__=\"bar_rule\", testLabel2=\"testValue2\"}"]}`,
 			expect: LabelMatchers{
 				raw: map[Source][]string{
 					API:  {`{__name__="bar_api", testLabel2="testValue2"}`, `{__name__="foo_api", testLabel1="testValue1"}`},
@@ -65,155 +69,51 @@ rule:
 					ANY:  {`{__name__="foo_any", testLabel1="testValue1"}`, `{__name__="bar_any", testLabel2="testValue2"}`},
 				},
 				bySource: map[Source]MatcherSetsForSource{
-					API: {
-						{
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_any",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_any",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_api",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_api",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						},
-					},
-					RULE: {
-						{
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_any",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_any",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_rule",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_rule",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						},
-					},
-					ANY: {
-						{
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_any",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_any",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_api",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_api",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "foo_rule",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel1",
-								Value: "testValue1",
-							},
-						}, {
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__name__",
-								Value: "bar_rule",
-							}, {
-								Type:  labels.MatchEqual,
-								Name:  "testLabel2",
-								Value: "testValue2",
-							},
-						},
-					},
+					API: {{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_any"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_any"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_api"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_api"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}},
+					RULE: {{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_any"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_any"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_rule"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_rule"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}},
+					ANY: {{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_any"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_any"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_api"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_api"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo_rule"},
+						{Type: labels.MatchEqual, Name: "testLabel1", Value: "testValue1"},
+					}, {
+						{Type: labels.MatchEqual, Name: "__name__", Value: "bar_rule"},
+						{Type: labels.MatchEqual, Name: "testLabel2", Value: "testValue2"},
+					}},
 				},
 				string: `any:{__name__="foo_any", testLabel1="testValue1"};any:{__name__="bar_any", testLabel2="testValue2"};api:{__name__="bar_api", testLabel2="testValue2"};api:{__name__="foo_api", testLabel1="testValue1"};rule:{__name__="foo_rule", testLabel1="testValue1"};rule:{__name__="bar_rule", testLabel2="testValue2"}`,
 			},
@@ -256,6 +156,26 @@ api:
 						gotYaml, err := yaml.Marshal(got)
 						require.NoError(t, err)
 						require.Equal(t, tc.inputYamlBlob, string(gotYaml))
+					})
+				}
+			})
+
+			t.Run("unmarshal json", func(t *testing.T) {
+				got := LabelMatchers{}
+				gotErr := json.Unmarshal([]byte(tc.inputJsonBlob), &got)
+				check(t, tc.expect, got, tc.expectErr, gotErr)
+
+				if !tc.expectErr {
+					t.Run("marshal json", func(t *testing.T) {
+						gotJson, err := json.Marshal(&got)
+						require.NoError(t, err)
+						require.Equal(t, tc.inputJsonBlob, string(gotJson))
+					})
+
+					t.Run("marshal json (non-pointer)", func(t *testing.T) {
+						gotJson, err := json.Marshal(got)
+						require.NoError(t, err)
+						require.Equal(t, tc.inputJsonBlob, string(gotJson))
 					})
 				}
 			})

--- a/pkg/util/ephemeral/source.go
+++ b/pkg/util/ephemeral/source.go
@@ -52,3 +52,16 @@ func (s *Source) UnmarshalYAML(value *yaml.Node) error {
 	*s = source
 	return nil
 }
+
+func (s Source) MarshalText() (text []byte, err error) {
+	return []byte(s.String()), nil
+}
+
+func (s *Source) UnmarshalText(text []byte) error {
+	source, err := convertStringToSource(string(text))
+	if err != nil {
+		return errors.Wrapf(err, "can't unmarshal source %q", string(text))
+	}
+	*s = source
+	return nil
+}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 func TestOverridesManager_GetOverrides(t *testing.T) {
@@ -645,4 +646,22 @@ metric_relabel_configs:
 		err := json.Unmarshal([]byte(cfg), &limits)
 		require.ErrorContains(t, err, "invalid metric_relabel_configs")
 	})
+}
+
+func TestUnmarshalMarshalLabelMatchers(t *testing.T) {
+	cfg := `
+ephemeral_series_matchers:
+    any:
+        - '{__name__!=""}'
+`
+
+	limits := Limits{}
+	err := yaml.Unmarshal([]byte(cfg), &limits)
+	require.NoError(t, err)
+
+	require.True(t, limits.EphemeralSeriesMatchers.ForSource(mimirpb.API).HasMatchers())
+
+	out, err := yaml.Marshal(&limits)
+	require.NoError(t, err)
+	require.Contains(t, string(out), cfg) // output contains many fields from Limits struct, but we only care for ephemeral_series_matchers
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -648,7 +648,7 @@ metric_relabel_configs:
 	})
 }
 
-func TestUnmarshalMarshalLabelMatchers(t *testing.T) {
+func TestYamlUnmarshalMarshalLabelMatchers(t *testing.T) {
 	cfg := `
 ephemeral_series_matchers:
     any:
@@ -662,6 +662,20 @@ ephemeral_series_matchers:
 	require.True(t, limits.EphemeralSeriesMatchers.ForSource(mimirpb.API).HasMatchers())
 
 	out, err := yaml.Marshal(&limits)
+	require.NoError(t, err)
+	require.Contains(t, string(out), cfg) // output contains many fields from Limits struct, but we only care for ephemeral_series_matchers
+}
+
+func TestJsonUnmarshalMarshalLabelMatchers(t *testing.T) {
+	cfg := `"ephemeral_series_matchers":{"any":["{__name__!=\"\"}"]}`
+
+	limits := Limits{}
+	err := json.Unmarshal([]byte("{"+cfg+"}"), &limits)
+	require.NoError(t, err)
+
+	require.True(t, limits.EphemeralSeriesMatchers.ForSource(mimirpb.API).HasMatchers())
+
+	out, err := json.Marshal(&limits)
 	require.NoError(t, err)
 	require.Contains(t, string(out), cfg) // output contains many fields from Limits struct, but we only care for ephemeral_series_matchers
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes marshalling of `ephemeral_series_matchers` field in Limits. This fixes its output in `/runtime_config` endpoint.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
