### PR TITLE
store-gateway: handle deferred matchers for Series()

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1201,12 +1201,12 @@ func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName 
 		return allValues, nil
 	}
 
-	p, deferredMatchers, err := indexr.ExpandedPostings(ctx, matchers, stats)
+	p, pendingMatchers, err := indexr.ExpandedPostings(ctx, matchers, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "expanded postings")
 	}
-	if len(deferredMatchers) > 0 {
-		return nil, fmt.Errorf("there are deferred matchers (%s) for query (%s)", util.MatchersStringer(deferredMatchers), util.MatchersStringer(matchers))
+	if len(pendingMatchers) > 0 {
+		return nil, fmt.Errorf("there are pending matchers (%s) for query (%s)", util.MatchersStringer(pendingMatchers), util.MatchersStringer(matchers))
 	}
 
 	keys := make([]labels.Label, len(allValues))

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1201,9 +1201,12 @@ func blockLabelValues(ctx context.Context, indexr *bucketIndexReader, labelName 
 		return allValues, nil
 	}
 
-	p, err := indexr.ExpandedPostings(ctx, matchers, stats)
+	p, deferredMatchers, err := indexr.ExpandedPostings(ctx, matchers, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "expanded postings")
+	}
+	if len(deferredMatchers) > 0 {
+		return nil, fmt.Errorf("there are deferred matchers (%s) for query (%s)", util.MatchersStringer(deferredMatchers), util.MatchersStringer(matchers))
 	}
 
 	keys := make([]labels.Label, len(allValues))

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -14,7 +14,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +29,9 @@ import (
 
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 	"github.com/grafana/mimir/pkg/storegateway/indexheader"
+	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 // expandedPostingsPromise is the promise returned by bucketIndexReader.expandedPostingsPromise.
@@ -77,12 +81,11 @@ func newBucketIndexReader(block *bucketBlock, postingsStrategy postingsSelection
 // Reminder: A posting is a reference (represented as a uint64) to a series reference, which in turn points to the first
 // chunk where the series contains the matching label-value pair for a given block of data. Postings can be fetched by
 // single label name=value.
-func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, returnErr error) {
+func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, pendingMatchers []*labels.Matcher, returnErr error) {
 	var (
 		loaded          bool
 		cached          bool
 		promise         expandedPostingsPromise
-		pendingMatchers []*labels.Matcher
 	)
 	span, ctx := tracing.StartSpan(ctx, "ExpandedPostings()")
 	defer func() {
@@ -94,14 +97,7 @@ func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.M
 	}()
 	promise, loaded = r.expandedPostingsPromise(ctx, ms, stats)
 	returnRefs, pendingMatchers, cached, returnErr = promise(ctx)
-	if len(pendingMatchers) > 0 {
-		// This shouldn't be reached since we do not have any postingsSelectionStrategy at the moment
-		// and all matchers should be applied via posting lists.
-		// This will change once the clients of ExpandedPostings can work with pending matchers.
-		return nil, fmt.Errorf("there are pending matchers (%s) for query (%s)", indexcache.CanonicalLabelMatchersKey(pendingMatchers), indexcache.CanonicalLabelMatchersKey(ms))
-	}
-
-	return returnRefs, returnErr
+	return returnRefs, pendingMatchers, returnErr
 }
 
 // expandedPostingsPromise provides a promise for the execution of expandedPostings method.
@@ -200,6 +196,7 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 	}
 
 	postingGroups, omittedPostingGroups := r.postingsStrategy.selectPostings(postingGroups)
+	logSelectedPostingGroups(ctx, r.block.logger, r.block.meta.ULID, postingGroups, omittedPostingGroups)
 
 	fetchedPostings, err := r.fetchPostings(ctx, extractLabels(postingGroups), stats)
 	if err != nil {
@@ -248,6 +245,22 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 	}
 
 	return ps, extractLabelMatchers(omittedPostingGroups), nil
+}
+
+func logSelectedPostingGroups(ctx context.Context, logger log.Logger, blockID ulid.ULID, selectedGroups, omittedGroups []postingGroup) {
+	numKeyvals := 2 /* msg */ + 2 /* ulid */ + 4*(len(selectedGroups)+len(omittedGroups))
+	keyvals := make([]any, 0, numKeyvals)
+	keyvals = append(keyvals, "msg", "select posting groups")
+	keyvals = append(keyvals, "ulid", blockID.String())
+	for i, g := range selectedGroups {
+		keyvals = append(keyvals, fmt.Sprintf("selected_%d", i), g.matcher.String())
+		keyvals = append(keyvals, fmt.Sprintf("selected_%d_size", i), g.totalSize)
+	}
+	for i, g := range omittedGroups {
+		keyvals = append(keyvals, fmt.Sprintf("omitted_%d", i), g.matcher.String())
+		keyvals = append(keyvals, fmt.Sprintf("omitted_%d_size", i), g.totalSize)
+	}
+	level.Debug(spanlogger.FromContext(ctx, logger)).Log(keyvals...)
 }
 
 func extractLabelMatchers(groups []postingGroup) []*labels.Matcher {
@@ -407,7 +420,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			l, pendingMatchers, err := r.decodePostings(b, stats)
 			if len(pendingMatchers) > 0 {
 				return nil, fmt.Errorf("not expecting matchers on non-expanded postings for %s=%s in block %s, but got %s",
-					key.Name, key.Value, r.block.meta.ULID, indexcache.CanonicalLabelMatchersKey(pendingMatchers))
+					key.Name, key.Value, r.block.meta.ULID, util.MatchersStringer(pendingMatchers))
 			}
 			if err == nil {
 				output[ix] = l

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -252,13 +252,23 @@ func logSelectedPostingGroups(ctx context.Context, logger log.Logger, blockID ul
 	keyvals := make([]any, 0, numKeyvals)
 	keyvals = append(keyvals, "msg", "select posting groups")
 	keyvals = append(keyvals, "ulid", blockID.String())
+
+	formatGroup := func(g postingGroup) (string, int64) {
+		if g.matcher == nil {
+			return "ALL_POSTINGS", -1
+		}
+		return g.matcher.String(), g.totalSize
+	}
+
 	for i, g := range selectedGroups {
-		keyvals = append(keyvals, fmt.Sprintf("selected_%d", i), g.matcher.String())
-		keyvals = append(keyvals, fmt.Sprintf("selected_%d_size", i), g.totalSize)
+		matcherStr, groupSize := formatGroup(g)
+		keyvals = append(keyvals, fmt.Sprintf("selected_%d", i), matcherStr)
+		keyvals = append(keyvals, fmt.Sprintf("selected_%d_size", i), groupSize)
 	}
 	for i, g := range omittedGroups {
-		keyvals = append(keyvals, fmt.Sprintf("omitted_%d", i), g.matcher.String())
-		keyvals = append(keyvals, fmt.Sprintf("omitted_%d_size", i), g.totalSize)
+		matcherStr, groupSize := formatGroup(g)
+		keyvals = append(keyvals, fmt.Sprintf("omitted_%d", i), matcherStr)
+		keyvals = append(keyvals, fmt.Sprintf("omitted_%d_size", i), groupSize)
 	}
 	level.Debug(spanlogger.FromContext(ctx, logger)).Log(keyvals...)
 }

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -83,9 +83,9 @@ func newBucketIndexReader(block *bucketBlock, postingsStrategy postingsSelection
 // single label name=value.
 func (r *bucketIndexReader) ExpandedPostings(ctx context.Context, ms []*labels.Matcher, stats *safeQueryStats) (returnRefs []storage.SeriesRef, pendingMatchers []*labels.Matcher, returnErr error) {
 	var (
-		loaded          bool
-		cached          bool
-		promise         expandedPostingsPromise
+		loaded  bool
+		cached  bool
+		promise expandedPostingsPromise
 	)
 	span, ctx := tracing.StartSpan(ctx, "ExpandedPostings()")
 	defer func() {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -519,7 +519,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 				// cache provides undecodable values
 				matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-				refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				refs, _, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Equal(t, series, len(refs))
 			})
@@ -576,7 +576,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					indexr := b.indexReader()
 					defer indexr.Close()
 
-					ress[0], errs[0] = indexr.ExpandedPostings(context.Background(), deduplicatedCallMatchers, newSafeQueryStats())
+					ress[0], _, errs[0] = indexr.ExpandedPostings(context.Background(), deduplicatedCallMatchers, newSafeQueryStats())
 				}()
 				// wait for this call to actually create a promise and call LabelValues
 				labelValuesCalls["i"].Wait()
@@ -588,7 +588,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					indexr := b.indexReader()
 					defer indexr.Close()
 
-					ress[1], errs[1] = indexr.ExpandedPostings(secondContext, deduplicatedCallMatchers, newSafeQueryStats())
+					ress[1], _, errs[1] = indexr.ExpandedPostings(secondContext, deduplicatedCallMatchers, newSafeQueryStats())
 				}()
 				// wait until this is waiting on the promise
 				<-secondContext.waitingDone
@@ -601,7 +601,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					indexr := b.indexReader()
 					defer indexr.Close()
 
-					ress[2], errs[2] = indexr.ExpandedPostings(thirdContext, deduplicatedCallMatchers, newSafeQueryStats())
+					ress[2], _, errs[2] = indexr.ExpandedPostings(thirdContext, deduplicatedCallMatchers, newSafeQueryStats())
 				}()
 				// wait until this is waiting on the promise
 				<-thirdContext.waitingDone
@@ -614,7 +614,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					indexr := b.indexReader()
 					defer indexr.Close()
 
-					ress[3], errs[3] = indexr.ExpandedPostings(context.Background(), otherMatchers, newSafeQueryStats())
+					ress[3], _, errs[3] = indexr.ExpandedPostings(context.Background(), otherMatchers, newSafeQueryStats())
 				}()
 				// wait for this call to actually create a promise and call LabelValues
 				labelValuesCalls["n"].Wait()
@@ -625,7 +625,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					indexr := b.indexReader()
 					defer indexr.Close()
 
-					ress[4], errs[4] = indexr.ExpandedPostings(context.Background(), failingMatchers, newSafeQueryStats())
+					ress[4], _, errs[4] = indexr.ExpandedPostings(context.Background(), failingMatchers, newSafeQueryStats())
 				}()
 				// wait for this call to actually create a promise and call LabelValues
 				labelValuesCalls["fail"].Wait()
@@ -637,7 +637,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					indexr := b.indexReader()
 					defer indexr.Close()
 
-					ress[5], errs[5] = indexr.ExpandedPostings(sixthContext, failingMatchers, newSafeQueryStats())
+					ress[5], _, errs[5] = indexr.ExpandedPostings(sixthContext, failingMatchers, newSafeQueryStats())
 				}()
 				// wait until this is waiting on the promise
 				<-sixthContext.waitingDone
@@ -681,20 +681,20 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 				// first call succeeds and caches value
 				matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-				refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				refs, _, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Equal(t, series, len(refs))
 				require.Equal(t, map[string]int{"i": 1}, labelValuesCalls, "Should have called LabelValues once for label 'i'.")
 
 				// second call uses cached value, so it doesn't call LabelValues again
-				refs, err = b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				refs, _, err = b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Equal(t, series, len(refs))
 				require.Equal(t, map[string]int{"i": 1}, labelValuesCalls, "Should have used cached value, so it shouldn't call LabelValues again for label 'i'.")
 
 				// different matcher on same label should not be cached
 				differentMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "i", "")}
-				refs, err = b.indexReader().ExpandedPostings(context.Background(), differentMatchers, newSafeQueryStats())
+				refs, _, err = b.indexReader().ExpandedPostings(context.Background(), differentMatchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Equal(t, series, len(refs))
 				require.Equal(t, map[string]int{"i": 2}, labelValuesCalls, "Should have called LabelValues again for label 'i'.")
@@ -705,7 +705,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 				b.indexCache = corruptedExpandedPostingsCache{}
 
 				matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-				refs, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				refs, _, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Equal(t, series, len(refs))
 			})
@@ -721,7 +721,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 				b.indexCache = cacheNotExpectingToStoreExpandedPostings{t: t}
 
 				matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")}
-				_, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				_, _, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.Error(t, err)
 			})
 
@@ -737,7 +737,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					// we don't need to fetch the rest of the postings lists from the caceh or the bucket.
 					labels.MustNewMatcher(labels.MatchEqual, "i", "non-existent-value"),
 				}
-				postings, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				postings, _, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Empty(t, postings)
 				mockBucket.Mock.AssertNotCalled(t, "Get")
@@ -755,7 +755,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 					// known set of values. For those regular expressions we can short-circuit the cache and bucket lookups too.
 					labels.MustNewMatcher(labels.MatchRegexp, "i", "non-existent-value-(1|2)"),
 				}
-				postings, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
+				postings, _, err := b.indexReader().ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 				require.NoError(t, err)
 				require.Empty(t, postings)
 				mockBucket.Mock.AssertNotCalled(t, "Get")
@@ -777,15 +777,13 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 				matchers := []*labels.Matcher{matcher, inverseMatcher}
 
-				// We're using the unexported method expandedPostings because currently ExpandedPostings doesn't support
-				// pending matchers. We can switch to that method once it does.
-				refsWithpendingMatchers, pendingMatchers, err := newBucketIndexReader(b, omitMatcherStrategy{inverseMatcher}).expandedPostings(ctx, matchers, stats)
+				refsWithpendingMatchers, pendingMatchers, err := newBucketIndexReader(b, omitMatcherStrategy{inverseMatcher}).ExpandedPostings(ctx, matchers, stats)
 				require.NoError(t, err)
 				if assert.Len(t, pendingMatchers, 1) {
 					assert.Equal(t, inverseMatcher, pendingMatchers[0])
 				}
 
-				refsWithoutpendingMatchers, pendingMatchers, err := newBucketIndexReader(b, selectAllStrategy{}).expandedPostings(ctx, matchers[:1], stats)
+				refsWithoutpendingMatchers, pendingMatchers, err := newBucketIndexReader(b, selectAllStrategy{}).ExpandedPostings(ctx, matchers[:1], stats)
 				require.NoError(t, err)
 				assert.Empty(t, pendingMatchers)
 				assert.Equal(t, refsWithoutpendingMatchers, refsWithpendingMatchers)
@@ -1019,7 +1017,7 @@ func benchmarkExpandedPostings(
 
 			tb.ResetTimer()
 			for i := 0; i < tb.N(); i++ {
-				p, err := indexr.ExpandedPostings(ctx, testCase.matchers, indexrStats)
+				p, _, err := indexr.ExpandedPostings(ctx, testCase.matchers, indexrStats)
 
 				if err != nil {
 					tb.Fatal(err.Error())

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -784,16 +784,16 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 
 				matchers := []*labels.Matcher{matcher, inverseMatcher}
 
-				refsWithpendingMatchers, pendingMatchers, err := newBucketIndexReader(b, omitMatchersStrategy{[]*labels.Matcher{inverseMatcher}}).ExpandedPostings(ctx, matchers, stats)
+				refsWithPendingMatchers, pendingMatchers, err := newBucketIndexReader(b, omitMatchersStrategy{[]*labels.Matcher{inverseMatcher}}).ExpandedPostings(ctx, matchers, stats)
 				require.NoError(t, err)
 				if assert.Len(t, pendingMatchers, 1) {
 					assert.Equal(t, inverseMatcher, pendingMatchers[0])
 				}
 
-				refsWithoutpendingMatchers, pendingMatchers, err := newBucketIndexReader(b, selectAllStrategy{}).ExpandedPostings(ctx, matchers[:1], stats)
+				refsWithoutPendingMatchers, pendingMatchers, err := newBucketIndexReader(b, selectAllStrategy{}).ExpandedPostings(ctx, matchers[:1], stats)
 				require.NoError(t, err)
 				assert.Empty(t, pendingMatchers)
-				assert.Equal(t, refsWithoutpendingMatchers, refsWithpendingMatchers)
+				assert.Equal(t, refsWithoutPendingMatchers, refsWithPendingMatchers)
 			})
 
 		})

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -725,7 +725,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		logger,
 	)
 	if len(deferredMatchers) > 0 {
-		iterator = &matchingSeriesChunkRefsSetIterator{from: iterator, matchers: deferredMatchers}
+		iterator = &filteringSeriesChunkRefsSetIterator{from: iterator, matchers: deferredMatchers}
 	}
 
 	// Track the time spent loading series and chunk refs.
@@ -1034,14 +1034,14 @@ func (s *loadingSeriesChunkRefsSetIterator) loadSeries(ref storage.SeriesRef, lo
 	return lset, s.chunkMetasBuffer, nil
 }
 
-type matchingSeriesChunkRefsSetIterator struct {
+type filteringSeriesChunkRefsSetIterator struct {
 	from     seriesChunkRefsSetIterator
 	matchers []*labels.Matcher
 
 	current seriesChunkRefsSet
 }
 
-func (m *matchingSeriesChunkRefsSetIterator) Next() bool {
+func (m *filteringSeriesChunkRefsSetIterator) Next() bool {
 	if !m.from.Next() {
 		return false
 	}
@@ -1072,11 +1072,11 @@ func (m *matchingSeriesChunkRefsSetIterator) Next() bool {
 	return true
 }
 
-func (m *matchingSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
+func (m *filteringSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
 	return m.current
 }
 
-func (m *matchingSeriesChunkRefsSetIterator) Err() error {
+func (m *filteringSeriesChunkRefsSetIterator) Err() error {
 	return m.from.Err()
 }
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -702,7 +702,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		return nil, errors.New("set size must be a positive number")
 	}
 
-	ps, deferredMatchers, err := indexr.ExpandedPostings(ctx, matchers, stats)
+	ps, pendingMatchers, err := indexr.ExpandedPostings(ctx, matchers, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "expanded matching postings")
 	}
@@ -724,8 +724,8 @@ func openBlockSeriesChunkRefsSetsIterator(
 		chunkRangesPerSeries,
 		logger,
 	)
-	if len(deferredMatchers) > 0 {
-		iterator = &filteringSeriesChunkRefsSetIterator{from: iterator, matchers: deferredMatchers}
+	if len(pendingMatchers) > 0 {
+		iterator = &filteringSeriesChunkRefsSetIterator{from: iterator, matchers: pendingMatchers}
 	}
 
 	// Track the time spent loading series and chunk refs.

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1261,7 +1261,7 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			// Setup
 			block := newTestBlock()
 			indexr := block.indexReader()
-			postings, err := indexr.ExpandedPostings(context.Background(), testCase.matchers, newSafeQueryStats())
+			postings, _, err := indexr.ExpandedPostings(context.Background(), testCase.matchers, newSafeQueryStats())
 			require.NoError(t, err)
 			postingsIterator := newPostingsSetsIterator(
 				postings,

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1640,71 +1640,49 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_pendingMatchers(t *testing.T) {
 		matchers        []*labels.Matcher
 		pendingMatchers []*labels.Matcher
 		batchSize       int
-
-		expectedSeries []seriesChunkRefsSet
 	}{
 		"applies pending matchers": {
-			matchers:        []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "1_1.*"), labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*")},
-			pendingMatchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "1_1.*")},
-			batchSize:       100,
-			expectedSeries: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_1"+labelLongSuffix, "s", "foo")},
-				}},
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "n", "1_1.*"),
+				labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*"),
 			},
+			pendingMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "n", "1_1.*"),
+			},
+			batchSize: 100,
 		},
 		"applies pending matchers when they match all series": {
-			matchers:        []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "n", ""), labels.MustNewMatcher(labels.MatchEqual, "s", "foo"), labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*")},
-			pendingMatchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "n", "")},
-			batchSize:       100,
-			expectedSeries: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_0"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_1"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_2"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_3"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_4"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_5"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_6"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_7"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_8"+labelLongSuffix, "s", "foo")},
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_9"+labelLongSuffix, "s", "foo")},
-				}},
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "n", ""),
+				labels.MustNewMatcher(labels.MatchEqual, "s", "foo"),
+				labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*"),
 			},
+			pendingMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "n", ""),
+			},
+			batchSize: 100,
 		},
 		"applies pending matchers when they match all series (with some completely empty batches)": {
-			matchers:        []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "n", ""), labels.MustNewMatcher(labels.MatchEqual, "s", "foo"), labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*")},
-			pendingMatchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "n", "")},
-			batchSize:       1,
-			expectedSeries: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_0"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_1"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_2"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_3"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_4"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_5"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_6"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_7"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_8"+labelLongSuffix, "s", "foo")},
-				}}, {series: []seriesChunkRefs{
-					{lset: labels.FromStrings("i", "100"+labelLongSuffix, "j", "bar", "n", "1_9"+labelLongSuffix, "s", "foo")},
-				}},
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "n", ""),
+				labels.MustNewMatcher(labels.MatchEqual, "s", "foo"),
+				labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*"),
 			},
+			pendingMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "n", ""),
+			},
+			batchSize: 1,
 		},
 		"applies pending matchers when they match no series": {
-			matchers:        []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", ""), labels.MustNewMatcher(labels.MatchEqual, "s", "foo"), labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*")},
-			pendingMatchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "")},
-			batchSize:       100,
-			expectedSeries:  []seriesChunkRefsSet{},
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "n", ""),
+				labels.MustNewMatcher(labels.MatchEqual, "s", "foo"),
+				labels.MustNewMatcher(labels.MatchRegexp, "i", "100.*"),
+			},
+			pendingMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "n", ""),
+			},
+			batchSize: 100,
 		},
 	}
 
@@ -1714,35 +1692,39 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_pendingMatchers(t *testing.T) {
 			require.Subset(t, testCase.matchers, testCase.pendingMatchers, "pending matchers should be a subset of all matchers")
 
 			var block = newTestBlock()
-			block.pendingReaders.Add(1) // this is hacky, but can be replaced only block.indexReade() accepts a strategy
-			indexReader := newBucketIndexReader(block, omitMatchersStrategy{testCase.pendingMatchers})
+			block.pendingReaders.Add(2) // this is hacky, but can be replaced only block.indexReade() accepts a strategy
+			querySeries := func(indexReader *bucketIndexReader) []seriesChunkRefsSet {
+				hashCache := hashcache.NewSeriesHashCache(1024 * 1024).GetBlockCache(block.meta.ULID.String())
+				iterator, err := openBlockSeriesChunkRefsSetsIterator(
+					ctx,
+					testCase.batchSize,
+					"",
+					indexReader,
+					newInMemoryIndexCache(t),
+					block.meta,
+					testCase.matchers,
+					nil,
+					cachedSeriesHasher{hashCache},
+					true, // skip chunks since we are testing labels filtering
+					block.meta.MinTime,
+					block.meta.MaxTime,
+					2,
+					newSafeQueryStats(),
+					nil,
+				)
+				require.NoError(t, err)
+				allSets := readAllSeriesChunkRefsSet(iterator)
+				assert.NoError(t, iterator.Err())
+				return allSets
+			}
+
+			indexReaderOmittingMatchers := newBucketIndexReader(block, omitMatchersStrategy{testCase.pendingMatchers})
+			defer indexReaderOmittingMatchers.Close()
+
+			indexReader := newBucketIndexReader(block, selectAllStrategy{})
 			defer indexReader.Close()
 
-			hashCache := hashcache.NewSeriesHashCache(1024 * 1024).GetBlockCache(block.meta.ULID.String())
-
-			minT, maxT := block.meta.MinTime, block.meta.MaxTime
-			iterator, err := openBlockSeriesChunkRefsSetsIterator(
-				ctx,
-				testCase.batchSize,
-				"",
-				indexReader,
-				newInMemoryIndexCache(t),
-				block.meta,
-				testCase.matchers,
-				nil,
-				cachedSeriesHasher{hashCache},
-				true, // skip chunks since we are testing labels filtering
-				minT,
-				maxT,
-				2,
-				newSafeQueryStats(),
-				nil,
-			)
-			require.NoError(t, err)
-
-			actualSeriesSets := readAllSeriesChunkRefsSet(iterator)
-			assertSeriesChunkRefsSetsEqual(t, block.meta.ULID, testCase.expectedSeries, actualSeriesSets)
-			assert.NoError(t, iterator.Err())
+			assert.Equal(t, querySeries(indexReader), querySeries(indexReaderOmittingMatchers))
 		})
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR adds deferred matchers to the exported interface of the
`bucketIndexReader` and adds an iterator which filters out series that do
not match the deferred matchers.

In practice this iterator will be unused because we are still
using the `selectAllStrategy` which doesn't omit any posting groups.
More strategies will be added in a later PR.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/4593

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
