### PR TITLE
Enable ingester to query native histograms

### DIFF
--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/integration/ingester_sharding_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+//go:build requires_docker
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/e2e"
+	e2edb "github.com/grafana/e2e/db"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/util/test"
+
+	"github.com/grafana/mimir/integration/e2emimir"
+)
+
+func TestIngesterMixedFloatHistogramSeries(t *testing.T) {
+	query := "foobar"
+	queryEnd := time.Now().Round(time.Second)
+	queryStart := queryEnd.Add(-1 * time.Hour)
+	queryStep := 10 * time.Minute
+
+	testCases := map[string]struct {
+		inSeries []prompb.TimeSeries
+		expected model.Matrix
+	}{
+		"float series": {
+			inSeries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: query,
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Timestamp: queryStart.UnixMilli(),
+							Value:     100,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep).UnixMilli(),
+							Value:     110,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 2).UnixMilli(),
+							Value:     120,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 3).UnixMilli(),
+							Value:     130,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 4).UnixMilli(),
+							Value:     140,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 5).UnixMilli(),
+							Value:     150,
+						},
+					},
+				},
+			},
+			expected: model.Matrix{
+				{
+					Metric: model.Metric(map[model.LabelName]model.LabelValue{"__name__": "foobar"}),
+					Values: []model.SamplePair{
+						{
+							Timestamp: model.Time(queryStart.UnixMilli()),
+							Value:     model.SampleValue(100),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+							Value:     model.SampleValue(110),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+							Value:     model.SampleValue(120),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+							Value:     model.SampleValue(130),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+							Value:     model.SampleValue(140),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+							Value:     model.SampleValue(150),
+						},
+					},
+				},
+			},
+		},
+		"native histogram series": {
+			inSeries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: query,
+						},
+					},
+					Histograms: []prompb.Histogram{
+						remote.HistogramToHistogramProto(queryStart.UnixMilli(), test.GenerateTestHistogram(1)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep).UnixMilli(), test.GenerateTestHistogram(2)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*2).UnixMilli(), test.GenerateTestHistogram(3)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*3).UnixMilli(), test.GenerateTestHistogram(4)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*4).UnixMilli(), test.GenerateTestHistogram(5)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*5).UnixMilli(), test.GenerateTestHistogram(6)),
+					},
+				},
+			},
+			expected: model.Matrix{
+				{
+					Metric: model.Metric(map[model.LabelName]model.LabelValue{"__name__": "foobar"}),
+					Histograms: []model.SampleHistogramPair{
+						{
+							Timestamp: model.Time(queryStart.UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(1),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(2),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(3),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(4),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(5),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(6),
+						},
+					},
+				},
+			},
+		},
+		"series switching from float to native histograms at timestamp": {
+			inSeries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: query,
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Timestamp: queryStart.UnixMilli(),
+							Value:     100,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep).UnixMilli(),
+							Value:     110,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 2).UnixMilli(),
+							Value:     120,
+						},
+					},
+					Histograms: []prompb.Histogram{
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*3).UnixMilli(), test.GenerateTestHistogram(4)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*4).UnixMilli(), test.GenerateTestHistogram(5)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*5).UnixMilli(), test.GenerateTestHistogram(6)),
+					},
+				},
+			},
+			expected: model.Matrix{
+				{
+					Metric: model.Metric(map[model.LabelName]model.LabelValue{"__name__": "foobar"}),
+					Values: []model.SamplePair{
+						{
+							Timestamp: model.Time(queryStart.UnixMilli()),
+							Value:     model.SampleValue(100),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+							Value:     model.SampleValue(110),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+							Value:     model.SampleValue(120),
+						},
+					},
+					Histograms: []model.SampleHistogramPair{
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(4),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(5),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(6),
+						},
+					},
+				},
+			},
+		},
+		"series including float and native histograms at same timestamp": {
+			inSeries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: query,
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Timestamp: queryStart.UnixMilli(),
+							Value:     100,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep).UnixMilli(),
+							Value:     110,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 2).UnixMilli(),
+							Value:     120,
+						},
+					},
+					Histograms: []prompb.Histogram{
+						// This first of these will fail to get appended because there's already a float sample for that timestamp.
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*2).UnixMilli(), test.GenerateTestHistogram(3)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*3).UnixMilli(), test.GenerateTestHistogram(4)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*4).UnixMilli(), test.GenerateTestHistogram(5)),
+						remote.HistogramToHistogramProto(queryStart.Add(queryStep*5).UnixMilli(), test.GenerateTestHistogram(6)),
+					},
+				},
+			},
+			expected: model.Matrix{
+				{
+					Metric: model.Metric(map[model.LabelName]model.LabelValue{"__name__": "foobar"}),
+					Values: []model.SamplePair{
+						{
+							Timestamp: model.Time(queryStart.UnixMilli()),
+							Value:     model.SampleValue(100),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+							Value:     model.SampleValue(110),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+							Value:     model.SampleValue(120),
+						},
+					},
+					Histograms: []model.SampleHistogramPair{
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(4),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(5),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+							Histogram: test.GenerateTestSampleHistogram(6),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			s, err := e2e.NewScenario(networkName)
+			require.NoError(t, err)
+			defer s.Close()
+
+			flags := mergeFlags(
+				BlocksStorageFlags(),
+				BlocksStorageS3Flags(),
+			)
+			flags["-distributor.ingestion-tenant-shard-size"] = "0"
+			flags["-ingester.ring.heartbeat-period"] = "1s"
+
+			// Start dependencies.
+			consul := e2edb.NewConsul()
+			minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+			require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+			// Start Mimir components.
+			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+			ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+			require.NoError(t, s.StartAndWaitReady(distributor, ingester, querier))
+
+			// Wait until distributor has updated the ring.
+			require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+			// Wait until querier has updated the ring.
+			require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+			client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+			require.NoError(t, err)
+
+			res, err := client.Push(tc.inSeries)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			result, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected.String(), result.String())
+		})
+	}
+}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1473,9 +1473,11 @@ func (i *Ingester) queryStreamSamples(ctx context.Context, db *userTSDB, from, t
 				t, v := it.At()
 				ts.Samples = append(ts.Samples, mimirpb.Sample{Value: v, TimestampMs: t})
 			case chunkenc.ValHistogram:
-				// ignore
+				t, v := it.AtHistogram()
+				ts.Histograms = append(ts.Histograms, mimirpb.FromHistogramToHistogramProto(t, v))
 			case chunkenc.ValFloatHistogram:
-				// ignore
+				t, v := it.AtFloatHistogram()
+				ts.Histograms = append(ts.Histograms, mimirpb.FromFloatHistogramToHistogramProto(t, v))
 			default:
 				return 0, 0, fmt.Errorf("unsupported value type: %v", valType)
 			}
@@ -1578,9 +1580,9 @@ func (i *Ingester) queryStreamChunks(ctx context.Context, db *userTSDB, from, th
 			case chunkenc.EncXOR:
 				ch.Encoding = int32(chunk.PrometheusXorChunk)
 			case chunkenc.EncHistogram:
-				continue // ignore
+				ch.Encoding = int32(chunk.PrometheusHistogramChunk)
 			case chunkenc.EncFloatHistogram:
-				continue // ignore
+				ch.Encoding = int32(chunk.PrometheusFloatHistogramChunk)
 			default:
 				return 0, 0, errors.Errorf("unknown chunk encoding from TSDB chunk querier: %v", meta.Chunk.Encoding())
 			}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -67,6 +66,7 @@ import (
 	"github.com/grafana/mimir/pkg/util/chunkcompat"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/push"
+	util_test "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
@@ -175,6 +175,72 @@ func TestIngester_Push(t *testing.T) {
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
 			`,
+		},
+		"should succeed on valid series with histograms and metadata": {
+			reqs: []*mimirpb.WriteRequest{
+				mimirpb.NewWriteRequest([]*mimirpb.MetricMetadata{
+					{MetricFamilyName: "metric_name_1", Help: "a help for metric_name_1", Unit: "", Type: mimirpb.HISTOGRAM},
+				}, mimirpb.API).AddHistogramSeries([]labels.Labels{metricLabels},
+					[]mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, util_test.GenerateTestHistogram(1))}, nil),
+				mimirpb.NewWriteRequest([]*mimirpb.MetricMetadata{
+					{MetricFamilyName: "metric_name_2", Help: "a help for metric_name_2", Unit: "", Type: mimirpb.GAUGEHISTOGRAM},
+				}, mimirpb.API).AddHistogramSeries([]labels.Labels{metricLabels},
+					[]mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(2, util_test.GenerateTestGaugeHistogram(2))}, nil),
+			},
+			expectedErr: nil,
+			expectedIngested: model.Matrix{
+				&model.SampleStream{Metric: metricLabelSet, Histograms: []model.SampleHistogramPair{
+					{Timestamp: model.Time(1), Histogram: mimirpb.FromHistogramToPromHistogram(util_test.GenerateTestHistogram(1))},
+					{Timestamp: model.Time(2), Histogram: mimirpb.FromHistogramToPromHistogram(util_test.GenerateTestGaugeHistogram(2))},
+				}},
+			},
+			expectedMetadataIngested: []*mimirpb.MetricMetadata{
+				{MetricFamilyName: "metric_name_2", Help: "a help for metric_name_2", Unit: "", Type: mimirpb.GAUGEHISTOGRAM},
+				{MetricFamilyName: "metric_name_1", Help: "a help for metric_name_1", Unit: "", Type: mimirpb.HISTOGRAM},
+			},
+			additionalMetrics: []string{
+				// Metadata.
+				"cortex_ingester_memory_metadata",
+				"cortex_ingester_memory_metadata_created_total",
+				"cortex_ingester_ingested_metadata_total",
+				"cortex_ingester_ingested_metadata_failures_total",
+			},
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_metadata_failures_total The total number of metadata that errored on ingestion.
+				# TYPE cortex_ingester_ingested_metadata_failures_total counter
+				cortex_ingester_ingested_metadata_failures_total 0
+				# HELP cortex_ingester_ingested_metadata_total The total number of metadata ingested.
+				# TYPE cortex_ingester_ingested_metadata_total counter
+				cortex_ingester_ingested_metadata_total 2
+				# HELP cortex_ingester_memory_metadata The current number of metadata in memory.
+				# TYPE cortex_ingester_memory_metadata gauge
+				cortex_ingester_memory_metadata 2
+				# HELP cortex_ingester_memory_metadata_created_total The total number of metadata that were created per user
+				# TYPE cortex_ingester_memory_metadata_created_total counter
+				cortex_ingester_memory_metadata_created_total{user="test"} 2
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 2
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				# HELP cortex_ingester_memory_users The current number of users in memory.
+				# TYPE cortex_ingester_memory_users gauge
+				cortex_ingester_memory_users 1
+				# HELP cortex_ingester_memory_series The current number of series in memory.
+				# TYPE cortex_ingester_memory_series gauge
+				cortex_ingester_memory_series 1
+				# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+				# TYPE cortex_ingester_memory_series_created_total counter
+				cortex_ingester_memory_series_created_total{user="test"} 1
+				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+				# TYPE cortex_ingester_memory_series_removed_total counter
+				cortex_ingester_memory_series_removed_total{user="test"} 0
+				# HELP cortex_ingester_active_series Number of currently active series per user.
+				# TYPE cortex_ingester_active_series gauge
+				cortex_ingester_active_series{user="test"} 1
+			`,
+			nativeHistograms: true,
 		},
 		"should succeed on valid series with exemplars": {
 			maxExemplars: 2,
@@ -426,7 +492,7 @@ func TestIngester_Push(t *testing.T) {
 							TimeSeries: &mimirpb.TimeSeries{
 								Labels:     metricLabelAdapters,
 								Samples:    []mimirpb.Sample{{Value: 0, TimestampMs: 1575043969 - (86400 * 1000)}, {Value: 1, TimestampMs: 1575043969 - (86000 * 1000)}},
-								Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1575043969-(86800*1000), tsdbutil.GenerateTestHistogram(0))},
+								Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1575043969-(86800*1000), util_test.GenerateTestHistogram(0))},
 							},
 						},
 					},
@@ -480,7 +546,7 @@ func TestIngester_Push(t *testing.T) {
 							TimeSeries: &mimirpb.TimeSeries{
 								Labels:     metricLabelAdapters,
 								Samples:    []mimirpb.Sample{{Value: 0, TimestampMs: 1575043969 + 1000}},
-								Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1575043969-(86800*1000), tsdbutil.GenerateTestHistogram(0))},
+								Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1575043969-(86800*1000), util_test.GenerateTestHistogram(0))},
 							},
 						},
 					},
@@ -6506,29 +6572,42 @@ func TestNewIngestErrMsgs(t *testing.T) {
 }
 
 func TestIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T) {
-	expectedSampleHistogram := mimirpb.FromMimirSampleToPromHistogram(mimirpb.FromFloatHistogramToSampleHistogram(tsdbutil.GenerateTestFloatHistogram(0)))
+	expectedSampleHistogram := mimirpb.FromMimirSampleToPromHistogram(mimirpb.FromFloatHistogramToSampleHistogram(util_test.GenerateTestFloatHistogram(0)))
 
 	tests := map[string]struct {
 		sampleHistograms []mimirpb.Histogram
 		expectHistogram  *model.SampleHistogram
+		streamChunks     bool
 	}{
-		"integer histogram": {
-			sampleHistograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, tsdbutil.GenerateTestHistogram(0))},
+		"integer histogram stream chunks": {
+			sampleHistograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, util_test.GenerateTestHistogram(0))},
 			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     true,
 		},
-		"float histogram": {
-			sampleHistograms: []mimirpb.Histogram{mimirpb.FromFloatHistogramToHistogramProto(1, tsdbutil.GenerateTestFloatHistogram(0))},
+		"float histogram stream chunks": {
+			sampleHistograms: []mimirpb.Histogram{mimirpb.FromFloatHistogramToHistogramProto(1, util_test.GenerateTestFloatHistogram(0))},
 			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     true,
+		},
+		"integer histogram stream samples": {
+			sampleHistograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, util_test.GenerateTestHistogram(0))},
+			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     false,
+		},
+		"float histogram stream samples": {
+			sampleHistograms: []mimirpb.Histogram{mimirpb.FromFloatHistogramToHistogramProto(1, util_test.GenerateTestFloatHistogram(0))},
+			expectHistogram:  expectedSampleHistogram,
+			streamChunks:     false,
 		},
 	}
 	for testName, testCfg := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testIngesterCanEnableIngestAndQueryNativeHistograms(t, testCfg.sampleHistograms, testCfg.expectHistogram)
+			testIngesterCanEnableIngestAndQueryNativeHistograms(t, testCfg.sampleHistograms, testCfg.expectHistogram, testCfg.streamChunks)
 		})
 	}
 }
 
-func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHistograms []mimirpb.Histogram, expectHistogram *model.SampleHistogram) {
+func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHistograms []mimirpb.Histogram, expectHistogram *model.SampleHistogram, streamChunks bool) {
 	limits := defaultLimitsTestConfig()
 	limits.NativeHistogramsIngestionEnabled = false
 
@@ -6556,6 +6635,7 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 		// Set RF=1 here to ensure the series and metadata limits
 		// are actually set to 1 instead of 3.
 		cfg.IngesterRing.ReplicationFactor = 1
+		cfg.StreamChunksWhenUsingBlocks = streamChunks
 		ing, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, "", "", registry)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
@@ -6654,6 +6734,10 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 		Values: []model.SamplePair{{
 			Timestamp: 0,
 			Value:     1,
+		}},
+		Histograms: []model.SampleHistogramPair{{
+			Timestamp: 2,
+			Histogram: expectHistogram,
 		}},
 	}}
 


### PR DESCRIPTION
#### What this PR does

Update chunkcompat/compat.go to be able to decode ingester reply in unit tests correctly.
Add an integration test for ingestion.

#### Which issue(s) this PR fixes or relates to

Related to: #3478 

#### Checklist

- [x] Tests updated
- N/A Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
**Next PR to enable query sharding as well and update the changelog**
