### PR TITLE
Native histograms support in querier remote read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [FEATURE] Querier: Support for native histograms in remote read. #4425
 * [CHANGE] Ingester: changed default value of `-blocks-storage.tsdb.retention-period` from `24h` to `13h`. If you're running Mimir with a custom configuration and you're overriding `-querier.query-store-after` to a value greater than the default `12h` then you should increase `-blocks-storage.tsdb.retention-period` accordingly. #4382
 * [CHANGE] Ruler: changed default value of `-ruler.evaluation-delay-duration` option from 0 to 1m. #4250
 * [CHANGE] Querier: Errors with status code `422` coming from the store-gateway are propagated and not converted to the consistency check error anymore. #4100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Grafana Mimir
 
-* [FEATURE] Querier: Support for native histograms in remote read. #4425
 * [CHANGE] Ingester: changed default value of `-blocks-storage.tsdb.retention-period` from `24h` to `13h`. If you're running Mimir with a custom configuration and you're overriding `-querier.query-store-after` to a value greater than the default `12h` then you should increase `-blocks-storage.tsdb.retention-period` accordingly. #4382
 * [CHANGE] Ruler: changed default value of `-ruler.evaluation-delay-duration` option from 0 to 1m. #4250
 * [CHANGE] Querier: Errors with status code `422` coming from the store-gateway are propagated and not converted to the consistency check error anymore. #4100

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -189,24 +189,41 @@ func seriesSetToQueryResponse(s storage.SeriesSet) (*client.QueryResponse, error
 	for s.Next() {
 		series := s.At()
 		samples := []mimirpb.Sample{}
+		histograms := []mimirpb.Histogram{}
 		it = series.Iterator(it)
 		for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
-			if valType != chunkenc.ValFloat {
-				return nil, fmt.Errorf("unsupported value type %v", valType)
+			switch valType {
+			case chunkenc.ValFloat:
+				t, v := it.At()
+				samples = append(samples, mimirpb.Sample{
+					TimestampMs: t,
+					Value:       v,
+				})
+			case chunkenc.ValHistogram:
+				t, h := it.AtHistogram()
+				histograms = append(histograms, mimirpb.FromHistogramToHistogramProto(t, h))
+			case chunkenc.ValFloatHistogram:
+				t, h := it.AtFloatHistogram()
+				histograms = append(histograms, mimirpb.FromFloatHistogramToHistogramProto(t, h))
+			default:
+				return nil, fmt.Errorf("unsupported value type: %v", valType)
 			}
-			t, v := it.At()
-			samples = append(samples, mimirpb.Sample{
-				TimestampMs: t,
-				Value:       v,
-			})
 		}
+
 		if err := it.Err(); err != nil {
 			return nil, err
 		}
-		result.Timeseries = append(result.Timeseries, mimirpb.TimeSeries{
-			Labels:  mimirpb.FromLabelsToLabelAdapters(series.Labels()),
-			Samples: samples,
-		})
+
+		ts := mimirpb.TimeSeries{Labels: mimirpb.FromLabelsToLabelAdapters(series.Labels())}
+
+		if len(samples) > 0 {
+			ts.Samples = samples
+		}
+		if len(histograms) > 0 {
+			ts.Histograms = histograms
+		}
+
+		result.Timeseries = append(result.Timeseries, ts)
 	}
 
 	return result, s.Err()

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -214,13 +214,10 @@ func seriesSetToQueryResponse(s storage.SeriesSet) (*client.QueryResponse, error
 			return nil, err
 		}
 
-		ts := mimirpb.TimeSeries{Labels: mimirpb.FromLabelsToLabelAdapters(series.Labels())}
-
-		if len(samples) > 0 {
-			ts.Samples = samples
-		}
-		if len(histograms) > 0 {
-			ts.Histograms = histograms
+		ts := mimirpb.TimeSeries{
+			Labels:     mimirpb.FromLabelsToLabelAdapters(series.Labels()),
+			Samples:    samples,
+			Histograms: histograms,
 		}
 
 		result.Timeseries = append(result.Timeseries, ts)


### PR DESCRIPTION
#### What this PR does

Enables Mimir's Prometheus remote read compatible API
https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#remote-read
to return native histogram samples.

#### Which issue(s) this PR fixes or relates to

Related to #3478 

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
