### PR TITLE
add am pvc config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,13 +84,13 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 ### Jsonnet
 
-* [ENHANCEMENT] Alertmanager: add `alertmanager_data_disk_size` and  `alertmanager_data_disk_class` configuration options, with default `null` storage class. #4389
 * [CHANGE] Create the `query-frontend-discovery` service only when Mimir is deployed in microservice mode without query-scheduler. #4353
 * [CHANGE] Add results cache backend config to `ruler-query-frontend` configuration to allow cache reuse for cardinality-estimation based sharding. #4257
 * [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381
 * [ENHANCEMENT] Add support for ruler auto-scaling. #4046
 * [ENHANCEMENT] Add optional `weight` param to `newQuerierScaledObject` and `newRulerQuerierScaledObject` to allow running multiple querier deployments on different node types. #4141
 * [ENHANCEMENT] Add support for query-frontend and ruler-query-frontend auto-scaling. #4199
+* [ENHANCEMENT] Alertmanager: add `alertmanager_data_disk_size` and  `alertmanager_data_disk_class` configuration options, by default no storage class is set. #4389
 * [BUGFIX] Shuffle sharding: when applying user class limits, honor the minimum shard size configured in `$._config.shuffle_sharding.*`. #4363
 
 ### Mimirtool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 ### Jsonnet
 
+* [ENHANCEMENT] Alertmanager: add `alertmanager_data_disk_size` and  `alertmanager_data_disk_class` configuration option
 * [CHANGE] Create the `query-frontend-discovery` service only when Mimir is deployed in microservice mode without query-scheduler. #4353
 * [CHANGE] Add results cache backend config to `ruler-query-frontend` configuration to allow cache reuse for cardinality-estimation based sharding. #4257
 * [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
 
 ### Jsonnet
 
-* [ENHANCEMENT] Alertmanager: add `alertmanager_data_disk_size` and  `alertmanager_data_disk_class` configuration option
+* [ENHANCEMENT] Alertmanager: add `alertmanager_data_disk_size` and  `alertmanager_data_disk_class` configuration options, with default `null` storage class. #4389
 * [CHANGE] Create the `query-frontend-discovery` service only when Mimir is deployed in microservice mode without query-scheduler. #4353
 * [CHANGE] Add results cache backend config to `ruler-query-frontend` configuration to allow cache reuse for cardinality-estimation based sharding. #4257
 * [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -40,11 +40,12 @@
   alertmanager_pvc::
     if $._config.alertmanager_enabled then
       pvc.new() +
-      if $._config.alertmanager_data_disk_class != null then
-        pvc.mixin.spec.withStorageClassName($._config.alertmanager_data_disk_class) +
       pvc.mixin.metadata.withName('alertmanager-data') +
       pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
-      pvc.mixin.spec.resources.withRequests({ storage: $._config.alertmanager_data_disk_size })
+      pvc.mixin.spec.resources.withRequests({ storage: $._config.alertmanager_data_disk_size }) +
+      if $._config.alertmanager_data_disk_class != null then
+        pvc.mixin.spec.withStorageClassName($._config.alertmanager_data_disk_class)
+      else {}
     else {},
 
   alertmanager_ports:: $.util.defaultPorts,

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -40,7 +40,8 @@
   alertmanager_pvc::
     if $._config.alertmanager_enabled then
       pvc.new() +
-      pvc.mixin.spec.withStorageClassName($._config.alertmanager_data_disk_class) +
+      if $._config.alertmanager_data_disk_class != null then
+        pvc.mixin.spec.withStorageClassName($._config.alertmanager_data_disk_class) +
       pvc.mixin.metadata.withName('alertmanager-data') +
       pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
       pvc.mixin.spec.resources.withRequests({ storage: $._config.alertmanager_data_disk_size })

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -40,9 +40,10 @@
   alertmanager_pvc::
     if $._config.alertmanager_enabled then
       pvc.new() +
+      pvc.mixin.spec.withStorageClassName($._config.alertmanager_data_disk_class) +
       pvc.mixin.metadata.withName('alertmanager-data') +
       pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
-      pvc.mixin.spec.resources.withRequests({ storage: '100Gi' })
+      pvc.mixin.spec.resources.withRequests({ storage: $._config.alertmanager_data_disk_size })
     else {},
 
   alertmanager_ports:: $.util.defaultPorts,

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -76,7 +76,7 @@
 
     // Allow to configure the alertmanager disk.
     alertmanager_data_disk_size: '100Gi',
-    alertmanager_data_disk_class: 'fast',
+    alertmanager_data_disk_class: null,
 
     // Allow to configure the ingester disk.
     ingester_data_disk_size: '100Gi',

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -74,6 +74,10 @@
 
     jaeger_agent_host: null,
 
+    // Allow to configure the alertmanager disk.
+    alertmanager_data_disk_size: '100Gi',
+    alertmanager_data_disk_class: 'fast',
+
     // Allow to configure the ingester disk.
     ingester_data_disk_size: '100Gi',
     ingester_data_disk_class: 'fast',


### PR DESCRIPTION
#### What this PR does

This PR adds a `alertmanager_data_disk_size` and `alertmanager_data_disk_class` configuration option

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
