### PR TITLE
feat: add tzdata to alpine dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   * `-query-scheduler.ring.etcd.*`
   * `-overrides-exporter.ring.etcd.*`
 * [FEATURE] Distributor, ingester, querier, query-frontend, store-gateway: add experimental support for native histograms. Requires that the experimental protobuf query result response format is enabled by `-query-frontend.query-result-response-format=protobuf` on the query frontend. #4286 #4352 #4354 #4376 #4377 #4387 #4396 #4425 #4442 #4494 #4512 #4513 #4526
+* [ENHANCEMENT] Add timezone information to Alpine Docker images. #4583
 * [ENHANCEMENT] Allow to define service name used for tracing via `JAEGER_SERVICE_NAME` environment variable. #4394
 * [ENHANCEMENT] Querier and query-frontend: add experimental, more performant protobuf query result response format enabled with `-query-frontend.query-result-response-format=protobuf`. #4304 #4318 #4375
 * [ENHANCEMENT] Compactor: added experimental configuration parameter `-compactor.first-level-compaction-wait-period`, to configure how long the compactor should wait before compacting 1st level blocks (uploaded by ingesters). This configuration option allows to reduce the chances compactor begins compacting blocks before all ingesters have uploaded their blocks to the storage. #4401

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -4,7 +4,7 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM       alpine:3.17.2
-RUN        apk add --no-cache ca-certificates
+RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/mimir-continuous-test/Dockerfile
+++ b/cmd/mimir-continuous-test/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 FROM       alpine:3.17.2
-RUN        apk add --no-cache ca-certificates
+RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -4,7 +4,7 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM       alpine:3.17.2
-RUN        apk add --no-cache ca-certificates
+RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM       alpine:3.17.2
-RUN        apk add --no-cache ca-certificates
+RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -4,7 +4,7 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM       alpine:3.17.2
-RUN        apk add --no-cache ca-certificates
+RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH


### PR DESCRIPTION
#### What this PR does

This PR populates the `/usr/share/zoneinfo` by installing timezones using `apk` on alpine.

#### Which issue(s) this PR fixes or relates to

Fixes #4582

Allows use of timezones for alertmanager.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
