### PR TITLE
Fix cortex_ingester_memory_series metric tracking at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [BUGFIX] Querier: track canceled requests with status code `499` in the metrics instead of `503` or `422`. #4099
 * [BUGFIX] Ingester: compact out-of-order data during `/ingester/flush` or when TSDB is idle. #4180
 * [BUGFIX] Ingester: conversion of global limits `max-series-per-user`, `max-series-per-metric`, `max-metadata-per-user` and `max-metadata-per-metric` into corresponding local limits now takes into account the number of ingesters in each zone. #4238
+* [BUGFIX] Ingester: track `cortex_ingester_memory_series` metric consistent with `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total`. #4312
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [BUGFIX] Querier: track canceled requests with status code `499` in the metrics instead of `503` or `422`. #4099
 * [BUGFIX] Ingester: compact out-of-order data during `/ingester/flush` or when TSDB is idle. #4180
 * [BUGFIX] Ingester: conversion of global limits `max-series-per-user`, `max-series-per-metric`, `max-metadata-per-user` and `max-metadata-per-metric` into corresponding local limits now takes into account the number of ingesters in each zone. #4238
-* [BUGFIX] Ingester: track `cortex_ingester_memory_series` metric consistent with `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total`. #4312
+* [BUGFIX] Ingester: track `cortex_ingester_memory_series` metric consistently with `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total`. #4312
 
 ### Mixin
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -304,16 +304,7 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetricsEnabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests)
 	i.activeGroups = activeGroupsCleanupService
 
-	// Replace specific metrics which we can't directly track but we need to read
-	// them from the underlying system (ie. TSDB).
 	if registerer != nil {
-		promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
-			Name: "cortex_ingester_memory_series",
-			Help: "The current number of series in memory.",
-		}, func() float64 {
-			return float64(i.seriesCount.Load())
-		})
-
 		promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
 			Name: "cortex_ingester_oldest_unshipped_block_timestamp_seconds",
 			Help: "Unix timestamp of the oldest TSDB block not shipped to the storage yet. 0 if ingester has no blocks or all blocks have been shipped.",

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -393,6 +393,7 @@ type tsdbMetrics struct {
 	checkpointCreationFail  *prometheus.Desc
 	checkpointCreationTotal *prometheus.Desc
 
+	memSeries             *prometheus.Desc
 	memSeriesCreatedTotal *prometheus.Desc
 	memSeriesRemovedTotal *prometheus.Desc
 
@@ -575,6 +576,10 @@ func newTSDBMetrics(r prometheus.Registerer, logger log.Logger) *tsdbMetrics {
 			"Total number of out-of-order samples appended.",
 			[]string{"user"}, nil),
 
+		memSeries: prometheus.NewDesc(
+			"cortex_ingester_memory_series",
+			"The current number of series in memory.",
+			nil, nil),
 		memSeriesCreatedTotal: prometheus.NewDesc(
 			"cortex_ingester_memory_series_created_total",
 			"The total number of series that were created per user.",
@@ -637,6 +642,7 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 
 	out <- sm.tsdbOOOAppendedSamples
 
+	out <- sm.memSeries
 	out <- sm.memSeriesCreatedTotal
 	out <- sm.memSeriesRemovedTotal
 }
@@ -689,6 +695,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 
 	data.SendSumOfCountersPerTenant(out, sm.tsdbOOOAppendedSamples, "prometheus_tsdb_head_out_of_order_samples_appended_total")
 
+	data.SendSumOfGauges(out, sm.memSeries, "prometheus_tsdb_head_series")
 	data.SendSumOfCountersPerTenant(out, sm.memSeriesCreatedTotal, "prometheus_tsdb_head_series_created_total")
 	data.SendSumOfCountersPerTenant(out, sm.memSeriesRemovedTotal, "prometheus_tsdb_head_series_removed_total")
 }

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -127,6 +127,10 @@ func TestTSDBMetrics(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_checkpoint_creations_total counter
 			cortex_ingester_tsdb_checkpoint_creations_total 1883489
 
+			# HELP cortex_ingester_memory_series The current number of series in memory.
+			# TYPE cortex_ingester_memory_series gauge
+			cortex_ingester_memory_series 396524
+
 			# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
 			# TYPE cortex_ingester_memory_series_created_total counter
 			# 5 * (12345, 85787 and 999 respectively)
@@ -367,6 +371,10 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_checkpoint_creations_total counter
 			cortex_ingester_tsdb_checkpoint_creations_total 1883489
 
+			# HELP cortex_ingester_memory_series The current number of series in memory.
+			# TYPE cortex_ingester_memory_series gauge
+			cortex_ingester_memory_series 392528
+
 			# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
 			# TYPE cortex_ingester_memory_series_created_total counter
 			# 5 * (12345, 85787 and 999 respectively)
@@ -514,6 +522,11 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 	uploadFailures.Add(4 * base)
 
 	// TSDB Head
+	headSeries := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_head_series",
+	})
+	headSeries.Add(4 * base)
+
 	seriesCreated := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_head_series_created_total",
 	})


### PR DESCRIPTION
#### What this PR does
This PR fixes #4310 delegating `cortex_ingester_memory_series` metrics tracking to TSDB. The reason why it fixes #4310 is because we don't track the per-TSDB registerer until after `tsdb.Open()` returned, so the spike during the WAL replay is not accounted. This also makes `cortex_ingester_memory_series` consistent with `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total` metrics.

#### Which issue(s) this PR fixes or relates to

Fixes #4310

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
