### PR TITLE
Fix publish-next-mimir-distributed PAT secret

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -63,7 +63,7 @@ jobs:
         host: "github.com"
         # PUBLISH_TO_WEBSITE_MIMIR is a fine-grained GitHub Personal Access Token that expires.
         # It must be updated in the grafanabot GitHub account.
-        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_MIMIR }}"
+        github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
         source_folder: "docs/sources/helm-charts/mimir-distributed"
         target_folder: "content/docs/helm-charts/mimir-distributed/next"
         allow_no_changes: true


### PR DESCRIPTION
Needs to match the publish-next-mimir secret which is centrally managed and rotated.

@osg-grafana, this fixes the pipeline failure you saw in https://github.com/grafana/mimir/actions/runs/4255598576/jobs/7403430101