### PR TITLE
move distributor push wrapper into distributor config

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -228,9 +228,8 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	pushFn := d.GetPushFunc(pushConfig.PushWrappers)
-	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, pushFn), true, false, "POST")
-	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, reg, pushFn), true, false, "POST")
+	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, d.PushWithMiddlewares), true, false, "POST")
+	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, reg, d.PushWithMiddlewares), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -46,8 +46,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation/exporter"
 )
 
-// DistributorPushWrapper wraps around a push. It is similar to middleware.Interface.
-type DistributorPushWrapper func(next push.Func) push.Func
 type ConfigHandler func(actualCfg interface{}, defaultCfg interface{}) http.HandlerFunc
 
 type Config struct {
@@ -59,13 +57,6 @@ type Config struct {
 	// The following configs are injected by the upstream caller.
 	ServerPrefix       string               `yaml:"-"`
 	HTTPAuthMiddleware middleware.Interface `yaml:"-"`
-
-	// This allows downstream projects to wrap the distributor push function
-	// and access the deserialized write requests before/after they are pushed.
-	// This function will only receive samples that don't get forwarded to an
-	// alternative remote_write endpoint by the distributor's forwarding feature,
-	// or dropped by HA deduplication.
-	DistributorPushWrapper DistributorPushWrapper `yaml:"-"`
 
 	// The CustomConfigHandler allows for providing a different handler for the
 	// `/config` endpoint. If this field is set _before_ the API module is
@@ -237,7 +228,7 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	pushFn := d.GetPushFunc(a.cfg.DistributorPushWrapper)
+	pushFn := d.GetPushFunc(pushConfig.PushWrappers)
 	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, pushFn), true, false, "POST")
 	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, reg, pushFn), true, false, "POST")
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -189,11 +189,11 @@ type Config struct {
 	// This function will only receive samples that don't get forwarded to an
 	// alternative remote_write endpoint by the distributor's forwarding feature,
 	// or dropped by HA deduplication.
-	PushWrappers []DistributorPushWrapper `yaml:"-"`
+	PushWrappers []PushWrapper `yaml:"-"`
 }
 
-// DistributorPushWrapper wraps around a push. It is similar to middleware.Interface.
-type DistributorPushWrapper func(next push.Func) push.Func
+// PushWrapper wraps around a push. It is similar to middleware.Interface.
+type PushWrapper func(next push.Func) push.Func
 
 type InstanceLimits struct {
 	MaxIngestionRate             float64 `yaml:"max_ingestion_rate" category:"advanced"`
@@ -707,7 +707,7 @@ func (d *Distributor) validateSeries(nowt time.Time, ts mimirpb.PreallocTimeseri
 
 // wrapPushWithMiddlewares returns push function wrapped in all Distributor's middlewares.
 // externalMiddlewares will be applied in the reverse order, so the last middleware in the slice will be the outermost one.
-func (d *Distributor) wrapPushWithMiddlewares(externalMiddlewares []DistributorPushWrapper, next push.Func) push.Func {
+func (d *Distributor) wrapPushWithMiddlewares(externalMiddlewares []PushWrapper, next push.Func) push.Func {
 	var middlewares []func(push.Func) push.Func
 
 	// The middlewares will be applied to the request (!) in the specified order, from first to last.
@@ -1239,7 +1239,7 @@ func (d *Distributor) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mim
 
 // GetPushFunc returns push.Func that can be used by push handler.
 // Wrapper, if not nil, is added to the list of distributor middlewares.
-func (d *Distributor) GetPushFunc(externalMiddleware []DistributorPushWrapper) push.Func {
+func (d *Distributor) GetPushFunc(externalMiddleware []PushWrapper) push.Func {
 	return d.wrapPushWithMiddlewares(externalMiddleware, d.push)
 }
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -720,7 +720,6 @@ func (d *Distributor) wrapPushWithMiddlewares(next push.Func) push.Func {
 	middlewares = append(middlewares, d.prePushValidationMiddleware)
 	middlewares = append(middlewares, d.prePushForwardingMiddleware)
 	middlewares = append(middlewares, d.prePushEphemeralMiddleware)
-
 	middlewares = append(middlewares, d.cfg.PushWrappers...)
 
 	for ix := len(middlewares) - 1; ix >= 0; ix-- {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -706,7 +706,7 @@ func (d *Distributor) validateSeries(nowt time.Time, ts mimirpb.PreallocTimeseri
 }
 
 // wrapPushWithMiddlewares returns push function wrapped in all Distributor's middlewares.
-// push wrappers will be applied in the reverse order, so the last middleware in the slice will be the outermost one.
+// push wrappers will be applied to incoming requests in the order in which they are in the slice in the config struct.
 func (d *Distributor) wrapPushWithMiddlewares(next push.Func) push.Func {
 	var middlewares []PushWrapper
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2985,7 +2985,7 @@ func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
 		enableTracker:       true,
 		maxInflightRequests: 1,
 	})
-	wrappedMockPush := ds[0].wrapPushWithMiddlewares(nil, mockPush)
+	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)
 
 	// Make sure first request hits the limit.
 	ds[0].inflightPushRequests.Inc()
@@ -3276,7 +3276,7 @@ func TestHaDedupeAndRelabelBeforeForwarding(t *testing.T) {
 		forwarding:      true,
 		getForwarder:    getForwarder,
 	})
-	wrappedMockPush := ds[0].wrapPushWithMiddlewares(nil, mockPush)
+	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)
 
 	// Submit the two write requests into the wrapped mock push function, it should:
 	// 1) Perform HA-deduplication
@@ -3410,7 +3410,7 @@ func TestValidationBeforeForwarding(t *testing.T) {
 		forwarding:      true,
 		getForwarder:    getForwarder,
 	})
-	wrappedMockPush := ds[0].wrapPushWithMiddlewares(nil, mockPush)
+	wrappedMockPush := ds[0].wrapPushWithMiddlewares(mockPush)
 
 	// Submit the write request into the wrapped mock push function,
 	// before samples get forwarded the invalid ones should be removed.


### PR DESCRIPTION
This moves the distributor push wrappers from the API configuration into the distributor configuration.

This move provides the advantage that now the push wrappers only must be initialized before the distributor, previously they had to be initialized before the API, which created dependency problems for external middlewares

Furthermore, it allows for multiple push wrappers to be added, instead of only a single one.