### PR TITLE
Return time.Duration from limits, instead of model.Duration

### DIFF
--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/weaveworks/common/user"
 
@@ -62,7 +61,7 @@ type Limits interface {
 	CompactorBlocksRetentionPeriod(userID string) time.Duration
 
 	// OutOfOrderTimeWindow returns the out-of-order time window for the user.
-	OutOfOrderTimeWindow(userID string) model.Duration
+	OutOfOrderTimeWindow(userID string) time.Duration
 
 	// CreationGracePeriod returns the time interval to control how far into the future
 	// incoming samples are accepted compared to the wall clock.

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -289,7 +288,7 @@ type mockLimits struct {
 	totalShards                      int
 	compactorShards                  int
 	compactorBlocksRetentionPeriod   time.Duration
-	outOfOrderTimeWindow             model.Duration
+	outOfOrderTimeWindow             time.Duration
 	creationGracePeriod              time.Duration
 	nativeHistogramsIngestionEnabled bool
 }
@@ -340,7 +339,7 @@ func (m mockLimits) CompactorBlocksRetentionPeriod(userID string) time.Duration 
 	return m.compactorBlocksRetentionPeriod
 }
 
-func (m mockLimits) OutOfOrderTimeWindow(userID string) model.Duration {
+func (m mockLimits) OutOfOrderTimeWindow(userID string) time.Duration {
 	return m.outOfOrderTimeWindow
 }
 

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -383,9 +383,7 @@ func (s *splitAndCacheMiddleware) fetchCacheExtents(ctx context.Context, keys []
 // storeCacheExtents stores the extents for given key in the cache.
 func (s *splitAndCacheMiddleware) storeCacheExtents(key string, tenantIDs []string, extents []Extent) {
 	ttl := resultsCacheTTL
-	lowerTTLWithinTimePeriod := validation.MaxDurationPerTenant(tenantIDs, func(tenantID string) time.Duration {
-		return time.Duration(s.limits.OutOfOrderTimeWindow(tenantID))
-	})
+	lowerTTLWithinTimePeriod := validation.MaxDurationPerTenant(tenantIDs, s.limits.OutOfOrderTimeWindow)
 	if lowerTTLWithinTimePeriod > 0 && len(extents) > 0 &&
 		extents[len(extents)-1].End >= time.Now().Add(-lowerTTLWithinTimePeriod).UnixMilli() {
 		ttl = resultsCacheLowerTTL

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1708,7 +1708,7 @@ func TestSplitAndCacheMiddlewareLowerTTL(t *testing.T) {
 	mcache := cache.NewMockCache()
 	m := splitAndCacheMiddleware{
 		limits: mockLimits{
-			outOfOrderTimeWindow: model.Duration(time.Hour),
+			outOfOrderTimeWindow: time.Hour,
 		},
 		cache: mcache,
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6425,7 +6425,7 @@ func TestNewIngestErrMsgs(t *testing.T) {
 			msg: `the sample has been rejected because its timestamp is too old (err-mimir-sample-timestamp-too-old). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
 		},
 		"newIngestErrSampleTimestampTooOld_out_of_order_enabled": {
-			err: newIngestErrSampleTimestampTooOldOOOEnabled(timestamp, metricLabelAdapters, model.Duration(2*time.Hour)),
+			err: newIngestErrSampleTimestampTooOldOOOEnabled(timestamp, metricLabelAdapters, 2*time.Hour),
 			msg: `the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of 2h (err-mimir-sample-timestamp-too-old). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
 		},
 		"newIngestErrSampleOutOfOrder": {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -560,8 +560,8 @@ func (o *Overrides) ActiveSeriesCustomTrackersConfig(userID string) activeseries
 }
 
 // OutOfOrderTimeWindow returns the out-of-order time window for the user.
-func (o *Overrides) OutOfOrderTimeWindow(userID string) model.Duration {
-	return o.getOverridesForUser(userID).OutOfOrderTimeWindow
+func (o *Overrides) OutOfOrderTimeWindow(userID string) time.Duration {
+	return time.Duration(o.getOverridesForUser(userID).OutOfOrderTimeWindow)
 }
 
 // OutOfOrderBlocksExternalLabelEnabled returns if the shipper is flagging out-of-order blocks with an external label.


### PR DESCRIPTION
#### What this PR does

This PR addresses comment https://github.com/grafana/mimir/pull/4385#discussion_r1126898542 from PR review. `OutOfOrderTimeWindow` was the only method in `validation/limits.go` returning `model.Duration` instead of `time.Duration`.


#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
