### PR TITLE
Query-frontend: do not require result caching to be enabled for cardinality estimation, align flag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
   * `cortex_ingester_queried_ephemeral_series`
 * [FEATURE] Ruler: added `keep_firing_for` support to alerting rules. #4099
 * [FEATURE] Distributor, ingester: ingestion of native histograms. The new per-tenant limit `-ingester.native-histograms-ingestion-enabled` controls whether native histograms are stored or ignored. #4159
-* [FEATURE] Query-frontend: Introduce experimental `-query-frontend.query-sharding-target-series-per-shard` to allow query sharding to take into account cardinality of similar requests executed previously. #4121 #4177 #4188 #4254
+* [FEATURE] Query-frontend: Introduce experimental `-query-frontend.query-sharding-target-series-per-shard` to allow query sharding to take into account cardinality of similar requests executed previously. This feature uses the same cache that's used for results caching. #4121 #4177 #4188 #4254
 * [ENHANCEMENT] Ingester: added `out_of_order_blocks_external_label_enabled` shipper option to label out-of-order blocks before shipping them to cloud storage. #4182
 * [ENHANCEMENT] Compactor: Add `reason` label to `cortex_compactor_runs_failed_total`. The value can be `shutdown` or `error`. #4012
 * [ENHANCEMENT] Store-gateway: enforce `max_fetched_series_per_query`. #4056

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
   * `cortex_ingester_queried_ephemeral_series`
 * [FEATURE] Ruler: added `keep_firing_for` support to alerting rules. #4099
 * [FEATURE] Distributor, ingester: ingestion of native histograms. The new per-tenant limit `-ingester.native-histograms-ingestion-enabled` controls whether native histograms are stored or ignored. #4159
-* [FEATURE] Query-frontend: Introduce experimental `-query-frontend.query-sharding-target-series-per-shard` to allow query sharding to take into account cardinality of similar requests executed previously. #4121 #4177 #4188
+* [FEATURE] Query-frontend: Introduce experimental `-query-frontend.query-sharding-target-series-per-shard` to allow query sharding to take into account cardinality of similar requests executed previously. #4121 #4177 #4188 #4254
 * [ENHANCEMENT] Ingester: added `out_of_order_blocks_external_label_enabled` shipper option to label out-of-order blocks before shipping them to cloud storage. #4182
 * [ENHANCEMENT] Compactor: Add `reason` label to `cortex_compactor_runs_failed_total`. The value can be `shutdown` or `error`. #4012
 * [ENHANCEMENT] Store-gateway: enforce `max_fetched_series_per_query`. #4056

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4341,7 +4341,7 @@
         },
         {
           "kind": "field",
-          "name": "query_sharding_max_series_per_shard",
+          "name": "query_sharding_target_series_per_shard",
           "required": false,
           "desc": "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.",
           "fieldValue": null,

--- a/docs/sources/mimir/operators-guide/architecture/query-sharding/index.md
+++ b/docs/sources/mimir/operators-guide/architecture/query-sharding/index.md
@@ -146,7 +146,8 @@ Queries that return more series, such as those that are of high cardinality, nee
 Queries that return few or no series should be executed with fewer or no shards at all.
 When determining the number of shards to use for a given query, the sharding logic can optionally take into account the cardinality (number of series) observed during previous executions of the same query for similar time ranges.
 
-To enable this experimental feature, set `-query-frontend.query-sharding-target-series-per-shard` to a value representing roughly how many series each shard should fetch, and enable result caching (the result cache is used to store cardinality estimates).
+To enable this experimental feature, set `-query-frontend.query-sharding-target-series-per-shard` to a value representing roughly how many series each shard should fetch, and configure the results cache via the `query-frontend.results-cache.*` flags.
+This is necessary even when results caching is disabled, as the estimates are stored in the same cache that's used for query result caching.
 The value that you set for this flag is one of several parameters that the sharding logic uses to determine the appropriate number of shards for a query.
 Therefore, it will not strictly be complied with in all cases, and the actual number of series fetched per shard might exceed the limit.
 This is likely to happen in cases where the cardinality of a query changes rapidly within a short period of time.

--- a/docs/sources/mimir/reference-configuration-parameters/index.md
+++ b/docs/sources/mimir/reference-configuration-parameters/index.md
@@ -1196,7 +1196,7 @@ results_cache:
 # sharding, but a hint given to the query sharding when the query execution is
 # initially planned. 0 to disable cardinality-based hints.
 # CLI flag: -query-frontend.query-sharding-target-series-per-shard
-[query_sharding_max_series_per_shard: <int> | default = 0]
+[query_sharding_target_series_per_shard: <int> | default = 0]
 
 # (experimental) Format to use when retrieving query results from queriers.
 # Supported values: json, protobuf

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -30,9 +30,6 @@ const (
 	day                    = 24 * time.Hour
 	queryRangePathSuffix   = "/query_range"
 	instantQueryPathSuffix = "/query"
-
-	cacheResultsFlagName      = "query-frontend.cache-results"
-	maxSeriesPerShardFlagName = "query-frontend.query-sharding-target-series-per-shard"
 )
 
 // Config for query_range middleware chain.
@@ -44,7 +41,7 @@ type Config struct {
 	MaxRetries             int    `yaml:"max_retries" category:"advanced"`
 	ShardedQueries         bool   `yaml:"parallelize_shardable_queries"`
 	CacheUnalignedRequests bool   `yaml:"cache_unaligned_requests" category:"advanced"`
-	MaxSeriesPerShard      uint64 `yaml:"query_sharding_max_series_per_shard" category:"experimental"`
+	TargetSeriesPerShard   uint64 `yaml:"query_sharding_target_series_per_shard" category:"experimental"`
 
 	// CacheSplitter allows to inject a CacheSplitter to use for generating cache keys.
 	// If nil, the querymiddleware package uses a ConstSplitter with SplitQueriesByInterval.
@@ -58,26 +55,22 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRetries, "query-frontend.max-retries-per-request", 5, "Maximum number of retries for a single request; beyond this, the downstream error is returned.")
 	f.DurationVar(&cfg.SplitQueriesByInterval, "query-frontend.split-queries-by-interval", 24*time.Hour, "Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it.")
 	f.BoolVar(&cfg.AlignQueriesWithStep, "query-frontend.align-queries-with-step", false, "Mutate incoming queries to align their start and end with their step.")
-	f.BoolVar(&cfg.CacheResults, cacheResultsFlagName, false, "Cache query results.")
+	f.BoolVar(&cfg.CacheResults, "query-frontend.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
 	f.BoolVar(&cfg.CacheUnalignedRequests, "query-frontend.cache-unaligned-requests", false, "Cache requests that are not step-aligned.")
-	f.Uint64Var(&cfg.MaxSeriesPerShard, maxSeriesPerShardFlagName, 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
+	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatJSON, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 }
 
 // Validate validates the config.
 func (cfg *Config) Validate() error {
-	if cfg.CacheResults {
+	if cfg.CacheResults || cardinalityBasedShardingEnabled(cfg) {
 		if cfg.SplitQueriesByInterval <= 0 {
 			return errors.New("-query-frontend.cache-results may only be enabled in conjunction with -query-frontend.split-queries-by-interval. Please set the latter")
 		}
 		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config")
-		}
-	} else {
-		if cfg.MaxSeriesPerShard > 0 {
-			return fmt.Errorf("-%s may only be enabled in conjunction with -%s", maxSeriesPerShardFlagName, cacheResultsFlagName)
 		}
 	}
 
@@ -86,6 +79,10 @@ func (cfg *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func cardinalityBasedShardingEnabled(cfg *Config) bool {
+	return cfg.TargetSeriesPerShard > 0
 }
 
 // HandlerFunc is like http.HandlerFunc, but for Handler.
@@ -193,19 +190,18 @@ func newQueryTripperware(
 	}
 
 	var c cache.Cache
+	if cfg.CacheResults || cardinalityBasedShardingEnabled(&cfg) {
+		var err error
+
+		c, err = newResultsCache(cfg.ResultsCacheConfig, log, registerer)
+		if err != nil {
+			return nil, err
+		}
+		c = cache.NewCompression(cfg.ResultsCacheConfig.Compression, c, log)
+	}
+
 	// Inject the middleware to split requests by interval + results cache (if at least one of the two is enabled).
 	if cfg.SplitQueriesByInterval > 0 || cfg.CacheResults {
-
-		// Init the cache client.
-		if cfg.CacheResults {
-			var err error
-
-			c, err = newResultsCache(cfg.ResultsCacheConfig, log, registerer)
-			if err != nil {
-				return nil, err
-			}
-			c = cache.NewCompression(cfg.ResultsCacheConfig.Compression, c, log)
-		}
 
 		shouldCache := func(r Request) bool {
 			return !r.GetOptions().CacheDisabled
@@ -243,7 +239,7 @@ func newQueryTripperware(
 		// Inject the cardinality estimation middleware after time-based splitting and
 		// before query-sharding so that it can operate on the partial queries that are
 		// considered for sharding.
-		if cfg.MaxSeriesPerShard > 0 {
+		if cardinalityBasedShardingEnabled(&cfg) {
 			cardinalityEstimationMiddleware := newCardinalityEstimationMiddleware(c, log, registerer)
 			queryRangeMiddleware = append(
 				queryRangeMiddleware,
@@ -261,7 +257,7 @@ func newQueryTripperware(
 			log,
 			engine,
 			limits,
-			cfg.MaxSeriesPerShard,
+			cfg.TargetSeriesPerShard,
 			registerer,
 		)
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -65,12 +65,18 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Validate validates the config.
 func (cfg *Config) Validate() error {
-	if cfg.CacheResults || cfg.cardinalityBasedShardingEnabled() {
+	if cfg.CacheResults {
 		if cfg.SplitQueriesByInterval <= 0 {
 			return errors.New("-query-frontend.cache-results may only be enabled in conjunction with -query-frontend.split-queries-by-interval. Please set the latter")
 		}
 		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config")
+		}
+	}
+
+	if cfg.cardinalityBasedShardingEnabled() {
+		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
+			return errors.Wrap(err, "invalid query-frontend results cache config")
 		}
 	}
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -69,12 +69,9 @@ func (cfg *Config) Validate() error {
 		if cfg.SplitQueriesByInterval <= 0 {
 			return errors.New("-query-frontend.cache-results may only be enabled in conjunction with -query-frontend.split-queries-by-interval. Please set the latter")
 		}
-		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
-			return errors.Wrap(err, "invalid ResultsCache config")
-		}
 	}
 
-	if cfg.cardinalityBasedShardingEnabled() {
+	if cfg.CacheResults || cfg.cardinalityBasedShardingEnabled() {
 		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
 			return errors.Wrap(err, "invalid query-frontend results cache config")
 		}

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -65,7 +65,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Validate validates the config.
 func (cfg *Config) Validate() error {
-	if cfg.CacheResults || cardinalityBasedShardingEnabled(cfg) {
+	if cfg.CacheResults || cfg.cardinalityBasedShardingEnabled() {
 		if cfg.SplitQueriesByInterval <= 0 {
 			return errors.New("-query-frontend.cache-results may only be enabled in conjunction with -query-frontend.split-queries-by-interval. Please set the latter")
 		}
@@ -81,7 +81,7 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
-func cardinalityBasedShardingEnabled(cfg *Config) bool {
+func (cfg *Config) cardinalityBasedShardingEnabled() bool {
 	return cfg.TargetSeriesPerShard > 0
 }
 
@@ -190,7 +190,7 @@ func newQueryTripperware(
 	}
 
 	var c cache.Cache
-	if cfg.CacheResults || cardinalityBasedShardingEnabled(&cfg) {
+	if cfg.CacheResults || cfg.cardinalityBasedShardingEnabled() {
 		var err error
 
 		c, err = newResultsCache(cfg.ResultsCacheConfig, log, registerer)
@@ -239,7 +239,7 @@ func newQueryTripperware(
 		// Inject the cardinality estimation middleware after time-based splitting and
 		// before query-sharding so that it can operate on the partial queries that are
 		// considered for sharding.
-		if cardinalityBasedShardingEnabled(&cfg) {
+		if cfg.cardinalityBasedShardingEnabled() {
 			cardinalityEstimationMiddleware := newCardinalityEstimationMiddleware(c, log, registerer)
 			queryRangeMiddleware = append(
 				queryRangeMiddleware,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR changes the way the cache client for the query-frontend is initialised for cardinality-based query sharding so that enabling result caching is not required any more.

It also aligns mismatched names between CLI flag and yaml config.

#### Which issue(s) this PR fixes or relates to

Part of #4108.

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
