### PR TITLE
store-gateway: report touched postings & series instead of fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * [BUGFIX] OTLP: Do not drop exemplars of the OTLP Monotonic Sum metric. #4063
 * [BUGFIX] Packaging: flag `/etc/default/mimir` and `/etc/sysconfig/mimir` as config to prevent overwrite. #4587
 * [BUGFIX] Query-frontend: don't retry queries which error inside PromQL. #4643
+* [BUGFIX] Store-gateway & query-frontend: report more consistent statistics for fetched index bytes. #4671
 
 ### Mixin
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -713,7 +713,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 	}
 
 	unsafeStats := stats.export()
-	if err = srv.Send(storepb.NewStatsResponse(unsafeStats.postingsFetchedSizeSum + unsafeStats.seriesFetchedSizeSum)); err != nil {
+	if err = srv.Send(storepb.NewStatsResponse(unsafeStats.postingsTouchedSizeSum + unsafeStats.seriesTouchedSizeSum)); err != nil {
 		err = status.Error(codes.Unknown, errors.Wrap(err, "sends series response stats").Error())
 		return
 	}


### PR DESCRIPTION
#### What this PR does

The store-gateway sends statistics about the involved index bytes
in each request in its response to the querier. These statistics
 are later combined in the query-frontend and included in `query stats` logs.

My understanding is that the purpose of these stats is to
 help gauge the cost of a query. Currently, the store-gateway reports
 its fetched bytes. I propose to report touched bytes instead.

__Fetched index bytes__ are based on the number of bytes fetched from
the bucket. This excludes bytes fetched from the cache and includes bytes overfetched
because of an incorrect size estimation or when joining adjacent ranges
from the index object.

__Touched bytes__ are the sum of bytes that were directly necessary in 
order to serve the request. This means that they exclude bytes that we
 overfetched (e.g. when joining adjacent regions of
an object in the object store or when incorrectly estimating the size of
a series).

The number of touched bytes should not generally change between query
executions and will give a better picture of how expensive the query was
and not depend on cache hit rates or the adjacency of requested regions
in the index.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>



#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
