### PR TITLE
ingester: elide two function calls in pushMetadata

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2543,9 +2543,13 @@ func (i *Ingester) pushMetadata(ctx context.Context, userID string, metadata []*
 	ingestedMetadata := 0
 	failedMetadata := 0
 
+	userMetadata := i.getOrCreateUserMetadata(userID)
 	var firstMetadataErr error
 	for _, metadata := range metadata {
-		err := i.appendMetadata(userID, metadata)
+		if metadata == nil {
+			continue
+		}
+		err := userMetadata.add(metadata.MetricFamilyName, metadata)
 		if err == nil {
 			ingestedMetadata++
 			continue
@@ -2568,11 +2572,6 @@ func (i *Ingester) pushMetadata(ctx context.Context, userID string, metadata []*
 	}
 
 	return ingestedMetadata
-}
-func (i *Ingester) appendMetadata(userID string, m *mimirpb.MetricMetadata) error {
-	userMetadata := i.getOrCreateUserMetadata(userID)
-
-	return userMetadata.add(m.GetMetricFamilyName(), m)
 }
 
 func (i *Ingester) getOrCreateUserMetadata(userID string) *userMetricsMetadata {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2545,11 +2545,11 @@ func (i *Ingester) pushMetadata(ctx context.Context, userID string, metadata []*
 
 	userMetadata := i.getOrCreateUserMetadata(userID)
 	var firstMetadataErr error
-	for _, metadata := range metadata {
-		if metadata == nil {
+	for _, m := range metadata {
+		if m == nil {
 			continue
 		}
-		err := userMetadata.add(metadata.MetricFamilyName, metadata)
+		err := userMetadata.add(m.MetricFamilyName, m)
 		if err == nil {
 			ingestedMetadata++
 			continue


### PR DESCRIPTION
#### What this PR does

Function `appendMetadata` was only ever called once; eliding it allows the call to `getOrCreateUserMetadata` to be hoisted out of the loop and save locking on every series.

The call to `GetMetricFamilyName` checked if the input was nil, which probably won't happen, but if it did we would rather ignore that input than store metadata under the metric name `""`.

#### Checklist

- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-visible
