### PR TITLE
Remove block validation mimirtool changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,6 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 ### Mimirtool
 
-* [CHANGE] Blocks uploaded with the `mimirtool backfill` command are now by default verified by a compactor before the upload is finalized. #3411
 * [FEATURE] Added `keep_firing_for` support to rules configuration. #4099
 * [ENHANCEMENT] Add `-tls-insecure-skip-verify` to rules, alertmanager and backfill commands. #4162
 


### PR DESCRIPTION
#### What this PR does

In #3411 I included a changelog entry for Mimirtool, but since it was a change in Mimir it's not really necessary. I originally added it to prevent confusion, but I could see it adding more as well.

Context: https://github.com/grafana/mimir/pull/3411#discussion_r1124206479