### PR TITLE
query-tee improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 * [CHANGE] Increase default value of `-backend.read-timeout` to 150s, to accommodate default querier and query frontend timeout of 120s. #4262
 * [ENHANCEMENT] Log errors that occur while performing requests to compare two endpoints. #4262
+* [ENHANCEMENT] When comparing two responses that both contain an error, only consider the comparison failed if the errors differ. Previously, if either response contained an error, the comparison always failed, even if both responses contained the same error. #4262
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [FEATURE] Added `keep_firing_for` support to rules configuration. #4099
 * [ENHANCEMENT] Add `-tls-insecure-skip-verify` to rules, alertmanager and backfill commands. #4162
 
+### Query-tee
+
+* [CHANGE] Increase default value of `-backend.read-timeout` to 150s, to accommodate default querier and query frontend timeout of 120s. #4262
+* [ENHANCEMENT] Log errors that occur while performing requests to compare two endpoints. #4262
+
 ### Documentation
 
 * [ENHANCEMENT] Document migration from microservices to read-write deployment mode. #3951

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [CHANGE] Increase default value of `-backend.read-timeout` to 150s, to accommodate default querier and query frontend timeout of 120s. #4262
 * [ENHANCEMENT] Log errors that occur while performing requests to compare two endpoints. #4262
 * [ENHANCEMENT] When comparing two responses that both contain an error, only consider the comparison failed if the errors differ. Previously, if either response contained an error, the comparison always failed, even if both responses contained the same error. #4262
+* [ENHANCEMENT] Include the value of the `X-Scope-OrgID` header when logging a comparison failure. #4262
 
 ### Documentation
 

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -43,7 +43,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.ServerGRPCServicePort, "server.grpc-service-port", 9095, "The GRPC port where the query-tee service listens to HTTP over gRPC messages.")
 	f.StringVar(&cfg.BackendEndpoints, "backend.endpoints", "", "Comma separated list of backend endpoints to query.")
 	f.StringVar(&cfg.PreferredBackend, "backend.preferred", "", "The hostname of the preferred backend when selecting the response to send back to the client. If no preferred backend is configured then the query-tee will send back to the client the first successful response received without waiting for other backends.")
-	f.DurationVar(&cfg.BackendReadTimeout, "backend.read-timeout", 90*time.Second, "The timeout when reading the response from a backend.")
+	f.DurationVar(&cfg.BackendReadTimeout, "backend.read-timeout", 150*time.Second, "The timeout when reading the response from a backend.")
 	f.BoolVar(&cfg.CompareResponses, "proxy.compare-responses", false, "Compare responses between preferred and secondary endpoints for supported routes.")
 	f.Float64Var(&cfg.ValueComparisonTolerance, "proxy.value-comparison-tolerance", 0.000001, "The tolerance to apply when comparing floating point values in the responses. 0 to disable tolerance and require exact match (not recommended).")
 	f.BoolVar(&cfg.UseRelativeError, "proxy.compare-use-relative-error", false, "Use relative error tolerance when comparing floating point values.")

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -165,7 +165,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 		err := p.compareResponses(expectedResponse, actualResponse)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", "response comparison failed", "route-name", p.routeName,
-				"query", r.URL.RawQuery, "err", err)
+				"query", r.URL.RawQuery, "org-id", r.Header.Get("X-Scope-OrgID"), "err", err)
 			result = comparisonFailed
 		}
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -217,15 +217,6 @@ func (p *ProxyEndpoint) compareResponses(expectedResponse, actualResponse *backe
 		return fmt.Errorf("skipped comparison of response because the request to the secondary backend failed: %w", actualResponse.err)
 	}
 
-	// compare response body only if we get a 200
-	if expectedResponse.status != 200 {
-		return fmt.Errorf("skipped comparison of response because we got status code %d from preferred backend's response", expectedResponse.status)
-	}
-
-	if actualResponse.status != 200 {
-		return fmt.Errorf("skipped comparison of response because we got status code %d from secondary backend's response", actualResponse.status)
-	}
-
 	if expectedResponse.status != actualResponse.status {
 		return fmt.Errorf("expected status code %d but got %d", expectedResponse.status, actualResponse.status)
 	}

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -209,6 +209,14 @@ func (p *ProxyEndpoint) waitBackendResponseForDownstream(resCh chan *backendResp
 }
 
 func (p *ProxyEndpoint) compareResponses(expectedResponse, actualResponse *backendResponse) error {
+	if expectedResponse.err != nil {
+		return fmt.Errorf("skipped comparison of response because the request to the preferred backend failed: %w", expectedResponse.err)
+	}
+
+	if actualResponse.err != nil {
+		return fmt.Errorf("skipped comparison of response because the request to the secondary backend failed: %w", actualResponse.err)
+	}
+
 	// compare response body only if we get a 200
 	if expectedResponse.status != 200 {
 		return fmt.Errorf("skipped comparison of response because we got status code %d from preferred backend's response", expectedResponse.status)

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -165,7 +165,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 		err := p.compareResponses(expectedResponse, actualResponse)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", "response comparison failed", "route-name", p.routeName,
-				"query", r.URL.RawQuery, "org-id", r.Header.Get("X-Scope-OrgID"), "err", err)
+				"query", r.URL.RawQuery, "user", r.Header.Get("X-Scope-OrgID"), "err", err)
 			result = comparisonFailed
 		}
 

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -22,8 +22,10 @@ import (
 type SamplesComparatorFunc func(expected, actual json.RawMessage, opts SampleComparisonOptions) error
 
 type SamplesResponse struct {
-	Status string
-	Data   struct {
+	Status    string
+	ErrorType string
+	Error     string
+	Data      struct {
 		ResultType string
 		Result     json.RawMessage
 	}
@@ -73,8 +75,20 @@ func (s *SamplesComparator) Compare(expectedResponse, actualResponse []byte) err
 		return fmt.Errorf("expected status %s but got %s", expected.Status, actual.Status)
 	}
 
+	if expected.ErrorType != actual.ErrorType {
+		return fmt.Errorf("expected error type '%s' but got '%s'", expected.ErrorType, actual.ErrorType)
+	}
+
+	if expected.Error != actual.Error {
+		return fmt.Errorf("expected error '%s' but got '%s'", expected.Error, actual.Error)
+	}
+
 	if expected.Data.ResultType != actual.Data.ResultType {
 		return fmt.Errorf("expected resultType %s but got %s", expected.Data.ResultType, actual.Data.ResultType)
+	}
+
+	if expected.Data.ResultType == "" && actual.Data.ResultType == "" && expected.Data.Result == nil && actual.Data.Result == nil {
+		return nil
 	}
 
 	comparator, ok := s.sampleTypesComparator[expected.Data.ResultType]

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -252,6 +252,44 @@ func TestCompareSamplesResponse(t *testing.T) {
 			err: errors.New("expected status success but got fail"),
 		},
 		{
+			name: "same error and error type",
+			expected: json.RawMessage(`{
+							"status": "error",
+							"errorType": "something",
+							"error": "something went wrong"
+						}`),
+			actual: json.RawMessage(`{
+							"status": "error",
+							"errorType": "something",
+							"error": "something went wrong"
+						}`),
+			err: nil,
+		},
+		{
+			name: "difference in response error type",
+			expected: json.RawMessage(`{
+							"status": "error",
+							"errorType": "something"
+						}`),
+			actual: json.RawMessage(`{
+							"status": "error",
+							"errorType": "something-else"
+						}`),
+			err: errors.New("expected error type 'something' but got 'something-else'"),
+		},
+		{
+			name: "difference in response error",
+			expected: json.RawMessage(`{
+							"status": "error",
+							"error": "something went wrong"
+						}`),
+			actual: json.RawMessage(`{
+							"status": "error",
+							"error": "something else went wrong"
+						}`),
+			err: errors.New("expected error 'something went wrong' but got 'something else went wrong'"),
+		},
+		{
 			name: "difference in resultType",
 			expected: json.RawMessage(`{
 							"status": "success",


### PR DESCRIPTION
#### What this PR does

This PR contains a number of small changes to `query-tee`:

* Increases the default read timeout in `query-tee` to 150s, to accommodate the default querier and query frontend timeout of 120s

* Improves the error message logged when a request fails (eg. due to a timeout or DNS resolution issue) when comparing two backends

  Currently, when an error occurs, we log a message like "skipped comparison of response because we got status code 0 from preferred backend's response", which is misleading (we didn't get a status code at all from the backend) and unhelpful (we don't log the error). With this change, we'll log the error and not mention anything about status codes.

* Changes the comparison behaviour when a response contains an error

  Currently, if either response contains an error, we consider the comparison failed. With this change, we'll only consider the comparison failed if the errors differ. This reduces the number of false-positive comparison failures for cases such as when a malformed query is submitted or a limit is exceeded.

* Adds the org ID to the message logged when a comparison failure occurs

Each of these changes is contained in its own commit, and I'd suggest reviewing each commit individually.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
