### PR TITLE
Helm: fix kube state metrics relabel

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -39,6 +39,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Apply `clusterLabel` to ServiceMonitors for kube-state-metrics, kubelet, and cadvisor. #4126
 * [BUGFIX] Add http port in distributor headless service. Fixes parity with jsonnet. #4392
 * [BUGFIX] Generate the pod security context on the pod level in graphite web deployment, instead of on container level. #4272
+* [BUGFIX] Fix kube-state-metrics metricRelabelings dropping pods and deployments. #4485
 
 ## 4.2.0
 

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
@@ -20,12 +20,12 @@ spec:
     - port: http-metrics
       metricRelabelings:
         - action: keep
-          regex: {{ include "mimir.resourceName" (dict "ctx"  $) }}.*
+          regex: "(^|.*;){{ include "mimir.resourceName" (dict "ctx"  $) }}.*"
           sourceLabels:
             - deployment
             - statefulset
             - pod
-          separator: ''
+          separator: ';'
       {{- if kindIs "string" .clusterLabel }}
       relabelings:
         - targetLabel: cluster

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
@@ -15,12 +15,12 @@ spec:
     - port: http-metrics
       metricRelabelings:
         - action: keep
-          regex: metamonitoring-values-mimir.*
+          regex: "(^|.*;)metamonitoring-values-mimir.*"
           sourceLabels:
             - deployment
             - statefulset
             - pod
-          separator: ''
+          separator: ';'
       relabelings:
         - targetLabel: cluster
           replacement: "metamonitoring-values"


### PR DESCRIPTION
#### What this PR does

Fix metricRelabelings for kube state monitor
    
The current version filters out statefulsets, since those metrics include a pod name that is of the ksm itself.
Fix is to check all values in the concatenated labels for a match.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
