### PR TITLE
Fix flaky TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents test.

### DIFF
--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -103,7 +103,7 @@ func mkAPIResponse(start, end, step int64) *PrometheusResponse {
 }
 
 func mkExtent(start, end int64) Extent {
-	return mkExtentWithStepAndQueryTime(start, end, 10, time.Now().UnixMilli())
+	return mkExtentWithStepAndQueryTime(start, end, 10, 0)
 }
 
 func mkExtentWithStepAndQueryTime(start, end, step, queryTime int64) Extent {


### PR DESCRIPTION
#### What this PR does

This PR modifies `mkExtent` helper function to set 0 query time, and not use current time.

PR #4439 added `QueryTime` field to cached extents. Originally PR considered extents with `QueryTime=0` as too old, but that has changed before merging the PR. So using 0 is safe, and there are other tests that cover non-zero query times.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
