### PR TITLE
Jsonnet: Add (ruler-)query-frontend auto-scaling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [ENHANCEMENT] Add auto-scaling panels to ruler dashboard. #4046
 * [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049 #4216
 * [ENHANCEMENT] Dashboards: distinguish between label names and label values queries. #4065
+* [ENHANCEMENT] Add query-frontend and ruler-query-frontend auto-scaling panels to Reads dashboard. #4199
 * [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric does not exist, to avoid false positives on scaled objects with 0 min replicas. #4045
 * [BUGFIX] Alerts: `MimirCompactorHasNotSuccessfullyRunCompaction` is no longer triggered by frequent compactor restarts. #4012
 
@@ -64,6 +65,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 * [ENHANCEMENT] Add support for ruler auto-scaling. #4046
 * [ENHANCEMENT] Add optional `weight` param to `newQuerierScaledObject` and `newRulerQuerierScaledObject` to allow running multiple querier deployments on different node types. #4141
+* [ENHANCEMENT] Add support for query-frontend and ruler-query-frontend auto-scaling. #4199
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [ENHANCEMENT] Add auto-scaling panels to ruler dashboard. #4046
 * [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049 #4216
 * [ENHANCEMENT] Dashboards: distinguish between label names and label values queries. #4065
-* [ENHANCEMENT] Add query-frontend and ruler-query-frontend auto-scaling panels to Reads dashboard. #4199
+* [ENHANCEMENT] Add query-frontend and ruler-query-frontend auto-scaling panels to Reads and Ruler dashboards. #4199
 * [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric does not exist, to avoid false positives on scaled objects with 0 min replicas. #4045
 * [BUGFIX] Alerts: `MimirCompactorHasNotSuccessfullyRunCompaction` is no longer triggered by frequent compactor restarts. #4012
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -594,6 +594,14 @@
 
     // Whether autoscaling panels and alerts should be enabled for specific Mimir services.
     autoscaling: {
+      query_frontend: {
+        enabled: false,
+        hpa_name: 'keda-hpa-query-frontend',
+      },
+      ruler_query_frontend: {
+        enabled: false,
+        hpa_name: 'keda-hpa-ruler-query-frontend',
+      },
       querier: {
         enabled: false,
         // hpa_name can be a regexp to support multiple querier deployments, like "keda-hpa-querier(-burst(-backup)?)?".

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -489,6 +489,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
   cpuAndMemoryBasedAutoScalingRow(componentTitle)::
     local component = std.asciiLower(componentTitle);
+    local field = std.strReplace(component, '-', '_');
     super.row('%s - autoscaling' % [componentTitle])
     .addPanel(
       local title = 'Replicas';
@@ -502,7 +503,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               0*kube_horizontalpodautoscaler_info{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s"}
           ||| % {
             namespace_matcher: $.namespaceMatcher(),
-            hpa_name: $._config.autoscaling[component].hpa_name,
+            hpa_name: $._config.autoscaling[field].hpa_name,
             cluster_labels: std.join(', ', $._config.cluster_labels),
           },
           |||
@@ -515,7 +516,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               0*kube_horizontalpodautoscaler_info{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s"}
           ||| % {
             namespace_matcher: $.namespaceMatcher(),
-            hpa_name: $._config.autoscaling[component].hpa_name,
+            hpa_name: $._config.autoscaling[field].hpa_name,
             cluster_labels: std.join(', ', $._config.cluster_labels),
           },
         ],
@@ -559,7 +560,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 "metric", "$1", "metric_name", "(.+)"
             )
           ||| % {
-            hpa_name: $._config.autoscaling[component].hpa_name,
+            hpa_name: $._config.autoscaling[field].hpa_name,
             namespace: $.namespaceMatcher(),
           },
         ], [
@@ -587,7 +588,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 "metric", "$1", "metric_name", "(.+)"
             )
           ||| % {
-            hpa_name: $._config.autoscaling[component].hpa_name,
+            hpa_name: $._config.autoscaling[field].hpa_name,
             namespace: $.namespaceMatcher(),
           },
         ], [
@@ -606,7 +607,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       local title = 'Autoscaler failures rate';
       $.panel(title) +
       $.queryPanel(
-        $.filterKedaMetricByHPA('sum by(metric) (rate(keda_metrics_adapter_scaler_errors[$__rate_interval]))', $._config.autoscaling[component].hpa_name),
+        $.filterKedaMetricByHPA('sum by(metric) (rate(keda_metrics_adapter_scaler_errors[$__rate_interval]))', $._config.autoscaling[field].hpa_name),
         '{{metric}} failures'
       ) +
       $.panelDescription(

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -250,6 +250,10 @@ local filename = 'mimir-reads.json';
       )
     )
     .addRowIf(
+      $._config.autoscaling.query_frontend.enabled,
+      $.cpuAndMemoryBasedAutoScalingRow('Query-frontend'),
+    )
+    .addRowIf(
       $._config.gateway_enabled && $._config.autoscaling.gateway.enabled,
       $.cpuAndMemoryBasedAutoScalingRow('Gateway'),
     )

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -250,12 +250,12 @@ local filename = 'mimir-reads.json';
       )
     )
     .addRowIf(
-      $._config.autoscaling.query_frontend.enabled,
-      $.cpuAndMemoryBasedAutoScalingRow('Query-frontend'),
-    )
-    .addRowIf(
       $._config.gateway_enabled && $._config.autoscaling.gateway.enabled,
       $.cpuAndMemoryBasedAutoScalingRow('Gateway'),
+    )
+    .addRowIf(
+      $._config.autoscaling.query_frontend.enabled,
+      $.cpuAndMemoryBasedAutoScalingRow('Query-frontend'),
     )
     .addRowIf(
       $._config.autoscaling.querier.enabled,

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -105,6 +105,10 @@ local filename = 'mimir-ruler.json';
       $._config.autoscaling.ruler.enabled,
       $.cpuAndMemoryBasedAutoScalingRow('Ruler'),
     )
+    .addRowIf(
+      $._config.autoscaling.ruler_query_frontend.enabled,
+      $.cpuAndMemoryBasedAutoScalingRow('Ruler-query-frontend'),
+    )
     .addRow(
       $.kvStoreRow('Ruler - key-value store for rulers ring', 'ruler', 'ruler')
     )

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -628,7 +628,6 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -949,7 +948,6 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1792,6 +1790,40 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
+  name: query-frontend
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 30
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: query-frontend
+  triggers:
+  - metadata:
+      metricName: query_frontend_cpu_hpa_default
+      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))[15m:])
+        * 1000
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2000"
+    type: prometheus
+  - metadata:
+      metricName: query_frontend_memory_hpa_default
+      query: max_over_time(sum(container_memory_working_set_bytes{container="query-frontend",namespace="default"})[15m:])
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "629145600"
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
   name: ruler-querier
   namespace: default
 spec:
@@ -1815,4 +1847,38 @@ spec:
         * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "200"
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ruler-query-frontend
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 30
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: ruler-query-frontend
+  triggers:
+  - metadata:
+      metricName: ruler_query_frontend_cpu_hpa_default
+      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))[15m:])
+        * 1000
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2000"
+    type: prometheus
+  - metadata:
+      metricName: ruler_query_frontend_memory_hpa_default
+      query: max_over_time(sum(container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})[15m:])
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "629145600"
     type: prometheus

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -26,6 +26,14 @@ mimir {
     autoscaling_distributor_enabled: true,
     autoscaling_distributor_min_replicas: 3,
     autoscaling_distributor_max_replicas: 30,
+
+    autoscaling_query_frontend_enabled: true,
+    autoscaling_query_frontend_min_replicas: 3,
+    autoscaling_query_frontend_max_replicas: 30,
+
+    autoscaling_ruler_query_frontend_enabled: true,
+    autoscaling_ruler_query_frontend_min_replicas: 3,
+    autoscaling_ruler_query_frontend_max_replicas: 30,
   },
 
   local k = import 'ksonnet-util/kausal.libsonnet',

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -322,7 +322,7 @@
   ruler_query_frontend_deployment: overrideSuperIfExists(
     'ruler_query_frontend_deployment',
     if $._config.autoscaling_ruler_query_frontend_enabled then removeReplicasFromSpec else
-      if $._config.query_sharding_enabled && $._config.autoscaling_ruler_querier_enabled then
+      if ($._config.query_sharding_enabled && $._config.autoscaling_ruler_querier_enabled) then
         queryFrontendReplicas($._config.autoscaling_ruler_querier_max_replicas) else
         {}
   ),

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -268,7 +268,7 @@
   query_frontend_deployment: overrideSuperIfExists(
     'query_frontend_deployment',
     if $._config.autoscaling_query_frontend_enabled then removeReplicasFromSpec else
-      if $._config.query_sharding_enabled && $._config.autoscaling_querier_enabled then
+      if ($._config.query_sharding_enabled && $._config.autoscaling_querier_enabled) then
         queryFrontendReplicas($._config.autoscaling_querier_max_replicas) else
         {}
   ),


### PR DESCRIPTION
#### What this PR does
Add query-frontend and ruler-query-frontend auto-scaling support to Jsonnet library, and corresponding panels to mixin.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
