### PR TITLE
Bump `actions/checkout` in GitHub Actions workflows and fix broken deploy job

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -13,7 +13,7 @@ jobs:
   compare-manifests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
         go-version: '1.20.1'

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
 
       - name: Run Git Config

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -21,7 +21,7 @@ jobs:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Git Config
         run: git config --global --add safe.directory '*'

--- a/.github/workflows/issue_and_pr_commands.yml
+++ b/.github/workflows/issue_and_pr_commands.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -52,7 +52,7 @@ jobs:
     container:
       image: grafana/doc-validator:v1.9.0
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -66,7 +66,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-72d66708c
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -92,7 +92,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -121,7 +121,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -156,7 +156,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -199,7 +199,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.20.1
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -246,7 +246,7 @@ jobs:
     container:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
       - name: Run doc-validator tool (mimir)
         run: doc-validator ./docs/sources/mimir /docs/mimir/latest
       - name: Run doc-validator tool (helm-charts)
@@ -65,7 +67,7 @@ jobs:
       image: grafana/mimir-build-image:goupdate-72d66708c
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -91,7 +93,7 @@ jobs:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -120,7 +122,7 @@ jobs:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Symlink Expected Path to Workspace
@@ -135,8 +137,8 @@ jobs:
   test-docs:
     runs-on: ubuntu-latest
     steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v2"
+      - name: Check out repository
+        uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: "Build website"
@@ -155,7 +157,7 @@ jobs:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Install Docker Client
@@ -198,7 +200,9 @@ jobs:
         with:
           go-version: 1.20.1
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
       - name: Install Docker Client
         run: sudo ./.github/workflows/scripts/install-docker.sh
       - name: Symlink Expected Path to Workspace
@@ -243,7 +247,9 @@ jobs:
       image: grafana/mimir-build-image:goupdate-751733fe1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
       - name: Install Docker Client
         run: ./.github/workflows/scripts/install-docker.sh
       - name: Symlink Expected Path to Workspace


### PR DESCRIPTION
#### What this PR does

This makes the version of `actions/checkout` consistent across all jobs, and fixes [the deploy job](https://github.com/grafana/mimir/actions/runs/4278441487/jobs/7448351606), which is currently broken.

This issue was triggered as a result of upgrading Git in #4266, which brings in the change described in https://github.blog/2022-04-12-git-security-vulnerability-announced/.

#### Which issue(s) this PR fixes or relates to

#4266

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
