### PR TITLE
store-gateway: Add BenchmarkOpenBlockSeriesChunkRefsSetsIterator

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -943,14 +943,44 @@ func createBlockFromHead(t testing.TB, dir string, head *tsdb.Head) ulid.ULID {
 	return ulid
 }
 
-// Very similar benchmark to ths: https://github.com/prometheus/prometheus/blob/1d1732bc25cc4b47f513cb98009a4eb91879f175/tsdb/querier_bench_test.go#L82,
-// but with postings results check when run as test.
 func benchmarkExpandedPostings(
-	t test.TB,
+	tb test.TB,
 	newTestBucketBlock func() *bucketBlock,
 	series int,
 ) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	tb.Cleanup(cancel)
+
+	seriesSelectionTestCases(tb, series, func(tb test.TB, testCase seriesSelectionTestCase) {
+		indexr := newBucketIndexReader(newTestBucketBlock())
+		indexrStats := newSafeQueryStats()
+
+		tb.ResetTimer()
+		for i := 0; i < tb.N(); i++ {
+			p, err := indexr.ExpandedPostings(ctx, testCase.matchers, indexrStats)
+
+			if err != nil {
+				tb.Fatal(err.Error())
+			}
+			if testCase.expectedSeriesLen != len(p) {
+				tb.Fatalf("expected %d postings but got %d", testCase.expectedSeriesLen, len(p))
+			}
+		}
+	})
+}
+
+type seriesSelectionTestCase struct {
+	name              string
+	matchers          []*labels.Matcher
+	expectedSeriesLen int
+}
+
+// Very similar benchmark to ths: https://github.com/prometheus/prometheus/blob/1d1732bc25cc4b47f513cb98009a4eb91879f175/tsdb/querier_bench_test.go#L82,
+func seriesSelectionTestCases(
+	t test.TB,
+	series int,
+	runTestCase func(tb test.TB, testCase seriesSelectionTestCase),
+) {
 	series = series / 5
 
 	iUniqueValues := series / 10      // The amount of unique values for "i" label prefix. See appendTestSeries.
@@ -984,12 +1014,7 @@ func benchmarkExpandedPostings(
 	// Just make sure that we're testing what we think we're testing.
 	require.NotEmpty(t, iRegexNotSetMatches.SetMatches(), "Should have non empty SetMatches to test the proper path.")
 
-	cases := []struct {
-		name     string
-		matchers []*labels.Matcher
-
-		expectedLen int
-	}{
+	cases := []seriesSelectionTestCase{
 		{`n="X"`, []*labels.Matcher{nX}, 0},
 		{`n="X",j="foo"`, []*labels.Matcher{nX, jFoo}, 0},
 		{`n="X",j!="foo"`, []*labels.Matcher{nX, jNotFoo}, 0},
@@ -1031,20 +1056,7 @@ func benchmarkExpandedPostings(
 
 	for _, c := range cases {
 		t.Run(c.name, func(t test.TB) {
-			indexr := newBucketIndexReader(newTestBucketBlock())
-			indexrStats := newSafeQueryStats()
-
-			t.ResetTimer()
-			for i := 0; i < t.N(); i++ {
-				p, err := indexr.ExpandedPostings(ctx, c.matchers, indexrStats)
-
-				if err != nil {
-					t.Fatal(err.Error())
-				}
-				if c.expectedLen != len(p) {
-					t.Fatalf("expected %d postings but got %d", c.expectedLen, len(p))
-				}
-			}
+			runTestCase(t, c)
 		})
 	}
 }

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1630,6 +1630,62 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 	}
 }
 
+func BenchmarkOpenBlockSeriesChunkRefsSetsIterator(b *testing.B) {
+	tb := test.NewTB(b)
+	const series = 5e6
+
+	newTestBlock := prepareTestBlockWithBinaryReader(tb, appendTestSeries(series))
+
+	testSetups := map[string]struct {
+		indexCache indexcache.IndexCache
+	}{
+		"without index cache": {indexCache: noopCache{}},
+		"with index cache":    {indexCache: newInMemoryIndexCache(tb)},
+	}
+
+	for name, setup := range testSetups {
+		tb.Run(name, func(tb test.TB) {
+			seriesSelectionTestCases(tb, series, func(tb test.TB, testCase seriesSelectionTestCase) {
+				ctx, cancel := context.WithCancel(context.Background())
+				tb.Cleanup(cancel)
+
+				var block = newTestBlock()
+				indexReader := block.indexReader()
+				tb.Cleanup(func() { require.NoError(tb, indexReader.Close()) })
+
+				hashCache := hashcache.NewSeriesHashCache(1024 * 1024).GetBlockCache(block.meta.ULID.String())
+
+				tb.ResetTimer()
+
+				for i := 0; i < tb.N(); i++ {
+					iterator, err := openBlockSeriesChunkRefsSetsIterator(
+						ctx,
+						5000,
+						"",
+						indexReader,
+						setup.indexCache,
+						block.meta,
+						testCase.matchers,
+						nil,
+						cachedSeriesHasher{hashCache},
+						false, // we don't skip chunks, so we can measure impact in loading chunk refs too
+						block.meta.MinTime,
+						block.meta.MaxTime,
+						2,
+						newSafeQueryStats(),
+						nil,
+					)
+					require.NoError(tb, err)
+
+					actualSeriesSets := readAllSeriesChunkRefs(newFlattenedSeriesChunkRefsIterator(iterator))
+					assert.Len(tb, actualSeriesSets, testCase.expectedSeriesLen)
+					assert.NoError(tb, iterator.Err())
+				}
+			})
+		})
+	}
+}
+
 func TestMetasToRanges(t *testing.T) {
 	blockID := ulid.MustNew(1, nil)
 	testCases := map[string]struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR add a benchmark for `openBlockSeriesChunkRefsSetsIterator` 
(which calculates postings and series for the Series() RPC).
It also includes an internal refactor to allow reusing the test cases
that `BenchmarkBucketIndexReader_ExpandedPostings` uses.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>


#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/4593

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
