### PR TITLE
Make extensions getter work with nil *Limits

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -886,6 +886,7 @@ func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
 // The name will be used as YAML/JSON key to decode the extensions.
 // This method is not thread safe and should be called only during package initialization.
 // Registering same name twice will cause a panic.
+// The provided getter will return nil for nil *Limits.
 func MustRegisterExtension[E any](name string) func(*Limits) *E {
 	if name == "" {
 		panic("extension name cannot be empty")
@@ -905,6 +906,10 @@ func MustRegisterExtension[E any](name string) func(*Limits) *E {
 	})
 
 	return func(l *Limits) *E {
+		if l == nil {
+			return nil
+		}
+
 		if e, ok := l.extensions[name]; ok {
 			return e.(*E)
 		}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -754,4 +754,8 @@ func TestExtensions(t *testing.T) {
 		// Default value did not change.
 		require.Equal(t, "default", *getExtensionString(&def))
 	})
+
+	t.Run("getter works with nil Limits", func(t *testing.T) {
+		require.Nil(t, getExtensionStruct(nil))
+	})
 }


### PR DESCRIPTION
#### What this PR does

The normal workflow would look like:

    var getter = validation.MustRegisterExtension[Ext]("ext")
    // ...
    if limits := getter(tenantLimits.ByUserID(id)); limits != nil {
        // ...
    }

However, validation.TenantLimits() may return nil tenant limits from ByUserID(). In order to avoid having to check that in every caller, we can just support nil value in the getter we create.
