### PR TITLE
Alertmanager: Expose missing upstream metrics from the dispatcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Store-gateway: add `data_type` label with values on `cortex_bucket_store_partitioner_extended_ranges_total`, `cortex_bucket_store_partitioner_expanded_ranges_total`, `cortex_bucket_store_partitioner_requested_ranges_total`, `cortex_bucket_store_partitioner_expanded_bytes_total`, `cortex_bucket_store_partitioner_requested_bytes_total` for `postings`, `series`, and `chunks`. #4095
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation rate when loading TSDB chunks from Memcached. #4074
 * [ENHANCEMENT] Query-frontend: track `cortex_frontend_query_response_codec_duration_seconds` and `cortex_frontend_query_response_codec_payload_bytes` metrics to measure the time taken and bytes read / written while encoding and decoding query result payloads. #4110
+* [ENHANCEMENT] Alertmanager: expose additional upstream metrics `cortex_alertmanager_dispatcher_aggregation_groups`, `cortex_alertmanager_dispatcher_alert_processing_duration_seconds`. #4151
 * [BUGFIX] Ingester: remove series from ephemeral storage even if there are no persistent series. #4052
 * [BUGFIX] Ingester: reuse memory when ingesting ephemeral series. #4072
 * [BUGFIX] Fix JSON and YAML marshalling of `ephemeral_series_matchers` field in `/runtime_config`. #4091

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -65,14 +65,14 @@ type alertmanagerMetrics struct {
 	persistFailed           *prometheus.Desc
 
 	// exported metrics, gathered from Alertmanager Dispatcher
-	dispatcherAggrGroups         *prometheus.Desc
-	dispatcherProcessingDuration *prometheus.Desc
-
-	notificationRateLimited                 *prometheus.Desc
+	dispatcherAggrGroups                    *prometheus.Desc
+	dispatcherProcessingDuration            *prometheus.Desc
 	dispatcherAggregationGroupsLimitReached *prometheus.Desc
-	insertAlertFailures                     *prometheus.Desc
-	alertsLimiterAlertsCount                *prometheus.Desc
-	alertsLimiterAlertsSize                 *prometheus.Desc
+
+	notificationRateLimited  *prometheus.Desc
+	insertAlertFailures      *prometheus.Desc
+	alertsLimiterAlertsCount *prometheus.Desc
+	alertsLimiterAlertsSize  *prometheus.Desc
 }
 
 func newAlertmanagerMetrics() *alertmanagerMetrics {
@@ -226,14 +226,14 @@ func newAlertmanagerMetrics() *alertmanagerMetrics {
 			"cortex_alertmanager_dispatcher_alert_processing_duration_seconds",
 			"Summary of latencies for the processing of alerts.",
 			nil, nil),
-		notificationRateLimited: prometheus.NewDesc(
-			"cortex_alertmanager_notification_rate_limited_total",
-			"Total number of rate-limited notifications per integration.",
-			[]string{"user", "integration"}, nil),
 		dispatcherAggregationGroupsLimitReached: prometheus.NewDesc(
 			"cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total",
 			"Number of times when dispatcher failed to create new aggregation group due to limit.",
 			[]string{"user"}, nil),
+		notificationRateLimited: prometheus.NewDesc(
+			"cortex_alertmanager_notification_rate_limited_total",
+			"Total number of rate-limited notifications per integration.",
+			[]string{"user", "integration"}, nil),
 		insertAlertFailures: prometheus.NewDesc(
 			"cortex_alertmanager_alerts_insert_limited_total",
 			"Total number of failures to store alert due to hitting alertmanager limits.",
@@ -297,8 +297,8 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.persistFailed
 	out <- m.dispatcherAggrGroups
 	out <- m.dispatcherProcessingDuration
-	out <- m.notificationRateLimited
 	out <- m.dispatcherAggregationGroupsLimitReached
+	out <- m.notificationRateLimited
 	out <- m.insertAlertFailures
 	out <- m.alertsLimiterAlertsCount
 	out <- m.alertsLimiterAlertsSize
@@ -350,9 +350,9 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 
 	data.SendSumOfGauges(out, m.dispatcherAggrGroups, "alertmanager_dispatcher_aggregation_groups")
 	data.SendSumOfSummaries(out, m.dispatcherProcessingDuration, "alertmanager_dispatcher_alert_processing_duration_seconds")
+	data.SendSumOfCountersPerUser(out, m.dispatcherAggregationGroupsLimitReached, "alertmanager_dispatcher_aggregation_group_limit_reached_total")
 
 	data.SendSumOfCountersPerUser(out, m.notificationRateLimited, "alertmanager_notification_rate_limited_total", util.WithLabels("integration"), util.WithSkipZeroValueMetrics)
-	data.SendSumOfCountersPerUser(out, m.dispatcherAggregationGroupsLimitReached, "alertmanager_dispatcher_aggregation_group_limit_reached_total")
 	data.SendSumOfCountersPerUser(out, m.insertAlertFailures, "alertmanager_alerts_insert_limited_total")
 	data.SendSumOfGaugesPerUser(out, m.alertsLimiterAlertsCount, "alertmanager_alerts_limiter_current_alerts")
 	data.SendSumOfGaugesPerUser(out, m.alertsLimiterAlertsSize, "alertmanager_alerts_limiter_current_alerts_size_bytes")


### PR DESCRIPTION
There are two metrics in the Dispatcher component of the upstream Alertmanager
we don't currently expose:

- `alertmanager_dispatcher_aggregation_groups`
- `alertmanager_dispatcher_alert_processing_duration_seconds`

I can't see any reasoning behind ommitting these, so I am assuming it was
perhaps just an oversight, and adding them in this commit. I've chosen not
to expose metrics per-user - we can consider this if a need arises.

The change also re-orders the code so all the Dispatcher metrics are grouped
together, and extends the unit test to get coverage on the existing metric
(`cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total`).
