### PR TITLE
Store-gateway: add separation of chunks into ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation rate when loading TSDB chunks from Memcached. #4074
 * [ENHANCEMENT] Query-frontend: track `cortex_frontend_query_response_codec_duration_seconds` and `cortex_frontend_query_response_codec_payload_bytes` metrics to measure the time taken and bytes read / written while encoding and decoding query result payloads. #4110
 * [ENHANCEMENT] Alertmanager: expose additional upstream metrics `cortex_alertmanager_dispatcher_aggregation_groups`, `cortex_alertmanager_dispatcher_alert_processing_duration_seconds`. #4151
-* [ENHANCEMENT] Store-gateway: use more efficient chunks fetching and caching. This should reduce CPU, memory utilization, and receive bandwidth of a store-gateway. #4163
+* [ENHANCEMENT] Store-gateway: use more efficient chunks fetching and caching. This should reduce CPU, memory utilization, and receive bandwidth of a store-gateway. #4163 #4174
 * [ENHANCEMENT] Query-frontend: Wait for in-flight queries to finish before shutting down. #4073 #4170
 * [BUGFIX] Ingester: remove series from ephemeral storage even if there are no persistent series. #4052
 * [BUGFIX] Store-gateway: return `Canceled` rather than `Aborted` or `Internal` error when the calling querier cancels a label names or values request, and return `Internal` if processing the request fails for another reason. #4061

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1139,7 +1139,7 @@ func (s *BucketStore) streamingSeriesSetForBlocks(
 
 	var set storepb.SeriesSet
 	if chunkReaders != nil {
-		set = newSeriesSetWithChunks(ctx, *chunkReaders, mergedIterator, s.maxSeriesPerBatch, stats)
+		set = newSeriesSetWithChunks(ctx, *chunkReaders, mergedIterator, s.maxSeriesPerBatch, stats, req.MinTime, req.MaxTime)
 	} else {
 		set = newSeriesSetWithoutChunks(ctx, mergedIterator, stats)
 	}

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -56,14 +56,21 @@ func (r *bucketChunkReader) reset() {
 // Chunk will be fetched and saved to res[seriesEntry][chunk] upon r.load(res, <...>) call.
 func (r *bucketChunkReader) addLoad(id chunks.ChunkRef, seriesEntry, chunk int) error {
 	var (
-		seq = int(id >> 32)
-		off = uint32(id)
+		seq = chunkSegmentFile(id)
+		off = chunkOffset(id)
 	)
 	if seq >= len(r.toLoad) {
 		return errors.Errorf("reference sequence %d out of range", seq)
 	}
 	r.toLoad[seq] = append(r.toLoad[seq], loadIdx{off, seriesEntry, chunk})
 	return nil
+}
+
+func chunkSegmentFile(id chunks.ChunkRef) int { return int(id >> 32) }
+func chunkOffset(id chunks.ChunkRef) uint32   { return uint32(id) }
+
+func chunkRef(segmentFile, offset uint32) chunks.ChunkRef {
+	return chunks.ChunkRef(uint64(segmentFile)<<32 | uint64(offset))
 }
 
 // load all added chunks and saves resulting chunks to res.

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -640,4 +641,22 @@ func (l *bucketIndexLoadedSeries) unsafeLoadSeriesForTime(ref storage.SeriesRef,
 	stats.seriesTouched++
 	stats.seriesTouchedSizeSum += len(b)
 	return decodeSeriesForTime(b, lset, chks, skipChunks, mint, maxt)
+}
+
+// unsafeLoadSeries populates the given symbolized labels for the series identified by the reference the series has at least one chunk in the block.
+// unsafeLoadSeries also populates the given chunk metas slice if skipChunks is set to false. The returned chunkMetas will be in the same
+// order as in the index, which at this point is ordered by minTime and by their ref. The returned chunk metas are all the chunk for the series.
+// unsafeLoadSeries returns false, when there are no series data.
+//
+// Error is returned on decoding error or if the reference does not resolve to a known series.
+//
+// It's NOT safe to call this function concurrently with addSeries().
+func (l *bucketIndexLoadedSeries) unsafeLoadSeries(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, stats *queryStats) (ok bool, err error) {
+	b, ok := l.series[ref]
+	if !ok {
+		return false, errors.Errorf("series %d not found", ref)
+	}
+	stats.seriesTouched++
+	stats.seriesTouchedSizeSum += len(b)
+	return decodeSeriesForTime(b, lset, chks, skipChunks, 0, math.MaxInt64)
 }

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -658,5 +658,5 @@ func (l *bucketIndexLoadedSeries) unsafeLoadSeries(ref storage.SeriesRef, lset *
 	}
 	stats.seriesTouched++
 	stats.seriesTouchedSizeSum += len(b)
-	return decodeSeriesForTime(b, lset, chks, skipChunks, 0, math.MaxInt64)
+	return decodeSeriesForTime(b, lset, chks, skipChunks, math.MinInt64, math.MaxInt64)
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -909,17 +909,6 @@ func clampLastChunkLength(series []seriesChunkRefs, metas []chunks.Meta) {
 	}
 }
 
-func nextChunkRef(metas [][]chunks.Meta, gIdx int, cIdx int) (chunks.ChunkRef, bool) {
-	if cIdx+1 >= len(metas[gIdx]) && gIdx+1 >= len(metas) {
-		return 0, false
-	}
-
-	if cIdx+1 < len(metas[gIdx]) {
-		return metas[gIdx][cIdx+1].Ref, true
-	}
-	return metas[gIdx+1][0].Ref, true
-}
-
 // partitionChunks creates a slice of seriesChunkRefsRange for each range of chunks within the same segment file.
 // It may also create more ranges if there are more chunks.
 // The partitioning here should be fairly static and not depend on the actual Series() request because
@@ -1005,6 +994,17 @@ func metasToRanges(metas [][]chunks.Meta, blockID ulid.ULID, minT, maxT int64) [
 		})
 	}
 	return ranges
+}
+
+func nextChunkRef(metas [][]chunks.Meta, gIdx int, cIdx int) (chunks.ChunkRef, bool) {
+	if cIdx+1 >= len(metas[gIdx]) && gIdx+1 >= len(metas) {
+		return 0, false
+	}
+
+	if cIdx+1 < len(metas[gIdx]) {
+		return metas[gIdx][cIdx+1].Ref, true
+	}
+	return metas[gIdx+1][0].Ref, true
 }
 
 func (s *loadingSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -191,26 +191,6 @@ type seriesChunkRef struct {
 	minTime, maxTime int64
 }
 
-// Compare returns > 0 if m should be before other when sorting seriesChunkRef,
-// 0 if they're equal or < 0 if m should be after other.
-func (m seriesChunkRef) Compare(other seriesChunkRef) int {
-	if m.minTime < other.minTime {
-		return 1
-	}
-	if m.minTime > other.minTime {
-		return -1
-	}
-
-	// Same min time.
-	if m.maxTime < other.maxTime {
-		return 1
-	}
-	if m.maxTime > other.maxTime {
-		return -1
-	}
-	return 0
-}
-
 // seriesChunkRefsIteratorImpl implements an iterator returning a sequence of seriesChunkRefs.
 type seriesChunkRefsIteratorImpl struct {
 	currentOffset int

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -153,7 +154,7 @@ func (g seriesChunkRefsRange) minTime() int64 {
 
 func (g seriesChunkRefsRange) maxTime() int64 {
 	// Since chunks are only ordered by minTime, we have no guarantee for their maxTime, so we need to iterate all.
-	var maxT int64
+	maxT := int64(math.MinInt64)
 	for _, c := range g.refs {
 		if c.maxTime > maxT {
 			maxT = c.maxTime

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -942,6 +942,9 @@ func metasToRanges(partitions [][]chunks.Meta, blockID ulid.ULID, minT, maxT int
 			rangesWithinTime++
 		}
 	}
+	if rangesWithinTime == 0 {
+		return nil
+	}
 	ranges := make([]seriesChunkRefsRange, 0, rangesWithinTime)
 
 	for pIdx, partition := range partitions {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -442,7 +442,7 @@ func (s *mergedSeriesChunkRefsSet) ensureItemAvailableToRead(curr *seriesChunkRe
 }
 
 // nextUniqueEntry returns the next unique entry from both a and b. If a.At() and b.At() have the same
-// label set, nextUniqueEntry merges their chunks ranges. The merged ranges are sorted by their MinTime and then by MaxTIme.
+// label set, nextUniqueEntry merges their chunks ranges. The merged ranges are sorted by their MinTime and then by MaxTime.
 func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIteratorImpl) (toReturn seriesChunkRefs, _ bool) {
 	if a.Done() && b.Done() {
 		return toReturn, false

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -896,7 +896,7 @@ func clampLastChunkLength(series []seriesChunkRefs, nextSeriesChunkMetas []chunk
 
 const (
 	chunksRangesPerSeries = 2
-	minChunksPerRange     = 2
+	minChunksPerRange     = 10
 )
 
 // partitionChunks creates a slice of []chunks.Meta for each range of chunks within the same segment file.

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -165,18 +165,18 @@ func (g seriesChunkRefsRange) maxTime() int64 {
 
 func (g seriesChunkRefsRange) Compare(other seriesChunkRefsRange) int {
 	if g.minTime() < other.minTime() {
-		return 1
+		return -1
 	}
 	if g.minTime() > other.minTime() {
-		return -1
+		return 1
 	}
 	// Same min time.
 
 	if g.maxTime() < other.maxTime() {
-		return 1
+		return -1
 	}
 	if g.maxTime() > other.maxTime() {
-		return -1
+		return 1
 	}
 	return 0
 }
@@ -490,7 +490,7 @@ Outer:
 				break Outer
 			}
 
-			if chksA[aChunksOffset].Compare(chksB[bChunksOffset]) > 0 {
+			if chksA[aChunksOffset].Compare(chksB[bChunksOffset]) < 0 {
 				toReturn.chunksRanges = append(toReturn.chunksRanges, chksA[aChunksOffset])
 				break
 			} else {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -870,24 +870,26 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 // If the length of that chunk is larger than the difference with the first chunk ref in metas
 // then the length is clamped at that difference.
 // clampLastChunkLength assumes that the chunks are sorted by their refs
-// (currently this is equivalent to also being sorted by their minTime)
+// (currently this is equivalent to also being sorted by their minTime) and that all series belong to the same block.
 // clampLastChunkLength is a noop if metas or series is empty.
-func clampLastChunkLength(series []seriesChunkRefs, metas []chunks.Meta) {
-	if len(series) == 0 || len(metas) == 0 {
+func clampLastChunkLength(series []seriesChunkRefs, nextSeriesChunkMetas []chunks.Meta) {
+	if len(series) == 0 || len(nextSeriesChunkMetas) == 0 {
 		return
 	}
 	var (
 		lastSeriesRanges = series[len(series)-1].chunksRanges
 		lastRange        = lastSeriesRanges[len(lastSeriesRanges)-1]
 		lastSeriesChunk  = lastRange.refs[len(lastRange.refs)-1]
-		firstRef         = metas[0].Ref
+		firstRef         = nextSeriesChunkMetas[0].Ref
 	)
 
+	// We only compare the segment file of the series because they all come from the same block.
 	if lastRange.segmentFile != uint32(chunkSegmentFile(firstRef)) {
 		return
 	}
 	diffWithNextChunk := chunkOffset(firstRef) - lastSeriesChunk.segFileOffset
-	if lastSeriesChunk.length > diffWithNextChunk {
+	// The diff should always be positive, but if for some reason it isn't (a bug?), we don't want to set length to a negative value.
+	if diffWithNextChunk > 0 && lastSeriesChunk.length > diffWithNextChunk {
 		lastRange.refs[len(lastRange.refs)-1].length = diffWithNextChunk
 	}
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -846,7 +846,7 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 			s.err = errors.Wrap(err, "read series")
 			return false
 		}
-		if len(lset) == 0 {
+		if lset.Len() == 0 {
 			// An empty label set means the series had no chunks in this block, so we skip it.
 			continue
 		}

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -998,7 +998,7 @@ func (s *loadingSeriesChunkRefsSetIterator) Err() error {
 	return s.err
 }
 
-// loadSeries returns a for chunks. It is not safe to use the buffer after calling loadSeries again
+// loadSeries returns a for chunks. It is not safe to use the returned []chunks.Meta after calling loadSeries again
 func (s *loadingSeriesChunkRefsSetIterator) loadSeries(ref storage.SeriesRef, loadedSeries *bucketIndexLoadedSeries, stats *queryStats) (labels.Labels, []chunks.Meta, error) {
 	ok, err := loadedSeries.unsafeLoadSeries(ref, &s.symbolizedLsetBuffer, &s.chunkMetasBuffer, s.skipChunks, stats)
 	if !ok || err != nil {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -451,9 +451,10 @@ func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIterator
 		return toReturn, true
 	}
 
-	// Both a and b contains the same series. Go through all chunk references and concatenate them from both
-	// series sets. We best effortly assume chunk references are sorted by min time, so that the sorting by min
-	// time is honored in the returned chunk references too.
+	// Both a and b contains the same series. Go through all chunk ranges and concatenate them from both
+	// series sets. We best effortly assume chunk ranges are sorted by min time. This means that
+	// if the ranges overlap, then the resulting chunks will not be in min time order.
+	// This is ok since the series API doesn't require us to return sorted chunks.
 	toReturn.lset = lsetA
 
 	// Slice reuse is not generally safe with nested merge iterators.

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -152,7 +152,7 @@ func (g seriesChunkRefsRange) minTime() int64 {
 }
 
 func (g seriesChunkRefsRange) maxTime() int64 {
-	// Since chunks are only ordered by minTime, we have no guarantee for their maxTIme, so we need to iterate all.
+	// Since chunks are only ordered by minTime, we have no guarantee for their maxTime, so we need to iterate all.
 	var maxT int64
 	for _, c := range g.refs {
 		if c.maxTime > maxT {
@@ -185,7 +185,8 @@ type seriesChunkRef struct {
 	// The order of these fields matters; having the uint32 on top makes the whole struct 24 bytes; in a different order the struct is 32B
 	segFileOffset uint32
 	// length will be 0 when the length of the chunk isn't known
-	length           uint32
+	length uint32
+	// minTime and maxTime are inclusive
 	minTime, maxTime int64
 }
 

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +22,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/test"
@@ -34,20 +34,20 @@ func init() {
 }
 
 func TestSeriesChunkRef_Compare(t *testing.T) {
-	input := []seriesChunkRef{
-		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
-		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
-		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
-		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
-		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
+	input := []seriesChunkRefsRange{
+		{blockID: ulid.MustNew(0, nil), refs: []seriesChunkRef{{minTime: 2, maxTime: 5}}},
+		{blockID: ulid.MustNew(1, nil), refs: []seriesChunkRef{{minTime: 1, maxTime: 5}}},
+		{blockID: ulid.MustNew(2, nil), refs: []seriesChunkRef{{minTime: 1, maxTime: 3}}},
+		{blockID: ulid.MustNew(3, nil), refs: []seriesChunkRef{{minTime: 4, maxTime: 7}}},
+		{blockID: ulid.MustNew(4, nil), refs: []seriesChunkRef{{minTime: 3, maxTime: 6}}},
 	}
 
-	expected := []seriesChunkRef{
-		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
-		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
-		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
-		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
-		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
+	expected := []seriesChunkRefsRange{
+		{blockID: ulid.MustNew(2, nil), refs: []seriesChunkRef{{minTime: 1, maxTime: 3}}},
+		{blockID: ulid.MustNew(1, nil), refs: []seriesChunkRef{{minTime: 1, maxTime: 5}}},
+		{blockID: ulid.MustNew(0, nil), refs: []seriesChunkRef{{minTime: 2, maxTime: 5}}},
+		{blockID: ulid.MustNew(4, nil), refs: []seriesChunkRef{{minTime: 3, maxTime: 6}}},
+		{blockID: ulid.MustNew(3, nil), refs: []seriesChunkRef{{minTime: 4, maxTime: 7}}},
 	}
 
 	sort.Slice(input, func(i, j int) bool {
@@ -58,7 +58,7 @@ func TestSeriesChunkRef_Compare(t *testing.T) {
 }
 
 func TestSeriesChunkRefsIterator(t *testing.T) {
-	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 5)
+	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 5)
 	series1 := labels.FromStrings(labels.MetricName, "metric_1")
 	series2 := labels.FromStrings(labels.MetricName, "metric_2")
 	series3 := labels.FromStrings(labels.MetricName, "metric_3")
@@ -80,9 +80,9 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 	t.Run("should iterate a set with some items", func(t *testing.T) {
 		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
 			series: []seriesChunkRefs{
-				{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
-				{lset: series2, chunks: []seriesChunkRef{c[2]}},
-				{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}},
+				{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}},
+				{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}},
+				{lset: series3, chunksRanges: []seriesChunkRefsRange{c[3], c[4]}},
 			},
 		})
 
@@ -90,15 +90,15 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 		require.Zero(t, it.At())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series2, chunks: []seriesChunkRef{c[2]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series3, chunksRanges: []seriesChunkRefsRange{c[3], c[4]}}, it.At())
 		require.False(t, it.Done())
 
 		require.False(t, it.Next())
@@ -109,9 +109,9 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 	t.Run("should re-initialize the internal state on reset()", func(t *testing.T) {
 		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
 			series: []seriesChunkRefs{
-				{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
-				{lset: series2, chunks: []seriesChunkRef{c[2]}},
-				{lset: series3, chunks: []seriesChunkRef{c[3], c[4]}},
+				{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}},
+				{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}},
+				{lset: series3, chunksRanges: []seriesChunkRefsRange{c[3], c[4]}},
 			},
 		})
 
@@ -119,29 +119,29 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 		require.Zero(t, it.At())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series2, chunks: []seriesChunkRef{c[2]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}}, it.At())
 		require.False(t, it.Done())
 
 		// Reset.
 		it.reset(seriesChunkRefsSet{
 			series: []seriesChunkRefs{
-				{lset: series1, chunks: []seriesChunkRef{c[3]}},
-				{lset: series4, chunks: []seriesChunkRef{c[4]}},
+				{lset: series1, chunksRanges: []seriesChunkRefsRange{c[3]}},
+				{lset: series4, chunksRanges: []seriesChunkRefsRange{c[4]}},
 			},
 		})
 
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series1, chunks: []seriesChunkRef{c[3]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series1, chunksRanges: []seriesChunkRefsRange{c[3]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series4, chunks: []seriesChunkRef{c[4]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series4, chunksRanges: []seriesChunkRefsRange{c[4]}}, it.At())
 		require.False(t, it.Done())
 
 		require.False(t, it.Next())
@@ -152,7 +152,7 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 
 func TestFlattenedSeriesChunkRefs(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are returned.
-	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 6)
+	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
 		input    seriesChunkRefsSetIterator
@@ -169,58 +169,58 @@ func TestFlattenedSeriesChunkRefs(t *testing.T) {
 		"should iterate a set with multiple items": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}}),
 			expected: []seriesChunkRefs{
-				{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-				{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+				{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+				{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 			},
 		},
 		"should iterate multiple sets with multiple items each": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}}),
 			expected: []seriesChunkRefs{
-				{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-				{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
-				{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
-				{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-				{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+				{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+				{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+				{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+				{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+				{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 			},
 		},
 		"should keep iterating on empty sets": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}},
 				seriesChunkRefsSet{}),
 			expected: []seriesChunkRefs{
-				{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-				{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
-				{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
-				{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-				{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+				{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+				{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+				{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+				{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+				{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 			},
 		},
 	}
@@ -240,7 +240,7 @@ func TestFlattenedSeriesChunkRefs(t *testing.T) {
 
 func TestMergedSeriesChunkRefsSet(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are merged.
-	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 6)
+	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
 		batchSize    int
@@ -252,18 +252,18 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1], c[2], c[3]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1], c[2], c[3]}},
 				}},
 			},
 		},
@@ -271,19 +271,19 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[0]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[0], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[0], c[2], c[3]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[0], c[0], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[0], c[0], c[2], c[3]}},
 				}},
 			},
 		},
@@ -292,14 +292,14 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			set1:      emptySeriesChunkRefsSetIterator{},
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
 				}},
 			},
 		},
@@ -307,12 +307,12 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
 				},
 			}),
 			expectedSets: nil, // We expect no returned sets because an error occurred while creating the first one.
@@ -322,12 +322,12 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
 				},
 			}),
 			expectedSets: nil, // We expect no returned sets because an error occurred while creating the first one.
@@ -337,15 +337,15 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v3"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v4"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: make([]seriesChunkRefsRange, 1)},
 				},
 			}),
 			expectedSets: nil, // We expect no returned sets because an error occurred while creating the first one.
@@ -355,62 +355,62 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 1, // Use a batch size of 1 in this test so that we can see when the iteration stops.
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[3]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}},
 			},
 			expectedErr: "something went wrong",
 		},
-		"should return merged chunks sorted by min time (assuming source sets have sorted chunks) on first chunk on first set": {
+		"should return merged chunks ranges sorted by min time (assuming source sets have sorted ranges) on first chunk on first set": {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1], c[3]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[2]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}},
 				}},
 			},
 		},
-		"should return merged chunks sorted by min time (assuming source sets have sorted chunks) on first chunk on second set": {
+		"should return merged chunks ranges sorted by min time (assuming source sets have sorted ranges) on first chunk on second set": {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[3]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1], c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1], c[2]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}},
 				}},
 			},
 		},
@@ -418,103 +418,103 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 1,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 				seriesChunkRefsSet{},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3], c[3]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3], c[3]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			},
 		},
 		"should keep iterating on empty underlying sets (batch size = 2)": {
 			batchSize: 2,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 				seriesChunkRefsSet{},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3], c[3]}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3], c[3]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}},
 			},
 		},
 		"should keep iterating on second set after first set is exhausted (batch size = 1)": {
 			batchSize: 1,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			},
 		},
 		"should keep iterating on second set after first set is exhausted (batch size = 100)": {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}},
 			},
 		},
@@ -522,43 +522,43 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 1,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			},
 		},
 		"should keep iterating on first set after second set is exhausted (batch size = 100)": {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}},
 			},
 		},
@@ -583,7 +583,7 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 				require.Len(t, sets[setIdx].series, len(expectedSet.series))
 				for expectedSeriesIdx, expectedSeries := range expectedSet.series {
 					assert.Equal(t, expectedSeries.lset, sets[setIdx].series[expectedSeriesIdx].lset)
-					assert.Equal(t, expectedSeries.chunks, sets[setIdx].series[expectedSeriesIdx].chunks)
+					assert.Equal(t, expectedSeries.chunksRanges, sets[setIdx].series[expectedSeriesIdx].chunksRanges)
 				}
 			}
 		})
@@ -741,7 +741,7 @@ func BenchmarkMergedSeriesChunkRefsSetIterators(b *testing.B) {
 
 func TestSeriesSetWithoutChunks(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are returned.
-	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 6)
+	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
 		input              seriesChunkRefsSetIterator
@@ -761,8 +761,8 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 		"should iterate a set with multiple items": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}}),
 			expectedSeries: []labels.Labels{
 				labels.FromStrings("l1", "v1"),
@@ -773,15 +773,15 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 		"should iterate multiple sets with multiple items each": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}}),
 			expectedSeries: []labels.Labels{
 				labels.FromStrings("l1", "v1"),
@@ -796,17 +796,17 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunks: []seriesChunkRef{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
 				}},
 				seriesChunkRefsSet{}),
 			expectedSeries: []labels.Labels{
@@ -840,20 +840,20 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 
 func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 	// Generate some chunk fixtures so that we can ensure the right chunks are returned.
-	c := generateSeriesChunkRef(ulid.MustNew(1, nil), 8)
+	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 8)
 
 	series1 := labels.FromStrings("l1", "v1")
 	series2 := labels.FromStrings("l1", "v2")
 	series3 := labels.FromStrings("l1", "v3")
 	sourceSets := []seriesChunkRefsSet{
 		{series: []seriesChunkRefs{
-			{lset: series1, chunks: []seriesChunkRef{c[0], c[1]}},
-			{lset: series1, chunks: []seriesChunkRef{c[2], c[3], c[4]}},
+			{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}},
+			{lset: series1, chunksRanges: []seriesChunkRefsRange{c[2], c[3], c[4]}},
 		}},
 		{series: []seriesChunkRefs{
-			{lset: series2, chunks: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
-			{lset: series3, chunks: []seriesChunkRef{c[0]}},
-			{lset: series3, chunks: []seriesChunkRef{c[1]}},
+			{lset: series2, chunksRanges: []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}},
+			{lset: series3, chunksRanges: []seriesChunkRefsRange{c[0]}},
+			{lset: series3, chunksRanges: []seriesChunkRefsRange{c[1]}},
 		}},
 	}
 
@@ -867,15 +867,15 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 
 		require.Len(t, sets[0].series, 1)
 		assert.Equal(t, series1, sets[0].series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunksRanges)
 
 		require.Len(t, sets[1].series, 1)
 		assert.Equal(t, series2, sets[1].series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, sets[1].series[0].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}, sets[1].series[0].chunksRanges)
 
 		require.Len(t, sets[2].series, 1)
 		assert.Equal(t, series3, sets[2].series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, sets[2].series[0].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1]}, sets[2].series[0].chunksRanges)
 	})
 
 	t.Run("batch size: 2", func(t *testing.T) {
@@ -890,16 +890,16 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 		require.Len(t, sets[0].series, 2)
 
 		assert.Equal(t, series1, sets[0].series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunksRanges)
 
 		assert.Equal(t, series2, sets[0].series[1].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, sets[0].series[1].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}, sets[0].series[1].chunksRanges)
 
 		// Second batch.
 		require.Len(t, sets[1].series, 1)
 
 		assert.Equal(t, series3, sets[1].series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, sets[1].series[0].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1]}, sets[1].series[0].chunksRanges)
 	})
 
 	t.Run("batch size: 3", func(t *testing.T) {
@@ -912,23 +912,23 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 		require.Len(t, sets[0].series, 3)
 
 		assert.Equal(t, series1, sets[0].series[0].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunksRanges)
 
 		assert.Equal(t, series2, sets[0].series[1].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, sets[0].series[1].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}, sets[0].series[1].chunksRanges)
 
 		assert.Equal(t, series3, sets[0].series[2].lset)
-		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, sets[0].series[2].chunks)
+		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1]}, sets[0].series[2].chunksRanges)
 	})
 }
 
 func TestDeduplicatingSeriesChunkRefsSetIterator_PropagatesErrors(t *testing.T) {
 	chainedSet := newDeduplicatingSeriesChunkRefsSetIterator(100, newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 		series: []seriesChunkRefs{
-			{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-			{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-			{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
-			{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+			{lset: labels.FromStrings("l1", "v1"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+			{lset: labels.FromStrings("l1", "v1"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+			{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+			{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
 		},
 	}))
 
@@ -939,6 +939,7 @@ func TestDeduplicatingSeriesChunkRefsSetIterator_PropagatesErrors(t *testing.T) 
 }
 
 func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
+	blockID := ulid.MustNew(1, nil)
 	testCases := map[string]struct {
 		sets                     []seriesChunkRefsSet
 		seriesLimit, chunksLimit int
@@ -953,10 +954,10 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedSetsCount: 1,
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -967,10 +968,10 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded chunks limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 2)},
-					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 3)},
-					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 4)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 2)},
+					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 3)},
+					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 4)},
 				}},
 			},
 		},
@@ -981,12 +982,23 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded chunks limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+				}},
+			},
+		},
+		"exceeds chunks limit with multiple chunks per range": {
+			seriesLimit:       2,
+			chunksLimit:       5,
+			expectedSetsCount: 0,
+			expectedErr:       "exceeded chunks limit",
+			sets: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRangesN(blockID, 2, 3)},
 				}},
 			},
 		},
@@ -997,10 +1009,10 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded series limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1011,12 +1023,12 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded series limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1028,12 +1040,12 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "something went wrong",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l2", "v1"), chunks: make([]seriesChunkRef, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunks: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1085,10 +1097,19 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{{minTime: 10, maxTime: 10, ref: 26}}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{{minTime: 20, maxTime: 20, ref: 234}}},
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{{minTime: 40, maxTime: 40, ref: 650}}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 10, maxTime: 10, segFileOffset: 26, length: 208},
+					}}}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 20, maxTime: 20, segFileOffset: 234, length: 208},
+					}}}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 30, maxTime: 30, segFileOffset: 442, length: 208},
+					}}}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						// For the rest of the chunks we could take the diff with the next series' chunk, but for the last we use the default estimate.
+						{minTime: 40, maxTime: 40, segFileOffset: 650, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
@@ -1099,12 +1120,20 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunks: []seriesChunkRef{{minTime: 10, maxTime: 10, ref: 26}}},
-					{lset: labels.FromStrings("l1", "v2"), chunks: []seriesChunkRef{{minTime: 20, maxTime: 20, ref: 234}}},
+					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 10, maxTime: 10, segFileOffset: 26, length: 208},
+					}}}},
+					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 20, maxTime: 20, segFileOffset: 234, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{{minTime: 40, maxTime: 40, ref: 650}}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 30, maxTime: 30, segFileOffset: 442, length: 208},
+					}}}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 40, maxTime: 40, segFileOffset: 650, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
@@ -1137,8 +1166,12 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
-					{lset: labels.FromStrings("l1", "v4"), chunks: []seriesChunkRef{{minTime: 40, maxTime: 40, ref: 650}}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 30, maxTime: 30, segFileOffset: 442, length: 208},
+					}}}},
+					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{minTime: 40, maxTime: 40, segFileOffset: 650, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
@@ -1169,7 +1202,12 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			matchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", "v[1-4]")},
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunks: []seriesChunkRef{{minTime: 30, maxTime: 30, ref: 442}}},
+					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						// We select only one series, but there are other series which aren't returned because of the shard.
+						// We still use those series' chunk refs to estimate lengths of other series. So in this case
+						// the last chunk didn't use the default estimation.
+						{minTime: 30, maxTime: 30, segFileOffset: 442, length: 208},
+					}}}},
 				}},
 			},
 		},
@@ -1227,31 +1265,41 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			// Tests
 			sets := readAllSeriesChunkRefsSet(loadingIterator)
 			assert.NoError(t, loadingIterator.Err())
-			if !assert.Len(t, sets, len(testCase.expectedSets), testName) {
-				return
-			}
-
-			for i, actualSet := range sets {
-				expectedSet := testCase.expectedSets[i]
-				if !assert.Equalf(t, expectedSet.len(), actualSet.len(), "%d", i) {
-					continue
-				}
-				for j, actualSeries := range actualSet.series {
-					expectedSeries := expectedSet.series[j]
-					assert.Truef(t, labels.Equal(actualSeries.lset, expectedSeries.lset), "%d, %d: expected labels %s got %s", i, j, expectedSeries.lset, actualSeries.lset)
-					if !assert.Lenf(t, actualSeries.chunks, len(expectedSeries.chunks), "%d, %d", i, j) {
-						continue
-					}
-					for k, actualChunk := range actualSeries.chunks {
-						expectedChunk := expectedSeries.chunks[k]
-						assert.Equalf(t, expectedChunk.maxTime, actualChunk.maxTime, "%d, %d, %d", i, j, k)
-						assert.Equalf(t, expectedChunk.minTime, actualChunk.minTime, "%d, %d, %d", i, j, k)
-						assert.Equalf(t, int(expectedChunk.ref), int(actualChunk.ref), "%d, %d, %d", i, j, k)
-						assert.Equalf(t, block.meta.ULID, actualChunk.blockID, "%d, %d, %d", i, j, k)
-					}
-				}
-			}
+			assertSeriesChunkRefsSetsEqual(t, block.meta.ULID, testCase.expectedSets, sets)
 		})
+	}
+}
+
+func assertSeriesChunkRefsSetsEqual(t testing.TB, blockID ulid.ULID, expected, actual []seriesChunkRefsSet) {
+	t.Helper()
+	if !assert.Len(t, actual, len(expected)) {
+		return
+	}
+	for i, actualSet := range actual {
+		expectedSet := expected[i]
+		if !assert.Equalf(t, expectedSet.len(), actualSet.len(), "%d", i) {
+			continue
+		}
+		for j, actualSeries := range actualSet.series {
+			expectedSeries := expectedSet.series[j]
+			assert.Truef(t, labels.Equal(actualSeries.lset, expectedSeries.lset), "[%d, %d]: expected labels %s got %s", i, j, expectedSeries.lset, actualSeries.lset)
+			if !assert.Lenf(t, actualSeries.chunksRanges, len(expectedSeries.chunksRanges), "chunk ranges len [%d, %d]", i, j) {
+				continue
+			}
+			for k, actualChunksRange := range actualSeries.chunksRanges {
+				expectedRange := expectedSeries.chunksRanges[k]
+				assert.Equalf(t, expectedRange.firstRef(), actualChunksRange.firstRef(), "first ref [%d, %d, %d]", i, j, k)
+				assert.Equalf(t, blockID, actualChunksRange.blockID, "blockID [%d, %d, %d]", i, j, k)
+				require.Lenf(t, actualChunksRange.refs, len(expectedRange.refs), "chunks len [%d, %d, %d]", i, j, k)
+				for l, actualChunk := range actualChunksRange.refs {
+					expectedChunk := expectedRange.refs[l]
+					assert.Equalf(t, int(expectedChunk.segFileOffset), int(actualChunk.segFileOffset), "ref [%d, %d, %d, %d]", i, j, k, l)
+					assert.Equalf(t, expectedChunk.minTime, actualChunk.minTime, "minT [%d, %d, %d, %d]", i, j, k, l)
+					assert.Equalf(t, expectedChunk.maxTime, actualChunk.maxTime, "maxT [%d, %d, %d, %d]", i, j, k, l)
+					assert.Equalf(t, int(expectedChunk.length), int(actualChunk.length), "length [%d, %d, %d, %d]", i, j, k, l)
+				}
+			}
+		}
 	}
 }
 
@@ -1260,6 +1308,11 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 	t.Cleanup(cancel)
 
 	newTestBlock := prepareTestBlockWithBinaryReader(test.NewTB(t), func(tb testing.TB, appender storage.Appender) {
+		const (
+			samplesFor1Chunk   = 100                  // not a complete chunk
+			samplesFor2Chunks  = samplesFor1Chunk * 2 // not a complete chunk
+			samplesFor10Chunks = 1200                 // 120 samples per chunk
+		)
 		earlySeries := []labels.Labels{
 			labels.FromStrings("a", "1", "b", "1"),
 			labels.FromStrings("a", "1", "b", "2"),
@@ -1270,56 +1323,113 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			labels.FromStrings("a", "2", "b", "1"),
 			labels.FromStrings("a", "2", "b", "2"),
 		}
-
-		const numSamples = 200
-		for i := int64(0); i < numSamples; i++ { // write 200 samples, so we get two chunks
+		for i := int64(0); i < samplesFor2Chunks; i++ { // write 200 samples, so we get two chunks
 			for _, s := range earlySeries {
 				_, err := appender.Append(0, s, i, 0)
 				assert.NoError(t, err)
 			}
 			for _, s := range lateSeries {
-				_, err := appender.Append(0, s, numSamples+i, 0)
+				_, err := appender.Append(0, s, samplesFor2Chunks+i, 0)
 				assert.NoError(t, err)
 			}
 		}
+
+		seriesWith50Chunks := []labels.Labels{
+			labels.FromStrings("a", "3", "b", "1"),
+			labels.FromStrings("a", "3", "b", "2"),
+		}
+
+		for i := int64(0); i < samplesFor10Chunks; i++ {
+			for _, s := range seriesWith50Chunks {
+				_, err := appender.Append(0, s, i, 0)
+				assert.NoError(t, err)
+			}
+		}
+
+		seriesWithSparseChunks := []labels.Labels{
+			labels.FromStrings("a", "4", "b", "1"),
+			labels.FromStrings("a", "4", "b", "2"),
+		}
+
+		for i := int64(0); i < samplesFor1Chunk; i++ {
+			// Write the first chunk with earlier timestamp
+			for _, s := range seriesWithSparseChunks {
+				_, err := appender.Append(0, s, i, 0)
+				assert.NoError(t, err)
+			}
+		}
+		for i := int64(0); i < samplesFor1Chunk; i++ {
+			// Write the next chunk with later timestamp
+			for _, s := range seriesWithSparseChunks {
+				_, err := appender.Append(0, s, 1000+i, 0)
+				assert.NoError(t, err)
+			}
+		}
+
 		assert.NoError(t, appender.Commit())
 	})
 
 	testCases := map[string]struct {
 		matcher    *labels.Matcher
 		batchSize  int
+		minT, maxT int64 // optional, will use block minT/maxT if 0
 		skipChunks bool
 
 		expectedErr    string
 		expectedSeries []seriesChunkRefsSet
 	}{
 		"selects all series in a single batch": {
-			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", "[12]"),
 			batchSize: 100,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
-					{lset: labels.FromStrings("a", "1", "b", "2"), chunks: []seriesChunkRef{{ref: 95, minTime: 0, maxTime: 124}, {ref: 144, minTime: 125, maxTime: 199}}},
-					{lset: labels.FromStrings("a", "2", "b", "1"), chunks: []seriesChunkRef{{ref: 182, minTime: 200, maxTime: 332}, {ref: 234, minTime: 333, maxTime: 399}}},
-					{lset: labels.FromStrings("a", "2", "b", "2"), chunks: []seriesChunkRef{{ref: 270, minTime: 200, maxTime: 332}, {ref: 322, minTime: 333, maxTime: 399}}},
+					{lset: labels.FromStrings("a", "1", "b", "1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 8, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 57, minTime: 125, maxTime: 199, length: 38},
+					}}}},
+					{lset: labels.FromStrings("a", "1", "b", "2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 95, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 144, minTime: 125, maxTime: 199, length: 38},
+					}}}},
+					{lset: labels.FromStrings("a", "2", "b", "1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 182, minTime: 200, maxTime: 332, length: 52},
+						{segFileOffset: 234, minTime: 333, maxTime: 399, length: 36},
+					}}}},
+					{lset: labels.FromStrings("a", "2", "b", "2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 270, minTime: 200, maxTime: 332, length: 52},
+						{segFileOffset: 322, minTime: 333, maxTime: 399, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
 		"selects all series in multiple batches": {
-			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", "[12]"),
 			batchSize: 1,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
+					{lset: labels.FromStrings("a", "1", "b", "1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 8, minTime: 0, maxTime: 124, length: 49},
+						// Since we don't know the ref of the next chunk we use the default estimation for the last chunk
+						{segFileOffset: 57, minTime: 125, maxTime: 199, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "1", "b", "2"), chunks: []seriesChunkRef{{ref: 95, minTime: 0, maxTime: 124}, {ref: 144, minTime: 125, maxTime: 199}}},
+					{lset: labels.FromStrings("a", "1", "b", "2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 95, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 144, minTime: 125, maxTime: 199, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "2", "b", "1"), chunks: []seriesChunkRef{{ref: 182, minTime: 200, maxTime: 332}, {ref: 234, minTime: 333, maxTime: 399}}},
+					{lset: labels.FromStrings("a", "2", "b", "1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 182, minTime: 200, maxTime: 332, length: 52},
+						{segFileOffset: 234, minTime: 333, maxTime: 399, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "2", "b", "2"), chunks: []seriesChunkRef{{ref: 270, minTime: 200, maxTime: 332}, {ref: 322, minTime: 333, maxTime: 399}}},
+					{lset: labels.FromStrings("a", "2", "b", "2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 270, minTime: 200, maxTime: 332, length: 52},
+						{segFileOffset: 322, minTime: 333, maxTime: 399, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
@@ -1328,8 +1438,14 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			batchSize: 100,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
-					{lset: labels.FromStrings("a", "1", "b", "2"), chunks: []seriesChunkRef{{ref: 95, minTime: 0, maxTime: 124}, {ref: 144, minTime: 125, maxTime: 199}}},
+					{lset: labels.FromStrings("a", "1", "b", "1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 8, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 57, minTime: 125, maxTime: 199, length: 38},
+					}}}},
+					{lset: labels.FromStrings("a", "1", "b", "2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 95, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 144, minTime: 125, maxTime: 199, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
@@ -1338,15 +1454,21 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			batchSize: 1,
 			expectedSeries: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "1", "b", "1"), chunks: []seriesChunkRef{{ref: 8, minTime: 0, maxTime: 124}, {ref: 57, minTime: 125, maxTime: 199}}},
+					{lset: labels.FromStrings("a", "1", "b", "1"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 8, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 57, minTime: 125, maxTime: 199, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("a", "1", "b", "2"), chunks: []seriesChunkRef{{ref: 95, minTime: 0, maxTime: 124}, {ref: 144, minTime: 125, maxTime: 199}}},
+					{lset: labels.FromStrings("a", "1", "b", "2"), chunksRanges: []seriesChunkRefsRange{{refs: []seriesChunkRef{
+						{segFileOffset: 95, minTime: 0, maxTime: 124, length: 49},
+						{segFileOffset: 144, minTime: 125, maxTime: 199, length: tsdb.EstimatedMaxChunkSize},
+					}}}},
 				}},
 			},
 		},
 		"selects all series in a single batch with skipChunks": {
-			matcher:    labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			matcher:    labels.MustNewMatcher(labels.MatchRegexp, "a", "[12]"),
 			batchSize:  100,
 			skipChunks: true,
 			expectedSeries: []seriesChunkRefsSet{
@@ -1359,7 +1481,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			},
 		},
 		"selects all series in multiple batches with skipChunks": {
-			matcher:    labels.MustNewMatcher(labels.MatchRegexp, "a", ".+"),
+			matcher:    labels.MustNewMatcher(labels.MatchRegexp, "a", "[12]"),
 			batchSize:  1,
 			skipChunks: true,
 			expectedSeries: []seriesChunkRefsSet{
@@ -1377,6 +1499,36 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				}},
 			},
 		},
+		//"partitions multiple chunks into 4 groups": {
+		//	matcher:     labels.MustNewMatcher(labels.MatchRegexp, "a", "3"),
+		//	batchSize:   1,
+		//	chunksLimit: 100,
+		//	seriesLimit: 100,
+		//	expectedSeries: []seriesChunkRefsSet{
+		//		{series: []seriesChunkRefs{
+		//			{lset: labels.FromStrings("a", "3", "b", "1"), groups: []seriesChunkRefsRange{
+		//				{chunks: []seriesChunkRef{{segFileOffset: 358, minTime: 0, maxTime: 124}, {segFileOffset: 407, minTime: 125, maxTime: 249}}},
+		//				{chunks: []seriesChunkRef{{segFileOffset: 457, minTime: 250, maxTime: 374}, {segFileOffset: 507, minTime: 375, maxTime: 499}}},
+		//				{chunks: []seriesChunkRef{{segFileOffset: 557, minTime: 500, maxTime: 624}, {segFileOffset: 607, minTime: 625, maxTime: 749}}},
+		//				{chunks: []seriesChunkRef{{segFileOffset: 657, minTime: 750, maxTime: 874}, {segFileOffset: 707, minTime: 875, maxTime: 999}, {segFileOffset: 757, minTime: 1000, maxTime: 1124}, {segFileOffset: 807, minTime: 1125, maxTime: 1199}}},
+		//			}},
+		//		}},
+		//		{series: []seriesChunkRefs{
+		//			{lset: labels.FromStrings("a", "3", "b", "2"), groups: []seriesChunkRefsRange{
+		//				{chunks: []seriesChunkRef{{segFileOffset: 845, minTime: 0, maxTime: 124}, {segFileOffset: 894, minTime: 125, maxTime: 249}}},
+		//				{chunks: []seriesChunkRef{{segFileOffset: 944, minTime: 250, maxTime: 374}, {segFileOffset: 994, minTime: 375, maxTime: 499}}},
+		//				{chunks: []seriesChunkRef{{segFileOffset: 1044, minTime: 500, maxTime: 624}, {segFileOffset: 1094, minTime: 625, maxTime: 749}}},
+		//				{chunks: []seriesChunkRef{{segFileOffset: 1144, minTime: 750, maxTime: 874}, {segFileOffset: 1194, minTime: 875, maxTime: 999}, {segFileOffset: 1244, minTime: 1000, maxTime: 1124}, {segFileOffset: 1294, minTime: 1125, maxTime: 1199}}},
+		//			}},
+		//		}},
+		//	},
+		//},
+		"doesn't return a series if its chunks are around minT/maxT but not within it": {
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "a", "4"),
+			minT:    500, maxT: 600, // The chunks for this timeseries are between 0 and 99 and 1000 and 1099
+			batchSize:      100,
+			expectedSeries: []seriesChunkRefsSet{},
+		},
 	}
 
 	for testName, testCase := range testCases {
@@ -1390,6 +1542,14 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 
 			hashCache := hashcache.NewSeriesHashCache(1024 * 1024).GetBlockCache(block.meta.ULID.String())
 
+			minT, maxT := block.meta.MinTime, block.meta.MaxTime
+			if testCase.minT != 0 {
+				minT = testCase.minT
+			}
+			if testCase.maxT != 0 {
+				maxT = testCase.maxT
+			}
+
 			iterator, err := openBlockSeriesChunkRefsSetsIterator(
 				ctx,
 				testCase.batchSize,
@@ -1401,36 +1561,15 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				nil,
 				cachedSeriesHasher{hashCache},
 				testCase.skipChunks,
-				block.meta.MinTime,
-				block.meta.MaxTime,
+				minT,
+				maxT,
 				newSafeQueryStats(),
 				nil,
 			)
 			require.NoError(t, err)
 
 			actualSeriesSets := readAllSeriesChunkRefsSet(iterator)
-
-			require.Lenf(t, actualSeriesSets, len(testCase.expectedSeries), "expected %d sets, but got %d", len(testCase.expectedSeries), len(actualSeriesSets))
-			for i, actualSeriesSet := range actualSeriesSets {
-				expectedSeriesSet := testCase.expectedSeries[i]
-				require.Equal(t, expectedSeriesSet.len(), actualSeriesSet.len(), i)
-				for j, actualSeries := range actualSeriesSet.series {
-					expectedSeries := testCase.expectedSeries[i].series[j]
-
-					actualLset := actualSeries.lset
-					expectedLset := expectedSeries.lset
-					assert.Truef(t, labels.Equal(actualLset, expectedLset), "%d, %d: expected labels %s got labels %s", i, j, expectedLset, actualLset)
-
-					require.Lenf(t, actualSeries.chunks, len(expectedSeries.chunks), "%d, %d", i, j)
-					for k, actualChunk := range actualSeries.chunks {
-						expectedChunk := expectedSeries.chunks[k]
-						assert.Equalf(t, block.meta.ULID, actualChunk.blockID, "%d, %d, %d", i, j, k)
-						assert.Equalf(t, int(expectedChunk.ref), int(actualChunk.ref), "%d, %d, %d", i, j, k)
-						assert.Equalf(t, expectedChunk.minTime, actualChunk.minTime, "%d, %d, %d", i, j, k)
-						assert.Equalf(t, expectedChunk.maxTime, actualChunk.maxTime, "%d, %d, %d", i, j, k)
-					}
-				}
-			}
+			assertSeriesChunkRefsSetsEqual(t, block.meta.ULID, testCase.expectedSeries, actualSeriesSets)
 			if testCase.expectedErr != "" {
 				assert.ErrorContains(t, iterator.Err(), "test limit exceeded")
 			} else {
@@ -1825,19 +1964,30 @@ func (l *limiter) Reserve(num uint64) error {
 	return nil
 }
 
-func generateSeriesChunkRef(blockID ulid.ULID, num int) []seriesChunkRef {
-	out := make([]seriesChunkRef, 0, num)
+func generateSeriesChunksRanges(blockID ulid.ULID, numRanges int) []seriesChunkRefsRange {
+	return generateSeriesChunksRangesN(blockID, 1, numRanges)
+}
 
-	for i := 0; i < num; i++ {
-		out = append(out, seriesChunkRef{
-			blockID: blockID,
-			ref:     chunks.ChunkRef(i),
-			minTime: int64(i),
-			maxTime: int64(i),
+func generateSeriesChunksRangesN(blockID ulid.ULID, numChunksPerRange, numRanges int) []seriesChunkRefsRange {
+	chunksRanges := make([]seriesChunkRefsRange, 0, numRanges)
+
+	for i := 0; i < numRanges; i++ {
+		refs := make([]seriesChunkRef, numChunksPerRange)
+		for rIdx := range refs {
+			refs[rIdx] = seriesChunkRef{segFileOffset: 10 * uint32(i),
+				minTime: int64(i),
+				maxTime: int64(i),
+				length:  10,
+			}
+		}
+		chunksRanges = append(chunksRanges, seriesChunkRefsRange{
+			blockID:     blockID,
+			segmentFile: 1,
+			refs:        refs,
 		})
 	}
 
-	return out
+	return chunksRanges
 }
 
 func readAllSeriesChunkRefsSet(it seriesChunkRefsSetIterator) []seriesChunkRefsSet {

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1336,7 +1336,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 		const (
 			samplesFor1Chunk   = 100                  // not a complete chunk
 			samplesFor2Chunks  = samplesFor1Chunk * 2 // not a complete chunk
-			samplesFor10Chunks = 1200                 // 120 samples per chunk
+			samplesFor13Chunks = 1560                 // 120 samples per chunk
 		)
 		earlySeries := []labels.Labels{
 			labels.FromStrings("a", "1", "b", "1"),
@@ -1364,7 +1364,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			labels.FromStrings("a", "3", "b", "2"),
 		}
 
-		for i := int64(0); i < samplesFor10Chunks; i++ {
+		for i := int64(0); i < samplesFor13Chunks; i++ {
 			for _, s := range seriesWith50Chunks {
 				_, err := appender.Append(0, s, i, 0)
 				assert.NoError(t, err)
@@ -1536,31 +1536,37 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 							{segFileOffset: 457, length: 50, minTime: 250, maxTime: 374},
 							{segFileOffset: 507, length: 50, minTime: 375, maxTime: 499},
 							{segFileOffset: 557, length: 50, minTime: 500, maxTime: 624},
-						}},
-						{refs: []seriesChunkRef{
 							{segFileOffset: 607, length: 50, minTime: 625, maxTime: 749},
 							{segFileOffset: 657, length: 50, minTime: 750, maxTime: 874},
 							{segFileOffset: 707, length: 50, minTime: 875, maxTime: 999},
 							{segFileOffset: 757, length: 50, minTime: 1000, maxTime: 1124},
-							{segFileOffset: 807, length: tsdb.EstimatedMaxChunkSize, minTime: 1125, maxTime: 1199},
+							{segFileOffset: 807, length: 50, minTime: 1125, maxTime: 1249},
+						}},
+						{refs: []seriesChunkRef{
+							{segFileOffset: 857, length: 50, minTime: 1250, maxTime: 1374},
+							{segFileOffset: 907, length: 50, minTime: 1375, maxTime: 1499},
+							{segFileOffset: 957, length: tsdb.EstimatedMaxChunkSize, minTime: 1500, maxTime: 1559},
 						}},
 					}},
 				}},
 				{series: []seriesChunkRefs{
 					{lset: labels.FromStrings("a", "3", "b", "2"), chunksRanges: []seriesChunkRefsRange{
 						{refs: []seriesChunkRef{
-							{segFileOffset: 845, length: 49, minTime: 0, maxTime: 124},
-							{segFileOffset: 894, length: 50, minTime: 125, maxTime: 249},
-							{segFileOffset: 944, length: 50, minTime: 250, maxTime: 374},
-							{segFileOffset: 994, length: 50, minTime: 375, maxTime: 499},
-							{segFileOffset: 1044, length: 50, minTime: 500, maxTime: 624},
+							{segFileOffset: 991, length: 49, minTime: 0, maxTime: 124},
+							{segFileOffset: 1040, length: 50, minTime: 125, maxTime: 249},
+							{segFileOffset: 1090, length: 50, minTime: 250, maxTime: 374},
+							{segFileOffset: 1140, length: 50, minTime: 375, maxTime: 499},
+							{segFileOffset: 1190, length: 50, minTime: 500, maxTime: 624},
+							{segFileOffset: 1240, length: 50, minTime: 625, maxTime: 749},
+							{segFileOffset: 1290, length: 50, minTime: 750, maxTime: 874},
+							{segFileOffset: 1340, length: 50, minTime: 875, maxTime: 999},
+							{segFileOffset: 1390, length: 50, minTime: 1000, maxTime: 1124},
+							{segFileOffset: 1440, length: 50, minTime: 1125, maxTime: 1249},
 						}},
 						{refs: []seriesChunkRef{
-							{segFileOffset: 1094, length: 50, minTime: 625, maxTime: 749},
-							{segFileOffset: 1144, length: 50, minTime: 750, maxTime: 874},
-							{segFileOffset: 1194, length: 50, minTime: 875, maxTime: 999},
-							{segFileOffset: 1244, length: 50, minTime: 1000, maxTime: 1124},
-							{segFileOffset: 1294, length: tsdb.EstimatedMaxChunkSize, minTime: 1125, maxTime: 1199},
+							{segFileOffset: 1490, length: 50, minTime: 1250, maxTime: 1374},
+							{segFileOffset: 1540, length: 50, minTime: 1375, maxTime: 1499},
+							{segFileOffset: 1590, length: tsdb.EstimatedMaxChunkSize, minTime: 1500, maxTime: 1559},
 						}},
 					}},
 				}},

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -51,7 +51,7 @@ func TestSeriesChunkRef_Compare(t *testing.T) {
 	}
 
 	sort.Slice(input, func(i, j int) bool {
-		return input[i].Compare(input[j]) > 0
+		return input[i].Compare(input[j]) < 0
 	})
 
 	assert.Equal(t, expected, input)

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1524,28 +1524,48 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				}},
 			},
 		},
-		//"partitions multiple chunks into 2 ranges": {
-		//	matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", "3"),
-		//	batchSize: 1,
-		//	expectedSeries: []seriesChunkRefsSet{
-		//		{series: []seriesChunkRefs{
-		//			{lset: labels.FromStrings("a", "3", "b", "1"), chunksRanges: []seriesChunkRefsRange{
-		//				{refs: []seriesChunkRef{{segFileOffset: 358, minTime: 0, maxTime: 124}, {segFileOffset: 407, minTime: 125, maxTime: 249}}},
-		//				{refs: []seriesChunkRef{{segFileOffset: 457, minTime: 250, maxTime: 374}, {segFileOffset: 507, minTime: 375, maxTime: 499}}},
-		//				{refs: []seriesChunkRef{{segFileOffset: 557, minTime: 500, maxTime: 624}, {segFileOffset: 607, minTime: 625, maxTime: 749}}},
-		//				{refs: []seriesChunkRef{{segFileOffset: 657, minTime: 750, maxTime: 874}, {segFileOffset: 707, minTime: 875, maxTime: 999}, {segFileOffset: 757, minTime: 1000, maxTime: 1124}, {segFileOffset: 807, minTime: 1125, maxTime: 1199}}},
-		//			}},
-		//		}},
-		//		{series: []seriesChunkRefs{
-		//			{lset: labels.FromStrings("a", "3", "b", "2"), chunksRanges: []seriesChunkRefsRange{
-		//				{refs: []seriesChunkRef{{segFileOffset: 845, minTime: 0, maxTime: 124}, {segFileOffset: 894, minTime: 125, maxTime: 249}}},
-		//				{refs: []seriesChunkRef{{segFileOffset: 944, minTime: 250, maxTime: 374}, {segFileOffset: 994, minTime: 375, maxTime: 499}}},
-		//				{refs: []seriesChunkRef{{segFileOffset: 1044, minTime: 500, maxTime: 624}, {segFileOffset: 1094, minTime: 625, maxTime: 749}}},
-		//				{refs: []seriesChunkRef{{segFileOffset: 1144, minTime: 750, maxTime: 874}, {segFileOffset: 1194, minTime: 875, maxTime: 999}, {segFileOffset: 1244, minTime: 1000, maxTime: 1124}, {segFileOffset: 1294, minTime: 1125, maxTime: 1199}}},
-		//			}},
-		//		}},
-		//	},
-		//},
+		"partitions multiple chunks into 2 ranges": {
+			matcher:   labels.MustNewMatcher(labels.MatchRegexp, "a", "3"),
+			batchSize: 1,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "3", "b", "1"), chunksRanges: []seriesChunkRefsRange{
+						{refs: []seriesChunkRef{
+							{segFileOffset: 358, length: 49, minTime: 0, maxTime: 124},
+							{segFileOffset: 407, length: 50, minTime: 125, maxTime: 249},
+							{segFileOffset: 457, length: 50, minTime: 250, maxTime: 374},
+							{segFileOffset: 507, length: 50, minTime: 375, maxTime: 499},
+							{segFileOffset: 557, length: 50, minTime: 500, maxTime: 624},
+						}},
+						{refs: []seriesChunkRef{
+							{segFileOffset: 607, length: 50, minTime: 625, maxTime: 749},
+							{segFileOffset: 657, length: 50, minTime: 750, maxTime: 874},
+							{segFileOffset: 707, length: 50, minTime: 875, maxTime: 999},
+							{segFileOffset: 757, length: 50, minTime: 1000, maxTime: 1124},
+							{segFileOffset: 807, length: tsdb.EstimatedMaxChunkSize, minTime: 1125, maxTime: 1199},
+						}},
+					}},
+				}},
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "3", "b", "2"), chunksRanges: []seriesChunkRefsRange{
+						{refs: []seriesChunkRef{
+							{segFileOffset: 845, length: 49, minTime: 0, maxTime: 124},
+							{segFileOffset: 894, length: 50, minTime: 125, maxTime: 249},
+							{segFileOffset: 944, length: 50, minTime: 250, maxTime: 374},
+							{segFileOffset: 994, length: 50, minTime: 375, maxTime: 499},
+							{segFileOffset: 1044, length: 50, minTime: 500, maxTime: 624},
+						}},
+						{refs: []seriesChunkRef{
+							{segFileOffset: 1094, length: 50, minTime: 625, maxTime: 749},
+							{segFileOffset: 1144, length: 50, minTime: 750, maxTime: 874},
+							{segFileOffset: 1194, length: 50, minTime: 875, maxTime: 999},
+							{segFileOffset: 1244, length: 50, minTime: 1000, maxTime: 1124},
+							{segFileOffset: 1294, length: tsdb.EstimatedMaxChunkSize, minTime: 1125, maxTime: 1199},
+						}},
+					}},
+				}},
+			},
+		},
 		"doesn't return a series if its chunks are around minT/maxT but not within it": {
 			matcher: labels.MustNewMatcher(labels.MatchRegexp, "a", "4"),
 			minT:    500, maxT: 600, // The chunks for this timeseries are between 0 and 99 and 1000 and 1099


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

### What this PR does

This is a continuation of https://github.com/grafana/mimir/pull/4163 which upstreams another part of https://github.com/grafana/mimir/pull/3968

#### Current state
Currently all `seriesChunkRefs` have a slice of chunk refs. Each chunk ref contains the ID of the block to which it belongs and its chunk ref. The chunk ref is 64 bits, the first 32 of which contain the sequence number of its segment file and the last 32 bites contain the offset in this file. At the `loadingSeriesChunksSetIterator` we can have many chunks from different segment files or blocks in the same slice of `seriesChunkRefs.chunks`.

#### Changes - Chunk ranges

The changes in this PR add a level of separation for chunks. Now a `seriesChunkRefs` contains a slice of `seriesChunkRefsRange`. Each range belongs to a single segment file of a single block.

This separation is helpful later when we start caching chunks of individual series of a block. In that change we will cache each individual chunk range.

There may be multiple ranges that contain chunks from the same segment file and the same block. The reason for this is so we can have finer granularity on the cache items.

##### Future changes

In an upcoming PR I will also change how loading of chunks happens. Currently it is still at the granularity of individual chunks (`bucketChunkReader.addLoad`), so the changes in this PR end at the `loadingSeriesChunksSetIterator`.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/3939 

#### Checklist

- [x] Tests updated
- [NA] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
