### PR TITLE
Fix documentation backend config indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 ### Documentation
 
 * [ENHANCEMENT] Document migration from microservices to read-write deployment mode. #3951
+* [BUGFIX] Added indentation to azure an swift backend definition.
 
 ### Tools
 

--- a/docs/sources/mimir/operators-guide/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-object-storage-backend.md
@@ -103,10 +103,10 @@ ruler_storage:
 common:
   storage:
     backend: azure
-  azure:
-    account_key: "${SWIFT_ACCOUNT_KEY}" # This is a secret injected via an environment variable
-    account_name: mimir-prod
-    endpoint_suffix: "blob.core.windows.net"
+    azure:
+      account_key: "${SWIFT_ACCOUNT_KEY}" # This is a secret injected via an environment variable
+      account_name: mimir-prod
+      endpoint_suffix: "blob.core.windows.net"
 
 blocks_storage:
   azure:

--- a/docs/sources/mimir/operators-guide/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/operators-guide/configure/configure-object-storage-backend.md
@@ -127,13 +127,13 @@ ruler_storage:
 common:
   storage:
     backend: swift
-  swift:
-    auth_url: http://10.121.xx.xx:5000/v3
-    username: mimir
-    user_domain_name: Default
-    password: "${OPENSTACK_API_KEY}" # This is a secret injected via an environment variable
-    project_name: mimir-prod
-    domain_name: Default
+    swift:
+      auth_url: http://10.121.xx.xx:5000/v3
+      username: mimir
+      user_domain_name: Default
+      password: "${OPENSTACK_API_KEY}" # This is a secret injected via an environment variable
+      project_name: mimir-prod
+      domain_name: Default
 
 blocks_storage:
   swift:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Fixes documentation where storage config examples for azure and swift were not indented sufficiently.
#### Which issue(s) this PR fixes or relates to

No issue found for this problem.
#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
