### PR TITLE
Use type label instead of dedicated histogram metrics and less validation for histograms

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -710,7 +710,7 @@ func (d *Distributor) validateSeries(nowt time.Time, ts mimirpb.PreallocTimeseri
 			d.sampleDelayHistogram.Observe(float64(delta) / 1000)
 		}
 
-		if err := validation.ValidateHistogram(d.histogramValidationMetrics, now, d.limits, userID, ts.Labels, h); err != nil {
+		if err := validation.ValidateSampleHistogram(d.sampleValidationMetrics, now, d.limits, userID, group, ts.Labels, h); err != nil {
 			return err
 		}
 	}

--- a/pkg/distributor/forwarding/forwarding_test.go
+++ b/pkg/distributor/forwarding/forwarding_test.go
@@ -223,7 +223,7 @@ func TestForwardingOmitOldSamples(t *testing.T) {
 			expectedMetrics: `
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="",reason="forwarded-sample-too-old",user="user"} 3
+			cortex_discarded_samples_total{group="",reason="forwarded-sample-too-old",type="float",user="user"} 3
 `,
 		}, {
 			name: "split one sample slice in the middle",

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -152,10 +152,12 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_metadata_created_total{user="test"} 2
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 2
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 2
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -225,10 +227,12 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 2
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 2
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -289,10 +293,12 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 2
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 2
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -331,10 +337,12 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 1
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 1
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 1
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 1
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -349,7 +357,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-order",user="test"} 1
+				cortex_discarded_samples_total{group="",reason="sample-out-of-order",type="float",user="test"} 1
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -383,10 +391,13 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 1
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 1
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 2
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 2
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
+				
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -401,7 +412,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 2
+				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",type="float",user="test"} 2
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -438,10 +449,12 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 2
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 2
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 2
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 2
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -456,7 +469,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 2
+				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",type="float",user="test"} 2
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -486,10 +499,12 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 1
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 1
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 1
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 1
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -504,7 +519,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 1
+				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",type="float",user="test"} 1
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -545,10 +560,12 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 				# TYPE cortex_ingester_ingested_samples_total counter
-				cortex_ingester_ingested_samples_total{user="test"} 0
+				cortex_ingester_ingested_samples_total{type="float",user="test"} 0
+				cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
-				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="float",user="test"} 0
+				cortex_ingester_ingested_samples_failures_total{type="histogram",user="test"} 0
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 1
@@ -889,12 +906,16 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 	expectedMetrics := `
 		# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 		# TYPE cortex_ingester_ingested_samples_total counter
-		cortex_ingester_ingested_samples_total{user="test-1"} 2
-		cortex_ingester_ingested_samples_total{user="test-2"} 2
+		cortex_ingester_ingested_samples_total{type="float",user="test-1"} 2
+		cortex_ingester_ingested_samples_total{type="float",user="test-2"} 2
+		cortex_ingester_ingested_samples_total{type="histogram",user="test-1"} 0
+		cortex_ingester_ingested_samples_total{type="histogram",user="test-2"} 0
 		# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 		# TYPE cortex_ingester_ingested_samples_failures_total counter
-		cortex_ingester_ingested_samples_failures_total{user="test-1"} 0
-		cortex_ingester_ingested_samples_failures_total{user="test-2"} 0
+		cortex_ingester_ingested_samples_failures_total{type="float",user="test-1"} 0
+		cortex_ingester_ingested_samples_failures_total{type="float",user="test-2"} 0
+		cortex_ingester_ingested_samples_failures_total{type="histogram",user="test-1"} 0
+		cortex_ingester_ingested_samples_failures_total{type="histogram",user="test-2"} 0
 		# HELP cortex_ingester_memory_users The current number of users in memory.
 		# TYPE cortex_ingester_memory_users gauge
 		cortex_ingester_memory_users 2
@@ -6215,11 +6236,11 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			expectedMetrics: `
 					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
-					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 2
+					cortex_ingester_ingested_ephemeral_samples_total{type="float",user="test"} 2
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
-					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 0
+					cortex_ingester_ingested_ephemeral_samples_failures_total{type="float",user="test"} 0
 
 					# HELP cortex_ingester_ephemeral_series_created_total The total number of series in ephemeral storage that were created per user.
 					# TYPE cortex_ingester_ephemeral_series_created_total counter
@@ -6291,11 +6312,11 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			expectedMetrics: `
 					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
-					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 0
+					cortex_ingester_ingested_ephemeral_samples_total{type="float",user="test"} 0
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
-					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 1
+					cortex_ingester_ingested_ephemeral_samples_failures_total{type="float",user="test"} 1
 
 					# HELP cortex_ingester_ephemeral_series_created_total The total number of series in ephemeral storage that were created per user.
 					# TYPE cortex_ingester_ephemeral_series_created_total counter
@@ -6319,7 +6340,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_discarded_samples_total The total number of samples that were discarded.
         	        # TYPE cortex_discarded_samples_total counter
-        	        cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-bounds",user="test"} 1
+        	        cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-bounds",type="float",user="test"} 1
 
 					# HELP cortex_ingester_memory_ephemeral_users The current number of users with ephemeral storage in memory.
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
@@ -6382,11 +6403,11 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			expectedMetrics: `
 					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
-					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 1
+					cortex_ingester_ingested_ephemeral_samples_total{type="float",user="test"} 1
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
-					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 1
+					cortex_ingester_ingested_ephemeral_samples_failures_total{type="float",user="test"} 1
 
 					# HELP cortex_ingester_ephemeral_series_created_total The total number of series in ephemeral storage that were created per user.
 					# TYPE cortex_ingester_ephemeral_series_created_total counter
@@ -6410,7 +6431,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 					# TYPE cortex_discarded_samples_total counter
-					cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-order",user="test"} 1
+					cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-order",type="float",user="test"} 1
 
 					# HELP cortex_ingester_memory_ephemeral_users The current number of users with ephemeral storage in memory.
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
@@ -6551,7 +6572,8 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 					# TYPE cortex_ingester_ingested_samples_total counter
-					cortex_ingester_ingested_samples_total{user="test"} 2
+					cortex_ingester_ingested_samples_total{type="float",user="test"} 2
+					cortex_ingester_ingested_samples_total{type="histogram",user="test"} 0
 
 					# HELP cortex_ingester_memory_series The current number of series in memory.
         	        # TYPE cortex_ingester_memory_series gauge
@@ -6567,11 +6589,11 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
-					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 5
+					cortex_ingester_ingested_ephemeral_samples_total{type="float",user="test"} 5
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
-					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 3
+					cortex_ingester_ingested_ephemeral_samples_failures_total{type="float",user="test"} 3
 
 					# HELP cortex_ingester_ephemeral_series_created_total The total number of series in ephemeral storage that were created per user.
 					# TYPE cortex_ingester_ephemeral_series_created_total counter
@@ -6587,9 +6609,9 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 					# TYPE cortex_discarded_samples_total counter
-					cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-bounds",user="test"} 1
-					cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-order",user="test"} 1
-					cortex_discarded_samples_total{group="",reason="ephemeral-new-value-for-timestamp",user="test"} 1
+					cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-bounds",type="float",user="test"} 1
+					cortex_discarded_samples_total{group="",reason="ephemeral-sample-out-of-order",type="float",user="test"} 1
+					cortex_discarded_samples_total{group="",reason="ephemeral-new-value-for-timestamp",type="float",user="test"} 1
 
 					# HELP cortex_ingester_memory_ephemeral_users The current number of users with ephemeral storage in memory.
 					# TYPE cortex_ingester_memory_ephemeral_users gauge
@@ -6759,11 +6781,11 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
-					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 3
+					cortex_ingester_ingested_ephemeral_samples_failures_total{type="float",user="test"} 3
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
-					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 0
+					cortex_ingester_ingested_ephemeral_samples_total{type="float",user="test"} 0
 			`,
 		},
 
@@ -6791,11 +6813,11 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 			expectedMetrics: `
 					# HELP cortex_ingester_ingested_ephemeral_samples_total The total number of samples ingested per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_total counter
-					cortex_ingester_ingested_ephemeral_samples_total{user="test"} 1
+					cortex_ingester_ingested_ephemeral_samples_total{type="float",user="test"} 1
 
 					# HELP cortex_ingester_ingested_ephemeral_samples_failures_total The total number of samples that errored on ingestion per user for ephemeral series.
 					# TYPE cortex_ingester_ingested_ephemeral_samples_failures_total counter
-					cortex_ingester_ingested_ephemeral_samples_failures_total{user="test"} 1
+					cortex_ingester_ingested_ephemeral_samples_failures_total{type="float",user="test"} 1
 
 					# HELP cortex_ingester_ephemeral_series_created_total The total number of series in ephemeral storage that were created per user.
 					# TYPE cortex_ingester_ephemeral_series_created_total counter
@@ -6853,7 +6875,7 @@ func TestIngester_PushAndQueryEphemeral(t *testing.T) {
 
 					# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 					# TYPE cortex_discarded_samples_total counter
-					cortex_discarded_samples_total{group="",reason="ephemeral-per_user_series_limit",user="test"} 1
+					cortex_discarded_samples_total{group="",reason="ephemeral-per_user_series_limit",type="float",user="test"} 1
 			`,
 		},
 	}
@@ -7308,18 +7330,14 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 	require.NoError(t, err)
 
 	expectedMetrics := `
-		# HELP cortex_ingester_ingested_histograms_failures_total The total number of histograms that errored on ingestion per user.
-		# TYPE cortex_ingester_ingested_histograms_failures_total counter
-		cortex_ingester_ingested_histograms_failures_total{user="1"} 1
-		# HELP cortex_ingester_ingested_histograms_total The total number of histograms ingested per user.
-		# TYPE cortex_ingester_ingested_histograms_total counter
-		cortex_ingester_ingested_histograms_total{user="1"} 0
 		# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 		# TYPE cortex_ingester_ingested_samples_failures_total counter
-		cortex_ingester_ingested_samples_failures_total{user="1"} 0
+		cortex_ingester_ingested_samples_failures_total{type="float",user="1"} 0
+		cortex_ingester_ingested_samples_failures_total{type="histogram",user="1"} 1
 		# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
 		# TYPE cortex_ingester_ingested_samples_total counter
-		cortex_ingester_ingested_samples_total{user="1"} 1
+		cortex_ingester_ingested_samples_total{type="float",user="1"} 1
+		cortex_ingester_ingested_samples_total{type="histogram",user="1"} 0
 				`
 	metricNames := []string{"cortex_ingester_ingested_samples_total", "cortex_ingester_ingested_samples_failures_total", "cortex_ingester_ingested_histograms_total", "cortex_ingester_ingested_histograms_failures_total"}
 	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...), "Except histogram writes to fail and floats to succeed")
@@ -7366,18 +7384,14 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 	require.NoError(t, err)
 
 	expectedMetrics = `
-		# HELP cortex_ingester_ingested_histograms_failures_total The total number of histograms that errored on ingestion per user.
-		# TYPE cortex_ingester_ingested_histograms_failures_total counter
-		cortex_ingester_ingested_histograms_failures_total{user="1"} 1
-		# HELP cortex_ingester_ingested_histograms_total The total number of histograms ingested per user.
-		# TYPE cortex_ingester_ingested_histograms_total counter
-		cortex_ingester_ingested_histograms_total{user="1"} 1
-		# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
-		# TYPE cortex_ingester_ingested_samples_failures_total counter
-		cortex_ingester_ingested_samples_failures_total{user="1"} 0
-		# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
-		# TYPE cortex_ingester_ingested_samples_total counter
-		cortex_ingester_ingested_samples_total{user="1"} 1
+	# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+	# TYPE cortex_ingester_ingested_samples_failures_total counter
+	cortex_ingester_ingested_samples_failures_total{type="float",user="1"} 0
+	cortex_ingester_ingested_samples_failures_total{type="histogram",user="1"} 1
+	# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+	# TYPE cortex_ingester_ingested_samples_total counter
+	cortex_ingester_ingested_samples_total{type="float",user="1"} 1
+	cortex_ingester_ingested_samples_total{type="histogram",user="1"} 1
 				`
 	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...), "Except histogram writes to succeed")
 

--- a/pkg/mimirpb/metric_labels.go
+++ b/pkg/mimirpb/metric_labels.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package mimirpb
+
+const (
+	// The label used to report different metrics for float and histogram samples
+	SampleMetricTypeLabel = "type"
+
+	SampleMetricTypeFloat     = "float"
+	SampleMetricTypeHistogram = "histogram"
+)

--- a/pkg/util/push/otel.go
+++ b/pkg/util/push/otel.go
@@ -134,7 +134,7 @@ func otelMetricsToTimeseries(ctx context.Context, discardedDueToOtelParseError *
 		}
 
 		dropped := len(multierr.Errors(errs))
-		discardedDueToOtelParseError.WithLabelValues(userID, "").Add(float64(dropped)) // Group is empty here as metrics couldn't be parsed
+		discardedDueToOtelParseError.WithLabelValues(userID, "", "").Add(float64(dropped)) // Group and sample type is empty here as metrics couldn't be parsed
 
 		parseErrs := errs.Error()
 		if len(parseErrs) > maxErrMsgLen {

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -202,30 +202,6 @@ func newExemplarMaxLabelLengthError(seriesLabels []mimirpb.LabelAdapter, exempla
 	}
 }
 
-func newHistogramDifferentNumberSpansBucketsError(spanBuckets, buckets int, timestamp int64, metricName string) ValidationError {
-	return fmt.Errorf(globalerror.HistogramSpansBucketsMismatch.Message(
-		"received a histogram whose spans require %d buckets, while %d buckets are provided, timestamp: %d series: '%.200s'",
-	), spanBuckets, buckets, timestamp, metricName)
-}
-
-func newHistogramSpanNegativeOffsetError(span int, offset int32, timestamp int64, metricName string) ValidationError {
-	return fmt.Errorf(globalerror.HistogramSpanNegativeOffset.Message(
-		"received a histogram which has a span (number %d) whose offset is negative: %d, timestamp: %d series: '%.200s'",
-	), span, offset, timestamp, metricName)
-}
-
-func newHistogramNegativeBucketCountError(bucket int, count int64, timestamp int64, metricName string) ValidationError {
-	return fmt.Errorf(globalerror.HistogramNegativeBucketCount.Message(
-		"received a histogram which has a bucket (number %d) whose observation count is negative: %d, timestamp: %d, series: '%.200s'",
-	), bucket, count, timestamp, metricName)
-}
-
-func newHistogramCountNotBigEnoughError(bucketCount, count uint64, timestamp int64, metricName string) ValidationError {
-	return fmt.Errorf(globalerror.HistogramCountNotBigEnough.Message(
-		"received a histogram which has %d observations in buckets but an overall count of %d, timestamp: %d, series: '%.200s'",
-	), bucketCount, count, timestamp, metricName)
-}
-
 type metadataMetricNameMissingError struct{}
 
 func newMetadataMetricNameMissingError() ValidationError {

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -37,7 +37,6 @@ var (
 	reasonLabelNameTooLong       = metricReasonFromErrorID(globalerror.SeriesLabelNameTooLong)
 	reasonLabelValueTooLong      = metricReasonFromErrorID(globalerror.SeriesLabelValueTooLong)
 	reasonDuplicateLabelNames    = metricReasonFromErrorID(globalerror.SeriesWithDuplicateLabelNames)
-	reasonLabelsNotSorted        = metricReasonFromErrorID(globalerror.SeriesLabelsNotSorted)
 	reasonTooFarInFuture         = metricReasonFromErrorID(globalerror.SampleTooFarInFuture)
 
 	// Discarded exemplars reasons.
@@ -139,7 +138,6 @@ type SampleValidationMetrics struct {
 	labelNameTooLong       *prometheus.CounterVec
 	labelValueTooLong      *prometheus.CounterVec
 	duplicateLabelNames    *prometheus.CounterVec
-	labelsNotSorted        *prometheus.CounterVec
 	tooFarInFuture         *prometheus.CounterVec
 }
 
@@ -153,7 +151,6 @@ func (m *SampleValidationMetrics) DeleteUserMetrics(userID string) {
 	m.labelNameTooLong.DeletePartialMatch(filter)
 	m.labelValueTooLong.DeletePartialMatch(filter)
 	m.duplicateLabelNames.DeletePartialMatch(filter)
-	m.labelsNotSorted.DeletePartialMatch(filter)
 	m.tooFarInFuture.DeletePartialMatch(filter)
 }
 
@@ -165,7 +162,6 @@ func (m *SampleValidationMetrics) DeleteUserMetricsForGroup(userID, group string
 	m.labelNameTooLong.DeleteLabelValues(userID, group)
 	m.labelValueTooLong.DeleteLabelValues(userID, group)
 	m.duplicateLabelNames.DeleteLabelValues(userID, group)
-	m.labelsNotSorted.DeleteLabelValues(userID, group)
 	m.tooFarInFuture.DeleteLabelValues(userID, group)
 }
 
@@ -178,7 +174,6 @@ func NewSampleValidationMetrics(r prometheus.Registerer) *SampleValidationMetric
 		labelNameTooLong:       DiscardedSamplesCounter(r, reasonLabelNameTooLong),
 		labelValueTooLong:      DiscardedSamplesCounter(r, reasonLabelValueTooLong),
 		duplicateLabelNames:    DiscardedSamplesCounter(r, reasonDuplicateLabelNames),
-		labelsNotSorted:        DiscardedSamplesCounter(r, reasonLabelsNotSorted),
 		tooFarInFuture:         DiscardedSamplesCounter(r, reasonTooFarInFuture),
 	}
 }

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -119,24 +119,27 @@ func TestValidateLabels(t *testing.T) {
 			nil,
 		},
 	} {
-		err := ValidateLabels(s, cfg, userID, "custom label", mimirpb.FromMetricsToLabelAdapters(c.metric), c.skipLabelNameValidation)
+		err := ValidateLabels(s, cfg, userID, "custom label", mimirpb.FromMetricsToLabelAdapters(c.metric), c.skipLabelNameValidation, mimirpb.SampleMetricTypeFloat)
 		assert.Equal(t, c.err, err, "wrong error")
 	}
 
 	randomReason := DiscardedSamplesCounter(reg, "random reason")
-	randomReason.WithLabelValues("different user", "custom label").Inc()
+	randomReason.WithLabelValues("different user", "custom label", mimirpb.SampleMetricTypeFloat).Inc()
+	// Check that it honors sample metric type
+	randomReason.WithLabelValues("different user", "custom label", mimirpb.SampleMetricTypeHistogram).Inc()
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="custom label",reason="label_invalid",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="label_name_too_long",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="label_value_too_long",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="max_label_names_per_series",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="metric_name_invalid",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="missing_metric_name",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="label_invalid",type="float",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="label_name_too_long",type="float",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="label_value_too_long",type="float",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="max_label_names_per_series",type="float",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="metric_name_invalid",type="float",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="missing_metric_name",type="float",user="testUser"} 1
 
-			cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1
+			cortex_discarded_samples_total{group="custom label",reason="random reason",type="float",user="different user"} 1
+			cortex_discarded_samples_total{group="custom label",reason="random reason",type="histogram",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 
 	s.DeleteUserMetrics(userID)
@@ -144,7 +147,8 @@ func TestValidateLabels(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1
+			cortex_discarded_samples_total{group="custom label",reason="random reason",type="float",user="different user"} 1
+			cortex_discarded_samples_total{group="custom label",reason="random reason",type="histogram",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 }
 
@@ -322,7 +326,7 @@ func TestValidateLabelDuplication(t *testing.T) {
 	actual := ValidateLabels(NewSampleValidationMetrics(nil), cfg, userID, "", []mimirpb.LabelAdapter{
 		{Name: model.MetricNameLabel, Value: "a"},
 		{Name: model.MetricNameLabel, Value: "b"},
-	}, false)
+	}, false, mimirpb.SampleMetricTypeFloat)
 	expected := newDuplicatedLabelError([]mimirpb.LabelAdapter{
 		{Name: model.MetricNameLabel, Value: "a"},
 		{Name: model.MetricNameLabel, Value: "b"},
@@ -333,7 +337,7 @@ func TestValidateLabelDuplication(t *testing.T) {
 		{Name: model.MetricNameLabel, Value: "a"},
 		{Name: "a", Value: "a"},
 		{Name: "a", Value: "a"},
-	}, false)
+	}, false, mimirpb.SampleMetricTypeFloat)
 	expected = newDuplicatedLabelError([]mimirpb.LabelAdapter{
 		{Name: model.MetricNameLabel, Value: "a"},
 		{Name: "a", Value: "a"},


### PR DESCRIPTION
#### What this PR does

Get rid of histogram specific metrics in favor of "type" label like Prometheus does.
Do not copy the validation from tsdb for histograms, let tsdb do the validation it needs.

#### Which issue(s) this PR fixes or relates to

Related to #3478 

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
