### PR TITLE
Remove namespace from PodSecurityPolicy helm template

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -40,7 +40,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Expose OTLP ingestion in the `gateway` NGINX configuration. #3851
 * [BUGFIX] Use alertmanager headless service in `gateway` NGINX configuration. #3851
 * [BUGFIX] Use `50Gi` persistent volume for ingesters in `capped-small.yaml`. #3919
-* [BUGFIX] Do not include namespace for the PodSecurityPolicy definition as it is not needed and some tools reject it outright.
+* [BUGFIX] Do not include namespace for the PodSecurityPolicy definition as it is not needed and some tools reject it outright. #4164
 
 ## 4.0.1
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -40,6 +40,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Expose OTLP ingestion in the `gateway` NGINX configuration. #3851
 * [BUGFIX] Use alertmanager headless service in `gateway` NGINX configuration. #3851
 * [BUGFIX] Use `50Gi` persistent volume for ingesters in `capped-small.yaml`. #3919
+* [BUGFIX] Do not include namespace for the PodSecurityPolicy definition as it is not needed and some tools reject it outright.
 
 ## 4.0.1
 

--- a/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" .) }}
   labels:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
-  namespace: {{ .Release.Namespace | quote }}
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/policies/policies.rego
+++ b/operations/helm/policies/policies.rego
@@ -6,20 +6,34 @@ has_key(x, k) {
 	_ = x[k]
 }
 
-deny[msg] {
-	obj := input[i].contents
-	msg := sprintf("Resource doesn't have a namespace %v", [obj])
-	namespace := obj.metadata.namespace
+should_be_namespaced(contents) {
+	# if we don't know the kind, then it should have a namespace
+	not has_key(contents, "kind")
+}
 
-	not regex.match(".+", namespace)
+should_be_namespaced(contents) {
+	not contents.kind in ["PodSecurityPolicy"]
+}
+
+metadata_has_namespace(metadata) {
+	has_key(metadata, "namespace")
+	regex.match(".+", metadata.namespace)
 }
 
 deny[msg] {
 	obj := input[i].contents
 	msg := sprintf("Resource doesn't have a namespace %v", [obj])
-	metadata := obj.metadata
 
-	not has_key(metadata, "namespace")
+	should_be_namespaced(obj)
+	not metadata_has_namespace(obj.metadata)
+}
+
+deny[msg] {
+	obj := input[i].contents
+	msg := sprintf("Resource has a namespace, but shouldn't %v", [obj])
+
+	not should_be_namespaced(obj)
+	metadata_has_namespace(obj.metadata)
 }
 
 can_use_topology_spread_constraints(kind) {

--- a/operations/helm/policies/policies_test.rego
+++ b/operations/helm/policies/policies_test.rego
@@ -57,6 +57,5 @@ passing_deployment := {"contents": {
 }}
 
 test_passing_deployment if {
-	input := [passing_deployment]
-	count(deny) == 0
+	count(deny) == 0 with input as [passing_deployment]
 }

--- a/operations/helm/policies/policies_test.rego
+++ b/operations/helm/policies/policies_test.rego
@@ -22,6 +22,7 @@ test_namespace_forbidden_on_psp if {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "resource", "namespace": "example"},
 	}}]
+
 	contains(reason, "Resource has a namespace, but shouldn't")
 }
 
@@ -30,7 +31,7 @@ passing_psp := {"contents": {
 	"metadata": {"name": "resource"},
 }}
 
-test_passing_psp_without_namespace {
+test_passing_psp_without_namespace if {
 	count(deny) == 0 with input as [passing_psp]
 }
 

--- a/operations/helm/policies/policies_test.rego
+++ b/operations/helm/policies/policies_test.rego
@@ -17,6 +17,23 @@ test_null_namespace_not_allowed if {
 	contains(reason, "Resource doesn't have a namespace")
 }
 
+test_namespace_forbidden_on_psp if {
+	deny[reason] with input as [{"contents": {
+		"kind": "PodSecurityPolicy",
+		"metadata": {"name": "resource", "namespace": "example"},
+	}}]
+	contains(reason, "Resource has a namespace, but shouldn't")
+}
+
+passing_psp := {"contents": {
+	"kind": "PodSecurityPolicy",
+	"metadata": {"name": "resource"},
+}}
+
+test_passing_psp_without_namespace {
+	count(deny) == 0 with input as [passing_psp]
+}
+
 passing_container := {
 	"image": "grafana/mimir",
 	"securityContext": {

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: graphite-enabled-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app: enterprise-metrics
     heritage: Helm
     release: test-enterprise-legacy-label-values
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/managed-by: Helm
-  namespace: "citestns"
   annotations:
     "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
 spec:


### PR DESCRIPTION
#### What this PR does

This PR fixes using the chart with kustomization terraform provider:

```
Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceDiff: "policy/PodSecurityPolicy/perfana/mimir-distributed": is not namespace scoped but has metadata.namespace set
```

K8S itself just gives a warning on this, but some utilities reject it like above. There is no explicit rule against it in the K8S documentation.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
