### PR TITLE
Compact userTSDB's OOO head when compacting head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Grafana Mimir
 
-* [BUGFIX] Ingester: compact out of order data when the compaction is forced or caused by idling. #4180
 * [CHANGE] Querier: Errors with status code `422` coming from the store-gateway are propagated and not converted to the consistency check error anymore. #4100
 * [CHANGE] Store-gateway: When a query hits `max_fetched_chunks_per_query` and `max_fetched_series_per_query` limits, an error with the status code `422` is created and returned. #4056
 * [CHANGE] Packaging: Migrate FPM packaging solution to NFPM. Rationalize packages dependencies and add package for all binaries. #3911
@@ -23,6 +22,7 @@
 * [BUGFIX] Ingester: reuse memory when ingesting ephemeral series. #4072
 * [BUGFIX] Fix JSON and YAML marshalling of `ephemeral_series_matchers` field in `/runtime_config`. #4091
 * [BUGFIX] Querier: track canceled requests with status code `499` in the metrics instead of `503` or `422`. #4099
+* [BUGFIX] Ingester: compact out-of-order data during `/ingester/flush` or when TSDB is idle. #4180
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Ingester: compact out of order data when the compaction is forced or caused by idling. #4180
 * [CHANGE] Querier: Errors with status code `422` coming from the store-gateway are propagated and not converted to the consistency check error anymore. #4100
 * [CHANGE] Store-gateway: When a query hits `max_fetched_chunks_per_query` and `max_fetched_series_per_query` limits, an error with the status code `422` is created and returned. #4056
 * [CHANGE] Packaging: Migrate FPM packaging solution to NFPM. Rationalize packages dependencies and add package for all binaries. #3911


### PR DESCRIPTION
#### What this PR does

This adds a call to `db.CompactOOOHead` as part of `userDb.compactHead`, which means the OOO head is also compacted apart from the in-order head. As a consequence, compactions caused by idling DBs or forced head compactions will now also compact the OOO head, see code below:


https://github.com/grafana/mimir/blob/6852e9442b5f13c065e9f7818c727e72e9fcd774/pkg/ingester/ingester.go#L2196-L2203

#### Which issue(s) this PR fixes or relates to

Fixes  https://github.com/grafana/mimir/issues/4160
#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
