### PR TITLE
Helm: nginx HPA and tests kubeversion fixes

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [BUGFIX] Allow override of Kubernetes version for nginx HPA.
+
 ## 4.2.0
 
 * [ENHANCEMENT] Allow NGINX error log level to be overridden and access log to be disabled. #4230

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,8 +28,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [BUGFIX] Allow override of Kubernetes version for nginx HPA. #4299
 * [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling starting with Kubernetes 1.23. #4285
+* [BUGFIX] Allow override of Kubernetes version for nginx HPA. #4299
 
 ## 4.2.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [BUGFIX] Allow override of Kubernetes version for nginx HPA.
+* [BUGFIX] Allow override of Kubernetes version for nginx HPA. #4299
 
 ## 4.2.0
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/gateway-enterprise-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/gateway-enterprise-values.yaml
@@ -1,3 +1,6 @@
+# Pin kube version so results are the same for running in CI and locally where the installed kube version may be different.
+kubeVersionOverride: "1.20"
+
 enterprise:
   enabled: true
 gateway:

--- a/operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml
@@ -1,3 +1,6 @@
+# Pin kube version so results are the same for running in CI and locally where the installed kube version may be different.
+kubeVersionOverride: "1.20"
+
 nginx:
   enabled: false
 gateway:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/_helpers.tpl
@@ -9,7 +9,7 @@ nginx auth secret name
 Returns the HorizontalPodAutoscaler API version for this verison of kubernetes.
 */}}
 {{- define "mimir.hpa.version" -}}
-{{- if semverCompare ">= 1.25-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">= 1.25-0" (include "mimir.kubeVersion" .) -}}
 autoscaling/v2
 {{- else -}}
 autoscaling/v2beta1

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -61,18 +61,19 @@ for FILEPATH in $TESTS; do
   TEST_NAME=$(basename -s '.yaml' "$FILEPATH")
   INTERMEDIATE_OUTPUT_DIR="${INTERMEDIATE_PATH}/${TEST_NAME}-generated"
   OUTPUT_DIR="${OUTPUT_PATH}/${TEST_NAME}-generated"
-  EXTRA_ARGS=""
 
   echo ""
   echo "Templating $TEST_NAME"
+  ARGS=("${TEST_NAME}" "${CHART_PATH}" "-f" "${FILEPATH}" "--output-dir" "${INTERMEDIATE_OUTPUT_DIR}" "--namespace" "citestns")
+
   echo -n "Checking for kubeVersionOverride..."
   if ! grep "^kubeVersionOverride:" "${FILEPATH}" ; then
     echo "Warning: injecting Kubernetes version override: kubeVersionOverride=${DEFAULT_KUBE_VERSION}"
-    EXTRA_ARGS+=" --set-string kubeVersionOverride=${DEFAULT_KUBE_VERSION}"
+    ARGS+=("--set-string" "kubeVersionOverride=${DEFAULT_KUBE_VERSION}")
   fi
 
   set -x
-  helm template "${TEST_NAME}" "${CHART_PATH}" -f "${FILEPATH}" --output-dir "${INTERMEDIATE_OUTPUT_DIR}" --namespace citestns${EXTRA_ARGS}
+  helm template "${ARGS[@]}"
   set +x
 
   echo "Removing mutable config checksum, helm chart, application, image tag version for clarity"

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -66,7 +66,7 @@ for FILEPATH in $TESTS; do
   echo "Templating $TEST_NAME"
   ARGS=("${TEST_NAME}" "${CHART_PATH}" "-f" "${FILEPATH}" "--output-dir" "${INTERMEDIATE_OUTPUT_DIR}" "--namespace" "citestns")
 
-  echo -n "Checking for kubeVersionOverride..."
+  echo "Checking for kubeVersionOverride inside tests' values.yaml ..."
   if ! grep "^kubeVersionOverride:" "${FILEPATH}" ; then
     echo "Warning: injecting Kubernetes version override: kubeVersionOverride=${DEFAULT_KUBE_VERSION}"
     ARGS+=("--set-string" "kubeVersionOverride=${DEFAULT_KUBE_VERSION}")

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
@@ -1,12 +1,12 @@
 ---
-# Source: mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
-apiVersion: autoscaling/v2
+# Source: mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: gateway-nginx-values-mimir-gateway
+  name: gateway-enterprise-values-mimir-gateway
   labels:
     app.kubernetes.io/name: mimir
-    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: gateway
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
@@ -14,19 +14,15 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: gateway-nginx-values-mimir-gateway
+    name: gateway-enterprise-values-mimir-gateway
   minReplicas: 1
   maxReplicas: 3
   metrics:
     - type: Resource
       resource:
         name: memory
-        target:
-          type: AverageValue
-          averageUtilization: 70
+        targetAverageUtilization: 70
     - type: Resource
       resource:
         name: cpu
-        target:
-          type: AverageValue
-          averageUtilization: 70
+        targetAverageUtilization: 70

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: gateway-enterprise-values-mimir-ingester

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: gateway-enterprise-values-mimir-store-gateway

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
@@ -1,12 +1,12 @@
 ---
-# Source: mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
-apiVersion: autoscaling/v2
+# Source: mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: gateway-enterprise-values-mimir-gateway
+  name: gateway-nginx-values-mimir-gateway
   labels:
     app.kubernetes.io/name: mimir
-    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: gateway
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
@@ -14,19 +14,15 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: gateway-enterprise-values-mimir-gateway
+    name: gateway-nginx-values-mimir-gateway
   minReplicas: 1
   maxReplicas: 3
   metrics:
     - type: Resource
       resource:
         name: memory
-        target:
-          type: AverageValue
-          averageUtilization: 70
+        targetAverageUtilization: 70
     - type: Resource
       resource:
         name: cpu
-        target:
-          type: AverageValue
-          averageUtilization: 70
+        targetAverageUtilization: 70

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: gateway-nginx-values-mimir-ingester

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: gateway-nginx-values-mimir-store-gateway

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: large-values-mimir-ingester

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: large-values-mimir-store-gateway

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: small-values-mimir-ingester

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: small-values-mimir-store-gateway

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
@@ -1,6 +1,6 @@
 ---
-# Source: mimir-distributed/templates/nginx/nginx-v2beta1-hpa.yaml
-apiVersion: autoscaling/v2beta1
+# Source: mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: test-oss-k8s-1.25-values-mimir-nginx
@@ -21,4 +21,6 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 60
+        target:
+          type: AverageValue
+          averageUtilization: 60


### PR DESCRIPTION
#### What this PR does

**Helm: fix Kubernetes override for nginx HPA**
    
The template did not take into account the override "kubeVersionOverride".  Fix by using the mimir template implemented for this reason.

**Helm: fix missing Kubernetes version overrides in tests**
    
The golden record tests need a fixed version because helm uses the version
of the default context and can produce different results between
contributor's machine and the CI environment.
    
Add logic to test build to inject the minimal version if not found in the
values file. Mainly because we cannot have a version override in the
small and large values files.


#### Which issue(s) this PR fixes or relates to

Related to #4285 

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
