### PR TITLE
Jsonnet: Add configurable autoscaling memory target utilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [ENHANCEMENT] Update memcached to `memcached:1.6.19-alpine`. #4581
 * [ENHANCEMENT] Add support for mTLS connections to Memcached servers. #4553
 * [ENHANCEMENT] Update the `memcached-exporter` to `v0.11.2`. #4570
+* [ENHANCEMENT] Autoscaling: Add `autoscaling_query_frontend_memory_target_utilization`, `autoscaling_ruler_query_frontend_memory_target_utilization`, and `autoscaling_ruler_memory_target_utilization` configuration options, for controlling the corresponding autoscaler memory thresholds. Each has a default of 1, i.e. 100%. #4612
 * [BUGFIX] Add missing query sharding settings for user_24M and user_32M plans. #4374
 
 ### Mimirtool


### PR DESCRIPTION
#### What this PR does
Add configurable autoscaling memory target utilization parameter for (ruler-)query-frontend and ruler components. This is useful so the autoscaler can trigger at a certain threshold before the memory request is hit.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
