### PR TITLE
Ruler: Sync rules when ruler JOINING the ring instead of ACTIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [FEATURE] Distributor, ingester, querier, query-frontend, store-gateway: add experimental support for native histograms. Requires that the experimental protobuf query result response format is enabled by `-query-frontend.query-result-response-format=protobuf` on the query frontend. #4286 #4352 #4354 #4376 #4377 #4387 #4396 #4425 #4442 #4494 #4512 #4513 #4526
 * [FEATURE] Add `freebsd` to the target OS when generating binaries for a Mimir release. #4654
 * [ENHANCEMENT] Add timezone information to Alpine Docker images. #4583
+* [ENHANCEMENT] Ruler: Sync rules when ruler JOINING the ring instead of ACTIVE. #4451
 * [ENHANCEMENT] Allow to define service name used for tracing via `JAEGER_SERVICE_NAME` environment variable. #4394
 * [ENHANCEMENT] Querier and query-frontend: add experimental, more performant protobuf query result response format enabled with `-query-frontend.query-result-response-format=protobuf`. #4304 #4318 #4375
 * [ENHANCEMENT] Compactor: added experimental configuration parameter `-compactor.first-level-compaction-wait-period`, to configure how long the compactor should wait before compacting 1st level blocks (uploaded by ingesters). This configuration option allows to reduce the chances compactor begins compacting blocks before all ingesters have uploaded their blocks to the storage. #4401

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [FEATURE] Distributor, ingester, querier, query-frontend, store-gateway: add experimental support for native histograms. Requires that the experimental protobuf query result response format is enabled by `-query-frontend.query-result-response-format=protobuf` on the query frontend. #4286 #4352 #4354 #4376 #4377 #4387 #4396 #4425 #4442 #4494 #4512 #4513 #4526
 * [FEATURE] Add `freebsd` to the target OS when generating binaries for a Mimir release. #4654
 * [ENHANCEMENT] Add timezone information to Alpine Docker images. #4583
-* [ENHANCEMENT] Ruler: Sync rules when ruler JOINING the ring instead of ACTIVE. #4451
+* [ENHANCEMENT] Ruler: Sync rules when ruler JOINING the ring instead of ACTIVE, In order to reducing missed rule iterations during ruler restarts. #4451
 * [ENHANCEMENT] Allow to define service name used for tracing via `JAEGER_SERVICE_NAME` environment variable. #4394
 * [ENHANCEMENT] Querier and query-frontend: add experimental, more performant protobuf query result response format enabled with `-query-frontend.query-result-response-format=protobuf`. #4304 #4318 #4375
 * [ENHANCEMENT] Compactor: added experimental configuration parameter `-compactor.first-level-compaction-wait-period`, to configure how long the compactor should wait before compacting 1st level blocks (uploaded by ingesters). This configuration option allows to reduce the chances compactor begins compacting blocks before all ingesters have uploaded their blocks to the storage. #4401

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -56,6 +56,7 @@ func TestSyncRuleGroups(t *testing.T) {
 		},
 	}
 	m.SyncRuleGroups(context.Background(), userRules)
+	m.Start()
 	mgr1 := getManager(m, user1)
 	require.NotNil(t, mgr1)
 	test.Poll(t, 1*time.Second, true, func() interface{} {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -350,7 +350,7 @@ func (r *Ruler) starting(ctx context.Context) error {
 		return errors.Wrap(err, "unable to start ruler subservices")
 	}
 
-	// Sync the rule when the ruler JOINING the ring,
+	// Sync the rule when the ruler is JOINING the ring.
 	// Activate the rule evaluation after the ruler is ACTIVE in the ring.
 	// This is to make sure that the ruler is ready to evaluate alert rules once it is ACTIVE in the ring.
 	level.Info(r.logger).Log("msg", "waiting until ruler is JOINING in the ring")

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -352,14 +352,14 @@ func (r *Ruler) starting(ctx context.Context) error {
 
 	// Sync the rule when the ruler is JOINING the ring.
 	// Activate the rule evaluation after the ruler is ACTIVE in the ring.
-	// This is to make sure that the ruler is ready to evaluate alert rules once it is ACTIVE in the ring.
+	// This is to make sure that the ruler is ready to evaluate rules immediately after it is ACTIVE in the ring.
 	level.Info(r.logger).Log("msg", "waiting until ruler is JOINING in the ring")
 	if err := ring.WaitInstanceState(ctx, r.ring, r.lifecycler.GetInstanceID(), ring.JOINING); err != nil {
 		return err
 	}
 	level.Info(r.logger).Log("msg", "ruler is JOINING in the ring")
 
-	// here during joining, we can start to download rules from object storage and sync them to the local rule manager
+	// Here during joining, we can download rules from object storage and sync them to the local rule manager
 	r.syncRules(ctx, rulerSyncReasonInitial)
 
 	if err = r.lifecycler.ChangeState(ctx, ring.ACTIVE); err != nil {

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -22,11 +22,18 @@ const (
 	ringAutoForgetUnhealthyPeriods = 2
 )
 
-// RingOp is the operation used for distributing rule groups between rulers.
-var RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceState) bool {
-	// Only ACTIVE rulers get any rule groups. If instance is not ACTIVE, we need to find another ruler.
-	return s != ring.ACTIVE
-})
+var (
+	// RuleEvalRingOp is the operation used for distributing rule groups between rulers.
+	RuleEvalRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceState) bool {
+		// Only ACTIVE rulers get any rule groups. If instance is not ACTIVE, we need to find another ruler.
+		return s != ring.ACTIVE
+	})
+
+	RuleSyncRingOp = ring.NewOp([]ring.InstanceState{ring.JOINING, ring.ACTIVE}, func(s ring.InstanceState) bool {
+		// Only ACTIVE or JOINING rulers can sync rule groups. If instance is not ACTIVE NOR JOINING, we need to find another ruler.
+		return s != ring.ACTIVE && s != ring.JOINING
+	})
+)
 
 // RingConfig masks the ring lifecycler config which contains
 // many options not really required by the rulers ring. This config

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -461,7 +461,7 @@ func TestGetRules(t *testing.T) {
 			totalConfiguredRules := 0
 
 			forEachRuler(func(rID string, r *Ruler) {
-				localRules, err := r.listRules(context.Background())
+				localRules, err := r.listRules(context.Background(), rulerSyncReasonPeriodic)
 				require.NoError(t, err)
 				for _, rules := range localRules {
 					totalLoadedRules += len(rules)
@@ -883,7 +883,7 @@ func TestSharding(t *testing.T) {
 			}
 
 			// Always add ruler1 to expected rulers, even if there is no ring (no sharding).
-			loadedRules1, err := r1.listRules(context.Background())
+			loadedRules1, err := r1.listRules(context.Background(), rulerSyncReasonPeriodic)
 			require.NoError(t, err)
 
 			expected := expectedRulesMap{
@@ -893,7 +893,7 @@ func TestSharding(t *testing.T) {
 			addToExpected := func(id string, r *Ruler) {
 				// Only expect rules from other rulers when using ring, and they are present in the ring.
 				if r != nil && rulerRing != nil && rulerRing.HasInstance(id) {
-					loaded, err := r.listRules(context.Background())
+					loaded, err := r.listRules(context.Background(), rulerSyncReasonPeriodic)
 					require.NoError(t, err)
 					// Normalize nil map to empty one.
 					if loaded == nil {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -818,8 +818,10 @@ func TestSharding(t *testing.T) {
 			shuffleShardSize: 2,
 
 			setupRing: func(desc *ring.Desc) {
+				// ruler1, group2 should have been owned by ruler2, but ruler2 is in JOINING state. So, it would be owned by ruler1.
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{userToken(user1, 0) + 1}), ring.ACTIVE, time.Now())
 				desc.AddIngester(ruler2, ruler2Addr, "", sortTokens([]uint32{userToken(user1, 1) + 1, user1Group2Token + 1, userToken(user2, 1) + 1, userToken(user3, 0) + 1}), ring.JOINING, time.Now())
+				// user2, user3 should been owned by ruler2 or ruler3, but ruler2 is in JOINING state. So, it would be owned by ruler3.
 				desc.AddIngester(ruler3, ruler3Addr, "", sortTokens([]uint32{userToken(user2, 0) + 1, userToken(user3, 1) + 1}), ring.ACTIVE, time.Now())
 			},
 
@@ -827,7 +829,7 @@ func TestSharding(t *testing.T) {
 				ruler1: map[string]rulespb.RuleGroupList{
 					user1: {user1Group1, user1Group2},
 				},
-				ruler2: map[string]rulespb.RuleGroupList{}, // ruler2 owns token for user1group2, but user1 will only be handled by ruler1 because ruler2 is not running yet.
+				ruler2: map[string]rulespb.RuleGroupList{},
 				ruler3: map[string]rulespb.RuleGroupList{
 					user2: {user2Group1},
 					user3: {user3Group1},

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -818,10 +818,10 @@ func TestSharding(t *testing.T) {
 			shuffleShardSize: 2,
 
 			setupRing: func(desc *ring.Desc) {
-				// ruler1, group2 should have been owned by ruler2, but ruler2 is in JOINING state. So, it would be owned by ruler1.
+				// user1, group2 should have been owned by ruler2, but ruler2 is in JOINING state. So, it would be owned by ruler1.
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{userToken(user1, 0) + 1}), ring.ACTIVE, time.Now())
 				desc.AddIngester(ruler2, ruler2Addr, "", sortTokens([]uint32{userToken(user1, 1) + 1, user1Group2Token + 1, userToken(user2, 1) + 1, userToken(user3, 0) + 1}), ring.JOINING, time.Now())
-				// user2, user3 should been owned by ruler2 or ruler3, but ruler2 is in JOINING state. So, it would be owned by ruler3.
+				// user2, user3 should have been owned by ruler2 or ruler3, but ruler2 is in JOINING state. So, it would be owned by ruler3.
 				desc.AddIngester(ruler3, ruler3Addr, "", sortTokens([]uint32{userToken(user2, 0) + 1, userToken(user3, 1) + 1}), ring.ACTIVE, time.Now())
 			},
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -818,16 +818,16 @@ func TestSharding(t *testing.T) {
 			shuffleShardSize: 2,
 
 			setupRing: func(desc *ring.Desc) {
-				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{userToken(user1, 0) + 1, user1Group1Token + 1}), ring.ACTIVE, time.Now())
-				desc.AddIngester(ruler2, ruler2Addr, "", sortTokens([]uint32{userToken(user1, 1) + 1, user1Group2Token + 1, userToken(user2, 1) + 1, userToken(user3, 1) + 1}), ring.JOINING, time.Now())
-				desc.AddIngester(ruler3, ruler3Addr, "", sortTokens([]uint32{userToken(user2, 0) + 1, userToken(user3, 0) + 1, user2Group1Token + 1, user3Group1Token + 1}), ring.ACTIVE, time.Now())
+				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{userToken(user1, 0) + 1}), ring.ACTIVE, time.Now())
+				desc.AddIngester(ruler2, ruler2Addr, "", sortTokens([]uint32{userToken(user1, 1) + 1, user1Group2Token + 1, userToken(user2, 1) + 1, userToken(user3, 0) + 1}), ring.JOINING, time.Now())
+				desc.AddIngester(ruler3, ruler3Addr, "", sortTokens([]uint32{userToken(user2, 0) + 1, userToken(user3, 1) + 1}), ring.ACTIVE, time.Now())
 			},
 
 			expectedRules: expectedRulesMap{
 				ruler1: map[string]rulespb.RuleGroupList{
 					user1: {user1Group1, user1Group2},
 				},
-				ruler2: map[string]rulespb.RuleGroupList{}, // ruler2 owns token for user1group2, but user-1 will only be handled by ruler-1 because ruler2 is not running yet.
+				ruler2: map[string]rulespb.RuleGroupList{}, // ruler2 owns token for user1group2, but user1 will only be handled by ruler1 because ruler2 is not running yet.
 				ruler3: map[string]rulespb.RuleGroupList{
 					user2: {user2Group1},
 					user3: {user3Group1},

--- a/pkg/ruler/tenant_federation_test.go
+++ b/pkg/ruler/tenant_federation_test.go
@@ -80,6 +80,7 @@ func TestRuler_TenantFederationFlag(t *testing.T) {
 			t.Cleanup(r.Stop)
 
 			r.SyncRuleGroups(context.Background(), existingRules)
+			r.Start()
 
 			var loadedGroupsNames []string
 			for _, g := range r.GetRules(userID) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
The ruler becomes active in the ring after all its services are started. When the ruler becomes ready it automatically starts "owning" rule groups. So other rules in the ring stop evaluating these rule groups because they now shard to the new ruler.

After becoming ACTIVE, the ruler proceeds to sync the rule groups for all the tenants that it own; to do that it needs to iterate the bucket and fetch the rule groups for all tenants. For larger cells with many tenants the time to iterate the bucket can exceed a minute. And this causes ruler to miss one iteration as a consequence alerts are auto solved. When the second alert arrives another alert notification is sent.

To solve this, instead of sync the rules after ruler becoming ACTIVE in the Ring, sync the rules when ruler JOINING the Ring, and when the other tenant would drop the rule groups once new ruler become ACTIVE.

#### Which issue(s) this PR fixes or relates to

Fixes #4117

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
