### PR TITLE
Helm: cut changelog for 4.1 release

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+## 4.1.0
+
 * [CHANGE] Configured `max_total_query_length: 12000h` limit to match Mimir jsonnet-based deployment. #3879
 * [ENHANCEMENT] Enable users to specify additional Kubernetes resource manifests using the `extraObjects` variable. #4102
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.2.0`. #3624


### PR DESCRIPTION
This cuts the changelog for the Helm 4.1 release.

My next steps are to
* make a new branch `mimir-distributed-release-4.1` as of `main` after merging _this_ PR
* write release notes for helm (another PR)
* trigger a release for helm (another PR)