### PR TITLE
ingester: save time by reusing hash calculation in active series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * [ENHANCEMENT] Query-frontend: improve readability of distributed tracing spans. #4656
 * [ENHANCEMENT] Update Docker base images from `alpine:3.17.2` to `alpine:3.17.3`. #4685
 * [ENHANCEMENT] Querier: improve performance when shuffle sharding is enabled and the shard size is large. #4711
+* [ENHANCEMENT] Ingester: improve performance when Active Series Tracker is in use. #4717
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -87,8 +87,7 @@ func (c *ActiveSeries) CurrentConfig() CustomTrackersConfig {
 }
 
 // UpdateSeries updates series timestamp to 'now'. Function is called to make a copy of labels if entry doesn't exist yet.
-func (c *ActiveSeries) UpdateSeries(series labels.Labels, now time.Time, labelsCopy func(labels.Labels) labels.Labels) {
-	fp := series.Hash()
+func (c *ActiveSeries) UpdateSeries(series labels.Labels, fp uint64, now time.Time, labelsCopy func(labels.Labels) labels.Labels) {
 	stripeID := fp % numStripes
 
 	c.stripes[stripeID].updateSeriesTimestamp(now, series, fp, labelsCopy)

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -32,17 +32,17 @@ func TestActiveSeries_UpdateSeries_NoMatchers(t *testing.T) {
 	assert.Nil(t, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, time.Now(), copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
 	allActive, _, valid = c.Active(time.Now())
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, time.Now(), copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
 	allActive, _, valid = c.Active(time.Now())
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls2, time.Now(), copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
 	allActive, _, valid = c.Active(time.Now())
 	assert.Equal(t, 2, allActive)
 	assert.True(t, valid)
@@ -61,25 +61,25 @@ func TestActiveSeries_UpdateSeries_WithMatchers(t *testing.T) {
 	assert.Equal(t, []int{0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, time.Now(), copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls2, time.Now(), copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 2, allActive)
 	assert.Equal(t, []int{1}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls3, time.Now(), copyFn)
+	c.UpdateSeries(ls3, ls3.Hash(), time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 3, allActive)
 	assert.Equal(t, []int{2}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls3, time.Now(), copyFn)
+	c.UpdateSeries(ls3, ls3.Hash(), time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 3, allActive)
 	assert.Equal(t, []int{2}, activeMatching)
@@ -93,8 +93,8 @@ func TestActiveSeries_ShouldCorrectlyHandleHashCollisions(t *testing.T) {
 
 	require.True(t, ls1.Hash() == ls2.Hash())
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
-	c.UpdateSeries(ls1, time.Now(), copyFn)
-	c.UpdateSeries(ls2, time.Now(), copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
 
 	allActive, _, valid := c.Active(time.Now())
 	assert.Equal(t, 2, allActive)
@@ -117,7 +117,7 @@ func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
 			c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 
 			for i := 0; i < len(series); i++ {
-				c.UpdateSeries(series[i], time.Unix(int64(i), 0), copyFn)
+				c.UpdateSeries(series[i], series[i].Hash(), time.Unix(int64(i), 0), copyFn)
 			}
 
 			c.purge(time.Unix(int64(ttl), 0))
@@ -156,7 +156,7 @@ func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
 			expMatchingSeries := 0
 
 			for i, s := range series {
-				c.UpdateSeries(series[i], time.Unix(int64(i), 0), copyFn)
+				c.UpdateSeries(series[i], series[i].Hash(), time.Unix(int64(i), 0), copyFn)
 
 				// if this series is matching, and they're within the ttl
 				if asm.matchers[0].Matches(s) && i >= ttl {
@@ -185,22 +185,22 @@ func TestActiveSeries_PurgeOpt(t *testing.T) {
 	currentTime := time.Now()
 	c := NewActiveSeries(&Matchers{}, 59*time.Second)
 
-	c.UpdateSeries(ls1, currentTime.Add(-2*time.Minute), copyFn)
-	c.UpdateSeries(ls2, currentTime, copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), currentTime.Add(-2*time.Minute), copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), currentTime, copyFn)
 
 	allActive, _, valid := c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, currentTime.Add(-1*time.Minute), copyFn)
-	c.UpdateSeries(ls2, currentTime, copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), currentTime.Add(-1*time.Minute), copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), currentTime, copyFn)
 
 	allActive, _, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
 	// This will *not* update the series, since there is already newer timestamp.
-	c.UpdateSeries(ls2, currentTime.Add(-1*time.Minute), copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), currentTime.Add(-1*time.Minute), copyFn)
 
 	allActive, _, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
@@ -223,7 +223,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 	assert.Equal(t, []int{0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, currentTime, copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1}, activeMatching)
@@ -235,8 +235,8 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 
 	// Adding timeout time to make Active results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
-	c.UpdateSeries(ls1, currentTime, copyFn)
-	c.UpdateSeries(ls2, currentTime, copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls2, ls2.Hash(), currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 2, allActive)
 	assert.Equal(t, []int{2}, activeMatching)
@@ -247,7 +247,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 
 	// Adding timeout time to make Active results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
-	c.UpdateSeries(ls3, currentTime, copyFn)
+	c.UpdateSeries(ls3, ls3.Hash(), currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int(nil), activeMatching)
@@ -261,7 +261,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 
 	// Adding timeout time to make Active results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
-	c.UpdateSeries(ls4, currentTime, copyFn)
+	c.UpdateSeries(ls4, ls4.Hash(), currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{0, 1}, activeMatching)
@@ -283,7 +283,7 @@ func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
 	assert.Equal(t, []int{0, 0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, currentTime, copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1, 1}, activeMatching)
@@ -319,7 +319,7 @@ func TestActiveSeries_ReloadSeriesMatchers_SameSizeNewLabels(t *testing.T) {
 	assert.Equal(t, []int{0, 0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, currentTime, copyFn)
+	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1, 1}, activeMatching)
@@ -353,6 +353,7 @@ func BenchmarkActiveSeriesTest_single_series(b *testing.B) {
 
 func benchmarkActiveSeriesConcurrencySingleSeries(b *testing.B, goroutines int) {
 	series := labels.FromStrings("a", "a")
+	hash := series.Hash()
 
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 
@@ -370,7 +371,7 @@ func benchmarkActiveSeriesConcurrencySingleSeries(b *testing.B, goroutines int) 
 
 			for ix := 0; ix < max; ix++ {
 				now = now.Add(time.Duration(ix) * time.Millisecond)
-				c.UpdateSeries(series, now, copyFn)
+				c.UpdateSeries(series, hash, now, copyFn)
 			}
 		}()
 	}
@@ -405,6 +406,7 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 		b.Run(fmt.Sprintf("rounds=%d series=%d", tt.nRounds, tt.nSeries), func(b *testing.B) {
 			// Prepare series
 			series := make([]labels.Labels, tt.nSeries)
+			hash := make([]uint64, tt.nSeries)
 			for s := 0; s < tt.nSeries; s++ {
 				lbls := make(labels.Labels, 10)
 				for i := 0; i < len(lbls); i++ {
@@ -412,6 +414,7 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 					lbls[i] = labels.Label{Name: fmt.Sprintf("abcdefghijabcdefghi%d", i), Value: fmt.Sprintf("abcdefghijabcdefghijabcdefghijabcd%d", s)}
 				}
 				series[s] = lbls
+				hash[s] = lbls.Hash()
 			}
 
 			now := time.Now().UnixNano()
@@ -421,7 +424,7 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 				c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 				for round := 0; round <= tt.nRounds; round++ {
 					for ix := 0; ix < tt.nSeries; ix++ {
-						c.UpdateSeries(series[ix], time.Unix(0, now), copyFn)
+						c.UpdateSeries(series[ix], hash[ix], time.Unix(0, now), copyFn)
 						now++
 					}
 				}
@@ -456,9 +459,9 @@ func benchmarkPurge(b *testing.B, twice bool) {
 		// Prepare series
 		for ix, s := range series {
 			if ix < numExpiresSeries {
-				c.UpdateSeries(s, currentTime.Add(-DefaultTimeout), copyFn)
+				c.UpdateSeries(s, s.Hash(), currentTime.Add(-DefaultTimeout), copyFn)
 			} else {
-				c.UpdateSeries(s, currentTime, copyFn)
+				c.UpdateSeries(s, s.Hash(), currentTime, copyFn)
 			}
 		}
 


### PR DESCRIPTION
#### What this PR does

Since we always calculate the hash to pass to `Appender.GetRef()` we can re-use that value and save time.

Profiles of ingesters using ActivityTracker show about 3.5% of CPU time goes into re-calculating the series hash.

```
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/ingester/activeseries
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                                             │  before.txt   │              after.txt              │
                                                             │    sec/op     │    sec/op     vs base               │
ActiveSeriesTest_single_series/50-4                             57.98n ±  5%   54.15n ±  3%   -6.61% (p=0.002 n=6)
ActiveSeriesTest_single_series/100-4                            57.82n ±  4%   52.32n ±  1%   -9.50% (p=0.002 n=6)
ActiveSeriesTest_single_series/500-4                            66.08n ± 13%   51.37n ±  4%  -22.27% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000-4             117.83m ± 54%   59.30m ±  2%  -49.67% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=1000000-4            1361.8m ± 16%   812.6m ±  6%  -40.33% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000-4             544.0m ±  3%   258.4m ± 10%  -52.50% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=1000000-4             5.777 ±  5%    3.033 ±  3%  -47.50% (p=0.002 n=6)
ActiveSeries_Active_once-4                                      300.1µ ±  7%   318.9µ ±  7%        ~ (p=0.310 n=6)
ActiveSeries_Active_twice-4                                     322.6µ ±  7%   319.0µ ±  4%        ~ (p=0.310 n=6)


                                                             │   before.txt   │              after.txt               │
                                                             │      B/op      │     B/op      vs base                │
ActiveSeriesTest_single_series/50-4                              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ActiveSeriesTest_single_series/100-4                             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ActiveSeriesTest_single_series/500-4                             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ActiveSeries_UpdateSeries/rounds=1_series=100000-4             18.69Mi ± 0%     18.70Mi ± 0%       ~ (p=0.310 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=1000000-4            227.4Mi ± 0%     227.4Mi ± 0%       ~ (p=0.485 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000-4            18.69Mi ± 0%     18.70Mi ± 0%       ~ (p=0.394 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=1000000-4           227.3Mi ± 0%     227.4Mi ± 0%       ~ (p=0.093 n=6)
ActiveSeries_Active_once-4                                       128.5 ± 6%       130.5 ± 5%       ~ (p=0.377 n=6)
ActiveSeries_Active_twice-4                                      136.5 ± 5%       134.0 ± 4%       ~ (p=0.437 n=6)
```

#### Checklist

- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
