### PR TITLE
Store-gateway: correctly estimate length of last posting list

### DIFF
--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -80,6 +80,10 @@ func WriteBinary(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID, f
 	}
 	defer runutil.CloseWithErrCapture(&err, bw, "close binary writer for %s", tmpFilename)
 
+	// We put the end of the last posting list as the beginning of the label indices table.
+	// As of now this value is also the actual end of the last posting list. In the future
+	// it may be some bytes after the actual end (e.g. in case Prometheus starts adding padding
+	// after the last posting list).
 	if err := bw.AddIndexMeta(indexVersion, ir.toc.LabelIndicesTable); err != nil {
 		return errors.Wrap(err, "add index meta")
 	}
@@ -363,10 +367,10 @@ func (fw *FileWriter) Remove() error {
 	return os.Remove(fw.name)
 }
 
-func (w *binaryWriter) AddIndexMeta(indexVersion int, indexLastPostingListEnd uint64) error {
+func (w *binaryWriter) AddIndexMeta(indexVersion int, indexLastPostingListEndBound uint64) error {
 	w.buf.Reset()
 	w.buf.PutByte(byte(indexVersion))
-	w.buf.PutBE64(indexLastPostingListEnd)
+	w.buf.PutBE64(indexLastPostingListEndBound)
 	return w.f.Write(w.buf.Get())
 }
 

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -80,7 +80,7 @@ func WriteBinary(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID, f
 	}
 	defer runutil.CloseWithErrCapture(&err, bw, "close binary writer for %s", tmpFilename)
 
-	if err := bw.AddIndexMeta(indexVersion, ir.toc.PostingsTable); err != nil {
+	if err := bw.AddIndexMeta(indexVersion, ir.toc.LabelIndicesTable); err != nil {
 		return errors.Wrap(err, "add index meta")
 	}
 
@@ -363,10 +363,10 @@ func (fw *FileWriter) Remove() error {
 	return os.Remove(fw.name)
 }
 
-func (w *binaryWriter) AddIndexMeta(indexVersion int, indexPostingOffsetTable uint64) error {
+func (w *binaryWriter) AddIndexMeta(indexVersion int, indexLabelOffsetTableOffset uint64) error {
 	w.buf.Reset()
 	w.buf.PutByte(byte(indexVersion))
-	w.buf.PutBE64(indexPostingOffsetTable)
+	w.buf.PutBE64(indexLabelOffsetTableOffset)
 	return w.f.Write(w.buf.Get())
 }
 

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -363,10 +363,10 @@ func (fw *FileWriter) Remove() error {
 	return os.Remove(fw.name)
 }
 
-func (w *binaryWriter) AddIndexMeta(indexVersion int, indexLabelOffsetTableOffset uint64) error {
+func (w *binaryWriter) AddIndexMeta(indexVersion int, indexLastPostingListEnd uint64) error {
 	w.buf.Reset()
 	w.buf.PutByte(byte(indexVersion))
-	w.buf.PutBE64(indexLabelOffsetTableOffset)
+	w.buf.PutBE64(indexLastPostingListEnd)
 	return w.f.Write(w.buf.Get())
 }
 

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -370,6 +370,8 @@ func (fw *FileWriter) Remove() error {
 func (w *binaryWriter) AddIndexMeta(indexVersion int, indexLastPostingListEndBound uint64) error {
 	w.buf.Reset()
 	w.buf.PutByte(byte(indexVersion))
+	// This value used to be the offset of the postings offset table up to and including Mimir 2.7.
+	// After that this is the offset of the label indices table.
 	w.buf.PutBE64(indexLastPostingListEndBound)
 	return w.f.Write(w.buf.Get())
 }

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -24,6 +24,7 @@ type Reader interface {
 	IndexVersion() (int, error)
 
 	// PostingsOffset returns start and end offsets of postings for given name and value.
+	// The start is inclusive and the end is exclusive.
 	// The end offset might be bigger than the actual posting ending, but not larger than the whole index file.
 	// NotFoundRangeErr is returned when no index can be found for given name and value.
 	// TODO(bwplotka): Move to PostingsOffsets(name string, value ...string) []index.Range and benchmark.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -39,17 +39,17 @@ type PostingOffsetTableV1 struct {
 	postings map[string]map[string]index.Range
 }
 
-func NewPostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexVersion int, indexLastPostingListEnd uint64, postingOffsetsInMemSampling int) (PostingOffsetTable, error) {
+func NewPostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexVersion int, indexLastPostingListEndBound uint64, postingOffsetsInMemSampling int) (PostingOffsetTable, error) {
 	if indexVersion == index.FormatV1 {
-		return newV1PostingOffsetTable(factory, tableOffset, indexLastPostingListEnd)
+		return newV1PostingOffsetTable(factory, tableOffset, indexLastPostingListEndBound)
 	} else if indexVersion == index.FormatV2 {
-		return newV2PostingOffsetTable(factory, tableOffset, indexLastPostingListEnd, postingOffsetsInMemSampling)
+		return newV2PostingOffsetTable(factory, tableOffset, indexLastPostingListEndBound, postingOffsetsInMemSampling)
 	}
 
 	return nil, fmt.Errorf("unknown index version %v", indexVersion)
 }
 
-func newV1PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLastPostingListEnd uint64) (*PostingOffsetTableV1, error) {
+func newV1PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLastPostingListEndBound uint64) (*PostingOffsetTableV1, error) {
 	t := PostingOffsetTableV1{
 		postings: map[string]map[string]index.Range{},
 	}
@@ -82,14 +82,14 @@ func newV1PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 		// In case lastValOffset is unknown as we don't have next posting anymore. Guess from the index table of contents.
 		// The last posting list ends before the label offset table.
 		// In worst case we will overfetch a few bytes.
-		prevRng.End = int64(indexLastPostingListEnd) - crc32.Size
+		prevRng.End = int64(indexLastPostingListEndBound) - crc32.Size
 		t.postings[lastKey][lastValue] = prevRng
 	}
 
 	return &t, nil
 }
 
-func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLastPostingListEnd uint64, postingOffsetsInMemSampling int) (table *PostingOffsetTableV2, err error) {
+func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLastPostingListEndBound uint64, postingOffsetsInMemSampling int) (table *PostingOffsetTableV2, err error) {
 	t := PostingOffsetTableV2{
 		factory:                     factory,
 		tableOffset:                 tableOffset,
@@ -183,7 +183,7 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 		// In case lastValOffset is unknown as we don't have next posting anymore. Guess from the index table of contents.
 		// The last posting list ends before the label offset table.
 		// In worst case we will overfetch a few bytes.
-		t.postings[currentName].lastValOffset = int64(indexLastPostingListEnd) - crc32.Size
+		t.postings[currentName].lastValOffset = int64(indexLastPostingListEndBound) - crc32.Size
 	}
 
 	// Trim any extra space in the slices.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -23,6 +23,8 @@ const postingLengthFieldSize = 4
 
 type PostingOffsetTable interface {
 	// PostingsOffset returns the byte range of the postings section for the label with the given name and value.
+	// The Start is inclusive and the End is exclusive.
+	// The end offset might be bigger than the actual posting ending, but not larger than the whole index file.
 	PostingsOffset(name string, value string) (rng index.Range, found bool, err error)
 
 	// LabelValues returns a list of values for the label named name that match filter and have the prefix provided.
@@ -37,17 +39,17 @@ type PostingOffsetTableV1 struct {
 	postings map[string]map[string]index.Range
 }
 
-func NewPostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexVersion int, indexLastPostingEnd uint64, postingOffsetsInMemSampling int) (PostingOffsetTable, error) {
+func NewPostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexVersion int, indexLabelOffsetTableOffset uint64, postingOffsetsInMemSampling int) (PostingOffsetTable, error) {
 	if indexVersion == index.FormatV1 {
-		return newV1PostingOffsetTable(factory, tableOffset, indexLastPostingEnd)
+		return newV1PostingOffsetTable(factory, tableOffset, indexLabelOffsetTableOffset)
 	} else if indexVersion == index.FormatV2 {
-		return newV2PostingOffsetTable(factory, tableOffset, indexLastPostingEnd, postingOffsetsInMemSampling)
+		return newV2PostingOffsetTable(factory, tableOffset, indexLabelOffsetTableOffset, postingOffsetsInMemSampling)
 	}
 
 	return nil, fmt.Errorf("unknown index version %v", indexVersion)
 }
 
-func newV1PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLastPostingEnd uint64) (*PostingOffsetTableV1, error) {
+func newV1PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLabelOffsetTableOffset uint64) (*PostingOffsetTableV1, error) {
 	t := PostingOffsetTableV1{
 		postings: map[string]map[string]index.Range{},
 	}
@@ -77,14 +79,17 @@ func newV1PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 	}
 
 	if len(t.postings) > 0 {
-		prevRng.End = int64(indexLastPostingEnd) - crc32.Size // Each posting offset table ends with a CRC32 checksum.
+		// In case lastValOffset is unknown as we don't have next posting anymore. Guess from the index table of contents.
+		// The last posting list ends before the label offset table.
+		// In worst case we will overfetch a few bytes.
+		prevRng.End = int64(indexLabelOffsetTableOffset) - crc32.Size
 		t.postings[lastKey][lastValue] = prevRng
 	}
 
 	return &t, nil
 }
 
-func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLastPostingEnd uint64, postingOffsetsInMemSampling int) (table *PostingOffsetTableV2, err error) {
+func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexLabelOffsetTableOffset uint64, postingOffsetsInMemSampling int) (table *PostingOffsetTableV2, err error) {
 	t := PostingOffsetTableV2{
 		factory:                     factory,
 		tableOffset:                 tableOffset,
@@ -175,9 +180,10 @@ func newV2PostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset 
 	}
 
 	if len(t.postings) > 0 {
-		// In any case lastValOffset is unknown as don't have next posting anymore. Guess from TOC table.
+		// In case lastValOffset is unknown as we don't have next posting anymore. Guess from the index table of contents.
+		// The last posting list ends before the label offset table.
 		// In worst case we will overfetch a few bytes.
-		t.postings[currentName].lastValOffset = int64(indexLastPostingEnd) - crc32.Size // Each posting offset table ends with a CRC32 checksum.
+		t.postings[currentName].lastValOffset = int64(indexLabelOffsetTableOffset) - crc32.Size
 	}
 
 	// Trim any extra space in the slices.

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -104,6 +104,9 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 	// As of now this value is also the actual end of the last posting list. In the future
 	// it may be some bytes after the actual end (e.g. in case Prometheus starts adding padding
 	// after the last posting list).
+	// This value used to be the offset of the postings offset table up to and including Mimir 2.7.
+	// After that this is the offset of the label indices table.
+	// So what we read here will depend on what version of Mimir created the index header file.
 	indexLastPostingListEndBound := d.Be64()
 
 	if err = d.Err(); err != nil {

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -100,7 +100,11 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 
 	r.version = int(d.Byte())
 	r.indexVersion = int(d.Byte())
-	indexLastPostingListEnd := d.Be64()
+
+	// As of now this value is also the actual end of the last posting list. In the future
+	// it may be some bytes after the actual end (e.g. in case Prometheus starts adding padding
+	// after the last posting list).
+	indexLastPostingListEndBound := d.Be64()
 
 	if err = d.Err(); err != nil {
 		return nil, fmt.Errorf("cannot read version and index version: %w", err)
@@ -120,7 +124,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 		return nil, fmt.Errorf("cannot load symbols: %w", err)
 	}
 
-	r.postingsOffsetTable, err = streamindex.NewPostingOffsetTable(r.factory, int(r.toc.PostingsOffsetTable), r.indexVersion, indexLastPostingListEnd, postingOffsetsInMemSampling)
+	r.postingsOffsetTable, err = streamindex.NewPostingOffsetTable(r.factory, int(r.toc.PostingsOffsetTable), r.indexVersion, indexLastPostingListEndBound, postingOffsetsInMemSampling)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -100,7 +100,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 
 	r.version = int(d.Byte())
 	r.indexVersion = int(d.Byte())
-	indexLabelOffsetTableOffset := d.Be64()
+	indexLastPostingListEnd := d.Be64()
 
 	if err = d.Err(); err != nil {
 		return nil, fmt.Errorf("cannot read version and index version: %w", err)
@@ -120,7 +120,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 		return nil, fmt.Errorf("cannot load symbols: %w", err)
 	}
 
-	r.postingsOffsetTable, err = streamindex.NewPostingOffsetTable(r.factory, int(r.toc.PostingsOffsetTable), r.indexVersion, indexLabelOffsetTableOffset, postingOffsetsInMemSampling)
+	r.postingsOffsetTable, err = streamindex.NewPostingOffsetTable(r.factory, int(r.toc.PostingsOffsetTable), r.indexVersion, indexLastPostingListEnd, postingOffsetsInMemSampling)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -100,7 +100,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 
 	r.version = int(d.Byte())
 	r.indexVersion = int(d.Byte())
-	indexLastPostingEnd := d.Be64()
+	indexLabelOffsetTableOffset := d.Be64()
 
 	if err = d.Err(); err != nil {
 		return nil, fmt.Errorf("cannot read version and index version: %w", err)
@@ -120,7 +120,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 		return nil, fmt.Errorf("cannot load symbols: %w", err)
 	}
 
-	r.postingsOffsetTable, err = streamindex.NewPostingOffsetTable(r.factory, int(r.toc.PostingsOffsetTable), r.indexVersion, indexLastPostingEnd, postingOffsetsInMemSampling)
+	r.postingsOffsetTable, err = streamindex.NewPostingOffsetTable(r.factory, int(r.toc.PostingsOffsetTable), r.indexVersion, indexLabelOffsetTableOffset, postingOffsetsInMemSampling)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The index header estimates the length of each posting list by looking at
the offset of the next posting list. For all posting lists but the last
one this estimation is exact. For the last posting list, the index
header uses the table of contents from the index for the estimation.

To do the estimation of the last posting list the index header was using
the offset of the posting offset table. For reference this is the layout
 in the Prometheus TSDB index ([docs](https://github.com/prometheus/prometheus/blob/fd8992cdbd6bf7274f2a815e4af64a0b8734841b/tsdb/docs/format/index.md))

```
│ ┌──────────────────────────────────────────────┐ │
│ │                 Symbol Table                 │ │
│ ├──────────────────────────────────────────────┤ │
│ │                    Series                    │ │
│ ├──────────────────────────────────────────────┤ │
│ │                 Label Index 1                │ │
│ ├──────────────────────────────────────────────┤ │
│ │                      ...                     │ │
│ ├──────────────────────────────────────────────┤ │
│ │                 Label Index N                │ │
│ ├──────────────────────────────────────────────┤ │
│ │                   Postings 1                 │ │
│ ├──────────────────────────────────────────────┤ │
│ │                      ...                     │ │
│ ├──────────────────────────────────────────────┤ │
│ │                   Postings N                 │ │
│ ├──────────────────────────────────────────────┤ │
│ │              Label Offset Table              │ │
│ ├──────────────────────────────────────────────┤ │
│ │             Postings Offset Table            │ │
│ ├──────────────────────────────────────────────┤ │
│ │                      TOC                     │ │
│ └──────────────────────────────────────────────┘ │
```

This means that the length of the last posting list started from its
real offset, but continued until after the label indices table.

The impact of this is probably not substantial, since the consumers of
the posting offsets are prepared for receiving ranges larger than the
actual posting list. Also, to put things into perspective, in a random
9.5GiB index file I took from a cluster at GL, the Label Offset Table
was around 16KB, so the overfetching wasn't that significant.

This PR also updates interface descriptions for PostingOffset and a few
variables names that were out of sync.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
