### PR TITLE
[Mixin] Add panel description for Read QPS panel in Ruler dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [ENHANCEMENT] Queries: Display data touched per sec in bytes instead of number of items. #4492
 * [ENHANCEMENT] `_config.job_names.<job>` values can now be arrays of regular expressions in addition to a single string. Strings are still supported and behave as before. #4543
 * [ENHANCEMENT] Queries dashboard: remove mention to store-gateway "streaming enabled" in panels because store-gateway only support streaming series since Mimir 2.7. #4569
+* [ENHANCEMENT] Ruler: Add panel description for Read QPS panel in Ruler dashboard to explain values when in remote ruler mode. #4675
 * [BUGFIX] Ruler dashboard: show data for reads from ingesters. #4543
 * [BUGFIX] Pod selector regex for deployments: change `(.*-mimir-)` to `(.*mimir-)`. #4603
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -29591,6 +29591,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
+                      "description": "### Read from ingesters - QPS\nNote: Even while operating in Remote ruler mode you will still see values for this panel.\n\nThis is because the metrics are inclusive of intermediate services and are showing the requests that ultimately reach the ingesters.\n\nFor a more detailed view of the read path when using remote ruler mode, see the Remote ruler reads dashboard.\n\n",
                       "fill": 1,
                       "format": "reqps",
                       "id": 3,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -192,6 +192,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Read from ingesters - QPS\nNote: Even while operating in Remote ruler mode you will still see values for this panel.\n\nThis is because the metrics are inclusive of intermediate services and are showing the requests that ultimately reach the ingesters.\n\nFor a more detailed view of the read path when using remote ruler mode, see the Remote ruler reads dashboard.\n\n",
                   "fill": 1,
                   "format": "reqps",
                   "id": 3,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -192,6 +192,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Read from ingesters - QPS\nNote: Even while operating in Remote ruler mode you will still see values for this panel.\n\nThis is because the metrics are inclusive of intermediate services and are showing the requests that ultimately reach the ingesters.\n\nFor a more detailed view of the read path when using remote ruler mode, see the Remote ruler reads dashboard.\n\n",
                   "fill": 1,
                   "format": "reqps",
                   "id": 3,

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -28,7 +28,17 @@ local filename = 'mimir-ruler.json';
       )
       .addPanel(
         $.panel('Read from ingesters - QPS') +
-        $.statPanel('sum(rate(cortex_ingester_client_request_duration_seconds_count{%s, operation="/cortex.Ingester/QueryStream"}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ruler + $._config.job_names.ruler_querier), format='reqps')
+        $.statPanel('sum(rate(cortex_ingester_client_request_duration_seconds_count{%s, operation="/cortex.Ingester/QueryStream"}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ruler + $._config.job_names.ruler_querier), format='reqps') +
+        $.panelDescription(
+          'Read from ingesters - QPS',
+          |||
+            Note: Even while operating in Remote ruler mode you will still see values for this panel.
+
+            This is because the metrics are inclusive of intermediate services and are showing the requests that ultimately reach the ingesters.
+
+            For a more detailed view of the read path when using remote ruler mode, see the Remote ruler reads dashboard.
+          |||
+        ),
       )
       .addPanel(
         $.panel('Write to ingesters - QPS') +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds a description to the `Read from Ingesters - QPS` panel on the Ruler dashboard to explain why you would still see a value here even in remote ruler mode. Similar to the PR at https://github.com/grafana/mimir/pull/4629 but just adding the note to the dashboard too for maximum coverage as suggested by @dimitarvdimitrov here: https://github.com/grafana/mimir/pull/4629#discussion_r1154273468 

#### Which issue(s) this PR fixes or relates to

Fixes #4674 

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
