### PR TITLE
Mimirtool: reduce allocations in `ParseMetricsInBoard`.

### DIFF
--- a/pkg/mimirtool/commands/analyse_grafana_test.go
+++ b/pkg/mimirtool/commands/analyse_grafana_test.go
@@ -45,6 +45,28 @@ func TestParseMetricsInBoard(t *testing.T) {
 	assert.Equal(t, dashboardMetrics, output.Dashboards[0].Metrics)
 }
 
+func BenchmarkParseMetricsInBoard(b *testing.B) {
+	var board minisdk.Board
+	output := &analyze.MetricsInGrafana{}
+	output.OverallMetrics = make(map[string]struct{})
+
+	buf, err := loadFile("testdata/apiserver.json")
+	if err != nil {
+		b.FailNow()
+	}
+
+	err = json.Unmarshal(buf, &board)
+	if err != nil {
+		b.FailNow()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		analyze.ParseMetricsInBoard(output, board)
+	}
+}
+
 func TestParseMetricsInBoardWithTimeseriesPanel(t *testing.T) {
 	var board minisdk.Board
 	output := &analyze.MetricsInGrafana{}


### PR DESCRIPTION
#### What this PR does
Reduce allocations in `ParseMetricsInBoard` by moving two regexps at pkg level and pre-allocating slices where possible.

To test the changes, I've copied an existing test into a benchmark.

Tested with:

`go test -run=^$ -bench=. -count=5 ./pkg/mimirtool/commands`

Benchmark comparison:

```
name                   old time/op    new time/op    delta
ParseMetricsInBoard-8    86.2µs ± 0%    80.5µs ± 0%   -6.57%  (p=0.008 n=5+5)

name                   old alloc/op   new alloc/op   delta
ParseMetricsInBoard-8    79.2kB ± 0%    67.6kB ± 0%  -14.72%  (p=0.008 n=5+5)

name                   old allocs/op  new allocs/op  delta
ParseMetricsInBoard-8     1.09k ± 0%     1.00k ± 0%   -7.82%  (p=0.008 n=5+5)
```

#### Which issue(s) this PR fixes or relates to
n.a.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
