### PR TITLE
Include podAnnotations on tokengen job

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* Include podAnnotations on the tokengen Job. #4540
+
 ## 4.3.0
 
 * [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       labels:
         {{- include "mimir.podLabels" (dict "ctx" . "component" "tokengen") | nindent 8 }}
+      annotations:
+        {{- include "mimir.podAnnotations" (dict "ctx" . "component" "tokengen") | nindent 8 }}
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/instance: gateway-enterprise-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
+      annotations:
       namespace: "citestns"
     spec:
       serviceAccountName: gateway-enterprise-values-mimir

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/instance: graphite-enabled-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
+      annotations:
       namespace: "citestns"
     spec:
       serviceAccountName: graphite-enabled-values-mimir

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/instance: openshift-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
+      annotations:
       namespace: "citestns"
     spec:
       serviceAccountName: openshift-values-mimir

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,6 +24,8 @@ spec:
         app.kubernetes.io/instance: test-enterprise-configmap-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
+      annotations:
+        minio-secret-version: "42"
       namespace: "citestns"
     spec:
       serviceAccountName: test-enterprise-configmap-values-mimir

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
+      annotations:
       namespace: "citestns"
     spec:
       serviceAccountName: test-enterprise-k8s-1.25-values-mimir

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -23,6 +23,7 @@ spec:
         name: tokengen
         target: tokengen
         release: test-enterprise-legacy-label-values
+      annotations:
       namespace: "citestns"
     spec:
       serviceAccountName: test-enterprise-legacy-label-values-enterprise-metrics

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/instance: test-enterprise-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: tokengen
+      annotations:
       namespace: "citestns"
     spec:
       serviceAccountName: test-enterprise-values-mimir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Include mimir.PodAnnotations on the tokengen Job. This seems to have been an oversight since https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml#L66 mentions that this field is used for tokegen job but hasn't been wired up correctly.

```
  # -- Pod annotations for all pods directly managed by this chart. Usable for example to associate a version to 'global.extraEnv' and 'global.extraEnvFrom' and trigger a restart of the affected services.
  # scope: admin-api, alertmanager, compactor, distributor, gateway, ingester, memcached, nginx, overrides-exporter, querier, query-frontend, query-scheduler, ruler, store-gateway, tokengen

```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
