### PR TITLE
Docs: Trigger helm docs release for branches too

### DIFF
--- a/.github/workflows/publish-technical-documentation-release-helm-charts.yml
+++ b/.github/workflows/publish-technical-documentation-release-helm-charts.yml
@@ -2,9 +2,10 @@ name: "publish-technical-documentation-release-helm-charts"
 
 on:
   push:
-    # branches: intentionally left off, do not publish incomplete documentation
     tags:  # this excludes pre-releases, e.g. mimir-distributed-2.2.0-weekly.192
     - "mimir-distributed-[0-9]+.[0-9]+.[0-9]+"
+    branch: # this excludes pre-releases, e.g. mimir-distributed-2.2.0-weekly.192
+    - "mimir-distributed-release-[0-9]+.[0-9]+"
     paths:
     - "docs/sources/helm-charts/**"
 


### PR DESCRIPTION
Our docs release didn't trigger for the 4.1 tag, so we're also adding
matching by branch name.