### PR TITLE
Automatically configure alertmanager URL for backend instances in read-write deployment mode

### DIFF
--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -191,15 +191,6 @@ func TestReadWriteModeAlertingRule(t *testing.T) {
 		},
 	)
 
-	// Set up alertmanager config for tenant
-	alertmanagerConfig := `
-route:
-  receiver: test-receiver
-receivers:
-  - name: test-receiver
-`
-	require.NoError(t, client.SetAlertmanagerConfig(context.Background(), alertmanagerConfig, map[string]string{}))
-
 	// Create alerting rule
 	alert := yaml.Node{}
 	testAlertName := "test_alert"
@@ -307,6 +298,15 @@ func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario, extraFlags ...map[
 		[]string{"cortex_ring_members"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"), labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
 	))
+
+	// Set up alertmanager config for tenant
+	alertmanagerConfig := `
+route:
+  receiver: test-receiver
+receivers:
+  - name: test-receiver
+`
+	require.NoError(t, client.SetAlertmanagerConfig(context.Background(), alertmanagerConfig, map[string]string{}))
 
 	return client, cluster
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Automatically configure alertmanager URL for backend instances in read-write deployment mode. Also, update the test.


#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/3876

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
