### PR TITLE
Implement TimeseriesToMatrix for native histograms

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6522,24 +6522,37 @@ func TestIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T) {
 	tests := map[string]struct {
 		sampleHistograms []mimirpb.Histogram
 		expectHistogram  *model.SampleHistogram
+		streamChunks     bool
 	}{
-		"integer histogram": {
+		"integer histogram stream chunks": {
 			sampleHistograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, util_test.GenerateTestHistogram(0))},
 			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     true,
 		},
-		"float histogram": {
+		"float histogram stream chunks": {
 			sampleHistograms: []mimirpb.Histogram{mimirpb.FromFloatHistogramToHistogramProto(1, util_test.GenerateTestFloatHistogram(0))},
 			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     true,
+		},
+		"integer histogram stream samples": {
+			sampleHistograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, util_test.GenerateTestHistogram(0))},
+			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     false,
+		},
+		"float histogram stream samples": {
+			sampleHistograms: []mimirpb.Histogram{mimirpb.FromFloatHistogramToHistogramProto(1, util_test.GenerateTestFloatHistogram(0))},
+			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     false,
 		},
 	}
 	for testName, testCfg := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testIngesterCanEnableIngestAndQueryNativeHistograms(t, testCfg.sampleHistograms, testCfg.expectHistogram)
+			testIngesterCanEnableIngestAndQueryNativeHistograms(t, testCfg.sampleHistograms, testCfg.expectHistogram, testCfg.streamChunks)
 		})
 	}
 }
 
-func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHistograms []mimirpb.Histogram, expectHistogram *model.SampleHistogram) {
+func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHistograms []mimirpb.Histogram, expectHistogram *model.SampleHistogram, streamChunks bool) {
 	limits := defaultLimitsTestConfig()
 	limits.NativeHistogramsIngestionEnabled = false
 
@@ -6567,6 +6580,7 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 		// Set RF=1 here to ensure the series and metadata limits
 		// are actually set to 1 instead of 3.
 		cfg.IngesterRing.ReplicationFactor = 1
+		cfg.StreamChunksWhenUsingBlocks = streamChunks
 		ing, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, "", "", registry)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR updates `TimeseriesToMatrix` to handle histograms correctly as well as expanding the `TestIngesterCanEnableIngestAndQueryNativeHistograms` tests to test the streaming samples path as well as the streaming chunks path.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/4378

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
