### PR TITLE
Mixin: Add experimental Loki recording rules for query analysis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Add auto-scaling panels to ruler dashboard. #4046
 * [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049
 * [ENHANCEMENT] Dashboards: distinguish between label names and label values queries. #4065
+* [ENHANCEMENT] Dashboards: add experimental recording rules and dashboards for viewing statistics from query-frontend log lines. Enabled by adding `experimental_query_loki_recording_rules_enabled: true` to the Mixin configuration. #4097
 * [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric does not exist, to avoid false positives on scaled objects with 0 min replicas. #4045
 * [BUGFIX] Alerts: `MimirCompactorHasNotSuccessfullyRunCompaction` is no longer triggered by frequent compactor restarts. #4012
 * [BUGFIX] Ingester: remove series from ephemeral storage even if there are no persistent series. #4052

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -629,5 +629,13 @@
     // Set to at least twice the scrape interval; otherwise, recording rules will output no data.
     // Set to four times the scrape interval to account for edge cases: https://www.robustperception.io/what-range-should-i-use-with-rate/
     recording_rules_range_interval: '1m',
+
+    // Enable experimental Loki recording rules to analyze query-frontend logs,
+    // and some additional dashboards to show the results.
+    experimental_query_loki_recording_rules_enabled: false,
+
+    // Optionally set to a suitable matcher for discovering Mimir logs stored in Loki. For example:
+    //   namespace=~".*(mimir).*"
+    loki_recording_rules_matcher: '',
   },
 }

--- a/operations/mimir-mixin/dashboards.libsonnet
+++ b/operations/mimir-mixin/dashboards.libsonnet
@@ -28,5 +28,9 @@
        (import 'dashboards/writes-networking.libsonnet') +
        (import 'dashboards/alertmanager-resources.libsonnet')) +
 
+    (if !$._config.experimental_query_loki_recording_rules_enabled then {} else
+       (import 'dashboards/tenants-queries.libsonnet') +
+       (import 'dashboards/top-tenants-queries.libsonnet')) +
+
     { _config:: $._config + $._group_config },
 }

--- a/operations/mimir-mixin/dashboards/tenants-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants-queries.libsonnet
@@ -1,0 +1,218 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-tenants-queries.json';
+
+(import 'dashboard-utils.libsonnet') {
+  [filename]:
+    ($.dashboard('Tenants (Queries)') + { uid: std.md5(filename) })
+    .addClusterSelectorTemplates(multi=false)
+    .addActiveUserSelectorTemplates()
+    .addRow(
+      ($.row('Tenants (Queries) dashboard description') { height: '25px', showTitle: false })
+      .addPanel(
+        $.textPanel('', |||
+          <p>
+            This dashboard shows statistics derived from query-frontend logs, detailed by tenant (user) selected above.
+          </p>
+        |||),
+      )
+    )
+
+
+    .addRow(
+      $.row('Queries')
+      .addPanel(
+        $.panel('Requests / sec') +
+        $.queryPanel(
+          |||
+            sum by (status) (mimir_user:queries:rate5m{%(matcher)s, user="$user"})
+          |||
+          % { matcher: $.namespaceMatcher() },
+          '{{ status }}'
+        ) +
+        $.stack +
+        {
+          yaxes: $.yaxes('reqps'),
+          aliasColors: {
+            success: '#7EB26D',
+            failed: '#E24D42',
+          },
+        }
+      )
+      .addPanel(
+        $.panel('Latency') +
+        $.queryPanel(
+          [
+            'mimir_user:query_response_time_seconds_p99:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_response_time_seconds_p90:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_response_time_seconds_p50:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            '99th Percentile',
+            '90th Percentile',
+            '50th Percentile',
+          ]
+        ) +
+        { yaxes: $.yaxes('s') }
+      )
+    )
+
+    .addRow(
+      $.row('Statistics: Wall Time')
+      .addPanel(
+        $.panel('Wall Time (per query)') +
+        $.queryPanel(
+          [
+            'mimir_user:query_wall_time_seconds_p99:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_wall_time_seconds_p90:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_wall_time_seconds_p50:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            '99th Percentile',
+            '90th Percentile',
+            '50th Percentile',
+          ]
+        ) +
+        { yaxes: $.yaxes('s') }
+      )
+      .addPanel(
+        $.panel('Wall Time (user total per second)') +
+        $.queryPanel(
+          [
+            'sum by (user) (mimir_user:query_wall_time_seconds:rate5m{%(matcher)s, user="$user"})'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            'total',
+          ]
+        ) +
+        { yaxes: $.yaxes('s') }
+      )
+      .addPanel(
+        $.panel('Wall Time (user total vs namespace total)') +
+        $.queryPanel(
+          [
+            |||
+              sum by (namespace, user) (mimir_user:query_wall_time_seconds:rate5m{%(matcher)s, user="$user"})
+              / on(namespace) group_left
+              sum by (namespace) (mimir_user:query_wall_time_seconds:rate5m{%(matcher)s})
+            |||
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            'percent',
+          ]
+        ) +
+        { yaxes: $.yaxes('percentunit') }
+      )
+    )
+    .addRow(
+      $.row('Statistics: Fetched Chunk Bytes')
+      .addPanel(
+        $.panel('Fetched Chunk Bytes (per query)') +
+        $.queryPanel(
+          [
+            'mimir_user:query_fetched_chunk_bytes_p99:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_fetched_chunk_bytes_p90:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_fetched_chunk_bytes_p50:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            '99th Percentile',
+            '90th Percentile',
+            '50th Percentile',
+          ]
+        ) +
+        { yaxes: $.yaxes('bytes') }
+      )
+      .addPanel(
+        $.panel('Fetched Chunk Bytes (user total per second)') +
+        $.queryPanel(
+          [
+            'sum by (user) (mimir_user:query_fetched_chunk_bytes:rate5m{%(matcher)s, user="$user"})'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            'total',
+          ]
+        ) +
+        { yaxes: $.yaxes('bytes') }
+      )
+      .addPanel(
+        $.panel('Fetched Chunk Bytes (user total vs namespace total)') +
+        $.queryPanel(
+          [
+            |||
+              sum by (namespace, user) (mimir_user:query_fetched_chunk_bytes:rate5m{%(matcher)s, user="$user"})
+              / on(namespace) group_left
+              sum by (namespace) (mimir_user:query_fetched_chunk_bytes:rate5m{%(matcher)s})
+            |||
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            'percent',
+          ]
+        ) +
+        { yaxes: $.yaxes('percentunit') }
+      )
+    )
+    .addRow(
+      $.row('Statistics: Fetched Index Bytes')
+      .addPanel(
+        $.panel('Fetched Index Bytes (per query)') +
+        $.queryPanel(
+          [
+            'mimir_user:query_fetched_index_bytes_p99:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_fetched_index_bytes_p90:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+            'mimir_user:query_fetched_index_bytes_p50:rate5m{%(matcher)s, user="$user"}'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            '99th Percentile',
+            '90th Percentile',
+            '50th Percentile',
+          ]
+        ) +
+        { yaxes: $.yaxes('bytes') }
+      )
+      .addPanel(
+        $.panel('Fetched Index Bytes (user total per second)') +
+        $.queryPanel(
+          [
+            'sum by (user) (mimir_user:query_fetched_index_bytes:rate5m{%(matcher)s, user="$user"})'
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            'total',
+          ]
+        ) +
+        { yaxes: $.yaxes('bytes') }
+      )
+      .addPanel(
+        $.panel('Fetched Index Bytes (user total vs namespace total)') +
+        $.queryPanel(
+          [
+            |||
+              sum by (namespace, user) (mimir_user:query_fetched_index_bytes:rate5m{%(matcher)s, user="$user"})
+              / on(namespace) group_left
+              sum by (namespace) (mimir_user:query_fetched_index_bytes:rate5m{%(matcher)s})
+            |||
+            % { matcher: $.namespaceMatcher() },
+          ],
+          [
+            'percent',
+          ]
+        ) +
+        { yaxes: $.yaxes('percentunit') }
+      )
+    ),
+}

--- a/operations/mimir-mixin/dashboards/top-tenants-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/top-tenants-queries.libsonnet
@@ -1,0 +1,292 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+local filename = 'mimir-top-tenants-queries.json';
+
+(import 'dashboard-utils.libsonnet') {
+  [filename]:
+    ($.dashboard('Top tenants (Queries)') + { uid: std.md5(filename) })
+    .addClusterSelectorTemplates()
+    .addCustomTemplate('limit', ['10', '50', '100'])
+    .addRow(
+      ($.row('Top tenants dashboard description') { height: '25px', showTitle: false })
+      .addPanel(
+        $.textPanel('', |||
+          <p>
+            This dashboard shows the top tenants based on statistics derived from query-frontend logs.
+            Rows are collapsed by default to avoid querying all of them.
+            Use the templating variable "limit" above to select the amount of users to be shown.
+          </p>
+        |||),
+      )
+    )
+
+    .addRow(
+      ($.row('By query rate') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by query rate') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:queries:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'queries/sec' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By query failure rate') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by query failure rate') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:queries:rate5m{%(matcher)s,status="failed"})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'failures/sec' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By query failure rate (percentage)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by query failure rate (as percentage of total rate)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:queries:rate5m{%(matcher)s,status="failed"})
+                /
+                sum by (namespace, user) (mimir_user:queries:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: '% failures/sec' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By response time (p99)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by query response time (p99)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                max by (namespace, user) (mimir_user:query_response_time_seconds_p99:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'seconds' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By wall clock time (p99)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by wall clock time per query (p99)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                max by (namespace, user) (mimir_user:query_wall_time_seconds_p99:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'seconds' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By wall clock time (total)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by wall clock time for all queries (querier seconds per second)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:query_wall_time_seconds:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'seconds/sec' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By wall clock time (total vs all users)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by wall clock time over all queries (percentage vs total for all users)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:query_wall_time_seconds:rate5m{%(matcher)s})
+                / on(namespace) group_left
+                sum by (namespace) (mimir_user:query_wall_time_seconds:rate5m{%(matcher)s})
+              )
+              * 100
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: '%' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By fetched chunk bytes (p99)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by fetched chunk bytes per query (p99)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                max by (namespace, user) (mimir_user:query_fetched_chunk_bytes_p99:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'bytes' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By fetched chunk bytes (total)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by fetched chunk bytes over all queries (bytes per second)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:query_fetched_chunk_bytes:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'bytes/sec' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By fetched chunk bytes (total vs all users)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by fetched chunk bytes over all queries (percentage vs total for all users)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:query_fetched_chunk_bytes:rate5m{%(matcher)s})
+                / on(namespace) group_left
+                sum by (namespace) (mimir_user:query_fetched_chunk_bytes:rate5m{%(matcher)s})
+              )
+              * 100
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: '%' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By fetched index bytes (p99)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by fetched index bytes per query (p99)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                max by (namespace, user) (mimir_user:query_fetched_index_bytes_p99:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'bytes' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By fetched index bytes (total)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by fetched index bytes over all queries (bytes per second)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:query_fetched_index_bytes:rate5m{%(matcher)s})
+              )
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: 'bytes/sec' } }
+        )
+      )
+    )
+
+    .addRow(
+      ($.row('By fetched index bytes (total vs all users)') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by fetched index bytes over all queries (percentage vs total for all users)') +
+        { sort: { col: 3, desc: true } } +
+        $.tablePanel(
+          [
+            |||
+              topk($limit,
+                sum by (namespace, user) (mimir_user:query_fetched_index_bytes:rate5m{%(matcher)s})
+                / on(namespace) group_left
+                sum by (namespace) (mimir_user:query_fetched_index_bytes:rate5m{%(matcher)s})
+              )
+              * 100
+            ||| % {
+              matcher: $.namespaceMatcher(),
+            },
+          ],
+          { Value: { alias: '%' } }
+        )
+      )
+    ),
+}


### PR DESCRIPTION
Adds some experimental Loki recording rules (and some associated dashboards) to extract useful insights about costly queries from query-frontend log lines. The motivation to use Loki recording rules is as follows:

- If we added similar metrics on a per-`user` basis, the metrics would potentially be very high cardinality, especially if we wanted to add histograms (for computing p99, etc).
- Querying the information from Loki over large time windows becomes prohibitively slow, particularly some interesting types of analysis, such as `(tenant wall time) / (total wall time)` or `topk()` over week.

I'm sure there is plenty to discuss here, including the necessity of the rules, but I would like to propose it anyway and perhaps we can merge it in some form, to get some feedback about how useful it is from users.

Screenshots:

![Screenshot from 2023-01-26 17-02-56](https://user-images.githubusercontent.com/78375245/215460260-c2e4b4b2-704a-43bd-81cb-2276e1f0209f.png)

![Screenshot from 2023-01-26 17-02-43](https://user-images.githubusercontent.com/78375245/215460280-761d7759-1fd8-4445-90bd-c8dcb322b918.png)
