### PR TITLE
math: Convert Min and Max to be generic

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -902,12 +902,12 @@ func (d *Distributor) prePushValidationMiddleware(next push.Func) push.Func {
 		earliestSampleTimestampMs, latestSampleTimestampMs := int64(math.MaxInt64), int64(0)
 		for _, ts := range req.Timeseries {
 			for _, s := range ts.Samples {
-				earliestSampleTimestampMs = util_math.Min64(earliestSampleTimestampMs, s.TimestampMs)
-				latestSampleTimestampMs = util_math.Max64(latestSampleTimestampMs, s.TimestampMs)
+				earliestSampleTimestampMs = util_math.Min(earliestSampleTimestampMs, s.TimestampMs)
+				latestSampleTimestampMs = util_math.Max(latestSampleTimestampMs, s.TimestampMs)
 			}
 			for _, h := range ts.Histograms {
-				earliestSampleTimestampMs = util_math.Min64(earliestSampleTimestampMs, h.Timestamp)
-				latestSampleTimestampMs = util_math.Max64(latestSampleTimestampMs, h.Timestamp)
+				earliestSampleTimestampMs = util_math.Min(earliestSampleTimestampMs, h.Timestamp)
+				latestSampleTimestampMs = util_math.Max(latestSampleTimestampMs, h.Timestamp)
 			}
 		}
 		// Update this metric even in case of errors.

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -107,7 +107,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
 	// Clamp the time range based on the max query lookback and block retention period.
 	blocksRetentionPeriod := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.CompactorBlocksRetentionPeriod)
 	maxQueryLookback := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxQueryLookback)
-	maxLookback := util_math.MinDuration(blocksRetentionPeriod, maxQueryLookback)
+	maxLookback := util_math.Min(blocksRetentionPeriod, maxQueryLookback)
 	if maxLookback > 0 {
 		minStartTime := util.TimeToMillis(time.Now().Add(-maxLookback))
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -476,7 +476,7 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(ctx context.Context, logg
 	if q.queryStoreAfter > 0 {
 		now := time.Now()
 		origMaxT := maxT
-		maxT = math.Min64(maxT, util.TimeToMillis(now.Add(-q.queryStoreAfter)))
+		maxT = math.Min(maxT, util.TimeToMillis(now.Add(-q.queryStoreAfter)))
 
 		if origMaxT != maxT {
 			level.Debug(logger).Log("msg", "the max time of the query to blocks storage has been manipulated", "original", origMaxT, "updated", maxT)

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -847,7 +847,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 			stats.streamingSeriesFetchSeriesAndChunksDuration += stats.streamingSeriesWaitBatchLoadedDuration
 			stats.streamingSeriesEncodeResponseDuration += encodeDuration
 			stats.streamingSeriesSendResponseDuration += sendDuration
-			stats.streamingSeriesOtherDuration += time.Duration(util_math.Max64(0, int64(time.Since(iterationBegin)-
+			stats.streamingSeriesOtherDuration += time.Duration(util_math.Max(0, int64(time.Since(iterationBegin)-
 				stats.streamingSeriesFetchSeriesAndChunksDuration-encodeDuration-sendDuration)))
 		})
 

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -5,42 +5,20 @@
 
 package math
 
-import "time"
+import (
+	"golang.org/x/exp/constraints"
+)
 
-// Max returns the maximum of two ints
-func Max(a, b int) int {
+// Max returns the maximum of two ordered arguments.
+func Max[T constraints.Ordered](a, b T) T {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-// Min returns the minimum of two ints
-func Min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// Max64 returns the maximum of two int64s
-func Max64(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// Min64 returns the minimum of two int64s
-func Min64(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// MinDuration returns the minimum of two time.Durations
-func MinDuration(a, b time.Duration) time.Duration {
+// Min returns the minimum of two ordered arguments.
+func Min[T constraints.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}


### PR DESCRIPTION
#### What this PR does
Convert `pkg/util/math.Min` and `pkg/util/math.Max` to be generic, so they can operate on any arguments fulfilling `constraints.Ordered`. Also removing non-generic min and max implementations.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
