### PR TITLE
Limits with Extensions

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -975,6 +975,8 @@ func newLimitsWithExtensions(limits *plainLimits) (any interface{}, getExtension
 	cfg := reflect.New(typ).Interface()
 
 	// set the limits provided (they probably contain default limits) to the new struct, so we'll unmarshal on top of them.
+	// In other words:
+	//     cfg.PlainLimits = limits
 	reflect.ValueOf(cfg).Elem().FieldByName(plainLimitsStructField.Name).Set(reflect.ValueOf(limits))
 
 	return cfg, func() map[string]interface{} {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -885,6 +885,7 @@ func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
 // and returns a function to get a pointer to the extensions E from a *Limits instance.
 // The name will be used as YAML/JSON key to decode the extensions.
 // This method is not thread safe and should be called only during package initialization.
+// Registering same name twice will cause a panic.
 func MustRegisterExtension[E any](name string) func(*Limits) *E {
 	if _, ok := registeredExtensionsIndexes[name]; ok {
 		panic(fmt.Errorf("extension %s already registered", name))

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -299,16 +299,18 @@ func (l *Limits) unmarshal(decode func(any) error) error {
 		extensions = getExtensions()
 	}
 
-	// Like the YAML method above, we want to set l to the defaults and then overwrite
-	// it with the input. We prevent an infinite loop of calling UnmarshalJSON by hiding
-	// behind type indirection.
+	// We want to set l to the defaults and then overwrite it with the input.
 	if defaultLimits != nil {
 		*l = *defaultLimits
 		// Make copy of default limits. Otherwise unmarshalling would modify map in default limits.
 		l.copyNotificationIntegrationLimits(defaultLimits.NotificationRateLimitPerIntegration)
 	}
 
+	// We prevent an infinite loop of calling UnmarshalJSON by hiding behind type indirection.
 	type plain Limits
+
+	// We use newLimitsConfigThrowingAwayExtensions to avoid decoder complain about known extension fields,
+	// which were already unmarshaled above. Limits will be unmarshaled as plain limits.
 	err := decode(newLimitsConfigThrowingAwayExtensions((*plain)(l)))
 	if err != nil {
 		return err

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -897,6 +897,7 @@ func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
 // RegisterExtensions registers the extensions type with given name
 // and returns a function to get the extensions from a *Limits instance.
 // The name will be used as YAML/JSON key to decode the extensions.
+// This method is not thread safe and should be called only during package initialization.
 func RegisterExtensions[E any](name string) func(*Limits) *E {
 	extensionsType := reflect.TypeOf(new(E))
 	registeredExtensions = append(registeredExtensions, extension{name: name, typ: extensionsType})

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -175,7 +175,7 @@ type Limits struct {
 	ForwardingDropOlderThan model.Duration  `yaml:"forwarding_drop_older_than" json:"forwarding_drop_older_than" doc:"nocli|description=If set, forwarding drops samples that are older than this duration. If unset or 0, no samples get dropped."`
 	ForwardingRules         ForwardingRules `yaml:"forwarding_rules" json:"forwarding_rules" doc:"nocli|description=Rules based on which the Distributor decides whether a metric should be forwarded to an alternative remote_write API endpoint."`
 
-	extensions interface{}
+	extensions map[string]interface{}
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -269,51 +269,100 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.AlertmanagerMaxAlertsSizeBytes, "alertmanager.max-alerts-size-bytes", 0, "Maximum total size of alerts that a single tenant can have, alert size is the sum of the bytes of its labels, annotations and generatorURL. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.")
 }
 
-// extensionsType is the type of the registered extensions.
-var extensionsType reflect.Type
+type extension struct {
+	name string
+	typ  reflect.Type
+}
+
+// registeredExtensions is the list of registered extensions
+var registeredExtensions []extension
 
 // newExtensionsOnlyLimitsConfig returns an interface{} value of a pointer to a struct of type:
 //
 //	struct {
-//	    Extensions T `yaml:"extensions"`
+//	    ExtName1 T1 `yaml:"extname1"`
+//	    ...
+//	    ExtN TN `yaml:"extN"`
 //	    Throwaway map[string]interface{} `yaml:",inline"`
 //	}
 //
-// Where T is the registered extensionsType.
-// The second return ar
-func newExtensionsOnlyLimitsConfig() (any interface{}, getter func() interface{}) {
-	typ := reflect.StructOf([]reflect.StructField{
-		{
-			Name: "Extensions",
-			Type: extensionsType,
-			Tag:  `yaml:"extensions"`,
-		},
-		{
-			Name: "Throwaway",
-			Type: reflect.TypeOf(map[string]interface{}{}),
-			Tag:  `yaml:",inline"`,
-		},
+// Where TN is the type of the registered extension, and extnameN is the name of it.
+func newExtensionsOnlyLimitsConfig() (any interface{}, getter func() map[string]interface{}) {
+	fields := make([]reflect.StructField, 0, len(registeredExtensions)+1)
+	for _, e := range registeredExtensions {
+		fields = append(fields, reflect.StructField{
+			Name: strings.ToTitle(e.name),
+			Type: e.typ,
+			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s"`, e.name)),
+		})
+	}
+	fields = append(fields, reflect.StructField{
+		Name: "Throwaway",
+		Type: reflect.TypeOf(map[string]interface{}{}),
+		Tag:  `yaml:",inline"`,
 	})
+	typ := reflect.StructOf(fields)
 	newExtensions := reflect.New(typ).Interface()
-	return newExtensions, func() interface{} {
-		return reflect.ValueOf(newExtensions).Elem().Field(0).Interface()
+	return newExtensions, func() map[string]interface{} {
+		ext := map[string]interface{}{}
+		for i, e := range registeredExtensions {
+			ext[e.name] = reflect.ValueOf(newExtensions).Elem().Field(i).Interface()
+		}
+		return ext
 	}
 }
 
-// RegisterExtensions registers the extensions type and returns a function to get the extensions from a *Limits instance.
-func RegisterExtensions[E any]() func(*Limits) E {
-	extensionsType = reflect.TypeOf(new(E)).Elem()
+// newLimitsConfigThrowingAwayExtensions returns an instance of a struct with following structure:
+//
+//		type limitsConfigThrowingAwayExtensions struct {
+//			IgnoredExtensionExt1 interface{} `yaml:"ext1"`
+//	     ...
+//			IgnoredExtensionExtN interface{} `yaml:"ext1"`
+//			*plain               `json:",inline"`
+//		}
+//
+// This makes the YAML parser ignore the extension fields, and still validate our plain config.
+func newLimitsConfigThrowingAwayExtensions(plainLimits interface{}) interface{} {
+	fields := make([]reflect.StructField, 0, len(registeredExtensions)+1)
+	for _, e := range registeredExtensions {
+		fields = append(fields, reflect.StructField{
+			Name: "IgnoredExtension" + strings.ToTitle(e.name),
+			Type: e.typ,
+			Tag:  reflect.StructTag(fmt.Sprintf(`yaml:"%s"`, e.name)),
+		})
+	}
+	fields = append(fields, reflect.StructField{
+		Name:      "PlainLimits",
+		Anonymous: true,
+		Type:      reflect.TypeOf(plainLimits),
+		Tag:       `yaml:",inline"`,
+	})
+	typ := reflect.StructOf(fields)
+	cfg := reflect.New(typ).Interface()
+	reflect.ValueOf(cfg).Elem().Field(len(registeredExtensions)).Set(reflect.ValueOf(plainLimits))
+	return cfg
+}
 
-	return func(l *Limits) E {
-		return l.extensions.(E)
+// RegisterExtensions registers the extensions type with given name
+// and returns a function to get the extensions from a *Limits instance.
+// The name will be used as yaml key to decode the extensions.
+func RegisterExtensions[E any](name string) func(*Limits) *E {
+	extensionsType := reflect.TypeOf(new(E))
+	registeredExtensions = append(registeredExtensions, extension{name: name, typ: extensionsType})
+
+	return func(l *Limits) *E {
+		if e, ok := l.extensions[name]; ok {
+			return e.(*E)
+		}
+		return nil
 	}
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (l *Limits) UnmarshalYAML(value *yaml.Node) error {
 	// First, decode the extensions ignoring the rest of the config (if any registered).
-	var extensions interface{}
-	if extensionsType != nil {
+	var extensions map[string]interface{}
+	if len(registeredExtensions) > 0 {
 		extensionsOnlyConfig, getExtensions := newExtensionsOnlyLimitsConfig()
 		err := value.DecodeWithOptions(extensionsOnlyConfig, yaml.DecodeOptions{KnownFields: true})
 		if err != nil {
@@ -334,13 +383,7 @@ func (l *Limits) UnmarshalYAML(value *yaml.Node) error {
 	}
 	type plain Limits
 
-	// withExtensions ignores the extensions field (as it was previously decoded, if any was registered).
-	type withExtensions struct {
-		UnknownTypeIgnoredExtensions interface{} `yaml:"extensions"`
-		*plain                       `json:",inline"`
-	}
-
-	err := value.DecodeWithOptions(&withExtensions{plain: (*plain)(l)}, yaml.DecodeOptions{KnownFields: true})
+	err := value.DecodeWithOptions(newLimitsConfigThrowingAwayExtensions((*plain)(l)), yaml.DecodeOptions{KnownFields: true})
 	if err != nil {
 		return err
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -894,11 +894,11 @@ func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
 	return false
 }
 
-// RegisterExtensions registers the extensions type with given name
+// MustRegisterExtension registers the extensions type with given name
 // and returns a function to get a pointer to the extensions E from a *Limits instance.
 // The name will be used as YAML/JSON key to decode the extensions.
 // This method is not thread safe and should be called only during package initialization.
-func RegisterExtensions[E any](name string) func(*Limits) *E {
+func MustRegisterExtension[E any](name string) func(*Limits) *E {
 	for _, e := range registeredExtensions {
 		if e.name == name {
 			panic(fmt.Errorf("extension %s already registered", name))

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -938,7 +938,7 @@ var plainLimitsStructField = reflect.StructField{
 // Embedding PlainLimits in the struct makes JSON parser act like `yaml:",inline"`.
 func newLimitsWithExtensions(limits *plainLimits) (any interface{}, getExtensions func() map[string]interface{}) {
 	if len(registeredExtensionsIndexes) == 0 {
-		// No extensions, so just return the plain limits and extension getter that returns nil.
+		// No extensions, so just return the plain limits and an extension getter that returns nil.
 		return limits, func() map[string]interface{} { return nil }
 	}
 
@@ -959,10 +959,6 @@ func newLimitsWithExtensions(limits *plainLimits) (any interface{}, getExtension
 	reflect.ValueOf(cfg).Elem().Field(len(fields)).Set(reflect.ValueOf(limits))
 
 	return cfg, func() map[string]interface{} {
-		if len(registeredExtensionsIndexes) == 0 {
-			return nil
-		}
-
 		ext := map[string]interface{}{}
 		for name, i := range registeredExtensionsIndexes {
 			ext[name] = reflect.ValueOf(cfg).Elem().Field(i).Interface()

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -899,6 +899,12 @@ func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
 // The name will be used as YAML/JSON key to decode the extensions.
 // This method is not thread safe and should be called only during package initialization.
 func RegisterExtensions[E any](name string) func(*Limits) *E {
+	for _, e := range registeredExtensions {
+		if e.name == name {
+			panic(fmt.Errorf("extension %s already registered", name))
+		}
+	}
+
 	extensionsType := reflect.TypeOf(new(E))
 	registeredExtensions = append(registeredExtensions, extension{name: name, typ: extensionsType})
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -975,7 +975,7 @@ func newLimitsWithExtensions(limits *plainLimits) (any interface{}, getExtension
 	cfg := reflect.New(typ).Interface()
 
 	// set the limits provided (they probably contain default limits) to the new struct, so we'll unmarshal on top of them.
-	reflect.ValueOf(cfg).Elem().Field(len(fields)).Set(reflect.ValueOf(limits))
+	reflect.ValueOf(cfg).Elem().FieldByName(plainLimitsStructField.Name).Set(reflect.ValueOf(limits))
 
 	return cfg, func() map[string]interface{} {
 		ext := map[string]interface{}{}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -270,18 +270,18 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (l *Limits) UnmarshalYAML(value *yaml.Node) error {
-	return l.unmarshal(func(typ any) error {
-		return value.DecodeWithOptions(typ, yaml.DecodeOptions{KnownFields: true})
+	return l.unmarshal(func(v any) error {
+		return value.DecodeWithOptions(v, yaml.DecodeOptions{KnownFields: true})
 	})
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (l *Limits) UnmarshalJSON(data []byte) error {
-	return l.unmarshal(func(typ any) error {
+	return l.unmarshal(func(v any) error {
 		dec := json.NewDecoder(bytes.NewReader(data))
 		dec.DisallowUnknownFields()
 
-		return dec.Decode(typ)
+		return dec.Decode(v)
 	})
 }
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/efficientgo/core/errors"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -295,7 +294,7 @@ func (l *Limits) unmarshal(decode func(any) error) error {
 
 		err := decode(extensionsOnlyConfig)
 		if err != nil {
-			return errors.Wrap(err, "decoding extensions")
+			return fmt.Errorf("can't decode extensions: %w", err)
 		}
 		extensions = getExtensions()
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -934,6 +934,7 @@ var plainLimitsStructField = reflect.StructField{
 //
 // Where TN is the type of the registered extension N, and extnameN is the name of it.
 // This makes the JSON/YAML unmarshaler go through each extension field, and unmarshal the rest of the payload in the plain limits field.
+// Embedding PlainLimits in the struct makes JSON parser act like `yaml:",inline"`.
 func newLimitsWithExtensions(limits interface{}) (any interface{}, getExtensions func() map[string]interface{}) {
 	fields := make([]reflect.StructField, 0, len(limitsExtensionsFields)+1)
 	fields = append(fields, limitsExtensionsFields...)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -895,7 +895,7 @@ func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
 }
 
 // RegisterExtensions registers the extensions type with given name
-// and returns a function to get the extensions from a *Limits instance.
+// and returns a function to get a pointer to the extensions E from a *Limits instance.
 // The name will be used as YAML/JSON key to decode the extensions.
 // This method is not thread safe and should be called only during package initialization.
 func RegisterExtensions[E any](name string) func(*Limits) *E {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -919,9 +919,9 @@ func init() {
 	for i := 0; i < limitsType.NumField(); i++ {
 		// yamlKey/jsonKey could be empty, but we also shouldn't allow registering a field with an empty name, so just add it to the map.
 		yamlKey, _, _ := strings.Cut(limitsType.Field(i).Tag.Get("yaml"), ",")
-		josnKey, _, _ := strings.Cut(limitsType.Field(i).Tag.Get("json"), ",")
+		jsonKey, _, _ := strings.Cut(limitsType.Field(i).Tag.Get("json"), ",")
 		standardLimitsYAMLJSONKeys[yamlKey] = struct{}{}
-		standardLimitsYAMLJSONKeys[josnKey] = struct{}{}
+		standardLimitsYAMLJSONKeys[jsonKey] = struct{}{}
 	}
 }
 

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -676,9 +676,9 @@ func TestExtensions(t *testing.T) {
 		Foo int `yaml:"foo"`
 	}
 	// By registering, we get a function that provides the extensions for a Limist instance.
-	getExtensionStruct := RegisterExtensions[testExtensions]("test_extension_struct")
-	getExtensionString := RegisterExtensions[string]("test_extension_string")
-	getExtensionNil := RegisterExtensions[int]("test_extension_null")
+	getExtensionStruct := MustRegisterExtension[testExtensions]("test_extension_struct")
+	getExtensionString := MustRegisterExtension[string]("test_extension_string")
+	getExtensionNil := MustRegisterExtension[int]("test_extension_null")
 
 	// Unmarshal a config with extensions.
 	// JSON is a valid YAML, so we can use it here to avoid having to fight the whitespaces.
@@ -706,8 +706,8 @@ func TestExtensions(t *testing.T) {
 
 	t.Run("can't register twice", func(t *testing.T) {
 		require.Panics(t, func() {
-			RegisterExtensions[testExtensions]("foo")
-			RegisterExtensions[testExtensions]("foo")
+			MustRegisterExtension[testExtensions]("foo")
+			MustRegisterExtension[testExtensions]("foo")
 		})
 	})
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -669,13 +669,16 @@ func TestEnabledByAnyTenant(t *testing.T) {
 }
 
 func TestExtensions(t *testing.T) {
-	t.Cleanup(func() { registeredExtensions = nil })
+	t.Cleanup(func() {
+		registeredExtensionsIndexes = map[string]int{}
+		limitsExtensionsFields = nil
+	})
 
 	// Downstream declares a new extension type and registers it.
 	type testExtensions struct {
 		Foo int `yaml:"foo"`
 	}
-	// By registering, we get a function that provides the extensions for a Limist instance.
+	// By registering, we get a function that provides the extensions for a Limits instance.
 	getExtensionStruct := MustRegisterExtension[testExtensions]("test_extension_struct")
 	getExtensionString := MustRegisterExtension[string]("test_extension_string")
 	getExtensionNil := MustRegisterExtension[int]("test_extension_null")

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -703,4 +703,11 @@ func TestExtensions(t *testing.T) {
 		assert.Equal(t, "bar", *getExtensionString(overrides["user"]))
 		assert.Nil(t, getExtensionNil(overrides["user"]), "Nil extension value should be returned as nil")
 	})
+
+	t.Run("can't register twice", func(t *testing.T) {
+		require.Panics(t, func() {
+			RegisterExtensions[testExtensions]("foo")
+			RegisterExtensions[testExtensions]("foo")
+		})
+	})
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -682,12 +682,25 @@ func TestExtensions(t *testing.T) {
 
 	// Unmarshal a config with extensions.
 	// JSON is a valid YAML, so we can use it here to avoid having to fight the whitespaces.
-	cfg := `{"user": {"test_extension_struct": {"foo": 1}, "test_extension_string": "bar"}}`
-	overrides := map[string]*Limits{}
-	require.NoError(t, yaml.Unmarshal([]byte(cfg), &overrides), "parsing overrides")
 
-	// Check that getExtensionStruct(*Limits) actually returns the proper type with filled extensions.
-	assert.Equal(t, &testExtensions{Foo: 1}, getExtensionStruct(overrides["user"]))
-	assert.Equal(t, "bar", *getExtensionString(overrides["user"]))
-	assert.Nil(t, getExtensionNil(overrides["user"]), "Nil extension value should be returned as nil")
+	cfg := `{"user": {"test_extension_struct": {"foo": 1}, "test_extension_string": "bar"}}`
+	t.Run("yaml", func(t *testing.T) {
+		overrides := map[string]*Limits{}
+		require.NoError(t, yaml.Unmarshal([]byte(cfg), &overrides), "parsing overrides")
+
+		// Check that getExtensionStruct(*Limits) actually returns the proper type with filled extensions.
+		assert.Equal(t, &testExtensions{Foo: 1}, getExtensionStruct(overrides["user"]))
+		assert.Equal(t, "bar", *getExtensionString(overrides["user"]))
+		assert.Nil(t, getExtensionNil(overrides["user"]), "Nil extension value should be returned as nil")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		overrides := map[string]*Limits{}
+		require.NoError(t, json.Unmarshal([]byte(cfg), &overrides), "parsing overrides")
+
+		// Check that getExtensionStruct(*Limits) actually returns the proper type with filled extensions.
+		assert.Equal(t, &testExtensions{Foo: 1}, getExtensionStruct(overrides["user"]))
+		assert.Equal(t, "bar", *getExtensionString(overrides["user"]))
+		assert.Nil(t, getExtensionNil(overrides["user"]), "Nil extension value should be returned as nil")
+	})
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -714,8 +714,23 @@ func TestExtensions(t *testing.T) {
 		})
 	})
 
+	t.Run("can't register name that is already a Limits JSON/YAML key", func(t *testing.T) {
+		require.Panics(t, func() {
+			MustRegisterExtension[int64]("max_global_series_per_user")
+		})
+	})
+
+	t.Run("can't register empty name", func(t *testing.T) {
+		require.Panics(t, func() {
+			MustRegisterExtension[int64]("")
+		})
+	})
+
 	t.Run("default limits does not interfere with tenants extensions", func(t *testing.T) {
 		// This test makes sure that sharing the default limits does not leak extensions values between tenants.
+		// Since we assign l = *defaultLimits before unmarshaling,
+		// there's a chance of unmarshaling on top of a reference that is already being used in different tenant's limits.
+		// This shouldn't happen, but let's have a test to make sure that it doesnt.
 		var def Limits
 		require.NoError(t, json.Unmarshal([]byte(`{"test_extension_string": "default"}`), &def), "parsing overrides")
 		require.Equal(t, "default", *getExtensionString(&def))


### PR DESCRIPTION
#### What this PR does

A proposal of an alternative approach to https://github.com/grafana/mimir/pull/4395

This allows extensions being complex types, where _complex_ means _not map[string]interface{} but a properly defined struct{}_

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
