### PR TITLE
Prevent package installation to overwrite configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580
 * [BUGFIX] OTLP: Do not drop exemplars of the OTLP Monotonic Sum metric. #4063
+* [BUGFIX] Packaging: flag `/etc/default/mimir` and `/etc/sysconfig/mimir` as config to prevent overwrite. #4587
 
 ### Mixin
 

--- a/packaging/nfpm/nfpm.jsonnet
+++ b/packaging/nfpm/nfpm.jsonnet
@@ -21,11 +21,13 @@ local overrides = {
       {
         src: './dist/tmp/dependencies-%s-%s-%s/mimir.env' % [name, packager, arch],
         dst: '/etc/default/mimir',
+        type: 'config|noreplace',
         packager: 'deb',
       },
       {
         src: './dist/tmp/dependencies-%s-%s-%s/mimir.env' % [name, packager, arch],
         dst: '/etc/sysconfig/mimir',
+        type: 'config|noreplace',
         packager: 'rpm',
       },
       {


### PR DESCRIPTION
When running Mimir installed  with the packages we use apt/dnf. To correctly configure systemd with use  either `/etc/default/mimir` or `/etc/sysconfig/mimir`. Both files allow users to define environment variables used by Mimir when the process is started by systemd. It is generally used to define the loglevel or the path of the configuration file. While upgrading apt/dnf overwrite those files as they are not flagged as `config` with `noreplace`.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
