### PR TITLE
Emit TSDB index bytes fetched as metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
   * `-compactor.block-upload-validation-enabled` has been added, `compactor_block_upload_validation_enabled` can be used to override per tenant
   * `-compactor.block-upload.block-validation-enabled` was the previous global flag and has been removed
 * [ENHANCEMENT] OTLP: Add support for converting OTel exponential histograms to Prometheus native histograms. The ingestion of native histograms must be enabled, please set `-ingester.native-histograms-ingestion-enabled` to `true`. #4063
+* [ENHANCEMENT] Query-frontend: add metric `cortex_query_fetched_index_bytes_total` to measure TSDB index bytes fetched to execute a query. #TBD
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
   * `-compactor.block-upload-validation-enabled` has been added, `compactor_block_upload_validation_enabled` can be used to override per tenant
   * `-compactor.block-upload.block-validation-enabled` was the previous global flag and has been removed
 * [ENHANCEMENT] OTLP: Add support for converting OTel exponential histograms to Prometheus native histograms. The ingestion of native histograms must be enabled, please set `-ingester.native-histograms-ingestion-enabled` to `true`. #4063
-* [ENHANCEMENT] Query-frontend: add metric `cortex_query_fetched_index_bytes_total` to measure TSDB index bytes fetched to execute a query. #TBD
+* [ENHANCEMENT] Query-frontend: add metric `cortex_query_fetched_index_bytes_total` to measure TSDB index bytes fetched to execute a query. #4597 
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
   * `-compactor.block-upload-validation-enabled` has been added, `compactor_block_upload_validation_enabled` can be used to override per tenant
   * `-compactor.block-upload.block-validation-enabled` was the previous global flag and has been removed
 * [ENHANCEMENT] OTLP: Add support for converting OTel exponential histograms to Prometheus native histograms. The ingestion of native histograms must be enabled, please set `-ingester.native-histograms-ingestion-enabled` to `true`. #4063
-* [ENHANCEMENT] Query-frontend: add metric `cortex_query_fetched_index_bytes_total` to measure TSDB index bytes fetched to execute a query. #4597 
+* [ENHANCEMENT] Query-frontend: add metric `cortex_query_fetched_index_bytes_total` to measure TSDB index bytes fetched to execute a query. #4597
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -69,11 +69,12 @@ type Handler struct {
 	at           *activitytracker.ActivityTracker
 
 	// Metrics.
-	querySeconds *prometheus.CounterVec
-	querySeries  *prometheus.CounterVec
-	queryBytes   *prometheus.CounterVec
-	queryChunks  *prometheus.CounterVec
-	activeUsers  *util.ActiveUsersCleanupService
+	querySeconds    *prometheus.CounterVec
+	querySeries     *prometheus.CounterVec
+	queryChunkBytes *prometheus.CounterVec
+	queryChunks     *prometheus.CounterVec
+	queryIndexBytes *prometheus.CounterVec
+	activeUsers     *util.ActiveUsersCleanupService
 
 	mtx              sync.Mutex
 	inflightRequests int
@@ -102,7 +103,7 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 			Help: "Number of series fetched to execute a query.",
 		}, []string{"user"})
 
-		h.queryBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		h.queryChunkBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_query_fetched_chunk_bytes_total",
 			Help: "Number of chunk bytes fetched to execute a query.",
 		}, []string{"user"})
@@ -112,12 +113,18 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 			Help: "Number of chunks fetched to execute a query.",
 		}, []string{"user"})
 
+		h.queryIndexBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_query_fetched_index_bytes_total",
+			Help: "Number of TSDB index bytes fetched to execute a query.",
+		}, []string{"user"})
+
 		h.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(func(user string) {
 			h.querySeconds.DeleteLabelValues(user, "true")
 			h.querySeconds.DeleteLabelValues(user, "false")
 			h.querySeries.DeleteLabelValues(user)
-			h.queryBytes.DeleteLabelValues(user)
+			h.queryChunkBytes.DeleteLabelValues(user)
 			h.queryChunks.DeleteLabelValues(user)
+			h.queryIndexBytes.DeleteLabelValues(user)
 		})
 		// If cleaner stops or fail, we will simply not clean the metrics for inactive users.
 		_ = h.activeUsers.StartAsync(context.Background())
@@ -253,8 +260,9 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 		// Track stats.
 		f.querySeconds.WithLabelValues(userID, sharded).Add(wallTime.Seconds())
 		f.querySeries.WithLabelValues(userID).Add(float64(numSeries))
-		f.queryBytes.WithLabelValues(userID).Add(float64(numBytes))
+		f.queryChunkBytes.WithLabelValues(userID).Add(float64(numBytes))
 		f.queryChunks.WithLabelValues(userID).Add(float64(numChunks))
+		f.queryIndexBytes.WithLabelValues(userID).Add(float64(numIndexBytes))
 		f.activeUsers.UpdateUserTimestamp(userID, time.Now())
 	}
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -115,7 +115,7 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 
 		h.queryIndexBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_query_fetched_index_bytes_total",
-			Help: "Number of TSDB index bytes fetched to execute a query.",
+			Help: "Number of TSDB index bytes fetched from store-gateway to execute a query.",
 		}, []string{"user"})
 
 		h.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(func(user string) {

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -84,7 +84,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:  4,
+			expectedMetrics:  5,
 			expectedActivity: "12345 POST /api/v1/query query=some_metric&time=42",
 		},
 		{
@@ -97,7 +97,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:  4,
+			expectedMetrics:  5,
 			expectedActivity: "12345 GET /api/v1/query query=some_metric&time=42",
 		},
 		{
@@ -107,7 +107,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				return httptest.NewRequest("GET", "/api/v1/query", nil)
 			},
 			expectedParams:   url.Values{},
-			expectedMetrics:  4,
+			expectedMetrics:  5,
 			expectedActivity: "12345 GET /api/v1/query (no params)",
 		},
 		{
@@ -164,6 +164,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"cortex_query_fetched_series_total",
 				"cortex_query_fetched_chunk_bytes_total",
 				"cortex_query_fetched_chunks_total",
+				"cortex_query_fetched_index_bytes_total",
 			)
 
 			assert.NoError(t, err)
@@ -228,7 +229,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 		{
 			name:                "Failed round trip with no query params",
 			cfg:                 HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics:     4,
+			expectedMetrics:     5,
 			path:                "/api/v1/query",
 			expectQueryParamLog: false,
 			queryErr:            context.Canceled,
@@ -258,6 +259,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 				"cortex_query_fetched_series_total",
 				"cortex_query_fetched_chunk_bytes_total",
 				"cortex_query_fetched_chunks_total",
+				"cortex_query_fetched_index_bytes_total",
 			)
 
 			require.NoError(t, err)


### PR DESCRIPTION
#### What this PR does

We collect the number of TSDB index bytes fetched as part of executing a query and include it in the query logs. However, we don't emit it as a metric even though we do this with other query statistics. This PR fixes that so that we do emit the number of index bytes fetched as a per-tenant metric.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
