### PR TITLE
Use a background context for all cache writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [BUGFIX] Ingester: compact out-of-order data during `/ingester/flush` or when TSDB is idle. #4180
 * [BUGFIX] Ingester: conversion of global limits `max-series-per-user`, `max-series-per-metric`, `max-metadata-per-user` and `max-metadata-per-metric` into corresponding local limits now takes into account the number of ingesters in each zone. #4238
 * [BUGFIX] Ingester: track `cortex_ingester_memory_series` metric consistently with `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total`. #4312
+* [BUGFIX] Cache: Use background context for cache writes to ensure they succeed even when still running after the originating request has completed. #4342
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -96,7 +96,7 @@ func (c *cardinalityEstimation) Do(ctx context.Context, request Request) (Respon
 	spanLog.LogFields(otlog.Uint64("actual cardinality", actualCardinality))
 
 	if !estimateAvailable || !isCardinalitySimilar(actualCardinality, estimatedCardinality) {
-		c.storeCardinalityForKey(ctx, k, actualCardinality)
+		c.storeCardinalityForKey(k, actualCardinality)
 		spanLog.LogFields(otlog.Bool("cache updated", true))
 	}
 
@@ -131,7 +131,7 @@ func (c *cardinalityEstimation) lookupCardinalityForKey(ctx context.Context, key
 
 // storeCardinalityForKey stores a cardinality estimate for the given key in the
 // results cache.
-func (c *cardinalityEstimation) storeCardinalityForKey(ctx context.Context, key string, count uint64) {
+func (c *cardinalityEstimation) storeCardinalityForKey(key string, count uint64) {
 	if c.cache == nil {
 		return
 	}
@@ -143,7 +143,7 @@ func (c *cardinalityEstimation) storeCardinalityForKey(ctx context.Context, key 
 	}
 	// The store is executed asynchronously, potential errors are logged and not
 	// propagated back up the stack.
-	c.cache.Store(ctx, map[string][]byte{key: marshaled}, cardinalityEstimateTTL)
+	c.cache.Store(context.Background(), map[string][]byte{key: marshaled}, cardinalityEstimateTTL)
 }
 
 func isCardinalitySimilar(actualCardinality, estimatedCardinality uint64) bool {

--- a/pkg/frontend/querymiddleware/cardinality_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_test.go
@@ -113,7 +113,7 @@ func Test_cardinalityEstimation_lookupCardinalityForKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ce := cardinalityEstimation{cache: tt.cache}
-			ce.storeCardinalityForKey(ctx, actualKey, actualValue)
+			ce.storeCardinalityForKey(actualKey, actualValue)
 			estimate, ok := ce.lookupCardinalityForKey(ctx, tt.key)
 			if tt.cache != nil {
 				expectedFetchCount++

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -281,7 +281,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 			}
 
 			// Put back into the cache the filtered ones.
-			s.storeCacheExtents(ctx, splitReq.cacheKey, tenantIDs, filteredExtents)
+			s.storeCacheExtents(splitReq.cacheKey, tenantIDs, filteredExtents)
 		}
 	}
 
@@ -381,7 +381,7 @@ func (s *splitAndCacheMiddleware) fetchCacheExtents(ctx context.Context, keys []
 }
 
 // storeCacheExtents stores the extents for given key in the cache.
-func (s *splitAndCacheMiddleware) storeCacheExtents(ctx context.Context, key string, tenantIDs []string, extents []Extent) {
+func (s *splitAndCacheMiddleware) storeCacheExtents(key string, tenantIDs []string, extents []Extent) {
 	ttl := resultsCacheTTL
 	lowerTTLWithinTimePeriod := validation.MaxDurationPerTenant(tenantIDs, func(tenantID string) time.Duration {
 		return time.Duration(s.limits.OutOfOrderTimeWindow(tenantID))
@@ -400,7 +400,7 @@ func (s *splitAndCacheMiddleware) storeCacheExtents(ctx context.Context, key str
 		return
 	}
 
-	s.cache.Store(ctx, map[string][]byte{cacheHashKey(key): buf}, ttl)
+	s.cache.Store(context.Background(), map[string][]byte{cacheHashKey(key): buf}, ttl)
 }
 
 // splitRequest holds information about a split request.

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -940,7 +940,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 
 			// Store all extents fixtures in the cache.
 			cacheKey := cacheSplitter.GenerateCacheKey(ctx, userID, testData.req)
-			mw.storeCacheExtents(ctx, cacheKey, []string{userID}, testData.cachedExtents)
+			mw.storeCacheExtents(cacheKey, []string{userID}, testData.cachedExtents)
 
 			// Run the request.
 			actualRes, err := mw.Do(ctx, testData.req)
@@ -990,8 +990,8 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 	})
 
 	t.Run("fetchCacheExtents() should return a slice with the same number of input keys and some extends filled up on partial cache hit", func(t *testing.T) {
-		mw.storeCacheExtents(ctx, "key-1", nil, []Extent{mkExtent(10, 20)})
-		mw.storeCacheExtents(ctx, "key-3", nil, []Extent{mkExtent(20, 30), mkExtent(40, 50)})
+		mw.storeCacheExtents("key-1", nil, []Extent{mkExtent(10, 20)})
+		mw.storeCacheExtents("key-3", nil, []Extent{mkExtent(20, 30), mkExtent(40, 50)})
 
 		actual := mw.fetchCacheExtents(ctx, []string{"key-1", "key-2", "key-3"})
 		expected := [][]Extent{{mkExtent(10, 20)}, nil, {mkExtent(20, 30), mkExtent(40, 50)}}
@@ -1004,7 +1004,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		require.NoError(t, err)
 		cacheBackend.Store(ctx, map[string][]byte{cacheHashKey("key-1"): buf}, 0)
 
-		mw.storeCacheExtents(ctx, "key-3", nil, []Extent{mkExtent(20, 30), mkExtent(40, 50)})
+		mw.storeCacheExtents("key-3", nil, []Extent{mkExtent(20, 30), mkExtent(40, 50)})
 
 		actual := mw.fetchCacheExtents(ctx, []string{"key-1", "key-2", "key-3"})
 		expected := [][]Extent{nil, nil, {mkExtent(20, 30), mkExtent(40, 50)}}
@@ -1588,11 +1588,10 @@ func TestSplitAndCacheMiddlewareLowerTTL(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	for i, c := range cases {
 		// Store.
 		key := fmt.Sprintf("k%d", i)
-		m.storeCacheExtents(ctx, key, []string{"ten1"}, []Extent{
+		m.storeCacheExtents(key, []string{"ten1"}, []Extent{
 			{Start: 0, End: c.endTime.UnixMilli()},
 		})
 

--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -210,7 +210,7 @@ func (cb *CachingBucket) Iter(ctx context.Context, dir string, f func(string) er
 	if err == nil && remainingTTL > 0 {
 		data, encErr := cfg.codec.Encode(list)
 		if encErr == nil {
-			cfg.cache.Store(ctx, map[string][]byte{key: data}, remainingTTL)
+			cfg.cache.Store(context.Background(), map[string][]byte{key: data}, remainingTTL)
 			return nil
 		}
 		level.Warn(cb.logger).Log("msg", "failed to encode Iter result", "key", key, "err", encErr)
@@ -256,7 +256,7 @@ func storeExistsCacheEntry(ctx context.Context, cachingKey string, exists bool, 
 	}
 
 	if ttl > 0 {
-		cache.Store(ctx, map[string][]byte{cachingKey: []byte(strconv.FormatBool(exists))}, ttl)
+		cache.Store(context.Background(), map[string][]byte{cachingKey: []byte(strconv.FormatBool(exists))}, ttl)
 	}
 }
 
@@ -315,7 +315,6 @@ func (cb *CachingBucket) Get(ctx context.Context, name string) (io.ReadCloser, e
 	storeExistsCacheEntry(ctx, existsKey, true, getTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
 	return &getReader{
 		c:         cfg.cache,
-		ctx:       ctx,
 		r:         reader,
 		buf:       new(bytes.Buffer),
 		startTime: getTime,
@@ -374,7 +373,7 @@ func (cb *CachingBucket) cachedAttributes(ctx context.Context, name, cfgName str
 	}
 
 	if raw, err := json.Marshal(attrs); err == nil {
-		cache.Store(ctx, map[string][]byte{key: raw}, ttl)
+		cache.Store(context.Background(), map[string][]byte{key: raw}, ttl)
 	} else {
 		level.Warn(cb.logger).Log("msg", "failed to encode cached Attributes result", "key", key, "err", err)
 	}
@@ -532,7 +531,7 @@ func (cb *CachingBucket) fetchMissingSubranges(ctx context.Context, name string,
 
 				if storeToCache {
 					cb.fetchedGetRangeBytes.WithLabelValues(originBucket, cfgName).Add(float64(len(subrangeData)))
-					cfg.cache.Store(gctx, map[string][]byte{key: subrangeData}, cfg.subrangeTTL)
+					cfg.cache.Store(context.Background(), map[string][]byte{key: subrangeData}, cfg.subrangeTTL)
 				} else {
 					cb.refetchedGetRangeBytes.WithLabelValues(originCache, cfgName).Add(float64(len(subrangeData)))
 				}
@@ -664,7 +663,6 @@ func (c *subrangesReader) subrangeAt(offset int64) ([]byte, error) {
 
 type getReader struct {
 	c         cache.Cache
-	ctx       context.Context
 	r         io.ReadCloser
 	buf       *bytes.Buffer
 	startTime time.Time
@@ -693,7 +691,7 @@ func (g *getReader) Read(p []byte) (n int, err error) {
 	if errors.Is(err, io.EOF) && g.buf != nil {
 		remainingTTL := g.ttl - time.Since(g.startTime)
 		if remainingTTL > 0 {
-			g.c.Store(g.ctx, map[string][]byte{g.cacheKey: g.buf.Bytes()}, remainingTTL)
+			g.c.Store(context.Background(), map[string][]byte{g.cacheKey: g.buf.Bytes()}, remainingTTL)
 		}
 		// Clear reference, to avoid doing another Store on next read.
 		g.buf = nil

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -782,7 +782,7 @@ func storeCachedSeries(ctx context.Context, indexCache indexcache.IndexCache, us
 		level.Error(spanlogger.FromContext(ctx, logger)).Log("msg", "can't encode series for caching", "err", err)
 		return
 	}
-	indexCache.StoreSeries(ctx, userID, blockID, entry.MatchersKey, shard, data)
+	indexCache.StoreSeries(context.Background(), userID, blockID, entry.MatchersKey, shard, data)
 }
 
 // Series implements the storepb.StoreServer interface.
@@ -1431,7 +1431,7 @@ func storeCachedLabelNames(ctx context.Context, indexCache indexcache.IndexCache
 		level.Error(spanlogger.FromContext(ctx, logger)).Log("msg", "can't encode label names for caching", "err", err)
 		return
 	}
-	indexCache.StoreLabelNames(ctx, userID, blockID, entry.MatchersKey, data)
+	indexCache.StoreLabelNames(context.Background(), userID, blockID, entry.MatchersKey, data)
 }
 
 // LabelValues implements the storepb.StoreServer interface.
@@ -1615,7 +1615,7 @@ func storeCachedLabelValues(ctx context.Context, indexCache indexcache.IndexCach
 		level.Error(spanlogger.FromContext(ctx, logger)).Log("msg", "can't encode label values for caching", "err", err)
 		return
 	}
-	indexCache.StoreLabelValues(ctx, userID, blockID, labelName, entry.MatchersKey, data)
+	indexCache.StoreLabelValues(context.Background(), userID, blockID, labelName, entry.MatchersKey, data)
 }
 
 // bucketBlockSet holds all blocks.

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -131,17 +131,17 @@ func (r *bucketIndexReader) expandedPostingsPromise(ctx context.Context, ms []*l
 	if err != nil {
 		return promise, false
 	}
-	r.cacheExpandedPostings(ctx, r.block.userID, key, refs)
+	r.cacheExpandedPostings(r.block.userID, key, refs)
 	return promise, false
 }
 
-func (r *bucketIndexReader) cacheExpandedPostings(ctx context.Context, userID string, key indexcache.LabelMatchersKey, refs []storage.SeriesRef) {
+func (r *bucketIndexReader) cacheExpandedPostings(userID string, key indexcache.LabelMatchersKey, refs []storage.SeriesRef) {
 	data, err := diffVarintSnappyEncode(index.NewListPostings(refs), len(refs))
 	if err != nil {
 		level.Warn(r.block.logger).Log("msg", "can't encode expanded postings cache", "err", err, "matchers_key", key, "block", r.block.meta.ULID)
 		return
 	}
-	r.block.indexCache.StoreExpandedPostings(ctx, userID, r.block.meta.ULID, key, data)
+	r.block.indexCache.StoreExpandedPostings(context.Background(), userID, r.block.meta.ULID, key, data)
 }
 
 func (r *bucketIndexReader) fetchCachedExpandedPostings(ctx context.Context, userID string, key indexcache.LabelMatchersKey, stats *safeQueryStats) ([]storage.SeriesRef, bool) {
@@ -463,7 +463,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 				// is expected to handle a different set of keys.
 				output[p.keyID] = newBigEndianPostings(pBytes[4:])
 
-				r.block.indexCache.StorePostings(ctx, r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache)
+				r.block.indexCache.StorePostings(context.Background(), r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache)
 
 				// If we just fetched it we still have to update the stats for touched postings.
 				stats.update(func(stats *queryStats) {
@@ -575,7 +575,7 @@ func (r *bucketIndexReader) loadSeries(ctx context.Context, ids []storage.Series
 
 		loaded.addSeries(id, c)
 
-		r.block.indexCache.StoreSeriesForRef(ctx, r.block.userID, r.block.meta.ULID, id, c)
+		r.block.indexCache.StoreSeriesForRef(context.Background(), r.block.userID, r.block.meta.ULID, id, c)
 	}
 	return nil
 }

--- a/pkg/storegateway/chunkscache/cache.go
+++ b/pkg/storegateway/chunkscache/cache.go
@@ -137,10 +137,10 @@ const (
 	defaultTTL = 7 * 24 * time.Hour
 )
 
-func (c *ChunksCache) StoreChunks(ctx context.Context, userID string, ranges map[Range][]byte) {
+func (c *ChunksCache) StoreChunks(_ context.Context, userID string, ranges map[Range][]byte) {
 	rangesWithTenant := make(map[string][]byte, len(ranges))
 	for r, v := range ranges {
 		rangesWithTenant[chunksKey(userID, r)] = v
 	}
-	c.cache.Store(ctx, rangesWithTenant, defaultTTL)
+	c.cache.Store(context.Background(), rangesWithTenant, defaultTTL)
 }

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1077,7 +1077,7 @@ func storeCachedSeriesForPostings(ctx context.Context, indexCache indexcache.Ind
 		logSeriesForPostingsCacheEvent(ctx, logger, userID, blockID, shard, itemID, "msg", "can't encode series for caching", "err", err)
 		return
 	}
-	indexCache.StoreSeriesForPostings(ctx, userID, blockID, shard, itemID.postingsKey, data)
+	indexCache.StoreSeriesForPostings(context.Background(), userID, blockID, shard, itemID.postingsKey, data)
 }
 
 func encodeCachedSeriesForPostings(set seriesChunkRefsSet, diffEncodedPostings []byte) ([]byte, error) {


### PR DESCRIPTION
#### What this PR does

Use `context.Background()` for all cache writes because writes are done asynchronously for Memcached and Redis backends. This means they potentially keep running after a request has otherwise completed. If the use the request context, the writes to the cache will fail after the request is completed.

#### Which issue(s) this PR fixes or relates to

Fixes #4341

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
