### PR TITLE
Add release 2.7.1 to backwards compatibility integration test

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -26,4 +26,5 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.4.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.5.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.6.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	"grafana/mimir:2.7.1": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 }

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -26,5 +26,5 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.4.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.5.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.6.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
-	"grafana/mimir:2.7.1": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
+	"grafana/mimir:2.7.1": e2emimir.FlagMapper(nil),
 }

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -26,5 +26,5 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.4.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.5.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.6.0": e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
-	"grafana/mimir:2.7.1": e2emimir.FlagMapper(nil),
+	"grafana/mimir:2.7.1": e2emimir.NoopFlagMapper,
 }


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

Adds Mimir 2.7.1 to the list of backwards compatibility tests.

#### Checklist

- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
