### PR TITLE
Add build info metric to mimir continuous test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@
 * [ENHANCEMENT] `gauge` panel type is supported now in `mimirtool analyze dashboard`. #4679
 * [ENHANCEMENT] Set a `User-Agent` header on requests to Mimir or Prometheus servers. #4700
 
+### Mimir Continuous Test
+
+* [ENHANCEMENT] Added a new metric `mimir_continuous_test_build_info` that reports version information, similar to the existing `cortex_build_info` metric exposed by other Mimir components. #4712
+
 ### Query-tee
 
 ### Documentation

--- a/cmd/mimir-continuous-test/main.go
+++ b/cmd/mimir-continuous-test/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/mimir/pkg/continuoustest"
 	"github.com/grafana/mimir/pkg/util/instrumentation"
 	util_log "github.com/grafana/mimir/pkg/util/log"
+	"github.com/grafana/mimir/pkg/util/version"
 )
 
 type Config struct {
@@ -56,6 +57,7 @@ func main() {
 
 	// Run the instrumentation server.
 	registry := prometheus.NewRegistry()
+	registry.MustRegister(version.NewCollector("mimir_continuous_test"))
 	registry.MustRegister(collectors.NewGoCollector())
 
 	i := instrumentation.NewMetricsServer(cfg.ServerMetricsPort, registry)


### PR DESCRIPTION
#### What this PR does

Add a metric `mimir_continuous_test_build_info` in mimir continuous test metrics endpoint. Same as cortex_build_info, it allow to make sure all deployment are up-to-date

#### Which issue(s) this PR fixes or relates to
None

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
