### PR TITLE
Start a Grafana instance in microservices docker-compose

### DIFF
--- a/development/mimir-microservices-mode/config/dashboards-mimir.yaml
+++ b/development/mimir-microservices-mode/config/dashboards-mimir.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+- name: Mimir
+  orgId: 1
+  type: file
+  disableDeletion: true
+  updateIntervalSeconds: 10
+  allowUiUpdates: false
+  options:
+    path: /var/lib/grafana/dashboards
+    foldersFromFilesStructure: true

--- a/development/mimir-microservices-mode/config/datasource-mimir.yaml
+++ b/development/mimir-microservices-mode/config/datasource-mimir.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+datasources:
+- name: Mimir
+  type: prometheus
+  access: proxy
+  uid: mimir
+  orgID: 1
+  url: http://query-frontend:8007/prometheus
+  jsonData:
+    prometheusType: Mimir
+    exemplarTraceIdDestinations:
+    - name: traceID
+      datasourceUid: jaeger
+- name: Jaeger
+  type: jaeger
+  access: proxy
+  uid: jaeger
+  orgID: 1
+  url: http://jaeger:16686/

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -31,6 +31,7 @@ std.manifestYamlDoc({
     self.alertmanagers(3) +
     self.minio +
     self.prometheus +
+    self.grafana +
     self.grafana_agent +
     self.otel_collector +
     self.jaeger +
@@ -253,6 +254,22 @@ std.manifestYamlDoc({
       ],
       volumes: ['./config:/etc/prometheus', '../../operations/mimir-mixin-compiled/alerts.yaml:/etc/alerts/alerts.yaml'],
       ports: ['9090:9090'],
+    },
+  },
+
+  grafana:: {
+    grafana: {
+      image: 'grafana/grafana:9.4.3',
+      environment: [
+        'GF_AUTH_ANONYMOUS_ENABLED=true',
+        'GF_AUTH_ANONYMOUS_ORG_ROLE=Admin',
+      ],
+      volumes: [
+        './config/datasource-mimir.yaml:/etc/grafana/provisioning/datasources/mimir.yaml',
+        './config/dashboards-mimir.yaml:/etc/grafana/provisioning/dashboards/mimir.yaml',
+        '../../operations/mimir-mixin-compiled/dashboards:/var/lib/grafana/dashboards/Mimir',
+      ],
+      ports: ['3000:3000'],
     },
   },
 

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -135,6 +135,17 @@
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
+  "grafana":
+    "environment":
+      - "GF_AUTH_ANONYMOUS_ENABLED=true"
+      - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
+    "image": "grafana/grafana:9.4.3"
+    "ports":
+      - "3000:3000"
+    "volumes":
+      - "./config/datasource-mimir.yaml:/etc/grafana/provisioning/datasources/mimir.yaml"
+      - "./config/dashboards-mimir.yaml:/etc/grafana/provisioning/dashboards/mimir.yaml"
+      - "../../operations/mimir-mixin-compiled/dashboards:/var/lib/grafana/dashboards/Mimir"
   "grafana-agent":
     "command":
       - "-config.file=/etc/agent-config/grafana-agent.yaml"


### PR DESCRIPTION
#### What this PR does

Create a Grafana instance pre-configured with Mimir and Jaeger as a datasources and the mixin dashboards available.

#### Which issue(s) this PR fixes or relates to

Related: #4236

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
