### PR TITLE
Update memcached to 1.6.19-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [CHANGE] Ruler: changed ruler deployment max surge from `0` to `50%`, and max unavailable from `1` to `0`. #4381
 * [ENHANCEMENT] Alertmanager: add `alertmanager_data_disk_size` and  `alertmanager_data_disk_class` configuration options, by default no storage class is set. #4389
 * [ENHANCEMENT] Update `rollout-operator` to `v0.4.0`. #4524
+* [ENHANCEMENT] Update memcached to `memcached:1.6.19-alpine`. #4581
 * [ENHANCEMENT] Add support for mTLS connections to Memcached servers. #4553
 * [ENHANCEMENT] Update the `memcached-exporter` to `v0.11.2`. #4570
 * [BUGFIX] Add missing query sharding settings for user_24M and user_32M plans. #4374

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -221,7 +221,7 @@ std.manifestYamlDoc({
 
   memcached:: {
     memcached: {
-      image: 'memcached:1.6.17',
+      image: 'memcached:1.6.19-alpine',
     },
   },
 

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -209,7 +209,7 @@
       - "16686:16686"
       - "14268"
   "memcached":
-    "image": "memcached:1.6.17"
+    "image": "memcached:1.6.19-alpine"
   "memcached-exporter":
     "command":
       - "--memcached.address=memcached:11211"

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -68,7 +68,7 @@ std.manifestYamlDoc({
 
   memcached:: {
     memcached: {
-      image: 'memcached:1.6.17-alpine',
+      image: 'memcached:1.6.19-alpine',
     },
   },
 

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -9,7 +9,7 @@
     "volumes":
       - "./config:/etc/agent-config"
   "memcached":
-    "image": "memcached:1.6.17-alpine"
+    "image": "memcached:1.6.19-alpine"
   "mimir-backend-1":
     "build":
       "context": "."

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.4.0`. #4524
 * [ENHANCEMENT] Update the `memcached-exporter` to `v0.11.2`. #4570
+* [ENHANCEMENT] Update memcached to `memcached:1.6.19-alpine`. #4581
 
 ## 4.3.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1527,7 +1527,7 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.6.17-alpine
+    tag: 1.6.19-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
 

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: memcached
-          image: memcached:1.6.17-alpine
+          image: memcached:1.6.19-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1378,7 +1378,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1431,7 +1431,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1484,7 +1484,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1537,7 +1537,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1426,7 +1426,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1479,7 +1479,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1532,7 +1532,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1585,7 +1585,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1863,7 +1863,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1916,7 +1916,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1969,7 +1969,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2022,7 +2022,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1316,7 +1316,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1369,7 +1369,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1422,7 +1422,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1475,7 +1475,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -838,7 +838,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -891,7 +891,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -944,7 +944,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -997,7 +997,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1913,7 +1913,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1966,7 +1966,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2019,7 +2019,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2072,7 +2072,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -1072,7 +1072,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1125,7 +1125,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1178,7 +1178,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1231,7 +1231,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1119,7 +1119,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1172,7 +1172,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1225,7 +1225,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1278,7 +1278,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1161,7 +1161,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1214,7 +1214,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1267,7 +1267,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1320,7 +1320,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1071,7 +1071,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1124,7 +1124,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1177,7 +1177,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1230,7 +1230,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1077,7 +1077,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1130,7 +1130,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1183,7 +1183,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1236,7 +1236,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1083,7 +1083,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1136,7 +1136,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1189,7 +1189,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1242,7 +1242,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1077,7 +1077,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1130,7 +1130,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1183,7 +1183,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1236,7 +1236,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1426,7 +1426,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1479,7 +1479,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1532,7 +1532,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1585,7 +1585,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1510,7 +1510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1563,7 +1563,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1616,7 +1616,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1669,7 +1669,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1510,7 +1510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1563,7 +1563,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1616,7 +1616,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1669,7 +1669,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1510,7 +1510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1563,7 +1563,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1616,7 +1616,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1669,7 +1669,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1510,7 +1510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1563,7 +1563,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1616,7 +1616,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1669,7 +1669,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1074,7 +1074,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1127,7 +1127,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1180,7 +1180,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1233,7 +1233,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1071,7 +1071,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1124,7 +1124,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1177,7 +1177,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1230,7 +1230,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1128,7 +1128,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1204,7 +1204,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1280,7 +1280,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1356,7 +1356,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1528,7 +1528,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1581,7 +1581,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1634,7 +1634,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1687,7 +1687,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1699,7 +1699,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1752,7 +1752,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1805,7 +1805,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1858,7 +1858,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1436,7 +1436,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1489,7 +1489,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1542,7 +1542,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1595,7 +1595,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1441,7 +1441,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1494,7 +1494,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1547,7 +1547,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1600,7 +1600,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1102,7 +1102,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1155,7 +1155,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1208,7 +1208,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1261,7 +1261,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1090,7 +1090,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1143,7 +1143,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1196,7 +1196,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1249,7 +1249,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1076,7 +1076,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1129,7 +1129,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1182,7 +1182,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1235,7 +1235,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -586,7 +586,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -639,7 +639,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -692,7 +692,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -745,7 +745,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -587,7 +587,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -640,7 +640,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -693,7 +693,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -746,7 +746,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1383,7 +1383,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1436,7 +1436,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1489,7 +1489,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1542,7 +1542,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1382,7 +1382,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1435,7 +1435,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1488,7 +1488,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1541,7 +1541,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1080,7 +1080,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1133,7 +1133,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1186,7 +1186,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1239,7 +1239,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1081,7 +1081,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1134,7 +1134,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1187,7 +1187,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1240,7 +1240,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1081,7 +1081,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1134,7 +1134,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1187,7 +1187,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1240,7 +1240,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1071,7 +1071,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1124,7 +1124,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1177,7 +1177,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1230,7 +1230,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1076,7 +1076,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1129,7 +1129,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1182,7 +1182,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1235,7 +1235,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -755,7 +755,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -808,7 +808,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -861,7 +861,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -914,7 +914,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.17-alpine
+        image: memcached:1.6.19-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.17-alpine',
+    memcached: 'memcached:1.6.19-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.11.2',
 
     // Our services.


### PR DESCRIPTION
#### What this PR does
Updates memcached from 1.6.17 to the latest version of 1.6.19. From reading the release notes there doesn't appear to be many changes that are relevant to us between these versions.

[1.6.18 Release notes](https://github.com/memcached/memcached/wiki/ReleaseNotes1618)
[1.6.19 Release notes](https://github.com/memcached/memcached/wiki/ReleaseNotes1619)
 
#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
