### PR TITLE
Update migrate-from-cortex.md

### DIFF
--- a/docs/sources/mimir/migration-guide/migrate-from-cortex.md
+++ b/docs/sources/mimir/migration-guide/migrate-from-cortex.md
@@ -174,7 +174,7 @@ jb install github.com/grafana/mimir/operations/mimir-mixin@main
    ```jsonnet
    (import 'github.com/grafana/mimir/operations/mimir/mimir.libsonnet') {
      _config+: {
-       server_http.port: 80,
+       server_http_port: 80,
      },
    }
    ```


### PR DESCRIPTION
The config option to change the http port is called `server_http_port` instead of `server_http.port`  (https://github.com/grafana/mimir/blob/main/operations/mimir/config.libsonnet#L250)

#### What this PR does

Fix `server_http_port` in cortex migration docs


