### PR TITLE
Simplify usage of Mimir's usage of Queryables in querier

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -679,7 +679,7 @@ type Mimir struct {
 	UsageStatsReporter       *usagestats.Reporter
 	BuildInfoHandler         http.Handler
 
-	StoreQueryable querier.Queryable
+	StoreQueryable prom_storage.Queryable
 }
 
 // New makes a new Mimir.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -679,8 +679,7 @@ type Mimir struct {
 	UsageStatsReporter       *usagestats.Reporter
 	BuildInfoHandler         http.Handler
 
-	// Queryables that the querier should use to query the long term storage.
-	StoreQueryables []querier.QueryableWithFilter
+	StoreQueryable querier.Queryable
 }
 
 // New makes a new Mimir.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -502,15 +502,12 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initStoreQueryable() (services.Service, error) {
-	var servs []services.Service
-
 	q, err := querier.NewBlocksStoreQueryableFromConfig(t.Cfg.Querier, t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, t.Registerer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize querier: %v", err)
 	}
 
 	t.StoreQueryable = q
-	servs = append(servs, q)
 	return q, nil
 }
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -370,7 +370,7 @@ func (t *Mimir) initQueryable() (serv services.Service, err error) {
 	querierRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, t.Registerer)
 
 	// Create a querier queryable and PromQL engine
-	t.QuerierQueryable, t.ExemplarQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, querierRegisterer, util_log.Logger, t.ActivityTracker)
+	t.QuerierQueryable, t.ExemplarQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryable, querierRegisterer, util_log.Logger, t.ActivityTracker)
 
 	// Use the distributor to return metric metadata by default
 	t.MetadataSupplier = t.Distributor
@@ -501,29 +501,17 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 	return querier_worker.NewQuerierWorker(t.Cfg.Worker, httpgrpc_server.NewServer(internalQuerierRouter), util_log.Logger, t.Registerer)
 }
 
-func (t *Mimir) initStoreQueryables() (services.Service, error) {
+func (t *Mimir) initStoreQueryable() (services.Service, error) {
 	var servs []services.Service
 
-	//nolint:revive // I prefer this form over removing 'else', because it allows q to have smaller scope.
-	if q, err := querier.NewBlocksStoreQueryableFromConfig(t.Cfg.Querier, t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, t.Registerer); err != nil {
+	q, err := querier.NewBlocksStoreQueryableFromConfig(t.Cfg.Querier, t.Cfg.StoreGateway, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, t.Registerer)
+	if err != nil {
 		return nil, fmt.Errorf("failed to initialize querier: %v", err)
-	} else {
-		t.StoreQueryables = append(t.StoreQueryables, querier.UseAlwaysQueryable(q))
-		servs = append(servs, q)
 	}
 
-	// Return service, if any.
-	switch len(servs) {
-	case 0:
-		return nil, nil
-	case 1:
-		return servs[0], nil
-	default:
-		// No need to support this case yet, since chunk store is not a service.
-		// When we get there, we will need a wrapper service, that starts all subservices, and will also monitor them for failures.
-		// Not difficult, but also not necessary right now.
-		return nil, fmt.Errorf("too many services")
-	}
+	t.StoreQueryable = q
+	servs = append(servs, q)
+	return q, nil
 }
 
 func (t *Mimir) initActiveGroupsCleanupService() (services.Service, error) {
@@ -698,7 +686,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		// TODO: Consider wrapping logger to differentiate from querier module logger
 		rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, t.Registerer)
 
-		queryable, _, eng := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, rulerRegisterer, util_log.Logger, t.ActivityTracker)
+		queryable, _, eng := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryable, rulerRegisterer, util_log.Logger, t.ActivityTracker)
 		queryable = querier.NewErrorTranslateQueryableWithFn(queryable, ruler.WrapQueryableErrors)
 
 		if t.Cfg.Ruler.TenantFederation.Enabled {
@@ -903,7 +891,7 @@ func (t *Mimir) setupModuleManager() error {
 	mm.RegisterModule(Flusher, t.initFlusher)
 	mm.RegisterModule(Queryable, t.initQueryable, modules.UserInvisibleModule)
 	mm.RegisterModule(Querier, t.initQuerier)
-	mm.RegisterModule(StoreQueryable, t.initStoreQueryables, modules.UserInvisibleModule)
+	mm.RegisterModule(StoreQueryable, t.initStoreQueryable, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontendTripperware, t.initQueryFrontendTripperware, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontend, t.initQueryFrontend)
 	mm.RegisterModule(RulerStorage, t.initRulerStorage, modules.UserInvisibleModule)

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -289,8 +289,8 @@ func (q *BlocksStoreQueryable) stopping(_ error) error {
 	return services.StopManagerAndAwaitStopped(context.Background(), q.subservices)
 }
 
-// Querier returns a new Querier on the storage.
-func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+// OptionalQuerier returns a new Querier on the storage.
+func (q *BlocksStoreQueryable) OptionalQuerier(ctx context.Context, now time.Time, mint, maxt int64) (storage.Querier, error) {
 	if s := q.State(); s != services.Running {
 		return nil, errors.Errorf("BlocksStoreQueryable is not running: %v", s)
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -289,7 +289,7 @@ func (q *BlocksStoreQueryable) stopping(_ error) error {
 	return services.StopManagerAndAwaitStopped(context.Background(), q.subservices)
 }
 
-// OptionalQuerier returns a new Querier on the storage.
+// Querier returns a new Querier on the storage.
 func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	if s := q.State(); s != services.Running {
 		return nil, errors.Errorf("BlocksStoreQueryable is not running: %v", s)

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -290,7 +290,7 @@ func (q *BlocksStoreQueryable) stopping(_ error) error {
 }
 
 // OptionalQuerier returns a new Querier on the storage.
-func (q *BlocksStoreQueryable) OptionalQuerier(ctx context.Context, now time.Time, mint, maxt int64) (storage.Querier, error) {
+func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	if s := q.State(); s != services.Running {
 		return nil, errors.Errorf("BlocksStoreQueryable is not running: %v", s)
 	}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1744,7 +1744,15 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 			})
 
 			// Query metrics.
-			q, err := engine.NewRangeQuery(queryable, nil, testData.query, queryStart, queryEnd, 15*time.Second)
+			qb := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+				q, err := queryable.OptionalQuerier(ctx, time.Now(), mint, maxt)
+				if q == nil && err == nil {
+					err = fmt.Errorf("nil queryable")
+				}
+				return q, err
+			})
+
+			q, err := engine.NewRangeQuery(qb, nil, testData.query, queryStart, queryEnd, 15*time.Second)
 			require.NoError(t, err)
 
 			ctx := user.InjectOrgID(context.Background(), "user-1")

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1745,7 +1745,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 
 			// Query metrics.
 			qb := storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-				q, err := queryable.OptionalQuerier(ctx, time.Now(), mint, maxt)
+				q, err := queryable.Querier(ctx, mint, maxt)
 				if q == nil && err == nil {
 					err = fmt.Errorf("nil queryable")
 				}

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -120,23 +120,20 @@ func TestDistributorQueryableFilter(t *testing.T) {
 
 	now := time.Now()
 
-	dq.now = func() time.Time { return now }
 	queryMinT := util.TimeToMillis(now.Add(-5 * time.Minute))
 	queryMaxT := util.TimeToMillis(now)
 
 	ctx := context.Background()
-	q, err := dq.Querier(ctx, queryMinT, queryMaxT)
+	q, err := dq.Querier(SetQueryTimeToContext(ctx, now), queryMinT, queryMaxT)
 	require.NoError(t, err)
 	require.NotNil(t, q)
 
-	dq.now = func() time.Time { return now.Add(time.Hour) }
-	q, err = dq.Querier(ctx, queryMinT, queryMaxT)
+	q, err = dq.Querier(SetQueryTimeToContext(ctx, now.Add(time.Hour)), queryMinT, queryMaxT)
 	require.NoError(t, err)
 	require.NotNil(t, q)
 
 	// Same query, hour+1ms later, is not sent to ingesters.
-	dq.now = func() time.Time { return now.Add(time.Hour).Add(1 * time.Millisecond) }
-	q, err = dq.Querier(ctx, queryMinT, queryMaxT)
+	q, err = dq.Querier(SetQueryTimeToContext(ctx, now.Add(time.Hour).Add(1*time.Millisecond)), queryMinT, queryMaxT)
 	require.NoError(t, err)
 	require.Equal(t, storage.NoopQuerier(), q)
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1171,18 +1171,17 @@ func TestStoreQueryable(t *testing.T) {
 	m := &mockQueryableWithFilter{}
 	now := time.Now()
 	sq := newStoreQueryable(m, time.Hour)
-	sq.now = func() time.Time { return now }
 
 	ctx := context.Background()
-	_, err := sq.Querier(ctx, util.TimeToMillis(now.Add(-5*time.Minute)), util.TimeToMillis(now))
+	_, err := sq.Querier(SetQueryTimeToContext(ctx, now), util.TimeToMillis(now.Add(-5*time.Minute)), util.TimeToMillis(now))
 	require.NoError(t, err)
 	require.False(t, m.queryableCalled)
 
-	_, err = sq.Querier(ctx, util.TimeToMillis(now.Add(-1*time.Hour).Add(time.Millisecond)), util.TimeToMillis(now))
+	_, err = sq.Querier(SetQueryTimeToContext(ctx, now), util.TimeToMillis(now.Add(-1*time.Hour).Add(time.Millisecond)), util.TimeToMillis(now))
 	require.NoError(t, err)
 	require.False(t, m.queryableCalled)
 
-	_, err = sq.Querier(ctx, util.TimeToMillis(now.Add(-1*time.Hour)), util.TimeToMillis(now))
+	_, err = sq.Querier(SetQueryTimeToContext(ctx, now), util.TimeToMillis(now.Add(-1*time.Hour)), util.TimeToMillis(now))
 	require.NoError(t, err)
 	require.True(t, m.queryableCalled)
 }


### PR DESCRIPTION
#### What this PR does

This is internal refactoring PR. It removes support for querying multiple store queryables (not needed anymore after chunks storage was removed), and it removes `querier.QueryableWithFilter` and replaces it with `querier.Queryable`, which is similar to `storage.Queryable` but can return `nil` querier.

This is a follow-up to discussion at https://github.com/grafana/mimir/pull/4287#discussion_r1132481888

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
