### PR TITLE
docs: force running website image as linux/amd64

### DIFF
--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -33,7 +33,7 @@ define docs_podman_run
 	@if [[ -z $${NON_INTERACTIVE} ]]; then \
 		read -p "Press a key to continue"; \
 	fi
-	@$(PODMAN) run -ti \
+	$(PODMAN) run --platform linux/amd64 -ti \
 		--init \
 		-v $(GIT_ROOT)/docs/sources/mimir:$(MIMIR_CONTENT_PATH)/$(MIMIR_VERSION):ro,z \
 		-v $(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed:$(HELM_CONTENT_PATH)/$(HELM_CHARTS_VERSION):ro,z \


### PR DESCRIPTION
The [grafana/docs-base](https://hub.docker.com/r/grafana/docs-base)
image doesn't have an arm build and Docker Desktop for Mac doesn't
attempt to run it on arm64 with virtualization it for some reason. This
PR forces Docker Desktop to attempt the virtualization.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

