### PR TITLE
Limits extensions with default values

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -980,8 +980,10 @@ func newLimitsWithExtensions(limits *plainLimits) (any interface{}, getExtension
 	// cfg is an instance of a pointer to a new struct.
 	cfg := reflect.New(typ)
 
+	// Set default values of each field
+	// In other words:
+	//     cfg.EXTNAME1 = cfg.EXTNAME1.Default()
 	for i := range limitsExtensionsFields {
-		// Call the Default() T method on each field and assign it to that field.
 		res := cfg.Elem().Field(i).MethodByName("Default").Call(nil)
 		cfg.Elem().Field(i).Set(res[0])
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -980,7 +980,6 @@ func newLimitsWithExtensions(limits *plainLimits) (any interface{}, getExtension
 	// cfg is an instance of a pointer to a new struct.
 	cfg := reflect.New(typ)
 
-	// As
 	for i := range limitsExtensionsFields {
 		// Call the Default() T method on each field and assign it to that field.
 		res := cfg.Elem().Field(i).MethodByName("Default").Call(nil)

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -668,20 +668,28 @@ func TestEnabledByAnyTenant(t *testing.T) {
 	require.True(t, EnabledByAnyTenant([]string{"tenant1", "tenant2", "tenant3"}, ov.NativeHistogramsIngestionEnabled))
 }
 
+type structExtension struct {
+	Foo int `yaml:"foo"`
+}
+
+func (te structExtension) Default() structExtension {
+	return structExtension{Foo: 42}
+}
+
+type stringExtension string
+
+func (stringExtension) Default() stringExtension {
+	return "default string extension value"
+}
+
 func TestExtensions(t *testing.T) {
 	t.Cleanup(func() {
 		registeredExtensionsIndexes = map[string]int{}
 		limitsExtensionsFields = nil
 	})
 
-	// Downstream declares a new extension type and registers it.
-	type testExtensions struct {
-		Foo int `yaml:"foo"`
-	}
-	// By registering, we get a function that provides the extensions for a Limits instance.
-	getExtensionStruct := MustRegisterExtension[testExtensions]("test_extension_struct")
-	getExtensionString := MustRegisterExtension[string]("test_extension_string")
-	getExtensionNil := MustRegisterExtension[int]("test_extension_null")
+	getExtensionStruct := MustRegisterExtension[structExtension]("test_extension_struct")
+	getExtensionString := MustRegisterExtension[stringExtension]("test_extension_string")
 
 	// Unmarshal a config with extensions.
 	// JSON is a valid YAML, so we can use it here to avoid having to fight the whitespaces.
@@ -692,9 +700,8 @@ func TestExtensions(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal([]byte(cfg), &overrides), "parsing overrides")
 
 		// Check that getExtensionStruct(*Limits) actually returns the proper type with filled extensions.
-		assert.Equal(t, &testExtensions{Foo: 1}, getExtensionStruct(overrides["user"]))
-		assert.Equal(t, "bar", *getExtensionString(overrides["user"]))
-		assert.Nil(t, getExtensionNil(overrides["user"]), "Nil extension value should be returned as nil")
+		assert.Equal(t, structExtension{Foo: 1}, getExtensionStruct(overrides["user"]))
+		assert.Equal(t, stringExtension("bar"), getExtensionString(overrides["user"]))
 	})
 
 	t.Run("json", func(t *testing.T) {
@@ -702,28 +709,34 @@ func TestExtensions(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(cfg), &overrides), "parsing overrides")
 
 		// Check that getExtensionStruct(*Limits) actually returns the proper type with filled extensions.
-		assert.Equal(t, &testExtensions{Foo: 1}, getExtensionStruct(overrides["user"]))
-		assert.Equal(t, "bar", *getExtensionString(overrides["user"]))
-		assert.Nil(t, getExtensionNil(overrides["user"]), "Nil extension value should be returned as nil")
+		assert.Equal(t, structExtension{Foo: 1}, getExtensionStruct(overrides["user"]))
+		assert.Equal(t, stringExtension("bar"), getExtensionString(overrides["user"]))
 	})
 
 	t.Run("can't register twice", func(t *testing.T) {
 		require.Panics(t, func() {
-			MustRegisterExtension[testExtensions]("foo")
-			MustRegisterExtension[testExtensions]("foo")
+			MustRegisterExtension[structExtension]("foo")
+			MustRegisterExtension[structExtension]("foo")
 		})
 	})
 
 	t.Run("can't register name that is already a Limits JSON/YAML key", func(t *testing.T) {
 		require.Panics(t, func() {
-			MustRegisterExtension[int64]("max_global_series_per_user")
+			MustRegisterExtension[stringExtension]("max_global_series_per_user")
 		})
 	})
 
 	t.Run("can't register empty name", func(t *testing.T) {
 		require.Panics(t, func() {
-			MustRegisterExtension[int64]("")
+			MustRegisterExtension[stringExtension]("")
 		})
+	})
+
+	t.Run("default value", func(t *testing.T) {
+		var limits Limits
+		require.NoError(t, json.Unmarshal([]byte(`{}`), &limits), "parsing overrides")
+		require.Equal(t, structExtension{Foo: 42}, getExtensionStruct(&limits))
+		require.Equal(t, stringExtension("default string extension value"), getExtensionString(&limits))
 	})
 
 	t.Run("default limits does not interfere with tenants extensions", func(t *testing.T) {
@@ -733,29 +746,29 @@ func TestExtensions(t *testing.T) {
 		// This shouldn't happen, but let's have a test to make sure that it doesnt.
 		var def Limits
 		require.NoError(t, json.Unmarshal([]byte(`{"test_extension_string": "default"}`), &def), "parsing overrides")
-		require.Equal(t, "default", *getExtensionString(&def))
+		require.Equal(t, stringExtension("default"), getExtensionString(&def))
 		SetDefaultLimitsForYAMLUnmarshalling(def)
 
 		cfg := `{"one": {"test_extension_string": "one"}, "two": {"test_extension_string": "two"}}`
 		overrides := map[string]*Limits{}
 		require.NoError(t, yaml.Unmarshal([]byte(cfg), &overrides), "parsing overrides")
-		require.Equal(t, "one", *getExtensionString(overrides["one"]))
-		require.Equal(t, "two", *getExtensionString(overrides["two"]))
+		require.Equal(t, stringExtension("one"), getExtensionString(overrides["one"]))
+		require.Equal(t, stringExtension("two"), getExtensionString(overrides["two"]))
 
 		cfg = `{"three": {"test_extension_string": "three"}}`
 		overrides2 := map[string]*Limits{}
 		require.NoError(t, yaml.Unmarshal([]byte(cfg), &overrides2), "parsing overrides")
-		require.Equal(t, "three", *getExtensionString(overrides2["three"]))
+		require.Equal(t, stringExtension("three"), getExtensionString(overrides2["three"]))
 
 		// Previous values did not change.
-		require.Equal(t, "one", *getExtensionString(overrides["one"]))
-		require.Equal(t, "two", *getExtensionString(overrides["two"]))
+		require.Equal(t, stringExtension("one"), getExtensionString(overrides["one"]))
+		require.Equal(t, stringExtension("two"), getExtensionString(overrides["two"]))
 
 		// Default value did not change.
-		require.Equal(t, "default", *getExtensionString(&def))
+		require.Equal(t, stringExtension("default"), getExtensionString(&def))
 	})
 
-	t.Run("getter works with nil Limits", func(t *testing.T) {
-		require.Nil(t, getExtensionStruct(nil))
+	t.Run("getter works with nil Limits returning default values", func(t *testing.T) {
+		require.Equal(t, structExtension{}.Default(), getExtensionStruct(nil))
 	})
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -684,7 +684,7 @@ func (stringExtension) Default() stringExtension {
 
 func TestExtensions(t *testing.T) {
 	t.Cleanup(func() {
-		registeredExtensionsIndexes = map[string]int{}
+		registeredExtensions = map[string]registeredExtension{}
 		limitsExtensionsFields = nil
 	})
 


### PR DESCRIPTION
#### What this PR does

We now require the extension types to provide their default value through `Default() E` method.

This also means that all Limits have all extensions now.

#### Which issue(s) this PR fixes or relates to

Fixes nothing, superesedes https://github.com/grafana/mimir/pull/4417

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
