### PR TITLE
Expose querymiddleware.Codec instance

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -659,6 +659,7 @@ type Mimir struct {
 	MetadataSupplier         querier.MetadataSupplier
 	QuerierEngine            *promql.Engine
 	QueryFrontendTripperware querymiddleware.Tripperware
+	QueryFrontendCodec       querymiddleware.Codec
 	Ruler                    *ruler.Ruler
 	RulerStorage             rulestore.RuleStore
 	Alertmanager             *alertmanager.MultitenantAlertmanager

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -543,13 +543,14 @@ func (t *Mimir) initFlusher() (serv services.Service, err error) {
 // initQueryFrontendTripperware instantiates the tripperware used by the query frontend
 // to optimize Prometheus query requests.
 func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error) {
+	t.QueryFrontendCodec = querymiddleware.NewPrometheusCodec(t.Registerer)
 	promqlEngineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "query-frontend"}, t.Registerer)
 
 	tripperware, err := querymiddleware.NewTripperware(
 		t.Cfg.Frontend.QueryMiddleware,
 		util_log.Logger,
 		t.Overrides,
-		querymiddleware.NewPrometheusCodec(t.Registerer),
+		t.QueryFrontendCodec,
 		querymiddleware.PrometheusResponseExtractor{},
 		engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer),
 		t.Registerer,


### PR DESCRIPTION
#### What this PR does

Changes #4110 added a constructor to build the PrometheusCodec, using a prometheus.Registerer to register some metrics.

This means that downstream projects extending Mimir (GEM) can't use the PrometheusCodec properly anymore, since if they call the constructor they would try to register the metrics again.

This exposes the created PrometheusCodec in Mimir's root datastructure, just like QueryTripperware is exposed.

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
