### PR TITLE
Allow to select storageClass per zone

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] You can now configure `storageClass` per zone for Alertmanager, StoreGateway and Ingester. #4234
 * [CHANGE] Change number of Memcached max idle connections to 150. #4591
 * [CHANGE] Set `unregister_on_shutdown` for `store-gateway` to `false` by default. #4690
 * [FEATURE] Add documentation to use external Redis support for chunks-cache, metadata-cache and results-cache. #4348

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -464,7 +464,8 @@ Return value:
     zoneName: {
       affinity: <affinity>,
       nodeSelector: <nodeSelector>,
-      replicas: <N>
+      replicas: <N>,
+      storageClass: <S>
     },
     ...
   }
@@ -475,7 +476,7 @@ which allows us to keep generating everything for the default zone.
 {{- define "mimir.zoneAwareReplicationMap" -}}
 {{- $zonesMap := (dict) -}}
 {{- $componentSection := include "mimir.componentSectionFromName" . | fromYaml -}}
-{{- $defaultZone := (dict "affinity" $componentSection.affinity "nodeSelector" $componentSection.nodeSelector "replicas" $componentSection.replicas) -}}
+{{- $defaultZone := (dict "affinity" $componentSection.affinity "nodeSelector" $componentSection.nodeSelector "replicas" $componentSection.replicas "storageClass" $componentSection.storageClass) -}}
 
 {{- if $componentSection.zoneAwareReplication.enabled -}}
 {{- $numberOfZones := len $componentSection.zoneAwareReplication.zones -}}
@@ -494,6 +495,7 @@ which allows us to keep generating everything for the default zone.
   "affinity" (($rolloutZone.extraAffinity | default (dict)) | mergeOverwrite (include "mimir.zoneAntiAffinity" (dict "component" $.component "rolloutZoneName" $rolloutZone.name "topologyKey" $componentSection.zoneAwareReplication.topologyKey ) | fromYaml ) )
   "nodeSelector" ($rolloutZone.nodeSelector | default (dict) )
   "replicas" $replicaPerZone
+  "storageClass" $rolloutZone.storageClass
   ) -}}
 {{- end -}}
 {{- if $componentSection.zoneAwareReplication.migration.enabled -}}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -35,11 +35,19 @@ spec:
           {{ toYaml .Values.alertmanager.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
+        {{- if $rolloutZone.storageClass}}
+        {{- if (eq "-" $rolloutZone.storageClass) }}
+        storageClassName: {{ .Values.alertmanager.persistentVolume.storageClass }}
+        {{- else }}
+        storageClassName: {{ $rolloutZone.storageClass }}
+        {{- end }}
+        {{- else }}
         {{- if .Values.alertmanager.persistentVolume.storageClass }}
         {{- if (eq "-" .Values.alertmanager.persistentVolume.storageClass) }}
         storageClassName: ""
         {{- else }}
         storageClassName: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
+        {{- end }}
         {{- end }}
         {{- end }}
         accessModes:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -35,19 +35,12 @@ spec:
           {{ toYaml .Values.alertmanager.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- if $rolloutZone.storageClass}}
-        {{- if (eq "-" $rolloutZone.storageClass) }}
-        storageClassName: {{ .Values.alertmanager.persistentVolume.storageClass }}
-        {{- else }}
-        storageClassName: {{ $rolloutZone.storageClass }}
-        {{- end }}
-        {{- else }}
-        {{- if .Values.alertmanager.persistentVolume.storageClass }}
-        {{- if (eq "-" .Values.alertmanager.persistentVolume.storageClass) }}
+        {{- $storageClass := default .Values.alertmanager.persistentVolume.storageClass $rolloutZone.storageClass }}
+        {{- if $storageClass }}
+        {{- if (eq "-" $storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
-        {{- end }}
+        storageClassName: {{ $storageClass }}
         {{- end }}
         {{- end }}
         accessModes:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -34,19 +34,12 @@ spec:
           {{- toYaml .Values.ingester.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- if $rolloutZone.storageClass}}
-        {{- if (eq "-" $rolloutZone.storageClass) }}
-        storageClassName: {{ .Values.ingester.persistentVolume.storageClass }}
-        {{- else }}
-        storageClassName: {{ $rolloutZone.storageClass }}
-        {{- end }}
-        {{- else }}
-        {{- if .Values.ingester.persistentVolume.storageClass }}
-        {{- if (eq "-" .Values.ingester.persistentVolume.storageClass) }}
+        {{- $storageClass := default .Values.ingester.persistentVolume.storageClass $rolloutZone.storageClass }}
+        {{- if $storageClass }}
+        {{- if (eq "-" $storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: "{{ .Values.ingester.persistentVolume.storageClass }}"
-        {{- end }}
+        storageClassName: {{ $storageClass }}
         {{- end }}
         {{- end }}
         accessModes:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -34,11 +34,19 @@ spec:
           {{- toYaml .Values.ingester.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
+        {{- if $rolloutZone.storageClass}}
+        {{- if (eq "-" $rolloutZone.storageClass) }}
+        storageClassName: {{ .Values.ingester.persistentVolume.storageClass }}
+        {{- else }}
+        storageClassName: {{ $rolloutZone.storageClass }}
+        {{- end }}
+        {{- else }}
         {{- if .Values.ingester.persistentVolume.storageClass }}
         {{- if (eq "-" .Values.ingester.persistentVolume.storageClass) }}
         storageClassName: ""
         {{- else }}
         storageClassName: "{{ .Values.ingester.persistentVolume.storageClass }}"
+        {{- end }}
         {{- end }}
         {{- end }}
         accessModes:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -33,11 +33,19 @@ spec:
           {{- toYaml .Values.store_gateway.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
+        {{- if $rolloutZone.storageClass}}
+        {{- if (eq "-" $rolloutZone.storageClass) }}
+        storageClassName: {{ .Values.store_gateway.persistentVolume.storageClass }}
+        {{- else }}
+        storageClassName: {{ $rolloutZone.storageClass }}
+        {{- end }}
+        {{- else }}
         {{- if .Values.store_gateway.persistentVolume.storageClass }}
         {{- if (eq "-" .Values.store_gateway.persistentVolume.storageClass) }}
         storageClassName: ""
         {{- else }}
         storageClassName: "{{ .Values.store_gateway.persistentVolume.storageClass }}"
+        {{- end }}
         {{- end }}
         {{- end }}
         accessModes:
@@ -136,7 +144,7 @@ spec:
             - name: storage
               mountPath: "/data"
               {{- if .Values.store_gateway.persistentVolume.subPath }}
-              subPath: {{ .Values.store_gateway.persistentVolume.subPath }}             
+              subPath: {{ .Values.store_gateway.persistentVolume.subPath }}
               {{- end }}
             - name: active-queries
               mountPath: /active-query-tracker

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -33,19 +33,12 @@ spec:
           {{- toYaml .Values.store_gateway.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- if $rolloutZone.storageClass}}
-        {{- if (eq "-" $rolloutZone.storageClass) }}
-        storageClassName: {{ .Values.store_gateway.persistentVolume.storageClass }}
-        {{- else }}
-        storageClassName: {{ $rolloutZone.storageClass }}
-        {{- end }}
-        {{- else }}
-        {{- if .Values.store_gateway.persistentVolume.storageClass }}
-        {{- if (eq "-" .Values.store_gateway.persistentVolume.storageClass) }}
+        {{- $storageClass := default .Values.store_gateway.persistentVolume.storageClass $rolloutZone.storageClass }}
+        {{- if $storageClass }}
+        {{- if (eq "-" $storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: "{{ .Values.store_gateway.persistentVolume.storageClass }}"
-        {{- end }}
+        storageClassName: {{ $storageClass }}
         {{- end }}
         {{- end }}
         accessModes:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -498,6 +498,7 @@ alertmanager:
     # If undefined (the default) or set to null, no storageClassName spec is
     #   set, choosing the default provisioner.
     #
+    # A per-zone storageClass configuration in `alertmanager.zoneAwareReplication.zones[*].storageClass` takes precedence over this field.
     # storageClass: "-"
 
   readinessProbe:
@@ -609,6 +610,11 @@ alertmanager:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- Alertmanager data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `alertmanager.persistentVolume.storageClass`.
+      storageClass: null
     # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     - name: zone-b
       # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -617,6 +623,11 @@ alertmanager:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- Alertmanager data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `alertmanager.persistentVolume.storageClass`.
+      storageClass: null
     # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     - name: zone-c
       # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -625,6 +636,11 @@ alertmanager:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- Alertmanager data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `alertmanager.persistentVolume.storageClass`.
+      storageClass: null
 
 distributor:
   replicas: 1
@@ -782,6 +798,8 @@ ingester:
     # If undefined (the default) or set to null, no storageClassName spec is
     #   set, choosing the default provisioner.
     #
+    # A per-zone storageClass configuration in `ingester.zoneAwareReplication.zones[*].storageClass` takes precedence over this field.
+    #
     # storageClass: "-"
 
   readinessProbe:
@@ -826,12 +844,15 @@ ingester:
   #     - name: zone-a
   #       nodeSelector:
   #         topology.kubernetes.io/zone: us-central1-a
+  #       storageClass: storage-class-us-central1-a
   #     - name: zone-a
   #       nodeSelector:
   #         topology.kubernetes.io/zone: us-central1-b
+  #       storageClass: storage-class-us-central1-b
   #     - name: zone-c
   #       nodeSelector:
   #         topology.kubernetes.io/zone: us-central1-c
+  #       storageClass: storage-class-us-central1-c
   #
   zoneAwareReplication:
     # -- Enable zone-aware replication for ingester
@@ -865,6 +886,11 @@ ingester:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- Ingester data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`.
+      storageClass: null
     # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     - name: zone-b
       # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -873,6 +899,11 @@ ingester:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- Ingester data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`.
+      storageClass: null
     # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     - name: zone-c
       # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -881,6 +912,11 @@ ingester:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- Ingester data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`.
+      storageClass: null
 
 overrides_exporter:
   enabled: true
@@ -1325,6 +1361,7 @@ store_gateway:
     # If undefined (the default) or set to null, no storageClassName spec is
     #   set, choosing the default provisioner.
     #
+    # A per-zone storageClass configuration in `store_gateway.zoneAwareReplication.zones[*].storageClass` takes precedence over this field.
     # storageClass: "-"
 
   readinessProbe:
@@ -1400,6 +1437,11 @@ store_gateway:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- StoreGateway data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `store_gateway.persistentVolume.storageClass`.
+      storageClass: null
     # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     - name: zone-b
       # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -1408,6 +1450,11 @@ store_gateway:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- StoreGateway data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `store_gateway.persistentVolume.storageClass`.
+      storageClass: null
     # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     - name: zone-c
       # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -1416,6 +1463,11 @@ store_gateway:
       nodeSelector: null
       # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
       extraAffinity: {}
+      # -- StoreGateway data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+      # If undefined or set to null (the default), then fall back to the value of `store_gateway.persistentVolume.storageClass`.
+      storageClass: null
 
 compactor:
   replicas: 1


### PR DESCRIPTION
#### What this PR does

Add option to configure the `storageClass` per zone when **zoneAwareReplication** is enabled.

#### Why this PR

When I enabled **zoneAwareReplication** for ingesters or store-gateway (should be the same for alertmanager), I notice that the `Persistent Volume` was not always created in the good zone (the pod one). 

Only 1 out of 3 Persistent Volume was accessible for the pod. 

Exemple: 
```
Pod: ingester-zone-a-0, Persistent Volume: zone-a -> OK 
Pod: ingester-zone-a-1, Persistent Volume: zone-b -> KO
Pod: ingester-zone-a-2, Persistent Volume: zone-c -> KO
Pod: ingester-zone-a-3, Persistent Volume: zone-a -> OK
```

To fix it I create one `Storage Class` per Zone and update the `volumeClaimTemplates` spec to use the `storageClassName` from the rollout. 

```
      zones:
        - name: zone-a
          storageClass: sc-zone-a
          nodeSelector:
            topology.kubernetes.io/zone: zone-a
        - name: zone-b
          storageClass: sc-zone-b
          nodeSelector:
            topology.kubernetes.io/zone: zone-b
        - name: zone-b
          storageClass: sc-zone-b
          nodeSelector:
            topology.kubernetes.io/zone: zone-c
```

#### Other proposition

I also have another proposition: automatically create `Storage Class` when **zoneAwareReplication** is enabled and add the created `Storage Class` to the `volumeClaimTemplate` spec automatically. 

What do you think ?

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`