### PR TITLE
Update integration tests for native histograms

### DIFF
--- a/integration/compactor_test.go
+++ b/integration/compactor_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/storage/tsdb/metadata"
 	"github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
@@ -73,16 +74,16 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 			Labels: labels.FromStrings("case", "native_histogram", "i", strconv.Itoa(i)),
 			Chunks: []chunks.Meta{
 				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
-					sample{10, 0, tsdbutil.GenerateTestHistogram(1), nil},
-					sample{20, 0, tsdbutil.GenerateTestHistogram(2), nil},
+					sample{10, 0, test.GenerateTestHistogram(1), nil},
+					sample{20, 0, test.GenerateTestHistogram(2), nil},
 				}),
 				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
-					sample{30, 0, tsdbutil.GenerateTestHistogram(3), nil},
-					sample{40, 0, tsdbutil.GenerateTestHistogram(4), nil},
+					sample{30, 0, test.GenerateTestHistogram(3), nil},
+					sample{40, 0, test.GenerateTestHistogram(4), nil},
 				}),
 				tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
-					sample{50, 0, tsdbutil.GenerateTestHistogram(5), nil},
-					sample{2*time.Hour.Milliseconds() - 1, 0, tsdbutil.GenerateTestHistogram(6), nil},
+					sample{50, 0, test.GenerateTestHistogram(5), nil},
+					sample{2*time.Hour.Milliseconds() - 1, 0, test.GenerateTestHistogram(6), nil},
 				}),
 			},
 		}

--- a/integration/distributor_forwarding_test.go
+++ b/integration/distributor_forwarding_test.go
@@ -26,7 +26,7 @@ func runPrometheus(name string, args ...string) *e2e.HTTPService {
 	port := 9090
 	cmd := e2e.NewCommandWithoutEntrypoint(
 		"/bin/prometheus",
-		append([]string{"--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"}, args...)...,
+		append([]string{"--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus", "--enable-feature=native-histograms"}, args...)...,
 	)
 	readiness := e2e.NewHTTPReadinessProbe(port, "/-/ready", http.StatusOK, http.StatusOK)
 	service := e2e.NewHTTPService(name, "prom/prometheus:latest", cmd, readiness, port)
@@ -151,9 +151,15 @@ func TestDistributorForwarding(t *testing.T) {
 
 			// Submit metrics to Mimir.
 			now := time.Now()
+			now2 := now.Add(time.Second)
 			for _, metric := range tc.submitMetrics {
-				series, _, _ := generateSeries(metric, now)
+				series, _, _ := generateFloatSeries(metric, now)
 				res, err := mimirClient.Push(series)
+				require.NoError(t, err)
+				require.Equal(t, 200, res.StatusCode)
+
+				series, _, _ = generateHistogramSeries(metric, now2)
+				res, err = mimirClient.Push(series)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)
 			}

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -9,13 +9,9 @@ package integration
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/prompb"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
@@ -41,38 +37,14 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 		"-blocks-storage.s3.bucket-name":       blocksBucketName,
 		"-blocks-storage.s3.endpoint":          fmt.Sprintf("%s-minio-9000:9000", networkName),
 		"-blocks-storage.s3.insecure":          "true",
+
+		// Enable protobuf format so that we can use native histograms.
+		"-query-frontend.query-result-response-format": "protobuf",
 	}
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
-	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
-	require.NoError(t, err)
-
-	// Push some series to Mimir.
-	now := time.Now()
-	series, expectedVector, expectedMatrix := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
-
-	res, err := c.Push(series)
-	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
-
-	// Query the series.
-	result, err := c.Query("series_1", now)
-	require.NoError(t, err)
-	require.Equal(t, model.ValVector, result.Type())
-	assert.Equal(t, expectedVector, result.(model.Vector))
-
-	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
-	require.NoError(t, err)
-	require.Equal(t, model.LabelValues{"bar"}, labelValues)
-
-	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
-	require.NoError(t, err)
-	require.Equal(t, []string{"__name__", "foo"}, labelNames)
-
-	rangeResult, err := c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
-	require.NoError(t, err)
-	require.Equal(t, model.ValMatrix, rangeResult.Type())
-	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
+	runTestPushSeriesAndQueryBack(t, mimir, "series_1", generateFloatSeries)
+	runTestPushSeriesAndQueryBack(t, mimir, "hseries_1", generateHistogramSeries)
 }

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -37,9 +37,6 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 		"-blocks-storage.s3.bucket-name":       blocksBucketName,
 		"-blocks-storage.s3.endpoint":          fmt.Sprintf("%s-minio-9000:9000", networkName),
 		"-blocks-storage.s3.insecure":          "true",
-
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
 	}
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -113,7 +113,7 @@ func runTestGettingStartedWithGossipedRing(t *testing.T, seriesName string, genS
 	c2, err := e2emimir.NewClient(mimir2.HTTPEndpoint(), mimir2.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	// Push some series to Mimir2
+	// Push some series to Mimir 2
 	now := time.Now()
 	series, expectedVector, _ := genSeries(seriesName, now)
 

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -55,9 +55,6 @@ func runTestGettingStartedWithGossipedRing(t *testing.T, seriesName string, genS
 		"-blocks-storage.s3.secret-access-key":              e2edb.MinioSecretKey,
 		"-blocks-storage.s3.endpoint":                       fmt.Sprintf("%s-minio-9000:9000", networkName),
 		"-blocks-storage.s3.insecure":                       "true",
-
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
 	}
 
 	// This mimir will fail to join the cluster configured in yaml file. That's fine.

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -26,12 +26,8 @@ func TestGettingStartedWithGrafanaMimir(t *testing.T) {
 	defer s.Close()
 
 	require.NoError(t, copyFileToSharedDir(s, "docs/configurations/demo.yaml", "demo.yaml"))
-	flags := map[string]string{
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
-	}
 
-	mimir := e2emimir.NewSingleBinary("mimir", flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile("demo.yaml"))
+	mimir := e2emimir.NewSingleBinary("mimir", nil, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile("demo.yaml"))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
 	runTestPushSeriesAndQueryBack(t, mimir, "series_1", generateFloatSeries)
@@ -59,9 +55,6 @@ func TestPlayWithGrafanaMimirTutorial(t *testing.T) {
 
 		// Override the list of members to join, setting the hostname we expect within the Docker network created by integration tests.
 		"-memberlist.join": networkName + "-mimir-1",
-
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
 	}
 
 	// Start Mimir (3 replicas).

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -90,7 +90,7 @@ func TestIngesterGlobalLimits(t *testing.T) {
 
 			// Try to push as many series with the same metric name as we can.
 			for i, errs := 0, 0; i < 10000; i++ {
-				series, _, _ := generateAllTypeSeries(i, "test_limit_per_metric", now, prompb.Label{
+				series, _, _ := generateAlternatingSeries(i)("test_limit_per_metric", now, prompb.Label{
 					Name:  "cardinality",
 					Value: strconv.Itoa(rand.Int()),
 				})
@@ -108,7 +108,7 @@ func TestIngesterGlobalLimits(t *testing.T) {
 
 			// Try to push as many series with the different metric name as we can.
 			for i, errs := 0, 0; i < 10000; i++ {
-				series, _, _ := generateAllTypeSeries(i, fmt.Sprintf("test_limit_per_tenant_%d", rand.Int()), now)
+				series, _, _ := generateAlternatingSeries(i)(fmt.Sprintf("test_limit_per_tenant_%d", rand.Int()), now)
 				res, err := client.Push(series)
 				require.NoError(t, err)
 

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -95,7 +95,13 @@ func TestIngesterSharding(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				series, expectedVector, _ := generateSeries(metricName, now)
+				var genSeries generateSeriesFunc
+				if i%2 == 0 {
+					genSeries = generateFloatSeries
+				} else {
+					genSeries = generateHistogramSeries
+				}
+				series, expectedVector, _ := genSeries(metricName, now)
 				res, err := client.Push(series)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -95,13 +95,7 @@ func TestIngesterSharding(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				var genSeries generateSeriesFunc
-				if i%2 == 0 {
-					genSeries = generateFloatSeries
-				} else {
-					genSeries = generateHistogramSeries
-				}
-				series, expectedVector, _ := genSeries(metricName, now)
+				series, expectedVector, _ := generateAlternatingSeries(i)(metricName, now)
 				res, err := client.Push(series)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -49,7 +49,7 @@ func TestOTLPIngestion(t *testing.T) {
 
 	// Push some series to Mimir.
 	now := time.Now()
-	series, expectedVector, expectedMatrix := generateSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := generateFloatSeries("series_1", now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := c.PushOTLP(series)
 	require.NoError(t, err)

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -35,10 +35,6 @@ func TestOTLPIngestion(t *testing.T) {
 		DefaultSingleBinaryFlags(),
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
-		map[string]string{
-			// Enable protobuf format so that we can use native histograms.
-			"-query-frontend.query-result-response-format": "protobuf",
-		},
 	)
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))

--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -141,7 +141,13 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				series, _, _ := generateSeries(metricName, now,
+				var genSeries generateSeriesFunc
+				if i%2 == 0 {
+					genSeries = generateFloatSeries
+				} else {
+					genSeries = generateHistogramSeries
+				}
+				series, _, _ := genSeries(metricName, now,
 					prompb.Label{Name: "env", Value: cardinalityEnvLabelValues[i%len(cardinalityEnvLabelValues)]},
 					prompb.Label{Name: "job", Value: cardinalityJobLabelValues[i%len(cardinalityJobLabelValues)]},
 				)
@@ -364,7 +370,13 @@ func TestQuerierLabelValuesCardinality(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				series, _, _ := generateSeries(metricName, now,
+				var genSeries generateSeriesFunc
+				if i%2 == 0 {
+					genSeries = generateFloatSeries
+				} else {
+					genSeries = generateHistogramSeries
+				}
+				series, _, _ := genSeries(metricName, now,
 					prompb.Label{Name: "env", Value: cardinalityEnvLabelValues[i%len(cardinalityEnvLabelValues)]},
 					prompb.Label{Name: "job", Value: cardinalityJobLabelValues[i%len(cardinalityJobLabelValues)]},
 				)

--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -141,13 +141,7 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				var genSeries generateSeriesFunc
-				if i%2 == 0 {
-					genSeries = generateFloatSeries
-				} else {
-					genSeries = generateHistogramSeries
-				}
-				series, _, _ := genSeries(metricName, now,
+				series, _, _ := generateAlternatingSeries(i)(metricName, now,
 					prompb.Label{Name: "env", Value: cardinalityEnvLabelValues[i%len(cardinalityEnvLabelValues)]},
 					prompb.Label{Name: "job", Value: cardinalityJobLabelValues[i%len(cardinalityJobLabelValues)]},
 				)
@@ -370,13 +364,7 @@ func TestQuerierLabelValuesCardinality(t *testing.T) {
 
 			for i := 1; i <= numSeriesToPush; i++ {
 				metricName := fmt.Sprintf("series_%d", i)
-				var genSeries generateSeriesFunc
-				if i%2 == 0 {
-					genSeries = generateFloatSeries
-				} else {
-					genSeries = generateHistogramSeries
-				}
-				series, _, _ := genSeries(metricName, now,
+				series, _, _ := generateAlternatingSeries(i)(metricName, now,
 					prompb.Label{Name: "env", Value: cardinalityEnvLabelValues[i%len(cardinalityEnvLabelValues)]},
 					prompb.Label{Name: "job", Value: cardinalityJobLabelValues[i%len(cardinalityJobLabelValues)]},
 				)

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -345,8 +345,7 @@ func TestQuerierStreamingRemoteRead(t *testing.T) {
 						enc = chunkenc.EncXOR
 					case prompb.Chunk_HISTOGRAM:
 						enc = chunkenc.EncHistogram
-					// TODO: Once prompb.Chunk_FLOAT_HISTOGRAM gets added in https://github.com/prometheus/prometheus/pull/12085 we can switch to using that
-					case prompb.Chunk_Encoding(3):
+					case prompb.Chunk_FLOAT_HISTOGRAM:
 						enc = chunkenc.EncFloatHistogram
 					default:
 						require.Fail(t, "unrecognized chunk type")

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -75,12 +75,6 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 		"-querier.max-outstanding-requests-per-tenant":      strconv.Itoa(numQueries), // To avoid getting errors.
 	})
 
-	if cfg.sendHistograms {
-		flags = mergeFlags(flags, map[string]string{
-			"-query-frontend.query-result-response-format": cfg.querierResponseFormat,
-		})
-	}
-
 	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
 	require.NoError(t, s.StartAndWaitReady(minio))
 

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -69,9 +69,6 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 		"-query-frontend.results-cache.memcached.addresses": "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 		"-tenant-federation.enabled":                        "true",
 		"-ingester.max-global-exemplars-per-user":           "10000",
-
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
 	})
 
 	// Start the query-scheduler if enabled.

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -131,13 +131,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 		require.NoError(t, err)
 
 		var series []prompb.TimeSeries
-		var genSeries generateSeriesFunc
-		if u%2 == 0 {
-			genSeries = generateFloatSeries
-		} else {
-			genSeries = generateHistogramSeries
-		}
-		series, expectedVectors[u], _ = genSeries("series_1", now)
+		series, expectedVectors[u], _ = generateAlternatingSeries(u)("series_1", now)
 
 		res, err := c.Push(series)
 		require.NoError(t, err)

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -83,9 +83,6 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 		"-blocks-storage.tsdb.block-ranges-period": blockRangePeriod.String(),
 		"-blocks-storage.tsdb.ship-interval":       "1s",
 		"-blocks-storage.tsdb.retention-period":    "1ms", // Retention period counts from the moment the block was uploaded to storage so we're setting it deliberatelly small so block gets deleted as soon as possible
-
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
 	})
 
 	// Start dependencies in common with all test cases.
@@ -387,9 +384,6 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 				"-compactor.cleanup-interval":                     "2s", // Update bucket index often.
 				// Query-frontend.
 				"-query-frontend.parallelize-shardable-queries": strconv.FormatBool(testCfg.queryShardingEnabled),
-
-				// Enable protobuf format so that we can use native histograms.
-				"-query-frontend.query-result-response-format": "protobuf",
 			})
 
 			// Start Mimir replicas.

--- a/integration/query_frontend_cache_test.go
+++ b/integration/query_frontend_cache_test.go
@@ -41,8 +41,6 @@ func TestQueryFrontendUnalignedQuery(t *testing.T) {
 				"-query-frontend.cache-results":             "true",
 				"-query-frontend.split-queries-by-interval": "2m",
 				"-query-frontend.max-cache-freshness":       "0", // Cache everything.
-				// Enable protobuf format so that we can use native histograms.
-				"-query-frontend.query-result-response-format": "protobuf",
 			}, cacheConfig(backend, cacheService))
 
 			// Start the query-frontend.

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -250,12 +250,6 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 		"-query-frontend.query-stats-enabled":               strconv.FormatBool(cfg.queryStatsEnabled),
 	})
 
-	if cfg.withHistograms {
-		flags = mergeFlags(flags, map[string]string{
-			"-query-frontend.query-result-response-format": "protobuf",
-		})
-	}
-
 	// Start the query-scheduler if enabled.
 	var queryScheduler *e2emimir.MimirService
 	if cfg.querySchedulerEnabled && cfg.querySchedulerDiscoveryMode == "dns" {

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -25,23 +26,33 @@ func TestReadWriteModeQueryingIngester(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	client, _ := startReadWriteModeCluster(t, s)
+	flags := map[string]string{
+		// Enable protobuf format so that we can use native histograms.
+		"-query-frontend.query-result-response-format": "protobuf",
+	}
 
+	client, _ := startReadWriteModeCluster(t, s, flags)
+
+	runQueryingIngester(t, client, "test_series_1", generateFloatSeries)
+	runQueryingIngester(t, client, "test_hseries_1", generateHistogramSeries)
+}
+
+func runQueryingIngester(t *testing.T, client *e2emimir.Client, seriesName string, genSeries generateSeriesFunc) {
 	// Push some data to the cluster.
 	now := time.Now()
-	series, expectedVector, expectedMatrix := generateSeries("test_series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := genSeries(seriesName, now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
 	// Verify we can read the data we just pushed, both with an instant query and a range query.
-	queryResult, err := client.Query("test_series_1", now)
+	queryResult, err := client.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 	require.Equal(t, expectedVector, queryResult.(model.Vector))
 
-	rangeResult, err := client.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
+	rangeResult, err := client.QueryRange(seriesName, now.Add(-5*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -67,11 +78,19 @@ func TestReadWriteModeQueryingStoreGateway(t *testing.T) {
 		"-blocks-storage.tsdb.ship-interval":                "1s",
 		"-blocks-storage.tsdb.retention-period":             "3s",
 		"-blocks-storage.tsdb.head-compaction-idle-timeout": "1s",
+
+		// Enable protobuf format so that we can use native histograms.
+		"-query-frontend.query-result-response-format": "protobuf",
 	})
 
+	runQueryingStoreGateway(t, client, cluster, "test_series_1", generateFloatSeries)
+	runQueryingStoreGateway(t, client, cluster, "test_hseries_1", generateHistogramSeries)
+}
+
+func runQueryingStoreGateway(t *testing.T, client *e2emimir.Client, cluster readWriteModeCluster, seriesName string, genSeries generateSeriesFunc) {
 	// Push some data to the cluster.
 	now := time.Now()
-	series, expectedVector, expectedMatrix := generateSeries("test_series_1", now, prompb.Label{Name: "foo", Value: "bar"})
+	series, expectedVector, expectedMatrix := genSeries(seriesName, now, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := client.Push(series)
 	require.NoError(t, err)
@@ -84,12 +103,12 @@ func TestReadWriteModeQueryingStoreGateway(t *testing.T) {
 	require.NoError(t, cluster.backendInstance.WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_bucket_store_blocks_loaded"))
 
 	// Verify we can read the data we just pushed, both with an instant query and a range query.
-	queryResult, err := client.Query("test_series_1", now)
+	queryResult, err := client.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 	require.Equal(t, expectedVector, queryResult.(model.Vector))
 
-	rangeResult, err := client.QueryRange("test_series_1", now.Add(-5*time.Minute), now, 15*time.Second)
+	rangeResult, err := client.QueryRange(seriesName, now.Add(-5*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -120,31 +139,40 @@ func TestReadWriteModeRecordingRule(t *testing.T) {
 		},
 	)
 
-	// Push data that should be captured by the recording rule
-	pushTime := time.Now()
-	series, _, _ := generateSeries("test_series", pushTime, prompb.Label{Name: "foo", Value: "bar"})
+	seriesNameFloat := "test_series"
+	seriesNameHisto := "test_hseries"
+	aggFuncFloat := "sum"
+	aggFuncHisto := "histogram_sum"
+	testRuleNameFloat := "test_rule"
+	testRuleNameHisto := "test_hrule"
 
-	res, err := client.Push(series)
-	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
+	seriesFloat := runRecordingRulePush(t, client, seriesNameFloat, generateFloatSeries)
+	seriesHisto := runRecordingRulePush(t, client, seriesNameHisto, generateHistogramSeries)
 
 	// Create recording rule
 	// (we create the rule after pushing the data to avoid race conditions around pushing the data and evaluating the rule -
 	// Mimir guarantees that previously pushed data will be captured by the recording rule evaluation)
-	record := yaml.Node{}
-	testRuleName := "test_rule"
-	record.SetString(testRuleName)
+	recordFloat := yaml.Node{}
+	recordFloat.SetString(testRuleNameFloat)
+	recordHisto := yaml.Node{}
+	recordHisto.SetString(testRuleNameHisto)
 
-	expr := yaml.Node{}
-	expr.SetString("sum(test_series)")
+	exprFloat := yaml.Node{}
+	exprFloat.SetString(fmt.Sprintf("%s(%s)", aggFuncFloat, seriesNameFloat))
+	exprHisto := yaml.Node{}
+	exprHisto.SetString(fmt.Sprintf("%s(%s)", aggFuncHisto, seriesNameHisto))
 
 	ruleGroup := rulefmt.RuleGroup{
 		Name:     "test_rule_group",
 		Interval: 1,
 		Rules: []rulefmt.RuleNode{
 			{
-				Record: record,
-				Expr:   expr,
+				Record: recordFloat,
+				Expr:   exprFloat,
+			},
+			{
+				Record: recordHisto,
+				Expr:   exprHisto,
 			},
 		},
 	}
@@ -154,18 +182,44 @@ func TestReadWriteModeRecordingRule(t *testing.T) {
 	// Wait for recording rule to evaluate
 	require.NoError(t, cluster.backendInstance.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
 
+	runRecordingRuleQuery(t, client, testRuleNameFloat, seriesFloat)
+	runRecordingRuleQuery(t, client, testRuleNameHisto, seriesHisto)
+}
+
+func runRecordingRulePush(t *testing.T, client *e2emimir.Client, seriesName string, genSeries generateSeriesFunc) []prompb.TimeSeries {
+	// Push data that should be captured by the recording rule
+	pushTime := time.Now()
+	series, _, _ := genSeries(seriesName, pushTime, prompb.Label{Name: "foo", Value: "bar"})
+
+	res, err := client.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	return series
+}
+
+func runRecordingRuleQuery(t *testing.T, client *e2emimir.Client, testRuleName string, series []prompb.TimeSeries) {
 	// Verify recorded series is as expected
 	queryTime := time.Now()
 	queryResult, err := client.Query(testRuleName, queryTime)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 
+	metric := model.Metric{
+		labels.MetricName: model.LabelValue(testRuleName),
+	}
+	var sum float64
+	if len(series[0].Samples) > 0 {
+		sum = series[0].Samples[0].Value
+	} else {
+		sum = series[0].Histograms[0].Sum
+		metric["foo"] = model.LabelValue("bar") // TODO(histograms): why is this necessary?
+	}
+
 	expectedVector := model.Vector{
 		&model.Sample{
-			Metric: model.Metric{
-				labels.MetricName: model.LabelValue(testRuleName),
-			},
-			Value:     model.SampleValue(series[0].Samples[0].Value),
+			Metric:    metric,
+			Value:     model.SampleValue(sum),
 			Timestamp: model.Time(e2e.TimeToMilliseconds(queryTime)),
 		},
 	}
@@ -174,6 +228,11 @@ func TestReadWriteModeRecordingRule(t *testing.T) {
 }
 
 func TestReadWriteModeAlertingRule(t *testing.T) {
+	runAlertingRule(t, "test_alert", "test_series", "sum", generateFloatSeries)
+	runAlertingRule(t, "test_halert", "test_hseries", "histogram_sum", generateHistogramSeries)
+}
+
+func runAlertingRule(t *testing.T, testAlertName, seriesName, aggFunc string, genSeries generateSeriesFunc) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
@@ -201,11 +260,10 @@ receivers:
 
 	// Create alerting rule
 	alert := yaml.Node{}
-	testAlertName := "test_alert"
 	alert.SetString(testAlertName)
 
 	expr := yaml.Node{}
-	expr.SetString("sum(test_series) > 0")
+	expr.SetString(fmt.Sprintf("%s(%s) > 0", aggFunc, seriesName))
 
 	ruleGroup := rulefmt.RuleGroup{
 		Name:     "test_rule_group",
@@ -223,7 +281,7 @@ receivers:
 
 	// Push data that should trigger the alerting rule
 	pushTime := time.Now()
-	series, _, _ := generateSeries("test_series", pushTime, prompb.Label{Name: "foo", Value: "bar"})
+	series, _, _ := genSeries(seriesName, pushTime, prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := client.Push(series)
 	require.NoError(t, err)
@@ -257,8 +315,13 @@ func TestReadWriteModeCompaction(t *testing.T) {
 		"-compactor.blocks-retention-period": "5s",
 	})
 
+	runCompaction(t, client, cluster, "test_series_1", generateFloatSeries)
+	runCompaction(t, client, cluster, "test_hseries_1", generateHistogramSeries)
+}
+
+func runCompaction(t *testing.T, client *e2emimir.Client, cluster readWriteModeCluster, seriesName string, genSeries generateSeriesFunc) {
 	// Push some data to the cluster.
-	series, _, _ := generateSeries("test_series_1", time.Now(), prompb.Label{Name: "foo", Value: "bar"})
+	series, _, _ := genSeries(seriesName, time.Now(), prompb.Label{Name: "foo", Value: "bar"})
 
 	res, err := client.Push(series)
 	require.NoError(t, err)

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -26,12 +26,7 @@ func TestReadWriteModeQueryingIngester(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	flags := map[string]string{
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
-	}
-
-	client, _ := startReadWriteModeCluster(t, s, flags)
+	client, _ := startReadWriteModeCluster(t, s)
 
 	runQueryingIngester(t, client, "test_series_1", generateFloatSeries)
 	runQueryingIngester(t, client, "test_hseries_1", generateHistogramSeries)
@@ -78,9 +73,6 @@ func TestReadWriteModeQueryingStoreGateway(t *testing.T) {
 		"-blocks-storage.tsdb.ship-interval":                "1s",
 		"-blocks-storage.tsdb.retention-period":             "3s",
 		"-blocks-storage.tsdb.head-compaction-idle-timeout": "1s",
-
-		// Enable protobuf format so that we can use native histograms.
-		"-query-frontend.query-result-response-format": "protobuf",
 	})
 
 	runQueryingStoreGateway(t, client, cluster, "test_series_1", generateFloatSeries)

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -597,13 +597,7 @@ func TestRulerMetricsForInvalidQueries(t *testing.T) {
 
 	// Push some series to Mimir -- enough so that we can hit some limits.
 	for i := 0; i < 10; i++ {
-		var genSeries generateSeriesFunc
-		if i%2 == 0 {
-			genSeries = generateFloatSeries
-		} else {
-			genSeries = generateHistogramSeries
-		}
-		series, _, _ := genSeries("metric", time.Now(), prompb.Label{Name: "foo", Value: fmt.Sprintf("%d", i)})
+		series, _, _ := generateAlternatingSeries(i)("metric", time.Now(), prompb.Label{Name: "foo", Value: fmt.Sprintf("%d", i)})
 
 		res, err := c.Push(series)
 		require.NoError(t, err)

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -784,20 +784,20 @@ func TestRulerFederatedRules(t *testing.T) {
 		tc = isolatedTestCase(tc, i)
 		t.Run(tc.name, func(t *testing.T) {
 			// Generate some series under different tenants
-			sampleTime := time.Now()
-			sampleTime2 := sampleTime.Add(time.Second)
+			floatTs := time.Now()
+			histTs := floatTs.Add(time.Second)
 			for _, tenantID := range tc.tenantsWithMetrics {
 				client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantID)
 				require.NoError(t, err)
 
-				series1, _, _ := generateFloatSeries("metric", sampleTime)
-				series2, _, _ := generateHistogramSeries("metric", sampleTime2)
+				seriesFloat, _, _ := generateFloatSeries("metric", floatTs)
+				seriesHist, _, _ := generateHistogramSeries("metric", histTs)
 
-				res, err := client.Push(series1)
+				res, err := client.Push(seriesFloat)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)
 
-				res, err = client.Push(series2)
+				res, err = client.Push(seriesHist)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)
 			}
@@ -937,20 +937,20 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 			require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(512+128), "cortex_ring_tokens_total"))
 
 			// Generate some series under different tenants
-			sampleTime := time.Now()
-			sampleTime2 := sampleTime.Add(time.Second)
+			floatTs := time.Now()
+			histTs := floatTs.Add(time.Second)
 			for _, tenantID := range tc.tenantsWithMetrics {
 				client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantID)
 				require.NoError(t, err)
 
-				series1, _, _ := generateFloatSeries("metric", sampleTime)
-				series2, _, _ := generateHistogramSeries("metric", sampleTime2)
+				seriesFloat, _, _ := generateFloatSeries("metric", floatTs)
+				seriesHist, _, _ := generateHistogramSeries("metric", histTs)
 
-				res, err := client.Push(series1)
+				res, err := client.Push(seriesFloat)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)
 
-				res, err = client.Push(series2)
+				res, err = client.Push(seriesHist)
 				require.NoError(t, err)
 				require.Equal(t, 200, res.StatusCode)
 			}

--- a/integration/store_gateway_limits_hit_test.go
+++ b/integration/store_gateway_limits_hit_test.go
@@ -70,7 +70,13 @@ func Test_MaxSeriesAndChunksPerQueryLimitHit(t *testing.T) {
 
 	for i, ts := range []time.Time{timeStamp1, timeStamp2, timeStamp3} {
 		seriesID := i + 1
-		series, _, _ := generateSeries(fmt.Sprintf("series_%d", seriesID), ts)
+		var genSeries generateSeriesFunc
+		if i%2 == 0 {
+			genSeries = generateFloatSeries
+		} else {
+			genSeries = generateHistogramSeries
+		}
+		series, _, _ := genSeries(fmt.Sprintf("series_%d", seriesID), ts)
 		pushTimeSeries(t, client, series)
 
 		// Wait until the TSDB head is shipped to storage and removed from the ingester.

--- a/integration/store_gateway_limits_hit_test.go
+++ b/integration/store_gateway_limits_hit_test.go
@@ -70,13 +70,7 @@ func Test_MaxSeriesAndChunksPerQueryLimitHit(t *testing.T) {
 
 	for i, ts := range []time.Time{timeStamp1, timeStamp2, timeStamp3} {
 		seriesID := i + 1
-		var genSeries generateSeriesFunc
-		if i%2 == 0 {
-			genSeries = generateFloatSeries
-		} else {
-			genSeries = generateHistogramSeries
-		}
-		series, _, _ := genSeries(fmt.Sprintf("series_%d", seriesID), ts)
+		series, _, _ := generateAlternatingSeries(i)(fmt.Sprintf("series_%d", seriesID), ts)
 		pushTimeSeries(t, client, series)
 
 		// Wait until the TSDB head is shipped to storage and removed from the ingester.

--- a/integration/util.go
+++ b/integration/util.go
@@ -30,9 +30,6 @@ var (
 	// with the package name in tests.
 	mergeFlags = e2e.MergeFlags
 
-	// Temporary alias to split up merging in native histogram tests
-	generateSeries = e2e.GenerateSeries
-
 	generateAllTypeSeries = GenerateAllTypeSeries
 
 	generateFloatSeries  = e2e.GenerateSeries

--- a/integration/util.go
+++ b/integration/util.go
@@ -30,8 +30,6 @@ var (
 	// with the package name in tests.
 	mergeFlags = e2e.MergeFlags
 
-	generateAllTypeSeries = GenerateAllTypeSeries
-
 	generateFloatSeries  = e2e.GenerateSeries
 	generateNFloatSeries = e2e.GenerateNSeries
 
@@ -50,20 +48,17 @@ var (
 	prometheusMaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
 )
 
-// Generates different typed series based on an index in i.
-// Use with a large enough number of series, e.g. i>100
-func GenerateAllTypeSeries(i int, name string, ts time.Time, additionalLabels ...prompb.Label) ([]prompb.TimeSeries, model.Vector, model.Matrix) {
-	switch i % 2 {
-	case 0:
-		return generateFloatSeries(name, ts, additionalLabels...)
-	case 1:
-		return generateHistogramSeries(name, ts, additionalLabels...)
-	}
-	return nil, nil, nil
-}
-
 // generateSeriesFunc defines what kind of series (and expected vectors/matrices) to generate - float samples or native histograms
 type generateSeriesFunc func(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix)
+
+// Generates different typed series based on an index in i.
+// Use with a large enough number of series, e.g. i>100
+func generateAlternatingSeries(i int) generateSeriesFunc {
+	if i%2 == 0 {
+		return generateFloatSeries
+	}
+	return generateHistogramSeries
+}
 
 // generateNSeriesFunc defines what kind of n * series (and expected vectors) to generate - float samples or native histograms
 type generateNSeriesFunc func(nSeries, nExemplars int, name func() string, ts time.Time, additionalLabels func() []prompb.Label) (series []prompb.TimeSeries, vector model.Vector)

--- a/integration/validation_separate_metrics_test.go
+++ b/integration/validation_separate_metrics_test.go
@@ -53,65 +53,68 @@ func TestValidateSeparateMetrics(t *testing.T) {
 	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", userID)
 	require.NoError(t, err)
 
-	// Push an invalid metric to increment cortex_discarded_samples_total
-	series, _, _ := generateSeries("TestMetric", now, prompb.Label{
+	// Push invalid metrics to increment cortex_discarded_samples_total
+	series, _, _ := generateFloatSeries("TestMetric", now, prompb.Label{
 		Name:  "Test|Invalid|Label|Char",
 		Value: "123",
 	}, prompb.Label{
 		Name:  "group_1",
 		Value: "test-group",
 	})
+	pushTimeSeriesWithStatus(t, client, series, 400)
 
-	res, err := client.Push(series)
-	require.NoError(t, err)
-	require.Equal(t, 400, res.StatusCode)
+	series, _, _ = generateHistogramSeries("TestMetric", now, prompb.Label{
+		Name:  "Test|Invalid|Label|Char",
+		Value: "123",
+	}, prompb.Label{
+		Name:  "group_1",
+		Value: "test-group",
+	})
+	pushTimeSeriesWithStatus(t, client, series, 400)
 
-	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_discarded_samples_total"},
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_discarded_samples_total"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "group", "test-group")),
 	))
 
 	// Push series with no group label
-	series, _, _ = generateSeries("TestMetric", now, prompb.Label{
+	series, _, _ = generateFloatSeries("TestMetric", now, prompb.Label{
 		Name:  "Test|Invalid|Label|Char",
 		Value: "123",
 	})
+	pushTimeSeriesWithStatus(t, client, series, 400)
 
-	res, err = client.Push(series)
-	require.NoError(t, err)
-	require.Equal(t, 400, res.StatusCode)
+	series, _, _ = generateHistogramSeries("TestMetric", now, prompb.Label{
+		Name:  "Test|Invalid|Label|Char",
+		Value: "123",
+	})
+	pushTimeSeriesWithStatus(t, client, series, 400)
 
-	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_discarded_samples_total"},
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_discarded_samples_total"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "group", "")),
 	))
 
 	// Ensure previous series didn't disappear
-	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_discarded_samples_total"},
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_discarded_samples_total"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "group", "test-group")),
 	))
 
 	// Push two series, group label only present in second series
-	series1, _, _ := generateSeries("TestMetric", now, prompb.Label{
+	series1, _, _ := generateFloatSeries("TestMetric", now, prompb.Label{
 		Name:  "Test|Invalid|Label|Char",
 		Value: "123",
 	})
+	pushTimeSeriesWithStatus(t, client, series1, 400)
 
-	res, err = client.Push(series1)
-	require.NoError(t, err)
-	require.Equal(t, 400, res.StatusCode)
-
-	series2, _, _ := generateSeries("TestMetric", now, prompb.Label{
+	series2, _, _ := generateHistogramSeries("TestMetric", now, prompb.Label{
 		Name:  "Test|Invalid|Label|Char",
 		Value: "123",
 	}, prompb.Label{
 		Name:  "group_1",
 		Value: "second-series",
 	})
+	pushTimeSeriesWithStatus(t, client, series2, 400)
 
-	res, err = client.Push(series2)
-	require.NoError(t, err)
-	require.Equal(t, 400, res.StatusCode)
-
-	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_discarded_samples_total"},
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(3), []string{"cortex_discarded_samples_total"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "group", "")),
 	))
 
@@ -155,7 +158,13 @@ func TestPushMultipleInvalidLabels(t *testing.T) {
 
 	// Push invalid series with different groups
 	for i := 0; i < 9; i++ {
-		series, _, _ := generateSeries("TestMetric", time.Now(), prompb.Label{
+		var genSeries generateSeriesFunc
+		if i%2 == 0 {
+			genSeries = generateFloatSeries
+		} else {
+			genSeries = generateHistogramSeries
+		}
+		series, _, _ := genSeries("TestMetric", time.Now(), prompb.Label{
 			Name:  "separate_metrics_group",
 			Value: strconv.Itoa(i % 2),
 		}, prompb.Label{
@@ -163,9 +172,7 @@ func TestPushMultipleInvalidLabels(t *testing.T) {
 			Value: "123",
 		})
 
-		res, err := client.Push(series)
-		require.NoError(t, err)
-		require.Equal(t, 400, res.StatusCode)
+		pushTimeSeriesWithStatus(t, client, series, 400)
 	}
 
 	// Odd group values
@@ -216,7 +223,13 @@ func TestSeparateMetricsGroupLimitExceeded(t *testing.T) {
 	// Push invalid series with different groups
 	now := time.Now()
 	for i := 0; i < 10; i++ {
-		series, _, _ := generateSeries("TestMetric", now, prompb.Label{
+		var genSeries generateSeriesFunc
+		if i%2 == 0 {
+			genSeries = generateFloatSeries
+		} else {
+			genSeries = generateHistogramSeries
+		}
+		series, _, _ := genSeries("TestMetric", now, prompb.Label{
 			Name:  "separate_metrics_group",
 			Value: strconv.Itoa(i),
 		}, prompb.Label{
@@ -224,13 +237,11 @@ func TestSeparateMetricsGroupLimitExceeded(t *testing.T) {
 			Value: "123",
 		})
 
-		res, err := client.Push(series)
-		require.NoError(t, err)
-		require.Equal(t, 400, res.StatusCode)
+		pushTimeSeriesWithStatus(t, client, series, 400)
 	}
 
 	// Push another series which should be registered as group "other" as active group limit exceeded
-	series, _, _ := generateSeries("TestMetric", now, prompb.Label{
+	series, _, _ := generateFloatSeries("TestMetric", now, prompb.Label{
 		Name:  "separate_metrics_group",
 		Value: "group_limit_exceeded",
 	}, prompb.Label{
@@ -238,9 +249,7 @@ func TestSeparateMetricsGroupLimitExceeded(t *testing.T) {
 		Value: "123",
 	})
 
-	res, err := client.Push(series)
-	require.NoError(t, err)
-	require.Equal(t, 400, res.StatusCode)
+	pushTimeSeriesWithStatus(t, client, series, 400)
 
 	for i := 0; i < 10; i++ {
 		require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_discarded_samples_total"},
@@ -251,4 +260,10 @@ func TestSeparateMetricsGroupLimitExceeded(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_discarded_samples_total"},
 		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "group", "other")),
 	))
+}
+
+func pushTimeSeriesWithStatus(t *testing.T, client *e2emimir.Client, timeSeries []prompb.TimeSeries, expectedStatusCode int) {
+	res, err := client.Push(timeSeries)
+	require.NoError(t, err)
+	require.Equal(t, expectedStatusCode, res.StatusCode)
 }

--- a/integration/validation_separate_metrics_test.go
+++ b/integration/validation_separate_metrics_test.go
@@ -158,13 +158,7 @@ func TestPushMultipleInvalidLabels(t *testing.T) {
 
 	// Push invalid series with different groups
 	for i := 0; i < 9; i++ {
-		var genSeries generateSeriesFunc
-		if i%2 == 0 {
-			genSeries = generateFloatSeries
-		} else {
-			genSeries = generateHistogramSeries
-		}
-		series, _, _ := genSeries("TestMetric", time.Now(), prompb.Label{
+		series, _, _ := generateAlternatingSeries(i)("TestMetric", time.Now(), prompb.Label{
 			Name:  "separate_metrics_group",
 			Value: strconv.Itoa(i % 2),
 		}, prompb.Label{
@@ -223,13 +217,7 @@ func TestSeparateMetricsGroupLimitExceeded(t *testing.T) {
 	// Push invalid series with different groups
 	now := time.Now()
 	for i := 0; i < 10; i++ {
-		var genSeries generateSeriesFunc
-		if i%2 == 0 {
-			genSeries = generateFloatSeries
-		} else {
-			genSeries = generateHistogramSeries
-		}
-		series, _, _ := genSeries("TestMetric", now, prompb.Label{
+		series, _, _ := generateAlternatingSeries(i)("TestMetric", now, prompb.Label{
 			Name:  "separate_metrics_group",
 			Value: strconv.Itoa(i),
 		}, prompb.Label{

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -76,7 +76,13 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	for i := 1; i <= numSeries; i++ {
 		metricName := fmt.Sprintf("series_%d", i)
-		series, expectedVector, _ := generateSeries(metricName, now)
+		var genSeries generateSeriesFunc
+		if i%2 == 0 {
+			genSeries = generateFloatSeries
+		} else {
+			genSeries = generateHistogramSeries
+		}
+		series, expectedVector, _ := genSeries(metricName, now)
 		res, err := client.Push(series)
 		require.NoError(t, err)
 		require.Equal(t, 200, res.StatusCode)
@@ -98,7 +104,7 @@ func TestZoneAwareReplication(t *testing.T) {
 	// Push 1 more series => all good
 	numSeries++
 	metricName := fmt.Sprintf("series_%d", numSeries)
-	series, expectedVector, _ := generateSeries(metricName, now)
+	series, expectedVector, _ := generateFloatSeries(metricName, now)
 	res, err := client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
@@ -119,7 +125,7 @@ func TestZoneAwareReplication(t *testing.T) {
 	// Push 1 more series => all good
 	numSeries++
 	metricName = fmt.Sprintf("series_%d", numSeries)
-	series, expectedVector, _ = generateSeries(metricName, now)
+	series, expectedVector, _ = generateHistogramSeries(metricName, now)
 	res, err = client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
@@ -148,7 +154,7 @@ func TestZoneAwareReplication(t *testing.T) {
 	require.NoError(t, ingester4.Kill())
 
 	// Push 1 more series => fail
-	series, _, _ = generateSeries("series_last", now)
+	series, _, _ = generateFloatSeries("series_last", now)
 	res, err = client.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 500, res.StatusCode)

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -76,13 +76,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	for i := 1; i <= numSeries; i++ {
 		metricName := fmt.Sprintf("series_%d", i)
-		var genSeries generateSeriesFunc
-		if i%2 == 0 {
-			genSeries = generateFloatSeries
-		} else {
-			genSeries = generateHistogramSeries
-		}
-		series, expectedVector, _ := genSeries(metricName, now)
+		series, expectedVector, _ := generateAlternatingSeries(i)(metricName, now)
 		res, err := client.Push(series)
 		require.NoError(t, err)
 		require.Equal(t, 200, res.StatusCode)


### PR DESCRIPTION
#### What this PR does

Add native histograms to integration tests where relevant.

#### Which issue(s) this PR fixes or relates to

Merging the remainder of https://github.com/grafana/mimir/pull/3505 in smaller chunks

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

The others don't seem relevant as these only update tests