### PR TITLE
Query-frontend: don't retry queries which error inside PromQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580
 * [BUGFIX] OTLP: Do not drop exemplars of the OTLP Monotonic Sum metric. #4063
 * [BUGFIX] Packaging: flag `/etc/default/mimir` and `/etc/sysconfig/mimir` as config to prevent overwrite. #4587
+* [BUGFIX] Query-frontend: don't retry queries which error inside PromQL. #4643
 
 ### Mixin
 

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -115,3 +115,16 @@ func IsAPIError(err error) bool {
 	apiErr := &apiError{}
 	return errors.As(err, &apiErr)
 }
+
+// IsAPIError returns true if err is an apiError which should be failed and not retried.
+func IsNonretryableAPIError(err error) bool {
+	apiErr := &apiError{}
+	// Reasoning:
+	// TypeNone, TypeUnavailable and TypeNotFound are not used anywhere in Mimir or Prometheus;
+	// TypeTimeout, TypeTooManyRequests, TypeNotAcceptable we presume a retry of the same request will fail in the same way.
+	// TypeCanceled means something wants us to stop.
+	// TypeExec, TypeBadData and TypeTooLargeEntry are caused by the input data.
+	// TypeInternal can be a 500 error e.g. from querier failing to contact storegateway.
+
+	return errors.As(err, &apiErr) && apiErr.Type != TypeInternal
+}

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -116,8 +116,8 @@ func IsAPIError(err error) bool {
 	return errors.As(err, &apiErr)
 }
 
-// IsAPIError returns true if err is an apiError which should be failed and not retried.
-func IsNonretryableAPIError(err error) bool {
+// IsNonRetryableAPIError returns true if err is an apiError which should be failed and not retried.
+func IsNonRetryableAPIError(err error) bool {
 	apiErr := &apiError{}
 	// Reasoning:
 	// TypeNone, TypeUnavailable and TypeNotFound are not used anywhere in Mimir or Prometheus;

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -77,8 +77,7 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 			return resp, nil
 		}
 
-		// Any error from the Prometheus API is non-retryable.
-		if apierror.IsAPIError(err) || errors.Is(err, context.Canceled) {
+		if apierror.IsNonretryableAPIError(err) || errors.Is(err, context.Canceled) {
 			return nil, err
 		}
 		// Retry if we get a HTTP 500 or a non-HTTP error.

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -77,7 +77,7 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 			return resp, nil
 		}
 
-		if apierror.IsNonretryableAPIError(err) || errors.Is(err, context.Canceled) {
+		if apierror.IsNonRetryableAPIError(err) || errors.Is(err, context.Canceled) {
 			return nil, err
 		}
 		// Retry if we get a HTTP 500 or a non-HTTP error.

--- a/pkg/frontend/querymiddleware/retry_test.go
+++ b/pkg/frontend/querymiddleware/retry_test.go
@@ -94,16 +94,16 @@ func TestRetry(t *testing.T) {
 			resp, err := h.Do(context.Background(), nil)
 			require.Equal(t, tc.err, err)
 			require.Equal(t, tc.resp, resp)
-			require.Equal(t, tc.expectedRetries, mockMetrics.retries)
+			require.Equal(t, float64(tc.expectedRetries), mockMetrics.retries)
 		})
 	}
 }
 
 type mockRetryMetrics struct {
-	retries int
+	retries float64
 }
 
-func (c *mockRetryMetrics) Observe(v int) {
+func (c *mockRetryMetrics) Observe(v float64) {
 	c.retries = v
 }
 


### PR DESCRIPTION
#### What this PR does

Break out of the retry loop if the error has been decoded from a Prometheus error, or is a cancellation.

~Extra drive-by fix: don't log "context canceled" as an error in the querier.  This is noticeable when running `TestQueryFrontendErrorMessageParity/query_time_range_exceeds_the_limit`, for instance.~

#### Which issue(s) this PR fixes or relates to

Fixes #4637

#### Checklist

- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
