### PR TITLE
query-tee: log query parameters from POSTed query requests when responses differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [ENHANCEMENT] Log errors that occur while performing requests to compare two endpoints. #4262
 * [ENHANCEMENT] When comparing two responses that both contain an error, only consider the comparison failed if the errors differ. Previously, if either response contained an error, the comparison always failed, even if both responses contained the same error. #4262
 * [ENHANCEMENT] Include the value of the `X-Scope-OrgID` header when logging a comparison failure. #4262
+* [BUGFIX] Parameters (expression, time range etc.) for a query request where the parameters are in the HTTP request body rather than in the URL are now logged correctly when responses differ. #4265
 
 ### Documentation
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -165,7 +165,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 		err := p.compareResponses(expectedResponse, actualResponse)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", "response comparison failed", "route-name", p.routeName,
-				"query", r.URL.RawQuery, "user", r.Header.Get("X-Scope-OrgID"), "err", err)
+				"query", query, "user", r.Header.Get("X-Scope-OrgID"), "err", err)
 			result = comparisonFailed
 		}
 


### PR DESCRIPTION
#### What this PR does

Before this change, if a query request uses a HTTP POST and includes parameters in the request body, rather than as URL query parameters, query-tee would not log them when response comparison fails.

This change ensures we log the parameters regardless of whether they're in the URL or in the request body.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
