### PR TITLE
Queries dashboard: display store-gateway bytes/sec instead of items/sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Queries: Display data touched per sec in bytes instead of number of items. #4492
+
 ### Jsonnet
 
 * [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2091,7 +2091,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any fetched metrics\n  rate(cortex_bucket_store_series_data_fetched_sum{component=\"store-gateway\", stage=\"\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - \"fetched\"\n  rate(cortex_bucket_store_series_data_fetched_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"fetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any fetched metrics\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", stage=\"\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - \"fetched\"\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"fetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2118,7 +2118,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ops",
+                        "format": "binBps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2167,7 +2167,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any touched metrics\n  rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"returned\"\n  rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"returned\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any touched metrics\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"returned\"\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"returned\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2194,7 +2194,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ops",
+                        "format": "binBps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2091,7 +2091,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any fetched metrics\n  rate(cortex_bucket_store_series_data_fetched_sum{component=\"store-gateway\", stage=\"\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - \"fetched\"\n  rate(cortex_bucket_store_series_data_fetched_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"fetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any fetched metrics\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", stage=\"\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - \"fetched\"\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"fetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2118,7 +2118,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ops",
+                        "format": "binBps",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -2167,7 +2167,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any touched metrics\n  rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"returned\"\n  rate(cortex_bucket_store_series_data_touched_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"returned\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any touched metrics\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"returned\"\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"returned\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2194,7 +2194,7 @@
                   },
                   "yaxes": [
                      {
-                        "format": "ops",
+                        "format": "binBps",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -228,28 +228,28 @@ local filename = 'mimir-queries.json';
         $.queryPanel(|||
           sum by(data_type) (
             # non-streaming store-gateway will not have the stage label on any fetched metrics
-            rate(cortex_bucket_store_series_data_fetched_sum{component="store-gateway", stage="", %(jobMatcher)s}[$__rate_interval])
+            rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component="store-gateway", stage="", %(jobMatcher)s}[$__rate_interval])
             or
             # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - "fetched"
-            rate(cortex_bucket_store_series_data_fetched_sum{component="store-gateway", data_type="chunks", stage="fetched", %(jobMatcher)s}[$__rate_interval])
+            rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component="store-gateway", data_type="chunks", stage="fetched", %(jobMatcher)s}[$__rate_interval])
           )
         ||| % { jobMatcher: $.jobMatcher($._config.job_names.store_gateway) }, '{{data_type}}') +
         $.stack +
-        { yaxes: $.yaxes('ops') },
+        { yaxes: $.yaxes('binBps') },
       )
       .addPanel(
         $.panel('Data touched / sec') +
         $.queryPanel(|||
           sum by(data_type) (
             # non-streaming store-gateway will not have the stage label on any touched metrics
-            rate(cortex_bucket_store_series_data_touched_sum{component="store-gateway", stage="",%(jobMatcher)s}[$__rate_interval])
+            rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component="store-gateway", stage="",%(jobMatcher)s}[$__rate_interval])
             or
             # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - "returned"
-            rate(cortex_bucket_store_series_data_touched_sum{component="store-gateway", data_type="chunks", stage="returned",%(jobMatcher)s}[$__rate_interval])
+            rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component="store-gateway", data_type="chunks", stage="returned",%(jobMatcher)s}[$__rate_interval])
           )
         ||| % { jobMatcher: $.jobMatcher($._config.job_names.store_gateway) }, '{{data_type}}') +
         $.stack +
-        { yaxes: $.yaxes('ops') },
+        { yaxes: $.yaxes('binBps') },
       )
     )
     .addRow(


### PR DESCRIPTION


#### What this PR does

The two panels for data fetched/sec and touched/sec currently show the
number of series, chunks or posting lists that the store-gateway
processes per second. They are also put on the same scale, but a single
posting list can have a lot bigger impact on query performance than a
single chunk.

Usually query performance and store-gateway resource usage are more
closely tied to the number of bytes processed per second rather than the
 number of items processed.

So this PR makes a change to display the number of bytes per sec for
postings, chunks and series (both touched and fetched) instead of the
number of items.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

##### Before 

<img width="3247" alt="Screenshot 2023-03-14 at 12 55 39" src="https://user-images.githubusercontent.com/21020035/224993496-d650b944-2c63-47fd-a51d-37aeb8436f91.png">


##### After 

<img width="3247" alt="Screenshot 2023-03-14 at 12 55 00" src="https://user-images.githubusercontent.com/21020035/224993369-ef92a820-e654-4a04-aa59-db78c1ce8492.png">

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
