### PR TITLE
Disable fast-forward merge in merge-script

### DIFF
--- a/tools/release/merge-approved-pr-branch-to-main.sh
+++ b/tools/release/merge-approved-pr-branch-to-main.sh
@@ -52,7 +52,7 @@ git reset --hard "$FULL_MAIN_NAME"
 
 # We use $FULL_BRANCH_NAME here to make sure we merge the correct version of the branch
 # as found on server (updated via git fetch origin), and not possibly outdated local copy.
-git merge -n -m "Merge branch $BRANCH_NAME to main." "$FULL_BRANCH_NAME" || (echo; echo "Merge failed. This can happen if there are unresolved merge conflicts."; echo "Please update $BRANCH_NAME to fix conflicts and run this script again."; exit 1)
+git merge --no-ff --no-stat -m "Merge branch $BRANCH_NAME to main." "$FULL_BRANCH_NAME" || (echo; echo "Merge failed. This can happen if there are unresolved merge conflicts."; echo "Please update $BRANCH_NAME to fix conflicts and run this script again."; exit 1)
 
 echo
 echo "Merge successful, pushing to origin..."


### PR DESCRIPTION
#### What this PR does
This PR updates `merged-approved-pr-branch-to-main.sh` script to never do fast-forward merge. 

This is what happened on last merge of `release-2.6` to `main`, as there were no additional commits on `main` since creation of the branch. We always want a merge commit when doing such a merge.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
