### PR TITLE
Proposal: allow subprojects to add per-tenant fields

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -321,7 +321,7 @@ func (l *Limits) validate() error {
 		}
 	}
 
-	if f := ExtentensionsValidation; f != nil {
+	if f := extensionsValidation; f != nil {
 		return f(l.Extensions)
 	}
 
@@ -349,7 +349,15 @@ func SetDefaultLimitsForYAMLUnmarshalling(defaults Limits) {
 }
 
 // Function to validate Extensions field of Limits.
-var ExtentensionsValidation func(extensions map[string]interface{}) error
+var extensionsValidation func(extensions map[string]interface{}) error
+
+func SetGlobalExtensionsValidation(fn func(extensions map[string]interface{}) error) {
+	if extensionsValidation != nil {
+		panic("extensions validation function already set")
+	}
+
+	extensionsValidation = fn
+}
 
 // TenantLimits exposes per-tenant limit overrides to various resource usage limits
 type TenantLimits interface {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -669,8 +669,22 @@ func TestEnabledByAnyTenant(t *testing.T) {
 	require.True(t, EnabledByAnyTenant([]string{"tenant1", "tenant2", "tenant3"}, ov.NativeHistogramsIngestionEnabled))
 }
 
+func TestSetGlobalExtensionsValidation(t *testing.T) {
+	extensionsValidation = nil
+	SetGlobalExtensionsValidation(func(extensions map[string]interface{}) error { return nil })
+
+	recovered := false
+	defer func() {
+		if a := recover(); a != nil {
+			recovered = true
+		}
+	}()
+	SetGlobalExtensionsValidation(func(extensions map[string]interface{}) error { return nil })
+	require.True(t, recovered)
+}
+
 func TestExtensions(t *testing.T) {
-	ExtentensionsValidation = func(extensions map[string]interface{}) error {
+	extensionsValidation = func(extensions map[string]interface{}) error {
 		for k, v := range extensions {
 			switch k {
 			case "message":


### PR DESCRIPTION
#### What this PR does

This PR shows how project derived from Mimir could add additional fields to per-tenant overrides in an easy way: by having new `extensions` field in per-tenant overrides.

Creating as draft to gather feedback.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
