### PR TITLE
Enable streaming store-gateway by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
    * `-blocks-storage.bucket-store.index-header.map-populate-enabled` has been removed
    * `-blocks-storage.bucket-store.index-header.stream-reader-enabled` has been removed
    * `-blocks-storage.bucket-store.index-header.stream-reader-max-idle-file-handles` has been renamed to `-blocks-storage.bucket-store.index-header.max-idle-file-handles`, and the corresponding configuration file option has been renamed from `stream_reader_max_idle_file_handles` to `max_idle_file_handles`
+* [CHANGE] Store-gateway: the streaming store-gateway is now enabled by default. The new default setting for `-blocks-storage.bucket-store.batch-series-size` is `5000`. #4330
 * [FEATURE] Ruler: added `keep_firing_for` support to alerting rules. #4099
 * [FEATURE] Distributor, ingester: ingestion of native histograms. The new per-tenant limit `-ingester.native-histograms-ingestion-enabled` controls whether native histograms are stored or ignored. #4159
 * [FEATURE] Query-frontend: Introduce experimental `-query-frontend.query-sharding-target-series-per-shard` to allow query sharding to take into account cardinality of similar requests executed previously. This feature uses the same cache that's used for results caching. #4121 #4177 #4188 #4254

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5798,10 +5798,10 @@
               "required": false,
               "desc": "If larger than 0, this option enables store-gateway series streaming. The store-gateway will load series from the bucket in batches instead of buffering them all in memory before returning to the querier. This option controls how many series to fetch per batch.",
               "fieldValue": null,
-              "fieldDefaultValue": 0,
+              "fieldDefaultValue": 5000,
               "fieldFlag": "blocks-storage.bucket-store.batch-series-size",
               "fieldType": "int",
-              "fieldCategory": "experimental"
+              "fieldCategory": "advanced"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -266,7 +266,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.backend string
     	Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem. (default "filesystem")
   -blocks-storage.bucket-store.batch-series-size int
-    	[experimental] If larger than 0, this option enables store-gateway series streaming. The store-gateway will load series from the bucket in batches instead of buffering them all in memory before returning to the querier. This option controls how many series to fetch per batch.
+    	If larger than 0, this option enables store-gateway series streaming. The store-gateway will load series from the bucket in batches instead of buffering them all in memory before returning to the querier. This option controls how many series to fetch per batch. (default 5000)
   -blocks-storage.bucket-store.block-sync-concurrency int
     	Maximum number of concurrent blocks synching per tenant. (default 20)
   -blocks-storage.bucket-store.bucket-index.enabled

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -91,7 +91,6 @@ The following features are currently experimental:
   - `-query-scheduler.querier-forget-delay`
   - Max number of used instances (`-query-scheduler.max-used-instances`)
 - Store-gateway
-  - `-blocks-storage.bucket-store.batch-series-size`
   - `-blocks-storage.bucket-store.chunks-cache.fine-grained-chunks-caching-enabled`
 - Blocks Storage, Alertmanager, and Ruler support for partitioning access to the same storage bucket
   - `-alertmanager-storage.storage-prefix`

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3148,12 +3148,12 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.max-idle-file-handles
     [max_idle_file_handles: <int> | default = 1]
 
-  # (experimental) If larger than 0, this option enables store-gateway series
+  # (advanced) If larger than 0, this option enables store-gateway series
   # streaming. The store-gateway will load series from the bucket in batches
   # instead of buffering them all in memory before returning to the querier.
   # This option controls how many series to fetch per batch.
   # CLI flag: -blocks-storage.bucket-store.batch-series-size
-  [streaming_series_batch_size: <int> | default = 0]
+  [streaming_series_batch_size: <int> | default = 5000]
 
 tsdb:
   # Directory to store TSDBs (including WAL) in the ingesters. This directory is

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -325,7 +325,7 @@ type BucketStoreConfig struct {
 	// Controls experimental options for index-header file reading.
 	IndexHeader indexheader.Config `yaml:"index_header" category:"experimental"`
 
-	StreamingBatchSize int `yaml:"streaming_series_batch_size" category:"experimental"`
+	StreamingBatchSize int `yaml:"streaming_series_batch_size" category:"advanced"`
 }
 
 // RegisterFlags registers the BucketStore flags
@@ -354,7 +354,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) 
 	f.BoolVar(&cfg.IndexHeaderLazyLoadingEnabled, "blocks-storage.bucket-store.index-header-lazy-loading-enabled", true, "If enabled, store-gateway will lazy load an index-header only once required by a query.")
 	f.DurationVar(&cfg.IndexHeaderLazyLoadingIdleTimeout, "blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout", 60*time.Minute, "If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity.")
 	f.Uint64Var(&cfg.PartitionerMaxGapBytes, "blocks-storage.bucket-store.partitioner-max-gap-bytes", DefaultPartitionerMaxGapSize, "Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests.")
-	f.IntVar(&cfg.StreamingBatchSize, "blocks-storage.bucket-store.batch-series-size", 0, "If larger than 0, this option enables store-gateway series streaming. The store-gateway will load series from the bucket in batches instead of buffering them all in memory before returning to the querier. This option controls how many series to fetch per batch.")
+	f.IntVar(&cfg.StreamingBatchSize, "blocks-storage.bucket-store.batch-series-size", 5000, "If larger than 0, this option enables store-gateway series streaming. The store-gateway will load series from the bucket in batches instead of buffering them all in memory before returning to the querier. This option controls how many series to fetch per batch.")
 }
 
 // Validate the config.

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -527,12 +527,10 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 			expectedSamplesForOverlappingChunks: []sample{{t: 20, v: 20}, {t: 21, v: 21}},
 		},
 		"query samples from 2nd (out of order) chunk only": {
-			minT: 10,
-			maxT: 11, // Not included.
-			// The BucketStore assumes chunks are ordered and has an optimization to stop looking up chunks when
-			// the current chunk minTime > query maxTime.
-			expectedSamplesForOutOfOrderChunks:  nil,
-			expectedSamplesForOverlappingChunks: nil,
+			minT:                                10,
+			maxT:                                11, // Not included.
+			expectedSamplesForOutOfOrderChunks:  []sample{{t: 10, v: 10}, {t: 11, v: 11}},
+			expectedSamplesForOverlappingChunks: []sample{{t: 10, v: 10}, {t: 20, v: 20}},
 		},
 	}
 

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1071,11 +1071,12 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 				// Ensure Mimir external labels have been removed.
 				assert.Equal(t, []mimirpb.LabelAdapter{{Name: "series_id", Value: strconv.Itoa(seriesID)}}, actual.Labels)
 
-				// Ensure samples have been correctly queried. The Thanos store also deduplicate samples
-				// in most cases, but it's not strictly required guaranteeing deduplication at this stage.
+				// Ensure samples have been correctly queried. The store-gateway doesn't deduplicate chunks,
+				// so the same sample is returned twice because in this test we query two identical blocks.
 				samples, err := readSamplesFromChunks(actual.Chunks)
 				require.NoError(t, err)
 				assert.Equal(t, []sample{
+					{t: minT + (step * int64(seriesID)), v: float64(seriesID)},
 					{t: minT + (step * int64(seriesID)), v: float64(seriesID)},
 				}, samples)
 			}


### PR DESCRIPTION
#### What this PR does
Since we're about to cut Mimir 2.7, I would like to enable the streaming store-gateway by default. The default batch size is 5000, the same value we run at Grafana Labs.

A couple of tests have changed because the streaming store-gateway implementation doesn't deduplicate chunks and doesn't have any optimization assuming chunks are in order.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
