### PR TITLE
Add ability to specify tenant ID through env variable

### DIFF
--- a/operations/k6/README.md
+++ b/operations/k6/README.md
@@ -37,6 +37,7 @@ The [load-testing-with-k6.js] script can be configured using the following envir
 | `K6_SCRAPE_INTERVAL_SECONDS`  |          | 20            | Simulated Prometheus scrape interval in seconds.                                      |
 | `K6_HA_REPLICAS`              |          | 1             | Number of HA replicas to simulate (use 1 for no HA).                                  |
 | `K6_HA_CLUSTERS`              |          | 1             | Number of HA clusters to simulate.                                                    |
+| `K6_TENANT_NAME`              |          | ''            | Tenant name for load test to write metrics to.                                        |
 
 For example, if Mimir is running on `localhost:80` you can run a small scale test with this command:
 

--- a/operations/k6/README.md
+++ b/operations/k6/README.md
@@ -37,7 +37,7 @@ The [load-testing-with-k6.js] script can be configured using the following envir
 | `K6_SCRAPE_INTERVAL_SECONDS`  |          | 20            | Simulated Prometheus scrape interval in seconds.                                      |
 | `K6_HA_REPLICAS`              |          | 1             | Number of HA replicas to simulate (use 1 for no HA).                                  |
 | `K6_HA_CLUSTERS`              |          | 1             | Number of HA clusters to simulate.                                                    |
-| `K6_TENANT_NAME`              |          | ''            | Tenant name for load test to write metrics to.                                        |
+| `K6_TENANT_NAME`              |          | ''            | Tenant name for load test to read metrics from and write metrics to.                  |
 
 For example, if Mimir is running on `localhost:80` you can run a small scale test with this command:
 

--- a/operations/k6/README.md
+++ b/operations/k6/README.md
@@ -37,7 +37,7 @@ The [load-testing-with-k6.js] script can be configured using the following envir
 | `K6_SCRAPE_INTERVAL_SECONDS`  |          | 20            | Simulated Prometheus scrape interval in seconds.                                      |
 | `K6_HA_REPLICAS`              |          | 1             | Number of HA replicas to simulate (use 1 for no HA).                                  |
 | `K6_HA_CLUSTERS`              |          | 1             | Number of HA clusters to simulate.                                                    |
-| `K6_TENANT_NAME`              |          | ''            | Tenant name for load test to read metrics from and write metrics to.                  |
+| `K6_TENANT_ID`                |          | ''            | Tenant ID used for load test to read metrics from and write metrics to.               |
 
 For example, if Mimir is running on `localhost:80` you can run a small scale test with this command:
 

--- a/operations/k6/load-testing-with-k6.js
+++ b/operations/k6/load-testing-with-k6.js
@@ -90,16 +90,16 @@ const HA_REPLICAS = parseInt(__ENV.K6_HA_REPLICAS || 1);
  */
 const HA_CLUSTERS = parseInt(__ENV.K6_HA_CLUSTERS || 1);
 /**
- * Allow for this script to write to a specific tenant in the Mimir cluster.
- * By default, no tenant is specified requiring the cluster to have multi-tenancy disabled.
+ * Tenant ID to read from/write to.
+ * By default, no tenant ID is specified requiring the cluster to have multi-tenancy disabled.
  * @constant {string}
 */
-const TENANT_NAME = __ENV.K6_TENANT_NAME || '';
+const TENANT_ID = __ENV.K6_TENANT_ID || '';
 
 const remote_write_url = get_remote_write_url();
 console.debug("Remote write URL:", remote_write_url)
 
-const write_client = new remote.Client({ url: remote_write_url, timeout: '32s', tenant_name: TENANT_NAME });
+const write_client = new remote.Client({ url: remote_write_url, timeout: '32s', tenant_name: TENANT_ID });
 
 const query_client_headers = {
     'User-Agent': 'k6-load-test',
@@ -501,8 +501,8 @@ function get_read_authentication_headers() {
         auth_headers.set('Authorization', `Basic ${encoding.b64encode(`${USERNAME}:${READ_TOKEN}`)}`)
     }
     
-    if (TENANT_NAME !== '') {
-        auth_headers.set('X-Scope-OrgID', TENANT_NAME)
+    if (TENANT_ID !== '') {
+        auth_headers.set('X-Scope-OrgID', TENANT_ID)
 
     }
     

--- a/operations/k6/load-testing-with-k6.js
+++ b/operations/k6/load-testing-with-k6.js
@@ -101,13 +101,18 @@ console.debug("Remote write URL:", remote_write_url)
 
 const write_client = new remote.Client({ url: remote_write_url, timeout: '32s', tenant_name: TENANT_NAME });
 
+const query_client_headers = {
+    'User-Agent': 'k6-load-test',
+    "Content-Type": 'application/x-www-form-urlencoded',
+}
+
+get_read_authentication_headers().forEach((value, key) => {
+    query_client_headers[key] = value
+})
+
 const query_client = new Httpx({
     baseURL: `${SCHEME}://${READ_HOSTNAME}/prometheus/api/v1`,
-    headers: {
-        'User-Agent': 'k6-load-test',
-        "Content-Type": 'application/x-www-form-urlencoded',
-        "Authorization": get_read_authentication_header()
-    },
+    headers: query_client_headers,
     timeout: 120e3 // 120s timeout.
 });
 
@@ -487,14 +492,21 @@ function get_remote_write_url() {
 
 /**
  * Returns the HTTP Authentication header to use on the read path.
- * @returns {string}
+ * @returns {map}
  */
-function get_read_authentication_header() {
+function get_read_authentication_headers() {
+    let auth_headers = new Map();
+    
     if (USERNAME !== '' || READ_TOKEN !== '') {
-        return `Basic ${encoding.b64encode(`${USERNAME}:${READ_TOKEN}`)}`;
+        auth_headers.set('Authorization', `Basic ${encoding.b64encode(`${USERNAME}:${READ_TOKEN}`)}`)
     }
+    
+    if (TENANT_NAME !== '') {
+        auth_headers.set('X-Scope-OrgID', TENANT_NAME)
 
-    return '';
+    }
+    
+    return auth_headers;
 }
 
 /**

--- a/operations/k6/load-testing-with-k6.js
+++ b/operations/k6/load-testing-with-k6.js
@@ -89,11 +89,17 @@ const HA_REPLICAS = parseInt(__ENV.K6_HA_REPLICAS || 1);
  * @constant {number}
  */
 const HA_CLUSTERS = parseInt(__ENV.K6_HA_CLUSTERS || 1);
+/**
+ * Allow for this script to write to a specific tenant in the Mimir cluster.
+ * By default, no tenant is specified requiring the cluster to have multi-tenancy disabled.
+ * @constant {string}
+*/
+const TENANT_NAME = __ENV.K6_TENANT_NAME || '';
 
 const remote_write_url = get_remote_write_url();
 console.debug("Remote write URL:", remote_write_url)
 
-const write_client = new remote.Client({ url: remote_write_url, timeout: '32s' });
+const write_client = new remote.Client({ url: remote_write_url, timeout: '32s', tenant_name: TENANT_NAME });
 
 const query_client = new Httpx({
     baseURL: `${SCHEME}://${READ_HOSTNAME}/prometheus/api/v1`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR allows for the `load-testing-with-k6.js` K6 job to set the tenant_name. This enables writing to clusters that have authentication enabled, requiring a tenant name to be set for all writes.

#### Which issue(s) this PR fixes or relates to
No issue present at the moment. Please let me know if I should create an associated issue for this.
Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
