### PR TITLE
Query-frontend: Log with info level when waiting on in-flight requests

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -131,12 +131,12 @@ func (f *Handler) Stop() {
 	f.mtx.Lock()
 	f.stopped = true
 
-	level.Debug(f.log).Log("msg", "waiting on in-flight requests", "requests", f.inflightRequests)
+	level.Info(f.log).Log("msg", "waiting on in-flight requests", "requests", f.inflightRequests)
 	for f.inflightRequests > 0 {
 		f.cond.Wait()
 	}
 	f.mtx.Unlock()
-	level.Debug(f.log).Log("msg", "done waiting on in-flight requests")
+	level.Info(f.log).Log("msg", "done waiting on in-flight requests")
 }
 
 func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### What this PR does
Upgrade query-frontend log messages when waiting on in-flight requests to info level. Requested by @pracucci.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
