### PR TITLE
Helm: relax HPA v2 version check to allow Kubernetes 1.23

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling starting with Kubernetes 1.23.
+
 ## 4.2.0
 
 * [ENHANCEMENT] Allow NGINX error log level to be overridden and access log to be disabled. #4230

--- a/operations/helm/charts/mimir-distributed/templates/nginx/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/_helpers.tpl
@@ -9,7 +9,7 @@ nginx auth secret name
 Returns the HorizontalPodAutoscaler API version for this verison of kubernetes.
 */}}
 {{- define "mimir.hpa.version" -}}
-{{- if semverCompare ">= 1.25-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version -}}
 autoscaling/v2
 {{- else -}}
 autoscaling/v2beta1

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
@@ -1,12 +1,12 @@
 ---
-# Source: mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
-apiVersion: autoscaling/v2beta1
+# Source: mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: gateway-nginx-values-mimir-gateway
+  name: gateway-enterprise-values-mimir-gateway
   labels:
     app.kubernetes.io/name: mimir
-    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: gateway
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
@@ -14,15 +14,19 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: gateway-nginx-values-mimir-gateway
+    name: gateway-enterprise-values-mimir-gateway
   minReplicas: 1
   maxReplicas: 3
   metrics:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: 70
+        target:
+          type: AverageValue
+          averageUtilization: 70
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 70
+        target:
+          type: AverageValue
+          averageUtilization: 70

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
@@ -1,12 +1,12 @@
 ---
-# Source: mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
-apiVersion: autoscaling/v2beta1
+# Source: mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: gateway-enterprise-values-mimir-gateway
+  name: gateway-nginx-values-mimir-gateway
   labels:
     app.kubernetes.io/name: mimir
-    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: gateway
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
@@ -14,15 +14,19 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: gateway-enterprise-values-mimir-gateway
+    name: gateway-nginx-values-mimir-gateway
   minReplicas: 1
   maxReplicas: 3
   metrics:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: 70
+        target:
+          type: AverageValue
+          averageUtilization: 70
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 70
+        target:
+          type: AverageValue
+          averageUtilization: 70

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
@@ -1,6 +1,6 @@
 ---
-# Source: mimir-distributed/templates/nginx/nginx-v2beta1-hpa.yaml
-apiVersion: autoscaling/v2beta1
+# Source: mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: test-oss-k8s-1.25-values-mimir-nginx
@@ -21,4 +21,6 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 60
+        target:
+          type: AverageValue
+          averageUtilization: 60


### PR DESCRIPTION
This follows helm recommendation. The best practice is to upgrade releases using deprecated API versions to supported API versions, prior to upgrading to a kubernetes cluster that removes those API versions.

See https://helm.sh/docs/topics/kubernetes_apis/ for reference.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
