### PR TITLE
Ruler: change deployment max surge and max unavailable to reduce ownership spillover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 * [CHANGE] Create the `query-frontend-discovery` service only when Mimir is deployed in microservice mode without query-scheduler. #4353
 * [CHANGE] Add results cache backend config to `ruler-query-frontend` configuration to allow cache reuse for cardinality-estimation based sharding. #4257
+* [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4380
 * [ENHANCEMENT] Add support for ruler auto-scaling. #4046
 * [ENHANCEMENT] Add optional `weight` param to `newQuerierScaledObject` and `newRulerQuerierScaledObject` to allow running multiple querier deployments on different node types. #4141
 * [ENHANCEMENT] Add support for query-frontend and ruler-query-frontend auto-scaling. #4199

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 * [CHANGE] Create the `query-frontend-discovery` service only when Mimir is deployed in microservice mode without query-scheduler. #4353
 * [CHANGE] Add results cache backend config to `ruler-query-frontend` configuration to allow cache reuse for cardinality-estimation based sharding. #4257
-* [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4380
+* [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381
 * [ENHANCEMENT] Add support for ruler auto-scaling. #4046
 * [ENHANCEMENT] Add optional `weight` param to `newQuerierScaledObject` and `newRulerQuerierScaledObject` to allow running multiple querier deployments on different node types. #4141
 * [ENHANCEMENT] Add support for query-frontend and ruler-query-frontend auto-scaling. #4199

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4380
+* [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381
 * [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling starting with Kubernetes 1.23. #4285
 * [BUGFIX] Allow override of Kubernetes version for nginx HPA. #4299
 * [BUGFIX] Do not generate query-frontend-headless service if query scheduler is enabled. Fixes parity with jsonnet. #4353

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4380
 * [ENHANCEMENT] Support autoscaling/v2 HorizontalPodAutoscaler for nginx autoscaling starting with Kubernetes 1.23. #4285
 * [BUGFIX] Allow override of Kubernetes version for nginx HPA. #4299
 * [BUGFIX] Do not generate query-frontend-headless service if query scheduler is enabled. Fixes parity with jsonnet. #4353

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1015,8 +1015,8 @@ ruler:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
 
   terminationGracePeriodSeconds: 180
 

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -19,8 +19,8 @@ spec:
       release: test-enterprise-legacy-label-values
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -750,8 +750,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1042,8 +1042,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1240,8 +1240,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1269,8 +1269,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -676,8 +676,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -703,8 +703,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -760,8 +760,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -675,8 +675,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -677,8 +677,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -679,8 +679,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -677,8 +677,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1042,8 +1042,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1096,8 +1096,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1096,8 +1096,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1096,8 +1096,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1096,8 +1096,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -678,8 +678,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -675,8 +675,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -885,8 +885,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -953,8 +953,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1052,8 +1052,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -789,8 +789,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -702,8 +702,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -690,8 +690,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -680,8 +680,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -753,8 +753,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -753,8 +753,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -680,8 +680,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -680,8 +680,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -677,8 +677,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -675,8 +675,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -676,8 +676,8 @@ spec:
       name: ruler
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 50%
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -48,8 +48,8 @@
 
     deployment.new(name, 2, [$.ruler_container]) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('50%') +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +
     deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
     $.newMimirSpreadTopology(name, $._config.querier_topology_spread_max_skew) +
     $.mimirVolumeMounts,


### PR DESCRIPTION
#### What this PR does
In this PR I'm upstreaming a change we rolled out few weeks ago at Grafana Labs, in order to reduce the ownership spillover during the rulers rolling updates:

- Increase max surge from 0 to 50%
- Decrease max unavailable from 1 to 0

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
