### PR TITLE
Remove replace directives in go.mod for hashicorp libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -230,11 +230,6 @@ require (
 // Using a fork of Prometheus with Mimir-specific changes.
 replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230309083841-242e82b8e667
 
-// Pin hashicorp depencencies since the Prometheus fork, go mod tries to update them.
-replace github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
-
-replace github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
-
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:
 // - https://github.com/hashicorp/memberlist/pull/260

--- a/go.sum
+++ b/go.sum
@@ -528,10 +528,12 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-hclog v0.12.2 h1:F1fdYblUEsxKiailtkhCCG2g4bipEgaHiDc8vffNpD4=
-github.com/hashicorp/go-hclog v0.12.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-immutable-radix v1.2.0 h1:l6UW37iCXwZkZoAbEYnptSHVE/cQ5bOTPYG5W3vf9+8=
-github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
+github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
+github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=

--- a/vendor/github.com/hashicorp/go-hclog/README.md
+++ b/vendor/github.com/hashicorp/go-hclog/README.md
@@ -17,11 +17,8 @@ JSON output mode for production.
 
 ## Stability Note
 
-While this library is fully open source and HashiCorp will be maintaining it
-(since we are and will be making extensive use of it), the API and output
-format is subject to minor changes as we fully bake and vet it in our projects.
-This notice will be removed once it's fully integrated into our major projects
-and no further changes are anticipated.
+This library has reached 1.0 stability. It's API can be considered solidified
+and promised through future versions.
 
 ## Installation and Docs
 
@@ -102,7 +99,7 @@ into all the callers.
 ### Using `hclog.Fmt()`
 
 ```go
-var int totalBandwidth = 200
+totalBandwidth := 200
 appLogger.Info("total bandwidth exceeded", "bandwidth", hclog.Fmt("%d GB/s", totalBandwidth))
 ```
 
@@ -146,3 +143,6 @@ log.Printf("[DEBUG] %d", 42)
 Notice that if `appLogger` is initialized with the `INFO` log level _and_ you
 specify `InferLevels: true`, you will not see any output here. You must change
 `appLogger` to `DEBUG` to see output. See the docs for more information.
+
+If the log lines start with a timestamp you can use the
+`InferLevelsWithTimestamp` option to try and ignore them.

--- a/vendor/github.com/hashicorp/go-hclog/colorize_unix.go
+++ b/vendor/github.com/hashicorp/go-hclog/colorize_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package hclog
@@ -21,6 +22,7 @@ func (l *intLogger) setColorization(opts *LoggerOptions) {
 		isCygwinTerm := isatty.IsCygwinTerminal(fi.Fd())
 		isTerm := isUnixTerm || isCygwinTerm
 		if !isTerm {
+			l.headerColor = ColorOff
 			l.writer.color = ColorOff
 		}
 	}

--- a/vendor/github.com/hashicorp/go-hclog/colorize_windows.go
+++ b/vendor/github.com/hashicorp/go-hclog/colorize_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package hclog
@@ -26,8 +27,12 @@ func (l *intLogger) setColorization(opts *LoggerOptions) {
 		isTerm := isUnixTerm || isCygwinTerm
 		if !isTerm {
 			l.writer.color = ColorOff
+			l.headerColor = ColorOff
 			return
 		}
-		l.writer.w = colorable.NewColorable(fi)
+
+		if l.headerColor == ColorOff {
+			l.writer.w = colorable.NewColorable(fi)
+		}
 	}
 }

--- a/vendor/github.com/hashicorp/go-hclog/exclude.go
+++ b/vendor/github.com/hashicorp/go-hclog/exclude.go
@@ -1,0 +1,71 @@
+package hclog
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ExcludeByMessage provides a simple way to build a list of log messages that
+// can be queried and matched. This is meant to be used with the Exclude
+// option on Options to suppress log messages. This does not hold any mutexs
+// within itself, so normal usage would be to Add entries at setup and none after
+// Exclude is going to be called. Exclude is called with a mutex held within
+// the Logger, so that doesn't need to use a mutex. Example usage:
+//
+//	f := new(ExcludeByMessage)
+//	f.Add("Noisy log message text")
+//	appLogger.Exclude = f.Exclude
+type ExcludeByMessage struct {
+	messages map[string]struct{}
+}
+
+// Add a message to be filtered. Do not call this after Exclude is to be called
+// due to concurrency issues.
+func (f *ExcludeByMessage) Add(msg string) {
+	if f.messages == nil {
+		f.messages = make(map[string]struct{})
+	}
+
+	f.messages[msg] = struct{}{}
+}
+
+// Return true if the given message should be included
+func (f *ExcludeByMessage) Exclude(level Level, msg string, args ...interface{}) bool {
+	_, ok := f.messages[msg]
+	return ok
+}
+
+// ExcludeByPrefix is a simple type to match a message string that has a common prefix.
+type ExcludeByPrefix string
+
+// Matches an message that starts with the prefix.
+func (p ExcludeByPrefix) Exclude(level Level, msg string, args ...interface{}) bool {
+	return strings.HasPrefix(msg, string(p))
+}
+
+// ExcludeByRegexp takes a regexp and uses it to match a log message string. If it matches
+// the log entry is excluded.
+type ExcludeByRegexp struct {
+	Regexp *regexp.Regexp
+}
+
+// Exclude the log message if the message string matches the regexp
+func (e ExcludeByRegexp) Exclude(level Level, msg string, args ...interface{}) bool {
+	return e.Regexp.MatchString(msg)
+}
+
+// ExcludeFuncs is a slice of functions that will called to see if a log entry
+// should be filtered or not. It stops calling functions once at least one returns
+// true.
+type ExcludeFuncs []func(level Level, msg string, args ...interface{}) bool
+
+// Calls each function until one of them returns true
+func (ff ExcludeFuncs) Exclude(level Level, msg string, args ...interface{}) bool {
+	for _, f := range ff {
+		if f(level, msg, args...) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/hashicorp/go-hclog/global.go
+++ b/vendor/github.com/hashicorp/go-hclog/global.go
@@ -2,6 +2,7 @@ package hclog
 
 import (
 	"sync"
+	"time"
 )
 
 var (
@@ -14,6 +15,7 @@ var (
 	DefaultOptions = &LoggerOptions{
 		Level:  DefaultLevel,
 		Output: DefaultOutput,
+		TimeFn: time.Now,
 	}
 )
 

--- a/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
@@ -18,8 +18,13 @@ type interceptLogger struct {
 }
 
 func NewInterceptLogger(opts *LoggerOptions) InterceptLogger {
+	l := newLogger(opts)
+	if l.callerOffset > 0 {
+		// extra frames for interceptLogger.{Warn,Info,Log,etc...}, and interceptLogger.log
+		l.callerOffset += 2
+	}
 	intercept := &interceptLogger{
-		Logger:    New(opts),
+		Logger:    l,
 		mu:        new(sync.Mutex),
 		sinkCount: new(int32),
 		Sinks:     make(map[SinkAdapter]struct{}),
@@ -31,6 +36,14 @@ func NewInterceptLogger(opts *LoggerOptions) InterceptLogger {
 }
 
 func (i *interceptLogger) Log(level Level, msg string, args ...interface{}) {
+	i.log(level, msg, args...)
+}
+
+// log is used to make the caller stack frame lookup consistent. If Warn,Info,etc
+// all called Log then direct calls to Log would have a different stack frame
+// depth. By having all the methods call the same helper we ensure the stack
+// frame depth is the same.
+func (i *interceptLogger) log(level Level, msg string, args ...interface{}) {
 	i.Logger.Log(level, msg, args...)
 	if atomic.LoadInt32(i.sinkCount) == 0 {
 		return
@@ -45,72 +58,27 @@ func (i *interceptLogger) Log(level Level, msg string, args ...interface{}) {
 
 // Emit the message and args at TRACE level to log and sinks
 func (i *interceptLogger) Trace(msg string, args ...interface{}) {
-	i.Logger.Trace(msg, args...)
-	if atomic.LoadInt32(i.sinkCount) == 0 {
-		return
-	}
-
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	for s := range i.Sinks {
-		s.Accept(i.Name(), Trace, msg, i.retrieveImplied(args...)...)
-	}
+	i.log(Trace, msg, args...)
 }
 
 // Emit the message and args at DEBUG level to log and sinks
 func (i *interceptLogger) Debug(msg string, args ...interface{}) {
-	i.Logger.Debug(msg, args...)
-	if atomic.LoadInt32(i.sinkCount) == 0 {
-		return
-	}
-
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	for s := range i.Sinks {
-		s.Accept(i.Name(), Debug, msg, i.retrieveImplied(args...)...)
-	}
+	i.log(Debug, msg, args...)
 }
 
 // Emit the message and args at INFO level to log and sinks
 func (i *interceptLogger) Info(msg string, args ...interface{}) {
-	i.Logger.Info(msg, args...)
-	if atomic.LoadInt32(i.sinkCount) == 0 {
-		return
-	}
-
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	for s := range i.Sinks {
-		s.Accept(i.Name(), Info, msg, i.retrieveImplied(args...)...)
-	}
+	i.log(Info, msg, args...)
 }
 
 // Emit the message and args at WARN level to log and sinks
 func (i *interceptLogger) Warn(msg string, args ...interface{}) {
-	i.Logger.Warn(msg, args...)
-	if atomic.LoadInt32(i.sinkCount) == 0 {
-		return
-	}
-
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	for s := range i.Sinks {
-		s.Accept(i.Name(), Warn, msg, i.retrieveImplied(args...)...)
-	}
+	i.log(Warn, msg, args...)
 }
 
 // Emit the message and args at ERROR level to log and sinks
 func (i *interceptLogger) Error(msg string, args ...interface{}) {
-	i.Logger.Error(msg, args...)
-	if atomic.LoadInt32(i.sinkCount) == 0 {
-		return
-	}
-
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	for s := range i.Sinks {
-		s.Accept(i.Name(), Error, msg, i.retrieveImplied(args...)...)
-	}
+	i.log(Error, msg, args...)
 }
 
 func (i *interceptLogger) retrieveImplied(args ...interface{}) []interface{} {
@@ -123,17 +91,11 @@ func (i *interceptLogger) retrieveImplied(args ...interface{}) []interface{} {
 	return cp
 }
 
-// Create a new sub-Logger that a name decending from the current name.
+// Create a new sub-Logger that a name descending from the current name.
 // This is used to create a subsystem specific Logger.
 // Registered sinks will subscribe to these messages as well.
 func (i *interceptLogger) Named(name string) Logger {
-	var sub interceptLogger
-
-	sub = *i
-
-	sub.Logger = i.Logger.Named(name)
-
-	return &sub
+	return i.NamedIntercept(name)
 }
 
 // Create a new sub-Logger with an explicit name. This ignores the current
@@ -141,13 +103,7 @@ func (i *interceptLogger) Named(name string) Logger {
 // within the normal hierarchy. Registered sinks will subscribe
 // to these messages as well.
 func (i *interceptLogger) ResetNamed(name string) Logger {
-	var sub interceptLogger
-
-	sub = *i
-
-	sub.Logger = i.Logger.ResetNamed(name)
-
-	return &sub
+	return i.ResetNamedIntercept(name)
 }
 
 // Create a new sub-Logger that a name decending from the current name.
@@ -157,9 +113,7 @@ func (i *interceptLogger) NamedIntercept(name string) InterceptLogger {
 	var sub interceptLogger
 
 	sub = *i
-
 	sub.Logger = i.Logger.Named(name)
-
 	return &sub
 }
 
@@ -171,9 +125,7 @@ func (i *interceptLogger) ResetNamedIntercept(name string) InterceptLogger {
 	var sub interceptLogger
 
 	sub = *i
-
 	sub.Logger = i.Logger.ResetNamed(name)
-
 	return &sub
 }
 
@@ -210,22 +162,28 @@ func (i *interceptLogger) DeregisterSink(sink SinkAdapter) {
 	atomic.AddInt32(i.sinkCount, -1)
 }
 
-// Create a *log.Logger that will send it's data through this Logger. This
-// allows packages that expect to be using the standard library to log to
-// actually use this logger, which will also send to any registered sinks.
 func (i *interceptLogger) StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger {
+	return i.StandardLogger(opts)
+}
+
+func (i *interceptLogger) StandardLogger(opts *StandardLoggerOptions) *log.Logger {
 	if opts == nil {
 		opts = &StandardLoggerOptions{}
 	}
 
-	return log.New(i.StandardWriterIntercept(opts), "", 0)
+	return log.New(i.StandardWriter(opts), "", 0)
 }
 
 func (i *interceptLogger) StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer {
+	return i.StandardWriter(opts)
+}
+
+func (i *interceptLogger) StandardWriter(opts *StandardLoggerOptions) io.Writer {
 	return &stdlogAdapter{
-		log:         i,
-		inferLevels: opts.InferLevels,
-		forceLevel:  opts.ForceLevel,
+		log:                      i,
+		inferLevels:              opts.InferLevels,
+		inferLevelsWithTimestamp: opts.InferLevelsWithTimestamp,
+		forceLevel:               opts.ForceLevel,
 	}
 }
 

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 )
 
 var (
@@ -38,6 +39,9 @@ const (
 
 	// Error information about unrecoverable events.
 	Error Level = 5
+
+	// Off disables all logging output.
+	Off Level = 6
 )
 
 // Format is a simple convience type for when formatting is required. When
@@ -51,6 +55,24 @@ type Format []interface{}
 func Fmt(str string, args ...interface{}) Format {
 	return append(Format{str}, args...)
 }
+
+// A simple shortcut to format numbers in hex when displayed with the normal
+// text output. For example: L.Info("header value", Hex(17))
+type Hex int
+
+// A simple shortcut to format numbers in octal when displayed with the normal
+// text output. For example: L.Info("perms", Octal(17))
+type Octal int
+
+// A simple shortcut to format numbers in binary when displayed with the normal
+// text output. For example: L.Info("bits", Binary(17))
+type Binary int
+
+// A simple shortcut to format strings with Go quoting. Control and
+// non-printable characters will be escaped with their backslash equivalents in
+// output. Intended for untrusted or multiline strings which should be logged
+// as concisely as possible.
+type Quote string
 
 // ColorOption expresses how the output should be colored, if at all.
 type ColorOption uint8
@@ -84,6 +106,8 @@ func LevelFromString(levelStr string) Level {
 		return Warn
 	case "error":
 		return Error
+	case "off":
+		return Off
 	default:
 		return NoLevel
 	}
@@ -103,6 +127,8 @@ func (l Level) String() string {
 		return "error"
 	case NoLevel:
 		return "none"
+	case Off:
+		return "off"
 	default:
 		return "unknown"
 	}
@@ -167,7 +193,8 @@ type Logger interface {
 	// the current name as well.
 	ResetNamed(name string) Logger
 
-	// Updates the level. This should affect all sub-loggers as well. If an
+	// Updates the level. This should affect all related loggers as well,
+	// unless they were created with IndependentLevels. If an
 	// implementation cannot update the level on the fly, it should no-op.
 	SetLevel(level Level)
 
@@ -186,12 +213,23 @@ type StandardLoggerOptions struct {
 	// [DEBUG] and strip it off before reapplying it.
 	InferLevels bool
 
+	// Indicate that some minimal parsing should be done on strings to try
+	// and detect their level and re-emit them while ignoring possible
+	// timestamp values in the beginning of the string.
+	// This supports the strings like [ERROR], [ERR] [TRACE], [WARN], [INFO],
+	// [DEBUG] and strip it off before reapplying it.
+	// The timestamp detection may result in false positives and incomplete
+	// string outputs.
+	InferLevelsWithTimestamp bool
+
 	// ForceLevel is used to force all output from the standard logger to be at
 	// the specified level. Similar to InferLevels, this will strip any level
 	// prefix contained in the logged string before applying the forced level.
 	// If set, this override InferLevels.
 	ForceLevel Level
 }
+
+type TimeFunction = func() time.Time
 
 // LoggerOptions can be used to configure a new logger.
 type LoggerOptions struct {
@@ -215,12 +253,38 @@ type LoggerOptions struct {
 	// Include file and line information in each log line
 	IncludeLocation bool
 
+	// AdditionalLocationOffset is the number of additional stack levels to skip
+	// when finding the file and line information for the log line
+	AdditionalLocationOffset int
+
 	// The time format to use instead of the default
 	TimeFormat string
+
+	// A function which is called to get the time object that is formatted using `TimeFormat`
+	TimeFn TimeFunction
+
+	// Control whether or not to display the time at all. This is required
+	// because setting TimeFormat to empty assumes the default format.
+	DisableTime bool
 
 	// Color the output. On Windows, colored logs are only avaiable for io.Writers that
 	// are concretely instances of *os.File.
 	Color ColorOption
+
+	// Only color the header, not the body. This can help with readability of long messages.
+	ColorHeaderOnly bool
+
+	// A function which is called with the log information and if it returns true the value
+	// should not be logged.
+	// This is useful when interacting with a system that you wish to suppress the log
+	// message for (because it's too noisy, etc)
+	Exclude func(level Level, msg string, args ...interface{}) bool
+
+	// IndependentLevels causes subloggers to be created with an independent
+	// copy of this logger's level. This means that using SetLevel on this
+	// logger will not effect any subloggers, and SetLevel on any subloggers
+	// will not effect the parent or sibling loggers.
+	IndependentLevels bool
 }
 
 // InterceptLogger describes the interface for using a logger
@@ -249,10 +313,10 @@ type InterceptLogger interface {
 	// the current name as well.
 	ResetNamedIntercept(name string) InterceptLogger
 
-	// Return a value that conforms to the stdlib log.Logger interface
+	// Deprecated: use StandardLogger
 	StandardLoggerIntercept(opts *StandardLoggerOptions) *log.Logger
 
-	// Return a value that conforms to io.Writer, which can be passed into log.SetOutput()
+	// Deprecated: use StandardWriter
 	StandardWriterIntercept(opts *StandardLoggerOptions) io.Writer
 }
 

--- a/vendor/github.com/hashicorp/go-hclog/stdlog.go
+++ b/vendor/github.com/hashicorp/go-hclog/stdlog.go
@@ -2,16 +2,23 @@ package hclog
 
 import (
 	"bytes"
+	"log"
+	"regexp"
 	"strings"
 )
+
+// Regex to ignore characters commonly found in timestamp formats from the
+// beginning of inputs.
+var logTimestampRegexp = regexp.MustCompile(`^[\d\s\:\/\.\+-TZ]*`)
 
 // Provides a io.Writer to shim the data out of *log.Logger
 // and back into our Logger. This is basically the only way to
 // build upon *log.Logger.
 type stdlogAdapter struct {
-	log         Logger
-	inferLevels bool
-	forceLevel  Level
+	log                      Logger
+	inferLevels              bool
+	inferLevelsWithTimestamp bool
+	forceLevel               Level
 }
 
 // Take the data, infer the levels if configured, and send it through
@@ -27,6 +34,10 @@ func (s *stdlogAdapter) Write(data []byte) (int, error) {
 		// Log at the forced level
 		s.dispatch(str, s.forceLevel)
 	} else if s.inferLevels {
+		if s.inferLevelsWithTimestamp {
+			str = s.trimTimestamp(str)
+		}
+
 		level, str := s.pickLevel(str)
 		s.dispatch(str, level)
 	} else {
@@ -63,7 +74,7 @@ func (s *stdlogAdapter) pickLevel(str string) (Level, string) {
 	case strings.HasPrefix(str, "[INFO]"):
 		return Info, strings.TrimSpace(str[6:])
 	case strings.HasPrefix(str, "[WARN]"):
-		return Warn, strings.TrimSpace(str[7:])
+		return Warn, strings.TrimSpace(str[6:])
 	case strings.HasPrefix(str, "[ERROR]"):
 		return Error, strings.TrimSpace(str[7:])
 	case strings.HasPrefix(str, "[ERR]"):
@@ -71,4 +82,29 @@ func (s *stdlogAdapter) pickLevel(str string) (Level, string) {
 	default:
 		return Info, str
 	}
+}
+
+func (s *stdlogAdapter) trimTimestamp(str string) string {
+	idx := logTimestampRegexp.FindStringIndex(str)
+	return str[idx[1]:]
+}
+
+type logWriter struct {
+	l *log.Logger
+}
+
+func (l *logWriter) Write(b []byte) (int, error) {
+	l.l.Println(string(bytes.TrimRight(b, " \n\t")))
+	return len(b), nil
+}
+
+// Takes a standard library logger and returns a Logger that will write to it
+func FromStandardLogger(l *log.Logger, opts *LoggerOptions) Logger {
+	var dl LoggerOptions = *opts
+
+	// Use the time format that log.Logger uses
+	dl.DisableTime = true
+	dl.Output = &logWriter{l}
+
+	return New(&dl)
 }

--- a/vendor/github.com/hashicorp/go-immutable-radix/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/go-immutable-radix/CHANGELOG.md
@@ -1,5 +1,19 @@
 # UNRELEASED
 
+# 1.3.0 (September 17th, 2020)
+
+FEATURES
+
+* Add reverse tree traversal [[GH-30](https://github.com/hashicorp/go-immutable-radix/pull/30)]
+
+# 1.2.0 (March 18th, 2020)
+
+FEATURES
+
+* Adds a `Clone` method to `Txn` allowing transactions to be split either into two independently mutable trees. [[GH-26](https://github.com/hashicorp/go-immutable-radix/pull/26)]
+
+# 1.1.0 (May 22nd, 2019)
+
 FEATURES
 
 * Add `SeekLowerBound` to allow for range scans. [[GH-24](https://github.com/hashicorp/go-immutable-radix/pull/24)]

--- a/vendor/github.com/hashicorp/go-immutable-radix/iter.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/iter.go
@@ -20,7 +20,7 @@ func (i *Iterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
 	watch = n.mutateCh
 	search := prefix
 	for {
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			i.node = n
 			return
@@ -60,10 +60,13 @@ func (i *Iterator) recurseMin(n *Node) *Node {
 	if n.leaf != nil {
 		return n
 	}
-	if len(n.edges) > 0 {
+	nEdges := len(n.edges)
+	if nEdges > 1 {
 		// Add all the other edges to the stack (the min node will be added as
 		// we recurse)
 		i.stack = append(i.stack, n.edges[1:])
+	}
+	if nEdges > 0 {
 		return i.recurseMin(n.edges[0].node)
 	}
 	// Shouldn't be possible
@@ -77,14 +80,30 @@ func (i *Iterator) recurseMin(n *Node) *Node {
 func (i *Iterator) SeekLowerBound(key []byte) {
 	// Wipe the stack. Unlike Prefix iteration, we need to build the stack as we
 	// go because we need only a subset of edges of many nodes in the path to the
-	// leaf with the lower bound.
+	// leaf with the lower bound. Note that the iterator will still recurse into
+	// children that we don't traverse on the way to the reverse lower bound as it
+	// walks the stack.
 	i.stack = []edges{}
+	// i.node starts off in the common case as pointing to the root node of the
+	// tree. By the time we return we have either found a lower bound and setup
+	// the stack to traverse all larger keys, or we have not and the stack and
+	// node should both be nil to prevent the iterator from assuming it is just
+	// iterating the whole tree from the root node. Either way this needs to end
+	// up as nil so just set it here.
 	n := i.node
+	i.node = nil
 	search := key
 
 	found := func(n *Node) {
-		i.node = n
 		i.stack = append(i.stack, edges{edge{node: n}})
+	}
+
+	findMin := func(n *Node) {
+		n = i.recurseMin(n)
+		if n != nil {
+			found(n)
+			return
+		}
 	}
 
 	for {
@@ -100,10 +119,7 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 			// Prefix is larger, that means the lower bound is greater than the search
 			// and from now on we need to follow the minimum path to the smallest
 			// leaf under this subtree.
-			n = i.recurseMin(n)
-			if n != nil {
-				found(n)
-			}
+			findMin(n)
 			return
 		}
 
@@ -115,27 +131,29 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 		}
 
 		// Prefix is equal, we are still heading for an exact match. If this is a
-		// leaf we're done.
-		if n.leaf != nil {
-			if bytes.Compare(n.leaf.key, key) < 0 {
-				i.node = nil
-				return
-			}
+		// leaf and an exact match we're done.
+		if n.leaf != nil && bytes.Equal(n.leaf.key, key) {
 			found(n)
 			return
 		}
 
-		// Consume the search prefix
-		if len(n.prefix) > len(search) {
-			search = []byte{}
-		} else {
-			search = search[len(n.prefix):]
+		// Consume the search prefix if the current node has one. Note that this is
+		// safe because if n.prefix is longer than the search slice prefixCmp would
+		// have been > 0 above and the method would have already returned.
+		search = search[len(n.prefix):]
+
+		if len(search) == 0 {
+			// We've exhausted the search key, but the current node is not an exact
+			// match or not a leaf. That means that the leaf value if it exists, and
+			// all child nodes must be strictly greater, the smallest key in this
+			// subtree must be the lower bound.
+			findMin(n)
+			return
 		}
 
 		// Otherwise, take the lower bound next edge.
 		idx, lbNode := n.getLowerBoundEdge(search[0])
 		if lbNode == nil {
-			i.node = nil
 			return
 		}
 
@@ -144,7 +162,6 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 			i.stack = append(i.stack, n.edges[idx+1:])
 		}
 
-		i.node = lbNode
 		// Recurse
 		n = lbNode
 	}
@@ -155,7 +172,7 @@ func (i *Iterator) Next() ([]byte, interface{}, bool) {
 	// Initialize our stack if needed
 	if i.stack == nil && i.node != nil {
 		i.stack = []edges{
-			edges{
+			{
 				edge{node: i.node},
 			},
 		}

--- a/vendor/github.com/hashicorp/go-immutable-radix/node.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/node.go
@@ -211,6 +211,12 @@ func (n *Node) Iterator() *Iterator {
 	return &Iterator{node: n}
 }
 
+// ReverseIterator is used to return an iterator at
+// the given node to walk the tree backwards
+func (n *Node) ReverseIterator() *ReverseIterator {
+	return NewReverseIterator(n)
+}
+
 // rawIterator is used to return a raw iterator at the given node to walk the
 // tree.
 func (n *Node) rawIterator() *rawIterator {
@@ -222,6 +228,11 @@ func (n *Node) rawIterator() *rawIterator {
 // Walk is used to walk the tree
 func (n *Node) Walk(fn WalkFn) {
 	recursiveWalk(n, fn)
+}
+
+// WalkBackwards is used to walk the tree in reverse order
+func (n *Node) WalkBackwards(fn WalkFn) {
+	reverseRecursiveWalk(n, fn)
 }
 
 // WalkPrefix is used to walk the tree under a prefix
@@ -297,6 +308,25 @@ func recursiveWalk(n *Node, fn WalkFn) bool {
 	// Recurse on the children
 	for _, e := range n.edges {
 		if recursiveWalk(e.node, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// reverseRecursiveWalk is used to do a reverse pre-order
+// walk of a node recursively. Returns true if the walk
+// should be aborted
+func reverseRecursiveWalk(n *Node, fn WalkFn) bool {
+	// Visit the leaf values if any
+	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
+		return true
+	}
+
+	// Recurse on the children in reverse order
+	for i := len(n.edges) - 1; i >= 0; i-- {
+		e := n.edges[i]
+		if reverseRecursiveWalk(e.node, fn) {
 			return true
 		}
 	}

--- a/vendor/github.com/hashicorp/go-immutable-radix/raw_iter.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/raw_iter.go
@@ -41,7 +41,7 @@ func (i *rawIterator) Next() {
 	// Initialize our stack if needed.
 	if i.stack == nil && i.node != nil {
 		i.stack = []rawStackEntry{
-			rawStackEntry{
+			{
 				edges: edges{
 					edge{node: i.node},
 				},

--- a/vendor/github.com/hashicorp/go-immutable-radix/reverse_iter.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/reverse_iter.go
@@ -1,0 +1,239 @@
+package iradix
+
+import (
+	"bytes"
+)
+
+// ReverseIterator is used to iterate over a set of nodes
+// in reverse in-order
+type ReverseIterator struct {
+	i *Iterator
+
+	// expandedParents stores the set of parent nodes whose relevant children have
+	// already been pushed into the stack. This can happen during seek or during
+	// iteration.
+	//
+	// Unlike forward iteration we need to recurse into children before we can
+	// output the value stored in an internal leaf since all children are greater.
+	// We use this to track whether we have already ensured all the children are
+	// in the stack.
+	expandedParents map[*Node]struct{}
+}
+
+// NewReverseIterator returns a new ReverseIterator at a node
+func NewReverseIterator(n *Node) *ReverseIterator {
+	return &ReverseIterator{
+		i: &Iterator{node: n},
+	}
+}
+
+// SeekPrefixWatch is used to seek the iterator to a given prefix
+// and returns the watch channel of the finest granularity
+func (ri *ReverseIterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
+	return ri.i.SeekPrefixWatch(prefix)
+}
+
+// SeekPrefix is used to seek the iterator to a given prefix
+func (ri *ReverseIterator) SeekPrefix(prefix []byte) {
+	ri.i.SeekPrefixWatch(prefix)
+}
+
+// SeekReverseLowerBound is used to seek the iterator to the largest key that is
+// lower or equal to the given key. There is no watch variant as it's hard to
+// predict based on the radix structure which node(s) changes might affect the
+// result.
+func (ri *ReverseIterator) SeekReverseLowerBound(key []byte) {
+	// Wipe the stack. Unlike Prefix iteration, we need to build the stack as we
+	// go because we need only a subset of edges of many nodes in the path to the
+	// leaf with the lower bound. Note that the iterator will still recurse into
+	// children that we don't traverse on the way to the reverse lower bound as it
+	// walks the stack.
+	ri.i.stack = []edges{}
+	// ri.i.node starts off in the common case as pointing to the root node of the
+	// tree. By the time we return we have either found a lower bound and setup
+	// the stack to traverse all larger keys, or we have not and the stack and
+	// node should both be nil to prevent the iterator from assuming it is just
+	// iterating the whole tree from the root node. Either way this needs to end
+	// up as nil so just set it here.
+	n := ri.i.node
+	ri.i.node = nil
+	search := key
+
+	if ri.expandedParents == nil {
+		ri.expandedParents = make(map[*Node]struct{})
+	}
+
+	found := func(n *Node) {
+		ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
+		// We need to mark this node as expanded in advance too otherwise the
+		// iterator will attempt to walk all of its children even though they are
+		// greater than the lower bound we have found. We've expanded it in the
+		// sense that all of its children that we want to walk are already in the
+		// stack (i.e. none of them).
+		ri.expandedParents[n] = struct{}{}
+	}
+
+	for {
+		// Compare current prefix with the search key's same-length prefix.
+		var prefixCmp int
+		if len(n.prefix) < len(search) {
+			prefixCmp = bytes.Compare(n.prefix, search[0:len(n.prefix)])
+		} else {
+			prefixCmp = bytes.Compare(n.prefix, search)
+		}
+
+		if prefixCmp < 0 {
+			// Prefix is smaller than search prefix, that means there is no exact
+			// match for the search key. But we are looking in reverse, so the reverse
+			// lower bound will be the largest leaf under this subtree, since it is
+			// the value that would come right before the current search key if it
+			// were in the tree. So we need to follow the maximum path in this subtree
+			// to find it. Note that this is exactly what the iterator will already do
+			// if it finds a node in the stack that has _not_ been marked as expanded
+			// so in this one case we don't call `found` and instead let the iterator
+			// do the expansion and recursion through all the children.
+			ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
+			return
+		}
+
+		if prefixCmp > 0 {
+			// Prefix is larger than search prefix, or there is no prefix but we've
+			// also exhausted the search key. Either way, that means there is no
+			// reverse lower bound since nothing comes before our current search
+			// prefix.
+			return
+		}
+
+		// If this is a leaf, something needs to happen! Note that if it's a leaf
+		// and prefixCmp was zero (which it must be to get here) then the leaf value
+		// is either an exact match for the search, or it's lower. It can't be
+		// greater.
+		if n.isLeaf() {
+
+			// Firstly, if it's an exact match, we're done!
+			if bytes.Equal(n.leaf.key, key) {
+				found(n)
+				return
+			}
+
+			// It's not so this node's leaf value must be lower and could still be a
+			// valid contender for reverse lower bound.
+
+			// If it has no children then we are also done.
+			if len(n.edges) == 0 {
+				// This leaf is the lower bound.
+				found(n)
+				return
+			}
+
+			// Finally, this leaf is internal (has children) so we'll keep searching,
+			// but we need to add it to the iterator's stack since it has a leaf value
+			// that needs to be iterated over. It needs to be added to the stack
+			// before its children below as it comes first.
+			ri.i.stack = append(ri.i.stack, edges{edge{node: n}})
+			// We also need to mark it as expanded since we'll be adding any of its
+			// relevant children below and so don't want the iterator to re-add them
+			// on its way back up the stack.
+			ri.expandedParents[n] = struct{}{}
+		}
+
+		// Consume the search prefix. Note that this is safe because if n.prefix is
+		// longer than the search slice prefixCmp would have been > 0 above and the
+		// method would have already returned.
+		search = search[len(n.prefix):]
+
+		if len(search) == 0 {
+			// We've exhausted the search key but we are not at a leaf. That means all
+			// children are greater than the search key so a reverse lower bound
+			// doesn't exist in this subtree. Note that there might still be one in
+			// the whole radix tree by following a different path somewhere further
+			// up. If that's the case then the iterator's stack will contain all the
+			// smaller nodes already and Previous will walk through them correctly.
+			return
+		}
+
+		// Otherwise, take the lower bound next edge.
+		idx, lbNode := n.getLowerBoundEdge(search[0])
+
+		// From here, we need to update the stack with all values lower than
+		// the lower bound edge. Since getLowerBoundEdge() returns -1 when the
+		// search prefix is larger than all edges, we need to place idx at the
+		// last edge index so they can all be place in the stack, since they
+		// come before our search prefix.
+		if idx == -1 {
+			idx = len(n.edges)
+		}
+
+		// Create stack edges for the all strictly lower edges in this node.
+		if len(n.edges[:idx]) > 0 {
+			ri.i.stack = append(ri.i.stack, n.edges[:idx])
+		}
+
+		// Exit if there's no lower bound edge. The stack will have the previous
+		// nodes already.
+		if lbNode == nil {
+			return
+		}
+
+		// Recurse
+		n = lbNode
+	}
+}
+
+// Previous returns the previous node in reverse order
+func (ri *ReverseIterator) Previous() ([]byte, interface{}, bool) {
+	// Initialize our stack if needed
+	if ri.i.stack == nil && ri.i.node != nil {
+		ri.i.stack = []edges{
+			{
+				edge{node: ri.i.node},
+			},
+		}
+	}
+
+	if ri.expandedParents == nil {
+		ri.expandedParents = make(map[*Node]struct{})
+	}
+
+	for len(ri.i.stack) > 0 {
+		// Inspect the last element of the stack
+		n := len(ri.i.stack)
+		last := ri.i.stack[n-1]
+		m := len(last)
+		elem := last[m-1].node
+
+		_, alreadyExpanded := ri.expandedParents[elem]
+
+		// If this is an internal node and we've not seen it already, we need to
+		// leave it in the stack so we can return its possible leaf value _after_
+		// we've recursed through all its children.
+		if len(elem.edges) > 0 && !alreadyExpanded {
+			// record that we've seen this node!
+			ri.expandedParents[elem] = struct{}{}
+			// push child edges onto stack and skip the rest of the loop to recurse
+			// into the largest one.
+			ri.i.stack = append(ri.i.stack, elem.edges)
+			continue
+		}
+
+		// Remove the node from the stack
+		if m > 1 {
+			ri.i.stack[n-1] = last[:m-1]
+		} else {
+			ri.i.stack = ri.i.stack[:n-1]
+		}
+		// We don't need this state any more as it's no longer in the stack so we
+		// won't visit it again
+		if alreadyExpanded {
+			delete(ri.expandedParents, elem)
+		}
+
+		// If this is a leaf, return it
+		if elem.leaf != nil {
+			return elem.leaf.key, elem.leaf.val, true
+		}
+
+		// it's not a leaf so keep walking the stack to find the previous leaf
+	}
+	return nil, nil, false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -550,10 +550,10 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-cleanhttp v0.5.2
 ## explicit; go 1.13
 github.com/hashicorp/go-cleanhttp
-# github.com/hashicorp/go-hclog v1.2.0 => github.com/hashicorp/go-hclog v0.12.2
+# github.com/hashicorp/go-hclog v1.2.0
 ## explicit; go 1.13
 github.com/hashicorp/go-hclog
-# github.com/hashicorp/go-immutable-radix v1.3.1 => github.com/hashicorp/go-immutable-radix v1.2.0
+# github.com/hashicorp/go-immutable-radix v1.3.1
 ## explicit
 github.com/hashicorp/go-immutable-radix
 # github.com/hashicorp/go-msgpack v0.5.5
@@ -1378,8 +1378,6 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230309083841-242e82b8e667
-# github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.2.0
-# github.com/hashicorp/go-hclog => github.com/hashicorp/go-hclog v0.12.2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 # google.golang.org/grpc => google.golang.org/grpc v1.47.0


### PR DESCRIPTION
#### What this PR does
Removing the `replace` directives for `hashicorp/go-immutable-radix` and `hashicorp/go-hclog` which are pinned to versions dating back to 2020. 

Affected packages:
```
go mod why github.com/hashicorp/go-immutable-radix

# github.com/hashicorp/go-immutable-radix
github.com/grafana/mimir/pkg/api
github.com/grafana/dskit/kv/memberlist
github.com/armon/go-metrics
github.com/hashicorp/go-immutable-radix
```

```
go mod why github.com/hashicorp/go-hclog

# github.com/hashicorp/go-hclog
github.com/grafana/mimir/tools/doc-generator/parse
github.com/grafana/dskit/kv/consul
github.com/hashicorp/consul/api
github.com/hashicorp/go-hclog
```


