### PR TITLE
Enable ingestion of native histograms in integration tests

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,11 +7,23 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.0.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-	"grafana/mimir:2.1.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-	"grafana/mimir:2.2.0": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-	"grafana/mimir:2.3.1": e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-	"grafana/mimir:2.4.0": e2emimir.NoopFlagMapper,
-	"grafana/mimir:2.5.0": e2emimir.NoopFlagMapper,
-	"grafana/mimir:2.6.0": e2emimir.NoopFlagMapper,
+	"grafana/mimir:2.0.0": e2emimir.ChainFlagMappers(
+		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
+		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	),
+	"grafana/mimir:2.1.0": e2emimir.ChainFlagMappers(
+		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
+		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	),
+	"grafana/mimir:2.2.0": e2emimir.ChainFlagMappers(
+		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
+		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	),
+	"grafana/mimir:2.3.1": e2emimir.ChainFlagMappers(
+		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
+		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	),
+	"grafana/mimir:2.4.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	"grafana/mimir:2.5.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	"grafana/mimir:2.6.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 }

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -142,6 +142,8 @@ func NewIngester(name string, consulAddress string, flags map[string]string, opt
 			"-ingester.ring.consul.hostname": consulAddress,
 			// Speed up the startup.
 			"-ingester.ring.min-ready-duration": "0s",
+			// Enable native histograms
+			"-ingester.native-histograms-ingestion-enabled": "true",
 		},
 		flags,
 		options...,
@@ -206,6 +208,8 @@ func NewSingleBinary(name string, flags map[string]string, options ...Option) *M
 			"-log.level": "warn",
 			// Speed up the startup.
 			"-ingester.ring.min-ready-duration": "0s",
+			// Enable native histograms
+			"-ingester.native-histograms-ingestion-enabled": "true",
 		},
 		flags,
 		options...,
@@ -234,6 +238,8 @@ func NewWriteInstance(name string, flags map[string]string, options ...Option) *
 			"-ingester.ring.replication-factor": "1",
 			// Speed up startup.
 			"-ingester.ring.min-ready-duration": "0s",
+			// Enable native histograms
+			"-ingester.native-histograms-ingestion-enabled": "true",
 		},
 		flags,
 		options...,


### PR DESCRIPTION
#### What this PR does

Enable ingestion of native histograms in integration tests
And remove flag via the mapper for backwards compatibility.

In preparation for incoming new e2e tests.

#### Which issue(s) this PR fixes or relates to

Related to: #3478 

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
