### PR TITLE
Query-frontend: add -query-frontend.query-sharding-max-regexp-size-bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [ENHANCEMENT] Query-frontend: add experimental limit to enforce a max query expression size in bytes via `-query-frontend.max-query-expression-size-bytes` or `max_query_expression_size_bytes`. #4604
 * [ENHANCEMENT] Query-tee: improve message logged when comparing responses and one response contains a non-JSON payload. #4588
 * [ENHANCEMENT] Distributor: add ability to set per-distributor limits via `distributor_limits` block in runtime configuration in addition to the existing configuration. #4619
+* [ENHANCEMENT] Query-frontend: added experimental `-query-frontend.query-sharding-max-regexp-size-bytes` limit to query-frontend. When set to a value greater than 0, query-frontend disabled query sharding for any query with a regexp matcher longer than the configured limit. #4632
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3220,6 +3220,17 @@
         },
         {
           "kind": "field",
+          "name": "query_sharding_max_regexp_size_bytes",
+          "required": false,
+          "desc": "Disable query sharding for any query containing a regular expression matcher longer than the configured number of bytes. 0 to disable the limit.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "query-frontend.query-sharding-max-regexp-size-bytes",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "split_instant_queries_by_interval",
           "required": false,
           "desc": "Split instant queries by an interval and execute in parallel. 0 to disable it.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1667,6 +1667,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] If a querier disconnects without sending notification about graceful shutdown, the query-frontend will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
   -query-frontend.query-result-response-format string
     	Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "protobuf")
+  -query-frontend.query-sharding-max-regexp-size-bytes int
+    	[experimental] Disable query sharding for any query containing a regular expression matcher longer than the configured number of bytes. 0 to disable the limit.
   -query-frontend.query-sharding-max-sharded-queries int
     	The max number of sharded queries that can be run for a given received query. 0 to disable limit. (default 128)
   -query-frontend.query-sharding-target-series-per-shard uint

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -94,6 +94,7 @@ The following features are currently experimental:
   - Cardinality-based query sharding (`-query-frontend.query-sharding-target-series-per-shard`)
   - Use of Redis cache backend (`-query-frontend.results-cache.backend=redis`)
   - Query expression size limit (`-query-frontend.max-query-expression-size-bytes`)
+  - `-query-frontend.query-sharding-max-regexp-size-bytes`
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
   - Max number of used instances (`-query-scheduler.max-used-instances`)

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2712,6 +2712,12 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.query-sharding-max-sharded-queries
 [query_sharding_max_sharded_queries: <int> | default = 128]
 
+# (experimental) Disable query sharding for any query containing a regular
+# expression matcher longer than the configured number of bytes. 0 to disable
+# the limit.
+# CLI flag: -query-frontend.query-sharding-max-regexp-size-bytes
+[query_sharding_max_regexp_size_bytes: <int> | default = 0]
+
 # (experimental) Split instant queries by an interval and execute in parallel. 0
 # to disable it.
 # CLI flag: -query-frontend.split-instant-queries-by-interval

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -54,6 +54,11 @@ type Limits interface {
 	// be run for a given received query. 0 to disable limit.
 	QueryShardingMaxShardedQueries(userID string) int
 
+	// QueryShardingMaxRegexpSizeBytes returns the limit to the max number of bytes allowed
+	// for a regexp matcher in a shardable query. If a query contains a regexp matcher longer
+	// than this limit, the query will not be sharded. 0 to disable limit.
+	QueryShardingMaxRegexpSizeBytes(userID string) int
+
 	// SplitInstantQueriesByInterval returns the time interval to split instant queries for a given tenant.
 	SplitInstantQueriesByInterval(userID string) time.Duration
 

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -387,6 +387,10 @@ func (m multiTenantMockLimits) QueryShardingMaxShardedQueries(userID string) int
 	return m.byTenant[userID].maxShardedQueries
 }
 
+func (m multiTenantMockLimits) QueryShardingMaxRegexpSizeBytes(userID string) int {
+	return m.byTenant[userID].maxRegexpSizeBytes
+}
+
 func (m multiTenantMockLimits) SplitInstantQueriesByInterval(userID string) time.Duration {
 	return m.byTenant[userID].splitInstantQueriesInterval
 }
@@ -427,6 +431,7 @@ type mockLimits struct {
 	maxCacheFreshness                time.Duration
 	maxQueryParallelism              int
 	maxShardedQueries                int
+	maxRegexpSizeBytes               int
 	splitInstantQueriesInterval      time.Duration
 	totalShards                      int
 	compactorShards                  int
@@ -474,6 +479,10 @@ func (m mockLimits) QueryShardingTotalShards(string) int {
 
 func (m mockLimits) QueryShardingMaxShardedQueries(string) int {
 	return m.maxShardedQueries
+}
+
+func (m mockLimits) QueryShardingMaxRegexpSizeBytes(string) int {
+	return m.maxRegexpSizeBytes
 }
 
 func (m mockLimits) SplitInstantQueriesByInterval(string) time.Duration {

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -446,9 +446,7 @@ func longestRegexpMatcherBytes(expr parser.Expr) int {
 				continue
 			}
 
-			if length := len(matcher.Value); length > longest {
-				longest = length
-			}
+			longest = util_math.Max(longest, len(matcher.Value))
 		}
 	}
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1184,6 +1184,99 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 	}
 }
 
+func TestQuerySharding_ShouldSupportMaxRegexpSizeBytes(t *testing.T) {
+	const (
+		totalShards       = 16
+		maxShardedQueries = 16
+	)
+
+	tests := map[string]struct {
+		query              string
+		maxRegexpSizeBytes int
+		expectedShards     int
+	}{
+		"query is shardable and has no regexp matchers": {
+			query:              `sum(metric{app="a-long-matcher-but-not-regexp"})`,
+			maxRegexpSizeBytes: 10,
+			expectedShards:     16,
+		},
+		"query is shardable and has short regexp matchers in vector selector": {
+			query:              `sum(metric{app="test",namespace=~"short"})`,
+			maxRegexpSizeBytes: 10,
+			expectedShards:     16,
+		},
+		"query is shardable and has long regexp matchers in vector selector": {
+			query:              `sum(metric{app="test",namespace=~"short",cluster!~"this-is-longer-than-limit"})`,
+			maxRegexpSizeBytes: 10,
+			expectedShards:     1,
+		},
+		"query is shardable, has long regexp matchers in vector selector but limit is disabled": {
+			query:              `sum(metric{app="test",namespace=~"short",cluster!~"this-is-longer-than-limit"})`,
+			maxRegexpSizeBytes: 0,
+			expectedShards:     16,
+		},
+		"query is shardable and has short regexp matchers in matrix selector": {
+			query:              `sum(sum_over_time(metric{app="test",namespace=~"short"}[5m]))`,
+			maxRegexpSizeBytes: 10,
+			expectedShards:     16,
+		},
+		"query is shardable and has long regexp matchers in matrix selector": {
+			query:              `sum(sum_over_time(metric{app="test",namespace=~"short",cluster!~"this-is-longer-than-limit"}[5m]))`,
+			maxRegexpSizeBytes: 10,
+			expectedShards:     1,
+		},
+		"query is shardable, has long regexp matchers in matrix selector but limit is disabled": {
+			query:              `sum(sum_over_time(metric{app="test",namespace=~"short",cluster!~"this-is-longer-than-limit"}[5m]))`,
+			maxRegexpSizeBytes: 0,
+			expectedShards:     16,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			req := &PrometheusRangeQueryRequest{
+				Path:  "/query_range",
+				Start: util.TimeToMillis(start),
+				End:   util.TimeToMillis(end),
+				Step:  step.Milliseconds(),
+				Query: testData.query,
+			}
+
+			limits := mockLimits{
+				totalShards:                      totalShards,
+				maxShardedQueries:                maxShardedQueries,
+				maxRegexpSizeBytes:               testData.maxRegexpSizeBytes,
+				compactorShards:                  0,
+				nativeHistogramsIngestionEnabled: false,
+			}
+			shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), limits, 0, nil)
+
+			// Keep track of the unique number of shards queried to downstream.
+			uniqueShardsMx := sync.Mutex{}
+			uniqueShards := map[string]struct{}{}
+
+			downstream := &mockHandler{}
+			downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
+				Status: statusSuccess, Data: &PrometheusData{
+					ResultType: string(parser.ValueTypeVector),
+				},
+			}, nil).Run(func(args mock.Arguments) {
+				req := args[1].(Request)
+				reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
+
+				uniqueShardsMx.Lock()
+				uniqueShards[reqShard] = struct{}{}
+				uniqueShardsMx.Unlock()
+			})
+
+			res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+			require.NoError(t, err)
+			assert.Equal(t, statusSuccess, res.(*PrometheusResponse).GetStatus())
+			assert.Equal(t, testData.expectedShards, len(uniqueShards))
+		})
+	}
+}
+
 func TestQuerySharding_ShouldReturnErrorOnDownstreamHandlerFailure(t *testing.T) {
 	req := &PrometheusRangeQueryRequest{
 		Path:  "/query_range",
@@ -1723,6 +1816,40 @@ func TestPromqlResultToSampleStreams(t *testing.T) {
 				require.Nil(t, err)
 				require.Equal(t, c.expected, result)
 			}
+		})
+	}
+}
+
+func TestLongestRegexpMatcherBytes(t *testing.T) {
+	tests := map[string]struct {
+		expr     string
+		expected int
+	}{
+		"should return 0 if the query has no vector selectors": {
+			expr:     "1",
+			expected: 0,
+		},
+		"should return 0 if the query has regexp matchers": {
+			expr:     `count(metric{app="test"})`,
+			expected: 0,
+		},
+		"should return the longest regexp matcher for a query with vector selectors": {
+			expr:     `avg(metric{app="test",namespace=~"short"}) / count(metric{app="very-very-long-but-ignored",namespace!~"longest-regexp"})`,
+			expected: 14,
+		},
+		"should return the longest regexp matcher for a query with matrix selectors": {
+			expr:     `avg_over_time(metric{app="test",namespace!~"short"}[5m]) / count_over_time(metric{app="very-very-long-but-ignored",namespace=~"longest-regexp"}[5m])`,
+			expected: 14,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			parsed, err := parser.ParseExpr(testData.expr)
+			require.NoError(t, err)
+
+			actual := longestRegexpMatcherBytes(parsed)
+			assert.Equal(t, testData.expected, actual)
 		})
 	}
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -112,19 +112,20 @@ type Limits struct {
 	SeparateMetricsGroupLabel string `yaml:"separate_metrics_group_label" json:"separate_metrics_group_label" category:"experimental"`
 
 	// Querier enforced limits.
-	MaxChunksPerQuery              int            `yaml:"max_fetched_chunks_per_query" json:"max_fetched_chunks_per_query"`
-	MaxFetchedSeriesPerQuery       int            `yaml:"max_fetched_series_per_query" json:"max_fetched_series_per_query"`
-	MaxFetchedChunkBytesPerQuery   int            `yaml:"max_fetched_chunk_bytes_per_query" json:"max_fetched_chunk_bytes_per_query"`
-	MaxQueryLookback               model.Duration `yaml:"max_query_lookback" json:"max_query_lookback"`
-	MaxQueryLength                 model.Duration `yaml:"max_query_length" json:"max_query_length" doc:"hidden"` // TODO: deprecated, remove in 2.8
-	MaxPartialQueryLength          model.Duration `yaml:"max_partial_query_length" json:"max_partial_query_length"`
-	MaxQueryParallelism            int            `yaml:"max_query_parallelism" json:"max_query_parallelism"`
-	MaxLabelsQueryLength           model.Duration `yaml:"max_labels_query_length" json:"max_labels_query_length"`
-	MaxCacheFreshness              model.Duration `yaml:"max_cache_freshness" json:"max_cache_freshness" category:"advanced"`
-	MaxQueriersPerTenant           int            `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
-	QueryShardingTotalShards       int            `yaml:"query_sharding_total_shards" json:"query_sharding_total_shards"`
-	QueryShardingMaxShardedQueries int            `yaml:"query_sharding_max_sharded_queries" json:"query_sharding_max_sharded_queries"`
-	SplitInstantQueriesByInterval  model.Duration `yaml:"split_instant_queries_by_interval" json:"split_instant_queries_by_interval" category:"experimental"`
+	MaxChunksPerQuery               int            `yaml:"max_fetched_chunks_per_query" json:"max_fetched_chunks_per_query"`
+	MaxFetchedSeriesPerQuery        int            `yaml:"max_fetched_series_per_query" json:"max_fetched_series_per_query"`
+	MaxFetchedChunkBytesPerQuery    int            `yaml:"max_fetched_chunk_bytes_per_query" json:"max_fetched_chunk_bytes_per_query"`
+	MaxQueryLookback                model.Duration `yaml:"max_query_lookback" json:"max_query_lookback"`
+	MaxQueryLength                  model.Duration `yaml:"max_query_length" json:"max_query_length" doc:"hidden"` // TODO: deprecated, remove in 2.8
+	MaxPartialQueryLength           model.Duration `yaml:"max_partial_query_length" json:"max_partial_query_length"`
+	MaxQueryParallelism             int            `yaml:"max_query_parallelism" json:"max_query_parallelism"`
+	MaxLabelsQueryLength            model.Duration `yaml:"max_labels_query_length" json:"max_labels_query_length"`
+	MaxCacheFreshness               model.Duration `yaml:"max_cache_freshness" json:"max_cache_freshness" category:"advanced"`
+	MaxQueriersPerTenant            int            `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
+	QueryShardingTotalShards        int            `yaml:"query_sharding_total_shards" json:"query_sharding_total_shards"`
+	QueryShardingMaxShardedQueries  int            `yaml:"query_sharding_max_sharded_queries" json:"query_sharding_max_sharded_queries"`
+	QueryShardingMaxRegexpSizeBytes int            `yaml:"query_sharding_max_regexp_size_bytes" json:"query_sharding_max_regexp_size_bytes" category:"experimental"`
+	SplitInstantQueriesByInterval   model.Duration `yaml:"split_instant_queries_by_interval" json:"split_instant_queries_by_interval" category:"experimental"`
 
 	// Query-frontend limits.
 	MaxTotalQueryLength                    model.Duration `yaml:"max_total_query_length" json:"max_total_query_length"`
@@ -236,6 +237,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxQueriersPerTenant, "query-frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
 	f.IntVar(&l.QueryShardingTotalShards, "query-frontend.query-sharding-total-shards", 16, "The amount of shards to use when doing parallelisation via query sharding by tenant. 0 to disable query sharding for tenant. Query sharding implementation will adjust the number of query shards based on compactor shards. This allows querier to not search the blocks which cannot possibly have the series for given query shard.")
 	f.IntVar(&l.QueryShardingMaxShardedQueries, "query-frontend.query-sharding-max-sharded-queries", 128, "The max number of sharded queries that can be run for a given received query. 0 to disable limit.")
+	f.IntVar(&l.QueryShardingMaxRegexpSizeBytes, "query-frontend.query-sharding-max-regexp-size-bytes", 0, "Disable query sharding for any query containing a regular expression matcher longer than the configured number of bytes. 0 to disable the limit.")
 	f.Var(&l.SplitInstantQueriesByInterval, "query-frontend.split-instant-queries-by-interval", "Split instant queries by an interval and execute in parallel. 0 to disable it.")
 
 	_ = l.RulerEvaluationDelay.Set("1m")
@@ -548,6 +550,13 @@ func (o *Overrides) QueryShardingTotalShards(userID string) int {
 // be run for a given received query. 0 to disable limit.
 func (o *Overrides) QueryShardingMaxShardedQueries(userID string) int {
 	return o.getOverridesForUser(userID).QueryShardingMaxShardedQueries
+}
+
+// QueryShardingMaxRegexpSizeBytes returns the limit to the max number of bytes allowed
+// for a regexp matcher in a shardable query. If a query contains a regexp matcher longer
+// than this limit, the query will not be sharded. 0 to disable limit.
+func (o *Overrides) QueryShardingMaxRegexpSizeBytes(userID string) int {
+	return o.getOverridesForUser(userID).QueryShardingMaxRegexpSizeBytes
 }
 
 // SplitInstantQueriesByInterval returns the split time interval to use when splitting an instant query


### PR DESCRIPTION
#### What this PR does
Query sharding amplifies the number of partial queries executed by queriers, and so label matchers evaluated by ingesters and store-gateway. We've seen some edge cases where very complex regexp can spike the ingesters CPU significantly, up to the point of saturating the node CPU. Despite our efforts to optimise the regexp matcher (which in many cases are very effective), I would like to add an optional limit to query sharding, to skip it if the query contains a regexp longer than the configured limit.

Note to reviewers:
- The regexp length is not synonymous of complexity, but evaluating the actual computatinal complexity of a regexp may be computationally expensive itself, so just checking the length is a simple approximation I suggest to begin with.
- I removed `TestQuerySharding_ShouldFallbackToDownstreamHandlerOnMappingFailure` beacuse it expects to push down to queriers a query we can't parse, which is not correct (there's no point doing it). The test aims to
ensure we push down to querier a query we fail to shard (but we can parse), but this can happen only in case of logic bugs in the query sharding, and so can't be reproduced unless mocking its internals. I tried to mock the internals to reproduce it, but the resulting code is pretty ugly, so I'm proposing to just get rid of that test.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
