### PR TITLE
Fix aliases for http reference docs

### DIFF
--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/mimir/latest/operators-guide/reference-http-api/
+  - ../operators-guide/reference-http-api/
 title: "Grafana Mimir HTTP API"
 menuTitle: "HTTP API"
 description: "Use the HTTP API to write and query time-series data, and to operate a Grafana Mimir cluster."

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - operators-guide/reference-http-api/
+  - /docs/mimir/latest/operators-guide/reference-http-api/
 title: "Grafana Mimir HTTP API"
 menuTitle: "HTTP API"
 description: "Use the HTTP API to write and query time-series data, and to operate a Grafana Mimir cluster."


### PR DESCRIPTION
#### What this PR does

Seems that it should start with /docs/

#### Which issue(s) this PR fixes or relates to

Ref: https://github.com/grafana/mimir/pull/4328

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
