### PR TITLE
Set a well known user agent in mimirtool analyze prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 
 * [ENHANCEMENT] Backfill: mimirtool will now sleep and retry if it receives a 429 response while trying to finish an upload due to validation concurrency limits. #4598
 * [ENHANCEMENT] `gauge` panel type is supported now in `mimirtool analyze dashboard`. #4679
+* [ENHANCEMENT] Set a `User-Agent` header on requests to Mimir or Prometheus servers. #4700
 
 ### Query-tee
 

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -15,10 +15,11 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/crypto/tls"
-	"github.com/grafana/mimir/pkg/util/version"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/mimir/pkg/util/version"
 )
 
 const (

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/crypto/tls"
+	"github.com/grafana/mimir/pkg/util/version"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/common/user"
@@ -26,6 +27,7 @@ const (
 )
 
 var (
+	UserAgent           = fmt.Sprintf("mimirtool/%s %s", version.Version, version.Info())
 	ErrResourceNotFound = errors.New("requested resource not found")
 	errConflict         = errors.New("conflict with current state of target resource")
 	errTooManyRequests  = errors.New("too many requests")
@@ -243,5 +245,6 @@ func buildRequest(ctx context.Context, p, m string, endpoint url.URL, payload io
 	if contentLength >= 0 {
 		r.ContentLength = contentLength
 	}
+	r.Header.Add("User-Agent", UserAgent)
 	return r, nil
 }

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/mimir/pkg/mimirtool/analyze"
+	"github.com/grafana/mimir/pkg/mimirtool/client"
 )
 
 type PrometheusAnalyzeCommand struct {
@@ -105,8 +106,9 @@ func (cmd *PrometheusAnalyzeCommand) parseUsedMetrics() (model.LabelValues, erro
 
 func (cmd *PrometheusAnalyzeCommand) newAPI() (v1.API, error) {
 	rt := api.DefaultRoundTripper
+	rt = config.NewUserAgentRoundTripper(client.UserAgent, rt)
 	if cmd.username != "" {
-		rt = config.NewBasicAuthRoundTripper(cmd.username, config.Secret(cmd.password), "", api.DefaultRoundTripper)
+		rt = config.NewBasicAuthRoundTripper(cmd.username, config.Secret(cmd.password), "", rt)
 	}
 
 	client, err := api.NewClient(api.Config{

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/grafana/mimir/pkg/mimirtool/client"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -30,6 +29,8 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/grafana/mimir/pkg/mimirtool/client"
 )
 
 var (

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/grafana/mimir/pkg/mimirtool/client"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -136,6 +137,9 @@ func (c *LoadgenCommand) run(k *kingpin.ParseContext) error {
 		writeClient, err := remote.NewWriteClient("loadgen", &remote.ClientConfig{
 			URL:     &config.URL{URL: writeURL},
 			Timeout: model.Duration(c.writeTimeout),
+			Headers: map[string]string{
+				"User-Agent": client.UserAgent,
+			},
 		})
 		if err != nil {
 			return err

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/mimir/pkg/mimirtool/backfill"
+	"github.com/grafana/mimir/pkg/mimirtool/client"
 )
 
 type RemoteReadCommand struct {
@@ -201,6 +202,9 @@ func (c *RemoteReadCommand) readClient() (remote.ReadClient, error) {
 				Username: c.tenantID,
 				Password: config_util.Secret(c.apiKey),
 			},
+		},
+		Headers: map[string]string{
+			"User-Agent": client.UserAgent,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
#### What this PR does

This PR adds a user agent header to mimirtool when interacting with Mimir or Prometheus servers. This is a change from the existing (default) user agent string of `Go-http-client/1.1`. Instead, it will be something like `mimirtool/2.7.1 (version=2.7.1, branch=logiraptor/set-mimirtool-ua, revision=92a468898)`.

We see many customers using mimirtool to optimize their metrics footprint in Grafana Cloud, but it's currently difficult to separate this use case from user queries. Adding this user agent makes it trivial, since the Mimir query frontend already logs user agents in the query stats logs.

It will most likely take a while for users to update to versions of mimirtool that include this change, but by getting this merged now we can point customers to upgrade when the issue arises.

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
