### PR TITLE
Sets server variable before proxy_pass to force DNS re-resolve

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2154,54 +2154,67 @@ nginx:
 
           # Distributor endpoints
           location /distributor {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$distributor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location = /api/v1/push {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$distributor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location /otlp/v1/metrics {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$distributor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           # Alertmanager endpoints
           location {{ template "mimir.alertmanagerHttpPrefix" . }} {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location = /multitenant_alertmanager/status {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location = /api/v1/alerts {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           # Ruler endpoints
           location {{ template "mimir.prometheusHttpPrefix" . }}/config/v1/rules {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/rules {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/alerts {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
           location = /ruler/ring {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           # Rest of {{ template "mimir.prometheusHttpPrefix" . }} goes to the query frontend
           location {{ template "mimir.prometheusHttpPrefix" . }} {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $query_frontend {{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$query_frontend:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           # Buildinfo endpoint can go to any component
           location = /api/v1/status/buildinfo {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $query_frontend {{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$query_frontend:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           # Compactor endpoint for uploading blocks
           location /api/v1/upload/block/ {
-            proxy_pass      http://{{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            set $compactor {{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
+            proxy_pass      http://$compactor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
 
           {{- with .Values.nginx.nginxConfig.serverSnippet }}

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://large-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor large-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://large-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor large-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://large-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor large-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://large-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager large-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://large-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager large-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://large-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager large-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://large-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler large-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://large-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler large-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://large-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler large-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://large-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler large-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://large-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend large-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://large-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend large-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://large-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor large-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://metamonitoring-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor metamonitoring-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://metamonitoring-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor metamonitoring-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://metamonitoring-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor metamonitoring-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://metamonitoring-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler metamonitoring-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://metamonitoring-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler metamonitoring-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://metamonitoring-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler metamonitoring-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://metamonitoring-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler metamonitoring-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://metamonitoring-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend metamonitoring-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://metamonitoring-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend metamonitoring-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://metamonitoring-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor metamonitoring-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://scheduler-name-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor scheduler-name-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://scheduler-name-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor scheduler-name-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://scheduler-name-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor scheduler-name-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://scheduler-name-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler scheduler-name-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://scheduler-name-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler scheduler-name-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://scheduler-name-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler scheduler-name-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://scheduler-name-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler scheduler-name-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://scheduler-name-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend scheduler-name-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://scheduler-name-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend scheduler-name-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://scheduler-name-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor scheduler-name-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://small-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor small-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://small-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor small-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://small-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor small-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://small-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager small-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://small-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager small-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://small-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager small-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://small-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler small-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://small-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler small-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://small-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler small-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://small-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler small-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://small-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend small-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://small-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend small-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://small-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor small-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-k8s-1.25-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-k8s-1.25-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-k8s-1.25-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-k8s-1.25-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-k8s-1.25-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-k8s-1.25-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://test-oss-k8s-1.25-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor test-oss-k8s-1.25-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-logical-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-logical-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-logical-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-logical-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-logical-multizone-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-logical-multizone-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://test-oss-logical-multizone-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor test-oss-logical-multizone-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://test-oss-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://test-oss-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://test-oss-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-multizone-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-multizone-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://test-oss-multizone-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-multizone-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://test-oss-multizone-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-multizone-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://test-oss-multizone-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor test-oss-multizone-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -56,54 +56,67 @@ data:
     
         # Distributor endpoints
         location /distributor {
-          proxy_pass      http://test-oss-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location = /api/v1/push {
-          proxy_pass      http://test-oss-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
         location /otlp/v1/metrics {
-          proxy_pass      http://test-oss-values-mimir-distributor-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $distributor test-oss-values-mimir-distributor-headless.citestns.svc.cluster.local
+          proxy_pass      http://$distributor:8080$request_uri;
         }
     
         # Alertmanager endpoints
         location /alertmanager {
-          proxy_pass      http://test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /multitenant_alertmanager/status {
-          proxy_pass      http://test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
         location = /api/v1/alerts {
-          proxy_pass      http://test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local:8080$request_uri;
+          set $alertmanager test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local
+          proxy_pass      http://$alertmanager:8080$request_uri;
         }
     
         # Ruler endpoints
         location /prometheus/config/v1/rules {
-          proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location /prometheus/api/v1/rules {
-          proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         location /prometheus/api/v1/alerts {
-          proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
         location = /ruler/ring {
-          proxy_pass      http://test-oss-values-mimir-ruler.citestns.svc.cluster.local:8080$request_uri;
+          set $ruler test-oss-values-mimir-ruler.citestns.svc.cluster.local
+          proxy_pass      http://$ruler:8080$request_uri;
         }
     
         # Rest of /prometheus goes to the query frontend
         location /prometheus {
-          proxy_pass      http://test-oss-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Buildinfo endpoint can go to any component
         location = /api/v1/status/buildinfo {
-          proxy_pass      http://test-oss-values-mimir-query-frontend.citestns.svc.cluster.local:8080$request_uri;
+          set $query_frontend test-oss-values-mimir-query-frontend.citestns.svc.cluster.local
+          proxy_pass      http://$query_frontend:8080$request_uri;
         }
     
         # Compactor endpoint for uploading blocks
         location /api/v1/upload/block/ {
-          proxy_pass      http://test-oss-values-mimir-compactor.citestns.svc.cluster.local:8080$request_uri;
+          set $compactor test-oss-values-mimir-compactor.citestns.svc.cluster.local
+          proxy_pass      http://$compactor:8080$request_uri;
         }
       }
     }


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #3783 

This PR implements the fix suggested by the creator of the issue. In each location stanza of the nginx config file, the server address is stored in a variable before being used in the `proxy_pass` statement. This causes nginx to re-resolve IPs when TTLs expire.

#### Checklist

- [X] Tests updated
- [N/A] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
