### PR TITLE
Mixin: remove dependency on upstream recording rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [ENHANCEMENT] Alerts: do not fire `MimirAllocatingTooMuchMemory` alert for any matching container outside of namespaces where Mimir is running. #5089
 * [BUGFIX] Dashboards: show cancelled requests in a different color to successful requests in throughput panels on dashboards. #5039
 * [BUGFIX] Dashboards: fix dashboard panels that showed percentages with axes from 0 to 10000%. #5084
+* [BUGFIX] Remove dependency on upstream Kubernetes mixin. #4732
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
@@ -412,7 +412,7 @@ spec:
         sum by (cluster, namespace, deployment) (
           label_replace(
             label_replace(
-              node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate,
+              sum by (cluster, namespace, pod)(rate(container_cpu_usage_seconds_total[1m])),
               "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
             ),
             # The question mark in "(.*?)" is used to make it non-greedy, otherwise it

--- a/operations/mimir-mixin-compiled/rules.yaml
+++ b/operations/mimir-mixin-compiled/rules.yaml
@@ -400,7 +400,7 @@ groups:
       sum by (cluster, namespace, deployment) (
         label_replace(
           label_replace(
-            node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate,
+            sum by (cluster, namespace, pod)(rate(container_cpu_usage_seconds_total[1m])),
             "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
           ),
           # The question mark in "(.*?)" is used to make it non-greedy, otherwise it

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -272,7 +272,7 @@
             sum by (%(alert_aggregation_labels)s, deployment) (
               label_replace(
                 label_replace(
-                  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate,
+                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total[1m])),
                   "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it

--- a/pkg/mimirtool/commands/analyse_rules_test.go
+++ b/pkg/mimirtool/commands/analyse_rules_test.go
@@ -25,7 +25,6 @@ var allMetricsInRuleTest = []string{
 	"apiserver_request_duration_seconds_bucket",
 	"apiserver_request_duration_seconds_count",
 	"apiserver_request_total",
-	"container_cpu_usage_seconds_total",
 	"container_memory_cache",
 	"container_memory_rss",
 	"container_memory_swap",

--- a/pkg/mimirtool/commands/testdata/prometheus_rules.yaml
+++ b/pkg/mimirtool/commands/testdata/prometheus_rules.yaml
@@ -506,13 +506,6 @@
 - "name": "k8s.rules"
   "rules":
   - "expr": |
-      sum by (cluster, namespace, pod, container) (
-        irate(container_cpu_usage_seconds_total{job="cadvisor", image!=""}[5m])
-      ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
-        1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
-      )
-    "record": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate"
-  - "expr": |
       container_memory_working_set_bytes{job="cadvisor", image!=""}
       * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
         max by(namespace, pod, node) (kube_pod_info{node!=""})


### PR DESCRIPTION
#### What this PR does

Instead of assuming there is a metric `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` which would be provided by the "Kubernetes mixin", use the underlying cAdvisor metric like we do for everything else.

(Also use `rate[1m]` which gives better information than `irate[5m]`)

#### Checklist

- NA Tests updated
- NA Documentation - we never documented the need for the upstream rule, so don't need to take that out.
- [x] `CHANGELOG.md` updated

