### PR TITLE
Helm: Set HPA default MetricTarget type to Utilization

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -35,7 +35,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Allow definition of multiple topology spread constraints. #4584
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
-* [BUGFIX] Set MetricTarget type to Utilization to align with usage of averageUtilization.
+* [BUGFIX] Set MetricTarget type to Utilization to align with usage of averageUtilization. #4642
 
 ## 4.3.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -35,7 +35,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Allow definition of multiple topology spread constraints. #4584
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
-* [BUGFIX] Set MetricTarget type to Utilization to align with usage of averageUtilization. #4642
+* [BUGFIX] Set `gateway` and `nginx` HPA MetricTarget type to Utilization to align with usage of averageUtilization. #4642
 
 ## 4.3.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -35,6 +35,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Allow definition of multiple topology spread constraints. #4584
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
+* [BUGFIX] Set MetricTarget type to Utilization to align with usage of averageUtilization.
 
 ## 4.3.0
 

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
@@ -20,7 +20,7 @@ spec:
       resource:
         name: memory
         target:
-          type: AverageValue
+          type: Utilization
           averageUtilization: {{ . }}
   {{- end }}
   {{- with .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
@@ -28,7 +28,7 @@ spec:
       resource:
         name: cpu
         target:
-          type: AverageValue
+          type: Utilization
           averageUtilization: {{ . }}
   {{- end }}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
@@ -21,7 +21,7 @@ spec:
       resource:
         name: memory
         target:
-          type: AverageValue
+          type: Utilization
           averageUtilization: {{ . }}
   {{- end }}
   {{- with .Values.nginx.autoscaling.targetCPUUtilizationPercentage }}
@@ -29,7 +29,7 @@ spec:
       resource:
         name: cpu
         target:
-          type: AverageValue
+          type: Utilization
           averageUtilization: {{ . }}
   {{- end }}
 {{- end -}}

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-v2-hpa.yaml
@@ -22,5 +22,5 @@ spec:
       resource:
         name: cpu
         target:
-          type: AverageValue
+          type: Utilization
           averageUtilization: 60


### PR DESCRIPTION
#### What this PR does
When averageUtilization is used as a [HPAv2 MetricTarget](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#metrictarget-v2-autoscaling), Kubernetes expects the type to also be Utilization. Currently, the usage of averageUtilization overrides the averageValue type and K8s defaults to a type of Utilization instead. This causes Helm to show drift, as the template wants averageValue but the applied resource has Utilization.

It is assumed that the intent is for the type to be Utilization given the usage of averageUtilization and the values file referring to percentage targets rather than absolute value targets. This PR sets the type to be Utilization, thus preventing spurious diffs when comparing the desired versus actual deployment state.

#### Which issue(s) this PR fixes or relates to

No issue raised.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
