### PR TITLE
[Docs] Expand zone-aware replication page to cover single physical availability zone deployments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 * [CHANGE] Clarify what deprecation means in the lifecycle of configuration parameters. #4499
 * [FEATURE] Add instructions about how to configure native histograms. #4527
 * [ENHANCEMENT] Runbook for MimirCompactorHasNotSuccessfullyRunCompaction extended to include scenario where compaction has fallen behind. #4609
+* [ENHANCEMENT] Expand zone-aware replication page to cover single physical availability zone deployments. #4631
 
 ### Tools
 

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -30,7 +30,7 @@ With zone-aware replication enabled, Grafana Mimir ensures data replication to r
 > Ensure that you configure deployment tooling so that it is also zone-aware.
 > The deployment tooling is responsible for executing rolling updates.
 > Rolling updates should only update replicas in a single zone at any given time.
-> You can utilize the [Kubernetes rollout operator](#kubernetes-operator-for-simplifying-rollouts-of-zone-aware-components) to assist with this.
+> You can utilize the [Kubernetes rollout Operator](#kubernetes-operator-for-simplifying-rollouts-of-zone-aware-components) to assist with this.
 
 Grafana Mimir supports zone-aware replication for the following:
 

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -91,7 +91,7 @@ The [Kubernetes Rollout Operator](https://github.com/grafana/rollout-operator) i
 
 Note that even in a scenario where you have deployed Grafana Mimir to a single physical availability zone, the Rollout Operator is immensely useful.
 
-This is because it automates and accelerates the process of rollouts by:
+This is because the Operator automates and accelerates the process of rollouts by:
 
 - Allowing an entire zone to be updated at a time
 - Prioritizing rollout of unhealthy zones over healthy zones to ensure stability

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -18,6 +18,7 @@ Grafana Mimir defines failure domains as _zones_. Depending on the underlying in
 - Availability zones
 - Data centers
 - Racks
+- Anti-affinity groups within a single availability zone
 
 Without zone-aware replication enabled, Grafana Mimir replicates data randomly across all component replicas, regardless of whether the replicas are running within the same zone.
 Even with a Grafana Mimir cluster deployed across multiple zones, the replicas for any given data could reside in the same zone.
@@ -29,6 +30,7 @@ With zone-aware replication enabled, Grafana Mimir ensures data replication to r
 > Ensure that you configure deployment tooling so that it is also zone-aware.
 > The deployment tooling is responsible for executing rolling updates.
 > Rolling updates should only update replicas in a single zone at any given time.
+> You can utilize the [Kubernetes rollout operator](#kubernetes-operator-for-simplifying-rollouts-of-zone-aware-components) to assist with this.
 
 Grafana Mimir supports zone-aware replication for the following:
 
@@ -86,6 +88,16 @@ Deploying Grafana Mimir with zone-aware replication across multiple cloud provid
 ## Kubernetes operator for simplifying rollouts of zone-aware components
 
 The [Kubernetes Rollout Operator](https://github.com/grafana/rollout-operator) is a Kubernetes operator that makes it easier for you to manage multi-availability-zone rollouts. Consider using the Kubernetes Rollout Operator when you run Grafana Mimir on Kubernetes with zone awareness enabled.
+
+Note that even in a scenario where you have deployed Grafana Mimir to a single physical availability zone, the Rollout Operator is immensely useful.
+
+This is because it automates and accelerates the process of rollouts by:
+
+- Allowing an entire zone to be updated at a time
+- Prioritizing rollout of unhealthy zones over healthy zones to ensure stability
+- Allowing the administrator to determine how aggressive rollouts should be
+
+This functionality is particularly useful in larger deployments where rollouts would otherwise take a very long time and likely require manual intervention if issues were to occur.
 
 ## Enabling zone-awareness via the Grafana Mimir Jsonnet
 

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -87,7 +87,7 @@ Deploying Grafana Mimir with zone-aware replication across multiple cloud provid
 
 ## Kubernetes operator for simplifying rollouts of zone-aware components
 
-The [Kubernetes Rollout Operator](https://github.com/grafana/rollout-operator) is a Kubernetes operator that makes it easier for you to manage multi-availability-zone rollouts. Consider using the Kubernetes Rollout Operator when you run Grafana Mimir on Kubernetes with zone awareness enabled.
+The [Kubernetes Rollout Operator](https://github.com/grafana/rollout-operator) is a Kubernetes Operator that makes it easier for you to manage multi-availability-zone rollouts. Consider using the Kubernetes Rollout Operator when you run Grafana Mimir on Kubernetes with zone awareness enabled.
 
 Note that even in a scenario where you have deployed Grafana Mimir to a single physical availability zone, the Rollout Operator is immensely useful.
 

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -93,7 +93,7 @@ Note that even in a scenario where you have deployed Grafana Mimir to a single p
 
 This is because the Operator automates and accelerates the process of rollouts by:
 
-- Allowing an entire zone to be updated at a time
+- Allowing an entire zone to be updated at one time
 - Prioritizing rollout of unhealthy zones over healthy zones to ensure stability
 - Allowing the administrator to determine how aggressive rollouts should be
 

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -97,7 +97,7 @@ This is because the Operator automates and accelerates the process of rollouts b
 - Prioritizing rollout of unhealthy zones over healthy zones to ensure stability
 - Allowing the administrator to determine how aggressive rollouts should be
 
-This functionality is particularly useful in larger deployments where rollouts would otherwise take a very long time and likely require manual intervention if issues were to occur.
+The automated functionality provided by an Operator is particularly useful in larger deployments where rollouts would otherwise take a very long time and likely require manual intervention if issues were to occur.
 
 ## Enabling zone-awareness via the Grafana Mimir Jsonnet
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

It's valid to deploy Mimir to a single physical availability zone and still use zone-aware replication but the way the page at https://grafana.com/docs/mimir/latest/operators-guide/configure/configure-zone-aware-replication/ is worded today would lead you to believe that that is not the case as it only mentions separate AZs/Data centers/Racks.

It's also very valid to use the rollout-operator in this configuration but it's not well described.

This PR adds language to fix that.

#### Which issue(s) this PR fixes or relates to

Fixes #4630 

#### Checklist

- [ ] Tests updated
- [X] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
