### PR TITLE
Include user agent in query stats logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Compactor: Add `reason` label to `cortex_compactor_runs_failed_total`. The value can be `shutdown` or `error`. #4012
 * [ENHANCEMENT] Store-gateway: enforce `max_fetched_series_per_query`. #4056
 * [ENHANCEMENT] Docs: use long flag names in runbook commands. #4088
+* [ENHANCEMENT] Query-frontend: log caller user agent in query stats logs. #4093
 
 ### Mixin
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -228,6 +228,7 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 		"component", "query-frontend",
 		"method", r.Method,
 		"path", r.URL.Path,
+		"user_agent", r.UserAgent(),
 		"response_time", queryResponseTime,
 		"query_wall_time_seconds", wallTime.Seconds(),
 		"fetched_series_count", numSeries,

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -72,6 +72,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 				r := httptest.NewRequest("POST", "/api/v1/query", strings.NewReader(form.Encode()))
 				r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+				r.Header.Add("User-Agent", "test-user-agent")
 				return r
 			},
 			expectedParams: url.Values{
@@ -175,6 +176,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.Equal(t, "query-frontend", msg["component"])
 				require.Equal(t, req.Method, msg["method"])
 				require.Equal(t, req.URL.Path, msg["path"])
+				require.Equal(t, req.UserAgent(), msg["user_agent"])
 				require.Contains(t, msg, "response_time")
 				require.Contains(t, msg, "query_wall_time_seconds")
 				require.EqualValues(t, 0, msg["fetched_series_count"])

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -172,8 +173,12 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.Len(t, logger.logMessages, 1)
 
 				msg := logger.logMessages[0]
+				require.Len(t, msg, 16+len(tt.expectedParams))
+				require.Equal(t, level.InfoValue(), msg["level"])
 				require.Equal(t, "query stats", msg["msg"])
 				require.Equal(t, "query-frontend", msg["component"])
+				require.Equal(t, "success", msg["status"])
+				require.Equal(t, "12345", msg["user"])
 				require.Equal(t, req.Method, msg["method"])
 				require.Equal(t, req.URL.Path, msg["path"])
 				require.Equal(t, req.UserAgent(), msg["user_agent"])


### PR DESCRIPTION
#### What this PR does

This PR adds the value of the `User-Agent` HTTP header to query stats logs. This is useful for diagnosing the source of query traffic (eg. a sudden increase in traffic or the source of a very expensive query).

This is only valuable if the caller sets a meaningful user agent, but it's better than nothing. For example, Grafana does send something meaningful (eg. `Grafana/9.3.6`), but other consumers don't (eg. `promtool` sends the default Golang user agent).

#### Which issue(s) this PR fixes or relates to

Fixes #3970.

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
