### PR TITLE
jsonnet: Add weight param to querier newScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Jsonnet
 
 * [ENHANCEMENT] Add support for ruler auto-scaling. #4046
+* [ENHANCEMENT] Add optional `weight` param to `newQuerierScaledObject` and `newRulerQuerierScaledObject` to allow running multiple querier deployments on different node types. #4141
 
 ### Mimirtool
 

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -32,6 +32,16 @@
     name: name,
   },
 
+  // metricWithWeight will multiply the metric by the weight provided if it's different from 1.
+  local metricWithWeight(metric, weight) =
+    if weight == 1 then metric
+    else '%s * %.2f' % [metric, weight],
+
+
+  // replicaswithWeight will return the portion of replicas that should be applied with the weight provided.
+  local replicasWithWeight(replicas, weight) =
+    if weight <= 0.5 then std.ceil(replicas * weight) else std.floor(replicas * weight),
+
   // The ScaledObject resource is watched by the KEDA operator. When this resource is created, KEDA
   // creates the related HPA resource in the namespace. Likewise, then ScaledObject is deleted, KEDA
   // deletes the related HPA.
@@ -100,9 +110,13 @@
     },
   },
 
-  newQuerierScaledObject(name, query_scheduler_container, querier_max_concurrent, min_replicas, max_replicas):: self.newScaledObject(name, $._config.namespace, {
-    min_replica_count: min_replicas,
-    max_replica_count: max_replicas,
+  // newQuerierScaledObject will create a scaled object for the querier component with the given name.
+  // `weight` param can be used to control just a portion of the expected queriers with the generated scaled object.
+  // For example, if you run multiple querier deployments on different node types, you can use the weight to control which portion of them runs on which nodes.
+  // The weight is a number between 0 and 1, where 1 means 100% of the expected queriers.
+  newQuerierScaledObject(name, query_scheduler_container, querier_max_concurrent, min_replicas, max_replicas, weight=1):: self.newScaledObject(name, $._config.namespace, {
+    min_replica_count: replicasWithWeight(min_replicas, weight),
+    max_replica_count: replicasWithWeight(max_replicas, weight),
 
     triggers: [
       {
@@ -115,7 +129,7 @@
         // Instead of measuring it as instant query, we look at the max 75th percentile over the last
         // 5 minutes. This allows us to scale up quickly, but scale down slowly (and not too early
         // if within the next 5 minutes after a scale up we have further spikes).
-        query: 'sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%s",namespace="%s",quantile="0.75"}[5m]))' % [query_scheduler_container, $._config.namespace],
+        query: metricWithWeight('sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%s",namespace="%s",quantile="0.75"}[5m]))' % [query_scheduler_container, $._config.namespace], weight),
 
         // Target to utilize 75% querier workers on peak traffic (as measured by query above),
         // so we have 25% room for higher peaks.
@@ -211,9 +225,11 @@
   // Ruler-queriers
   //
 
-  newRulerQuerierScaledObject(name, querier_cpu_requests, min_replicas, max_replicas):: self.newScaledObject(name, $._config.namespace, {
-    min_replica_count: min_replicas,
-    max_replica_count: max_replicas,
+  // newRulerQuerierScaledObject will create a scaled object for the ruler-querier component with the given name.
+  // `weight` param works in the same way as in `newQuerierScaledObject`, see docs there.
+  newRulerQuerierScaledObject(name, querier_cpu_requests, min_replicas, max_replicas, weight=1):: self.newScaledObject(name, $._config.namespace, {
+    min_replica_count: replicasWithWeight(min_replicas, weight),
+    max_replica_count: replicasWithWeight(max_replicas, weight),
 
     triggers: [
       {
@@ -222,7 +238,7 @@
         // Due to the more predicatable nature of the ruler-querier workload we can scale on CPU usage.
         // To scale out relatively quickly, but scale in slower, we look at the average CPU utilization per ruler-querier over 5m (rolling window)
         // and then we pick the highest value over the last 15m.
-        query: 'max_over_time(sum(rate(container_cpu_usage_seconds_total{container="%s",namespace="%s"}[5m]))[15m:]) * 1000' % [name, $._config.namespace],
+        query: metricWithWeight('max_over_time(sum(rate(container_cpu_usage_seconds_total{container="%s",namespace="%s"}[5m]))[15m:]) * 1000' % [name, $._config.namespace], weight),
 
         // threshold is expected to be a string.
         threshold: std.toString(cpuToMilliCPUInt(querier_cpu_requests)),


### PR DESCRIPTION
#### What this PR does

This is the first step towards open-sourcing the jsonnet we use to run multiple querier deployments taking advantage of the spot nodes on different cloud providers.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
