### PR TITLE
Update docker-compose development configs for native histograms

### DIFF
--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -158,6 +158,7 @@ limits:
   query_sharding_total_shards: 16
   query_sharding_max_sharded_queries: 32
   ingestion_rate: 50000
+  native_histograms_ingestion_enabled: true
 
 runtime_config:
   file: ./config/runtime.yaml

--- a/development/mimir-microservices-mode/config/prometheus.yaml
+++ b/development/mimir-microservices-mode/config/prometheus.yaml
@@ -36,6 +36,7 @@ scrape_configs:
 
 remote_write:
   - url: http://distributor-1:8000/api/v1/push
+    send_native_histograms: true
     send_exemplars: true
 
 rule_files:

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -247,10 +247,11 @@ std.manifestYamlDoc({
 
   prometheus:: {
     prometheus: {
-      image: 'prom/prometheus:v2.32.1',
+      image: 'prom/prometheus:v2.40.6',
       command: [
         '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',
+        '--enable-feature=native-histograms',
       ],
       volumes: [
         './config:/etc/prometheus',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -239,7 +239,8 @@
     "command":
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
-    "image": "prom/prometheus:v2.32.1"
+      - "--enable-feature=native-histograms"
+    "image": "prom/prometheus:v2.40.6"
     "ports":
       - "9090:9090"
     "volumes":

--- a/development/mimir-monolithic-mode-with-swift-storage/config/mimir.yaml
+++ b/development/mimir-monolithic-mode-with-swift-storage/config/mimir.yaml
@@ -74,5 +74,8 @@ ruler_storage:
     region_name:       RegionOne
     container_name: mimir-rules
 
+limits:
+  native_histograms_ingestion_enabled: true
+
 runtime_config:
   file: ./config/runtime.yaml

--- a/development/mimir-monolithic-mode-with-swift-storage/config/prometheus.yaml
+++ b/development/mimir-monolithic-mode-with-swift-storage/config/prometheus.yaml
@@ -17,3 +17,4 @@ scrape_configs:
 
 remote_write:
   - url: http://mimir-1:8001/api/v1/push
+    send_native_histograms: true

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -33,8 +33,8 @@ services:
 
   prometheus:
 
-    image: prom/prometheus:v2.16.0
-    command: ["--config.file=/etc/prometheus/prometheus.yaml"]
+    image: prom/prometheus:v2.40.6
+    command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus
     ports:

--- a/development/mimir-monolithic-mode/config/mimir.yaml
+++ b/development/mimir-monolithic-mode/config/mimir.yaml
@@ -71,5 +71,8 @@ ruler_storage:
     secret_access_key: supersecret
     insecure: true
 
+limits:
+  native_histograms_ingestion_enabled: true
+
 runtime_config:
   file: ./config/runtime.yaml

--- a/development/mimir-monolithic-mode/config/prometheus.yaml
+++ b/development/mimir-monolithic-mode/config/prometheus.yaml
@@ -17,3 +17,4 @@ scrape_configs:
 
 remote_write:
   - url: http://mimir-1:8001/api/v1/push
+    send_native_histograms: true

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       - .data-minio:/data:delegated
 
   prometheus:
-    image: prom/prometheus:v2.16.0
-    command: ["--config.file=/etc/prometheus/prometheus.yaml"]
+    image: prom/prometheus:v2.40.6
+    command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus
     ports:

--- a/development/mimir-read-write-mode/config/mimir.yaml
+++ b/development/mimir-read-write-mode/config/mimir.yaml
@@ -62,5 +62,8 @@ overrides_exporter:
     enabled: true
     wait_stability_min_duration: 30s
 
+limits:
+  native_histograms_ingestion_enabled: true
+
 runtime_config:
   file: ./config/runtime.yaml


### PR DESCRIPTION
#### What this PR does

Allow us to run our docker-compose setups with native histograms enabled.

#### Which issue(s) this PR fixes or relates to

Merging the remainder of https://github.com/grafana/mimir/pull/3505 in smaller chunks

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

The above don't seem relevant as this is just updating our development docker-compose files.