### PR TITLE
Native histograms: add support for new internal query result payload format

### DIFF
--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -208,31 +208,26 @@ func TestQueryFrontendTLSWithBlocksStorageViaFlags(t *testing.T) {
 
 func TestQueryFrontendWithQueryResultPayloadFormats(t *testing.T) {
 	formats := []string{"json", "protobuf"}
-	histograms := map[string]bool{"with native histograms": true, "without native histograms": false}
 
 	for _, format := range formats {
 		t.Run(format, func(t *testing.T) {
-			for name, withHistograms := range histograms {
-				t.Run(name, func(t *testing.T) {
-					runQueryFrontendTest(t, queryFrontendTestConfig{
-						setup: func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string) {
-							flags = mergeFlags(
-								BlocksStorageFlags(),
-								BlocksStorageS3Flags(),
-								map[string]string{
-									"-query-frontend.query-result-response-format": format,
-								},
-							)
-
-							minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
-							require.NoError(t, s.StartAndWaitReady(minio))
-
-							return "", flags
+			runQueryFrontendTest(t, queryFrontendTestConfig{
+				setup: func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string) {
+					flags = mergeFlags(
+						BlocksStorageFlags(),
+						BlocksStorageS3Flags(),
+						map[string]string{
+							"-query-frontend.query-result-response-format": format,
 						},
-						withHistograms: withHistograms,
-					})
-				})
-			}
+					)
+
+					minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+					require.NoError(t, s.StartAndWaitReady(minio))
+
+					return "", flags
+				},
+				withHistograms: true,
+			})
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/codec_protobuf_test.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf_test.go
@@ -379,7 +379,7 @@ var protobufCodecScenarios = []struct {
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
 				Result: []SampleStream{
-					{Labels: []mimirpb.LabelAdapter{}, Samples: []mimirpb.Sample{}},
+					{Labels: []mimirpb.LabelAdapter{}, Samples: []mimirpb.Sample{}, Histograms: []mimirpb.SampleHistogramPair{}},
 				},
 			},
 			Headers: expectedProtobufResponseHeaders,
@@ -402,7 +402,7 @@ var protobufCodecScenarios = []struct {
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
 				Result: []SampleStream{
-					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{}},
+					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{}, Histograms: []mimirpb.SampleHistogramPair{}},
 				},
 			},
 			Headers: expectedProtobufResponseHeaders,
@@ -430,7 +430,8 @@ var protobufCodecScenarios = []struct {
 							{Name: "foo", Value: "bar"},
 							{Name: "baz", Value: "blah"},
 						},
-						Samples: []mimirpb.Sample{},
+						Samples:    []mimirpb.Sample{},
+						Histograms: []mimirpb.SampleHistogramPair{},
 					},
 				},
 			},
@@ -467,6 +468,7 @@ var protobufCodecScenarios = []struct {
 						Samples: []mimirpb.Sample{
 							{TimestampMs: 1_000, Value: 100},
 						},
+						Histograms: []mimirpb.SampleHistogramPair{},
 					},
 				},
 			},
@@ -505,6 +507,7 @@ var protobufCodecScenarios = []struct {
 							{TimestampMs: 1_000, Value: 100},
 							{TimestampMs: 1_001, Value: 101},
 						},
+						Histograms: []mimirpb.SampleHistogramPair{},
 					},
 				},
 			},
@@ -529,8 +532,16 @@ var protobufCodecScenarios = []struct {
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
 				Result: []SampleStream{
-					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 100}, {TimestampMs: 2_000, Value: 200}}},
-					{Labels: []mimirpb.LabelAdapter{{Name: "bar", Value: "baz"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 101}, {TimestampMs: 2_000, Value: 201}}},
+					{
+						Labels:     []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}},
+						Samples:    []mimirpb.Sample{{TimestampMs: 1_000, Value: 100}, {TimestampMs: 2_000, Value: 200}},
+						Histograms: []mimirpb.SampleHistogramPair{},
+					},
+					{
+						Labels:     []mimirpb.LabelAdapter{{Name: "bar", Value: "baz"}},
+						Samples:    []mimirpb.Sample{{TimestampMs: 1_000, Value: 101}, {TimestampMs: 2_000, Value: 201}},
+						Histograms: []mimirpb.SampleHistogramPair{},
+					},
 				},
 			},
 			Headers: expectedProtobufResponseHeaders,
@@ -558,6 +569,7 @@ var protobufCodecScenarios = []struct {
 				Result: []SampleStream{
 					{
 						Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}, {Name: "name-2", Value: "value-2"}},
+						Samples:    []mimirpb.Sample{},
 						Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
 					},
 				},

--- a/pkg/frontend/querymiddleware/codec_protobuf_test.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf_test.go
@@ -19,626 +19,629 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
+var expectedProtobufResponseHeaders = []*PrometheusResponseHeader{
+	{
+		Name:   "Content-Type",
+		Values: []string{mimirpb.QueryResponseMimeType},
+	},
+}
+
+var protobufResponseHistogram = mimirpb.FloatHistogram{
+	Timestamp: 1234,
+
+	ResetHint:      mimirpb.Histogram_GAUGE,
+	Schema:         3,
+	ZeroThreshold:  1.23,
+	ZeroCountFloat: 456,
+	CountFloat:     9001,
+	Sum:            789.1,
+	PositiveSpans: []mimirpb.BucketSpan{
+		{Offset: 4, Length: 1},
+		{Offset: 3, Length: 2},
+	},
+	NegativeSpans: []mimirpb.BucketSpan{
+		{Offset: 7, Length: 3},
+		{Offset: 9, Length: 1},
+	},
+	PositiveCounts: []float64{100, 200, 300},
+	NegativeCounts: []float64{400, 500, 600, 700},
+}
+
+var expectedHistogram = mimirpb.SampleHistogram{
+	Count: 9001,
+	Sum:   789.1,
+	Buckets: []*mimirpb.HistogramBucket{
+		{
+			Boundaries: 1,
+			Count:      700,
+			Lower:      -5.187358218604039,
+			Upper:      -4.756828460010884,
+		},
+		{
+			Boundaries: 1,
+			Count:      600,
+			Lower:      -2.1810154653305154,
+			Upper:      -2,
+		},
+		{
+			Boundaries: 1,
+			Count:      500,
+			Lower:      -2,
+			Upper:      -1.8340080864093422,
+		},
+		{
+			Boundaries: 1,
+			Count:      400,
+			Lower:      -1.8340080864093422,
+			Upper:      -1.6817928305074288,
+		},
+		{
+			Boundaries: 3,
+			Count:      456,
+			Lower:      -1.23,
+			Upper:      1.23,
+		},
+		{
+			Count: 100,
+			Lower: 1.2968395546510096,
+			Upper: 1.414213562373095,
+		},
+		{
+			Count: 200,
+			Lower: 1.8340080864093422,
+			Upper: 2,
+		},
+		{
+			Count: 300,
+			Lower: 2,
+			Upper: 2.1810154653305154,
+		},
+	},
+}
+
+var protobufCodecScenarios = []struct {
+	name        string
+	resp        mimirpb.QueryResponse
+	expected    *PrometheusResponse
+	expectedErr error
+}{
+	{
+		name: "successful string response",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_String_{
+				String_: &mimirpb.StringData{Value: "foo", TimestampMilliseconds: 1500},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValString.String(),
+				Result: []SampleStream{
+					{
+						Labels:  []mimirpb.LabelAdapter{{Name: "value", Value: "foo"}},
+						Samples: []mimirpb.Sample{{TimestampMs: 1_500}},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful scalar response",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Scalar{
+				Scalar: &mimirpb.ScalarData{
+					Value:                 200,
+					TimestampMilliseconds: 1000,
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValScalar.String(),
+				Result: []SampleStream{
+					{Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful empty vector response",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result:     []SampleStream{},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with single series with no labels",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Samples: []mimirpb.VectorSample{
+						{Metric: []string{}, TimestampMilliseconds: 1_000, Value: 200},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result: []SampleStream{
+					{Labels: []mimirpb.LabelAdapter{}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with single series with one label",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Samples: []mimirpb.VectorSample{
+						{Metric: []string{"foo", "bar"}, TimestampMilliseconds: 1_000, Value: 200},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result: []SampleStream{
+					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with single series with many labels",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Samples: []mimirpb.VectorSample{
+						{Metric: []string{"foo", "bar", "baz", "blah"}, TimestampMilliseconds: 1_000, Value: 200},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result: []SampleStream{
+					{
+						Labels: []mimirpb.LabelAdapter{
+							{Name: "foo", Value: "bar"},
+							{Name: "baz", Value: "blah"},
+						},
+						Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with multiple series",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Samples: []mimirpb.VectorSample{
+						{Metric: []string{"foo", "bar"}, TimestampMilliseconds: 1_000, Value: 200},
+						{Metric: []string{"bar", "baz"}, TimestampMilliseconds: 1_000, Value: 201},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result: []SampleStream{
+					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
+					{Labels: []mimirpb.LabelAdapter{{Name: "bar", Value: "baz"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 201}}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with histogram value",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Histograms: []mimirpb.VectorHistogram{
+						{
+							Metric:    []string{"name-1", "value-1"},
+							Histogram: protobufResponseHistogram,
+						},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result: []SampleStream{
+					{
+						Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}},
+						Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with float and histogram values",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Samples: []mimirpb.VectorSample{
+						{Metric: []string{"foo", "bar"}, TimestampMilliseconds: 1000, Value: 200},
+					},
+					Histograms: []mimirpb.VectorHistogram{
+						{
+							Metric:    []string{"baz", "blah"},
+							Histogram: protobufResponseHistogram,
+						},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValVector.String(),
+				Result: []SampleStream{
+					{
+						Labels:  []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}},
+						Samples: []mimirpb.Sample{{TimestampMs: 1000, Value: 200}},
+					},
+					{
+						Labels:     []mimirpb.LabelAdapter{{Name: "baz", Value: "blah"}},
+						Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful vector response with malformed metric symbols",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Vector{
+				Vector: &mimirpb.VectorData{
+					Samples: []mimirpb.VectorSample{
+						{Metric: []string{"foo"}, TimestampMilliseconds: 1_000, Value: 200},
+					},
+				},
+			},
+		},
+		expectedErr: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
+	},
+	{
+		name: "successful matrix response with no series",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result:     []SampleStream{},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with single series with no labels and no samples",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{Metric: []string{}, Samples: []mimirpb.MatrixSample{}},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{Labels: []mimirpb.LabelAdapter{}, Samples: []mimirpb.Sample{}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with single series with one label and no samples",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{Metric: []string{"foo", "bar"}, Samples: []mimirpb.MatrixSample{}},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with single series with many labels and no samples",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{Metric: []string{"foo", "bar", "baz", "blah"}, Samples: []mimirpb.MatrixSample{}},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{
+						Labels: []mimirpb.LabelAdapter{
+							{Name: "foo", Value: "bar"},
+							{Name: "baz", Value: "blah"},
+						},
+						Samples: []mimirpb.Sample{},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with single series with one sample",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{
+							Metric: []string{"foo", "bar", "baz", "blah"},
+							Samples: []mimirpb.MatrixSample{
+								{TimestampMilliseconds: 1_000, Value: 100},
+							},
+						},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{
+						Labels: []mimirpb.LabelAdapter{
+							{Name: "foo", Value: "bar"},
+							{Name: "baz", Value: "blah"},
+						},
+						Samples: []mimirpb.Sample{
+							{TimestampMs: 1_000, Value: 100},
+						},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with single series with many samples",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{
+							Metric: []string{"foo", "bar", "baz", "blah"},
+							Samples: []mimirpb.MatrixSample{
+								{TimestampMilliseconds: 1_000, Value: 100},
+								{TimestampMilliseconds: 1_001, Value: 101},
+							},
+						},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{
+						Labels: []mimirpb.LabelAdapter{
+							{Name: "foo", Value: "bar"},
+							{Name: "baz", Value: "blah"},
+						},
+						Samples: []mimirpb.Sample{
+							{TimestampMs: 1_000, Value: 100},
+							{TimestampMs: 1_001, Value: 101},
+						},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with multiple series",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{Metric: []string{"foo", "bar"}, Samples: []mimirpb.MatrixSample{{TimestampMilliseconds: 1_000, Value: 100}, {TimestampMilliseconds: 2_000, Value: 200}}},
+						{Metric: []string{"bar", "baz"}, Samples: []mimirpb.MatrixSample{{TimestampMilliseconds: 1_000, Value: 101}, {TimestampMilliseconds: 2_000, Value: 201}}},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 100}, {TimestampMs: 2_000, Value: 200}}},
+					{Labels: []mimirpb.LabelAdapter{{Name: "bar", Value: "baz"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 101}, {TimestampMs: 2_000, Value: 201}}},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with histogram value",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{
+							Metric:     []string{"name-1", "value-1", "name-2", "value-2"},
+							Histograms: []mimirpb.FloatHistogram{protobufResponseHistogram},
+						},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{
+						Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}, {Name: "name-2", Value: "value-2"}},
+						Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with float and histogram values",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{
+							Metric:     []string{"name-1", "value-1", "name-2", "value-2"},
+							Samples:    []mimirpb.MatrixSample{{TimestampMilliseconds: 1000, Value: 200}},
+							Histograms: []mimirpb.FloatHistogram{protobufResponseHistogram},
+						},
+					},
+				},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result: []SampleStream{
+					{
+						Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}, {Name: "name-2", Value: "value-2"}},
+						Samples:    []mimirpb.Sample{{TimestampMs: 1000, Value: 200}},
+						Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
+					},
+				},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "successful matrix response with malformed metric symbols",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{
+					Series: []mimirpb.MatrixSeries{
+						{Metric: []string{"foo"}, Samples: []mimirpb.MatrixSample{{TimestampMilliseconds: 1_000, Value: 100}, {TimestampMilliseconds: 2_000, Value: 200}}},
+					},
+				},
+			},
+		},
+		expectedErr: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
+	},
+	{
+		name: "successful empty matrix response",
+		resp: mimirpb.QueryResponse{
+			Status: mimirpb.QueryResponse_SUCCESS,
+			Data: &mimirpb.QueryResponse_Matrix{
+				Matrix: &mimirpb.MatrixData{},
+			},
+		},
+		expected: &PrometheusResponse{
+			Status: statusSuccess,
+			Data: &PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result:     []SampleStream{},
+			},
+			Headers: expectedProtobufResponseHeaders,
+		},
+	},
+	{
+		name: "error response",
+		resp: mimirpb.QueryResponse{
+			Status:    mimirpb.QueryResponse_ERROR,
+			ErrorType: mimirpb.QueryResponse_UNAVAILABLE,
+			Error:     "failed",
+		},
+		expectedErr: apierror.New(apierror.TypeUnavailable, "failed"),
+	},
+}
+
 func TestProtobufFormat_DecodeResponse(t *testing.T) {
 	headers := http.Header{"Content-Type": []string{mimirpb.QueryResponseMimeType}}
-	expectedRespHeaders := []*PrometheusResponseHeader{
-		{
-			Name:   "Content-Type",
-			Values: []string{mimirpb.QueryResponseMimeType},
-		},
-	}
 
-	responseHistogram := mimirpb.FloatHistogram{
-		Timestamp: 1234,
-
-		ResetHint:      mimirpb.Histogram_GAUGE,
-		Schema:         3,
-		ZeroThreshold:  1.23,
-		ZeroCountFloat: 456,
-		CountFloat:     9001,
-		Sum:            789.1,
-		PositiveSpans: []mimirpb.BucketSpan{
-			{Offset: 4, Length: 1},
-			{Offset: 3, Length: 2},
-		},
-		NegativeSpans: []mimirpb.BucketSpan{
-			{Offset: 7, Length: 3},
-			{Offset: 9, Length: 1},
-		},
-		PositiveCounts: []float64{100, 200, 300},
-		NegativeCounts: []float64{400, 500, 600, 700},
-	}
-
-	expectedHistogram := mimirpb.SampleHistogram{
-		Count: 9001,
-		Sum:   789.1,
-		Buckets: []*mimirpb.HistogramBucket{
-			{
-				Boundaries: 1,
-				Count:      700,
-				Lower:      -5.187358218604039,
-				Upper:      -4.756828460010884,
-			},
-			{
-				Boundaries: 1,
-				Count:      600,
-				Lower:      -2.1810154653305154,
-				Upper:      -2,
-			},
-			{
-				Boundaries: 1,
-				Count:      500,
-				Lower:      -2,
-				Upper:      -1.8340080864093422,
-			},
-			{
-				Boundaries: 1,
-				Count:      400,
-				Lower:      -1.8340080864093422,
-				Upper:      -1.6817928305074288,
-			},
-			{
-				Boundaries: 3,
-				Count:      456,
-				Lower:      -1.23,
-				Upper:      1.23,
-			},
-			{
-				Count: 100,
-				Lower: 1.2968395546510096,
-				Upper: 1.414213562373095,
-			},
-			{
-				Count: 200,
-				Lower: 1.8340080864093422,
-				Upper: 2,
-			},
-			{
-				Count: 300,
-				Lower: 2,
-				Upper: 2.1810154653305154,
-			},
-		},
-	}
-
-	for _, tc := range []struct {
-		name        string
-		resp        mimirpb.QueryResponse
-		expected    *PrometheusResponse
-		expectedErr error
-	}{
-		{
-			name: "successful string response",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_String_{
-					String_: &mimirpb.StringData{Value: "foo", TimestampMilliseconds: 1500},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValString.String(),
-					Result: []SampleStream{
-						{
-							Labels:  []mimirpb.LabelAdapter{{Name: "value", Value: "foo"}},
-							Samples: []mimirpb.Sample{{TimestampMs: 1_500}},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful scalar response",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Scalar{
-					Scalar: &mimirpb.ScalarData{
-						Value:                 200,
-						TimestampMilliseconds: 1000,
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValScalar.String(),
-					Result: []SampleStream{
-						{Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful empty vector response",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result:     []SampleStream{},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with single series with no labels",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Samples: []mimirpb.VectorSample{
-							{Metric: []string{}, TimestampMilliseconds: 1_000, Value: 200},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result: []SampleStream{
-						{Labels: []mimirpb.LabelAdapter{}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with single series with one label",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Samples: []mimirpb.VectorSample{
-							{Metric: []string{"foo", "bar"}, TimestampMilliseconds: 1_000, Value: 200},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result: []SampleStream{
-						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with single series with many labels",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Samples: []mimirpb.VectorSample{
-							{Metric: []string{"foo", "bar", "baz", "blah"}, TimestampMilliseconds: 1_000, Value: 200},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result: []SampleStream{
-						{
-							Labels: []mimirpb.LabelAdapter{
-								{Name: "foo", Value: "bar"},
-								{Name: "baz", Value: "blah"},
-							},
-							Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with multiple series",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Samples: []mimirpb.VectorSample{
-							{Metric: []string{"foo", "bar"}, TimestampMilliseconds: 1_000, Value: 200},
-							{Metric: []string{"bar", "baz"}, TimestampMilliseconds: 1_000, Value: 201},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result: []SampleStream{
-						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
-						{Labels: []mimirpb.LabelAdapter{{Name: "bar", Value: "baz"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 201}}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with histogram value",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Histograms: []mimirpb.VectorHistogram{
-							{
-								Metric:    []string{"name-1", "value-1"},
-								Histogram: responseHistogram,
-							},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result: []SampleStream{
-						{
-							Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}},
-							Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with float and histogram values",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Samples: []mimirpb.VectorSample{
-							{Metric: []string{"foo", "bar"}, TimestampMilliseconds: 1000, Value: 200},
-						},
-						Histograms: []mimirpb.VectorHistogram{
-							{
-								Metric:    []string{"baz", "blah"},
-								Histogram: responseHistogram,
-							},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValVector.String(),
-					Result: []SampleStream{
-						{
-							Labels:  []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}},
-							Samples: []mimirpb.Sample{{TimestampMs: 1000, Value: 200}},
-						},
-						{
-							Labels:     []mimirpb.LabelAdapter{{Name: "baz", Value: "blah"}},
-							Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful vector response with malformed metric symbols",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Vector{
-					Vector: &mimirpb.VectorData{
-						Samples: []mimirpb.VectorSample{
-							{Metric: []string{"foo"}, TimestampMilliseconds: 1_000, Value: 200},
-						},
-					},
-				},
-			},
-			expectedErr: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
-		},
-		{
-			name: "successful matrix response with no series",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result:     []SampleStream{},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with single series with no labels and no samples",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{Metric: []string{}, Samples: []mimirpb.MatrixSample{}},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{Labels: []mimirpb.LabelAdapter{}, Samples: []mimirpb.Sample{}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with single series with one label and no samples",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{Metric: []string{"foo", "bar"}, Samples: []mimirpb.MatrixSample{}},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with single series with many labels and no samples",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{Metric: []string{"foo", "bar", "baz", "blah"}, Samples: []mimirpb.MatrixSample{}},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{
-							Labels: []mimirpb.LabelAdapter{
-								{Name: "foo", Value: "bar"},
-								{Name: "baz", Value: "blah"},
-							},
-							Samples: []mimirpb.Sample{},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with single series with one sample",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{
-								Metric: []string{"foo", "bar", "baz", "blah"},
-								Samples: []mimirpb.MatrixSample{
-									{TimestampMilliseconds: 1_000, Value: 100},
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{
-							Labels: []mimirpb.LabelAdapter{
-								{Name: "foo", Value: "bar"},
-								{Name: "baz", Value: "blah"},
-							},
-							Samples: []mimirpb.Sample{
-								{TimestampMs: 1_000, Value: 100},
-							},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with single series with many samples",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{
-								Metric: []string{"foo", "bar", "baz", "blah"},
-								Samples: []mimirpb.MatrixSample{
-									{TimestampMilliseconds: 1_000, Value: 100},
-									{TimestampMilliseconds: 1_001, Value: 101},
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{
-							Labels: []mimirpb.LabelAdapter{
-								{Name: "foo", Value: "bar"},
-								{Name: "baz", Value: "blah"},
-							},
-							Samples: []mimirpb.Sample{
-								{TimestampMs: 1_000, Value: 100},
-								{TimestampMs: 1_001, Value: 101},
-							},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with multiple series",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{Metric: []string{"foo", "bar"}, Samples: []mimirpb.MatrixSample{{TimestampMilliseconds: 1_000, Value: 100}, {TimestampMilliseconds: 2_000, Value: 200}}},
-							{Metric: []string{"bar", "baz"}, Samples: []mimirpb.MatrixSample{{TimestampMilliseconds: 1_000, Value: 101}, {TimestampMilliseconds: 2_000, Value: 201}}},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 100}, {TimestampMs: 2_000, Value: 200}}},
-						{Labels: []mimirpb.LabelAdapter{{Name: "bar", Value: "baz"}}, Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 101}, {TimestampMs: 2_000, Value: 201}}},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with histogram value",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{
-								Metric:     []string{"name-1", "value-1", "name-2", "value-2"},
-								Histograms: []mimirpb.FloatHistogram{responseHistogram},
-							},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{
-							Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}, {Name: "name-2", Value: "value-2"}},
-							Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with float and histogram values",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{
-								Metric:     []string{"name-1", "value-1", "name-2", "value-2"},
-								Samples:    []mimirpb.MatrixSample{{TimestampMilliseconds: 1000, Value: 200}},
-								Histograms: []mimirpb.FloatHistogram{responseHistogram},
-							},
-						},
-					},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: []SampleStream{
-						{
-							Labels:     []mimirpb.LabelAdapter{{Name: "name-1", Value: "value-1"}, {Name: "name-2", Value: "value-2"}},
-							Samples:    []mimirpb.Sample{{TimestampMs: 1000, Value: 200}},
-							Histograms: []mimirpb.SampleHistogramPair{{Timestamp: 1234, Histogram: &expectedHistogram}},
-						},
-					},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "successful matrix response with malformed metric symbols",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{
-						Series: []mimirpb.MatrixSeries{
-							{Metric: []string{"foo"}, Samples: []mimirpb.MatrixSample{{TimestampMilliseconds: 1_000, Value: 100}, {TimestampMilliseconds: 2_000, Value: 200}}},
-						},
-					},
-				},
-			},
-			expectedErr: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
-		},
-		{
-			name: "successful empty matrix response",
-			resp: mimirpb.QueryResponse{
-				Status: mimirpb.QueryResponse_SUCCESS,
-				Data: &mimirpb.QueryResponse_Matrix{
-					Matrix: &mimirpb.MatrixData{},
-				},
-			},
-			expected: &PrometheusResponse{
-				Status: statusSuccess,
-				Data: &PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result:     []SampleStream{},
-				},
-				Headers: expectedRespHeaders,
-			},
-		},
-		{
-			name: "error response",
-			resp: mimirpb.QueryResponse{
-				Status:    mimirpb.QueryResponse_ERROR,
-				ErrorType: mimirpb.QueryResponse_UNAVAILABLE,
-				Error:     "failed",
-			},
-			expectedErr: apierror.New(apierror.TypeUnavailable, "failed"),
-		},
-	} {
+	for _, tc := range protobufCodecScenarios {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			codec := NewPrometheusCodec(reg, formatProtobuf)
@@ -670,6 +673,32 @@ func TestProtobufFormat_DecodeResponse(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, uint64(1), *payloadSizeHistogram.SampleCount)
 			require.Equal(t, float64(len(body)), *payloadSizeHistogram.SampleSum)
+		})
+	}
+}
+
+func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
+	headers := http.Header{"Content-Type": []string{mimirpb.QueryResponseMimeType}}
+	reg := prometheus.NewPedanticRegistry()
+	codec := NewPrometheusCodec(reg, formatProtobuf)
+
+	for _, tc := range protobufCodecScenarios {
+		body, err := tc.resp.Marshal()
+		require.NoError(b, err)
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				httpResponse := &http.Response{
+					StatusCode:    200,
+					Header:        headers,
+					Body:          io.NopCloser(bytes.NewBuffer(body)),
+					ContentLength: int64(len(body)),
+				}
+
+				_, err = codec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
+				if err != nil || tc.expectedErr != nil {
+					require.Equal(b, tc.expectedErr, err)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR adds support for decoding native histograms in the new internal query result payload format in the query frontend. 

(Queriers already support encoding native histograms in the new format, this was added in https://github.com/grafana/mimir/pull/4153.)

I'd suggest reviewing each commit individually, as a refactoring step makes the overall diff difficult to follow.

I haven't added a changelog entry as I assume this will be covered by a single changelog entry when we merge native histogram support into `main`.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/4104

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
