### PR TITLE
Added missing imagePullSecrets configuration to the graphite-web mimir helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -42,6 +42,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
 * [BUGFIX] Set `gateway` and `nginx` HPA MetricTarget type to Utilization to align with usage of averageUtilization. #4642
+* [BUGFIX] Add missing imagePullSecrets configuration to the `graphite-web` deployment template. #4716
 
 ## 4.3.0
 

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-web/graphite-web-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-web/graphite-web-dep.yaml
@@ -29,6 +29,11 @@ spec:
       {{- end }}
       securityContext:
         {{- include "mimir.lib.podSecurityContext" (dict "ctx" . "component" "graphite-web") | nindent 8 }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: graphite-web
           image: "{{ .Values.graphite.web.image.repository }}:{{ .Values.graphite.web.image.tag }}"

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-web/graphite-web-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-web/graphite-web-dep.yaml
@@ -29,6 +29,7 @@ spec:
       {{- end }}
       securityContext:
         {{- include "mimir.lib.podSecurityContext" (dict "ctx" . "component" "graphite-web") | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}


### PR DESCRIPTION
What this PR does:
Adds imagePullSecrets option for graphite-web deployment for the graphite-proxy, like in every other deployment.