### PR TITLE
Mixin: Change CPU/memory based scaling metric panels into showing desired replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Mixin
 
 * [CHANGE] Move auto-scaling panel rows down beneath logical network path in Reads and Writes dashboards. #4049
+* [CHANGE] Make distributor auto-scaling metric panels show desired number of replicas. #4218
 * [ENHANCEMENT] Alerts: Added `MimirAutoscalerKedaFailing` alert firing when a KEDA scaler is failing. #4045
 * [ENHANCEMENT] Add auto-scaling panels to ruler dashboard. #4046
 * [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -1029,7 +1029,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Scaling metric (CPU)\nThis panel shows the result of the query used as scaling metric and target/threshold used.\nThe desired number of replicas is computed by HPA as: <scaling metric> / <target per replica>.\n\n",
+                  "description": "### Scaling metric (CPU): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                   "fill": 1,
                   "id": 14,
                   "legend": {
@@ -1049,30 +1049,17 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [
-                     {
-                        "alias": "Target per replica",
-                        "yaxis": 2
-                     }
-                  ],
+                  "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "(keda_metrics_adapter_scaler_metrics_value{metric=~\".*cpu.*\"} / 1000) +\non(metric) group_left\nlabel_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n    * 0, \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*cpu.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Scaling metric",
-                        "legendLink": null,
-                        "step": 10
-                     },
-                     {
-                        "expr": "kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\", metric_name=~\".*cpu.*\"} / 1000",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Target per replica",
+                        "legendFormat": "{{ scaledObject }}",
                         "legendLink": null,
                         "step": 10
                      }
@@ -1080,7 +1067,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Scaling metric (CPU)",
+                  "title": "Scaling metric (CPU): Desired replicas",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -1109,7 +1096,7 @@
                         "logBase": 1,
                         "max": null,
                         "min": null,
-                        "show": true
+                        "show": false
                      }
                   ]
                },
@@ -1119,7 +1106,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Scaling metric (Memory)\nThis panel shows the result of the query used as scaling metric and target/threshold used.\nThe desired number of replicas is computed by HPA as: <scaling metric> / <target per replica>.\n\n",
+                  "description": "### Scaling metric (memory): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                   "fill": 1,
                   "id": 15,
                   "legend": {
@@ -1139,30 +1126,17 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [
-                     {
-                        "alias": "Target per replica",
-                        "yaxis": 2
-                     }
-                  ],
+                  "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"} +\non(metric) group_left\nlabel_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n    * 0, \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Scaling metric",
-                        "legendLink": null,
-                        "step": 10
-                     },
-                     {
-                        "expr": "kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\", metric_name=~\".*memory.*\"}",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Target per replica",
+                        "legendFormat": "{{ scaledObject }}",
                         "legendLink": null,
                         "step": 10
                      }
@@ -1170,7 +1144,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Scaling metric (Memory)",
+                  "title": "Scaling metric (memory): Desired replicas",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -1186,7 +1160,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "bytes",
+                        "format": "short",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1194,7 +1168,7 @@
                         "show": true
                      },
                      {
-                        "format": "bytes",
+                        "format": "short",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -1029,7 +1029,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Scaling metric (CPU)\nThis panel shows the result of the query used as scaling metric and target/threshold used.\nThe desired number of replicas is computed by HPA as: <scaling metric> / <target per replica>.\n\n",
+                  "description": "### Scaling metric (CPU): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                   "fill": 1,
                   "id": 14,
                   "legend": {
@@ -1049,30 +1049,17 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [
-                     {
-                        "alias": "Target per replica",
-                        "yaxis": 2
-                     }
-                  ],
+                  "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "(keda_metrics_adapter_scaler_metrics_value{metric=~\".*cpu.*\"} / 1000) +\non(metric) group_left\nlabel_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n    * 0, \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*cpu.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Scaling metric",
-                        "legendLink": null,
-                        "step": 10
-                     },
-                     {
-                        "expr": "kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\", metric_name=~\".*cpu.*\"} / 1000",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Target per replica",
+                        "legendFormat": "{{ scaledObject }}",
                         "legendLink": null,
                         "step": 10
                      }
@@ -1080,7 +1067,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Scaling metric (CPU)",
+                  "title": "Scaling metric (CPU): Desired replicas",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -1109,7 +1096,7 @@
                         "logBase": 1,
                         "max": null,
                         "min": null,
-                        "show": true
+                        "show": false
                      }
                   ]
                },
@@ -1119,7 +1106,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Scaling metric (Memory)\nThis panel shows the result of the query used as scaling metric and target/threshold used.\nThe desired number of replicas is computed by HPA as: <scaling metric> / <target per replica>.\n\n",
+                  "description": "### Scaling metric (memory): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                   "fill": 1,
                   "id": 15,
                   "legend": {
@@ -1139,30 +1126,17 @@
                   "pointradius": 5,
                   "points": false,
                   "renderer": "flot",
-                  "seriesOverrides": [
-                     {
-                        "alias": "Target per replica",
-                        "yaxis": 2
-                     }
-                  ],
+                  "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"} +\non(metric) group_left\nlabel_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"}\n    * 0, \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "Scaling metric",
-                        "legendLink": null,
-                        "step": 10
-                     },
-                     {
-                        "expr": "kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-distributor\", metric_name=~\".*memory.*\"}",
-                        "format": "time_series",
-                        "intervalFactor": 2,
-                        "legendFormat": "Target per replica",
+                        "legendFormat": "{{ scaledObject }}",
                         "legendLink": null,
                         "step": 10
                      }
@@ -1170,7 +1144,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Scaling metric (Memory)",
+                  "title": "Scaling metric (memory): Desired replicas",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -1186,7 +1160,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "bytes",
+                        "format": "short",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1194,7 +1168,7 @@
                         "show": true
                      },
                      {
-                        "format": "bytes",
+                        "format": "short",
                         "label": null,
                         "logBase": 1,
                         "max": null,


### PR DESCRIPTION
#### What this PR does
In the mixin, change CPU/memory based scaling metric panels into showing desired replicas.

The same change is done for queriers in #3962.

Distributor panels after changes in this PR:
![localhost_9090_d_8280707b8f16e7b87b840fc1cc92d4c5_mimir-writes_orgId=1 refresh=1m var-datasource=default var-cluster=All var-namespace=cortex-ops-01](https://user-images.githubusercontent.com/281303/218046345-69f9dc42-c31f-4694-95fc-7458a71eb920.png)
![localhost_9090_d_8280707b8f16e7b87b840fc1cc92d4c5_mimir-writes_orgId=1 refresh=1m var-datasource=default var-cluster=All var-namespace=cortex-ops-01 (2)](https://user-images.githubusercontent.com/281303/218049283-9af6c0eb-9d64-4309-bd9a-0cf4583336ee.png)

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
