### PR TITLE
[CHANGE] Make use stable policy/v1 in distributed helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [CHANGE] Move auto-scaling panel rows down beneath logical network path in Reads and Writes dashboards. #4049
 * [CHANGE] Make distributor auto-scaling metric panels show desired number of replicas. #4218
 * [CHANGE] Alerts: The alert `MimirMemcachedRequestErrors` has been renamed to `MimirCacheRequestErrors`. #4242
+* [CHANGE] Make use stable `policy/v1` in distributed helm chart. #4337
 * [ENHANCEMENT] Alerts: Added `MimirAutoscalerKedaFailing` alert firing when a KEDA scaler is failing. #4045
 * [ENHANCEMENT] Add auto-scaling panels to ruler dashboard. #4046
 * [ENHANCEMENT] Add gateway auto-scaling panels to Reads and Writes dashboards. #4049 #4216

--- a/operations/helm/charts/mimir-distributed/scripts/create-pdb
+++ b/operations/helm/charts/mimir-distributed/scripts/create-pdb
@@ -73,7 +73,7 @@ fi
 
 cat <<EOF
 {{- if .Values.${snake_cased}.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "${component}") }}

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -371,7 +371,7 @@ Cluster name that shows up in dashboard metrics
   {{- if semverCompare ">= 1.21-0" (include "mimir.kubeVersion" .) -}}
     {{- print "policy/v1" -}}
   {{- else -}}
-    {{- print "policy/v1beta1" -}}
+    {{- print "policy/v1" -}}
   {{- end -}}
 {{- end -}}
 

--- a/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "mimir.rbac.usePodSecurityPolicy" .) "true" }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" .) }}


### PR DESCRIPTION
Use stable `policy/v1` rather than deprecated v1beta1 when deploying distributed deployment mode via helm

#### What this PR does
Fixes the use of the removed `policy/v1beta1` in kubernetes 1.25

Fixes #4336

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
