### PR TITLE
Fix marshalling of Limits extensions

### DIFF
--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -648,7 +648,7 @@ metric_relabel_configs:
 }
 
 type structExtension struct {
-	Foo int `yaml:"foo"`
+	Foo int `yaml:"foo" json:"foo"`
 }
 
 func (te structExtension) Default() structExtension {
@@ -749,5 +749,68 @@ func TestExtensions(t *testing.T) {
 
 	t.Run("getter works with nil Limits returning default values", func(t *testing.T) {
 		require.Equal(t, structExtension{}.Default(), getExtensionStruct(nil))
+	})
+
+	t.Run("marshal limits with no extension values", func(t *testing.T) {
+		overrides := map[string]*Limits{
+			"test": {},
+		}
+
+		val, err := yaml.Marshal(overrides)
+		require.NoError(t, err)
+		require.Contains(t, string(val),
+			`test:
+    test_extension_struct:
+        foo: 0
+    test_extension_string: ""
+    request_rate: 0
+    request_burst_size: 0`)
+
+		val, err = json.Marshal(overrides)
+		require.NoError(t, err)
+		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":0},"test_extension_string":"","request_rate":0,"request_burst_size":0,`)
+	})
+
+	t.Run("marshal limits with partial extension values", func(t *testing.T) {
+		overrides := map[string]*Limits{
+			"test": {
+				extensions: map[string]interface{}{
+					"test_extension_struct": structExtension{Foo: 421237},
+				},
+			},
+		}
+
+		val, err := yaml.Marshal(overrides)
+		require.NoError(t, err)
+		require.Contains(t, string(val),
+			`test:
+    test_extension_struct:
+        foo: 421237
+    test_extension_string: ""
+    request_rate: 0
+    request_burst_size: 0`)
+
+		val, err = json.Marshal(overrides)
+		require.NoError(t, err)
+		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":421237},"test_extension_string":"","request_rate":0,"request_burst_size":0,`)
+	})
+
+	t.Run("marshal limits with default extension values", func(t *testing.T) {
+		overrides := map[string]*Limits{}
+		require.NoError(t, yaml.Unmarshal([]byte(`{"user": {}}`), &overrides), "parsing overrides")
+
+		val, err := yaml.Marshal(overrides)
+		require.NoError(t, err)
+		require.Contains(t, string(val),
+			`user:
+    test_extension_struct:
+        foo: 42
+    test_extension_string: default string extension value
+    request_rate: 0
+    request_burst_size: 0`)
+
+		val, err = json.Marshal(overrides)
+		require.NoError(t, err)
+		require.Contains(t, string(val), `{"user":{"test_extension_struct":{"foo":42},"test_extension_string":"default string extension value","request_rate":0,"request_burst_size":0,`)
 	})
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -7,6 +7,7 @@ package validation
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -750,6 +751,16 @@ func TestExtensions(t *testing.T) {
 	t.Run("getter works with nil Limits returning default values", func(t *testing.T) {
 		require.Equal(t, structExtension{}.Default(), getExtensionStruct(nil))
 	})
+}
+
+func TestExtensionMarshalling(t *testing.T) {
+	t.Cleanup(func() {
+		registeredExtensions = map[string]registeredExtension{}
+		limitsExtensionsFields = nil
+	})
+
+	MustRegisterExtension[structExtension]("test_extension_struct")
+	MustRegisterExtension[stringExtension]("test_extension_string")
 
 	t.Run("marshal limits with no extension values", func(t *testing.T) {
 		overrides := map[string]*Limits{
@@ -758,17 +769,17 @@ func TestExtensions(t *testing.T) {
 
 		val, err := yaml.Marshal(overrides)
 		require.NoError(t, err)
+		fmt.Println(string(val))
 		require.Contains(t, string(val),
 			`test:
     test_extension_struct:
         foo: 0
     test_extension_string: ""
-    request_rate: 0
-    request_burst_size: 0`)
+    request_rate: 0`)
 
 		val, err = json.Marshal(overrides)
 		require.NoError(t, err)
-		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":0},"test_extension_string":"","request_rate":0,"request_burst_size":0,`)
+		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":0},"test_extension_string":"","request_rate":0,`)
 	})
 
 	t.Run("marshal limits with partial extension values", func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This PR fixes JSON and YAML marshalling of Limits extensions to make them visible in `/runtime_config` endpoint.

No changelog entry, as this mechanism is not used by Mimir, only by enterprise version to add additional reloadable limits.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
