### PR TITLE
Bump actions/setup-go to v3 to resolve Node.js 12 deprecation warning.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -196,7 +196,7 @@ jobs:
         test_group_total: [4]
     steps:
       - name: Upgrade golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20.1
       - name: Check out repository


### PR DESCRIPTION
#### What this PR does

Same as #4343: GitHub has deprecated the use of Node.js v12-based actions ([source](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)).

v2 of `actions/setup-go` uses Node.js v12, whereas v3 uses a supported version.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
