### PR TITLE
Update tooling for native histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
 
 * [ENHANCEMENT] Document migration from microservices to read-write deployment mode. #3951
 
+### Tools
+
+* [ENHANCEMENT] Adapt tsdb-print-chunk for native histograms. #4186
+* [ENHANCEMENT] Adapt tsdb-index-health for blocks containing native histograms. #4186
+* [ENHANCEMENT] Adapt tsdb-chunks tool to handle native histograms. #4186
+
 ## 2.6.0
 
 ### Grafana Mimir

--- a/tools/tsdb-chunks/main.go
+++ b/tools/tsdb-chunks/main.go
@@ -81,8 +81,27 @@ func printChunksFile(filename string, printSamples bool) error {
 					}
 
 					fmt.Printf("Chunk #%d, sample #%d: ts: %d (%s), val: %g\n", cix, six, ts, formatTimestamp(ts), val)
+				case chunkenc.ValHistogram:
+					ts, hist := it.AtHistogram()
+					if ts < minTS {
+						minTS = ts
+					}
+					if ts > maxTS {
+						maxTS = ts
+					}
+
+					fmt.Printf("Chunk #%d, sample #%d: ts: %d (%s), val: %s\n", cix, six, ts, formatTimestamp(ts), hist.String())
+				case chunkenc.ValFloatHistogram:
+					ts, hist := it.AtFloatHistogram()
+					if ts < minTS {
+						minTS = ts
+					}
+					if ts > maxTS {
+						maxTS = ts
+					}
+
+					fmt.Printf("Chunk #%d, sample #%d: ts: %d (%s), val: %s\n", cix, six, ts, formatTimestamp(ts), hist.String())
 				default:
-					// TODO handle native histograms
 					fmt.Printf("Chunk #%d, sample #%d: ts: N/A (N/A), unsupported value type %v", cix, six, valType)
 				}
 				six++

--- a/tools/tsdb-chunks/main_test.go
+++ b/tools/tsdb-chunks/main_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package main
 
 import (

--- a/tools/tsdb-chunks/main_test.go
+++ b/tools/tsdb-chunks/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/grafana/mimir/pkg/util/test"
+)
+
+func TestTSDBChunks(t *testing.T) {
+	userID := "user"
+	tmpDir := t.TempDir()
+
+	spec := testutil.BlockSeriesSpec{
+		Labels: labels.FromStrings(labels.MetricName, "asdf"),
+		Chunks: []chunks.Meta{
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{10, 11, nil, nil},
+				sample{20, 12, nil, nil},
+				sample{30, 13, nil, nil},
+			}),
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{40, 0, tsdb.GenerateTestHistogram(1), nil},
+				sample{50, 0, tsdb.GenerateTestHistogram(2), nil},
+				sample{60, 0, tsdb.GenerateTestHistogram(3), nil},
+			}),
+		},
+	}
+
+	meta, err := testutil.GenerateBlockFromSpec(userID, tmpDir, []*testutil.BlockSeriesSpec{&spec})
+	require.NoError(t, err)
+
+	co := test.CaptureOutput(t)
+
+	chunkFilename := path.Join(tmpDir, meta.ULID.String(), "chunks", "000001")
+	require.NoError(t, printChunksFile(chunkFilename, true))
+
+	sout, _ := co.Done()
+
+	expected := `%s
+Chunk #0: position: 8 length: 15 encoding: XOR, crc32: 3d73a06f, samples: 3
+Chunk #0, sample #0: ts: 10 (1970-01-01T00:00:00.01Z), val: 11
+Chunk #0, sample #1: ts: 20 (1970-01-01T00:00:00.02Z), val: 12
+Chunk #0, sample #2: ts: 30 (1970-01-01T00:00:00.03Z), val: 13
+Chunk #0: minTS=10 (1970-01-01T00:00:00.01Z), maxTS=30 (1970-01-01T00:00:00.03Z)
+Chunk #1: position: 29 length: 56 encoding: histogram, crc32: 3e1d4429, samples: 3
+Chunk #1, sample #0: ts: 40 (1970-01-01T00:00:00.04Z), val: {count:18, sum:36.8, [-4,-2.82842712474619):2, [-2.82842712474619,-2):2, [-1.414213562373095,-1):3, [-1,-0.7071067811865475):2, [-0.001,0.001]:3, (0.7071067811865475,1]:2, (1,1.414213562373095]:3, (2,2.82842712474619]:2, (2.82842712474619,4]:2}
+Chunk #1, sample #1: ts: 50 (1970-01-01T00:00:00.05Z), val: {count:26, sum:55.199999999999996, [-4,-2.82842712474619):3, [-2.82842712474619,-2):3, [-1.414213562373095,-1):4, [-1,-0.7071067811865475):3, [-0.001,0.001]:4, (0.7071067811865475,1]:3, (1,1.414213562373095]:4, (2,2.82842712474619]:3, (2.82842712474619,4]:3}
+Chunk #1, sample #2: ts: 60 (1970-01-01T00:00:00.06Z), val: {count:34, sum:73.6, [-4,-2.82842712474619):4, [-2.82842712474619,-2):4, [-1.414213562373095,-1):5, [-1,-0.7071067811865475):4, [-0.001,0.001]:5, (0.7071067811865475,1]:4, (1,1.414213562373095]:5, (2,2.82842712474619]:4, (2.82842712474619,4]:4}
+Chunk #1: minTS=40 (1970-01-01T00:00:00.04Z), maxTS=60 (1970-01-01T00:00:00.06Z)
+`
+	expected = fmt.Sprintf(expected, chunkFilename)
+
+	require.Equal(t, expected, sout)
+}
+
+type sample struct {
+	t  int64
+	v  float64
+	h  *histogram.Histogram
+	fh *histogram.FloatHistogram
+}
+
+func (s sample) T() int64                      { return s.t }
+func (s sample) V() float64                    { return s.v }
+func (s sample) H() *histogram.Histogram       { return s.h }
+func (s sample) FH() *histogram.FloatHistogram { return s.fh }
+
+func (s sample) Type() chunkenc.ValueType {
+	switch {
+	case s.h != nil:
+		return chunkenc.ValHistogram
+	case s.fh != nil:
+		return chunkenc.ValFloatHistogram
+	default:
+		return chunkenc.ValFloat
+	}
+}

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package main
 
 import (

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"path"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatherIndexHealthStats(t *testing.T) {
+	userID := "user"
+	tmpDir := t.TempDir()
+
+	spec1 := testutil.BlockSeriesSpec{
+		Labels: labels.FromStrings(labels.MetricName, "asdf"),
+		Chunks: []chunks.Meta{
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{10, 11, nil, nil},
+				sample{20, 12, nil, nil},
+				sample{30, 13, nil, nil},
+			}),
+		},
+	}
+	spec2 := testutil.BlockSeriesSpec{
+		Labels: labels.FromStrings(labels.MetricName, "zxcv", "foo", "bar"),
+		Chunks: []chunks.Meta{
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{40, 0, tsdb.GenerateTestHistogram(1), nil},
+				sample{50, 0, tsdb.GenerateTestHistogram(2), nil},
+				sample{60, 0, tsdb.GenerateTestHistogram(3), nil},
+			}),
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{70, 0, tsdb.GenerateTestHistogram(4), nil},
+				sample{80, 0, tsdb.GenerateTestHistogram(5), nil},
+				sample{90, 0, tsdb.GenerateTestHistogram(6), nil},
+			}),
+		},
+	}
+
+	meta, err := testutil.GenerateBlockFromSpec(userID, tmpDir, []*testutil.BlockSeriesSpec{&spec1, &spec2})
+	require.NoError(t, err)
+
+	blockDir := path.Join(tmpDir, meta.ULID.String())
+	stats, err := GatherIndexHealthStats(log.NewNopLogger(), blockDir, meta.MinTime, meta.MaxTime, true)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(2), stats.TotalSeries)
+	require.Equal(t, int64(1), stats.SeriesMinChunks)
+	require.Equal(t, int64(1), stats.SeriesAvgChunks)
+	require.Equal(t, int64(2), stats.SeriesMaxChunks)
+	require.Equal(t, int64(3), stats.TotalChunks)
+	require.Equal(t, int64(2), stats.LabelNamesCount)
+	require.Equal(t, int64(2), stats.MetricLabelValuesCount)
+}
+
+type sample struct {
+	t  int64
+	v  float64
+	h  *histogram.Histogram
+	fh *histogram.FloatHistogram
+}
+
+func (s sample) T() int64                      { return s.t }
+func (s sample) V() float64                    { return s.v }
+func (s sample) H() *histogram.Histogram       { return s.h }
+func (s sample) FH() *histogram.FloatHistogram { return s.fh }
+
+func (s sample) Type() chunkenc.ValueType {
+	switch {
+	case s.h != nil:
+		return chunkenc.ValHistogram
+	case s.fh != nil:
+		return chunkenc.ValFloatHistogram
+	default:
+		return chunkenc.ValFloat
+	}
+}

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -13,6 +12,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
 )
 
 func TestGatherIndexHealthStats(t *testing.T) {

--- a/tools/tsdb-print-chunk/main_test.go
+++ b/tools/tsdb-print-chunk/main_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package main
 
 import (

--- a/tools/tsdb-print-chunk/main_test.go
+++ b/tools/tsdb-print-chunk/main_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/grafana/mimir/pkg/util/test"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTSDBPrintChunk(t *testing.T) {
+	userID := "user"
+	tmpDir := t.TempDir()
+
+	spec := testutil.BlockSeriesSpec{
+		Labels: labels.FromStrings(labels.MetricName, "asdf"),
+		Chunks: []chunks.Meta{
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{10, 11, nil, nil},
+				sample{20, 12, nil, nil},
+				sample{30, 13, nil, nil},
+			}),
+			tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+				sample{40, 0, tsdb.GenerateTestHistogram(1), nil},
+				sample{50, 0, tsdb.GenerateTestHistogram(2), nil},
+				sample{60, 0, tsdb.GenerateTestHistogram(3), nil},
+			}),
+		},
+	}
+
+	meta, err := testutil.GenerateBlockFromSpec(userID, tmpDir, []*testutil.BlockSeriesSpec{&spec})
+	require.NoError(t, err)
+
+	blockDir := path.Join(tmpDir, meta.ULID.String())
+
+	var chunkRefs []string
+	for _, chkMeta := range spec.Chunks {
+		chunkRefs = append(chunkRefs, strconv.Itoa(int(chkMeta.Ref)))
+	}
+
+	co := test.CaptureOutput(t)
+	printChunks(blockDir, chunkRefs)
+	sout, _ := co.Done()
+
+	expected := `Chunk ref: 8 samples: 3 bytes: 15
+11	10 (1970-01-01T00:00:00.01Z)
+12	20 (1970-01-01T00:00:00.02Z)
+13	30 (1970-01-01T00:00:00.03Z)
+Chunk ref: 29 samples: 3 bytes: 56
+{count:18, sum:36.8, [-4,-2.82842712474619):2, [-2.82842712474619,-2):2, [-1.414213562373095,-1):3, [-1,-0.7071067811865475):2, [-0.001,0.001]:3, (0.7071067811865475,1]:2, (1,1.414213562373095]:3, (2,2.82842712474619]:2, (2.82842712474619,4]:2}	40 (1970-01-01T00:00:00.04Z)
+{count:26, sum:55.199999999999996, [-4,-2.82842712474619):3, [-2.82842712474619,-2):3, [-1.414213562373095,-1):4, [-1,-0.7071067811865475):3, [-0.001,0.001]:4, (0.7071067811865475,1]:3, (1,1.414213562373095]:4, (2,2.82842712474619]:3, (2.82842712474619,4]:3}	50 (1970-01-01T00:00:00.05Z)
+{count:34, sum:73.6, [-4,-2.82842712474619):4, [-2.82842712474619,-2):4, [-1.414213562373095,-1):5, [-1,-0.7071067811865475):4, [-0.001,0.001]:5, (0.7071067811865475,1]:4, (1,1.414213562373095]:5, (2,2.82842712474619]:4, (2.82842712474619,4]:4}	60 (1970-01-01T00:00:00.06Z)
+`
+
+	require.Equal(t, expected, sout)
+}
+
+type sample struct {
+	t  int64
+	v  float64
+	h  *histogram.Histogram
+	fh *histogram.FloatHistogram
+}
+
+func (s sample) T() int64                      { return s.t }
+func (s sample) V() float64                    { return s.v }
+func (s sample) H() *histogram.Histogram       { return s.h }
+func (s sample) FH() *histogram.FloatHistogram { return s.fh }
+
+func (s sample) Type() chunkenc.ValueType {
+	switch {
+	case s.h != nil:
+		return chunkenc.ValHistogram
+	case s.fh != nil:
+		return chunkenc.ValFloatHistogram
+	default:
+		return chunkenc.ValFloat
+	}
+}

--- a/tools/tsdb-print-chunk/main_test.go
+++ b/tools/tsdb-print-chunk/main_test.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
-	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -14,6 +12,9 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestTSDBPrintChunk(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR updates the following tools to deal with native histograms and also adds tests:
 - tsdb-chunks
 - tsdb-index-health
 - tsdb-print-chunk

#### Which issue(s) this PR fixes or relates to

Fixes:
- https://github.com/grafana/mimir/issues/3944
- https://github.com/grafana/mimir/issues/3947
- https://github.com/grafana/mimir/issues/3949

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
