### PR TITLE
Add "streaming enabled" to avg latency panel

### DIFF
--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2266,7 +2266,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request average latency",
+                  "title": "Series request average latency (streaming enabled)",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2266,7 +2266,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request average latency",
+                  "title": "Series request average latency (streaming enabled)",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -255,7 +255,7 @@ local filename = 'mimir-queries.json';
     .addRow(
       $.row('')
       .addPanel(
-        $.panel('Series request average latency') +
+        $.panel('Series request average latency (streaming enabled)') +
         $.queryPanel(
           |||
             sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_sum{%s}[$__rate_interval]))


### PR DESCRIPTION
#### What this PR does


Align the panel headings here so it's clear they all refer to the same "streaming enabled" thing:
![image](https://user-images.githubusercontent.com/2903904/226882270-21d66d8a-dcd8-4f14-b2d2-880a2a9514e2.png)

I've checked the first two panels in the row - they both use the `cortex_bucket_store_series_request_stage_duration_seconds_(bucket|sum|count)` metric

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- ~~Tests updated~~
- ~~Documentation added~~
- ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~

This change is so small I don't think any of these are needed, but let me know if they are. I wasn't sure about the Changelog.
