### PR TITLE
Add query sharding settings for 24M and 32M plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 * [ENHANCEMENT] Add optional `weight` param to `newQuerierScaledObject` and `newRulerQuerierScaledObject` to allow running multiple querier deployments on different node types. #4141
 * [ENHANCEMENT] Add support for query-frontend and ruler-query-frontend auto-scaling. #4199
 * [BUGFIX] Shuffle sharding: when applying user class limits, honor the minimum shard size configured in `$._config.shuffle_sharding.*`. #4363
+* [BUGFIX] Add missing query sharding settings for user_24M and user_32M plans. #4374
 
 ### Mimirtool
 

--- a/operations/mimir/query-sharding.libsonnet
+++ b/operations/mimir/query-sharding.libsonnet
@@ -20,6 +20,16 @@
       mega_user+:: {
         query_sharding_total_shards: 8,
       },
+
+      // Target 24M active series.
+      user_24M+:: {
+        query_sharding_total_shards: 8,
+      },
+
+      // Target 32M active series.
+      user_32M+:: {
+        query_sharding_total_shards: 8,
+      },
     }
     else {},
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We set `query_sharding_total_shards: 8` for all plans `big_user` and larger, but we were missing settings for the new `user_24M` and `user_32M`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
