### PR TITLE
Helm: add configuration options to override NGINX access and error logs

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -36,6 +36,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add ability to manage PrometheusRule for metamonitoring with Prometheus operator from the Helm chart. The alerts are disabled by default but can be enabled with `prometheusRule.mimirAlerts` set to `true`. To enable the default rules, set `mimirRules` to `true`. #2134 #2609
 * [ENHANCEMENT] Update memcached image to `memcached:1.6.17-alpine`. #3914
 * [ENHANCEMENT] Update minio subchart to `5.0.4`. #3942
+* [ENHANCEMENT] Allow NGINX error log level to be overidden and access log to be disabled. #4230
 * [BUGFIX] Enable `rollout-operator` to use PodSecurityPolicies if necessary
 * [BUGFIX] Fixed gateway's checksum/config when using nginx #3780
 * [BUGFIX] Disable gateway's serviceMonitor when using nginx #3781

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2079,6 +2079,10 @@ nginx:
       main '$remote_addr - $remote_user [$time_local]  $status '
               '"$request" $body_bytes_sent "$http_referer" '
               '"$http_user_agent" "$http_x_forwarded_for"';
+    # -- Sets the log level of the NGINX error log. One of `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg`
+    errorLogLevel: info
+    # -- Enables NGINX access logs
+    accessLogEnabled: true
     # -- Allows appending custom configuration to the server block
     serverSnippet: ""
     # -- Allows appending custom configuration to the http block
@@ -2089,7 +2093,7 @@ nginx:
     # @default -- See values.yaml
     file: |
       worker_processes  5;  ## Default: 1
-      error_log  /dev/stderr;
+      error_log  /dev/stderr {{ .Values.nginx.nginxConfig.errorLogLevel }};
       pid        /tmp/nginx.pid;
       worker_rlimit_nofile 8192;
 
@@ -2115,7 +2119,7 @@ nginx:
           ~^[23]  0;
           default 1;
         }
-        access_log   /dev/stderr  main  if=$loggable;
+        access_log   {{ .Values.nginx.nginxConfig.accessLogEnabled | ternary "/dev/stderr  main  if=$loggable;" "off;" }}
         {{- end }}
 
         sendfile     on;
@@ -2424,6 +2428,10 @@ gateway:
         main '$remote_addr - $remote_user [$time_local]  $status '
                 '"$request" $body_bytes_sent "$http_referer" '
                 '"$http_user_agent" "$http_x_forwarded_for"';
+      # -- Sets the log level of the NGINX error log. One of `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg`
+      errorLogLevel: info
+      # -- Enables NGINX access logs
+      accessLogEnabled: true
       # -- Allows appending custom configuration to the server block
       serverSnippet: ""
       # -- Allows appending custom configuration to the http block
@@ -2433,7 +2441,7 @@ gateway:
       # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating.
       file: |
         worker_processes  5;  ## Default: 1
-        error_log  /dev/stderr;
+        error_log  /dev/stderr {{ .Values.gateway.nginx.config.errorLogLevel }};
         pid        /tmp/nginx.pid;
         worker_rlimit_nofile 8192;
 
@@ -2459,7 +2467,7 @@ gateway:
             ~^[23]  0;
             default 1;
           }
-          access_log   /dev/stderr  main  if=$loggable;
+          access_log   {{ .Values.gateway.nginx.config.accessLogEnabled | ternary "/dev/stderr  main  if=$loggable;" "off;" }}
           {{- end }}
 
           sendfile     on;

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2080,7 +2080,7 @@ nginx:
               '"$request" $body_bytes_sent "$http_referer" '
               '"$http_user_agent" "$http_x_forwarded_for"';
     # -- Sets the log level of the NGINX error log. One of `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg`
-    errorLogLevel: info
+    errorLogLevel: error
     # -- Enables NGINX access logs
     accessLogEnabled: true
     # -- Allows appending custom configuration to the server block
@@ -2429,7 +2429,7 @@ gateway:
                 '"$request" $body_bytes_sent "$http_referer" '
                 '"$http_user_agent" "$http_x_forwarded_for"';
       # -- Sets the log level of the NGINX error log. One of `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg`
-      errorLogLevel: info
+      errorLogLevel: error
       # -- Enables NGINX access logs
       accessLogEnabled: true
       # -- Allows appending custom configuration to the server block

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr info;
+    error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
+    error_log  /dev/stderr info;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
     


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This adds configuration options to override the NGINX error log level and to optionally disable the NGINX access log since the default options can create a large volume of logs. 

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
