### PR TITLE
`ASTExprMapper` maps `MatrixSelector.VectorSelector`

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -156,7 +156,15 @@ func (em ASTExprMapper) Map(expr parser.Expr) (parser.Expr, error) {
 		e.Expr = mapped
 		return e, nil
 
-	case *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector, *parser.MatrixSelector:
+	case *parser.MatrixSelector:
+		mapped, err := em.Map(e.VectorSelector)
+		if err != nil {
+			return nil, err
+		}
+		e.VectorSelector = mapped
+		return e, nil
+
+	case *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector:
 		return e, nil
 
 	default:


### PR DESCRIPTION
#### What this PR does

ASTExprMapper was mapping every AST subtree elements except for the VectorSelector which is an Expr leaf of MatrixSelector, which required ExprMappers to handle them separately. This simplifies that.

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
