### PR TITLE
Exhaust iterators.chunkIterator after seek shortcut

### DIFF
--- a/pkg/querier/iterators/chunk_iterator_test.go
+++ b/pkg/querier/iterators/chunk_iterator_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package iterators
 
 import (

--- a/pkg/querier/iterators/chunk_iterator_test.go
+++ b/pkg/querier/iterators/chunk_iterator_test.go
@@ -1,0 +1,42 @@
+package iterators
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/chunk"
+)
+
+func TestChunkIterator_ScanShortcut(t *testing.T) {
+	encChk, err := chunk.NewForEncoding(chunk.PrometheusXorChunk)
+	require.NoError(t, err)
+
+	for i := 0; i < 120; i++ {
+		overflow, err := encChk.Add(model.SamplePair{
+			Timestamp: model.Time(i),
+			Value:     model.SampleValue(i),
+		})
+		require.NoError(t, err)
+		require.Nil(t, overflow)
+	}
+
+	chk := chunk.NewChunk(labels.FromStrings(labels.MetricName, "foobar"), encChk, 0, 119)
+
+	it := chunkIterator{Chunk: chk, it: chk.Data.NewIterator(nil)}
+
+	// Seek past what's in the chunk; triggers the shortcut in seek and returns chunkenc.ValNone.
+	valType := it.Seek(120)
+	require.Equal(t, chunkenc.ValNone, valType)
+
+	// The iterator is exhausted so it returns chunkenc.ValNone.
+	valType = it.Next()
+	require.Equal(t, chunkenc.ValNone, valType)
+
+	// Likewise for seeking.
+	valType = it.Seek(100)
+	require.Equal(t, chunkenc.ValNone, valType)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR makes `iterator.chunkIterator` consider itself exhausted after seeking past the end of its chunk. Before, the iterator would actually still be pointing at whatever sample it was pointed at before the call to `Seek`.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/4415

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
