### PR TITLE
Store-gateway: Add metrics for fine-grained chunks caching

### DIFF
--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2167,7 +2167,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))",
+                        "expr": "# non-streaming store-gateway will not have the stage label on any touched metrics\nsum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\nor\n# streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"selected\"\nsum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"selected\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2167,7 +2167,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))",
+                        "expr": "# non-streaming store-gateway will not have the stage label on any touched metrics\nsum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\nor\n# streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"selected\"\nsum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"selected\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -231,7 +231,13 @@ local filename = 'mimir-queries.json';
       )
       .addPanel(
         $.panel('Data touched / sec') +
-        $.queryPanel('sum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component="store-gateway",%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.store_gateway), '{{data_type}}') +
+        $.queryPanel(|||
+          # non-streaming store-gateway will not have the stage label on any touched metrics
+          sum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component="store-gateway", stage="",%(jobMatcher)s}[$__rate_interval]))
+          or
+          # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - "selected"
+          sum by(data_type) (rate(cortex_bucket_store_series_data_touched_sum{component="store-gateway", data_type="chunks", stage="selected",%(jobMatcher)s}[$__rate_interval]))
+        ||| % { jobMatcher: $.jobMatcher($._config.job_names.store_gateway) }, '{{data_type}}') +
         $.stack +
         { yaxes: $.yaxes('ops') },
       )

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -83,20 +83,20 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	m.seriesDataTouched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
 		Name: "cortex_bucket_store_series_data_touched",
 		Help: "How many items of a data type in a block were touched for a single series request.",
-	}, []string{"data_type"})
+	}, []string{"data_type", "stage"})
 	m.seriesDataFetched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
 		Name: "cortex_bucket_store_series_data_fetched",
 		Help: "How many items of a data type in a block were fetched for a single series request.",
-	}, []string{"data_type"})
+	}, []string{"data_type", "stage"})
 
 	m.seriesDataSizeTouched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
 		Name: "cortex_bucket_store_series_data_size_touched_bytes",
 		Help: "Size of all items of a data type in a block were touched for a single series request.",
-	}, []string{"data_type"})
+	}, []string{"data_type", "stage"})
 	m.seriesDataSizeFetched = promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
 		Name: "cortex_bucket_store_series_data_size_fetched_bytes",
 		Help: "Size of all items of a data type in a block were fetched for a single series request.",
-	}, []string{"data_type"})
+	}, []string{"data_type", "stage"})
 
 	m.seriesBlocksQueried = promauto.With(reg).NewSummary(prometheus.SummaryOpts{
 		Name: "cortex_bucket_store_series_blocks_queried",

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -41,11 +41,16 @@ type queryStats struct {
 	seriesHashCacheRequests int
 	seriesHashCacheHits     int
 
+	chunksParsed           int
+	chunksParsedSizeSum    int
+	chunksRefetched        int
+	chunksRefetchedSizeSum int
 	chunksTouched          int
 	chunksTouchedSizeSum   int
 	chunksFetched          int
 	chunksFetchedSizeSum   int
 	chunksFetchCount       int
+	// Fetch duration records the time we spent fetching the chunks, regardless if it was from the cache, a regular fetch or a refetch
 	chunksFetchDurationSum time.Duration
 
 	mergedSeriesCount int


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->


#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/3939; upstreams part of https://github.com/grafana/mimir/pull/3968


#### What this PR does

Proposes changes to the metrics that the store-gateway exposes to give more granular insight into the sizes of chunks through the loading process. At this point this PR should be a noop. I'm opening more as a preliminary discussion for the followup PR which will also record these metrics.

This PR adds a `stage` label to these four metrics
* `cortex_bucket_store_series_data_fetched`
* `cortex_bucket_store_series_data_size_fetched_bytes`
* `cortex_bucket_store_series_data_touched`
* `cortex_bucket_store_series_data_size_touched_bytes`


The `stage` label doesn't have a value for `series` and `postings`, so for them these metrics work the same way. The `stage` label is also empty even for chunks when the store-gateway is non-streaming and when the fine-grained chunks caching for the streaming store-gateway is disabled (as of this PR this caching is still not implemented).

When the fine-grained caching is enabled the `stage` label will have the following values for `data_type="chunks"`
* `cortex_bucket_store_series_data_fetched`
	* `normal` - the number of chunks that we had to fetch; this doesn't include refetched chunks; this includes chunks outside of the request minT/maxT
	* `refetch` - the number of chunks from ranges that we had to refetch because they were underfetched
* `cortex_bucket_store_series_data_size_fetched_bytes`
	* `normal` - the raw size of chunk ranges fetched from both the cache and the bucket; this doesn't include overfetched bytes caused by the partitioner
		* __I am not sure whether or not we should include the partitioner effect into this or not.__ If we include it, then we can make weaker conclusions about how effective our chunk length estimation is because the fetched bytes can include almost arbitrary bytes that we have little control over
	* `refetch` - same as normal, but includes only the raw range sizes that had to be refetched
* `cortex_bucket_store_series_data_touched`
	* `parsed` - the number of chunks that we parsed; this is equal to `cortex_bucket_store_series_data_fetched{stage="normal"}` and is here for completeness
	* `selected`  - the number of chunks that were selected because they overlap with the request's minT/maxT; the value of this is included in `parsed`
* `cortex_bucket_store_series_data_size_touched_bytes`
	* `parsed` - the total bytes from the raw ranges that were enough to parse the range; this is the total size of raw ranges minus the bytes we overfetched due to overestimating the chunk size
	* `selected` - the raw size of chunks that were selected because they overlap with the request's minT/maxT

To make these changes I also had to change the dashboards so that we don't double-count `stage="parsed"` and `stage="selected"` as their records overlap.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
