### PR TITLE
Fix OpenShift route targetPort matching to service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## main / unreleased
 
 ### Grafana Mimir
-* [BUGFIX] Helm-Chart: fix route to service port mapping. #4727 
+
 * [CHANGE] Ingester: changed experimental CLI flag from `-out-of-order-blocks-external-label-enabled` to `-ingester.out-of-order-blocks-external-label-enabled` #4440
 * [CHANGE] Store-gateway: The following metrics have been removed: #4332
     * `cortex_bucket_store_series_get_all_duration_seconds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## main / unreleased
 
 ### Grafana Mimir
-
+* [BUGFIX] Helm-Chart: fix route to service port mapping. #4727 
 * [CHANGE] Ingester: changed experimental CLI flag from `-out-of-order-blocks-external-label-enabled` to `-ingester.out-of-order-blocks-external-label-enabled` #4440
 * [CHANGE] Store-gateway: The following metrics have been removed: #4332
     * `cortex_bucket_store_series_get_all_duration_seconds`

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -39,6 +39,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Expose image repo path as helm vars for containers created by grafana-agent-operator #4645
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.4.1`. #4659
 * [ENHANCEMENT] Update minio subchart to `5.0.7`. #4705
+* [BUGFIX] Helm-Chart: fix route to service port mapping. #4727
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
 * [BUGFIX] Set `gateway` and `nginx` HPA MetricTarget type to Utilization to align with usage of averageUtilization. #4642

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-route.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-route.yaml
@@ -17,7 +17,7 @@ spec:
     name: {{ include "mimir.gateway.service.name" . }}
     weight: 100
   port:
-    targetPort: http-metric
+    targetPort: http-metrics
 {{- with .Values.gateway.route.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-route.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-route.yaml
@@ -17,6 +17,6 @@ spec:
     name: gateway-enterprise-values-mimir-gateway
     weight: 100
   port:
-    targetPort: http-metric
+    targetPort: http-metrics
   tls:
     termination: edge

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-route.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-route.yaml
@@ -17,6 +17,6 @@ spec:
     name: gateway-nginx-values-mimir-gateway
     weight: 100
   port:
-    targetPort: http-metric
+    targetPort: http-metrics
   tls:
     termination: edge


### PR DESCRIPTION
#### What this PR does
This PR fixes the wrong port mapping from the OpenShift route to the gateway service.

#### Which issue(s) this PR fixes or relates to
Fixes #4727 

#### Checklist
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
