### PR TITLE
Add protobuf internal query result payload format to experimental features list.

### DIFF
--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -111,6 +111,9 @@ The following features are currently experimental:
   - `-max-separate-metrics-groups-per-user`
 - Overrides-exporter
   - Peer discovery / tenant sharding for overrides exporters (`-overrides-exporter.ring.enabled`)
+- Protobuf internal query result payload format
+  - `-query-frontend.query-result-response-format=protobuf`
+  - `-ruler.query-frontend.query-result-response-format=protobuf`
 
 ## Deprecated features
 


### PR DESCRIPTION
#### What this PR does

This PR adds the new internal query result payload format to the experimental features list.

As part of this feature (covering the querier -> query-frontend path) is included in v2.7, once this is merged I'll also backport the relevant part to the 2.7 release as well.

#### Which issue(s) this PR fixes or relates to

#4104

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
