### PR TITLE
Ingester: add logs for finishing block upload

### DIFF
--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -172,6 +172,8 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 			level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
 			uploadErrs++
 			continue
+		} else {
+			level.Info(s.logger).Log("msg", "finished uploading new block", "id", m.ULID)
 		}
 
 		meta.Shipped[m.ULID] = model.Now()
@@ -198,7 +200,6 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 // library could actually unload the block if it found meta.json file missing.
 func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 	level.Info(s.logger).Log("msg", "uploading new block", "id", meta.ULID)
-	defer level.Info(s.logger).Log("msg", "finished uploading new block", "id", meta.ULID)
 
 	blockDir := filepath.Join(s.dir, meta.ULID.String())
 

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -197,7 +197,8 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 // This updated version of meta.json is however not persisted locally on the disk, to avoid race condition when TSDB
 // library could actually unload the block if it found meta.json file missing.
 func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
-	level.Info(s.logger).Log("msg", "upload new block", "id", meta.ULID)
+	level.Info(s.logger).Log("msg", "uploading new block", "id", meta.ULID)
+	defer level.Info(s.logger).Log("msg", "finished uploading new block", "id", meta.ULID)
 
 	blockDir := filepath.Join(s.dir, meta.ULID.String())
 

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -166,6 +166,7 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 			continue
 		}
 
+		level.Info(s.logger).Log("msg", "shipping new block", "block", m.ULID)
 		if err := s.upload(ctx, m); err != nil {
 			// No error returned, just log line. This is because we want other blocks to be shipped even
 			// though this one failed. It will be retried on second Sync iteration.
@@ -173,7 +174,7 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 			uploadErrs++
 			continue
 		}
-		level.Info(s.logger).Log("msg", "finished uploading new block", "id", m.ULID)
+		level.Info(s.logger).Log("msg", "finished shipping new block", "block", m.ULID)
 
 		meta.Shipped[m.ULID] = model.Now()
 		shipped++
@@ -198,8 +199,6 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 // This updated version of meta.json is however not persisted locally on the disk, to avoid race condition when TSDB
 // library could actually unload the block if it found meta.json file missing.
 func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
-	level.Info(s.logger).Log("msg", "uploading new block", "id", meta.ULID)
-
 	blockDir := filepath.Join(s.dir, meta.ULID.String())
 
 	meta.Thanos.Source = s.source

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -166,15 +166,15 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 			continue
 		}
 
-		level.Info(s.logger).Log("msg", "shipping new block", "block", m.ULID)
+		level.Info(s.logger).Log("msg", "uploading new block to long-term storage", "block", m.ULID)
 		if err := s.upload(ctx, m); err != nil {
 			// No error returned, just log line. This is because we want other blocks to be shipped even
 			// though this one failed. It will be retried on second Sync iteration.
-			level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
+			level.Error(s.logger).Log("msg", "uploading new block to long-term storage failed", "block", m.ULID, "err", err)
 			uploadErrs++
 			continue
 		}
-		level.Info(s.logger).Log("msg", "finished shipping new block", "block", m.ULID)
+		level.Info(s.logger).Log("msg", "finished uploading new block to long-term storage", "block", m.ULID)
 
 		meta.Shipped[m.ULID] = model.Now()
 		shipped++

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -172,9 +172,8 @@ func (s *Shipper) Sync(ctx context.Context) (shipped int, err error) {
 			level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
 			uploadErrs++
 			continue
-		} else {
-			level.Info(s.logger).Log("msg", "finished uploading new block", "id", m.ULID)
 		}
+		level.Info(s.logger).Log("msg", "finished uploading new block", "id", m.ULID)
 
 		meta.Shipped[m.ULID] = model.Now()
 		shipped++


### PR DESCRIPTION
I couldn't find any logs that indicate a successful block upload.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>