### PR TITLE
Docs: fix again broken reference configuration aliases

### DIFF
--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../operators-guide/configure/reference-configuration-parameters/
-  - ../../operators-guide/configuring/reference-configuration-parameters/
-  - ../../reference-configuration-parameters/
+  - ../operators-guide/configure/reference-configuration-parameters/
+  - ../operators-guide/configuring/reference-configuration-parameters/
+  - ../reference-configuration-parameters/
 description: Describes parameters used to configure Grafana Mimir.
 menuTitle: Configuration parameters
 title: Grafana Mimir configuration parameters

--- a/docs/sources/mimir/references/configuration-parameters/index.template
+++ b/docs/sources/mimir/references/configuration-parameters/index.template
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../operators-guide/configure/reference-configuration-parameters/
-  - ../../operators-guide/configuring/reference-configuration-parameters/
-  - ../../reference-configuration-parameters/
+  - ../operators-guide/configure/reference-configuration-parameters/
+  - ../operators-guide/configuring/reference-configuration-parameters/
+  - ../reference-configuration-parameters/
 description: Describes parameters used to configure Grafana Mimir.
 menuTitle: Configuration parameters
 title: Grafana Mimir configuration parameters


### PR DESCRIPTION
The alias is relative to the URL path, not the filesystem path.

As in docs/sources/mimir/references/configuration-parameters/index.md is one step removed from the root, since it's rendered as /references/configuration-parameters, not directly as index.md which is two steps down in the filesystem.
