### PR TITLE
mimirtool: Fix typos in rules subcommand help and error messages

### DIFF
--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -197,12 +197,12 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 
 	// Get RuleGroup Command
 	getRuleGroupCmd.Arg("namespace", "Namespace of the rulegroup to retrieve.").Required().StringVar(&r.Namespace)
-	getRuleGroupCmd.Arg("group", "Name of the rulegroup ot retrieve.").Required().StringVar(&r.RuleGroup)
+	getRuleGroupCmd.Arg("group", "Name of the rulegroup to retrieve.").Required().StringVar(&r.RuleGroup)
 	getRuleGroupCmd.Flag("disable-color", "disable colored output").BoolVar(&r.DisableColor)
 
 	// Delete RuleGroup Command
 	deleteRuleGroupCmd.Arg("namespace", "Namespace of the rulegroup to delete.").Required().StringVar(&r.Namespace)
-	deleteRuleGroupCmd.Arg("group", "Name of the rulegroup ot delete.").Required().StringVar(&r.RuleGroup)
+	deleteRuleGroupCmd.Arg("group", "Name of the rulegroup to delete.").Required().StringVar(&r.RuleGroup)
 
 	// Load Rules Command
 	loadRulesCmd.Arg("rule-files", "The rule files to check.").Required().ExistingFilesVar(&r.RuleFilesList)

--- a/pkg/mimirtool/rules/parser.go
+++ b/pkg/mimirtool/rules/parser.go
@@ -40,7 +40,7 @@ func ParseFiles(backend string, files []string) (map[string]RuleNamespace, error
 	for _, f := range files {
 		nss, errs := parseFn(f)
 		for _, err := range errs {
-			log.WithError(err).WithField("file", f).Errorln("unable parse rules file")
+			log.WithError(err).WithField("file", f).Errorln("unable to parse rules file")
 			return nil, errFileReadError
 		}
 
@@ -73,7 +73,7 @@ func ParseFiles(backend string, files []string) (map[string]RuleNamespace, error
 func Parse(f string) ([]RuleNamespace, []error) {
 	content, err := loadFile(f)
 	if err != nil {
-		log.WithError(err).WithField("file", f).Errorln("unable load rules file")
+		log.WithError(err).WithField("file", f).Errorln("unable to load rules file")
 		return nil, []error{errFileReadError}
 	}
 


### PR DESCRIPTION
#### What this PR does
Fix a couple of typos in rules subcommand help output, plus a couple more in error messages.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
