### PR TITLE
tsdb-index: use equal matcher to speed up listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Tools
 
+* [ENHANCEMENT] tsdb-index: iteration over index is now faster when any equal matcher is supplied.
+
 ## 2.7.0-rc.0
 
 ### Grafana Mimir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### Tools
 
-* [ENHANCEMENT] tsdb-index: iteration over index is now faster when any equal matcher is supplied.
+* [ENHANCEMENT] tsdb-index: iteration over index is now faster when any equal matcher is supplied. #4515
 
 ## 2.7.0-rc.0
 


### PR DESCRIPTION
#### What this PR does
If any equal matcher is used, we can use it for getting postings, and massively speed up iteration of index.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
