### PR TITLE
Adding support of generic panels to `mimirtool analyze dashboard` command and query parsing improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
 * [ENHANCEMENT] Backfill: mimirtool will now sleep and retry if it receives a 429 response while trying to finish an upload due to validation concurrency limits. #4598
 * [ENHANCEMENT] `gauge` panel type is supported now in `mimirtool analyze dashboard`. #4679
 * [ENHANCEMENT] Set a `User-Agent` header on requests to Mimir or Prometheus servers. #4700
+* [ENHANCEMENT] Generic panel type support in `mimirtool analyze dashboard` + support for queries with variables. #4726
 
 ### Mimir Continuous Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
 
+### Mimirtool
+
+* [ENHANCEMENT] Generic panel type support in `mimirtool analyze dashboard` + support for queries with variables. #4726
+
 ### Documentation
 
 * [ENHANCEMENT] Improve `MimirIngesterReachingTenantsLimit` runbook. #4744 #4752
@@ -141,7 +145,6 @@
 * [ENHANCEMENT] Backfill: mimirtool will now sleep and retry if it receives a 429 response while trying to finish an upload due to validation concurrency limits. #4598
 * [ENHANCEMENT] `gauge` panel type is supported now in `mimirtool analyze dashboard`. #4679
 * [ENHANCEMENT] Set a `User-Agent` header on requests to Mimir or Prometheus servers. #4700
-* [ENHANCEMENT] Generic panel type support in `mimirtool analyze dashboard` + support for queries with variables. #4726
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -205,6 +205,8 @@ func parseQuery(query string, metrics map[string]struct{}) error {
 	query = strings.ReplaceAll(query, "$__range", "1d")
 	query = strings.ReplaceAll(query, "${__range_s:glob}", "30")
 	query = strings.ReplaceAll(query, "${__range_s}", "30")
+	re := regexp.MustCompile(`\[\$.*\]`)
+	query = re.ReplaceAllString(query, "[5m]")
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
 		return err

--- a/pkg/mimirtool/analyze/grafana_test.go
+++ b/pkg/mimirtool/analyze/grafana_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/cortex-tools/blob/main/pkg/analyse/grafana.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package analyze
+
+import (
+	"testing"
+)
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		query           string
+		expectedMetrics map[string]struct{}
+		shouldError     bool
+		errorMsg        string
+	}{
+		{
+			query: `sum(rate(my_metric[$__interval])) by (my_label) > 0`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `sum(rate(my_metric[$interval])) by (my_label) > 0`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `sum(rate(my_metric[$resolution])) by (my_label) > 0`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `sum(rate(my_metric[$__rate_interval])) by (my_label) > 0`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `sum(rate(my_metric[$__range])) by (my_label) > 0`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `sum(rate(my_metric[$agregation_window])) by (my_label) > 0`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `sum(my_metric)`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `my_metric`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `my_metric{label=${value}}`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `my_metric{label=${value:format}}`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `my_metric{label=$value}`,
+			expectedMetrics: map[string]struct{}{
+				"my_metric": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `$my_metric{label=$value}`,
+			expectedMetrics: map[string]struct{}{
+				"variable": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `${my_metric}{label=$value}`,
+			expectedMetrics: map[string]struct{}{
+				"variable": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+		{
+			query: `${my_metric:format}{label=$value}`,
+			expectedMetrics: map[string]struct{}{
+				"variable": {},
+			},
+			shouldError: false,
+			errorMsg:    "",
+		},
+	}
+
+	for _, test := range tests {
+		metrics := make(map[string]struct{})
+		err := parseQuery(test.query, metrics)
+
+		if test.shouldError && err == nil {
+			t.Errorf("Expected error, but got no error for query: %s", test.query)
+		}
+
+		if !test.shouldError && err != nil {
+			t.Errorf("Unexpected error for query: %s: %v", test.query, err)
+		}
+
+		if len(metrics) != len(test.expectedMetrics) {
+			t.Errorf("For query %s: Expected %d metrics, but got %d", test.query, len(test.expectedMetrics), len(metrics))
+		} else {
+			for m := range metrics {
+				if _, ok := test.expectedMetrics[m]; !ok {
+					t.Errorf("For query %s: Unexpected metric found: %s", test.query, m)
+				}
+			}
+		}
+	}
+}

--- a/pkg/mimirtool/minisdk/panel.go
+++ b/pkg/mimirtool/minisdk/panel.go
@@ -139,7 +139,7 @@ func (p *Panel) GetTargets() *[]Target {
 	case TextType:
 		return &p.TextPanel.Targets
 	case LogsType:
-		return &p.LogsPanel.Targets
+		return &[]Target{}
 	case DashlistType:
 		return &p.DashlistPanel.Targets
 	case PluginlistType:

--- a/pkg/mimirtool/minisdk/panel.go
+++ b/pkg/mimirtool/minisdk/panel.go
@@ -27,6 +27,7 @@ const (
 	HeatmapType
 	TimeseriesType
 	GaugeType
+	LogsType
 )
 
 type (
@@ -48,6 +49,7 @@ type (
 		*HeatmapPanel
 		*TimeseriesPanel
 		*GaugePanel
+		*LogsPanel
 		*CustomPanel
 	}
 	panelType   int8
@@ -64,21 +66,30 @@ type (
 	TablePanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
-	TextPanel       struct{}
+	TextPanel struct {
+		Targets []Target `json:"targets,omitempty"`
+	}
 	SinglestatPanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
 	StatPanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
-	DashlistPanel   struct{}
-	PluginlistPanel struct{}
-	AlertlistPanel  struct{}
+	DashlistPanel   struct {
+		Targets []Target `json:"targets,omitempty"`
+	}
+	PluginlistPanel struct {
+		Targets []Target `json:"targets,omitempty"`
+	}
+	AlertlistPanel  struct {
+		Targets []Target `json:"targets,omitempty"`
+	}
 	BarGaugePanel   struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
 	RowPanel struct {
-		Panels []Panel `json:"panels"`
+		Panels  []Panel `json:"panels"`
+		Targets []Target `json:"targets,omitempty"`
 	}
 	HeatmapPanel struct {
 		Targets []Target `json:"targets,omitempty"`
@@ -89,7 +100,12 @@ type (
 	GaugePanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
-	CustomPanel map[string]interface{}
+	LogsPanel struct {
+		Targets []Target `json:"targets,omitempty"`
+	}
+	CustomPanel struct {
+		Targets []Target `json:"targets,omitempty"`
+	}
 )
 
 // for an any panel
@@ -118,6 +134,20 @@ func (p *Panel) GetTargets() *[]Target {
 		return &p.TimeseriesPanel.Targets
 	case GaugeType:
 		return &p.GaugePanel.Targets
+	case RowType:
+		return &p.RowPanel.Targets
+	case TextType:
+		return &p.TextPanel.Targets
+	case LogsType:
+		return &p.LogsPanel.Targets
+	case DashlistType:
+		return &p.DashlistPanel.Targets
+	case PluginlistType:
+		return &p.PluginlistPanel.Targets
+	case AlertlistType:
+		return &p.AlertlistPanel.Targets
+	case CustomType:
+		return &p.CustomPanel.Targets
 	default:
 		return nil
 	}
@@ -202,8 +232,14 @@ func (p *Panel) UnmarshalJSON(b []byte) (err error) {
 		if err = json.Unmarshal(b, &gauge); err == nil {
 			p.GaugePanel = &gauge
 		}
+	case "logs":
+		var logs LogsPanel
+		p.OfType = LogsType
+		if err = json.Unmarshal(b, &logs); err == nil {
+			p.LogsPanel = &logs
+		}
 	default:
-		var custom = make(CustomPanel)
+		var custom CustomPanel
 		p.OfType = CustomType
 		if err = json.Unmarshal(b, &custom); err == nil {
 			p.CustomPanel = &custom

--- a/pkg/mimirtool/minisdk/panel.go
+++ b/pkg/mimirtool/minisdk/panel.go
@@ -75,20 +75,20 @@ type (
 	StatPanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
-	DashlistPanel   struct {
+	DashlistPanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
 	PluginlistPanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
-	AlertlistPanel  struct {
+	AlertlistPanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
-	BarGaugePanel   struct {
+	BarGaugePanel struct {
 		Targets []Target `json:"targets,omitempty"`
 	}
 	RowPanel struct {
-		Panels  []Panel `json:"panels"`
+		Panels  []Panel  `json:"panels"`
 		Targets []Target `json:"targets,omitempty"`
 	}
 	HeatmapPanel struct {


### PR DESCRIPTION
#### What this PR does

Adding generic panel type support to `mimirtool analyze dashboard` command. Current implementation requires explicit panel implementation for each panel type. Generic implementation tries to parse targets of unimplemented panel types. It will mute parsing errors for the panels, which can't have any targets (row, text, alertlist) or ignore targets of panels, which can't have valid Prometheus queries (logs).

Queries may contain also dashboard variables with different formatting, e.g. 
```
sum(
   $My_metric{
     label1=$LABELVALUE1,
     label2=${Label_value2},
     label3=${LABELvalue3:raw}
  }[$aggregation_window]
)
```
Support for these variables is added into query parsing function.

#### Which issue(s) this PR fixes or relates to

Fixes #4699

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
