### PR TITLE
Default to requesting protobuf format on query path, and remove experimental status on flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] Ingester: the configuration parameter `-blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup` has been deprecated and will be removed in Mimir 2.10. #4445
 * [CHANGE] Query-frontend: Cached results now contain timestamp which allows Mimir to check if cached results are still valid based on current TTL configured for tenant. Results cached by previous Mimir version are used until they expire from cache, which can take up to 7 days. If you need to use per-tenant TTL sooner, please flush results cache manually. #4439
 * [CHANGE] Ingester: the `cortex_ingester_tsdb_wal_replay_duration_seconds` metrics has been removed. #4465
+* [CHANGE] Query-frontend: use protobuf internal query result payload format by default. This feature is no longer considered experimental. #4557
 * [FEATURE] Cache: Introduce experimental support for using Redis for results, chunks, index, and metadata caches. #4371
 * [FEATURE] Vault: Introduce experimental integration with Vault to fetch secrets used to configure TLS for clients. Server TLS secrets will still be read from a file. `tls-ca-path`, `tls-cert-path` and `tls-key-path` will denote the path in Vault for the following CLI flags when `-vault.enabled` is true: #4446.
   * `-distributor.ha-tracker.etcd.*`

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4768,10 +4768,9 @@
           "required": false,
           "desc": "Format to use when retrieving query results from queriers. Supported values: json, protobuf",
           "fieldValue": null,
-          "fieldDefaultValue": "json",
+          "fieldDefaultValue": "protobuf",
           "fieldFlag": "query-frontend.query-result-response-format",
-          "fieldType": "string",
-          "fieldCategory": "experimental"
+          "fieldType": "string"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1656,7 +1656,7 @@ Usage of ./cmd/mimir/mimir:
   -query-frontend.querier-forget-delay duration
     	[experimental] If a querier disconnects without sending notification about graceful shutdown, the query-frontend will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
   -query-frontend.query-result-response-format string
-    	[experimental] Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "json")
+    	Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "protobuf")
   -query-frontend.query-sharding-max-sharded-queries int
     	The max number of sharded queries that can be run for a given received query. 0 to disable limit. (default 128)
   -query-frontend.query-sharding-target-series-per-shard uint

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -457,6 +457,8 @@ Usage of ./cmd/mimir/mimir:
     	Limit the total query time range (end - start time). This limit is enforced in the query-frontend on the received query. Defaults to the value of -store.max-query-length if set to 0.
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
+  -query-frontend.query-result-response-format string
+    	Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "protobuf")
   -query-frontend.query-sharding-max-sharded-queries int
     	The max number of sharded queries that can be run for a given received query. 0 to disable limit. (default 128)
   -query-frontend.query-sharding-total-shards int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -112,9 +112,8 @@ The following features are currently experimental:
   - `-max-separate-metrics-groups-per-user`
 - Overrides-exporter
   - Peer discovery / tenant sharding for overrides exporters (`-overrides-exporter.ring.enabled`)
-- Protobuf internal query result payload format
-  - `-query-frontend.query-result-response-format=protobuf`
-  - `-ruler.query-frontend.query-result-response-format=protobuf`
+- Protobuf internal query result payload format for rule evaluation (`-ruler.query-frontend.query-result-response-format=protobuf`)
+  - Note that using the protobuf format for the query path (`-query-frontend.query-result-response-format=protobuf`) is not considered experimental
 - Per-tenant Results cache TTL (`-query-frontend.results-cache-ttl`, `-query-frontend.results-cache-ttl-for-out-of-order-time-window`)
 - Fetching TLS secrets from Vault for various clients (`-vault.enabled`)
 

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1223,10 +1223,10 @@ results_cache:
 # CLI flag: -query-frontend.query-sharding-target-series-per-shard
 [query_sharding_target_series_per_shard: <int> | default = 0]
 
-# (experimental) Format to use when retrieving query results from queriers.
-# Supported values: json, protobuf
+# Format to use when retrieving query results from queriers. Supported values:
+# json, protobuf
 # CLI flag: -query-frontend.query-result-response-format
-[query_result_response_format: <string> | default = "json"]
+[query_result_response_format: <string> | default = "protobuf"]
 
 # (advanced) URL of downstream Prometheus.
 # CLI flag: -query-frontend.downstream-url

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -205,6 +205,12 @@ func (c *Client) QueryRaw(query string) (*http.Response, []byte, error) {
 	return c.DoGetBody(addr)
 }
 
+func (c *Client) QueryRawAt(query string, ts time.Time) (*http.Response, []byte, error) {
+	addr := fmt.Sprintf("http://%s/prometheus/api/v1/query?query=%s&time=%s", c.querierAddress, url.QueryEscape(query), FormatTime(ts))
+
+	return c.DoGetBody(addr)
+}
+
 // Series finds series by label matchers.
 func (c *Client) Series(matches []string, start, end time.Time) ([]model.LabelSet, error) {
 	result, _, err := c.querierClient.Series(context.Background(), matches, start, end)

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -47,7 +47,7 @@ type Config struct {
 	// If nil, the querymiddleware package uses a ConstSplitter with SplitQueriesByInterval.
 	CacheSplitter CacheSplitter `yaml:"-"`
 
-	QueryResultResponseFormat string `yaml:"query_result_response_format" category:"experimental"`
+	QueryResultResponseFormat string `yaml:"query_result_response_format"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -59,7 +59,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
 	f.BoolVar(&cfg.CacheUnalignedRequests, "query-frontend.cache-unaligned-requests", false, "Cache requests that are not step-aligned.")
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
-	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatJSON, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
+	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 }
 


### PR DESCRIPTION
#### What this PR does

This PR makes two related changes:
* it makes the protobuf format the default format for the query path
* it removes the experimental status on the `-query-frontend.query-result-response-format` flag

Note that this does not change the default or experimental status of the equivalent flag for the ruler-query-frontend -> ruler path, `-ruler.query-frontend.query-result-response-format`.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/4104

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
