### PR TITLE
Store-gateway: remove refs field from seriesEntry

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -535,7 +535,6 @@ func (s *BucketStore) TimeRange() (mint, maxt int64) {
 
 type seriesEntry struct {
 	lset labels.Labels
-	refs []chunks.ChunkRef
 	chks []storepb.AggrChunk
 }
 


### PR DESCRIPTION


Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This field is no longer used after #4332, but it was used it tests.
This PR introduces a new type `testBlockSeries` which can be used in
tests and removes the `refs` field from `seriesEntry`.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/4406

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
