### PR TITLE
Rewrite aliases to be relative

### DIFF
--- a/docs/sources/mimir/operators-guide/configure/_index.md
+++ b/docs/sources/mimir/operators-guide/configure/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/
+  - configuring/
 description: This section provides links to Grafana Mimir configuration topics.
 keywords:
   - Mimir configuration

--- a/docs/sources/mimir/operators-guide/configure/about-configurations.md
+++ b/docs/sources/mimir/operators-guide/configure/about-configurations.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/about-configurations/
+  - ../configuring/about-configurations/
 description: Learn about Grafana Mimir configuration and key guidelines to consider.
 menuTitle: About configurations
 title: About Grafana Mimir configurations

--- a/docs/sources/mimir/operators-guide/configure/about-dns-service-discovery.md
+++ b/docs/sources/mimir/operators-guide/configure/about-dns-service-discovery.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/about-dns-service-discovery/
+  - ../configuring/about-dns-service-discovery/
 description:
   DNS service discovery finds addresses of backend services to which Grafana
   Mimir connects.

--- a/docs/sources/mimir/operators-guide/configure/about-ip-address-logging.md
+++ b/docs/sources/mimir/operators-guide/configure/about-ip-address-logging.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/about-ip-address-logging/
+  - ../configuring/about-ip-address-logging/
 description: Troubleshoot errors by logging IP addresses of reverse proxies.
 menuTitle: About IP address logging of a reverse proxy
 title: About Grafana Mimir IP address logging of a reverse proxy

--- a/docs/sources/mimir/operators-guide/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/operators-guide/configure/about-runtime-configuration.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/about-runtime-configuration/
+  - ../configuring/about-runtime-configuration/
 description:
   Runtime configuration enables you to change a subset of configurations
   without restarting Grafana Mimir.

--- a/docs/sources/mimir/operators-guide/configure/about-tenant-ids.md
+++ b/docs/sources/mimir/operators-guide/configure/about-tenant-ids.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/about-tenant-ids/
+  - ../configuring/about-tenant-ids/
 description: Learn about tenant ID restrictions.
 menuTitle: About tenant IDs
 title: About Grafana Mimir tenant IDs

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/about-versioning/
+  - ../configuring/about-versioning/
 description: Learn about guarantees for this Grafana Mimir major release.
 menuTitle: About versioning
 title: About Grafana Mimir versioning

--- a/docs/sources/mimir/operators-guide/configure/configure-custom-trackers.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-custom-trackers.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-custom-trackers/
-  - /docs/mimir/latest/operators-guide/configure/configuring-custom-trackers/
+  - ../configuring/configuring-custom-trackers/
+  - configuring-custom-trackers/
 description: Use the custom tracker to count the number of active series on an ingester.
 menuTitle: Configure custom active series trackers
 title: Configure custom active series trackers

--- a/docs/sources/mimir/operators-guide/configure/configure-hash-rings.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-hash-rings.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-hash-rings/
-  - /docs/mimir/latest/operators-guide/configure/configuring-hash-rings/
+  - ../configuring/configuring-hash-rings/
+  - configuring-hash-rings/
 description: Learn how to configure Grafana Mimir hash rings.
 menuTitle: Configure hash rings
 title: Configure Grafana Mimir hash rings

--- a/docs/sources/mimir/operators-guide/configure/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-helm-ha-deduplication-consul/index.md
@@ -1,9 +1,13 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configure-helm-ha-deduplication-consul/
-description: Learn how to configure the Grafana Mimir Helm chart to handle HA Prometheus server deduplication with Consul.
+  - ../configuring/configure-helm-ha-deduplication-consul/
+description:
+  Learn how to configure the Grafana Mimir Helm chart to handle HA Prometheus
+  server deduplication with Consul.
 menuTitle: Configure high-availability deduplication with Consul
-title: Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication with Consul
+title:
+  Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication
+  with Consul
 weight: 70
 ---
 

--- a/docs/sources/mimir/operators-guide/configure/configure-high-availability-deduplication.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-high-availability-deduplication.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-high-availability-deduplication/
-  - /docs/mimir/latest/operators-guide/configure/configuring-high-availability-deduplication/
+  - ../configuring/configuring-high-availability-deduplication/
+  - configuring-high-availability-deduplication/
 description: Learn how to configure Grafana Mimir to handle HA Prometheus server deduplication.
 menuTitle: Configure high-availability deduplication
 title: Configure Grafana Mimir high-availability deduplication

--- a/docs/sources/mimir/operators-guide/configure/configure-shuffle-sharding/index.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-shuffle-sharding/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-shuffle-sharding/
-  - /docs/mimir/latest/operators-guide/configure/configuring-shuffle-sharding/
+  - ../configuring/configuring-shuffle-sharding/
+  - configuring-shuffle-sharding/
 description: Learn how to configure shuffle sharding.
 menuTitle: Configure shuffle sharding
 title: Configure Grafana Mimir shuffle sharding

--- a/docs/sources/mimir/operators-guide/configure/configure-the-query-frontend-work-with-prometheus.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-the-query-frontend-work-with-prometheus.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-the-query-frontend-work-with-prometheus/
-  - /docs/mimir/latest/operators-guide/configure/configuring-the-query-frontend-work-with-prometheus/
+  - ../configuring/configuring-the-query-frontend-work-with-prometheus/
+  - configuring-the-query-frontend-work-with-prometheus/
 description: Learn how to configure the query-frontend to work with Prometheus.
 menuTitle: Configure the query-frontend to work with Prometheus
 title: Configure the Grafana Mimir query-frontend to work with Prometheus

--- a/docs/sources/mimir/operators-guide/configure/configure-tracing.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-tracing.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-tracing/
-  - /docs/mimir/latest/operators-guide/configure/configuring-tracing/
+  - ../configuring/configuring-tracing/
+  - configuring-tracing/
 description: Learn how to configure Grafana Mimir to send traces to Jaeger.
 menuTitle: Configure tracing
 title: Configure Grafana Mimir tracing

--- a/docs/sources/mimir/operators-guide/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-zone-aware-replication.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/configuring-zone-aware-replication/
-  - /docs/mimir/latest/operators-guide/configure/configuring-zone-aware-replication/
+  - ../configuring/configuring-zone-aware-replication/
+  - configuring-zone-aware-replication/
 description: Learn how to replicate data across failure domains.
 menuTitle: Configure zone-aware replication
 title: Configure Grafana Mimir zone-aware replication

--- a/docs/sources/mimir/operators-guide/configure/mirror-requests-to-a-second-cluster/index.md
+++ b/docs/sources/mimir/operators-guide/configure/mirror-requests-to-a-second-cluster/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/mirroring-requests-to-a-second-cluster/
-  - /docs/mimir/latest/operators-guide/configure/mirroring-requests-to-a-second-cluster/
+  - ../configuring/mirroring-requests-to-a-second-cluster/
+  - mirroring-requests-to-a-second-cluster/
 description:
   Learn how to set up a testing cluster that receives the same series of
   the primary cluster.

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/_index.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/
+  - deploying-grafana-mimir/
 description: Learn how to deploy Grafana Mimir on Kubernetes.
 keywords:
   - Mimir deployment

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/getting-started-helm-charts/_index.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/getting-started-helm-charts/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/getting-started-helm-charts/
+  - ../deploying-grafana-mimir/getting-started-helm-charts/
 description: Learn how to get started with Grafana Mimir using the Helm chart.
 menuTitle: Getting started using the Helm chart
 title: Getting started with Grafana Mimir using the Helm chart

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/_index.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/
+  - ../deploying-grafana-mimir/jsonnet/
 description: Learn how to deploy Grafana Mimir on Kubernetes with Jsonnet and Tanka.
 keywords:
   - Mimir deployment

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/configure-autoscaling.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/configure-autoscaling.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/configuring-autoscaling/
-  - /docs/mimir/latest/operators-guide/deploy-grafana-mimir/jsonnet/configuring-autoscaling/
+  - ../../deploying-grafana-mimir/jsonnet/configuring-autoscaling/
+  - configuring-autoscaling/
 description: Learn how to configure Grafana Mimir autoscaling when using Jsonnet.
 menuTitle: Configure autoscaling
 title: Configure Grafana Mimir autoscaling with Jsonnet

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/configure-low-resources.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/configure-low-resources.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/configuring-low-resources/
-  - /docs/mimir/latest/operators-guide/deploy-grafana-mimir/jsonnet/configuring-low-resources/
+  - ../../deploying-grafana-mimir/jsonnet/configuring-low-resources/
+  - configuring-low-resources/
 description: Learn how to configure Grafana Mimir when using Jsonnet.
 menuTitle: Configure low resources
 title: Configure Grafana Mimir to use low resources with Jsonnet

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/configure-ruler.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/configure-ruler.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/configuring-ruler/
-  - /docs/mimir/latest/operators-guide/deploy-grafana-mimir/jsonnet/configuring-ruler/
+  - ../../deploying-grafana-mimir/jsonnet/configuring-ruler/
+  - configuring-ruler/
 description: Learn how to configure the Grafana Mimir ruler when using Jsonnet.
 menuTitle: Configure ruler
 title: Configure the Grafana Mimir ruler with Jsonnet

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/deploy.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/deploy.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/deploying/
-  - /docs/mimir/latest/operators-guide/deploy-grafana-mimir/jsonnet/deploying/
+  - ../../deploying-grafana-mimir/jsonnet/deploying/
+  - deploying/
 description: Learn how to deploy Grafana Mimir on Kubernetes with Jsonnet and Tanka.
 menuTitle: Deploy with Jsonnet
 title: Deploy Grafana Mimir with Jsonnet and Tanka

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-from-consul-to-memberlist.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/jsonnet/migrate-from-consul-to-memberlist.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/jsonnet/migrating-from-consul-to-memberlist/
-  - /docs/mimir/latest/operators-guide/deploy-grafana-mimir/jsonnet/migrating-from-consul-to-memberlist/
+  - ../../deploying-grafana-mimir/jsonnet/migrating-from-consul-to-memberlist/
+  - migrating-from-consul-to-memberlist/
 description:
   Learn how to migrate from using Consul as KV store for hash rings to
   using memberlist without any downtime.

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/migrate-to-unified-proxy-deployment/_index.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/migrate-to-unified-proxy-deployment/_index.md
@@ -1,10 +1,12 @@
 ---
-description: "Migrate to the unified gateway deployment for NGINX and GEM gateway in Helm"
-title: "Migrate to the unified gateway deployment for NGINX and GEM gateway in Helm"
-menuTitle: "Unified gateway deployment for NGINX and GEM gateway in Helm"
-weight: 110
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/migrate-to-unified-gateway-deployment/
+  - ../deploying-grafana-mimir/migrate-to-unified-gateway-deployment/
+description:
+  Migrate to the unified gateway deployment for NGINX and GEM gateway in
+  Helm
+menuTitle: Unified gateway deployment for NGINX and GEM gateway in Helm
+title: Migrate to the unified gateway deployment for NGINX and GEM gateway in Helm
+weight: 110
 ---
 
 This page has moved to a new location in [the Grafana Mimir Helm chart documentation](/docs/helm-charts/mimir-distributed/latest/).

--- a/docs/sources/mimir/operators-guide/deploy-grafana-mimir/upgrade-helm-chart-2.1-to-3.0/_index.md
+++ b/docs/sources/mimir/operators-guide/deploy-grafana-mimir/upgrade-helm-chart-2.1-to-3.0/_index.md
@@ -1,9 +1,9 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/deploying-grafana-mimir/upgrade-helm-chart-2.1-to-3.0/
-description: "Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0"
-title: "Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0"
-menuTitle: "Upgrade Helm chart 2.1 to 3.0"
+  - ../deploying-grafana-mimir/upgrade-helm-chart-2.1-to-3.0/
+description: Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0
+menuTitle: Upgrade Helm chart 2.1 to 3.0
+title: Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0
 weight: 100
 ---
 

--- a/docs/sources/mimir/operators-guide/get-started/_index.md
+++ b/docs/sources/mimir/operators-guide/get-started/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/getting-started/
+  - getting-started/
 description: Learn how to get started with Grafana Mimir.
 menuTitle: Get started
 title: Get started with Grafana Mimir

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/_index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/
+  - monitoring-grafana-mimir/
   - /visualizing-metrics/
 description: View example Grafana Mimir dashboards.
 keywords:

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/collecting-metrics-and-logs/
+  - ../monitoring-grafana-mimir/collecting-metrics-and-logs/
 description: Learn how to collect metrics and logs from Grafana Mimir itself
 menuTitle: Collecting metrics and logs
 title: Collecting metrics and logs from Grafana Mimir

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/_index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../visualizing-metrics/dashboards/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/
+  - ../monitoring-grafana-mimir/dashboards/
 description: View examples of production-ready Grafana Mimir dashboards.
 menuTitle: Viewing dashboards
 title: Viewing Grafana Mimir dashboards

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/alertmanager-resources/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/alertmanager-resources/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/alertmanager-resources/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager-resources/
+  - ../../monitoring-grafana-mimir/dashboards/alertmanager-resources/
 description: View an example Alertmanager resources dashboard.
 menuTitle: Alertmanager resources
 title: Grafana Mimir Alertmanager resources dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/alertmanager/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/alertmanager/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/alertmanager/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/alertmanager/
+  - ../../monitoring-grafana-mimir/dashboards/alertmanager/
 description: View an example Alertmanager dashboard.
 menuTitle: Alertmanager
 title: Grafana Mimir Alertmanager dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/compactor-resources/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/compactor-resources/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/compactor-resources/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/compactor-resources/
+  - ../../monitoring-grafana-mimir/dashboards/compactor-resources/
 description: View an example Compactor resources dashboard.
 menuTitle: Compactor resources
 title: Grafana Mimir Compactor resources dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/compactor/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/compactor/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/compactor/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/compactor/
+  - ../../monitoring-grafana-mimir/dashboards/compactor/
 description: View an example Compactor dashboard.
 menuTitle: Compactor
 title: Grafana Mimir Compactor dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/config/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/config/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/config/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/config/
+  - ../../monitoring-grafana-mimir/dashboards/config/
 description: View an example Config dashboard.
 menuTitle: Config
 title: Grafana Mimir Config dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/object-store/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/object-store/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/object-store/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/object-store/
+  - ../../monitoring-grafana-mimir/dashboards/object-store/
 description: View an example Object Store dashboard.
 menuTitle: Object Store
 title: Grafana Mimir Object Store dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/overrides/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/overrides/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/overrides/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/overrides/
+  - ../../monitoring-grafana-mimir/dashboards/overrides/
 description: View an example Overrides dashboard.
 menuTitle: Overrides
 title: Grafana Mimir Overrides dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/queries/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/queries/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/queries/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/queries/
+  - ../../monitoring-grafana-mimir/dashboards/queries/
 description: View an example Queries dashboard.
 menuTitle: Queries
 title: Grafana Mimir Queries dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/reads-networking/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/reads-networking/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/reads-networking/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/reads-networking/
+  - ../../monitoring-grafana-mimir/dashboards/reads-networking/
 description: View an example Reads networking dashboard.
 menuTitle: Reads networking
 title: Grafana Mimir Reads networking dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/reads-resources/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/reads-resources/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/reads-resources/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/reads-resources/
+  - ../../monitoring-grafana-mimir/dashboards/reads-resources/
 description: View an example Reads resources dashboard.
 menuTitle: Reads resources
 title: Grafana Mimir Reads resources dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/reads/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/reads/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/reads/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/reads/
+  - ../../monitoring-grafana-mimir/dashboards/reads/
 description: View an example Reads dashboard.
 menuTitle: Reads
 title: Grafana Mimir Reads dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/remote-ruler-reads-resources/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/remote-ruler-reads-resources/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/remote-ruler-reads-resources/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads-resources/
+  - ../../monitoring-grafana-mimir/dashboards/remote-ruler-reads-resources/
 description: View an example Remote ruler reads resources dashboard.
 menuTitle: Remote ruler reads resources
 title: Grafana Mimir Remote ruler reads resources dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/remote-ruler-reads/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/remote-ruler-reads/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/remote-ruler-reads/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/remote-ruler-reads/
+  - ../../monitoring-grafana-mimir/dashboards/remote-ruler-reads/
 description: View an example Remote ruler reads dashboard.
 menuTitle: Remote ruler reads
 title: Grafana Mimir Remote ruler reads dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/rollout-progress/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/rollout-progress/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/rollout-progress/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/rollout-progress/
+  - ../../monitoring-grafana-mimir/dashboards/rollout-progress/
 description: View an example Rollout progress dashboard.
 menuTitle: Rollout progress
 title: Grafana Mimir Rollout progress dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/ruler/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/ruler/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/ruler/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/ruler/
+  - ../../monitoring-grafana-mimir/dashboards/ruler/
 description: View an example Ruler dashboard.
 menuTitle: Ruler
 title: Grafana Mimir Ruler dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/scaling/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/scaling/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/scaling/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/scaling/
+  - ../../monitoring-grafana-mimir/dashboards/scaling/
 description: View an example Scaling dashboard.
 menuTitle: Scaling
 title: Grafana Mimir scaling dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/slow-queries/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/slow-queries/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/slow-queries/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/slow-queries/
+  - ../../monitoring-grafana-mimir/dashboards/slow-queries/
 description: Review a description of the Slow queries dashboard.
 menuTitle: Slow queries
 title: Grafana Mimir Slow queries dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/tenants/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/tenants/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/tenants/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/tenants/
+  - ../../monitoring-grafana-mimir/dashboards/tenants/
 description: View an example Tenants dashboard.
 menuTitle: Tenants
 title: Grafana Mimir Tenants dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/top-tenants/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/top-tenants/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/top-tenants/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/top-tenants/
+  - ../../monitoring-grafana-mimir/dashboards/top-tenants/
 description: Review a description of the Top tenants dashboard.
 menuTitle: Top tenants
 title: Grafana Mimir Top tenants dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/writes-networking/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/writes-networking/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/writes-networking/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/writes-networking/
+  - ../../monitoring-grafana-mimir/dashboards/writes-networking/
 description: View an example Writes networking dashboard.
 menuTitle: Writes networking
 title: Grafana Mimir Writes networking dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/writes-resources/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/writes-resources/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/writes-resources/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/writes-resources/
+  - ../../monitoring-grafana-mimir/dashboards/writes-resources/
 description: View an example Writes resources dashboard.
 menuTitle: Writes resources
 title: Grafana Mimir Writes resources dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/writes/index.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/dashboards/writes/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../visualizing-metrics/dashboards/writes/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/dashboards/writes/
+  - ../../monitoring-grafana-mimir/dashboards/writes/
 description: View an example Writes dashboard.
 menuTitle: Writes
 title: Grafana Mimir Writes dashboard

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/deploying-monitoring-mixin.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/deploying-monitoring-mixin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../visualizing-metrics/deploying-monitor-mixin/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/deploying-monitoring-mixin/
+  - ../monitoring-grafana-mimir/deploying-monitoring-mixin/
 description: Learn how to deploy the Grafana Mimir monitoring mixin.
 menuTitle: Deploying the monitoring mixin
 title: Deploying the Grafana Mimir monitoring mixin

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../visualizing-metrics/installing-dashboards-and-alerts/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/installing-dashboards-and-alerts/
+  - ../monitoring-grafana-mimir/installing-dashboards-and-alerts/
 description: Learn how to install Grafana Mimir dashboards and alerts.
 menuTitle: Installing dashboards and alerts
 title: Installing Grafana Mimir dashboards and alerts

--- a/docs/sources/mimir/operators-guide/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/operators-guide/monitor-grafana-mimir/requirements.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../visualizing-metrics/requirements/
-  - /docs/mimir/latest/operators-guide/monitoring-grafana-mimir/requirements/
+  - ../monitoring-grafana-mimir/requirements/
 description: Requirements for installing Grafana Mimir dashboards and alerts.
 menuTitle: About dashboards and alerts requirements
 title: About Grafana Mimir dashboards and alerts requirements

--- a/docs/sources/mimir/operators-guide/run-production-environment/_index.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/running-production-environment/
+  - running-production-environment/
 description: Learn how to run Grafana Mimir in production.
 menuTitle: Run in production
 title: Run Grafana Mimir in production

--- a/docs/sources/mimir/operators-guide/run-production-environment/perform-a-rolling-update.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/perform-a-rolling-update.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/running-production-environment/performing-a-rolling-update/
-  - /docs/mimir/latest/operators-guide/running-production-environment/perform-a-rolling-update/
+  - ../running-production-environment/performing-a-rolling-update/
+  - ../running-production-environment/perform-a-rolling-update/
 description: Learn how to perform a rolling update to Grafana Mimir.
 menuTitle: Perform a rolling update
 title: Perform a rolling update to Grafana Mimir

--- a/docs/sources/mimir/operators-guide/run-production-environment/planning-capacity.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/planning-capacity.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/running-production-environment/planning-capacity/
+  - ../running-production-environment/planning-capacity/
 description: Learn how to plan the resources required to deploy Grafana Mimir.
 menuTitle: Planning capacity
 title: Planning Grafana Mimir capacity

--- a/docs/sources/mimir/operators-guide/run-production-environment/production-tips/index.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/production-tips/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/running-production-environment/production-tips/
+  - ../running-production-environment/production-tips/
 description: Learn tips for setting up a production Grafana Mimir cluster.
 menuTitle: Production tips
 title: Grafana Mimir production tips

--- a/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/operators-guide/run-production-environment/scaling-out.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/running-production-environment/scaling-out/
+  - ../running-production-environment/scaling-out/
 description: Learn how to scale out Grafana Mimir.
 menuTitle: Scaling out
 title: Scaling out Grafana Mimir

--- a/docs/sources/mimir/operators-guide/secure/_index.md
+++ b/docs/sources/mimir/operators-guide/secure/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/securing/
+  - securing/
 description: Learn how to secure Grafana Mimir data and communication paths.
 keywords:
   - Mimir security

--- a/docs/sources/mimir/operators-guide/secure/authentication-and-authorization.md
+++ b/docs/sources/mimir/operators-guide/secure/authentication-and-authorization.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/securing/authentication-and-authorization/
+  - ../securing/authentication-and-authorization/
 description: Learn how to configure and run Grafana Mimir with multi-tenancy.
 menuTitle: Authentication and authorization
 title: Grafana Mimir authentication and authorization

--- a/docs/sources/mimir/operators-guide/secure/encrypting-data-at-rest.md
+++ b/docs/sources/mimir/operators-guide/secure/encrypting-data-at-rest.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/securing/encrypting-data-at-rest/
+  - ../securing/encrypting-data-at-rest/
 description: Learn how to configure object storage encryption.
 menuTitle: Encrypting data at rest
 title: Encrypting Grafana Mimir data at rest

--- a/docs/sources/mimir/operators-guide/secure/securing-alertmanager.md
+++ b/docs/sources/mimir/operators-guide/secure/securing-alertmanager.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/securing/securing-alertmanager/
+  - ../securing/securing-alertmanager/
 description: Learn how to secure the Alertmanager.
 menuTitle: Securing Alertmanager
 title: Securing Grafana Mimir Alertmanager

--- a/docs/sources/mimir/operators-guide/secure/securing-communications-with-tls.md
+++ b/docs/sources/mimir/operators-guide/secure/securing-communications-with-tls.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/securing/securing-communications-with-tls/
+  - ../securing/securing-communications-with-tls/
 description: Learn how to configure TLS between Grafana Mimir components.
 menuTitle: Securing communications with TLS
 title: Securing Grafana Mimir communications with TLS

--- a/docs/sources/mimir/operators-guide/use-exemplars/_index.md
+++ b/docs/sources/mimir/operators-guide/use-exemplars/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/using-exemplars/
+  - using-exemplars/
 description: Learn how to use exemplars with Grafana Mimir.
 keywords:
   - Mimir exemplars

--- a/docs/sources/mimir/operators-guide/use-exemplars/about-exemplars.md
+++ b/docs/sources/mimir/operators-guide/use-exemplars/about-exemplars.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/using-exemplars/about-exemplars/
+  - ../using-exemplars/about-exemplars/
 description:
   Learn about using exemplars in Grafana Mimir to identify high cardinality
   in time series events.

--- a/docs/sources/mimir/operators-guide/use-exemplars/before-you-begin.md
+++ b/docs/sources/mimir/operators-guide/use-exemplars/before-you-begin.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/using-exemplars/before-you-begin/
+  - ../using-exemplars/before-you-begin/
 description: Refer to this checklist before you begin using exemplars in Grafana Mimir.
 menuTitle: Before you begin
 title: Before you begin using exemplars with Grafana Mimir

--- a/docs/sources/mimir/operators-guide/use-exemplars/storing-exemplars.md
+++ b/docs/sources/mimir/operators-guide/use-exemplars/storing-exemplars.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/using-exemplars/storing-exemplars/
+  - ../using-exemplars/storing-exemplars/
 description: Learn how to store exemplars in Grafana Mimir.
 menuTitle: Storing exemplars
 title: Storing exemplars in Grafana Mimir

--- a/docs/sources/mimir/operators-guide/use-exemplars/viewing-exemplar-data.md
+++ b/docs/sources/mimir/operators-guide/use-exemplars/viewing-exemplar-data.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/using-exemplars/viewing-exemplar-data/
+  - ../using-exemplars/viewing-exemplar-data/
 description: Learn how to view exemplar data in Grafana Mimir.
 menuTitle: Viewing exemplar data
 title: Viewing exemplar data in Grafana Explore

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/reference-configuration-parameters/
-  - /docs/mimir/latest/operators-guide/configure/reference-configuration-parameters/
+  - operators-guide/configuring/reference-configuration-parameters/
+  - operators-guide/configure/reference-configuration-parameters/
 description: Describes parameters used to configure Grafana Mimir.
 menuTitle: Configuration
 title: Grafana Mimir configuration reference

--- a/docs/sources/mimir/reference-configuration-parameters/index.template
+++ b/docs/sources/mimir/reference-configuration-parameters/index.template
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/configuring/reference-configuration-parameters/
-  - /docs/mimir/latest/operators-guide/configure/reference-configuration-parameters/
+  - operators-guide/configuring/reference-configuration-parameters/
+  - operators-guide/configure/reference-configuration-parameters/
 description: Describes parameters used to configure Grafana Mimir.
 menuTitle: Configuration
 title: Grafana Mimir configuration reference


### PR DESCRIPTION
Absolute aliases containing versions can redirect "latest" content to
old versions when a page has been removed in newer versions.
The redirected pages are indexed by search engines but our robots.txt forbids them crawling the non-latest page.

Relative aliases behave consistently across versions and do not suffer the same problems.

I've checked a bunch of aliases manually by:
1. Running `$ make docs`
1. Picking an absolute alias path from a random file
1. Checking that I end up at the page represented by the file containing the alias.

For example, to test the relative alias in the file `docs/sources/mimir/operators-guide/configure/_index.md`:
1. `$ make docs`
1. Browse to http://localhost:3002/docs/mimir/next/operators-guide/configuring/
1. Confirm that I am redirected to http://localhost:3002/docs/mimir/next/configure/
