### PR TITLE
store-gateway index header: return posting offset in LabelVales

### DIFF
--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -38,7 +38,7 @@ type Reader interface {
 
 	// LabelValues returns all label values for given label name or error.
 	// If no values are found for label name, or label name does not exists,
-	// then empty string is returned and no error.
+	// then empty slice is returned and no error.
 	// If non-empty prefix is provided, only values starting with the prefix are returned.
 	// If non-nil filter is provided, then only values for which filter returns true are returned.
 	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
@@ -46,7 +46,7 @@ type Reader interface {
 	// LabelValuesOffsets returns all label values and the offsets for their posting lists for given label name or error.
 	// The ranges of each posting list are the same as returned by PostingsOffset.
 	// If no values are found for label name, or label name does not exists,
-	// then empty string is returned and no error.
+	// then empty slice is returned and no error.
 	// If non-empty prefix is provided, only posting lists starting with the prefix are returned.
 	// If non-nil filter is provided, then only posting lists for which filter returns true are returned.
 	LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error)

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -37,6 +37,7 @@ type Reader interface {
 	LookupSymbol(o uint32) (string, error)
 
 	// LabelValues returns all label values for given label name or error.
+	// The returned label values are sorted lexicographically.
 	// If no values are found for label name, or label name does not exists,
 	// then empty slice is returned and no error.
 	// If non-empty prefix is provided, only values starting with the prefix are returned.
@@ -44,6 +45,7 @@ type Reader interface {
 	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
 
 	// LabelValuesOffsets returns all label values and the offsets for their posting lists for given label name or error.
+	// The returned label values are sorted lexicographically (which the same as sorted by posting offset).
 	// The ranges of each posting list are the same as returned by PostingsOffset.
 	// If no values are found for label name, or label name does not exists,
 	// then empty slice is returned and no error.

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb/index"
+
+	streamindex "github.com/grafana/mimir/pkg/storegateway/indexheader/index"
 )
 
 // NotFoundRangeErr is an error returned by PostingsOffset when there is no posting for given name and value pairs.
@@ -24,10 +26,10 @@ type Reader interface {
 	IndexVersion() (int, error)
 
 	// PostingsOffset returns start and end offsets of postings for given name and value.
-	// The start is inclusive and the end is exclusive.
-	// The end offset might be bigger than the actual posting ending, but not larger than the whole index file.
+	// The Start is inclusive and is the byte offset of the number_of_entries field of a posting list.
+	// The End is exclusive and is typically the byte offset of the CRC32 field.
+	// The End might be bigger than the actual posting ending, but not larger than the whole index file.
 	// NotFoundRangeErr is returned when no index can be found for given name and value.
-	// TODO(bwplotka): Move to PostingsOffsets(name string, value ...string) []index.Range and benchmark.
 	PostingsOffset(name string, value string) (index.Range, error)
 
 	// LookupSymbol returns string based on given reference.
@@ -40,6 +42,14 @@ type Reader interface {
 	// If non-empty prefix is provided, only values starting with the prefix are returned.
 	// If non-nil filter is provided, then only values for which filter returns true are returned.
 	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
+
+	// LabelValuesOffsets returns all label values and the offsets for their posting lists for given label name or error.
+	// The ranges of each posting list are the same as returned by PostingsOffset.
+	// If no values are found for label name, or label name does not exists,
+	// then empty string is returned and no error.
+	// If non-empty prefix is provided, only posting lists starting with the prefix are returned.
+	// If non-nil filter is provided, then only posting lists for which filter returns true are returned.
+	LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error)
 
 	// LabelNames returns all label names in sorted order.
 	LabelNames() ([]string, error)

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -191,22 +191,22 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 		require.NoError(t, err)
 		strValsFromOffsets := make([]string, len(valOffsets))
 		for i := range valOffsets {
-			strValsFromOffsets[i] = valOffsets[i].Value
+			strValsFromOffsets[i] = valOffsets[i].LabelValue
 		}
 		require.Equal(t, expectedLabelVals, strValsFromOffsets)
 
 		for _, v := range valOffsets {
-			if minStart > expRanges[labels.Label{Name: lname, Value: v.Value}].Start {
-				minStart = expRanges[labels.Label{Name: lname, Value: v.Value}].Start
+			if minStart > expRanges[labels.Label{Name: lname, Value: v.LabelValue}].Start {
+				minStart = expRanges[labels.Label{Name: lname, Value: v.LabelValue}].Start
 			}
-			if maxEnd < expRanges[labels.Label{Name: lname, Value: v.Value}].End {
-				maxEnd = expRanges[labels.Label{Name: lname, Value: v.Value}].End
+			if maxEnd < expRanges[labels.Label{Name: lname, Value: v.LabelValue}].End {
+				maxEnd = expRanges[labels.Label{Name: lname, Value: v.LabelValue}].End
 			}
 
-			ptr, err := headerReader.PostingsOffset(lname, v.Value)
+			ptr, err := headerReader.PostingsOffset(lname, v.LabelValue)
 			require.NoError(t, err)
-			assert.Equal(t, expRanges[labels.Label{Name: lname, Value: v.Value}], ptr)
-			assert.Equal(t, expRanges[labels.Label{Name: lname, Value: v.Value}], v.Off)
+			assert.Equal(t, expRanges[labels.Label{Name: lname, Value: v.LabelValue}], ptr)
+			assert.Equal(t, expRanges[labels.Label{Name: lname, Value: v.LabelValue}], v.Off)
 		}
 	}
 

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -8,7 +8,6 @@ package indexheader
 import (
 	"context"
 	"fmt"
-	"math"
 	"path/filepath"
 	"testing"
 
@@ -177,8 +176,6 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 	expRanges, err := indexReader.PostingsRanges()
 	require.NoError(t, err)
 
-	minStart := int64(math.MaxInt64)
-	maxEnd := int64(math.MinInt64)
 	for _, lname := range expLabelNames {
 		expectedLabelVals, err := indexReader.SortedLabelValues(lname)
 		require.NoError(t, err)
@@ -196,13 +193,6 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 		require.Equal(t, expectedLabelVals, strValsFromOffsets)
 
 		for _, v := range valOffsets {
-			if minStart > expRanges[labels.Label{Name: lname, Value: v.LabelValue}].Start {
-				minStart = expRanges[labels.Label{Name: lname, Value: v.LabelValue}].Start
-			}
-			if maxEnd < expRanges[labels.Label{Name: lname, Value: v.LabelValue}].End {
-				maxEnd = expRanges[labels.Label{Name: lname, Value: v.LabelValue}].End
-			}
-
 			ptr, err := headerReader.PostingsOffset(lname, v.LabelValue)
 			require.NoError(t, err)
 			assert.Equal(t, expRanges[labels.Label{Name: lname, Value: v.LabelValue}], ptr)

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -32,11 +32,11 @@ import (
 
 var implementations = []struct {
 	name    string
-	factory func(t testing.TB, ctx context.Context, dir string, id ulid.ULID) Reader
+	factory func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader
 }{
 	{
 		name: "stream binary reader",
-		factory: func(t testing.TB, ctx context.Context, dir string, id ulid.ULID) Reader {
+		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
 			br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 			require.NoError(t, err)
 			requireCleanup(t, br.Close)
@@ -45,7 +45,7 @@ var implementations = []struct {
 	},
 	{
 		name: "lazy stream binary reader",
-		factory: func(t testing.TB, ctx context.Context, dir string, id ulid.ULID) Reader {
+		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
 			readerFactory := func() (Reader, error) {
 				return NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 			}

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -10,7 +10,6 @@ import (
 	"hash/crc32"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/grafana/dskit/runutil"
 	"github.com/pkg/errors"
@@ -441,73 +440,35 @@ func (t *PostingOffsetTableV2) PostingsOffset(name string, value string) (r inde
 	return index.Range{}, false, nil
 }
 
-var labelValuesAccumulators = sync.Pool{New: func() any {
-	return &postingsTableV2Accumulator[string]{
-		transform: func(offset PostingListOffset) string {
-			return offset.LabelValue
-		},
-	}
-}}
-
 func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
-	acc := labelValuesAccumulators.Get().(*postingsTableV2Accumulator[string])
-	defer func() {
-		acc.acc = nil
-		labelValuesAccumulators.Put(acc)
-	}()
-
-	if err := t.postingOffsets(name, prefix, filter, acc); err != nil {
-		return nil, errors.Wrap(err, "get label values")
-	}
-	return acc.acc, nil
-}
-
-var labelValuesOffsetsAccumulators = sync.Pool{New: func() any {
-	return &postingsTableV2Accumulator[PostingListOffset]{
-		transform: func(offset PostingListOffset) PostingListOffset {
-			return offset
-		},
-	}
-}}
-
-func (t *PostingOffsetTableV2) LabelValuesOffsets(name, prefix string, filter func(string) bool) ([]PostingListOffset, error) {
-	acc := labelValuesOffsetsAccumulators.Get().(*postingsTableV2Accumulator[PostingListOffset])
-	defer func() {
-		acc.acc = nil
-		labelValuesOffsetsAccumulators.Put(acc)
-	}()
-
-	if err := t.postingOffsets(name, prefix, filter, acc); err != nil {
+	offsets, err := postingOffsets(t, name, prefix, filter, postingListOffsetValue)
+	if err != nil {
 		return nil, errors.Wrap(err, "get label values offsets")
 	}
-	return acc.acc, nil
+	return offsets, nil
 }
 
-type postingsTableV2Accumulator[T any] struct {
-	transform func(PostingListOffset) T
-	acc       []T
+func (t *PostingOffsetTableV2) LabelValuesOffsets(name, prefix string, filter func(string) bool) ([]PostingListOffset, error) {
+	offsets, err := postingOffsets(t, name, prefix, filter, postingListOffsetIdentity)
+	if err != nil {
+		return nil, errors.Wrap(err, "get label values offsets")
+	}
+	return offsets, nil
 }
 
-func (v *postingsTableV2Accumulator[T]) estimatedValues(n int) {
-	v.acc = make([]T, 0, n)
-}
+// postingListOffsetIdentity cam be used with postingOffsets.
+func postingListOffsetIdentity(offset PostingListOffset) PostingListOffset { return offset }
 
-func (v *postingsTableV2Accumulator[T]) visit(offset PostingListOffset) {
-	v.acc = append(v.acc, v.transform(offset))
-}
+// postingListOffsetValue can be used with postingOffsets.
+func postingListOffsetValue(offset PostingListOffset) string { return offset.LabelValue }
 
-type postingsTableV2Visitor interface {
-	estimatedValues(n int)
-	visit(offset PostingListOffset)
-}
-
-func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter func(string) bool, visitor postingsTableV2Visitor) (err error) {
+func postingOffsets[T any](t *PostingOffsetTableV2, name string, prefix string, filter func(string) bool, extract func(PostingListOffset) T) (_ []T, err error) {
 	e, ok := t.postings[name]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	if len(e.offsets) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if filter == nil {
@@ -518,10 +479,10 @@ func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter
 	if prefix != "" {
 		offsetIdx, ok = e.prefixOffset(prefix)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 	}
-	visitor.estimatedValues((len(e.offsets) - offsetIdx) * t.postingOffsetsInMemSampling)
+	result := make([]T, 0, (len(e.offsets)-offsetIdx)*t.postingOffsetsInMemSampling)
 
 	// Don't Crc32 the entire postings offset table, this is very slow
 	// so hope any issues were caught at startup.
@@ -532,7 +493,7 @@ func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter
 	lastVal := e.offsets[len(e.offsets)-1].value
 
 	var skip int
-	skipToValue := func() {
+	readNextList := func() (val string, startOff int64, isAMatch bool, noMoreMatches bool) {
 		if skip == 0 {
 			// These are always the same number of bytes, since it's the same label name each time.
 			// It's faster to skip than parse.
@@ -543,10 +504,7 @@ func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter
 		} else {
 			d.Skip(skip)
 		}
-	}
 
-	readNextList := func() (val string, startOff int64, isAMatch bool, noMoreMatches bool) {
-		skipToValue()
 		val = yoloString(d.UnsafeUvarintBytes())
 
 		prefixMatches := strings.HasPrefix(val, prefix)
@@ -601,13 +559,13 @@ func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter
 				// Between these two there is the posting list length field of the next list, and the CRC32 of the current list.
 				currList.Off.End = nextOffset - crc32.Size - postingLengthFieldSize
 			}
-			visitor.visit(currList)
+			result = append(result, extract(currList))
 		}
 		if currentValueIsLast {
 			break
 		}
 	}
-	return d.Err()
+	return result, d.Err()
 }
 
 func (t *PostingOffsetTableV2) LabelNames() ([]string, error) {

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -595,6 +595,10 @@ func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter
 			} else {
 				nextIsConsumed = true
 				nextValueSafe, nextOffset, nextValueMatches, noMoreMatches = readNextList()
+
+				// The end we want for the current posting list should be the byte offset of the CRC32 field.
+				// The start of the next posting list is the byte offset of the number_of_entries field.
+				// Between these two there is the posting list length field of the next list, and the CRC32 of the current list.
 				currList.Off.End = nextOffset - crc32.Size - postingLengthFieldSize
 			}
 			visitor.visit(currList)

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -551,8 +551,8 @@ func postingOffsets[T any](t *PostingOffsetTableV2, name string, prefix string, 
 				// There is no next value though. Since we only need the offset, we can use what we have in the sampled postings.
 				currList.Off.End = e.lastValOffset
 			} else {
-				nextIsPopulated = true
 				nextValueSafe, nextOffset, nextValueMatches, nextValueIsLast = readNextList()
+				nextIsPopulated = true
 
 				// The end we want for the current posting list should be the byte offset of the CRC32 field.
 				// The start of the next posting list is the byte offset of the number_of_entries field.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -29,10 +29,12 @@ type PostingOffsetTable interface {
 	PostingsOffset(name string, value string) (rng index.Range, found bool, err error)
 
 	// LabelValues returns a list of values for the label named name that match filter and have the prefix provided.
+	// The returned label values are sorted lexicographically.
 	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
 
 	// LabelValuesOffsets returns all postings lists for the label named name that match filter and have the prefix provided.
 	// The ranges of each posting list are the same as returned by PostingsOffset.
+	// The returned label values are sorted lexicographically (which the same as sorted by posting offset).
 	LabelValuesOffsets(name, prefix string, filter func(string) bool) ([]PostingListOffset, error)
 
 	// LabelNames returns a sorted list of all label names in this table.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -458,7 +458,7 @@ func (t *PostingOffsetTableV2) LabelValuesOffsets(name, prefix string, filter fu
 	return offsets, nil
 }
 
-// postingListOffsetIdentity cam be used with postingOffsets.
+// postingListOffsetIdentity can be used with postingOffsets.
 func postingListOffsetIdentity(offset PostingListOffset) PostingListOffset { return offset }
 
 // postingListOffsetValue can be used with postingOffsets.
@@ -510,7 +510,7 @@ func postingOffsets[T any](t *PostingOffsetTableV2, name string, prefix string, 
 		noMoreMatches = val == lastVal || (!prefixMatches && prefix < val)
 		// Clone the yolo string since its bytes will be invalidated as soon as
 		// any other reads against the decoding buffer are performed.
-		// We'll only need the sting if it matches our filter.
+		// We'll only need the string if it matches our filter.
 		if isAMatch {
 			val = strings.Clone(val)
 		} else {

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -471,10 +471,6 @@ func postingOffsets[T any](t *PostingOffsetTableV2, name string, prefix string, 
 		return nil, nil
 	}
 
-	if filter == nil {
-		filter = func(string) bool { return true }
-	}
-
 	offsetIdx := 0
 	if prefix != "" {
 		offsetIdx, ok = e.prefixOffset(prefix)
@@ -508,7 +504,7 @@ func postingOffsets[T any](t *PostingOffsetTableV2, name string, prefix string, 
 		val = yoloString(d.UnsafeUvarintBytes())
 
 		prefixMatches := strings.HasPrefix(val, prefix)
-		isAMatch = prefixMatches && filter(val)
+		isAMatch = prefixMatches && (filter == nil || filter(val))
 		noMoreMatches = val == lastVal || (!prefixMatches && prefix < val)
 		// Clone the yolo string since its bytes will be invalidated as soon as
 		// any other reads against the decoding buffer are performed.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc32"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/grafana/dskit/runutil"
 	"github.com/pkg/errors"
@@ -23,15 +24,29 @@ const postingLengthFieldSize = 4
 
 type PostingOffsetTable interface {
 	// PostingsOffset returns the byte range of the postings section for the label with the given name and value.
-	// The Start is inclusive and the End is exclusive.
-	// The end offset might be bigger than the actual posting ending, but not larger than the whole index file.
+	// The Start is inclusive and is the byte offset of the number_of_entries field of a posting list.
+	// The End is exclusive and is typically the byte offset of the CRC32 field.
+	// The End might be bigger than the actual posting ending, but not larger than the whole index file.
 	PostingsOffset(name string, value string) (rng index.Range, found bool, err error)
 
 	// LabelValues returns a list of values for the label named name that match filter and have the prefix provided.
 	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
 
+	// LabelValuesOffsets returns all postings lists for the label named name that match filter and have the prefix provided.
+	// The ranges of each posting list are the same as returned by PostingsOffset.
+	LabelValuesOffsets(name, prefix string, filter func(string) bool) ([]PostingListOffset, error)
+
 	// LabelNames returns a sorted list of all label names in this table.
 	LabelNames() ([]string, error)
+}
+
+// PostingListOffset contains the start and end offset of a posting list.
+// The Start is inclusive and is the byte offset of the number_of_entries field of a posting list.
+// The End is exclusive and is typically the byte offset of the CRC32 field.
+// The End might be bigger than the actual posting ending, but not larger than the whole index file.
+type PostingListOffset struct {
+	Value string
+	Off   index.Range
 }
 
 type PostingOffsetTableV1 struct {
@@ -257,6 +272,23 @@ func (t *PostingOffsetTableV1) LabelValues(name string, prefix string, filter fu
 	return values, nil
 }
 
+func (t *PostingOffsetTableV1) LabelValuesOffsets(name, prefix string, filter func(string) bool) ([]PostingListOffset, error) {
+	e, ok := t.postings[name]
+	if !ok {
+		return nil, nil
+	}
+	values := make([]PostingListOffset, 0, len(e))
+	for k, r := range e {
+		if strings.HasPrefix(k, prefix) && (filter == nil || filter(k)) {
+			values = append(values, PostingListOffset{Value: k, Off: r})
+		}
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].Value < values[j].Value
+	})
+	return values, nil
+}
+
 func (t *PostingOffsetTableV1) LabelNames() ([]string, error) {
 	labelNames := make([]string, 0, len(t.postings))
 	allPostingsKeyName, _ := index.AllPostingsKey()
@@ -409,22 +441,87 @@ func (t *PostingOffsetTableV2) PostingsOffset(name string, value string) (r inde
 	return index.Range{}, false, nil
 }
 
-func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter func(string) bool) (v []string, err error) {
+var labelValuesAccumulators = sync.Pool{New: func() any {
+	return &postingsTableV2Accumulator[string]{
+		transform: func(offset PostingListOffset) string {
+			return offset.Value
+		},
+	}
+}}
+
+func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
+	acc := labelValuesAccumulators.Get().(*postingsTableV2Accumulator[string])
+	defer func() {
+		acc.acc = nil
+		labelValuesAccumulators.Put(acc)
+	}()
+
+	if err := t.postingOffsets(name, prefix, filter, acc); err != nil {
+		return nil, errors.Wrap(err, "get label values")
+	}
+	return acc.acc, nil
+}
+
+var labelValuesOffsetsAccumulators = sync.Pool{New: func() any {
+	return &postingsTableV2Accumulator[PostingListOffset]{
+		transform: func(offset PostingListOffset) PostingListOffset {
+			return offset
+		},
+	}
+}}
+
+func (t *PostingOffsetTableV2) LabelValuesOffsets(name, prefix string, filter func(string) bool) ([]PostingListOffset, error) {
+	acc := labelValuesOffsetsAccumulators.Get().(*postingsTableV2Accumulator[PostingListOffset])
+	defer func() {
+		acc.acc = nil
+		labelValuesOffsetsAccumulators.Put(acc)
+	}()
+
+	if err := t.postingOffsets(name, prefix, filter, acc); err != nil {
+		return nil, errors.Wrap(err, "get label values offsets")
+	}
+	return acc.acc, nil
+}
+
+type postingsTableV2Accumulator[T any] struct {
+	transform func(PostingListOffset) T
+	acc       []T
+}
+
+func (v *postingsTableV2Accumulator[T]) estimatedValues(n int) {
+	v.acc = make([]T, 0, n)
+}
+
+func (v *postingsTableV2Accumulator[T]) visit(offset PostingListOffset) {
+	v.acc = append(v.acc, v.transform(offset))
+}
+
+type postingsTableV2Visitor interface {
+	estimatedValues(n int)
+	visit(offset PostingListOffset)
+}
+
+func (t *PostingOffsetTableV2) postingOffsets(name string, prefix string, filter func(string) bool, visitor postingsTableV2Visitor) (err error) {
 	e, ok := t.postings[name]
 	if !ok {
-		return nil, nil
+		return nil
 	}
 	if len(e.offsets) == 0 {
-		return nil, nil
+		return nil
+	}
+
+	if filter == nil {
+		filter = func(string) bool { return true }
 	}
 
 	offsetIdx := 0
 	if prefix != "" {
 		offsetIdx, ok = e.prefixOffset(prefix)
 		if !ok {
-			return nil, nil
+			return nil
 		}
 	}
+	visitor.estimatedValues((len(e.offsets) - offsetIdx) * t.postingOffsetsInMemSampling)
 
 	// Don't Crc32 the entire postings offset table, this is very slow
 	// so hope any issues were caught at startup.
@@ -434,12 +531,11 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 	d.ResetAt(e.offsets[offsetIdx].tableOff)
 	lastVal := e.offsets[len(e.offsets)-1].value
 
-	skip := 0
-	values := make([]string, 0, (len(e.offsets)-offsetIdx)*t.postingOffsetsInMemSampling)
-	for d.Err() == nil {
+	var skip int
+	skipToValue := func() {
 		if skip == 0 {
-			// These are always the same number of bytes,
-			// and it's faster to skip than parse.
+			// These are always the same number of bytes, since it's the same label name each time.
+			// It's faster to skip than parse.
 			skip = d.Len()
 			d.Uvarint()          // Keycount.
 			d.SkipUvarintBytes() // Label name.
@@ -447,37 +543,67 @@ func (t *PostingOffsetTableV2) LabelValues(name string, prefix string, filter fu
 		} else {
 			d.Skip(skip)
 		}
+	}
 
-		unsafeValue := yoloString(d.UnsafeUvarintBytes())
-		if prefix == "" {
-			// Quick path for no prefix matching.
-			if filter == nil || filter(unsafeValue) {
-				// Clone the yolo string since its bytes will be invalidated as soon as
-				// any other reads against the decoding buffer are performed.
-				values = append(values, strings.Clone(unsafeValue))
-			}
+	readNextList := func() (val string, startOff int64, isAMatch bool, noMoreMatches bool) {
+		skipToValue()
+		val = yoloString(d.UnsafeUvarintBytes())
+
+		prefixMatches := strings.HasPrefix(val, prefix)
+		isAMatch = prefixMatches && filter(val)
+		noMoreMatches = val == lastVal || (!prefixMatches && prefix < val)
+		// Clone the yolo string since its bytes will be invalidated as soon as
+		// any other reads against the decoding buffer are performed.
+		// We'll only need the sting if it matches our filter.
+		if isAMatch {
+			val = strings.Clone(val)
 		} else {
-			if strings.HasPrefix(unsafeValue, prefix) {
-				if filter == nil || filter(unsafeValue) {
-					// Clone the yolo string since its bytes will be invalidated as soon as
-					// any other reads against the decoding buffer are performed.
-					values = append(values, strings.Clone(unsafeValue))
-				}
-			} else if prefix < unsafeValue {
-				// There will be no more values with the prefix.
-				break
-			}
+			val = ""
+		}
+		// The information in length and number of entries is redundant,
+		// so we can omit the first one - length - and return
+		// the offset of the number_of_entries field.
+		startOff = int64(d.Uvarint64()) + postingLengthFieldSize
+		return
+	}
+
+	var (
+		currList         PostingListOffset
+		nextIsConsumed   bool
+		nextValueSafe    string
+		nextValueMatches bool
+		nextOffset       int64
+		noMoreMatches    bool
+	)
+
+	for d.Err() == nil {
+		currentValueIsLast := noMoreMatches
+		currentValueMatches := nextValueMatches
+		if nextIsConsumed {
+			currList.Value, currList.Off.Start = nextValueSafe, nextOffset
+			nextIsConsumed = false
+		} else {
+			currList.Value, currList.Off.Start, currentValueMatches, currentValueIsLast = readNextList()
 		}
 
-		if unsafeValue == lastVal {
+		// If the next value matches, we need to also populate its end offset and then call the visitor.
+		if currentValueMatches {
+			// We peek at the next list, so we can use it as the end offset of the current one.
+			if currList.Value == lastVal {
+				// There is no next value though. Since we only need the offset, we can use what we have in the sampled postings.
+				currList.Off.End = e.lastValOffset
+			} else {
+				nextIsConsumed = true
+				nextValueSafe, nextOffset, nextValueMatches, noMoreMatches = readNextList()
+				currList.Off.End = nextOffset - crc32.Size - postingLengthFieldSize
+			}
+			visitor.visit(currList)
+		}
+		if currentValueIsLast {
 			break
 		}
-		d.Uvarint64() // Offset.
 	}
-	if d.Err() != nil {
-		return nil, errors.Wrap(d.Err(), "get label values")
-	}
-	return values, nil
+	return d.Err()
 }
 
 func (t *PostingOffsetTableV2) LabelNames() ([]string, error) {

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -233,6 +233,26 @@ func BenchmarkLabelValuesIndexV2(b *testing.B) {
 	})
 }
 
+func BenchmarkLabelValuesIndexV2_WithPrefix(b *testing.B) {
+	tests, blockID, blockDir := labelValuesTestCases(test.NewTB(b))
+	r, err := NewStreamBinaryReader(context.Background(), log.NewNopLogger(), nil, blockDir, blockID, 32, NewStreamBinaryReaderMetrics(nil), Config{})
+	require.NoError(b, err)
+
+	for lbl, tcs := range tests {
+		b.Run(lbl, func(b *testing.B) {
+			for _, tc := range tcs {
+				b.Run(fmt.Sprintf("prefix='%s'%s", tc.prefix, tc.desc), func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						values, err := r.LabelValues(lbl, tc.prefix, tc.filter)
+						require.NoError(b, err)
+						require.Equal(b, tc.expected, len(values))
+					}
+				})
+			}
+		})
+	}
+}
+
 func BenchmarkPostingsOffset(b *testing.B) {
 	ctx := context.Background()
 

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -178,7 +178,6 @@ func (r *StreamBinaryReader) IndexVersion() (int, error) {
 	return r.indexVersion, nil
 }
 
-// TODO(bwplotka): Get advantage of multi value offset fetch.
 func (r *StreamBinaryReader) PostingsOffset(name, value string) (index.Range, error) {
 	rng, found, err := r.postingsOffsetTable.PostingsOffset(name, value)
 	if err != nil {
@@ -225,6 +224,10 @@ func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
 
 func (r *StreamBinaryReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
 	return r.postingsOffsetTable.LabelValues(name, prefix, filter)
+}
+
+func (r *StreamBinaryReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {
+	return r.postingsOffsetTable.LabelValuesOffsets(name, prefix, filter)
 }
 
 func (r *StreamBinaryReader) LabelNames() ([]string, error) {


### PR DESCRIPTION
Related to #4593 

### What does this PR do?

This PR introduces the `LabelValuesOffsets` method to `indexheader.Reader` and `indexheader.PostingsOfssetTableV(1|2)`. The method creates behaves the same was as `LabelValues` but instead of only the string values of each posting list, it returns the offsets in the index file of each posting list. This method is currently unused, but will be used once I make progress on #4593.

For `PostingsOfssetTableV1` I chose to copy the implementation of `LabelValues` since it is short and trivial.

For `PostingsOffsetTableV2` I extracted the traversal logic from `LabelValues` into a new method `postingOffsets` which takes a transformer, which is called with every matching posting list. The result of the transformer is appended to a slice. Both `LabelValues` and `LabelValuesOffsets` use `postingOffsets`, but pass different transformers. The former accumulates extracts only the string label values, the latter accumulates whole `PostingListOffset`.

The goal was to not have negative performance impact on `LabelValues`. Below are some benchmarks that I ran[^1]. The impact on memory doesn't seem significant. I think the differences for CPU time are due to noise on my machine. The benchmarks took a long time to run for each implementation (>30m per implementation) and could have been affected by ambient processes. I can't find a pattern that the differences follow. And the geomean is -1.84%, which doesn't seem massively significant.

[Benchmark.txt](https://github.com/grafana/mimir/files/11122790/BenchmarkReadersLabelValues.txt) (too large to paste, sorry)


#### Checklist

- [x] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`


[^1]: What you see as `BenchmarkReadersLabelValues` in the `benchcmp` output is `BenchmarkLabelValuesIndexV2_WithPrefix` in this PR. I reshuffled them in https://github.com/grafana/mimir/pull/4641/commits/2a566a1170782e129c5e3c70aab9cd89cc7d962f