### PR TITLE
allow targetable invisible modules to start

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -744,7 +744,7 @@ func (t *Mimir) Run() error {
 	usagestats.SetTarget(t.Cfg.Target.String())
 
 	for _, module := range t.Cfg.Target {
-		if !t.ModuleManager.IsUserVisibleModule(module) {
+		if !t.ModuleManager.IsTargetableModule(module) {
 			return fmt.Errorf("selected target (%s) is an internal module, which is not allowed", module)
 		}
 	}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -744,7 +744,6 @@ func (t *Mimir) Run() error {
 	usagestats.SetTarget(t.Cfg.Target.String())
 
 	for _, module := range t.Cfg.Target {
-
 		if !t.ModuleManager.IsTargetableModule(module) {
 			return fmt.Errorf("selected target (%s) is an internal module, which is not allowed", module)
 		}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -744,6 +744,7 @@ func (t *Mimir) Run() error {
 	usagestats.SetTarget(t.Cfg.Target.String())
 
 	for _, module := range t.Cfg.Target {
+
 		if !t.ModuleManager.IsTargetableModule(module) {
 			return fmt.Errorf("selected target (%s) is an internal module, which is not allowed", module)
 		}


### PR DESCRIPTION
In recent versions of dskit we differentiate between "invisible" and "targetable" modules.
With this change we decide whether a module should be allowed to run based on if it is "targetable".
By default all "invisible" modules are not "targetable".