### PR TITLE
Don't allocate an extra pointer in `mimirpb.ReuseSlice()`

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -240,7 +240,7 @@ std.manifestYamlDoc({
         '--maxmemory 64mb',
         '--maxmemory-policy allkeys-lru',
         "--save ''",
-         '--appendonly no'
+        '--appendonly no',
       ],
     },
   },

--- a/pkg/util/push/push_test.go
+++ b/pkg/util/push/push_test.go
@@ -534,9 +534,9 @@ func createPrometheusRemoteWriteProtobuf(t testing.TB) []byte {
 			},
 		},
 	}
-	inoutBytes, err := input.Marshal()
+	inputBytes, err := input.Marshal()
 	require.NoError(t, err)
-	return inoutBytes
+	return inputBytes
 }
 
 func createMimirWriteRequestProtobuf(t *testing.T, skipLabelNameValidation bool) []byte {
@@ -590,6 +590,7 @@ func BenchmarkPushHandler(b *testing.B) {
 	buf := bytes.NewBuffer(snappy.Encode(nil, protobuf))
 	req := createRequest(b, protobuf)
 	pushFunc := func(ctx context.Context, pushReq *Request) (response *mimirpb.WriteResponse, err error) {
+		pushReq.WriteRequest()
 		pushReq.CleanUp()
 		return &mimirpb.WriteResponse{}, nil
 	}

--- a/pkg/util/push/push_test.go
+++ b/pkg/util/push/push_test.go
@@ -590,7 +590,9 @@ func BenchmarkPushHandler(b *testing.B) {
 	buf := bytes.NewBuffer(snappy.Encode(nil, protobuf))
 	req := createRequest(b, protobuf)
 	pushFunc := func(ctx context.Context, pushReq *Request) (response *mimirpb.WriteResponse, err error) {
-		pushReq.WriteRequest()
+		if _, err := pushReq.WriteRequest(); err != nil {
+			return nil, err
+		}
 		pushReq.CleanUp()
 		return &mimirpb.WriteResponse{}, nil
 	}


### PR DESCRIPTION
#### What this PR does

We can avoid allocating an extra pointer just to put something into a pool if we store the pointer we got from the first pool in a second pool. Used the implementation of a pool from Prometheus for this.

```
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/util/push
cpu: 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz
               │   old.txt   │            new.txt            │
               │   sec/op    │   sec/op     vs base          │
PushHandler-16   1.635µ ± 8%   1.608µ ± 4%  ~ (p=0.289 n=10)

               │  old.txt   │              new.txt              │
               │    B/op    │    B/op     vs base               │
PushHandler-16   659.0 ± 0%   633.0 ± 0%  -3.95% (p=0.000 n=10)

               │  old.txt   │              new.txt              │
               │ allocs/op  │ allocs/op   vs base               │
PushHandler-16   17.00 ± 0%   16.00 ± 0%  -5.88% (p=0.000 n=10)
```

#### Which issue(s) this PR fixes or relates to

None, was just passing by.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
