### PR TITLE
Improve querymiddleware tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [ENHANCEMENT] Distributor: add ability to set per-distributor limits via `distributor_limits` block in runtime configuration in addition to the existing configuration. #4619
 * [ENHANCEMENT] Querier: reduce peak memory consumption for queries that touch a large number of chunks. #4625
 * [ENHANCEMENT] Query-frontend: added experimental `-query-frontend.query-sharding-max-regexp-size-bytes` limit to query-frontend. When set to a value greater than 0, query-frontend disabled query sharding for any query with a regexp matcher longer than the configured limit. #4632
+* [ENHANCEMENT] Query-frontend: improve readability of distributed tracing spans. #4656
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580

--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -64,8 +64,7 @@ func newCardinalityEstimationMiddleware(cache cache.Cache, logger log.Logger, re
 // Do injects a cardinality estimate into the query hints (if available) and
 // caches the actual cardinality observed for this query.
 func (c *cardinalityEstimation) Do(ctx context.Context, request Request) (Response, error) {
-	spanLog, ctx := spanlogger.NewWithLogger(ctx, c.logger, "cardinalityEstimation.Do")
-	defer spanLog.Finish()
+	spanLog := spanlogger.FromContext(ctx, c.logger)
 
 	tenants, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -359,16 +359,16 @@ func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 		return nil, apierror.New(apierror.TypeTooLargeEntry, string(mustReadAllBody(r)))
 	}
 
-	log, ctx := spanlogger.NewWithLogger(ctx, logger, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
-	defer log.Finish()
-	log.LogFields(otlog.Int("status_code", r.StatusCode))
+	log := spanlogger.FromContext(ctx, logger)
 
 	buf, err := bodyBuffer(r)
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
-	log.LogFields(otlog.Int("bytes", len(buf)))
+	log.LogFields(otlog.String("message", "ParseQueryRangeResponse"),
+		otlog.Int("status_code", r.StatusCode),
+		otlog.Int("bytes", len(buf)))
 
 	contentType := r.Header.Get("Content-Type")
 	formatter := findFormatter(contentType)

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -98,8 +98,7 @@ func newQueryShardingMiddleware(
 }
 
 func (s *querySharding) Do(ctx context.Context, r Request) (Response, error) {
-	log, ctx := spanlogger.NewWithLogger(ctx, s.logger, "querySharding.Do")
-	defer log.Span.Finish()
+	log := spanlogger.FromContext(ctx, s.logger)
 
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
@@ -75,7 +76,8 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		if !ok || httpResp.Code/100 == 5 {
 			lastErr = err
-			level.Error(util_log.WithContext(ctx, r.log)).Log("msg", "error processing request", "try", tries, "err", err)
+			log := util_log.WithContext(ctx, spanlogger.FromContext(ctx, r.log))
+			level.Error(log).Log("msg", "error processing request", "try", tries, "err", err)
 			continue
 		}
 

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
 
 	util_log "github.com/grafana/mimir/pkg/util/log"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 type retryMiddlewareMetrics struct {


### PR DESCRIPTION
#### What this PR does

See example trace:
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/8125524/229495756-34de641a-5b0d-4da1-9c5c-89aab70faa36.png">

This PR removes the `cardinalityEstimation.Do` and `querySharding.Do` spans which exactly parallel their parents.
It removes the spans for `ParseQueryRangeResponse`, turning each into an event on the parent span.
It adds an event to the `retry` span containing the error that triggered a retry.
And simplifies slightly the code for instrumentMiddleware.

#### Checklist

- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated.
