### PR TITLE
Helm: do 4.1.0 release

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -36,6 +36,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add ability to manage PrometheusRule for metamonitoring with Prometheus operator from the Helm chart. The alerts are disabled by default but can be enabled with `prometheusRule.mimirAlerts` set to `true`. To enable the default rules, set `mimirRules` to `true`. #2134 #2609
 * [ENHANCEMENT] Update memcached image to `memcached:1.6.17-alpine`. #3914
 * [ENHANCEMENT] Update minio subchart to `5.0.4`. #3942
+* [ENHANCEMENT] Release chart 4.1.0 with Mimir image `grafana/mimir:2.6.0` and GEM image `grafana/enterprise-metrics:v2.5.1`. #4221
 * [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary. #3686
 * [BUGFIX] Fixed gateway's checksum/config when using nginx #3780
 * [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-version: 4.1.0-weekly.224
-appVersion: r224
+version: 4.1.0
+appVersion: 2.6.0
 description: "Grafana Mimir"
-home: https://grafana.com/docs/mimir/v2.5.x/
+home: https://grafana.com/docs/mimir/v2.6.x/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg
 kubeVersion: ^1.20.0-0
 name: mimir-distributed

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -1,6 +1,6 @@
 # Grafana Mimir Helm chart
 
-Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.5.x/) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.5.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
+Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/v2.6.x/) or optionally [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/v2.5.x/) to Kubernetes. Derived from [Grafana Enterprise Metrics Helm chart](https://github.com/grafana/helm-charts/blob/main/charts/enterprise-metrics/README.md)
 
 See the [Grafana Mimir version 2.5 release notes](https://grafana.com/docs/mimir/v2.5.x/release-notes/v2.5/).
 
@@ -11,7 +11,7 @@ When upgrading from Helm chart version 2.1, please see [Upgrade the Grafana Mimi
 
 # mimir-distributed
 
-![Version: 4.1.0-weekly.224](https://img.shields.io/badge/Version-4.1.0--weekly.224-informational?style=flat-square) ![AppVersion: r224](https://img.shields.io/badge/AppVersion-r224-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
 
 Grafana Mimir
 
@@ -32,7 +32,7 @@ Kubernetes: `^1.20.0-0`
 Grafana Mimir and Grafana Enterprise Metrics require an object storage backend to store metrics and indexes.
 
 The default chart values will deploy [Minio](https://min.io) for initial set up. Production deployments should use a separately deployed object store.
-See [Grafana Mimir documentation](https://grafana.com/docs/mimir/v2.5.x/) for details on storage types and documentation.
+See [Grafana Mimir documentation](https://grafana.com/docs/mimir/v2.6.x/) for details on storage types and documentation.
 
 ### Grafana Enterprise Metrics license
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -34,7 +34,7 @@ image:
   # -- Grafana Mimir container image repository. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.repository'
   repository: grafana/mimir
   # -- Grafana Mimir container image tag. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.tag'
-  tag: r224-ba7a966
+  tag: 2.6.0
   # -- Container pull policy - shared between Grafana Mimir and Grafana Enterprise Metrics
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets - shared between Grafana Mimir and Grafana Enterprise Metrics
@@ -2807,7 +2807,7 @@ enterprise:
     # -- Grafana Enterprise Metrics container image repository. Note: for Grafana Mimir use the value 'image.repository'
     repository: grafana/enterprise-metrics
     # -- Grafana Enterprise Metrics container image tag. Note: for Grafana Mimir use the value 'image.tag'
-    tag: r224-40ff0980
+    tag: v2.5.1
     # Note: pullPolicy and optional pullSecrets are set in toplevel 'image' section, not here
 
 # In order to use Grafana Enterprise Metrics features, you will need to provide the contents of your Grafana Enterprise Metrics
@@ -3286,7 +3286,7 @@ gr-metricname-cache:
 smoke_test:
   image:
     repository: grafana/mimir-continuous-test
-    tag: r224-ba7a966
+    tag: 2.6.0
     pullPolicy: IfNotPresent
   tenantId: ''
   extraArgs: {}
@@ -3306,7 +3306,7 @@ continuous_test:
   replicas: 1
   image:
     repository: grafana/mimir-continuous-test
-    tag: r224-ba7a966
+    tag: 2.6.0
     pullPolicy: IfNotPresent
     # Note: optional pullSecrets are set in toplevel 'image' section, not here
 


### PR DESCRIPTION
This updates
* the chart version, app version, home version
* image version of smoke_test, continuous_test, mimir, and GEM
	* since the GEM release is slightly delayed, this release uses GEM version `2.5.1`
	* all the other images use `2.6.0`
* Helm README
* Helm CHANGELOG with the actual images used