### PR TITLE
New internal query result payload format: add support for remote rule evaluation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [ENHANCEMENT] Store-gateway: Reduce memory allocation rate when loading TSDB chunks from Memcached. #4074
 * [ENHANCEMENT] Query-frontend: track `cortex_frontend_query_response_codec_duration_seconds` and `cortex_frontend_query_response_codec_payload_bytes` metrics to measure the time taken and bytes read / written while encoding and decoding query result payloads. #4110
 * [ENHANCEMENT] Alertmanager: expose additional upstream metrics `cortex_alertmanager_dispatcher_aggregation_groups`, `cortex_alertmanager_dispatcher_alert_processing_duration_seconds`. #4151
-* [ENHANCEMENT] Querier and query-frontend: add experimental, more performant protobuf query result response format enabled with `-query-frontend.query-result-response-format=protobuf`. #4153 #4304 #4318 #4375
+* [ENHANCEMENT] Querier and query-frontend: add experimental, more performant protobuf internal query result response format enabled with `-query-frontend.query-result-response-format=protobuf`. #4153 #4304 #4318 #4375
+* [ENHANCEMENT] Query-frontend and ruler: add experimental, more performant protobuf internal query result response format enabled with `-ruler.query-frontend.query-result-response-format=protobuf`. #4331
 * [ENHANCEMENT] Store-gateway: use more efficient chunks fetching and caching. This should reduce CPU, memory utilization, and receive bandwidth of a store-gateway. Enable with `-blocks-storage.bucket-store.chunks-cache.fine-grained-chunks-caching-enabled=true`. #4163 #4174 #4227 #4255
 * [ENHANCEMENT] Query-frontend: Wait for in-flight queries to finish before shutting down. #4073 #4170
 * [ENHANCEMENT] Store-gateway: added `encode` and `other` stage to `cortex_bucket_store_series_request_stage_duration_seconds` metric. #4179

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -9515,6 +9515,17 @@
               ],
               "fieldValue": null,
               "fieldDefaultValue": null
+            },
+            {
+              "kind": "field",
+              "name": "query_result_response_format",
+              "required": false,
+              "desc": "Format to use when retrieving query results from query-frontends. Supported values: json, protobuf",
+              "fieldValue": null,
+              "fieldDefaultValue": "json",
+              "fieldFlag": "ruler.query-frontend.query-result-response-format",
+              "fieldType": "string",
+              "fieldCategory": "experimental"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2013,6 +2013,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
   -ruler.query-frontend.grpc-client-config.tls-server-name string
     	Override the expected name on the server certificate.
+  -ruler.query-frontend.query-result-response-format string
+    	[experimental] Format to use when retrieving query results from query-frontends. Supported values: json, protobuf (default "json")
   -ruler.query-stats-enabled
     	Report the wall time for ruler queries to complete as a per-tenant metric and as an info level log message.
   -ruler.recording-rules-evaluation-enabled

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1571,6 +1571,11 @@ query_frontend:
   # ruler.query-frontend.grpc-client-config
   [grpc_client_config: <grpc_client>]
 
+  # (experimental) Format to use when retrieving query results from
+  # query-frontends. Supported values: json, protobuf
+  # CLI flag: -ruler.query-frontend.query-result-response-format
+  [query_result_response_format: <string> | default = "json"]
+
 tenant_federation:
   # Enable running rule groups against multiple tenants. The tenant IDs involved
   # need to be in the rule group's 'source_tenants' field. If this flag is set

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.69.0
 	github.com/thanos-io/objstore v0.0.0-20230201072718-11ffbc490204
 	github.com/xlab/treeprint v1.1.0
@@ -177,7 +178,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/ncw/swift v1.0.53 // indirect
 	github.com/oklog/run v1.1.0 // indirect

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -887,20 +887,26 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 	// Start up services
 	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
 	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
-	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags)
 	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
 
-	require.NoError(t, s.StartAndWaitReady(distributor, ingester, ruler, querier))
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester, querier))
 	require.NoError(t, s.WaitReady(queryFrontend))
 
-	// Wait until both the distributor and ruler are ready
+	// Wait until the distributor is ready
 	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
-	// Ruler will see 512 tokens from ingester, and 128 tokens from itself.
-	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(512+128), "cortex_ring_tokens_total"))
 
 	for tName, tc := range tcs {
 		t.Run(tName, func(t *testing.T) {
+			ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags)
+			require.NoError(t, s.StartAndWaitReady(ruler))
+			t.Cleanup(func() {
+				s.Stop(ruler)
+			})
+
+			// Ruler will see 512 tokens from ingester, and 128 tokens from itself.
+			require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(512+128), "cortex_ring_tokens_total"))
+
 			// Generate some series under different tenants
 			sampleTime := time.Now()
 			for _, tenantID := range tc.tenantsWithMetrics {

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -160,11 +160,11 @@ type formatter interface {
 	ContentType() v1.MIMEType
 }
 
-var defaultFormatter = jsonFormat{}
+var defaultFormatter = jsonFormatter{}
 
 var knownFormats = []formatter{
 	defaultFormatter,
-	protobufFormat{},
+	protobufFormatter{},
 }
 
 func NewPrometheusCodec(registerer prometheus.Registerer, queryResultResponseFormat string) Codec {

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -160,10 +160,10 @@ type formatter interface {
 	ContentType() v1.MIMEType
 }
 
-var defaultFormatter = jsonFormatter{}
+var jsonFormatterInstance = jsonFormatter{}
 
 var knownFormats = []formatter{
-	defaultFormatter,
+	jsonFormatterInstance,
 	protobufFormatter{},
 }
 
@@ -445,7 +445,7 @@ func (c prometheusCodec) EncodeResponse(ctx context.Context, req *http.Request, 
 
 func (prometheusCodec) negotiateContentType(acceptHeader string) (string, formatter) {
 	if acceptHeader == "" {
-		return jsonMimeType, defaultFormatter
+		return jsonMimeType, jsonFormatterInstance
 	}
 
 	for _, clause := range goautoneg.ParseAccept(acceptHeader) {

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -371,7 +371,7 @@ func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 	log.LogFields(otlog.Int("bytes", len(buf)))
 
 	contentType := r.Header.Get("Content-Type")
-	formatter := c.findFormatter(contentType)
+	formatter := findFormatter(contentType)
 	if formatter == nil {
 		return nil, apierror.Newf(apierror.TypeInternal, "unknown response content type '%v'", contentType)
 	}
@@ -395,7 +395,7 @@ func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 	return resp, nil
 }
 
-func (c prometheusCodec) findFormatter(contentType string) formatter {
+func findFormatter(contentType string) formatter {
 	for _, f := range knownFormats {
 		if f.ContentType().String() == contentType {
 			return f

--- a/pkg/frontend/querymiddleware/codec_json.go
+++ b/pkg/frontend/querymiddleware/codec_json.go
@@ -9,13 +9,13 @@ import v1 "github.com/prometheus/prometheus/web/api/v1"
 
 const jsonMimeType = "application/json"
 
-type jsonFormat struct{}
+type jsonFormatter struct{}
 
-func (j jsonFormat) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
+func (j jsonFormatter) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
 	return json.Marshal(resp)
 }
 
-func (j jsonFormat) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
+func (j jsonFormatter) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
 	var resp PrometheusResponse
 
 	if err := json.Unmarshal(buf, &resp); err != nil {
@@ -25,10 +25,10 @@ func (j jsonFormat) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
 	return &resp, nil
 }
 
-func (j jsonFormat) Name() string {
+func (j jsonFormatter) Name() string {
 	return formatJSON
 }
 
-func (j jsonFormat) ContentType() v1.MIMEType {
+func (j jsonFormatter) ContentType() v1.MIMEType {
 	return v1.MIMEType{Type: "application", SubType: "json"}
 }

--- a/pkg/frontend/querymiddleware/codec_json.go
+++ b/pkg/frontend/querymiddleware/codec_json.go
@@ -5,6 +5,8 @@
 
 package querymiddleware
 
+import v1 "github.com/prometheus/prometheus/web/api/v1"
+
 const jsonMimeType = "application/json"
 
 type jsonFormat struct{}
@@ -25,4 +27,8 @@ func (j jsonFormat) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
 
 func (j jsonFormat) Name() string {
 	return formatJSON
+}
+
+func (j jsonFormat) ContentType() v1.MIMEType {
+	return v1.MIMEType{Type: "application", SubType: "json"}
 }

--- a/pkg/frontend/querymiddleware/codec_json_test.go
+++ b/pkg/frontend/querymiddleware/codec_json_test.go
@@ -199,9 +199,9 @@ func TestPrometheusCodec_JSONResponse(t *testing.T) {
 			require.Equal(t, uint64(1), *payloadSizeHistogram.SampleCount)
 			require.Equal(t, float64(len(body)), *payloadSizeHistogram.SampleSum)
 
-			httpRequest, err := http.NewRequest(http.MethodGet, "/something", nil)
-			require.NoError(t, err)
-			httpRequest.Header.Set("Accept", jsonMimeType)
+			httpRequest := &http.Request{
+				Header: http.Header{"Accept": []string{jsonMimeType}},
+			}
 
 			// Reset response, as the above call will have consumed the body reader.
 			httpResponse = &http.Response{
@@ -358,8 +358,11 @@ func TestPrometheusCodec_JSONEncoding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			codec := NewPrometheusCodec(reg, formatJSON)
+			httpRequest := &http.Request{
+				Header: http.Header{"Accept": []string{jsonMimeType}},
+			}
 
-			encoded, err := codec.EncodeResponse(context.Background(), tc.response)
+			encoded, err := codec.EncodeResponse(context.Background(), httpRequest, tc.response)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, encoded.StatusCode)
 			require.Equal(t, "application/json", encoded.Header.Get("Content-Type"))

--- a/pkg/frontend/querymiddleware/codec_json_test.go
+++ b/pkg/frontend/querymiddleware/codec_json_test.go
@@ -199,6 +199,10 @@ func TestPrometheusCodec_JSONResponse(t *testing.T) {
 			require.Equal(t, uint64(1), *payloadSizeHistogram.SampleCount)
 			require.Equal(t, float64(len(body)), *payloadSizeHistogram.SampleSum)
 
+			httpRequest, err := http.NewRequest(http.MethodGet, "/something", nil)
+			require.NoError(t, err)
+			httpRequest.Header.Set("Accept", jsonMimeType)
+
 			// Reset response, as the above call will have consumed the body reader.
 			httpResponse = &http.Response{
 				StatusCode:    200,
@@ -206,7 +210,7 @@ func TestPrometheusCodec_JSONResponse(t *testing.T) {
 				Body:          io.NopCloser(bytes.NewBuffer(body)),
 				ContentLength: int64(len(body)),
 			}
-			encoded, err := codec.EncodeResponse(context.Background(), decoded)
+			encoded, err := codec.EncodeResponse(context.Background(), httpRequest, decoded)
 			require.NoError(t, err)
 
 			expectedJSON, err := bodyBuffer(httpResponse)

--- a/pkg/frontend/querymiddleware/codec_protobuf.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf.go
@@ -79,7 +79,7 @@ func (f protobufFormatter) EncodeResponse(resp *PrometheusResponse) ([]byte, err
 
 func (protobufFormatter) encodeStringData(data []SampleStream) (mimirpb.StringData, error) {
 	if len(data) != 1 {
-		return mimirpb.StringData{}, fmt.Errorf("expected string response to contain exactly one stream, but is has %d", len(data))
+		return mimirpb.StringData{}, fmt.Errorf("expected string response to contain exactly one stream, but it has %d", len(data))
 	}
 
 	stream := data[0]
@@ -108,7 +108,7 @@ func (protobufFormatter) encodeStringData(data []SampleStream) (mimirpb.StringDa
 
 func (protobufFormatter) encodeScalarData(data []SampleStream) (mimirpb.ScalarData, error) {
 	if len(data) != 1 {
-		return mimirpb.ScalarData{}, fmt.Errorf("expected scalar response to contain exactly one stream, but is has %d", len(data))
+		return mimirpb.ScalarData{}, fmt.Errorf("expected scalar response to contain exactly one stream, but it has %d", len(data))
 	}
 
 	stream := data[0]

--- a/pkg/frontend/querymiddleware/codec_protobuf.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf.go
@@ -12,17 +12,17 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-type protobufFormat struct{}
+type protobufFormatter struct{}
 
-func (f protobufFormat) Name() string {
+func (f protobufFormatter) Name() string {
 	return formatProtobuf
 }
 
-func (f protobufFormat) ContentType() v1.MIMEType {
+func (f protobufFormatter) ContentType() v1.MIMEType {
 	return v1.MIMEType{Type: mimirpb.QueryResponseMimeTypeType, SubType: mimirpb.QueryResponseMimeTypeSubType}
 }
 
-func (f protobufFormat) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
+func (f protobufFormatter) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
 	status, err := mimirpb.StatusFromPrometheusString(resp.Status)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (f protobufFormat) EncodeResponse(resp *PrometheusResponse) ([]byte, error)
 	return payload.Marshal()
 }
 
-func (protobufFormat) encodeStringData(data []SampleStream) (mimirpb.StringData, error) {
+func (protobufFormatter) encodeStringData(data []SampleStream) (mimirpb.StringData, error) {
 	if len(data) != 1 {
 		return mimirpb.StringData{}, fmt.Errorf("expected string response to contain exactly one stream, but is has %d", len(data))
 	}
@@ -106,7 +106,7 @@ func (protobufFormat) encodeStringData(data []SampleStream) (mimirpb.StringData,
 	}, nil
 }
 
-func (protobufFormat) encodeScalarData(data []SampleStream) (mimirpb.ScalarData, error) {
+func (protobufFormatter) encodeScalarData(data []SampleStream) (mimirpb.ScalarData, error) {
 	if len(data) != 1 {
 		return mimirpb.ScalarData{}, fmt.Errorf("expected scalar response to contain exactly one stream, but is has %d", len(data))
 	}
@@ -125,7 +125,7 @@ func (protobufFormat) encodeScalarData(data []SampleStream) (mimirpb.ScalarData,
 	}, nil
 }
 
-func (protobufFormat) encodeVectorData(data []SampleStream) (mimirpb.VectorData, error) {
+func (protobufFormatter) encodeVectorData(data []SampleStream) (mimirpb.VectorData, error) {
 	floatCount := 0
 	histogramCount := 0
 
@@ -170,7 +170,7 @@ func (protobufFormat) encodeVectorData(data []SampleStream) (mimirpb.VectorData,
 	}, nil
 }
 
-func (protobufFormat) encodeMatrixData(data []SampleStream) mimirpb.MatrixData {
+func (protobufFormatter) encodeMatrixData(data []SampleStream) mimirpb.MatrixData {
 	series := make([]mimirpb.MatrixSeries, len(data))
 
 	for i, stream := range data {
@@ -184,7 +184,7 @@ func (protobufFormat) encodeMatrixData(data []SampleStream) mimirpb.MatrixData {
 	return mimirpb.MatrixData{Series: series}
 }
 
-func (f protobufFormat) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
+func (f protobufFormatter) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
 	var resp mimirpb.QueryResponse
 
 	if err := resp.Unmarshal(buf); err != nil {
@@ -214,7 +214,7 @@ func (f protobufFormat) DecodeResponse(buf []byte) (*PrometheusResponse, error) 
 	}, nil
 }
 
-func (f protobufFormat) decodeData(resp mimirpb.QueryResponse) (*PrometheusData, error) {
+func (f protobufFormatter) decodeData(resp mimirpb.QueryResponse) (*PrometheusData, error) {
 	if resp.Data == nil {
 		if resp.Status != mimirpb.QueryResponse_SUCCESS {
 			return nil, nil
@@ -237,7 +237,7 @@ func (f protobufFormat) decodeData(resp mimirpb.QueryResponse) (*PrometheusData,
 	}
 }
 
-func (f protobufFormat) decodeStringData(data *mimirpb.StringData) *PrometheusData {
+func (f protobufFormatter) decodeStringData(data *mimirpb.StringData) *PrometheusData {
 	return &PrometheusData{
 		ResultType: model.ValString.String(),
 		Result: []SampleStream{
@@ -249,7 +249,7 @@ func (f protobufFormat) decodeStringData(data *mimirpb.StringData) *PrometheusDa
 	}
 }
 
-func (f protobufFormat) decodeScalarData(data *mimirpb.ScalarData) *PrometheusData {
+func (f protobufFormatter) decodeScalarData(data *mimirpb.ScalarData) *PrometheusData {
 	return &PrometheusData{
 		ResultType: model.ValScalar.String(),
 		Result: []SampleStream{
@@ -260,7 +260,7 @@ func (f protobufFormat) decodeScalarData(data *mimirpb.ScalarData) *PrometheusDa
 	}
 }
 
-func (f protobufFormat) decodeVectorData(data *mimirpb.VectorData) (*PrometheusData, error) {
+func (f protobufFormatter) decodeVectorData(data *mimirpb.VectorData) (*PrometheusData, error) {
 	streams := make([]SampleStream, len(data.Samples)+len(data.Histograms))
 
 	for i, sample := range data.Samples {
@@ -300,7 +300,7 @@ func (f protobufFormat) decodeVectorData(data *mimirpb.VectorData) (*PrometheusD
 	}, nil
 }
 
-func (f protobufFormat) decodeMatrixData(data *mimirpb.MatrixData) (*PrometheusData, error) {
+func (f protobufFormatter) decodeMatrixData(data *mimirpb.MatrixData) (*PrometheusData, error) {
 	streams := make([]SampleStream, len(data.Series))
 
 	for seriesIdx, series := range data.Series {

--- a/pkg/frontend/querymiddleware/codec_protobuf.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf.go
@@ -18,7 +18,165 @@ func (f protobufFormat) Name() string {
 }
 
 func (f protobufFormat) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
-	panic("not yet implemented")
+	status, err := mimirpb.StatusFromPrometheusString(resp.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	errorType, err := mimirpb.ErrorTypeFromPrometheusString(resp.ErrorType)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := mimirpb.QueryResponse{
+		Status:    status,
+		ErrorType: errorType,
+		Error:     resp.Error,
+	}
+
+	if resp.Data != nil {
+		switch resp.Data.ResultType {
+		case model.ValString.String():
+			data, err := f.encodeStringData(resp.Data.Result)
+			if err != nil {
+				return nil, err
+			}
+
+			payload.Data = &mimirpb.QueryResponse_String_{String_: &data}
+
+		case model.ValScalar.String():
+			data, err := f.encodeScalarData(resp.Data.Result)
+			if err != nil {
+				return nil, err
+			}
+
+			payload.Data = &mimirpb.QueryResponse_Scalar{Scalar: &data}
+
+		case model.ValVector.String():
+			data, err := f.encodeVectorData(resp.Data.Result)
+			if err != nil {
+				return nil, err
+			}
+
+			payload.Data = &mimirpb.QueryResponse_Vector{Vector: &data}
+
+		case model.ValMatrix.String():
+			data := f.encodeMatrixData(resp.Data.Result)
+			payload.Data = &mimirpb.QueryResponse_Matrix{Matrix: &data}
+
+		default:
+			return nil, fmt.Errorf("unknown result type '%s'", resp.Data.ResultType)
+		}
+	}
+
+	return payload.Marshal()
+}
+
+func (protobufFormat) encodeStringData(data []SampleStream) (mimirpb.StringData, error) {
+	if len(data) != 1 {
+		return mimirpb.StringData{}, fmt.Errorf("expected string response to contain exactly one stream, but is has %d", len(data))
+	}
+
+	stream := data[0]
+
+	if len(stream.Samples) != 1 {
+		return mimirpb.StringData{}, fmt.Errorf("expected string response stream to contain exactly one sample, but it has %d", len(stream.Samples))
+	}
+
+	sample := stream.Samples[0]
+
+	if len(stream.Labels) != 1 {
+		return mimirpb.StringData{}, fmt.Errorf("expected string response stream to contain exactly one label, but it has %d", len(stream.Labels))
+	}
+
+	label := stream.Labels[0]
+
+	if label.Name != "value" {
+		return mimirpb.StringData{}, fmt.Errorf("expected string response stream label to have name 'value', but it has name '%s'", label.Name)
+	}
+
+	return mimirpb.StringData{
+		TimestampMs: sample.TimestampMs,
+		Value:       label.Value,
+	}, nil
+}
+
+func (protobufFormat) encodeScalarData(data []SampleStream) (mimirpb.ScalarData, error) {
+	if len(data) != 1 {
+		return mimirpb.ScalarData{}, fmt.Errorf("expected scalar response to contain exactly one stream, but is has %d", len(data))
+	}
+
+	stream := data[0]
+
+	if len(stream.Samples) != 1 {
+		return mimirpb.ScalarData{}, fmt.Errorf("expected scalar response stream to contain exactly one sample, but it has %d", len(stream.Samples))
+	}
+
+	sample := stream.Samples[0]
+
+	return mimirpb.ScalarData{
+		TimestampMs: sample.TimestampMs,
+		Value:       sample.Value,
+	}, nil
+}
+
+func (protobufFormat) encodeVectorData(data []SampleStream) (mimirpb.VectorData, error) {
+	floatCount := 0
+	histogramCount := 0
+
+	for _, stream := range data {
+		if len(stream.Samples) == 1 {
+			floatCount++
+		} else if len(stream.Histograms) == 1 {
+			histogramCount++
+		} else {
+			return mimirpb.VectorData{}, fmt.Errorf("expected vector response series to contain exactly one float sample or one histogram, but it contains %d float sample(s) and %d histogram(s)", len(stream.Samples), len(stream.Histograms))
+		}
+	}
+
+	samples := make([]mimirpb.VectorSample, 0, floatCount)
+	histograms := make([]mimirpb.VectorHistogram, 0, histogramCount)
+
+	for _, stream := range data {
+		metric := stringArrayFromLabels(stream.Labels)
+
+		if len(stream.Samples) == 1 {
+			sample := stream.Samples[0]
+
+			samples = append(samples, mimirpb.VectorSample{
+				Metric:      metric,
+				Value:       sample.Value,
+				TimestampMs: sample.TimestampMs,
+			})
+		} else {
+			sample := stream.Histograms[0]
+
+			histograms = append(histograms, mimirpb.VectorHistogram{
+				Metric:      metric,
+				Histogram:   sample.Histogram,
+				TimestampMs: sample.TimestampMs,
+			})
+		}
+	}
+
+	return mimirpb.VectorData{
+		Samples:    samples,
+		Histograms: histograms,
+	}, nil
+}
+
+func (protobufFormat) encodeMatrixData(data []SampleStream) mimirpb.MatrixData {
+	series := make([]mimirpb.MatrixSeries, len(data))
+
+	for i, stream := range data {
+		series[i] = mimirpb.MatrixSeries{
+			Metric:     stringArrayFromLabels(stream.Labels),
+			Samples:    stream.Samples,
+			Histograms: stream.Histograms,
+		}
+	}
+
+	return mimirpb.MatrixData{Series: series}
 }
 
 func (f protobufFormat) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
@@ -175,4 +333,15 @@ func labelsFromStringArray(s []string) ([]mimirpb.LabelAdapter, error) {
 	}
 
 	return l, nil
+}
+
+func stringArrayFromLabels(labels []mimirpb.LabelAdapter) []string {
+	s := make([]string, len(labels)*2)
+
+	for i, l := range labels {
+		s[2*i] = l.Name
+		s[2*i+1] = l.Value
+	}
+
+	return s
 }

--- a/pkg/frontend/querymiddleware/codec_protobuf.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus/common/model"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
@@ -15,6 +16,10 @@ type protobufFormat struct{}
 
 func (f protobufFormat) Name() string {
 	return formatProtobuf
+}
+
+func (f protobufFormat) ContentType() v1.MIMEType {
+	return v1.MIMEType{Type: mimirpb.QueryResponseMimeTypeType, SubType: mimirpb.QueryResponseMimeTypeSubType}
 }
 
 func (f protobufFormat) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {

--- a/pkg/frontend/querymiddleware/codec_protobuf_test.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf_test.go
@@ -707,3 +707,28 @@ func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkProtobufFormat_EncodeResponse(b *testing.B) {
+	reg := prometheus.NewPedanticRegistry()
+	codec := NewPrometheusCodec(reg, formatProtobuf)
+
+	req := &http.Request{
+		Header: http.Header{"Accept": []string{mimirpb.QueryResponseMimeType}},
+	}
+
+	for _, tc := range protobufCodecScenarios {
+		if tc.response == nil {
+			continue
+		}
+
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := codec.EncodeResponse(context.Background(), req, tc.response)
+
+				if err != nil {
+					require.NoError(b, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/codec_protobuf_test.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf_test.go
@@ -47,20 +47,20 @@ var protobufResponseHistogram = mimirpb.FloatHistogram{
 }
 
 var protobufCodecScenarios = []struct {
-	name        string
-	resp        mimirpb.QueryResponse
-	expected    *PrometheusResponse
-	expectedErr error
+	name                  string
+	payload               mimirpb.QueryResponse
+	response              *PrometheusResponse
+	expectedDecodingError error
 }{
 	{
 		name: "successful string response",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_String_{
 				String_: &mimirpb.StringData{Value: "foo", TimestampMs: 1500},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValString.String(),
@@ -76,7 +76,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful scalar response",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Scalar{
 				Scalar: &mimirpb.ScalarData{
@@ -85,7 +85,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValScalar.String(),
@@ -98,13 +98,13 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful empty vector response",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -115,17 +115,17 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with single series with no labels",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
 					Samples: []mimirpb.VectorSample{
-						{Metric: []string{}, TimestampMs: 1_000, Value: 200},
+						{Metric: nil, TimestampMs: 1_000, Value: 200},
 					},
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -138,7 +138,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with single series with one label",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
@@ -148,7 +148,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -161,7 +161,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with single series with many labels",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
@@ -171,7 +171,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -190,7 +190,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with multiple series",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
@@ -201,7 +201,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -215,7 +215,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with histogram value",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
@@ -229,7 +229,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -245,7 +245,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with float and histogram values",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
@@ -262,7 +262,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValVector.String(),
@@ -282,7 +282,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful vector response with malformed metric symbols",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Vector{
 				Vector: &mimirpb.VectorData{
@@ -292,17 +292,17 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expectedErr: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
+		expectedDecodingError: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
 	},
 	{
 		name: "successful matrix response with no series",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -313,17 +313,17 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with single series with no labels and no samples",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
 					Series: []mimirpb.MatrixSeries{
-						{Metric: []string{}, Samples: []mimirpb.Sample{}},
+						{Metric: nil, Samples: nil},
 					},
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -336,17 +336,17 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with single series with one label and no samples",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
 					Series: []mimirpb.MatrixSeries{
-						{Metric: []string{"foo", "bar"}, Samples: []mimirpb.Sample{}},
+						{Metric: []string{"foo", "bar"}, Samples: nil},
 					},
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -359,17 +359,17 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with single series with many labels and no samples",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
 					Series: []mimirpb.MatrixSeries{
-						{Metric: []string{"foo", "bar", "baz", "blah"}, Samples: []mimirpb.Sample{}},
+						{Metric: []string{"foo", "bar", "baz", "blah"}, Samples: nil},
 					},
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -387,7 +387,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with single series with one sample",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
@@ -402,7 +402,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -423,7 +423,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with single series with many samples",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
@@ -439,7 +439,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -461,7 +461,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with multiple series",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
@@ -472,7 +472,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -492,7 +492,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with histogram value",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
@@ -505,7 +505,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -521,7 +521,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with float and histogram values",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
@@ -535,7 +535,7 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -552,7 +552,7 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "successful matrix response with malformed metric symbols",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{
@@ -562,17 +562,17 @@ var protobufCodecScenarios = []struct {
 				},
 			},
 		},
-		expectedErr: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
+		expectedDecodingError: apierror.New(apierror.TypeInternal, "error decoding response: metric is malformed: expected even number of symbols, but got 1"),
 	},
 	{
 		name: "successful empty matrix response",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status: mimirpb.QueryResponse_SUCCESS,
 			Data: &mimirpb.QueryResponse_Matrix{
 				Matrix: &mimirpb.MatrixData{},
 			},
 		},
-		expected: &PrometheusResponse{
+		response: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
 				ResultType: model.ValMatrix.String(),
@@ -583,12 +583,18 @@ var protobufCodecScenarios = []struct {
 	},
 	{
 		name: "error response",
-		resp: mimirpb.QueryResponse{
+		payload: mimirpb.QueryResponse{
 			Status:    mimirpb.QueryResponse_ERROR,
 			ErrorType: mimirpb.QueryResponse_UNAVAILABLE,
 			Error:     "failed",
 		},
-		expectedErr: apierror.New(apierror.TypeUnavailable, "failed"),
+		response: &PrometheusResponse{
+			Status:    statusError,
+			ErrorType: string(apierror.TypeUnavailable),
+			Error:     "failed",
+			Headers:   expectedProtobufResponseHeaders,
+		},
+		expectedDecodingError: apierror.New(apierror.TypeUnavailable, "failed"),
 	},
 }
 
@@ -600,7 +606,7 @@ func TestProtobufFormat_DecodeResponse(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			codec := NewPrometheusCodec(reg, formatProtobuf)
 
-			body, err := tc.resp.Marshal()
+			body, err := tc.payload.Marshal()
 			require.NoError(t, err)
 			httpResponse := &http.Response{
 				StatusCode:    200,
@@ -609,13 +615,13 @@ func TestProtobufFormat_DecodeResponse(t *testing.T) {
 				ContentLength: int64(len(body)),
 			}
 			decoded, err := codec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
-			if err != nil || tc.expectedErr != nil {
-				require.Equal(t, tc.expectedErr, err)
+			if err != nil || tc.expectedDecodingError != nil {
+				require.Equal(t, tc.expectedDecodingError, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, decoded)
+			require.Equal(t, tc.response, decoded)
 
 			metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
 			require.NoError(t, err)
@@ -631,13 +637,58 @@ func TestProtobufFormat_DecodeResponse(t *testing.T) {
 	}
 }
 
+func TestProtobufFormat_EncodeResponse(t *testing.T) {
+	for _, tc := range protobufCodecScenarios {
+		if tc.response == nil {
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			codec := NewPrometheusCodec(reg, formatProtobuf)
+
+			expectedBodyBytes, err := tc.payload.Marshal()
+			require.NoError(t, err)
+
+			httpRequest := &http.Request{
+				Header: http.Header{"Accept": []string{mimirpb.QueryResponseMimeType}},
+			}
+
+			httpResponse, err := codec.EncodeResponse(context.Background(), httpRequest, tc.response)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+			require.Equal(t, mimirpb.QueryResponseMimeType, httpResponse.Header.Get("Content-Type"))
+
+			actualBodyBytes, err := io.ReadAll(httpResponse.Body)
+			require.NoError(t, err)
+
+			actualBody := mimirpb.QueryResponse{}
+			err = actualBody.Unmarshal(actualBodyBytes)
+			require.NoError(t, err)
+			require.Equal(t, tc.payload, actualBody)
+			require.Len(t, actualBodyBytes, len(expectedBodyBytes))
+
+			metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
+			require.NoError(t, err)
+			durationHistogram, err := findHistogramMatchingLabels(metrics, "cortex_frontend_query_response_codec_duration_seconds", "format", "protobuf", "operation", "encode")
+			require.NoError(t, err)
+			require.Equal(t, uint64(1), *durationHistogram.SampleCount)
+			require.Less(t, *durationHistogram.SampleSum, 0.1)
+			payloadSizeHistogram, err := findHistogramMatchingLabels(metrics, "cortex_frontend_query_response_codec_payload_bytes", "format", "protobuf", "operation", "encode")
+			require.NoError(t, err)
+			require.Equal(t, uint64(1), *payloadSizeHistogram.SampleCount)
+			require.Equal(t, float64(len(expectedBodyBytes)), *payloadSizeHistogram.SampleSum)
+		})
+	}
+}
+
 func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
 	headers := http.Header{"Content-Type": []string{mimirpb.QueryResponseMimeType}}
 	reg := prometheus.NewPedanticRegistry()
 	codec := NewPrometheusCodec(reg, formatProtobuf)
 
 	for _, tc := range protobufCodecScenarios {
-		body, err := tc.resp.Marshal()
+		body, err := tc.payload.Marshal()
 		require.NoError(b, err)
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -649,8 +700,8 @@ func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
 				}
 
 				_, err = codec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
-				if err != nil || tc.expectedErr != nil {
-					require.Equal(b, tc.expectedErr, err)
+				if err != nil || tc.expectedDecodingError != nil {
+					require.Equal(b, tc.expectedDecodingError, err)
 				}
 			}
 		})

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -128,6 +128,73 @@ func TestPrometheusCodec_EncodeRequest_AcceptHeader(t *testing.T) {
 	}
 }
 
+func TestPrometheusCodec_EncodeResponse_ContentNegotiation(t *testing.T) {
+	testResponse := &PrometheusResponse{
+		Status:    statusError,
+		ErrorType: string(v1.ErrExec),
+		Error:     "something went wrong",
+	}
+
+	jsonBody, err := jsonFormat{}.EncodeResponse(testResponse)
+	require.NoError(t, err)
+
+	protobufBody, err := protobufFormat{}.EncodeResponse(testResponse)
+	require.NoError(t, err)
+
+	scenarios := map[string]struct {
+		acceptHeader                string
+		expectedResponseContentType string
+		expectedResponseBody        []byte
+		expectedError               error
+	}{
+		"no content type in Accept header": {
+			acceptHeader:                "",
+			expectedResponseContentType: jsonMimeType,
+			expectedResponseBody:        jsonBody,
+		},
+		"unsupported content type in Accept header": {
+			acceptHeader:  "testing/not-a-supported-content-type",
+			expectedError: apierror.New(apierror.TypeNotAcceptable, "none of the content types in the Accept header are supported"),
+		},
+		"multiple unsupported content types in Accept header": {
+			acceptHeader:  "testing/not-a-supported-content-type,testing/also-not-a-supported-content-type",
+			expectedError: apierror.New(apierror.TypeNotAcceptable, "none of the content types in the Accept header are supported"),
+		},
+		"single supported content type in Accept header": {
+			acceptHeader:                "application/json",
+			expectedResponseContentType: jsonMimeType,
+			expectedResponseBody:        jsonBody,
+		},
+		"multiple supported content types in Accept header": {
+			acceptHeader:                "application/vnd.mimir.queryresponse+protobuf,application/json",
+			expectedResponseContentType: mimirpb.QueryResponseMimeType,
+			expectedResponseBody:        protobufBody,
+		},
+	}
+
+	codec := newTestPrometheusCodec()
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/something", nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept", scenario.acceptHeader)
+
+			encodedResponse, err := codec.EncodeResponse(context.Background(), req, testResponse)
+			require.Equal(t, scenario.expectedError, err)
+
+			if scenario.expectedError == nil {
+				actualResponseContentType := encodedResponse.Header.Get("Content-Type")
+				require.Equal(t, scenario.expectedResponseContentType, actualResponseContentType)
+
+				actualResponseBody, err := io.ReadAll(encodedResponse.Body)
+				require.NoError(t, err)
+				require.Equal(t, scenario.expectedResponseBody, actualResponseBody)
+			}
+		})
+	}
+}
+
 type prometheusAPIResponse struct {
 	Status    string       `json:"status"`
 	Data      interface{}  `json:"data,omitempty"`
@@ -654,6 +721,8 @@ func BenchmarkPrometheusCodec_EncodeResponse(b *testing.B) {
 	)
 
 	codec := newTestPrometheusCodec()
+	req, err := http.NewRequest(http.MethodGet, "/something", nil)
+	require.NoError(b, err)
 
 	// Generate a mocked response and marshal it.
 	res := mockPrometheusResponse(numSeries, numSamplesPerSeries)
@@ -662,7 +731,7 @@ func BenchmarkPrometheusCodec_EncodeResponse(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		_, err := codec.EncodeResponse(context.Background(), res)
+		_, err := codec.EncodeResponse(context.Background(), req, res)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -165,6 +165,16 @@ func TestPrometheusCodec_EncodeResponse_ContentNegotiation(t *testing.T) {
 			expectedResponseContentType: jsonMimeType,
 			expectedResponseBody:        jsonBody,
 		},
+		"wildcard subtype in Accept header": {
+			acceptHeader:                "application/*",
+			expectedResponseContentType: jsonMimeType,
+			expectedResponseBody:        jsonBody,
+		},
+		"wildcard in Accept header": {
+			acceptHeader:                "*/*",
+			expectedResponseContentType: jsonMimeType,
+			expectedResponseBody:        jsonBody,
+		},
 		"multiple supported content types in Accept header": {
 			acceptHeader:                "application/vnd.mimir.queryresponse+protobuf,application/json",
 			expectedResponseContentType: mimirpb.QueryResponseMimeType,

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -135,10 +135,10 @@ func TestPrometheusCodec_EncodeResponse_ContentNegotiation(t *testing.T) {
 		Error:     "something went wrong",
 	}
 
-	jsonBody, err := jsonFormat{}.EncodeResponse(testResponse)
+	jsonBody, err := jsonFormatter{}.EncodeResponse(testResponse)
 	require.NoError(t, err)
 
-	protobufBody, err := protobufFormat{}.EncodeResponse(testResponse)
+	protobufBody, err := protobufFormatter{}.EncodeResponse(testResponse)
 	require.NoError(t, err)
 
 	scenarios := map[string]struct {

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -266,7 +266,7 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 		return nil, err
 	}
 
-	return rt.codec.EncodeResponse(ctx, response)
+	return rt.codec.EncodeResponse(ctx, r, response)
 }
 
 // roundTripperHandler is an adapter that implements the Handler interface using a http.RoundTripper to perform

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -139,7 +139,7 @@ func TestInstantTripperware(t *testing.T) {
 			return nil, err
 		}
 
-		return codec.EncodeResponse(r.Context(), &PrometheusResponse{
+		return codec.EncodeResponse(r.Context(), r, &PrometheusResponse{
 			Status: "success",
 			Data: &PrometheusData{
 				ResultType: "vector",

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1361,17 +1361,6 @@ func mockProtobufResponseWithSamplesAndHistograms(labels []mimirpb.LabelAdapter,
 	}
 }
 
-func stringArrayFromLabels(labels []mimirpb.LabelAdapter) []string {
-	s := make([]string, len(labels)*2)
-
-	for i, l := range labels {
-		s[2*i] = l.Name
-		s[2*i+1] = l.Value
-	}
-
-	return s
-}
-
 func protobufEncodePrometheusResponse(t *testing.T, res *mimirpb.QueryResponse) []byte {
 	encoded, err := res.Marshal()
 	require.NoError(t, err)
@@ -1438,7 +1427,7 @@ func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	return q.codec.EncodeResponse(r.Context(), response)
+	return q.codec.EncodeResponse(r.Context(), r, response)
 }
 
 const seconds = 1e3 // 1e3 milliseconds per second.

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -314,7 +314,7 @@ func writeError(w http.ResponseWriter, err error) {
 		}
 	}
 
-	// if the error error is an APIError, ensure it gets written as a JSON response
+	// if the error is an APIError, ensure it gets written as a JSON response
 	if resp, ok := apierror.HTTPResponseFromError(err); ok {
 		_ = server.WriteResponse(w, resp)
 		return

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -634,7 +634,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		if err != nil {
 			return nil, err
 		}
-		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Querier.EngineConfig.Timeout, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
+		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Querier.EngineConfig.Timeout, t.Cfg.Ruler.QueryFrontend.QueryResultResponseFormat, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
 
 		embeddedQueryable = prom_remote.NewSampleAndChunkQueryableClient(
 			remoteQuerier,

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -127,6 +127,7 @@ func NewRemoteQuerier(
 	middlewares ...Middleware,
 ) *RemoteQuerier {
 	json := jsonDecoder{}
+	protobuf := protobufDecoder{}
 
 	return &RemoteQuerier{
 		client:                             client,
@@ -136,7 +137,8 @@ func NewRemoteQuerier(
 		logger:                             logger,
 		preferredQueryResultResponseFormat: preferredQueryResultResponseFormat,
 		decoders: map[string]decoder{
-			json.ContentType(): json,
+			json.ContentType():     json,
+			protobuf.ContentType(): protobuf,
 		},
 	}
 }

--- a/pkg/ruler/remotequerier_decoder.go
+++ b/pkg/ruler/remotequerier_decoder.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ruler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+)
+
+type decoder interface {
+	ContentType() string
+	Decode(body []byte) (promql.Vector, error)
+}
+
+type jsonDecoder struct{}
+
+func (jsonDecoder) ContentType() string {
+	return "application/json"
+}
+
+func (d jsonDecoder) Decode(body []byte) (promql.Vector, error) {
+	var apiResp struct {
+		Status    string          `json:"status"`
+		Data      json.RawMessage `json:"data"`
+		ErrorType string          `json:"errorType"`
+		Error     string          `json:"error"`
+	}
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&apiResp); err != nil {
+		return promql.Vector{}, err
+	}
+	if apiResp.Status == statusError {
+		return promql.Vector{}, fmt.Errorf("query response error: %s", apiResp.Error)
+	}
+	v := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	if err := json.Unmarshal(apiResp.Data, &v); err != nil {
+		return promql.Vector{}, err
+	}
+	return d.decodeQueryResponse(v.Type, v.Result)
+}
+
+func (d jsonDecoder) decodeQueryResponse(valTyp model.ValueType, result json.RawMessage) (promql.Vector, error) {
+	switch valTyp {
+	case model.ValScalar:
+		var sv model.Scalar
+		if err := json.Unmarshal(result, &sv); err != nil {
+			return nil, err
+		}
+		return d.scalarToPromQLVector(&sv), nil
+
+	case model.ValVector:
+		var vv model.Vector
+		if err := json.Unmarshal(result, &vv); err != nil {
+			return nil, err
+		}
+		return d.vectorToPromQLVector(vv), nil
+
+	default:
+		return nil, fmt.Errorf("rule result is not a vector or scalar: %q", valTyp)
+	}
+}
+
+func (jsonDecoder) vectorToPromQLVector(vec model.Vector) promql.Vector {
+	retVal := make(promql.Vector, 0, len(vec))
+	for _, p := range vec {
+
+		lbl := make(labels.Labels, 0, len(p.Metric))
+		for ln, lv := range p.Metric {
+			lbl = append(lbl, labels.Label{
+				Name:  string(ln),
+				Value: string(lv),
+			})
+		}
+
+		retVal = append(retVal, promql.Sample{
+			Metric: lbl,
+			Point: promql.Point{
+				V: float64(p.Value),
+				T: int64(p.Timestamp),
+			},
+		})
+	}
+	return retVal
+}
+
+func (jsonDecoder) scalarToPromQLVector(sc *model.Scalar) promql.Vector {
+	return promql.Vector{promql.Sample{
+		Point: promql.Point{
+			V: float64(sc.Value),
+			T: int64(sc.Timestamp),
+		},
+		Metric: labels.Labels{},
+	}}
+}

--- a/pkg/ruler/remotequerier_decoder.go
+++ b/pkg/ruler/remotequerier_decoder.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 type decoder interface {
@@ -34,7 +36,7 @@ func (d jsonDecoder) Decode(body []byte) (promql.Vector, error) {
 		return promql.Vector{}, err
 	}
 	if apiResp.Status == statusError {
-		return promql.Vector{}, fmt.Errorf("query response error: %s", apiResp.Error)
+		return promql.Vector{}, fmt.Errorf("query execution failed with error: %s", apiResp.Error)
 	}
 	v := struct {
 		Type   model.ValueType `json:"resultType"`
@@ -99,4 +101,107 @@ func (jsonDecoder) scalarToPromQLVector(sc *model.Scalar) promql.Vector {
 		},
 		Metric: labels.Labels{},
 	}}
+}
+
+type protobufDecoder struct{}
+
+func (protobufDecoder) ContentType() string {
+	return mimirpb.QueryResponseMimeType
+}
+
+func (d protobufDecoder) Decode(body []byte) (promql.Vector, error) {
+	resp := mimirpb.QueryResponse{}
+	if err := resp.Unmarshal(body); err != nil {
+		return promql.Vector{}, err
+	}
+
+	if resp.Status == mimirpb.QueryResponse_ERROR {
+		return promql.Vector{}, fmt.Errorf("query execution failed with error: %s", resp.Error)
+	}
+
+	switch data := resp.Data.(type) {
+	case *mimirpb.QueryResponse_Scalar:
+		return d.decodeScalar(data.Scalar), nil
+	case *mimirpb.QueryResponse_Vector:
+		return d.decodeVector(data.Vector)
+	default:
+		return promql.Vector{}, fmt.Errorf("rule result is not a vector or scalar: \"%s\"", d.dataTypeToHumanFriendlyName(resp))
+	}
+}
+
+func (d protobufDecoder) decodeScalar(s *mimirpb.ScalarData) promql.Vector {
+	return promql.Vector{promql.Sample{
+		Point: promql.Point{
+			V: s.Value,
+			T: s.TimestampMs,
+		},
+		Metric: labels.Labels{},
+	}}
+}
+
+func (d protobufDecoder) decodeVector(v *mimirpb.VectorData) (promql.Vector, error) {
+	floatSampleCount := len(v.Samples)
+	samples := make(promql.Vector, floatSampleCount+len(v.Histograms))
+
+	for i, s := range v.Samples {
+		m, err := d.metricToLabels(s.Metric)
+		if err != nil {
+			return nil, err
+		}
+
+		samples[i] = promql.Sample{
+			Metric: m,
+			Point: promql.Point{
+				V: s.Value,
+				T: s.TimestampMs,
+			},
+		}
+	}
+
+	for i, s := range v.Histograms {
+		m, err := d.metricToLabels(s.Metric)
+		if err != nil {
+			return nil, err
+		}
+
+		samples[floatSampleCount+i] = promql.Sample{
+			Metric: m,
+			Point: promql.Point{
+				H: s.Histogram.ToPrometheusModel(),
+				T: s.TimestampMs,
+			},
+		}
+	}
+
+	return samples, nil
+}
+
+func (protobufDecoder) metricToLabels(metric []string) (labels.Labels, error) {
+	if len(metric)%2 != 0 {
+		return nil, fmt.Errorf("metric is malformed, it contains an odd number of symbols: %d", len(metric))
+	}
+
+	labelCount := len(metric) / 2
+	m := make([]labels.Label, labelCount)
+
+	for i := 0; i < labelCount; i++ {
+		m[i] = labels.Label{Name: metric[2*i], Value: metric[2*i+1]}
+	}
+
+	return m, nil
+}
+
+func (protobufDecoder) dataTypeToHumanFriendlyName(resp mimirpb.QueryResponse) string {
+	switch resp.Data.(type) {
+	case *mimirpb.QueryResponse_Scalar:
+		return "scalar"
+	case *mimirpb.QueryResponse_String_:
+		return "string"
+	case *mimirpb.QueryResponse_Vector:
+		return "vector"
+	case *mimirpb.QueryResponse_Matrix:
+		return "matrix"
+	default:
+		return fmt.Sprintf("%T", resp.Data)
+	}
 }

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -4,6 +4,7 @@ package ruler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,6 +15,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/status"
 	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
@@ -21,6 +23,8 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 type mockHTTPGRPCClient func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error)
@@ -115,8 +119,9 @@ func TestRemoteQuerier_QueryReq(t *testing.T) {
 
 func TestRemoteQuerier_QueryJSONDecoding(t *testing.T) {
 	scenarios := map[string]struct {
-		body     string
-		expected promql.Vector
+		body          string
+		expected      promql.Vector
+		expectedError error
 	}{
 		"vector response with no series": {
 			body: `{
@@ -185,6 +190,21 @@ func TestRemoteQuerier_QueryJSONDecoding(t *testing.T) {
 				},
 			},
 		},
+		"matrix response": {
+			body: `{
+					"status": "success",
+					"data": {"resultType":"matrix","result":[]}
+				}`,
+			expectedError: errors.New("rule result is not a vector or scalar: \"matrix\""),
+		},
+		"execution error": {
+			body: `{
+					"status": "error",
+					"errorType": "errorExec",
+					"error": "something went wrong"
+				}`,
+			expectedError: errors.New("query execution failed with error: something went wrong"),
+		},
 	}
 
 	for name, scenario := range scenarios {
@@ -202,8 +222,276 @@ func TestRemoteQuerier_QueryJSONDecoding(t *testing.T) {
 
 			tm := time.Unix(1649092025, 515834)
 			actual, err := q.Query(context.Background(), "qs", tm)
-			require.NoError(t, err)
-			require.Equal(t, scenario.expected, actual)
+			require.Equal(t, scenario.expectedError, err)
+
+			if scenario.expectedError == nil {
+				require.Equal(t, scenario.expected, actual)
+			}
+		})
+	}
+}
+
+func TestRemoteQuerier_QueryProtobufDecoding(t *testing.T) {
+	protobufHistogram := mimirpb.FloatHistogram{
+		CounterResetHint: histogram.GaugeType,
+		Schema:           3,
+		ZeroThreshold:    1.23,
+		ZeroCount:        456,
+		Count:            9001,
+		Sum:              789.1,
+		PositiveSpans: []mimirpb.BucketSpan{
+			{Offset: 4, Length: 1},
+			{Offset: 3, Length: 2},
+		},
+		NegativeSpans: []mimirpb.BucketSpan{
+			{Offset: 7, Length: 3},
+			{Offset: 9, Length: 1},
+		},
+		PositiveBuckets: []float64{100, 200, 300},
+		NegativeBuckets: []float64{400, 500, 600, 700},
+	}
+
+	promqlHistogram := histogram.FloatHistogram{
+		CounterResetHint: histogram.GaugeType,
+		Schema:           3,
+		ZeroThreshold:    1.23,
+		ZeroCount:        456,
+		Count:            9001,
+		Sum:              789.1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 4, Length: 1},
+			{Offset: 3, Length: 2},
+		},
+		NegativeSpans: []histogram.Span{
+			{Offset: 7, Length: 3},
+			{Offset: 9, Length: 1},
+		},
+		PositiveBuckets: []float64{100, 200, 300},
+		NegativeBuckets: []float64{400, 500, 600, 700},
+	}
+
+	scenarios := map[string]struct {
+		body          mimirpb.QueryResponse
+		expected      promql.Vector
+		expectedError error
+	}{
+		"vector response with no series": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{},
+				},
+			},
+			expected: promql.Vector{},
+		},
+		"vector response with one series": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{
+						Samples: []mimirpb.VectorSample{
+							{
+								Metric:      []string{"foo", "bar"},
+								TimestampMs: 1649092025515,
+								Value:       1.23,
+							},
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					Point:  promql.Point{T: 1649092025515, V: 1.23},
+				},
+			},
+		},
+		"vector response with many series": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{
+						Samples: []mimirpb.VectorSample{
+							{
+								Metric:      []string{"foo", "bar"},
+								TimestampMs: 1649092025515,
+								Value:       1.23,
+							},
+							{
+								Metric:      []string{"bar", "baz"},
+								TimestampMs: 1649092025515,
+								Value:       4.56,
+							},
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					Point:  promql.Point{T: 1649092025515, V: 1.23},
+				},
+				{
+					Metric: labels.FromStrings("bar", "baz"),
+					Point:  promql.Point{T: 1649092025515, V: 4.56},
+				},
+			},
+		},
+		"vector response with many labels": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{
+						Samples: []mimirpb.VectorSample{
+							{
+								Metric:      []string{"bar", "baz", "foo", "blah"},
+								TimestampMs: 1649092025515,
+								Value:       1.23,
+							},
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("bar", "baz", "foo", "blah"),
+					Point:  promql.Point{T: 1649092025515, V: 1.23},
+				},
+			},
+		},
+		"vector response with histogram value": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{
+						Histograms: []mimirpb.VectorHistogram{
+							{
+								Metric:      []string{"foo", "baz"},
+								TimestampMs: 1649092025515,
+								Histogram:   protobufHistogram,
+							},
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "baz"),
+					Point:  promql.Point{T: 1649092025515, H: &promqlHistogram},
+				},
+			},
+		},
+		"vector response with float and histogram values": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{
+						Samples: []mimirpb.VectorSample{
+							{
+								Metric:      []string{"foo", "baz"},
+								TimestampMs: 1649092025515,
+								Value:       1.23,
+							},
+						},
+						Histograms: []mimirpb.VectorHistogram{
+							{
+								Metric:      []string{"foo", "bar"},
+								TimestampMs: 1649092025515,
+								Histogram:   protobufHistogram,
+							},
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "baz"),
+					Point:  promql.Point{T: 1649092025515, V: 1.23},
+				},
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					Point:  promql.Point{T: 1649092025515, H: &promqlHistogram},
+				},
+			},
+		},
+		"vector response with malformed metric": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Vector{
+					Vector: &mimirpb.VectorData{
+						Samples: []mimirpb.VectorSample{
+							{
+								Metric:      []string{"foo", "bar", "baz"},
+								TimestampMs: 1649092025515,
+								Value:       1.23,
+							},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("metric is malformed, it contains an odd number of symbols: 3"),
+		},
+		"scalar response": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Scalar{
+					Scalar: &mimirpb.ScalarData{
+						TimestampMs: 1649092025515,
+						Value:       1.23,
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.EmptyLabels(),
+					Point:  promql.Point{T: 1649092025515, V: 1.23},
+				},
+			},
+		},
+		"matrix response": {
+			body: mimirpb.QueryResponse{
+				Status: mimirpb.QueryResponse_SUCCESS,
+				Data: &mimirpb.QueryResponse_Matrix{
+					Matrix: &mimirpb.MatrixData{},
+				},
+			},
+			expectedError: errors.New("rule result is not a vector or scalar: \"matrix\""),
+		},
+		"execution error": {
+			body: mimirpb.QueryResponse{
+				Status:    mimirpb.QueryResponse_ERROR,
+				ErrorType: mimirpb.QueryResponse_EXECUTION,
+				Error:     "something went wrong",
+			},
+			expectedError: errors.New("query execution failed with error: something went wrong"),
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+				b, err := scenario.body.Marshal()
+				if err != nil {
+					return nil, err
+				}
+
+				return &httpgrpc.HTTPResponse{
+					Code: http.StatusOK,
+					Headers: []*httpgrpc.Header{
+						{Key: "Content-Type", Values: []string{mimirpb.QueryResponseMimeType}},
+					},
+					Body: b,
+				}, nil
+			}
+			q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, formatProtobuf, "/prometheus", log.NewNopLogger())
+
+			tm := time.Unix(1649092025, 515834)
+			actual, err := q.Query(context.Background(), "qs", tm)
+			require.Equal(t, scenario.expectedError, err)
+
+			if scenario.expectedError == nil {
+				require.Equal(t, scenario.expected, actual)
+			}
 		})
 	}
 }

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -125,6 +125,11 @@ func (cfg *Config) Validate(limits validation.Limits, log log.Logger) error {
 	if err := cfg.ClientTLSConfig.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid ruler gRPC client config")
 	}
+
+	if err := cfg.QueryFrontend.Validate(); err != nil {
+		return errors.Wrap(err, "invalid ruler query-frontend config")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does

This PR adds support for decoding the new internal query result payload format in the ruler, and encoding it in the query-frontend to send to rulers.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/4104

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
