### PR TITLE
Docs: clarify deprecation in "Parameter lifecycle"

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -119,6 +119,9 @@ The following features are currently experimental:
 
 ## Deprecated features
 
+Deprecated features are usable until the release which indicates their removal.
+For more details about what "deprecated" means see [Parameter lifecycle]({{ relref "../references/configuration-parameters#parameter-lifecycle" }}).
+
 The following features are currently deprecated and will be **removed in Mimir 2.9**:
 
 - Compactor

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -75,6 +75,8 @@ When new parameters are added, they can be introduced as **basic**, **advanced**
 **Experimental** parameters will remain experimental until they are either made stable or removed. Parameters that are made stable will be classified as either **basic** or **advanced**. We aim to make this decision on an experimental parameter within 6 months of its initial release, but this decision may take longer depending on what we discover during testing, or if upstream dependencies (e.g., Prometheus) of our code changes.
 
 If we decide to eliminate a **basic** or **advanced** parameter, we will first mark it deprecated. After two more minor releases, a deprecated flag will be removed entirely. Use the metric `deprecated_flags_inuse_total` to determine whether you're using deprecated flags.
+A configuration parameter is in maintenance and usable as usual between its deprecation and removal.
+When configured with a removed parameter Mimir will fail to start.
 
 ![Parameter states](param-states.png)
 

--- a/docs/sources/mimir/references/configuration-parameters/index.template
+++ b/docs/sources/mimir/references/configuration-parameters/index.template
@@ -75,6 +75,8 @@ When new parameters are added, they can be introduced as **basic**, **advanced**
 **Experimental** parameters will remain experimental until they are either made stable or removed. Parameters that are made stable will be classified as either **basic** or **advanced**. We aim to make this decision on an experimental parameter within 6 months of its initial release, but this decision may take longer depending on what we discover during testing, or if upstream dependencies (e.g., Prometheus) of our code changes.
 
 If we decide to eliminate a **basic** or **advanced** parameter, we will first mark it deprecated. After two more minor releases, a deprecated flag will be removed entirely. Use the metric `deprecated_flags_inuse_total` to determine whether you're using deprecated flags.
+A configuration parameter is in maintenance and usable as usual between its deprecation and removal.
+When configured with a removed parameter Mimir will fail to start.
 
 ![Parameter states](param-states.png)
 


### PR DESCRIPTION
We're moving towards a different definition of "deprecated."
One definition has been used in the past, however since
recently we've started using the new definition. The currently 
deprecated config parameters were deprecated using the new
definition. So this PR only clarifies documentation.

### Previous definition of "deprecated"

So far the definition that Mimir (and Cortex) has been using is to mean
that a feature or configuration parameter is effectively ignored.
Providing this parameter has no effect on Mimir. At the end of the
deprecation period the configuration parameter is removed and Mimir
fails to start if provided said parameter.

### New definition of "deprecated"

As per an internal design document the definition of "deprecated" should
 be more standardized across Grafana projects and should mean

> **Deprecation** occurs when a feature or product is planned for removal
> in a future release. In the period between deprecation and removal, it
> will be in maintenance.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
