### PR TITLE
Fix IsFloatHistogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [BUGFIX] Packaging: flag `/etc/default/mimir` and `/etc/sysconfig/mimir` as config to prevent overwrite. #4587
 * [BUGFIX] Query-frontend: don't retry queries which error inside PromQL. #4643
 * [BUGFIX] Store-gateway & query-frontend: report more consistent statistics for fetched index bytes. #4671
+* [BUGFIX] Native histograms: fix how IsFloatHistogram determines if mimirpb.Histogram is a float histogram. #4706
 
 ### Mixin
 

--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -8,17 +8,7 @@ import (
 
 func (h Histogram) IsFloatHistogram() bool {
 	_, ok := h.GetCount().(*Histogram_CountFloat)
-	// _, ok := h.GetZeroCount().(*Histogram_ZeroCountFloat)
 	return ok
-	// spanTotalPos := 0
-	// for _, sp := range h.GetPositiveSpans() {
-	// 	spanTotalPos += int(sp.Length)
-	// }
-	// spanTotalNeg := 0
-	// for _, sp := range h.GetNegativeSpans() {
-	// 	spanTotalNeg += int(sp.Length)
-	// }
-	// return spanTotalPos == len(h.GetPositiveCounts()) && spanTotalNeg == len(h.GetNegativeCounts())
 }
 
 func (h Histogram) IsGauge() bool {

--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -7,7 +7,18 @@ import (
 )
 
 func (h Histogram) IsFloatHistogram() bool {
-	return h.GetCountFloat() > 0 || h.GetZeroCountFloat() > 0
+	_, ok := h.GetCount().(*Histogram_CountFloat)
+	// _, ok := h.GetZeroCount().(*Histogram_ZeroCountFloat)
+	return ok
+	// spanTotalPos := 0
+	// for _, sp := range h.GetPositiveSpans() {
+	// 	spanTotalPos += int(sp.Length)
+	// }
+	// spanTotalNeg := 0
+	// for _, sp := range h.GetNegativeSpans() {
+	// 	spanTotalNeg += int(sp.Length)
+	// }
+	// return spanTotalPos == len(h.GetPositiveCounts()) && spanTotalNeg == len(h.GetNegativeCounts())
 }
 
 func (h Histogram) IsGauge() bool {

--- a/pkg/mimirpb/custom_test.go
+++ b/pkg/mimirpb/custom_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/cortexpb/compat_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package mimirpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/histogram"
+)
+
+func TestIsFloatHistogram(t *testing.T) {
+	tests := map[string]struct {
+		histogram Histogram
+		expected  bool
+	}{
+		"empty int histogram": {
+			histogram: FromHistogramToHistogramProto(0, &histogram.Histogram{
+				Sum:           0,
+				Count:         0,
+				ZeroThreshold: 0.001,
+				Schema:        2,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 1},
+					{Offset: 3, Length: 1},
+					{Offset: 2, Length: 2},
+				},
+				PositiveBuckets: []int64{0, 0, 0, 0},
+			}),
+			expected: false,
+		},
+		"empty float histogram": {
+			histogram: FromFloatHistogramToHistogramProto(0, &histogram.FloatHistogram{
+				Sum:           0,
+				Count:         0,
+				ZeroThreshold: 0.001,
+				Schema:        2,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 1},
+					{Offset: 3, Length: 1},
+					{Offset: 2, Length: 2},
+				},
+				PositiveBuckets: []float64{0, 0, 0, 0},
+			}),
+			expected: true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			res := testData.histogram.IsFloatHistogram()
+			require.Equal(t, testData.expected, res)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does

Fix bug mentioned in slack: float histograms are sometimes wrongly interpreted as integer histograms (you can test the 1st commit to see the failing new test, and the 2nd and 3rd commits make that test pass)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
