### PR TITLE
Helm docs: make getting started less scary and self contained

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -18,9 +18,13 @@ The Grafana Mimir [Helm](https://helm.sh/) chart allows you to configure, instal
 
 ## Before you begin
 
-The instructions that follow are common across any flavor of Kubernetes. They also assume that you know how to install a Kubernetes cluster, and configure and operate it.
+The instructions that follow are common across any flavor of Kubernetes. If you don't have experience with Kubernetes, you can still try by installing a lightweight flavor of Kubernetes, for example [kind](https://kind.sigs.k8s.io/).
 
-It also assumes that you have an understanding of what the `kubectl` command does.
+Experience with the following is recommended, but not essential:
+
+- General knowledge about using a Kubernetes cluster.
+- Understanding of what the `kubectl` command does.
+- Understanding of what the `helm` command does.
 
 > **Caution:** This procedure is primarily aimed at local or development setups. To set up in a production environment, see [Run Grafana Mimir in production using the Helm chart]({{< relref "../run-production-environment-with-helm/" >}}).
 
@@ -31,19 +35,31 @@ It also assumes that you have an understanding of what the `kubectl` command doe
 ### Software requirements
 
 - Kubernetes 1.20 or higher
-- The `kubectl` command for your version of Kubernetes
-- Helm 3 or higher
+- The [kubectl](https://kubernetes.io/docs/reference/kubectl/) command for your version of Kubernetes
+
+  Run the following command to get both the Kubernetes and `kubectl` version: `kubectl version`. The command prints out the server and client versions, where the server is the Kubernetes itself and client means `kubectl`.
+
+- The [helm](https://helm.sh) command version 3.8 or higher
+
+  Run the following command to get the Helm version: `helm version`.
 
 ### Verify that you have
 
 - Access to the Kubernetes cluster
-- Persistent storage is enabled in the Kubernetes cluster, which has a default storage class set up. You can [change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/).
-- DNS service works in the Kubernetes cluster
-- An ingress controller is set up in the Kubernetes cluster, for example [ingress-nginx](https://kubernetes.github.io/ingress-nginx/)
 
-> **Note:** Although this is not strictly necessary, if you want to access Mimir from outside of the Kubernetes cluster, you will need an ingress. This procedure assumes you have an ingress controller set up.
+  For example by running the command `kubectl get ns`, which lists all namespaces.
+
+- Persistent storage is enabled in the Kubernetes cluster, which has a default storage class set up. You can [change the default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/).
+
+  > **Note:** If you are using `kind` or you are unsure, assume it is enabled and continue.
+
+- DNS service works in the Kubernetes cluster
+
+  > **Note:** If you are using `kind` or you are unsure, assume it works and continue.
 
 ### Security setup
+
+If you are using `kind` or similar local Kubernetes setup and haven't set security policies, you can safely skip this section.
 
 This installation will not succeed if you have enabled the
 [PodSecurityPolicy](https://v1-23.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) admission controller
@@ -63,7 +79,7 @@ Using a custom namespace solves problems later on because you do not have to ove
 
 1. Create a unique Kubernetes namespace, for example `mimir-test`:
 
-   ```console
+   ```bash
    kubectl create namespace mimir-test
    ```
 
@@ -71,18 +87,128 @@ Using a custom namespace solves problems later on because you do not have to ove
 
 1. Set up a Helm repository using the following commands:
 
-   ```console
+   ```bash
    helm repo add grafana https://grafana.github.io/helm-charts
    helm repo update
    ```
 
    > **Note:** The Helm chart at [https://grafana.github.io/helm-charts](https://grafana.github.io/helm-charts) is a publication of the source code at [**grafana/mimir**](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed).
 
+1. Install Grafana Mimir using the Helm chart:
+
+   ```bash
+   helm -n mimir-test install mimir grafana/mimir-distributed
+   ```
+
+   > **Note:** The output of the command contains the write and read URLs necessary for the following steps.
+
+1. Check the statuses of the Mimir pods:
+
+   ```bash
+   kubectl -n mimir-test get pods
+   ```
+
+   The results look similar to this:
+
+   ```bash
+   kubectl -n mimir-test get pods
+   NAME                                        READY   STATUS      RESTARTS   AGE
+   mimir-minio-7bd89b757d-q5hp6                1/1     Running     0          2m44s
+   mimir-rollout-operator-76c67c7d56-v6xtl     1/1     Running     0          2m44s
+   mimir-nginx-858455979c-hjvhx                1/1     Running     0          2m44s
+   mimir-make-minio-buckets-svgvd              0/1     Completed   1          2m44s
+   mimir-ruler-64b9d59b94-tvj7z                1/1     Running     0          2m44s
+   mimir-query-frontend-c444b56f9-jrmwl        1/1     Running     0          2m44s
+   mimir-overrides-exporter-86c4d54645-zktkm   1/1     Running     0          2m44s
+   mimir-querier-5d9c55d6d9-l6fdc              1/1     Running     0          2m44s
+   mimir-distributor-7796db494f-rsvdx          1/1     Running     0          2m44s
+   mimir-query-scheduler-d5dccfff7-5c5rw       1/1     Running     0          2m44s
+   mimir-querier-5d9c55d6d9-xghl6              1/1     Running     0          2m44s
+   mimir-query-scheduler-d5dccfff7-vz4vf       1/1     Running     0          2m44s
+   mimir-alertmanager-0                        1/1     Running     0          2m44s
+   mimir-store-gateway-zone-b-0                1/1     Running     0          2m44s
+   mimir-store-gateway-zone-c-0                1/1     Running     0          2m43s
+   mimir-ingester-zone-b-0                     1/1     Running     0          2m43s
+   mimir-compactor-0                           1/1     Running     0          2m44s
+   mimir-ingester-zone-a-0                     1/1     Running     0          2m43s
+   mimir-store-gateway-zone-a-0                1/1     Running     0          2m44s
+   mimir-ingester-zone-c-0                     1/1     Running     0          2m44s
+   ```
+
+1. Wait until all of the pods have a status of `Running` or `Completed`, which might take a few minutes.
+
+## Generate some metrics for testing
+
+The Grafana Mimir Helm chart can collect metrics or logs, or both, about Grafana Mimir itself. This is called _metamonitoring_.
+In the example that follows, metamonitoring scrapes metrics about Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
+
+1. Create a YAML file called `custom.yaml` for your Helm values.
+
+1. To enable metamonitoring in Grafana Mimir, add the following YAML snippet to your Grafana Mimir `custom.yaml` file:
+
+   ```yaml
+   metaMonitoring:
+     serviceMonitor:
+       enabled: true
+     grafanaAgent:
+       enabled: true
+       installOperator: true
+       metrics:
+         additionalRemoteWriteConfigs:
+           - url: "http://mimir-nginx.mimir-test.svc:80/api/v1/push"
+   ```
+
+   > **Note:** In a production environment the `url` above would point to an external system, independent of your Grafana Mimir instance, such as an instance of Grafana Cloud Metrics.
+
+1. Upgrade Grafana Mimir by using the `helm` command:
+
+   ```bash
+   helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
+   ```
+
+## Start Grafana in Kubernetes and query metrics
+
+1. Install Grafana in the same Kubernetes cluster.
+
+   For details, see [Deploy Grafana on Kubernetes](/docs/grafana/latest/setup-grafana/installation/kubernetes/).
+
+1. If you haven't done it as part of the previous step, port-forward Grafana to `localhost`, by using the `kubectl` command:
+
+   ```bash
+   kubectl port-forward service/grafana 3000:3000
+   ```
+
+1. In a browser, go to the Grafana server at [http://localhost:3000](http://localhost:3000).
+1. Sign in using the default username `admin` and password `admin`.
+1. On the left-hand side, go to **Configuration** > **Data sources**.
+1. Configure a new Prometheus data source to query the local Grafana Mimir server, by using the following settings:
+
+   | Field | Value                                           |
+   | ----- | ----------------------------------------------- |
+   | Name  | Mimir                                           |
+   | URL   | http://mimir-nginx.mimir-test.svc:80/prometheus |
+
+   To add a data source, see [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
+
+1. Verify success:
+
+   You should be able to query metrics in [Grafana Explore](/docs/grafana/latest/explore/),
+   as well as create dashboard panels by using your newly configured `Mimir` data source.
+
+## Advanced setup with external access
+
+In this procedure you'll set up external access for Grafana Mimir to allow writing and quering metrics from outside the Kubernetes cluster.
+You'll set up an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) that enables you to externally access a Kubernetes cluster.
+
+### Before you begin
+
+Verify that an ingress controller is set up in the Kubernetes cluster, for example [ingress-nginx](https://kubernetes.github.io/ingress-nginx/)
+
+### Set up ingress
+
 1. Configure an ingress:
 
-   a. Create a YAML file of Helm values called `custom.yaml`.
-
-   b. Add the following configuration to the file:
+   b. Add the following to your `custom.yaml` Helm values file:
 
    ```yaml
    nginx:
@@ -98,54 +224,28 @@ Using a custom namespace solves problems later on because you do not have to ove
          # empty, disabled.
    ```
 
-   > **Note:** To see all of the configurable parameters for a Helm chart installation, use `helm show values grafana/mimir-distributed`.
-
-   An ingress enables you to externally access a Kubernetes cluster.
    Replace _`<ingress-host>`_ with a suitable hostname that DNS can resolve
    to the external IP address of the Kubernetes cluster.
    For more information, see [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
    > **Note:** On Linux systems, and if it is not possible for you set up local DNS resolution, you can use the `--add-host=<ingress-host>:<kubernetes-cluster-external-address>` command-line flag to define the _`<ingress-host>`_ local address for the `docker` commands in the examples that follow.
 
-1. Install Grafana Mimir using the Helm chart:
+   > **Note:** To see all of the configurable parameters for a Helm chart installation, use `helm show values grafana/mimir-distributed`.
+
+1. Upgrade Grafana Mimir by using the `helm` command:
 
    ```bash
-   helm -n mimir-test install mimir grafana/mimir-distributed -f custom.yaml
+   helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
    ```
 
-   > **Note:** The output of the command contains the write and read URLs necessary for the following steps.
-
-1. Check the statuses of the Mimir pods:
+   The output of the command should contain the URL to use for querying Grafana Mimir from the outside, for example:
 
    ```bash
-   kubectl -n mimir-test get pods
+   From outside the cluster via ingress:
+   http://myhost.mynetwork/prometheus
    ```
 
-   The results look similar to this:
-
-   ```bash
-   kubectl -n mimir-test get pods
-   NAME                                            READY   STATUS      RESTARTS   AGE
-   mimir-minio-78b59f5569-fhlhs                    1/1     Running     0          2m4s
-   mimir-nginx-74f8bff8dc-7kr7z                    1/1     Running     0          2m5s
-   mimir-distributed-make-bucket-job-z2hc8         0/1     Completed   0          2m4s
-   mimir-overrides-exporter-5fd94b745b-htrdr       1/1     Running     0          2m5s
-   mimir-query-frontend-68cbbfbfb5-pt2ng           1/1     Running     0          2m5s
-   mimir-ruler-56586c9774-28k7h                    1/1     Running     0          2m5s
-   mimir-querier-7894f6c5f9-pj9sp                  1/1     Running     0          2m5s
-   mimir-querier-7894f6c5f9-cwjf6                  1/1     Running     0          2m4s
-   mimir-alertmanager-0                            1/1     Running     0          2m4s
-   mimir-distributor-55745599b5-r26kr              1/1     Running     0          2m4s
-   mimir-compactor-0                               1/1     Running     0          2m4s
-   mimir-store-gateway-0                           1/1     Running     0          2m4s
-   mimir-ingester-1                                1/1     Running     0          2m4s
-   mimir-ingester-2                                1/1     Running     0          2m4s
-   mimir-ingester-0                                1/1     Running     0          2m4s
-   ```
-
-1. Wait until all of the pods have a status of `Running` or `Completed`, which might take a few minutes.
-
-## Configure Prometheus to write to Grafana Mimir
+### Configure Prometheus to write to Grafana Mimir
 
 You can either configure Prometheus to write to Grafana Mimir or [configure Grafana Agent to write to Mimir](#configure-grafana-agent-to-write-to-grafana-mimir). Although you can configure both, you do not need to.
 
@@ -189,7 +289,7 @@ Make a choice based on whether or not you already have a Prometheus server set u
 
      > **Note:** On Linux systems, if \<ingress-host\> cannot be resolved by the Prometheus server, use the additional command-line flag `--add-host=<ingress-host>:<kubernetes-cluster-external-address>` to set it up.
 
-## Configure Grafana Agent to write to Grafana Mimir
+### Configure Grafana Agent to write to Grafana Mimir
 
 You can either configure Grafana Agent to write to Grafana Mimir or [configure Prometheus to write to Mimir](#configure-prometheus-to-write-to-grafana-mimir). Although you can configure both, you do not need to.
 
@@ -238,7 +338,11 @@ Make a choice based on whether or not you already have a Grafana Agent set up:
 
      > **Note:** On Linux systems, if \<ingress-host\> cannot be resolved by the Grafana Agent, use the additional command-line flag `--add-host=<ingress-host>:<kubernetes-cluster-external-address>` to set it up.
 
-## Query metrics in Grafana
+### Query metrics in Grafana
+
+You can use the Grafana installed in Kubernetes in the [Start Grafana in Kubernetes and query metrics](#start-grafana-in-kubernetes-and-query-metrics) section as well or follow the instructions bellow.
+
+> **Note:** If you have the port-forward running for Grafana from an earlier step, stop it.
 
 First install Grafana, and then add Mimir as a Prometheus data source.
 
@@ -267,63 +371,3 @@ First install Grafana, and then add Mimir as a Prometheus data source.
    You should be able to query metrics in [Grafana Explore](http://localhost:3000/explore),
    as well as create dashboard panels by using your newly configured `Mimir` data source.
    For more information, see [Monitor Grafana Mimir]({{< relref "../run-production-environment-with-helm/monitor-system-health.md" >}}).
-
-## Set up metamonitoring
-
-Grafana Mimir metamonitoring collects metrics or logs, or both,
-about Grafana Mimir itself.
-In the example that follows, metamonitoring scrapes metrics about
-Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
-
-1. To enable metamonitoring in Grafana Mimir, add the following YAML snippet to your Grafana Mimir `custom.yaml` file:
-
-   ```yaml
-   metaMonitoring:
-     serviceMonitor:
-       enabled: true
-     grafanaAgent:
-       enabled: true
-       installOperator: true
-       metrics:
-         additionalRemoteWriteConfigs:
-           - url: "http://mimir-nginx.mimir-test.svc:80/api/v1/push"
-   ```
-
-1. Upgrade Grafana Mimir by using the `helm` command:
-
-   ```bash
-   helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
-   ```
-
-1. From [Grafana Explore](http://localhost:3000/explore), verify that your metrics are being written to Grafana Mimir, by querying `sum(rate(cortex_ingester_ingested_samples_total[$__rate_interval]))`.
-
-## Query metrics in Grafana that is running within the same Kubernetes cluster
-
-1. Install Grafana in the same Kubernetes cluster.
-
-   For details, see [Deploy Grafana on Kubernetes](/docs/grafana/latest/setup-grafana/installation/kubernetes/).
-
-1. Stop the Grafana instance that is running in the Docker container, to allow for port-forwarding.
-
-1. Port-forward Grafana to `localhost`, by using the `kubectl` command:
-
-   ```bash
-   kubectl port-forward service/grafana 3000:3000
-   ```
-
-1. In a browser, go to the Grafana server at [http://localhost:3000](http://localhost:3000).
-1. Sign in using the default username `admin` and password `admin`.
-1. On the left-hand side, go to **Configuration** > **Data sources**.
-1. Configure a new Prometheus data source to query the local Grafana Mimir server, by using the following settings:
-
-   | Field | Value                                           |
-   | ----- | ----------------------------------------------- |
-   | Name  | Mimir                                           |
-   | URL   | http://mimir-nginx.mimir-test.svc:80/prometheus |
-
-   To add a data source, see [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
-
-1. Verify success:
-
-   You should be able to query metrics in [Grafana Explore](/docs/grafana/latest/explore/),
-   as well as create dashboard panels by using your newly configured `Mimir` data source.

--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -18,7 +18,7 @@ The Grafana Mimir [Helm](https://helm.sh/) chart allows you to configure, instal
 
 ## Before you begin
 
-The instructions that follow are common across any flavor of Kubernetes. If you don't have experience with Kubernetes, you can still try by installing a lightweight flavor of Kubernetes, for example [kind](https://kind.sigs.k8s.io/).
+The instructions that follow are common across any flavor of Kubernetes. If you don't have experience with Kubernetes, you can install a lightweight flavor of Kubernetes such as [kind](https://kind.sigs.k8s.io/).
 
 Experience with the following is recommended, but not essential:
 
@@ -35,11 +35,11 @@ Experience with the following is recommended, but not essential:
 ### Software requirements
 
 - Kubernetes 1.20 or higher
-- The [kubectl](https://kubernetes.io/docs/reference/kubectl/) command for your version of Kubernetes
+- The [`kubectl`](https://kubernetes.io/docs/reference/kubectl/) command for your version of Kubernetes
 
   Run the following command to get both the Kubernetes and `kubectl` version: `kubectl version`. The command prints out the server and client versions, where the server is the Kubernetes itself and client means `kubectl`.
 
-- The [helm](https://helm.sh) command version 3.8 or higher
+- The [`helm`](https://helm.sh) command version 3.8 or higher
 
   Run the following command to get the Helm version: `helm version`.
 


### PR DESCRIPTION
#### What this PR does

Reorder Getting Started guide to avoid needing complicated ingress setup at first. Also to run everything in kubernetes and not have to use docker at first.

#### Which issue(s) this PR fixes or relates to

We've tested the guide on @osg-grafana 's machine and this order and instructions make better sense.

#### Checklist

- N/A Tests updated
- [x] Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Fixes https://github.com/grafana/mimir/issues/4616.