### PR TITLE
Add unit tests to verify Prometheus and Mimir are in sync on SampleHistogram and Label types

### DIFF
--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -566,3 +566,12 @@ func TestPrometheusSampleHistogramInSyncWithMimirPbSampleHistogram(t *testing.T)
 
 	test.RequireSameShape(t, prometheusType, protoType)
 }
+
+// Check that Promtheus Label and MimirPb LabelAdapter types converted
+// into each other with unsafe.Pointer are compatible
+func TestPrometheusLabelsInSyncWithMimirPbLabelAdapter(t *testing.T) {
+	protoType := reflect.TypeOf(LabelAdapter{})
+	prometheusType := reflect.TypeOf(labels.Label{})
+
+	test.RequireSameShape(t, prometheusType, protoType)
+}

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -8,6 +8,7 @@ package mimirpb
 import (
 	stdlibjson "encoding/json"
 	"math"
+	"reflect"
 	"strconv"
 	"testing"
 	"unsafe"
@@ -555,4 +556,13 @@ func TestFromFloatHistogramToPromHistogram(t *testing.T) {
 			require.Equal(t, c.exp, *FromFloatHistogramToPromHistogram(&c.h))
 		})
 	}
+}
+
+// Check that Prometheus and Mimir SampleHistogram types converted
+// into each other with unsafe.Pointer are compatible
+func TestPrometheusSampleHistogramInSyncWithMimirPbSampleHistogram(t *testing.T) {
+	protoType := reflect.TypeOf(SampleHistogram{})
+	prometheusType := reflect.TypeOf(model.SampleHistogram{})
+
+	test.RequireSameShape(t, prometheusType, protoType)
 }

--- a/pkg/mimirpb/query_response_extra_test.go
+++ b/pkg/mimirpb/query_response_extra_test.go
@@ -3,7 +3,6 @@
 package mimirpb
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,7 +11,8 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/stretchr/testify/require"
-	"github.com/xlab/treeprint"
+
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestAllPrometheusStatusValues(t *testing.T) {
@@ -86,73 +86,5 @@ func TestFloatHistogramProtobufTypeRemainsInSyncWithPrometheus(t *testing.T) {
 	protoType := reflect.TypeOf(FloatHistogram{})
 	prometheusType := reflect.TypeOf(histogram.FloatHistogram{})
 
-	requireSameShape(t, prometheusType, protoType)
-}
-
-func requireSameShape(t *testing.T, expectedType reflect.Type, actualType reflect.Type) {
-	expectedFormatted := prettyPrintType(expectedType)
-	actualFormatted := prettyPrintType(actualType)
-
-	require.Equal(t, expectedFormatted, actualFormatted)
-}
-
-func prettyPrintType(t reflect.Type) string {
-	if t.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("expected %s to be a struct but is %s", t.Name(), t.Kind()))
-	}
-
-	tree := treeprint.NewWithRoot("<root>")
-	addTypeToTree(t, tree)
-
-	return tree.String()
-}
-
-func addTypeToTree(t reflect.Type, tree treeprint.Tree) {
-	if t.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("unexpected kind %s", t.Kind()))
-	}
-
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-
-		switch f.Type.Kind() {
-		case reflect.Slice:
-			name := fmt.Sprintf("+%v %s: []%s", f.Offset, f.Name, f.Type.Elem().Kind())
-
-			if isPrimitive(f.Type.Elem().Kind()) {
-				tree.AddNode(name)
-			} else {
-				addTypeToTree(f.Type.Elem(), tree.AddBranch(name))
-			}
-		default:
-			name := fmt.Sprintf("+%v %s: %s", f.Offset, f.Name, f.Type.Kind())
-			tree.AddNode(name)
-		}
-	}
-}
-
-func isPrimitive(k reflect.Kind) bool {
-	switch k {
-	case reflect.Bool,
-		reflect.Int,
-		reflect.Int8,
-		reflect.Int16,
-		reflect.Int32,
-		reflect.Int64,
-		reflect.Uint,
-		reflect.Uint8,
-		reflect.Uint16,
-		reflect.Uint32,
-		reflect.Uint64,
-		reflect.Uintptr,
-		reflect.Float32,
-		reflect.Float64,
-		reflect.Complex64,
-		reflect.Complex128,
-		reflect.String,
-		reflect.UnsafePointer:
-		return true
-	default:
-		return false
-	}
+	test.RequireSameShape(t, prometheusType, protoType)
 }

--- a/pkg/mimirpb/query_response_extra_test.go
+++ b/pkg/mimirpb/query_response_extra_test.go
@@ -74,15 +74,10 @@ func extractPrometheusStrings(t *testing.T, constantType string) []string {
 	return strings
 }
 
+// Check that the Prometheus histogram.FloatHistogram and MimirPb
+// FloatHistogram types converted into each other with unsafe.Pointer
+// are compatible
 func TestFloatHistogramProtobufTypeRemainsInSyncWithPrometheus(t *testing.T) {
-	// Why does this test exist?
-	// We use unsafe casting to convert between mimirpb.FloatHistogram and Prometheus' histogram.FloatHistogram in
-	// FloatHistogramFromPrometheusModel and FloatHistogram.ToPrometheusModel.
-	// For this to be safe, the two types need to have the same shape (same fields in the same order).
-	// This test ensures that this property is maintained.
-	// The fields do not need to have the same names to make the conversion safe, but we also check the names are
-	// the same here to ensure there's no confusion (eg. two bool fields swapped).
-
 	protoType := reflect.TypeOf(FloatHistogram{})
 	prometheusType := reflect.TypeOf(histogram.FloatHistogram{})
 

--- a/pkg/util/test/shape.go
+++ b/pkg/util/test/shape.go
@@ -11,6 +11,12 @@ import (
 	"github.com/xlab/treeprint"
 )
 
+// We use unsafe casting to convert between some Mimir and Prometheus types
+// For this to be safe, the two types need to have the same shape (same fields
+// in the same order). This function requires that this property is maintained.
+// The fields do not need to have the same names to make the conversion safe,
+// but we also check the names are the same here to ensure there's no confusion
+// (eg. two bool fields swapped).
 func RequireSameShape(t *testing.T, expectedType reflect.Type, actualType reflect.Type) {
 	expectedFormatted := prettyPrintType(expectedType)
 	actualFormatted := prettyPrintType(actualType)

--- a/pkg/util/test/shape.go
+++ b/pkg/util/test/shape.go
@@ -30,6 +30,12 @@ func prettyPrintType(t reflect.Type) string {
 }
 
 func addTypeToTree(t reflect.Type, tree treeprint.Tree) {
+	if t.Kind() == reflect.Pointer {
+		name := fmt.Sprintf("%s: *%s", t.Name(), t.Elem().Kind())
+		addTypeToTree(t.Elem(), tree.AddBranch(name))
+		return
+	}
+
 	if t.Kind() != reflect.Struct {
 		panic(fmt.Sprintf("unexpected kind %s", t.Kind()))
 	}
@@ -38,6 +44,9 @@ func addTypeToTree(t reflect.Type, tree treeprint.Tree) {
 		f := t.Field(i)
 
 		switch f.Type.Kind() {
+		case reflect.Pointer:
+			name := fmt.Sprintf("+%v %s: *%s", f.Offset, f.Name, f.Type.Elem().Kind())
+			addTypeToTree(f.Type.Elem(), tree.AddBranch(name))
 		case reflect.Slice:
 			name := fmt.Sprintf("+%v %s: []%s", f.Offset, f.Name, f.Type.Elem().Kind())
 

--- a/pkg/util/test/shape.go
+++ b/pkg/util/test/shape.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xlab/treeprint"
+)
+
+func RequireSameShape(t *testing.T, expectedType reflect.Type, actualType reflect.Type) {
+	expectedFormatted := prettyPrintType(expectedType)
+	actualFormatted := prettyPrintType(actualType)
+
+	require.Equal(t, expectedFormatted, actualFormatted)
+}
+
+func prettyPrintType(t reflect.Type) string {
+	if t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("expected %s to be a struct but is %s", t.Name(), t.Kind()))
+	}
+
+	tree := treeprint.NewWithRoot("<root>")
+	addTypeToTree(t, tree)
+
+	return tree.String()
+}
+
+func addTypeToTree(t reflect.Type, tree treeprint.Tree) {
+	if t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("unexpected kind %s", t.Kind()))
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+
+		switch f.Type.Kind() {
+		case reflect.Slice:
+			name := fmt.Sprintf("+%v %s: []%s", f.Offset, f.Name, f.Type.Elem().Kind())
+
+			if isPrimitive(f.Type.Elem().Kind()) {
+				tree.AddNode(name)
+			} else {
+				addTypeToTree(f.Type.Elem(), tree.AddBranch(name))
+			}
+		default:
+			name := fmt.Sprintf("+%v %s: %s", f.Offset, f.Name, f.Type.Kind())
+			tree.AddNode(name)
+		}
+	}
+}
+
+func isPrimitive(k reflect.Kind) bool {
+	switch k {
+	case reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.String,
+		reflect.UnsafePointer:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
#### What this PR does

We are using unsafe.Pointer to convert some data without copy. Add check for compatibility.
Inspired by @charleskorn .

#### Which issue(s) this PR fixes or relates to

Fixes N/A
Related to #4351 
Related to #4303 

#### Checklist

- [x] Tests updated
- N/A Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
