### PR TITLE
Remove 'steaming enabled' from Queries dashboard panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 * [ENHANCEMENT] Queries: Display data touched per sec in bytes instead of number of items. #4492
 * [ENHANCEMENT] `_config.job_names.<job>` values can now be arrays of regular expressions in addition to a single string. Strings are still supported and behave as before. #4543
+* [ENHANCEMENT] Queries dashboard: remove mention to store-gateway "streaming enabled" in panels because store-gateway only support streaming series since Mimir 2.7. #4569
 * [BUGFIX] Ruler dashboard: show data for reads from ingesters. #4543
 
 ### Jsonnet

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2091,7 +2091,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any fetched metrics\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", stage=\"\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - \"fetched\"\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"fetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # Exclude \"chunks refetched\".\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", stage!=\"refetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2167,7 +2167,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any touched metrics\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"returned\"\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"returned\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # Exclude \"chunks processed\" to only count \"chunks processed\", other than postings and series.\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", stage!=\"processed\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2266,7 +2266,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request average latency (streaming enabled)",
+                  "title": "Series request average latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2342,7 +2342,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request 99th percentile latency (streaming enabled)",
+                  "title": "Series request 99th percentile latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2419,7 +2419,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series batch preloading efficiency (streaming enabled)",
+                  "title": "Series batch preloading efficiency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2091,7 +2091,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any fetched metrics\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", stage=\"\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - \"fetched\"\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"fetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # Exclude \"chunks refetched\".\n  rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component=\"store-gateway\", stage!=\"refetched\", cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2167,7 +2167,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum by(data_type) (\n  # non-streaming store-gateway will not have the stage label on any touched metrics\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", stage=\"\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n  or\n  # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - \"returned\"\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", data_type=\"chunks\", stage=\"returned\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
+                        "expr": "sum by(data_type) (\n  # Exclude \"chunks processed\" to only count \"chunks processed\", other than postings and series.\n  rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component=\"store-gateway\", stage!=\"processed\",cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
                         "legendFormat": "{{data_type}}",
@@ -2266,7 +2266,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request average latency (streaming enabled)",
+                  "title": "Series request average latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2342,7 +2342,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series request 99th percentile latency (streaming enabled)",
+                  "title": "Series request 99th percentile latency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -2419,7 +2419,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series batch preloading efficiency (streaming enabled)",
+                  "title": "Series batch preloading efficiency",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -227,11 +227,8 @@ local filename = 'mimir-queries.json';
         $.panel('Data fetched / sec') +
         $.queryPanel(|||
           sum by(data_type) (
-            # non-streaming store-gateway will not have the stage label on any fetched metrics
-            rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component="store-gateway", stage="", %(jobMatcher)s}[$__rate_interval])
-            or
-            # streaming store-gateway with new caching will have overlapping metrics for fetched chunks data; we select only the most narrow one - "fetched"
-            rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component="store-gateway", data_type="chunks", stage="fetched", %(jobMatcher)s}[$__rate_interval])
+            # Exclude "chunks refetched".
+            rate(cortex_bucket_store_series_data_size_fetched_bytes_sum{component="store-gateway", stage!="refetched", %(jobMatcher)s}[$__rate_interval])
           )
         ||| % { jobMatcher: $.jobMatcher($._config.job_names.store_gateway) }, '{{data_type}}') +
         $.stack +
@@ -241,11 +238,8 @@ local filename = 'mimir-queries.json';
         $.panel('Data touched / sec') +
         $.queryPanel(|||
           sum by(data_type) (
-            # non-streaming store-gateway will not have the stage label on any touched metrics
-            rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component="store-gateway", stage="",%(jobMatcher)s}[$__rate_interval])
-            or
-            # streaming store-gateway with new caching will have overlapping metrics for touched chunks data; we select only the most narrow one - "returned"
-            rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component="store-gateway", data_type="chunks", stage="returned",%(jobMatcher)s}[$__rate_interval])
+            # Exclude "chunks processed" to only count "chunks processed", other than postings and series.
+            rate(cortex_bucket_store_series_data_size_touched_bytes_sum{component="store-gateway", stage!="processed",%(jobMatcher)s}[$__rate_interval])
           )
         ||| % { jobMatcher: $.jobMatcher($._config.job_names.store_gateway) }, '{{data_type}}') +
         $.stack +
@@ -255,7 +249,7 @@ local filename = 'mimir-queries.json';
     .addRow(
       $.row('')
       .addPanel(
-        $.panel('Series request average latency (streaming enabled)') +
+        $.panel('Series request average latency') +
         $.queryPanel(
           |||
             sum by(stage) (rate(cortex_bucket_store_series_request_stage_duration_seconds_sum{%s}[$__rate_interval]))
@@ -268,7 +262,7 @@ local filename = 'mimir-queries.json';
         { yaxes: $.yaxes('s') },
       )
       .addPanel(
-        $.panel('Series request 99th percentile latency (streaming enabled)') +
+        $.panel('Series request 99th percentile latency') +
         $.queryPanel(
           |||
             histogram_quantile(0.99, sum by(stage, le) (rate(cortex_bucket_store_series_request_stage_duration_seconds_bucket{%s}[$__rate_interval])))
@@ -279,7 +273,7 @@ local filename = 'mimir-queries.json';
         { yaxes: $.yaxes('s') },
       )
       .addPanel(
-        $.panel('Series batch preloading efficiency (streaming enabled)') +
+        $.panel('Series batch preloading efficiency') +
         $.queryPanel(
           |||
             # Clamping min to 0 because if preloading not useful at all, then the actual value we get is


### PR DESCRIPTION
#### What this PR does
This is a follow up of https://github.com/grafana/mimir/pull/4567. The store-gateway only support streaming series, so there's no need to explicitly mention it in the Queries dashboard panels.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
