### PR TITLE
Allow query sharding with native histograms

### DIFF
--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -85,8 +85,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 		"-blocks-storage.tsdb.retention-period":    "1ms", // Retention period counts from the moment the block was uploaded to storage so we're setting it deliberatelly small so block gets deleted as soon as possible
 
 		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format":  "protobuf",
-		"-ingester.native-histograms-ingestion-enabled": "true",
+		"-query-frontend.query-result-response-format": "protobuf",
 	})
 
 	// Start dependencies in common with all test cases.

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -85,7 +85,8 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 		"-blocks-storage.tsdb.retention-period":    "1ms", // Retention period counts from the moment the block was uploaded to storage so we're setting it deliberatelly small so block gets deleted as soon as possible
 
 		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
+		"-query-frontend.query-result-response-format":  "protobuf",
+		"-ingester.native-histograms-ingestion-enabled": "true",
 	})
 
 	// Start dependencies in common with all test cases.

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -259,11 +259,6 @@ func (s *querySharding) getShardsForQuery(ctx context.Context, tenantIDs []strin
 		return 1
 	}
 
-	// TODO: Remove when https://github.com/grafana/mimir/issues/3992 is solved. Also remove EnabledByAnyTenant (unless used elsewhere)
-	if validation.EnabledByAnyTenant(tenantIDs, s.limit.NativeHistogramsIngestionEnabled) {
-		return 1
-	}
-
 	// Check the default number of shards configured for the given tenant.
 	totalShards := validation.SmallestPositiveIntPerTenant(tenantIDs, s.limit.QueryShardingTotalShards)
 	if totalShards <= 1 {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1135,7 +1135,7 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 			maxShardedQueries: 64,
 			nativeHistograms:  true,
 			compactorShards:   10,
-			expectedShards:    1,
+			expectedShards:    10,
 		},
 	}
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -889,15 +889,6 @@ func MaxDurationPerTenant(tenantIDs []string, f func(string) time.Duration) time
 	return result
 }
 
-func EnabledByAnyTenant(tenantIDs []string, f func(string) bool) bool {
-	for _, tenantID := range tenantIDs {
-		if f(tenantID) {
-			return true
-		}
-	}
-	return false
-}
-
 // MustRegisterExtension registers the extensions type with given name
 // and returns a function to get the extensions value from a *Limits instance.
 //

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -647,27 +647,6 @@ metric_relabel_configs:
 	})
 }
 
-func TestEnabledByAnyTenant(t *testing.T) {
-	tenantLimits := map[string]*Limits{
-		"tenant1": {
-			NativeHistogramsIngestionEnabled: false,
-		},
-		"tenant2": {
-			NativeHistogramsIngestionEnabled: true,
-		},
-	}
-
-	defaults := Limits{
-		NativeHistogramsIngestionEnabled: false,
-	}
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
-
-	require.False(t, EnabledByAnyTenant([]string{"tenant1", "tenant3"}, ov.NativeHistogramsIngestionEnabled))
-
-	require.True(t, EnabledByAnyTenant([]string{"tenant1", "tenant2", "tenant3"}, ov.NativeHistogramsIngestionEnabled))
-}
-
 type structExtension struct {
 	Foo int `yaml:"foo"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR allows query sharding with native histograms. I also added the `-ingester.native-histograms-ingestion-enable-=true` to an existing integration test to make it fail without this change.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/3992

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
