### PR TITLE
Revert "Add "streaming enabled" to avg latency panel"

### DIFF
--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2266,7 +2266,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request average latency (streaming enabled)",
+                  "title": "Series request average latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2266,7 +2266,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request average latency (streaming enabled)",
+                  "title": "Series request average latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -255,7 +255,7 @@ local filename = 'mimir-queries.json';
     .addRow(
       $.row('')
       .addPanel(
-        $.panel('Series request average latency (streaming enabled)') +
+        $.panel('Series request average latency') +
         $.queryPanel(
           |||
             sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_sum{%s}[$__rate_interval]))


### PR DESCRIPTION
I think we should revert grafana/mimir#4563. There's no more any option to disable streaming, so when querying series from store-gateway it's always streaming. Instead, we should remove "streaming enabled" mentioning from other panels (will do in a separate PR).