### PR TITLE
Deprecate consistency delay config option (#4409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Querying with using `{__mimir_storage__="ephemeral"}` selector no longer works. 
    * `-blocks-storage.bucket-store.index-header.stream-reader-enabled` has been removed
    * `-blocks-storage.bucket-store.index-header.stream-reader-max-idle-file-handles` has been renamed to `-blocks-storage.bucket-store.index-header.max-idle-file-handles`, and the corresponding configuration file option has been renamed from `stream_reader_max_idle_file_handles` to `max_idle_file_handles`
 * [CHANGE] Store-gateway: the streaming store-gateway is now enabled by default. The new default setting for `-blocks-storage.bucket-store.batch-series-size` is `5000`. #4330
+* [CHANGE] Compactor: the configuration parameter `-compactor.consistency-delay` has been deprecated and will be removed in Mimir 2.9. #4409
+* [CHANGE] Store-gateway: the configuration parameter `-blocks-storage.bucket-store.consistency-delay` has been deprecated and will be removed in Mimir 2.9. #4409
 * [FEATURE] Ruler: added `keep_firing_for` support to alerting rules. #4099
 * [FEATURE] Distributor, ingester: ingestion of native histograms. The new per-tenant limit `-ingester.native-histograms-ingestion-enabled` controls whether native histograms are stored or ignored. #4159
 * [FEATURE] Query-frontend: Introduce experimental `-query-frontend.query-sharding-target-series-per-shard` to allow query sharding to take into account cardinality of similar requests executed previously. This feature uses the same cache that's used for results caching. #4121 #4177 #4188 #4254

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5029,7 +5029,7 @@
               "fieldDefaultValue": 0,
               "fieldFlag": "blocks-storage.bucket-store.consistency-delay",
               "fieldType": "duration",
-              "fieldCategory": "advanced"
+              "fieldCategory": "deprecated"
             },
             {
               "kind": "block",
@@ -6109,7 +6109,7 @@
           "fieldDefaultValue": 0,
           "fieldFlag": "compactor.consistency-delay",
           "fieldType": "duration",
-          "fieldCategory": "advanced"
+          "fieldCategory": "deprecated"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -312,7 +312,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.chunks-cache.subrange-ttl duration
     	TTL for caching individual chunks subranges. (default 24h0m0s)
   -blocks-storage.bucket-store.consistency-delay duration
-    	Minimum age of a block before it's being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.
+    	[deprecated] Minimum age of a block before it's being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.
   -blocks-storage.bucket-store.ignore-blocks-within duration
     	Blocks with minimum time within this duration are ignored, and not loaded by store-gateway. Useful when used together with -querier.query-store-after to prevent loading young blocks, because there are usually many of them (depending on number of ingesters) and they are not yet compacted. Negative values or 0 disable the filter. (default 10h0m0s)
   -blocks-storage.bucket-store.ignore-deletion-marks-delay duration
@@ -648,7 +648,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.compactor-tenant-shard-size int
     	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.consistency-delay duration
-    	Minimum age of fresh (non-compacted) blocks before they are being processed.
+    	[deprecated] Minimum age of fresh (non-compacted) blocks before they are being processed.
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
   -compactor.deletion-delay duration

--- a/docs/sources/mimir/operators-guide/configure/about-versioning.md
+++ b/docs/sources/mimir/operators-guide/configure/about-versioning.md
@@ -14,7 +14,7 @@ This topic describes our guarantees for this Grafana Mimir major release.
 ## Flags, configuration, and minor version upgrades
 
 Upgrading Grafana Mimir from one minor version to the next minor version should work, but we don't want to bump the major version every time we remove a configuration parameter.
-We will keep deprecated flags and YAML configuration parameters in place for two minor releases.
+We will keep [deprecated features](#deprecated-features) in place for two minor releases.
 You can use the `deprecated_flags_inuse_total` metric to generate an alert that helps you determine if you're using a deprecated flag.
 
 These guarantees don't apply to [experimental features](#experimental-features).
@@ -106,3 +106,12 @@ The following features are currently experimental:
   - `-max-separate-metrics-groups-per-user`
 - Overrides-exporter
   - Peer discovery / tenant sharding for overrides exporters (`-overrides-exporter.ring.enabled`)
+
+## Deprecated features
+
+The following features are currently deprecated and will be **removed in Mimir 2.9**:
+
+- Compactor
+  - `-compactor.consistency-delay`
+- Store-gateway
+  - `-blocks-storage.bucket-store.consistency-delay`

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2938,7 +2938,7 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.meta-sync-concurrency
   [meta_sync_concurrency: <int> | default = 20]
 
-  # (advanced) Minimum age of a block before it's being read. Set it to safe
+  # (deprecated) Minimum age of a block before it's being read. Set it to safe
   # value (e.g 30m) if your object storage is eventually consistent. GCS and S3
   # are (roughly) strongly consistent.
   # CLI flag: -blocks-storage.bucket-store.consistency-delay
@@ -3302,7 +3302,7 @@ The `compactor` block configures the compactor component.
 # CLI flag: -compactor.meta-sync-concurrency
 [meta_sync_concurrency: <int> | default = 20]
 
-# (advanced) Minimum age of fresh (non-compacted) blocks before they are being
+# (deprecated) Minimum age of fresh (non-compacted) blocks before they are being
 # processed.
 # CLI flag: -compactor.consistency-delay
 [consistency_delay: <duration> | default = 0s]

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -49,6 +49,8 @@ const (
 const (
 	blocksMarkedForDeletionName = "cortex_compactor_blocks_marked_for_deletion_total"
 	blocksMarkedForDeletionHelp = "Total number of blocks marked for deletion in compactor."
+
+	consistencyDelayFlag = "compactor.consistency-delay"
 )
 
 var (
@@ -80,19 +82,19 @@ type BlocksCompactorFactory func(
 
 // Config holds the MultitenantCompactor config.
 type Config struct {
-	BlockRanges           mimir_tsdb.DurationList `yaml:"block_ranges" category:"advanced"`
-	BlockSyncConcurrency  int                     `yaml:"block_sync_concurrency" category:"advanced"`
-	MetaSyncConcurrency   int                     `yaml:"meta_sync_concurrency" category:"advanced"`
-	ConsistencyDelay      time.Duration           `yaml:"consistency_delay" category:"advanced"`
-	DataDir               string                  `yaml:"data_dir"`
-	CompactionInterval    time.Duration           `yaml:"compaction_interval" category:"advanced"`
-	CompactionRetries     int                     `yaml:"compaction_retries" category:"advanced"`
-	CompactionConcurrency int                     `yaml:"compaction_concurrency" category:"advanced"`
-	CleanupInterval       time.Duration           `yaml:"cleanup_interval" category:"advanced"`
-	CleanupConcurrency    int                     `yaml:"cleanup_concurrency" category:"advanced"`
-	DeletionDelay         time.Duration           `yaml:"deletion_delay" category:"advanced"`
-	TenantCleanupDelay    time.Duration           `yaml:"tenant_cleanup_delay" category:"advanced"`
-	MaxCompactionTime     time.Duration           `yaml:"max_compaction_time" category:"advanced"`
+	BlockRanges                mimir_tsdb.DurationList `yaml:"block_ranges" category:"advanced"`
+	BlockSyncConcurrency       int                     `yaml:"block_sync_concurrency" category:"advanced"`
+	MetaSyncConcurrency        int                     `yaml:"meta_sync_concurrency" category:"advanced"`
+	DeprecatedConsistencyDelay time.Duration           `yaml:"consistency_delay" category:"deprecated"` // Deprecated. Remove in Mimir 2.9.
+	DataDir                    string                  `yaml:"data_dir"`
+	CompactionInterval         time.Duration           `yaml:"compaction_interval" category:"advanced"`
+	CompactionRetries          int                     `yaml:"compaction_retries" category:"advanced"`
+	CompactionConcurrency      int                     `yaml:"compaction_concurrency" category:"advanced"`
+	CleanupInterval            time.Duration           `yaml:"cleanup_interval" category:"advanced"`
+	CleanupConcurrency         int                     `yaml:"cleanup_concurrency" category:"advanced"`
+	DeletionDelay              time.Duration           `yaml:"deletion_delay" category:"advanced"`
+	TenantCleanupDelay         time.Duration           `yaml:"tenant_cleanup_delay" category:"advanced"`
+	MaxCompactionTime          time.Duration           `yaml:"max_compaction_time" category:"advanced"`
 
 	// Compactor concurrency options
 	MaxOpeningBlocksConcurrency int `yaml:"max_opening_blocks_concurrency" category:"advanced"` // Number of goroutines opening blocks before compaction.
@@ -130,7 +132,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.retryMaxBackoff = time.Minute
 
 	f.Var(&cfg.BlockRanges, "compactor.block-ranges", "List of compaction time ranges.")
-	f.DurationVar(&cfg.ConsistencyDelay, "compactor.consistency-delay", 0, "Minimum age of fresh (non-compacted) blocks before they are being processed.")
+	f.DurationVar(&cfg.DeprecatedConsistencyDelay, consistencyDelayFlag, 0, "Minimum age of fresh (non-compacted) blocks before they are being processed.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "compactor.block-sync-concurrency", 8, "Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "compactor.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from the long term storage.")
 	f.StringVar(&cfg.DataDir, "compactor.data-dir", "./data-compactor/", "Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts.")
@@ -154,7 +156,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.Var(&cfg.DisabledTenants, "compactor.disabled-tenants", "Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.")
 }
 
-func (cfg *Config) Validate() error {
+func (cfg *Config) Validate(logger log.Logger) error {
 	// Each block range period should be divisible by the previous one.
 	for i := 1; i < len(cfg.BlockRanges); i++ {
 		if cfg.BlockRanges[i]%cfg.BlockRanges[i-1] != 0 {
@@ -171,9 +173,11 @@ func (cfg *Config) Validate() error {
 	if cfg.SymbolsFlushersConcurrency < 1 {
 		return errInvalidSymbolFlushersConcurrency
 	}
-
 	if !util.StringsContain(CompactionOrders, cfg.CompactionJobsOrder) {
 		return errInvalidCompactionOrder
+	}
+	if cfg.DeprecatedConsistencyDelay > 0 {
+		util.WarnDeprecatedConfig(consistencyDelayFlag, logger)
 	}
 
 	return nil
@@ -696,7 +700,7 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 			mimir_tsdb.DeprecatedTenantIDExternalLabel,
 			mimir_tsdb.DeprecatedIngesterIDExternalLabel,
 		}),
-		block.NewConsistencyDelayMetaFilter(ulogger, c.compactorCfg.ConsistencyDelay, reg),
+		block.NewConsistencyDelayMetaFilter(ulogger, c.compactorCfg.DeprecatedConsistencyDelay, reg),
 		excludeMarkedForDeletionFilter,
 		deduplicateBlocksFilter,
 		// removes blocks that should not be compacted due to being marked so.

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -66,7 +66,7 @@ compaction_retries: 123
 	flagext.DefaultValues(&cfg)
 	assert.NoError(t, yaml.Unmarshal([]byte(yamlCfg), &cfg))
 	assert.Equal(t, mimir_tsdb.DurationList{2 * time.Hour, 48 * time.Hour}, cfg.BlockRanges)
-	assert.Equal(t, time.Hour, cfg.ConsistencyDelay)
+	assert.Equal(t, time.Hour, cfg.DeprecatedConsistencyDelay)
 	assert.Equal(t, 123, cfg.BlockSyncConcurrency)
 	assert.Equal(t, "/tmp", cfg.DataDir)
 	assert.Equal(t, 15*time.Minute, cfg.CompactionInterval)
@@ -87,7 +87,7 @@ func TestConfig_ShouldSupportCliFlags(t *testing.T) {
 	}))
 
 	assert.Equal(t, mimir_tsdb.DurationList{2 * time.Hour, 48 * time.Hour}, cfg.BlockRanges)
-	assert.Equal(t, time.Hour, cfg.ConsistencyDelay)
+	assert.Equal(t, time.Hour, cfg.DeprecatedConsistencyDelay)
 	assert.Equal(t, 123, cfg.BlockSyncConcurrency)
 	assert.Equal(t, "/tmp", cfg.DataDir)
 	assert.Equal(t, 15*time.Minute, cfg.CompactionInterval)
@@ -141,7 +141,7 @@ func TestConfig_Validate(t *testing.T) {
 			flagext.DefaultValues(cfg)
 			testData.setup(cfg)
 
-			if actualErr := cfg.Validate(); testData.expected != "" {
+			if actualErr := cfg.Validate(log.NewNopLogger()); testData.expected != "" {
 				assert.EqualError(t, actualErr, testData.expected)
 			} else {
 				assert.NoError(t, actualErr)

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -221,7 +221,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.Ruler.Validate(c.LimitsConfig, log); err != nil {
 		return errors.Wrap(err, "invalid ruler config")
 	}
-	if err := c.BlocksStorage.Validate(); err != nil {
+	if err := c.BlocksStorage.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid TSDB config")
 	}
 	if err := c.Distributor.Validate(c.LimitsConfig); err != nil {
@@ -246,7 +246,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.StoreGateway.Validate(c.LimitsConfig); err != nil {
 		return errors.Wrap(err, "invalid store-gateway config")
 	}
-	if err := c.Compactor.Validate(); err != nil {
+	if err := c.Compactor.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid compactor config")
 	}
 	if err := c.AlertmanagerStorage.Validate(); err != nil {

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -252,7 +252,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	consistency := NewBlocksConsistencyChecker(
 		// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
 		// to discover and load them (3 times the sync interval).
-		storageCfg.BucketStore.ConsistencyDelay+(3*storageCfg.BucketStore.SyncInterval),
+		storageCfg.BucketStore.DeprecatedConsistencyDelay+(3*storageCfg.BucketStore.SyncInterval),
 		// To avoid any false positive in the consistency check, we do exclude blocks which have been
 		// recently marked for deletion, until the "ignore delay / 2". This means the consistency checker
 		// exclude such blocks about 50% of the time before querier and store-gateway stops querying them.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storegateway/indexheader"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -80,6 +81,8 @@ const (
 	headPostingsForMatchersCacheTTLHelp  = "How long to cache postings for matchers in the Head and OOOHead. 0 disables the cache and just deduplicates the in-flight calls."
 	headPostingsForMatchersCacheSizeHelp = "Maximum number of entries in the cache for postings for matchers in the Head and OOOHead when ttl > 0."
 	headPostingsForMatchersCacheForce    = "Force the cache to be used for postings for matchers in the Head and OOOHead, even if it's not a concurrent (query-sharding) call."
+
+	consistencyDelayFlag = "blocks-storage.bucket-store.consistency-delay"
 )
 
 // Validation errors
@@ -145,7 +148,7 @@ func (cfg *BlocksStorageConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger
 }
 
 // Validate the config.
-func (cfg *BlocksStorageConfig) Validate() error {
+func (cfg *BlocksStorageConfig) Validate(logger log.Logger) error {
 	if err := cfg.Bucket.Validate(); err != nil {
 		return err
 	}
@@ -154,7 +157,7 @@ func (cfg *BlocksStorageConfig) Validate() error {
 		return err
 	}
 
-	return cfg.BucketStore.Validate()
+	return cfg.BucketStore.Validate(logger)
 }
 
 // TSDBConfig holds the config for TSDB opened in the ingesters.
@@ -286,19 +289,19 @@ func (cfg *TSDBConfig) IsBlocksShippingEnabled() bool {
 
 // BucketStoreConfig holds the config information for Bucket Stores used by the querier and store-gateway.
 type BucketStoreConfig struct {
-	SyncDir                  string              `yaml:"sync_dir"`
-	SyncInterval             time.Duration       `yaml:"sync_interval" category:"advanced"`
-	MaxConcurrent            int                 `yaml:"max_concurrent" category:"advanced"`
-	TenantSyncConcurrency    int                 `yaml:"tenant_sync_concurrency" category:"advanced"`
-	BlockSyncConcurrency     int                 `yaml:"block_sync_concurrency" category:"advanced"`
-	MetaSyncConcurrency      int                 `yaml:"meta_sync_concurrency" category:"advanced"`
-	ConsistencyDelay         time.Duration       `yaml:"consistency_delay" category:"advanced"`
-	IndexCache               IndexCacheConfig    `yaml:"index_cache"`
-	ChunksCache              ChunksCacheConfig   `yaml:"chunks_cache"`
-	MetadataCache            MetadataCacheConfig `yaml:"metadata_cache"`
-	IgnoreDeletionMarksDelay time.Duration       `yaml:"ignore_deletion_mark_delay" category:"advanced"`
-	BucketIndex              BucketIndexConfig   `yaml:"bucket_index"`
-	IgnoreBlocksWithin       time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
+	SyncDir                    string              `yaml:"sync_dir"`
+	SyncInterval               time.Duration       `yaml:"sync_interval" category:"advanced"`
+	MaxConcurrent              int                 `yaml:"max_concurrent" category:"advanced"`
+	TenantSyncConcurrency      int                 `yaml:"tenant_sync_concurrency" category:"advanced"`
+	BlockSyncConcurrency       int                 `yaml:"block_sync_concurrency" category:"advanced"`
+	MetaSyncConcurrency        int                 `yaml:"meta_sync_concurrency" category:"advanced"`
+	DeprecatedConsistencyDelay time.Duration       `yaml:"consistency_delay" category:"deprecated"` // Deprecated. Remove in Mimir 2.9.
+	IndexCache                 IndexCacheConfig    `yaml:"index_cache"`
+	ChunksCache                ChunksCacheConfig   `yaml:"chunks_cache"`
+	MetadataCache              MetadataCacheConfig `yaml:"metadata_cache"`
+	IgnoreDeletionMarksDelay   time.Duration       `yaml:"ignore_deletion_mark_delay" category:"advanced"`
+	BucketIndex                BucketIndexConfig   `yaml:"bucket_index"`
+	IgnoreBlocksWithin         time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
 
 	// Chunk pool.
 	MaxChunkPoolBytes           uint64 `yaml:"max_chunk_pool_bytes" category:"advanced"`
@@ -346,7 +349,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) 
 	f.IntVar(&cfg.TenantSyncConcurrency, "blocks-storage.bucket-store.tenant-sync-concurrency", 10, "Maximum number of concurrent tenants synching blocks.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "blocks-storage.bucket-store.block-sync-concurrency", 20, "Maximum number of concurrent blocks synching per tenant.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "blocks-storage.bucket-store.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from object storage per tenant.")
-	f.DurationVar(&cfg.ConsistencyDelay, "blocks-storage.bucket-store.consistency-delay", 0, "Minimum age of a block before it's being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.")
+	f.DurationVar(&cfg.DeprecatedConsistencyDelay, consistencyDelayFlag, 0, "Minimum age of a block before it's being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.")
 	f.DurationVar(&cfg.IgnoreDeletionMarksDelay, "blocks-storage.bucket-store.ignore-deletion-marks-delay", time.Hour*1, "Duration after which the blocks marked for deletion will be filtered out while fetching blocks. "+
 		"The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet.")
 	f.DurationVar(&cfg.IgnoreBlocksWithin, "blocks-storage.bucket-store.ignore-blocks-within", 10*time.Hour, "Blocks with minimum time within this duration are ignored, and not loaded by store-gateway. Useful when used together with -querier.query-store-after to prevent loading young blocks, because there are usually many of them (depending on number of ingesters) and they are not yet compacted. Negative values or 0 disable the filter.")
@@ -358,7 +361,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) 
 }
 
 // Validate the config.
-func (cfg *BucketStoreConfig) Validate() error {
+func (cfg *BucketStoreConfig) Validate(logger log.Logger) error {
 	err := cfg.IndexCache.Validate()
 	if err != nil {
 		return errors.Wrap(err, "index-cache configuration")
@@ -370,6 +373,9 @@ func (cfg *BucketStoreConfig) Validate() error {
 	err = cfg.MetadataCache.Validate()
 	if err != nil {
 		return errors.Wrap(err, "metadata-cache configuration")
+	}
+	if cfg.DeprecatedConsistencyDelay > 0 {
+		util.WarnDeprecatedConfig(consistencyDelayFlag, logger)
 	}
 	return nil
 }

--- a/pkg/storage/tsdb/config_test.go
+++ b/pkg/storage/tsdb/config_test.go
@@ -131,7 +131,7 @@ func TestConfig_Validate(t *testing.T) {
 			flagext.DefaultValues(cfg)
 			testData.setup(cfg)
 
-			actualErr := cfg.Validate()
+			actualErr := cfg.Validate(log.NewNopLogger())
 			assert.Equal(t, testData.expectedErr, actualErr)
 		})
 	}

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -427,7 +427,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 	// The sharding strategy filter MUST be before the ones we create here (order matters).
 	filters := []block.MetadataFilter{
 		NewShardingMetadataFilterAdapter(userID, u.shardingStrategy),
-		block.NewConsistencyDelayMetaFilter(userLogger, u.cfg.BucketStore.ConsistencyDelay, fetcherReg),
+		block.NewConsistencyDelayMetaFilter(userLogger, u.cfg.BucketStore.DeprecatedConsistencyDelay, fetcherReg),
 		newMinTimeMetaFilter(u.cfg.BucketStore.IgnoreBlocksWithin),
 		// Use our own custom implementation.
 		NewIgnoreDeletionMarkFilter(userLogger, userBkt, u.cfg.BucketStore.IgnoreDeletionMarksDelay, u.cfg.BucketStore.MetaSyncConcurrency),

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1481,7 +1481,7 @@ func mockStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
 
-	cfg.BucketStore.ConsistencyDelay = 0
+	cfg.BucketStore.DeprecatedConsistencyDelay = 0
 	cfg.BucketStore.BucketIndex.Enabled = false // mocks used in tests don't expect index reads
 	cfg.BucketStore.IgnoreBlocksWithin = 0
 	cfg.BucketStore.SyncDir = tmpDir

--- a/pkg/util/fieldcategory/overrides.go
+++ b/pkg/util/fieldcategory/overrides.go
@@ -13,6 +13,8 @@ const (
 	Advanced
 	// Experimental is the experimental field category.
 	Experimental
+	// Deprecated is the deprecated field category.
+	Deprecated
 )
 
 func (c Category) String() string {
@@ -23,6 +25,8 @@ func (c Category) String() string {
 		return "advanced"
 	case Experimental:
 		return "experimental"
+	case Deprecated:
+		return "deprecated"
 	default:
 		panic(fmt.Sprintf("Unknown field category: %d", c))
 	}

--- a/pkg/util/flags.go
+++ b/pkg/util/flags.go
@@ -4,7 +4,12 @@ package util
 
 import (
 	"flag"
+	"fmt"
 	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
 )
 
 // RegisteredFlags contains the flags registered by some config.
@@ -38,4 +43,9 @@ func TrackRegisteredFlags(prefix string, f *flag.FlagSet, register func(prefix s
 	})
 
 	return rf
+}
+
+func WarnDeprecatedConfig(flagName string, logger log.Logger) {
+	flagext.DeprecatedFlagsUsed.Inc()
+	level.Warn(logger).Log("msg", fmt.Sprintf("the configuration parameter -%s is deprecated and will be soon removed from Mimir", flagName))
 }

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -50,6 +50,8 @@ func Usage(printAll bool, configs ...interface{}) error {
 					fieldCat = fieldcategory.Advanced
 				case "experimental":
 					fieldCat = fieldcategory.Experimental
+				case "deprecated":
+					fieldCat = fieldcategory.Deprecated
 				}
 			}
 		}
@@ -70,8 +72,11 @@ func Usage(printAll bool, configs ...interface{}) error {
 		// Four spaces before the tab triggers good alignment
 		// for both 4- and 8-space tab stops.
 		b.WriteString("\n    \t")
-		if fieldCat == fieldcategory.Experimental {
+		switch fieldCat {
+		case fieldcategory.Experimental:
 			b.WriteString("[experimental] ")
+		case fieldcategory.Deprecated:
+			b.WriteString("[deprecated] ")
 		}
 		b.WriteString(strings.ReplaceAll(fl.Usage, "\n", "\n    \t"))
 


### PR DESCRIPTION
This is a backport of #4409 into `release-2.7` branch.
