### PR TITLE
querier: simplify error message from block store consistency check

### DIFF
--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -824,7 +824,7 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	_, err = c.Query("series_1", series1Timestamp)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
-	assert.Contains(t, err.(*promv1.Error).Detail, "consistency check failed because some blocks were not queried")
+	assert.Contains(t, err.(*promv1.Error).Detail, "failed to fetch some blocks")
 }
 
 func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -583,7 +583,7 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(ctx context.Context, logg
 }
 
 func newStoreConsistencyCheckFailedError(remainingBlocks []ulid.ULID) error {
-	return fmt.Errorf("%v. The non-queried blocks are: %s", globalerror.StoreConsistencyCheckFailed.Message("the consistency check failed because some blocks were not queried"), strings.Join(convertULIDsToString(remainingBlocks), " "))
+	return fmt.Errorf("%v. The failed blocks are: %s", globalerror.StoreConsistencyCheckFailed.Message("failed to fetch some blocks"), strings.Join(convertULIDsToString(remainingBlocks), " "))
 }
 
 // filterBlocksByShard removes blocks that can be safely ignored when using query sharding. We know that block can be safely

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2132,7 +2132,7 @@ func TestBlocksStoreQueryableErrMsgs(t *testing.T) {
 	}{
 		"newStoreConsistencyCheckFailedError": {
 			err: newStoreConsistencyCheckFailedError([]ulid.ULID{ulid.MustNew(1, nil)}),
-			msg: `failed to fetch some blocks (err-mimir-store-consistency-check-failed). The non-queried blocks are: 00000000010000000000000000`,
+			msg: `failed to fetch some blocks (err-mimir-store-consistency-check-failed). The failed blocks are: 00000000010000000000000000`,
 		},
 	}
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2132,7 +2132,7 @@ func TestBlocksStoreQueryableErrMsgs(t *testing.T) {
 	}{
 		"newStoreConsistencyCheckFailedError": {
 			err: newStoreConsistencyCheckFailedError([]ulid.ULID{ulid.MustNew(1, nil)}),
-			msg: `the consistency check failed because some blocks were not queried (err-mimir-store-consistency-check-failed). The non-queried blocks are: 00000000010000000000000000`,
+			msg: `failed to fetch some blocks (err-mimir-store-consistency-check-failed). The non-queried blocks are: 00000000010000000000000000`,
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does

When I read "failed because some blocks were not queried", I wonder why were they not queried? It isn't clear to me what went wrong.

We explain in the [docs](https://github.com/grafana/mimir/blob/8fb2b79bcddb92b9a31f6db7a19390fae34d547c/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md#L1677):

> This error occurs when the querier is unable to fetch some of the expected blocks after multiple retries and connections to different store-gateways.

So I suggest "failed to fetch some blocks" covers this and is easier to understand. The unique code `err-mimir-store-consistency-check-failed` lets the admin find the right point in the docs to read more.

#### Checklist

- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - I don't think it is worth announcing this change.
