### PR TITLE
Clarify that memberlist cannot be used for HA dedupe.

### DIFF
--- a/docs/sources/mimir/operators-guide/architecture/key-value-store.md
+++ b/docs/sources/mimir/operators-guide/architecture/key-value-store.md
@@ -30,6 +30,8 @@ We recommend that you use memberlist to run Grafana Mimir.
 
 To configure memberlist, refer to [configuring hash rings]({{< relref "../configure/configure-hash-rings.md" >}}).
 
+> **Note:** The Gossip-based memberlist protocol is not supported for the [optional distributor high-availability tracker]({{< relref "../configure/configure-high-availability-deduplication.md" >}}).
+
 ### Consul
 
 Grafana Mimir supports [Consul](https://www.consul.io) as a backend KV store.


### PR DESCRIPTION
#### What this PR does

This PR clarifies the docs for memberlist, making it clear that memberlist is not supported for HA dedupe.

See https://grafana.slack.com/archives/C039863E8P7/p1674794022250729 for community question about this.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
