### PR TITLE
Fix promToMimirHistogram() slices pre-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 * [ENHANCEMENT] Compactor: validation of blocks uploaded via the TSDB block upload feature is now configurable on a per tenant basis: #4585
   * `-compactor.block-upload-validation-enabled` has been added, `compactor_block_upload_validation_enabled` can be used to override per tenant
   * `-compactor.block-upload.block-validation-enabled` was the previous global flag and has been removed
-* [ENHANCEMENT] OTLP: Add support for converting OTel exponential histograms to Prometheus native histograms. The ingestion of native histograms must be enabled, please set `-ingester.native-histograms-ingestion-enabled` to `true`. #4063
+* [ENHANCEMENT] OTLP: Add support for converting OTel exponential histograms to Prometheus native histograms. The ingestion of native histograms must be enabled, please set `-ingester.native-histograms-ingestion-enabled` to `true`. #4063 #4639
 * [ENHANCEMENT] Query-frontend: add metric `cortex_query_fetched_index_bytes_total` to measure TSDB index bytes fetched to execute a query. #4597
 * [ENHANCEMENT] Query-frontend: add experimental limit to enforce a max query expression size in bytes via `-query-frontend.max-query-expression-size-bytes` or `max_query_expression_size_bytes`. #4604
 * [ENHANCEMENT] Query-tee: improve message logged when comparing responses and one response contains a non-JSON payload. #4588

--- a/pkg/util/push/otel.go
+++ b/pkg/util/push/otel.go
@@ -205,7 +205,7 @@ func promToMimirTimeseries(promTs *prompb.TimeSeries) mimirpb.PreallocTimeseries
 }
 
 func promToMimirHistogram(h *prompb.Histogram) mimirpb.Histogram {
-	pSpans := make([]mimirpb.BucketSpan, len(h.PositiveSpans))
+	pSpans := make([]mimirpb.BucketSpan, 0, len(h.PositiveSpans))
 	for _, span := range h.PositiveSpans {
 		pSpans = append(
 			pSpans, mimirpb.BucketSpan{
@@ -214,7 +214,7 @@ func promToMimirHistogram(h *prompb.Histogram) mimirpb.Histogram {
 			},
 		)
 	}
-	nSpans := make([]mimirpb.BucketSpan, len(h.NegativeSpans))
+	nSpans := make([]mimirpb.BucketSpan, 0, len(h.NegativeSpans))
 	for _, span := range h.NegativeSpans {
 		nSpans = append(
 			nSpans, mimirpb.BucketSpan{


### PR DESCRIPTION
#### What this PR does
I was doing a post-merge review of https://github.com/grafana/mimir/pull/4063 and I've noticed that the slices in `promToMimirHistogram()` are incorrectly pre-allocated.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
