### PR TITLE
Mixin: Make CPU/memory based auto-scaling panel labels differentiate between targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * [CHANGE] Make distributor auto-scaling metric panels show desired number of replicas. #4218
 * [ENHANCEMENT] Alerts: Added `MimirAutoscalerKedaFailing` alert firing when a KEDA scaler is failing. #4045
 * [ENHANCEMENT] Add auto-scaling panels to ruler dashboard. #4046
-* [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049
+* [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049 #4216
 * [ENHANCEMENT] Dashboards: distinguish between label names and label values queries. #4065
 * [BUGFIX] Alerts: Fixed `MimirAutoscalerNotActive` to not fire if scaling metric does not exist, to avoid false positives on scaled objects with 0 min replicas. #4045
 * [BUGFIX] Alerts: `MimirCompactorHasNotSuccessfullyRunCompaction` is no longer triggered by frequent compactor restarts. #4012

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -936,7 +936,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nPlease note that the current number of replicas can still show 1 replica even when scaled to 0.\nSince HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fill": 1,
                   "id": 13,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -936,7 +936,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe minimum, maximum, and current number of distributor replicas.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nPlease note that the current number of replicas can still show 1 replica even when scaled to 0.\nSince HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fill": 1,
                   "id": 13,
                   "legend": {
@@ -956,33 +956,35 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [ ],
+                  "seriesOverrides": [
+                     {
+                        "alias": "/Max .+/",
+                        "dashes": true,
+                        "fill": 0
+                     },
+                     {
+                        "alias": "/Current .+/",
+                        "fill": 0
+                     }
+                  ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}",
+                        "expr": "kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n# Add the scaletargetref_name label for readability\n+ on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n  0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Min",
+                        "legendFormat": "Max {{ scaletargetref_name }}",
                         "legendLink": null,
                         "step": 10
                      },
                      {
-                        "expr": "kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}",
+                        "expr": "kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n# HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n* on (cluster, namespace, horizontalpodautoscaler)\n  kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\", condition=\"ScalingActive\", status=\"true\"}\n# Add the scaletargetref_name label for readability\n+ on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n  0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Max",
-                        "legendLink": null,
-                        "step": 10
-                     },
-                     {
-                        "expr": "kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Current",
+                        "legendFormat": "Current {{ scaletargetref_name }}",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -936,7 +936,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nPlease note that the current number of replicas can still show 1 replica even when scaled to 0.\nSince HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fill": 1,
                   "id": 13,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -936,7 +936,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe minimum, maximum, and current number of distributor replicas.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nPlease note that the current number of replicas can still show 1 replica even when scaled to 0.\nSince HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fill": 1,
                   "id": 13,
                   "legend": {
@@ -956,33 +956,35 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [ ],
+                  "seriesOverrides": [
+                     {
+                        "alias": "/Max .+/",
+                        "dashes": true,
+                        "fill": 0
+                     },
+                     {
+                        "alias": "/Current .+/",
+                        "fill": 0
+                     }
+                  ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}",
+                        "expr": "kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n# Add the scaletargetref_name label for readability\n+ on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n  0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Min",
+                        "legendFormat": "Max {{ scaletargetref_name }}",
                         "legendLink": null,
                         "step": 10
                      },
                      {
-                        "expr": "kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}",
+                        "expr": "kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n# HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n* on (cluster, namespace, horizontalpodautoscaler)\n  kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\", condition=\"ScalingActive\", status=\"true\"}\n# Add the scaletargetref_name label for readability\n+ on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n  0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Max",
-                        "legendLink": null,
-                        "step": 10
-                     },
-                     {
-                        "expr": "kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Current",
+                        "legendFormat": "Current {{ scaletargetref_name }}",
                         "legendLink": null,
                         "step": 10
                      }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -495,22 +495,56 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.panel(title) +
       $.queryPanel(
         [
-          'kube_horizontalpodautoscaler_spec_min_replicas{%s, horizontalpodautoscaler=~"%s"}' % [$.namespaceMatcher(), $._config.autoscaling[component].hpa_name],
-          'kube_horizontalpodautoscaler_spec_max_replicas{%s, horizontalpodautoscaler=~"%s"}' % [$.namespaceMatcher(), $._config.autoscaling[component].hpa_name],
-          'kube_horizontalpodautoscaler_status_current_replicas{%s, horizontalpodautoscaler=~"%s"}' % [$.namespaceMatcher(), $._config.autoscaling[component].hpa_name],
+          |||
+            kube_horizontalpodautoscaler_spec_max_replicas{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s"}
+            # Add the scaletargetref_name label for readability
+            + on (%(cluster_labels)s, horizontalpodautoscaler) group_left (scaletargetref_name)
+              0*kube_horizontalpodautoscaler_info{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s"}
+          ||| % {
+            namespace_matcher: $.namespaceMatcher(),
+            hpa_name: $._config.autoscaling[component].hpa_name,
+            cluster_labels: std.join(', ', $._config.cluster_labels),
+          },
+          |||
+            kube_horizontalpodautoscaler_status_current_replicas{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s"}
+            # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active
+            * on (%(cluster_labels)s, horizontalpodautoscaler)
+              kube_horizontalpodautoscaler_status_condition{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s", condition="ScalingActive", status="true"}
+            # Add the scaletargetref_name label for readability
+            + on (%(cluster_labels)s, horizontalpodautoscaler) group_left (scaletargetref_name)
+              0*kube_horizontalpodautoscaler_info{%(namespace_matcher)s, horizontalpodautoscaler=~"%(hpa_name)s"}
+          ||| % {
+            namespace_matcher: $.namespaceMatcher(),
+            hpa_name: $._config.autoscaling[component].hpa_name,
+            cluster_labels: std.join(', ', $._config.cluster_labels),
+          },
         ],
         [
-          'Min',
-          'Max',
-          'Current',
+          'Max {{ scaletargetref_name }}',
+          'Current {{ scaletargetref_name }}',
         ],
       ) +
       $.panelDescription(
         title,
         |||
-          The minimum, maximum, and current number of %s replicas.
+          The maximum and current number of %s replicas.
+          Please note that the current number of replicas can still show 1 replica even when scaled to 0.
+          Since HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
         ||| % [component]
-      ),
+      ) +
+      {
+        seriesOverrides+: [
+          {
+            alias: '/Max .+/',
+            dashes: true,
+            fill: 0,
+          },
+          {
+            alias: '/Current .+/',
+            fill: 0,
+          },
+        ],
+      },
     )
     .addPanel(
       local title = 'Scaling metric (CPU): Desired replicas';

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -528,7 +528,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         title,
         |||
           The maximum and current number of %s replicas.
-          Please note that the current number of replicas can still show 1 replica even when scaled to 0.
+          Note: The current number of replicas can still show 1 replica even when scaled to 0.
           Since HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
         ||| % [component]
       ) +

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -529,7 +529,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         |||
           The maximum and current number of %s replicas.
           Note: The current number of replicas can still show 1 replica even when scaled to 0.
-          Since HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
+          Because HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
         ||| % [component]
       ) +
       {


### PR DESCRIPTION
#### What this PR does
Fix CPU/memory based auto-scaling panels so labels differentiate between targets, the _Min_ label is dropped to reduce the amount of information in a single panel (same change was done for queriers in #3692).

I've tested the changes locally (`make mixin-serve`).

Based on #3962.

#### Which issue(s) this PR fixes or relates to

Fixes #4134.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
