### PR TITLE
Cache unapplied matchers in ExpandedPostings

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -147,10 +147,10 @@ func (noopCache) FetchMultiSeriesForRefs(_ context.Context, _ string, _ ulid.ULI
 	return map[storage.SeriesRef][]byte{}, ids
 }
 
-func (c noopCache) StoreExpandedPostings(_ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ []byte) {
+func (c noopCache) StoreExpandedPostings(_ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ string, _ []byte) {
 }
 
-func (c noopCache) FetchExpandedPostings(_ context.Context, _ string, _ ulid.ULID, _ indexcache.LabelMatchersKey) ([]byte, bool) {
+func (c noopCache) FetchExpandedPostings(_ context.Context, _ string, _ ulid.ULID, _ indexcache.LabelMatchersKey, _ string) ([]byte, bool) {
 	return nil, false
 }
 
@@ -1482,7 +1482,8 @@ func (b *bucketBlock) chunkRangeReader(ctx context.Context, seq int, off, length
 
 func (b *bucketBlock) indexReader() *bucketIndexReader {
 	b.pendingReaders.Add(1)
-	return newBucketIndexReader(b)
+	// This will be replaced with a strategy selected via a CLI flag.
+	return newBucketIndexReader(b, selectAllStrategy{})
 }
 
 func (b *bucketBlock) chunkReader(ctx context.Context) *bucketChunkReader {

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -31,9 +31,9 @@ type rawPostingGroup struct {
 	labelName  string
 	keys       []labels.Label
 
-	isLazy      bool
-	lazyMatcher func(string) bool
-	prefix      string
+	isLazy          bool
+	originalMatcher *labels.Matcher
+	prefix          string
 }
 
 func newRawIntersectingPostingGroup(labelName string, keys []labels.Label) rawPostingGroup {
@@ -52,70 +52,85 @@ func newRawSubtractingPostingGroup(labelName string, keys []labels.Label) rawPos
 	}
 }
 
-func newLazyIntersectingPostingGroup(labelName string, prefix string, matcher func(string) bool) rawPostingGroup {
+func newLazyIntersectingPostingGroup(m *labels.Matcher) rawPostingGroup {
 	return rawPostingGroup{
-		isLazy:      true,
-		isSubtract:  false,
-		labelName:   labelName,
-		lazyMatcher: matcher,
-		prefix:      prefix,
+		isLazy:          true,
+		isSubtract:      false,
+		labelName:       m.Name,
+		prefix:          m.Prefix(),
+		originalMatcher: m,
 	}
 }
 
-func newLazySubtractingPostingGroup(labelName string, prefix string, matcher func(string) bool) rawPostingGroup {
+func newLazySubtractingPostingGroup(m *labels.Matcher) rawPostingGroup {
 	return rawPostingGroup{
-		isLazy:      true,
-		isSubtract:  true,
-		labelName:   labelName,
-		lazyMatcher: matcher,
-		prefix:      prefix,
+		isLazy:          true,
+		isSubtract:      true,
+		labelName:       m.Name,
+		prefix:          m.Prefix(),
+		originalMatcher: m,
 	}
 }
 
 // toPostingGroup returns a postingGroup which shares the underlying keys slice with g.
 // This means that after calling toPostingGroup g.keys will be modified.
 func (g rawPostingGroup) toPostingGroup(r indexheader.Reader) (postingGroup, error) {
-	var keys []labels.Label
+	var (
+		keys      []labels.Label
+		totalSize int64
+	)
 	if g.isLazy {
-		vals, err := r.LabelValues(g.labelName, g.prefix, g.lazyMatcher)
+		filter := g.originalMatcher.Matches
+		if g.isSubtract {
+			filter = not(filter)
+		}
+		vals, err := r.LabelValuesOffsets(g.labelName, g.prefix, filter)
 		if err != nil {
 			return postingGroup{}, err
 		}
 		keys = make([]labels.Label, len(vals))
 		for i := range vals {
-			keys[i] = labels.Label{Name: g.labelName, Value: vals[i]}
+			keys[i] = labels.Label{Name: g.labelName, Value: vals[i].LabelValue}
+			totalSize += vals[i].Off.End - vals[i].Off.Start
 		}
 	} else {
 		var err error
-		keys, err = g.filterNonExistingKeys(r)
+		keys, totalSize, err = g.filterNonExistingKeys(r)
 		if err != nil {
 			return postingGroup{}, errors.Wrap(err, "filter posting keys")
 		}
 	}
 
 	return postingGroup{
-		isSubtract: g.isSubtract,
-		keys:       keys,
+		isSubtract:      g.isSubtract,
+		originalMatcher: g.originalMatcher,
+		keys:            keys,
+		totalSize:       totalSize,
 	}, nil
 }
 
 // filterNonExistingKeys uses the indexheader.Reader to filter out any label values that do not exist in this index.
 // modifies the underlying keys slice of the group. Do not use the rawPostingGroup after calling toPostingGroup.
-func (g rawPostingGroup) filterNonExistingKeys(r indexheader.Reader) ([]labels.Label, error) {
-	writeIdx := 0
+func (g rawPostingGroup) filterNonExistingKeys(r indexheader.Reader) ([]labels.Label, int64, error) {
+	var (
+		writeIdx  int
+		totalSize int64
+	)
 	for _, l := range g.keys {
-		if _, err := r.PostingsOffset(l.Name, l.Value); errors.Is(err, indexheader.NotFoundRangeErr) {
+		offset, err := r.PostingsOffset(l.Name, l.Value)
+		if errors.Is(err, indexheader.NotFoundRangeErr) {
 			// This label name and value doesn't exist in this block, so there are 0 postings we can match.
 			// Try with the rest of the set matchers, maybe they can match some series.
 			// Continue so we overwrite it next time there's an existing value.
 			continue
 		} else if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		g.keys[writeIdx] = l
 		writeIdx++
+		totalSize += offset.End - offset.Start
 	}
-	return g.keys[:writeIdx], nil
+	return g.keys[:writeIdx], totalSize, nil
 }
 
 func toRawPostingGroup(m *labels.Matcher) rawPostingGroup {
@@ -153,12 +168,12 @@ func toRawPostingGroup(m *labels.Matcher) rawPostingGroup {
 	// have the label name set too. See: https://github.com/prometheus/prometheus/issues/3575
 	// and https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555.
 	if m.Matches("") {
-		return newLazySubtractingPostingGroup(m.Name, m.Prefix(), not(m.Matches))
+		return newLazySubtractingPostingGroup(m)
 	}
 
 	// Our matcher does not match the empty value, so we just need the postings that correspond
 	// to label values matched by the matcher.
-	return newLazyIntersectingPostingGroup(m.Name, m.Prefix(), m.Matches)
+	return newLazyIntersectingPostingGroup(m)
 }
 
 func not(filter func(string) bool) func(string) bool {
@@ -171,8 +186,12 @@ func not(filter func(string) bool) func(string) bool {
 // All the labels in keys should have a corresponding postings list in the index.
 // This computation happens in expandedPostings.
 type postingGroup struct {
-	isSubtract bool
-	keys       []labels.Label
+	isSubtract      bool
+	originalMatcher *labels.Matcher
+	keys            []labels.Label
+
+	// totalSize is the size in bytes of all the posting lists for keys
+	totalSize int64
 }
 
 type postingPtr struct {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -32,18 +32,35 @@ import (
 
 // expandedPostingsPromise is the promise returned by bucketIndexReader.expandedPostingsPromise.
 // The second return value indicates whether the returned data comes from the cache.
-type expandedPostingsPromise func(ctx context.Context) ([]storage.SeriesRef, bool, error)
+type expandedPostingsPromise func(ctx context.Context) ([]storage.SeriesRef, []*labels.Matcher, bool, error)
+
+type postingsSelectionStrategy interface {
+	name() string
+	selectPostings([]postingGroup) (selected, omitted []postingGroup)
+}
+
+type selectAllStrategy struct{}
+
+func (selectAllStrategy) name() string {
+	return "selectAll"
+}
+
+func (selectAllStrategy) selectPostings(groups []postingGroup) (selected, omitted []postingGroup) {
+	return groups, nil
+}
 
 // bucketIndexReader is a custom index reader (not conforming index.Reader interface) that reads index that is stored in
 // object storage without having to fully download it.
 type bucketIndexReader struct {
-	block *bucketBlock
-	dec   *index.Decoder
+	block         *bucketBlock
+	postingsStrat postingsSelectionStrategy
+	dec           *index.Decoder
 }
 
-func newBucketIndexReader(block *bucketBlock) *bucketIndexReader {
+func newBucketIndexReader(block *bucketBlock, postingsStrat postingsSelectionStrategy) *bucketIndexReader {
 	r := &bucketIndexReader{
-		block: block,
+		block:         block,
+		postingsStrat: postingsStrat,
 		dec: &index.Decoder{
 			LookupSymbol: block.indexHeaderReader.LookupSymbol,
 		},
@@ -62,8 +79,10 @@ func newBucketIndexReader(block *bucketBlock) *bucketIndexReader {
 // single label name=value.
 func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, returnErr error) {
 	var (
-		loaded bool
-		cached bool
+		loaded            bool
+		cached            bool
+		promise           expandedPostingsPromise
+		unappliedMatchers []*labels.Matcher
 	)
 	span, ctx := tracing.StartSpan(ctx, "ExpandedPostings()")
 	defer func() {
@@ -73,9 +92,15 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 		}
 		span.Finish()
 	}()
-	var promise expandedPostingsPromise
 	promise, loaded = r.expandedPostingsPromise(ctx, ms, stats)
-	returnRefs, cached, returnErr = promise(ctx)
+	returnRefs, unappliedMatchers, cached, returnErr = promise(ctx)
+	if len(unappliedMatchers) > 0 {
+		// This shouldn't be reached since we do not have any postingsSelectionStrategy at the moment
+		// and all matchers should be applied via posting lists.
+		// This will change once the clients of ExpandedPostings can work with unapplied matchers.
+		return nil, fmt.Errorf("there are unapplied matchers (%s) for query (%s)", indexcache.CanonicalLabelMatchersKey(unappliedMatchers), indexcache.CanonicalLabelMatchersKey(ms))
+	}
+
 	return returnRefs, returnErr
 }
 
@@ -88,28 +113,29 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 // TODO: https://github.com/grafana/mimir/issues/331
 func (r *bucketIndexReader) expandedPostingsPromise(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (promise expandedPostingsPromise, loaded bool) {
 	var (
-		refs   []storage.SeriesRef
-		err    error
-		done   = make(chan struct{})
-		cached bool
+		refs              []storage.SeriesRef
+		unappliedMatchers []*labels.Matcher
+		err               error
+		done              = make(chan struct{})
+		cached            bool
 	)
 
-	promise = func(ctx context.Context) ([]storage.SeriesRef, bool, error) {
+	promise = func(ctx context.Context) ([]storage.SeriesRef, []*labels.Matcher, bool, error) {
 		select {
 		case <-ctx.Done():
-			return nil, false, ctx.Err()
+			return nil, nil, false, ctx.Err()
 		case <-done:
 		}
 
 		if err != nil {
-			return nil, false, err
+			return nil, nil, false, err
 		}
 
 		// We must make a copy of refs to return, because caller can modify the postings slice in place.
 		refsCopy := make([]storage.SeriesRef, len(refs))
 		copy(refsCopy, refs)
 
-		return refsCopy, cached, nil
+		return refsCopy, unappliedMatchers, cached, nil
 	}
 
 	key := indexcache.CanonicalLabelMatchersKey(ms)
@@ -122,62 +148,66 @@ func (r *bucketIndexReader) expandedPostingsPromise(ctx context.Context, ms []*l
 	defer close(done)
 	defer r.block.expandedPostingsPromises.Delete(key)
 
-	refs, cached = r.fetchCachedExpandedPostings(ctx, r.block.userID, key, stats)
+	refs, unappliedMatchers, cached = r.fetchCachedExpandedPostings(ctx, r.block.userID, key, stats)
 	if cached {
 		return promise, false
 	}
-	refs, err = r.expandedPostings(ctx, ms, stats)
+	refs, unappliedMatchers, err = r.expandedPostings(ctx, ms, stats)
 	if err != nil {
 		return promise, false
 	}
-	r.cacheExpandedPostings(r.block.userID, key, refs)
+	r.cacheExpandedPostings(r.block.userID, key, refs, unappliedMatchers)
 	return promise, false
 }
 
-func (r *bucketIndexReader) cacheExpandedPostings(userID string, key indexcache.LabelMatchersKey, refs []storage.SeriesRef) {
-	data, err := diffVarintSnappyEncode(index.NewListPostings(refs), len(refs))
+func (r *bucketIndexReader) cacheExpandedPostings(userID string, key indexcache.LabelMatchersKey, refs []storage.SeriesRef, unappliedMatchers []*labels.Matcher) {
+	data, err := diffVarintSnappyMatchersEncode(index.NewListPostings(refs), len(refs), unappliedMatchers)
 	if err != nil {
 		level.Warn(r.block.logger).Log("msg", "can't encode expanded postings cache", "err", err, "matchers_key", key, "block", r.block.meta.ULID)
 		return
 	}
-	r.block.indexCache.StoreExpandedPostings(userID, r.block.meta.ULID, key, data)
+	r.block.indexCache.StoreExpandedPostings(userID, r.block.meta.ULID, key, r.postingsStrat.name(), data)
 }
 
-func (r *bucketIndexReader) fetchCachedExpandedPostings(ctx context.Context, userID string, key indexcache.LabelMatchersKey, stats *safeQueryStats) ([]storage.SeriesRef, bool) {
-	data, ok := r.block.indexCache.FetchExpandedPostings(ctx, userID, r.block.meta.ULID, key)
+func (r *bucketIndexReader) fetchCachedExpandedPostings(ctx context.Context, userID string, key indexcache.LabelMatchersKey, stats *safeQueryStats) ([]storage.SeriesRef, []*labels.Matcher, bool) {
+	data, ok := r.block.indexCache.FetchExpandedPostings(ctx, userID, r.block.meta.ULID, key, r.postingsStrat.name())
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 
-	p, err := r.decodePostings(data, stats)
+	p, unappliedMatchers, err := r.decodePostings(data, stats)
 	if err != nil {
 		level.Warn(r.block.logger).Log("msg", "can't decode expanded postings cache", "err", err, "matchers_key", key, "block", r.block.meta.ULID)
-		return nil, false
+		return nil, nil, false
 	}
 
 	refs, err := index.ExpandPostings(p)
 	if err != nil {
 		level.Warn(r.block.logger).Log("msg", "can't expand decoded expanded postings cache", "err", err, "matchers_key", key, "block", r.block.meta.ULID)
-		return nil, false
+		return nil, nil, false
 	}
-	return refs, true
+	return refs, unappliedMatchers, true
 }
 
 // expandedPostings is the main logic of ExpandedPostings, without the promise wrapper.
-func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, returnErr error) {
-	postingGroups, keys, err := toPostingGroups(ms, r.block.indexHeaderReader)
+func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, unappliedMatchers []*labels.Matcher, returnErr error) {
+	postingGroups, err := toPostingGroups(ms, r.block.indexHeaderReader)
 	if err != nil {
-		return nil, errors.Wrap(err, "toPostingGroups")
+		return nil, nil, errors.Wrap(err, "toPostingGroups")
 	}
-	if len(keys) == 0 {
-		return nil, nil
+	if len(postingGroups) == 0 {
+		return nil, nil, nil
 	}
 
-	fetchedPostings, err := r.fetchPostings(ctx, keys, stats)
+	postingGroups, omittedPostingGroups := r.postingsStrat.selectPostings(postingGroups)
+
+	fetchedPostings, err := r.fetchPostings(ctx, extractLabels(postingGroups), stats)
 	if err != nil {
-		return nil, errors.Wrap(err, "get postings")
+		return nil, nil, errors.Wrap(err, "get postings")
 	}
 
+	// The order of the fetched postings is the same as the order of the requested keys.
+	// This is guaranteed by extractLabels.
 	postingIndex := 0
 
 	var groupAdds, groupRemovals []index.Postings
@@ -202,14 +232,14 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 
 	ps, err := index.ExpandPostings(result)
 	if err != nil {
-		return nil, errors.Wrap(err, "expand")
+		return nil, nil, errors.Wrap(err, "expand")
 	}
 
 	// As of version two all series entries are 16 byte padded. All references
 	// we get have to account for that to get the correct offset.
 	version, err := r.block.indexHeaderReader.IndexVersion()
 	if err != nil {
-		return nil, errors.Wrap(err, "get index version")
+		return nil, nil, errors.Wrap(err, "get index version")
 	}
 	if version >= 2 {
 		for i, id := range ps {
@@ -217,13 +247,36 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 		}
 	}
 
-	return ps, nil
+	return ps, extractLabelMatchers(omittedPostingGroups), nil
+}
+
+func extractLabelMatchers(groups []postingGroup) []*labels.Matcher {
+	if len(groups) == 0 {
+		return nil
+	}
+	m := make([]*labels.Matcher, len(groups))
+	for i := range groups {
+		m[i] = groups[i].originalMatcher
+	}
+	return m
+}
+
+// extractLabels returns the keys of the posting groups in the that they are found in each posting group.
+func extractLabels(groups []postingGroup) []labels.Label {
+	numKeys := 0
+	for _, pg := range groups {
+		numKeys += len(pg.keys)
+	}
+	keys := make([]labels.Label, 0, numKeys)
+	for _, pg := range groups {
+		keys = append(keys, pg.keys...)
+	}
+	return keys
 }
 
 // toPostingGroups returns a set of labels for which to look up postings lists. It guarantees that
-// each postingGroup's keys exist in the index. The order of the returned labels
-// is the same as iterating through the posting groups and for each group adding all keys.
-func toPostingGroups(ms []*labels.Matcher, indexhdr indexheader.Reader) ([]postingGroup, []labels.Label, error) {
+// each postingGroup's keys exist in the index.
+func toPostingGroups(ms []*labels.Matcher, indexhdr indexheader.Reader) ([]postingGroup, error) {
 	var (
 		rawPostingGroups = make([]rawPostingGroup, 0, len(ms))
 		allRequested     = false
@@ -262,22 +315,20 @@ func toPostingGroups(ms []*labels.Matcher, indexhdr indexheader.Reader) ([]posti
 	// Next we check whether the posting groups won't select an empty set of postings.
 	// Based on the previous sorting, we start with the ones that have a known set of values because it's less expensive to check them in
 	// the index header.
-	numKeys := 0
 	for _, rawGroup := range rawPostingGroups {
 		pg, err := rawGroup.toPostingGroup(indexhdr)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "filtering posting group")
+			return nil, errors.Wrap(err, "filtering posting group")
 		}
 
 		// If this group has no keys to work though and is not a subtract group, then it's an empty group.
 		// We can shortcut this, since intersection with empty postings would return no postings.
 		// E.g. `label="non-existent-value"` returns empty group.
 		if !pg.isSubtract && len(pg.keys) == 0 {
-			return nil, nil, nil
+			return nil, nil
 		}
 
 		postingGroups = append(postingGroups, pg)
-		numKeys += len(pg.keys)
 		// If the group is a subtraction group, we must fetch all postings and remove the ones that this matcher selects.
 		allRequested = allRequested || pg.isSubtract
 		hasAdds = hasAdds || !pg.isSubtract
@@ -291,7 +342,6 @@ func toPostingGroups(ms []*labels.Matcher, indexhdr indexheader.Reader) ([]posti
 		allPostingsLabel := labels.Label{Name: name, Value: value}
 
 		postingGroups = append(postingGroups, postingGroup{isSubtract: false, keys: []labels.Label{allPostingsLabel}})
-		numKeys++
 	}
 
 	// If hasAdds is false, then there were no posting lists for any labels that we will intersect.
@@ -299,15 +349,10 @@ func toPostingGroups(ms []*labels.Matcher, indexhdr indexheader.Reader) ([]posti
 	// Shortcut doing any set operations and just return an empty set here.
 	// A query that might end up in this case is `{pod=~"non-existent-value.*"}`.
 	if !allRequested && !hasAdds {
-		return nil, nil, nil
+		return nil, nil
 	}
 
-	keys := make([]labels.Label, 0, numKeys)
-	for _, pg := range postingGroups {
-		keys = append(keys, pg.keys...)
-	}
-
-	return postingGroups, keys, nil
+	return postingGroups, nil
 }
 
 // FetchPostings fills postings requested by posting groups.
@@ -359,7 +404,11 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 				stats.postingsTouchedSizeSum += len(b)
 			})
 
-			l, err := r.decodePostings(b, stats)
+			l, unappliedMatchers, err := r.decodePostings(b, stats)
+			if len(unappliedMatchers) > 0 {
+				return nil, fmt.Errorf("not expecting matchers on non-expanded postings for %s=%s in block %s, but got %s",
+					key.Name, key.Value, r.block.meta.ULID, indexcache.CanonicalLabelMatchersKey(unappliedMatchers))
+			}
 			if err == nil {
 				output[ix] = l
 				continue
@@ -482,14 +531,17 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 	return output, g.Wait()
 }
 
-func (r *bucketIndexReader) decodePostings(b []byte, stats *safeQueryStats) (index.Postings, error) {
+// decodePostings may retain pointers to the buffer.
+func (r *bucketIndexReader) decodePostings(b []byte, stats *safeQueryStats) (index.Postings, []*labels.Matcher, error) {
 	// Even if this instance is not using compression, there may be compressed
 	// entries in the cache written by other stores.
 	var (
-		l   index.Postings
-		err error
+		l        index.Postings
+		matchers []*labels.Matcher
+		err      error
 	)
-	if isDiffVarintSnappyEncodedPostings(b) {
+	switch {
+	case isDiffVarintSnappyEncodedPostings(b):
 		s := time.Now()
 		l, err = diffVarintSnappyDecode(b)
 
@@ -500,10 +552,22 @@ func (r *bucketIndexReader) decodePostings(b []byte, stats *safeQueryStats) (ind
 				stats.cachedPostingsDecompressionErrors++
 			}
 		})
-	} else {
+
+	case isDiffVarintSnappyWithmatchersEncodedPostings(b):
+		s := time.Now()
+		l, matchers, err = diffVarintSnappyMatchersDecode(b)
+
+		stats.update(func(stats *queryStats) {
+			stats.cachedPostingsDecompressions++
+			stats.cachedPostingsDecompressionTimeSum += time.Since(s)
+			if err != nil {
+				stats.cachedPostingsDecompressionErrors++
+			}
+		})
+	default:
 		_, l, err = r.dec.Postings(b)
 	}
-	return l, err
+	return l, matchers, err
 }
 func (r *bucketIndexReader) preloadSeries(ctx context.Context, ids []storage.SeriesRef, stats *safeQueryStats) (*bucketIndexLoadedSeries, error) {
 	span, ctx := tracing.StartSpan(ctx, "preloadSeries()")

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -59,10 +59,10 @@ type IndexCache interface {
 	FetchMultiSeriesForRefs(ctx context.Context, userID string, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef)
 
 	// StoreExpandedPostings stores the result of ExpandedPostings, encoded with an unspecified codec.
-	StoreExpandedPostings(userID string, blockID ulid.ULID, key LabelMatchersKey, v []byte)
+	StoreExpandedPostings(userID string, blockID ulid.ULID, key LabelMatchersKey, postingsSelectionStrategy string, v []byte)
 
 	// FetchExpandedPostings fetches the result of ExpandedPostings, encoded with an unspecified codec.
-	FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey) ([]byte, bool)
+	FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey, postingsSelectionStrategy string) ([]byte, bool)
 
 	// StoreSeriesForPostings stores a series set for the provided postings.
 	StoreSeriesForPostings(userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte)

--- a/pkg/storegateway/indexcache/inmemory.go
+++ b/pkg/storegateway/indexcache/inmemory.go
@@ -336,13 +336,13 @@ func (c *InMemoryIndexCache) FetchMultiSeriesForRefs(_ context.Context, userID s
 }
 
 // StoreExpandedPostings stores the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
-func (c *InMemoryIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, key LabelMatchersKey, v []byte) {
-	c.set(cacheKeyExpandedPostings{userID, blockID, key}, v)
+func (c *InMemoryIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, key LabelMatchersKey, postingsSelectionStrategy string, v []byte) {
+	c.set(cacheKeyExpandedPostings{userID, blockID, key, postingsSelectionStrategy}, v)
 }
 
 // FetchExpandedPostings fetches the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
-func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey) ([]byte, bool) {
-	return c.get(cacheKeyExpandedPostings{userID, blockID, key})
+func (c *InMemoryIndexCache) FetchExpandedPostings(_ context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey, postingsSelectionStrategy string) ([]byte, bool) {
+	return c.get(cacheKeyExpandedPostings{userID, blockID, key, postingsSelectionStrategy})
 }
 
 // StoreSeriesForPostings stores a series set for the provided postings.
@@ -412,9 +412,10 @@ func (c cacheKeySeriesForRef) size() uint64 {
 
 // cacheKeyPostings implements cacheKey and is used to reference an expanded postings cache entry in the inmemory cache.
 type cacheKeyExpandedPostings struct {
-	userID      string
-	block       ulid.ULID
-	matchersKey LabelMatchersKey
+	userID                    string
+	block                     ulid.ULID
+	matchersKey               LabelMatchersKey
+	postingsSelectionStrategy string
 }
 
 func (c cacheKeyExpandedPostings) typ() string { return cacheTypeExpandedPostings }

--- a/pkg/storegateway/indexcache/inmemory_test.go
+++ b/pkg/storegateway/indexcache/inmemory_test.go
@@ -162,10 +162,10 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		{
 			typ: cacheTypeExpandedPostings,
 			set: func(id uint64, b []byte) {
-				cache.StoreExpandedPostings(user, uid(id), CanonicalLabelMatchersKey(matchers), b)
+				cache.StoreExpandedPostings(user, uid(id), CanonicalLabelMatchersKey(matchers), "strategy", b)
 			},
 			get: func(id uint64) ([]byte, bool) {
-				return cache.FetchExpandedPostings(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers))
+				return cache.FetchExpandedPostings(ctx, user, uid(id), CanonicalLabelMatchersKey(matchers), "strategy")
 			},
 		},
 		{

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -206,18 +206,18 @@ func seriesForRefCacheKey(userID string, blockID ulid.ULID, id storage.SeriesRef
 }
 
 // StoreExpandedPostings stores the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
-func (c *RemoteIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, lmKey LabelMatchersKey, v []byte) {
-	c.set(cacheTypeExpandedPostings, expandedPostingsCacheKey(userID, blockID, lmKey), v)
+func (c *RemoteIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, lmKey LabelMatchersKey, postingsSelectionStrategy string, v []byte) {
+	c.set(cacheTypeExpandedPostings, expandedPostingsCacheKey(userID, blockID, lmKey, postingsSelectionStrategy), v)
 }
 
 // FetchExpandedPostings fetches the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
-func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, lmKey LabelMatchersKey) ([]byte, bool) {
-	return c.get(ctx, cacheTypeExpandedPostings, expandedPostingsCacheKey(userID, blockID, lmKey))
+func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, lmKey LabelMatchersKey, postingsSelectionStrategy string) ([]byte, bool) {
+	return c.get(ctx, cacheTypeExpandedPostings, expandedPostingsCacheKey(userID, blockID, lmKey, postingsSelectionStrategy))
 }
 
-func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatchersKey) string {
+func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatchersKey, postingsSelectionStrategy string) string {
 	hash := blake2b.Sum256([]byte(lmKey))
-	return "E:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(hash[0:])
+	return "E:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(hash[0:]) + ":" + postingsSelectionStrategy
 }
 
 // StoreSeriesForPostings stores a series set for the provided postings.

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -70,18 +70,19 @@ func (t *TracingIndexCache) FetchMultiSeriesForRefs(ctx context.Context, userID 
 	return hits, misses
 }
 
-func (t *TracingIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, key LabelMatchersKey, v []byte) {
-	t.c.StoreExpandedPostings(userID, blockID, key, v)
+func (t *TracingIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, key LabelMatchersKey, postingsSelectionStrategy string, v []byte) {
+	t.c.StoreExpandedPostings(userID, blockID, key, postingsSelectionStrategy, v)
 }
 
-func (t *TracingIndexCache) FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey) ([]byte, bool) {
+func (t *TracingIndexCache) FetchExpandedPostings(ctx context.Context, userID string, blockID ulid.ULID, key LabelMatchersKey, postingsSelectionStrategy string) ([]byte, bool) {
 	t0 := time.Now()
-	data, found := t.c.FetchExpandedPostings(ctx, userID, blockID, key)
+	data, found := t.c.FetchExpandedPostings(ctx, userID, blockID, key, postingsSelectionStrategy)
 
 	spanLogger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(spanLogger).Log(
 		"msg", "IndexCache.FetchExpandedPostings",
 		"requested key", key,
+		"postings selection strategy", postingsSelectionStrategy,
 		"found", found,
 		"time elapsed", time.Since(t0),
 		"returned bytes", len(data),

--- a/pkg/storegateway/postings_codec.go
+++ b/pkg/storegateway/postings_codec.go
@@ -156,7 +156,7 @@ func encodeMatchers(totalLen int, matchers []*labels.Matcher, dest []byte) (writ
 		written += binary.PutUvarint(dest[written:], uint64(len(m.Name)))
 		written += copy(dest[written:], m.Name)
 
-		dest[written] = byte(m.Type) // TODO dimitarvdimitrov add a test which breaks when m.Type changes its values (i.e. Equal is not 0, NotEqual is not 1)
+		dest[written] = byte(m.Type)
 		written++
 
 		written += binary.PutUvarint(dest[written:], uint64(len(m.Value)))
@@ -225,6 +225,7 @@ func decodeMatchers(src []byte) ([]*labels.Matcher, int, error) {
 		value = yoloString(src[:n])
 		src = src[n:]
 
+		// TODO dimitarvdimitrov add a test to make sure the matcher is compiled (maybe we can even take it from the compiled query matchers?)
 		m, err := labels.NewMatcher(typ, labelName, value)
 		if err != nil {
 			return nil, 0, err

--- a/pkg/storegateway/postings_codec_test.go
+++ b/pkg/storegateway/postings_codec_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 )
 
 func TestDiffVarintCodec(t *testing.T) {
@@ -53,7 +55,7 @@ func TestDiffVarintCodec(t *testing.T) {
 		`i=~".+"`:  matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", ".+")),
 		`i=~"1.+"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "1.+")),
 		`i=~"^$"'`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "^$")),
-		`i!~""`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "i", "")),
+		`i!=""`:    matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "i", "")),
 		`n!="2"`:   matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+labelLongSuffix)),
 		`i!~"2.*"`: matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")),
 	}
@@ -91,6 +93,106 @@ func TestDiffVarintCodec(t *testing.T) {
 				comparePostings(t, p, decodedPostings)
 			})
 		}
+	}
+}
+
+func TestLabelMatchersTypeValues(t *testing.T) {
+	expectedValues := map[labels.MatchType]int{
+		labels.MatchEqual:     0,
+		labels.MatchNotEqual:  1,
+		labels.MatchRegexp:    2,
+		labels.MatchNotRegexp: 3,
+	}
+
+	for matcherType, val := range expectedValues {
+		assert.Equal(t, int(labels.MustNewMatcher(matcherType, "", "").Type), val,
+			"diffVarintSnappyMatchersEncode relies on the number values of hte matchers not changing. "+
+				"It caches each matcher type as these integer values. "+
+				"If the integer values change, then the already cached values in the index cache will be improperly decoded.")
+	}
+}
+
+func TestDiffVarintMatchersCodec(t *testing.T) {
+	chunksDir := t.TempDir()
+
+	headOpts := tsdb.DefaultHeadOptions()
+	headOpts.ChunkDirRoot = chunksDir
+	headOpts.ChunkRange = 1000
+	h, err := tsdb.NewHead(nil, nil, nil, nil, headOpts, nil)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, h.Close())
+		assert.NoError(t, os.RemoveAll(chunksDir))
+	})
+
+	appendTestSeries(1e4)(t, h.Appender(context.Background()))
+
+	idx, err := h.Index()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, idx.Close())
+	})
+
+	postingsMap := map[string]index.Postings{
+		`no postings`:    index.EmptyPostings(),
+		`single posting`: index.NewListPostings([]storage.SeriesRef{123}),
+		`n="1"`:          matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "n", "1"+labelLongSuffix)),
+		`j="foo"`:        matchPostings(t, idx, labels.MustNewMatcher(labels.MatchEqual, "j", "foo")),
+		`j!="foo"`:       matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")),
+		`i=~".*"`:        matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", ".*")),
+		`i=~".+"`:        matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", ".+")),
+		`i=~"1.+"`:       matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "1.+")),
+		`i=~"^$"'`:       matchPostings(t, idx, labels.MustNewMatcher(labels.MatchRegexp, "i", "^$")),
+		`i!=""`:          matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "i", "")),
+		`n!="2"`:         matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotEqual, "n", "2"+labelLongSuffix)),
+		`i!~"2.*"`:       matchPostings(t, idx, labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")),
+	}
+
+	unappliedMatchersList := [][]*labels.Matcher{
+		nil,
+		{},
+		{{}},
+		{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "cpu_seconds")},
+		{labels.MustNewMatcher(labels.MatchNotEqual, labels.MetricName, "cpu_seconds")},
+		{labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "^cpu_.*$")},
+		{labels.MustNewMatcher(labels.MatchNotRegexp, labels.MetricName, "^cpu_.*$")},
+		{labels.MustNewMatcher(labels.MatchEqual, "n", "1"+labelLongSuffix)},
+		{labels.MustNewMatcher(labels.MatchEqual, labelLongSuffix, "1"+labelLongSuffix)},
+		{labels.MustNewMatcher(labels.MatchEqual, "n", "")},
+		{labels.MustNewMatcher(labels.MatchEqual, "n", "1"), labels.MustNewMatcher(labels.MatchEqual, "i", "2")},
+		{labels.MustNewMatcher(labels.MatchRegexp, "n", ""), labels.MustNewMatcher(labels.MatchEqual, "i", "1")},
+		{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "\n")},
+	}
+
+	for postingsName, postings := range postingsMap {
+		p, err := toUint64Postings(postings)
+		assert.NoError(t, err)
+
+		t.Run(postingsName, func(t *testing.T) {
+			for _, matchers := range unappliedMatchersList {
+				t.Run(string(indexcache.CanonicalLabelMatchersKey(matchers)), func(t *testing.T) {
+
+					t.Log("postings entries:", p.len())
+					t.Log("original size (4*entries):", 4*p.len(), "bytes")
+					p.reset() // We reuse postings between runs, so we need to reset iterator.
+
+					data, err := diffVarintSnappyMatchersEncode(p, p.len(), matchers)
+					assert.NoError(t, err)
+
+					t.Log("encoded size", len(data), "bytes")
+					t.Logf("ratio: %0.3f", float64(len(data))/float64(4*p.len()))
+
+					decodedPostings, decodedMatchers, err := diffVarintSnappyMatchersDecode(data)
+					assert.NoError(t, err)
+					if assert.Len(t, decodedMatchers, len(matchers)) && len(matchers) > 0 {
+						assert.Equal(t, matchers, decodedMatchers)
+					}
+
+					p.reset()
+					comparePostings(t, p, decodedPostings)
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
> __Draft__: I'm still running benchmarks, and there's one more test that I want to add for decoding matchers from cache.

#### What this PR does

* Adds total size in bytes of a posting group; this is the sum of all posting lists as they appear in the index
* Changes the internal implementation of `bucketIndexReader.ExpandedPostings` to be able to handle partially resolved expanded postings. A partially resolved expanded posting list for a query is a posting list where not all the matchers from the query have been applied

##### Total size of posting groups

This PR uses the `LabelValuesOffsets` (instead of `LabelValues`) and `PostingsOffset` methods of the index header reader to calculate the size of each posting list and sum them to give the size of the whole posting group.

This is expected to increase the memory footprint of ExpandedPostings, although not by a lot. I am in the process of running benchmarks now.

##### Partially resolved expanded postings lists

This PR introduces a pluggable `postingsSelectionStrategy` interface which the `bucketIndexReader` uses to select only some posting groups. Currently, this interface has only one implementation `selectAllStrategy`, which just selects all posting groups.
The plan is to make the strategy selectable via a configuration option.

After running the strategy, the index reader fetches and then intersects/subtracts only the selected posting groups. The reader returns the original matchers of the posting groups that weren't selected - called "unapplied matchers" (naming suggestions welcome).

##### Caching

The unapplied matchers are stored in the cache item for expanded postings, so they can be applied in each cache fetch. Currently the code doesn't attempt to deal with applying the unapplied matchers, so ExpandedPostings returns an error if it finds any in a cache item. But since `selectAllStrategy` never returns unapplied matchers, this case shouldn't be reached.

This PR also changes the cache key of expanded postings in order to be able to run different strategies concurrently by different store-gateway replicas. The cache key now contains the name of the strategy that was used to derive the partial postings and the unapplied matchers. This has the side effect that the expanded postings cache will be "invalidated" after rolling out this change. 


#### Which issue(s) this PR fixes or relates to

Related to #4593 

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
