### PR TITLE
Make block upload validation configurable per tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
   * `-blocks-storage.tsdb.block-postings-for-matchers-cache-ttl`
   * `-blocks-storage.tsdb.block-postings-for-matchers-cache-size`
   * `-blocks-storage.tsdb.block-postings-for-matchers-cache-force`
+* [ENHANCEMENT] Compactor: validation of blocks uploaded via the TSDB block upload feature is now configurable on a per tenant basis: #4585
+  * `-compactor.block-upload-validation-enabled` has been added, `compactor_block_upload_validation_enabled` can be used to override per tenant
+  * `-compactor.block-upload.block-validation-enabled` was the previous global flag and has been removed
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3425,6 +3425,16 @@
         },
         {
           "kind": "field",
+          "name": "compactor_block_upload_validation_enabled",
+          "required": false,
+          "desc": "Enable block upload validation for the tenant.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "compactor.block-upload-validation-enabled",
+          "fieldType": "boolean"
+        },
+        {
+          "kind": "field",
           "name": "compactor_block_upload_verify_chunks",
           "required": false,
           "desc": "Verify chunks when uploading blocks via the upload API for the tenant.",
@@ -8316,27 +8326,6 @@
           "fieldFlag": "compactor.compaction-jobs-order",
           "fieldType": "string",
           "fieldCategory": "advanced"
-        },
-        {
-          "kind": "block",
-          "name": "block_upload",
-          "required": false,
-          "desc": "",
-          "blockEntries": [
-            {
-              "kind": "field",
-              "name": "block_validation_enabled",
-              "required": false,
-              "desc": "Validate blocks before finalizing a block upload",
-              "fieldValue": null,
-              "fieldDefaultValue": true,
-              "fieldFlag": "compactor.block-upload.block-validation-enabled",
-              "fieldType": "boolean",
-              "fieldCategory": "experimental"
-            }
-          ],
-          "fieldValue": null,
-          "fieldDefaultValue": null
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -843,10 +843,10 @@ Usage of ./cmd/mimir/mimir:
     	Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
   -compactor.block-upload-enabled
     	Enable block upload API for the tenant.
+  -compactor.block-upload-validation-enabled
+    	Enable block upload validation for the tenant. (default true)
   -compactor.block-upload-verify-chunks
     	Verify chunks when uploading blocks via the upload API for the tenant. (default true)
-  -compactor.block-upload.block-validation-enabled
-    	[experimental] Validate blocks before finalizing a block upload (default true)
   -compactor.blocks-retention-period duration
     	Delete blocks containing samples older than the specified retention period. Also used by query-frontend to avoid querying beyond the retention period. 0 to disable.
   -compactor.cleanup-concurrency int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -844,7 +844,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.block-upload-enabled
     	Enable block upload API for the tenant.
   -compactor.block-upload-validation-enabled
-    	Enable block upload validation for a tenant. (default true)
+    	Enable block upload validation for the tenant. (default true)
   -compactor.block-upload-verify-chunks
     	Verify chunks when uploading blocks via the upload API for the tenant. (default true)
   -compactor.blocks-retention-period duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -844,7 +844,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.block-upload-enabled
     	Enable block upload API for the tenant.
   -compactor.block-upload-validation-enabled
-    	Enable block upload validation for the tenant. (default true)
+    	Enable block upload validation for a tenant. (default true)
   -compactor.block-upload-verify-chunks
     	Verify chunks when uploading blocks via the upload API for the tenant. (default true)
   -compactor.blocks-retention-period duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -289,6 +289,8 @@ Usage of ./cmd/mimir/mimir:
     	OpenStack Swift username.
   -compactor.block-upload-enabled
     	Enable block upload API for the tenant.
+  -compactor.block-upload-validation-enabled
+    	Enable block upload validation for the tenant. (default true)
   -compactor.block-upload-verify-chunks
     	Verify chunks when uploading blocks via the upload API for the tenant. (default true)
   -compactor.blocks-retention-period duration

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2822,6 +2822,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -compactor.block-upload-enabled
 [compactor_block_upload_enabled: <boolean> | default = false]
 
+# Enable block upload validation for the tenant.
+# CLI flag: -compactor.block-upload-validation-enabled
+[compactor_block_upload_validation_enabled: <boolean> | default = true]
+
 # Verify chunks when uploading blocks via the upload API for the tenant.
 # CLI flag: -compactor.block-upload-verify-chunks
 [compactor_block_upload_verify_chunks: <boolean> | default = true]
@@ -3571,11 +3575,6 @@ sharding_ring:
 # smallest-range-oldest-blocks-first, newest-blocks-first.
 # CLI flag: -compactor.compaction-jobs-order
 [compaction_jobs_order: <string> | default = "smallest-range-oldest-blocks-first"]
-
-block_upload:
-  # (experimental) Validate blocks before finalizing a block upload
-  # CLI flag: -compactor.block-upload.block-validation-enabled
-  [block_validation_enabled: <boolean> | default = true]
 ```
 
 ### store_gateway

--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -40,14 +39,6 @@ const (
 	validationHeartbeatInterval = 1 * time.Minute       // Duration of time between heartbeats of an in-progress block upload validation
 	validationHeartbeatTimeout  = 5 * time.Minute       // Maximum duration of time to wait until a validation is able to be restarted
 )
-
-type BlockUploadConfig struct {
-	BlockValidationEnabled bool `yaml:"block_validation_enabled" category:"experimental"`
-}
-
-func (cfg *BlockUploadConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet, logger log.Logger) {
-	f.BoolVar(&cfg.BlockValidationEnabled, prefix+".block-validation-enabled", true, "Validate blocks before finalizing a block upload")
-}
 
 var rePath = regexp.MustCompile(`^(index|chunks/\d{6})$`)
 
@@ -112,7 +103,7 @@ func (c *MultitenantCompactor) FinishBlockUpload(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if c.compactorCfg.BlockUpload.BlockValidationEnabled {
+	if c.cfgProvider.CompactorBlockUploadValidationEnabled(tenantID) {
 		// create validation file to signal that block validation has started
 		if err := c.uploadValidation(ctx, blockID, userBkt); err != nil {
 			writeBlockUploadError(err, op, "while creating validation file", logger, w)

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -1229,15 +1229,13 @@ func TestMultitenantCompactor_FinishBlockUpload(t *testing.T) {
 
 			cfgProvider := newMockConfigProvider()
 			cfgProvider.blockUploadEnabled[tc.tenantID] = !tc.disableBlockUpload
+			cfgProvider.blockUploadValidationEnabled[tc.tenantID] = false
 			c := &MultitenantCompactor{
 				logger:       log.NewNopLogger(),
 				bucketClient: &injectedBkt,
 				cfgProvider:  cfgProvider,
 			}
 
-			c.compactorCfg.BlockUpload = BlockUploadConfig{
-				BlockValidationEnabled: false,
-			}
 			c.compactorCfg.DataDir = t.TempDir()
 
 			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/finish", tc.blockID), nil)
@@ -1572,13 +1570,13 @@ func TestMultitenantCompactor_ValidateBlock(t *testing.T) {
 
 			// create a compactor
 			cfgProvider := newMockConfigProvider()
+			cfgProvider.blockUploadValidationEnabled[tenantID] = true
 			cfgProvider.verifyChunks[tenantID] = tc.verifyChunks
 			c := &MultitenantCompactor{
 				logger:       log.NewNopLogger(),
 				bucketClient: bkt,
 				cfgProvider:  cfgProvider,
 			}
-			c.compactorCfg.BlockUpload.BlockValidationEnabled = true
 
 			// upload the block
 			require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, testDir, nil))

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -972,6 +972,7 @@ type mockConfigProvider struct {
 	instancesShardSize           map[string]int
 	splitGroups                  map[string]int
 	blockUploadEnabled           map[string]bool
+	blockUploadValidationEnabled map[string]bool
 	userPartialBlockDelay        map[string]time.Duration
 	userPartialBlockDelayInvalid map[string]bool
 	verifyChunks                 map[string]bool
@@ -983,6 +984,7 @@ func newMockConfigProvider() *mockConfigProvider {
 		splitAndMergeShards:          make(map[string]int),
 		splitGroups:                  make(map[string]int),
 		blockUploadEnabled:           make(map[string]bool),
+		blockUploadValidationEnabled: make(map[string]bool),
 		userPartialBlockDelay:        make(map[string]time.Duration),
 		userPartialBlockDelayInvalid: make(map[string]bool),
 		verifyChunks:                 make(map[string]bool),
@@ -1019,6 +1021,10 @@ func (m *mockConfigProvider) CompactorTenantShardSize(user string) int {
 
 func (m *mockConfigProvider) CompactorBlockUploadEnabled(tenantID string) bool {
 	return m.blockUploadEnabled[tenantID]
+}
+
+func (m *mockConfigProvider) CompactorBlockUploadValidationEnabled(tenantID string) bool {
+	return m.blockUploadValidationEnabled[tenantID]
 }
 
 func (m *mockConfigProvider) CompactorPartialBlockDeletionDelay(user string) (time.Duration, bool) {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -119,14 +119,11 @@ type Config struct {
 	// Allow downstream projects to customise the blocks compactor.
 	BlocksGrouperFactory   BlocksGrouperFactory   `yaml:"-"`
 	BlocksCompactorFactory BlocksCompactorFactory `yaml:"-"`
-
-	BlockUpload BlockUploadConfig `yaml:"block_upload"`
 }
 
 // RegisterFlags registers the MultitenantCompactor flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.ShardingRing.RegisterFlags(f, logger)
-	cfg.BlockUpload.RegisterFlagsWithPrefix("compactor.block-upload", f, logger)
 
 	cfg.BlockRanges = mimir_tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}
 	cfg.retryMinBackoff = 10 * time.Second
@@ -209,6 +206,9 @@ type ConfigProvider interface {
 
 	// CompactorBlockUploadEnabled returns whether block upload is enabled for a given tenant.
 	CompactorBlockUploadEnabled(tenantID string) bool
+
+	// CompactorBlockUploadValidationEnabled returns whether block upload validation is enabled for a given tenant.
+	CompactorBlockUploadValidationEnabled(tenantID string) bool
 
 	// CompactorBlockUploadVerifyChunks returns whether chunk verification is enabled for a given tenant.
 	CompactorBlockUploadVerifyChunks(tenantID string) bool

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -147,13 +147,14 @@ type Limits struct {
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
 
 	// Compactor.
-	CompactorBlocksRetentionPeriod     model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
-	CompactorSplitAndMergeShards       int            `yaml:"compactor_split_and_merge_shards" json:"compactor_split_and_merge_shards"`
-	CompactorSplitGroups               int            `yaml:"compactor_split_groups" json:"compactor_split_groups"`
-	CompactorTenantShardSize           int            `yaml:"compactor_tenant_shard_size" json:"compactor_tenant_shard_size"`
-	CompactorPartialBlockDeletionDelay model.Duration `yaml:"compactor_partial_block_deletion_delay" json:"compactor_partial_block_deletion_delay"`
-	CompactorBlockUploadEnabled        bool           `yaml:"compactor_block_upload_enabled" json:"compactor_block_upload_enabled"`
-	CompactorBlockUploadVerifyChunks   bool           `yaml:"compactor_block_upload_verify_chunks" json:"compactor_block_upload_verify_chunks"`
+	CompactorBlocksRetentionPeriod        model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
+	CompactorSplitAndMergeShards          int            `yaml:"compactor_split_and_merge_shards" json:"compactor_split_and_merge_shards"`
+	CompactorSplitGroups                  int            `yaml:"compactor_split_groups" json:"compactor_split_groups"`
+	CompactorTenantShardSize              int            `yaml:"compactor_tenant_shard_size" json:"compactor_tenant_shard_size"`
+	CompactorPartialBlockDeletionDelay    model.Duration `yaml:"compactor_partial_block_deletion_delay" json:"compactor_partial_block_deletion_delay"`
+	CompactorBlockUploadEnabled           bool           `yaml:"compactor_block_upload_enabled" json:"compactor_block_upload_enabled"`
+	CompactorBlockUploadValidationEnabled bool           `yaml:"compactor_block_upload_validation_enabled" json:"compactor_block_upload_validation_enabled"`
+	CompactorBlockUploadVerifyChunks      bool           `yaml:"compactor_block_upload_verify_chunks" json:"compactor_block_upload_verify_chunks"`
 
 	// This config doesn't have a CLI flag registered here because they're registered in
 	// their own original config struct.
@@ -249,6 +250,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.CompactorTenantShardSize, "compactor.compactor-tenant-shard-size", 0, "Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.")
 	f.Var(&l.CompactorPartialBlockDeletionDelay, "compactor.partial-block-deletion-delay", fmt.Sprintf("If a partial block (unfinished block without %s file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is %s: a lower value will be ignored and the feature disabled. 0 to disable.", block.MetaFilename, MinCompactorPartialBlockDeletionDelay.String()))
 	f.BoolVar(&l.CompactorBlockUploadEnabled, "compactor.block-upload-enabled", false, "Enable block upload API for the tenant.")
+	f.BoolVar(&l.CompactorBlockUploadValidationEnabled, "compactor.block-upload-validation-enabled", true, "Enable block upload validation for the tenant.")
 	f.BoolVar(&l.CompactorBlockUploadVerifyChunks, "compactor.block-upload-verify-chunks", true, "Verify chunks when uploading blocks via the upload API for the tenant.")
 
 	// Query-frontend.
@@ -632,6 +634,11 @@ func (o *Overrides) CompactorPartialBlockDeletionDelay(userID string) (delay tim
 // CompactorBlockUploadEnabled returns whether block upload is enabled for a certain tenant.
 func (o *Overrides) CompactorBlockUploadEnabled(tenantID string) bool {
 	return o.getOverridesForUser(tenantID).CompactorBlockUploadEnabled
+}
+
+// CompactorBlockUploadValidationEnabled returns whether block upload validation is enabled for a certain tenant.
+func (o *Overrides) CompactorBlockUploadValidationEnabled(tenantID string) bool {
+	return o.getOverridesForUser(tenantID).CompactorBlockUploadValidationEnabled
 }
 
 // CompactorBlockUploadVerifyChunks returns whether compaction chunk verification is enabled for a certain tenant.


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

This PR makes validation of uploaded blocks configurable on a per tenant basis. This brings it in line with other block upload parameters like block upload enabled, and chunk checking during validation.

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
