### PR TITLE
`mimir-rules-action`: `set-output` is deprecated

### DIFF
--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -72,7 +72,6 @@ case "${ACTION}" in
     ;;
 esac
 
-
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="%0A" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
 echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -75,6 +75,8 @@ esac
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="%0A" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
 echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
-echo "summary=${SUMMARY}" >> $GITHUB_OUTPUT
+echo 'summary<<EOF' >> $GITHUB_OUTPUT
+echo "${SUMMARY}" >> $GITHUB_OUTPUT
+echo 'EOF' >> $GITHUB_OUTPUT
 
 exit $STATUS

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -75,8 +75,8 @@ esac
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="%0A" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
 echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
-echo 'summary<<EOF' >> $GITHUB_OUTPUT
+echo 'summary<<ENDOFSUMMARY' >> $GITHUB_OUTPUT
 echo "${SUMMARY}" >> $GITHUB_OUTPUT
-echo 'EOF' >> $GITHUB_OUTPUT
+echo 'ENDOFSUMMARY' >> $GITHUB_OUTPUT
 
 exit $STATUS

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -72,9 +72,10 @@ case "${ACTION}" in
     ;;
 esac
 
+
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="%0A" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
-echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
+echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
-echo ::set-output name=summary::"${SUMMARY}"
+echo "summary=${SUMMARY}" >> $GITHUB_OUTPUT
 
 exit $STATUS


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

`set-output` will stop working on June 1st and is currently warning

**This was tested on our internal workflow**
