### PR TITLE
Use abstractions around Labels

### DIFF
--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -47,7 +47,7 @@ func TestMimirtoolBackfill(t *testing.T) {
 			labels.FromStrings("test", "test1", "a", "2"),
 			labels.FromStrings("test", "test1", "a", "3"),
 		},
-		100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), nil)
+		100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), labels.EmptyLabels())
 	require.NoError(t, err)
 
 	block2, err := testhelper.CreateBlock(
@@ -57,7 +57,7 @@ func TestMimirtoolBackfill(t *testing.T) {
 			labels.FromStrings("test", "test2", "a", "2"),
 			labels.FromStrings("test", "test2", "a", "3"),
 		},
-		100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), nil)
+		100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), labels.EmptyLabels())
 	require.NoError(t, err)
 
 	s, err := e2e.NewScenario(networkName)
@@ -154,7 +154,7 @@ overrides:
 				labels.FromStrings("test", "bad", "a", "2"),
 				labels.FromStrings("test", "bad", "a", "3"),
 			},
-			100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), nil)
+			100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), labels.EmptyLabels())
 		require.NoError(t, err)
 		require.NoError(t, os.Remove(filepath.Join(tmpDir, b.String(), block.MetaFilename)))
 

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -1563,12 +1563,14 @@ func TestMultitenantCompactor_ValidateBlock(t *testing.T) {
 		{
 			name: "out of order labels",
 			lbls: func() []labels.Labels {
+				b := labels.NewScratchBuilder(2)
+				b.Add("d", "4")
+				b.Add("a", "1")
 				oooLabels := []labels.Labels{
-					labels.FromStrings("a", "1", "d", "4"),
+					b.Labels(), // Haven't called Sort(), so they will be out of order.
 					labels.FromStrings("b", "2"),
 					labels.FromStrings("c", "3"),
 				}
-				oooLabels[0].Swap(0, 1)
 				return oooLabels
 			},
 			expectError: true,
@@ -1611,7 +1613,7 @@ func TestMultitenantCompactor_ValidateBlock(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// create a test block
 			now := time.Now()
-			blockID, err := testhelper.CreateBlock(ctx, tmpDir, tc.lbls(), 300, now.Add(-2*time.Hour).UnixMilli(), now.UnixMilli(), nil)
+			blockID, err := testhelper.CreateBlock(ctx, tmpDir, tc.lbls(), 300, now.Add(-2*time.Hour).UnixMilli(), now.UnixMilli(), labels.EmptyLabels())
 			require.NoError(t, err)
 			testDir := filepath.Join(tmpDir, blockID.String())
 			meta, err := metadata.ReadFromDir(testDir)

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -195,7 +195,7 @@ func DefaultGroupKey(meta metadata.Thanos) string {
 }
 
 func defaultGroupKey(res int64, lbls labels.Labels) string {
-	return fmt.Sprintf("%d@%v", res, lbls.Hash())
+	return fmt.Sprintf("%d@%v", res, labels.StableHash(lbls))
 }
 
 func minTime(metas []*metadata.Meta) time.Time {

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -782,10 +782,10 @@ func putOutOfOrderIndex(blockDir string, minTime int64, maxTime int64) error {
 
 	symbols := map[string]struct{}{}
 	for _, lset := range lbls {
-		for _, l := range lset {
+		lset.Range(func(l labels.Label) {
 			symbols[l.Name] = struct{}{}
 			symbols[l.Value] = struct{}{}
-		}
+		})
 	}
 
 	var input indexWriterSeriesSlice
@@ -842,14 +842,14 @@ func putOutOfOrderIndex(blockDir string, minTime int64, maxTime int64) error {
 			return err
 		}
 
-		for _, l := range s.labels {
+		s.labels.Range(func(l labels.Label) {
 			valset, ok := values[l.Name]
 			if !ok {
 				valset = map[string]struct{}{}
 				values[l.Name] = valset
 			}
 			valset[l.Value] = struct{}{}
-		}
+		})
 		postings.Add(storage.SeriesRef(i), s.labels)
 	}
 

--- a/pkg/compactor/job_test.go
+++ b/pkg/compactor/job_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ import (
 )
 
 func TestJob_MinCompactionLevel(t *testing.T) {
-	job := NewJob("user-1", "group-1", nil, 0, true, 2, "shard-1")
+	job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, "shard-1")
 	require.NoError(t, job.AppendMeta(&metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: ulid.MustNew(1, nil), Compaction: tsdb.BlockMetaCompaction{Level: 2}}}))
 	assert.Equal(t, 2, job.MinCompactionLevel())
 
@@ -106,7 +107,7 @@ func TestJobWaitPeriodElapsed(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			job := NewJob("user-1", "group-1", nil, 0, true, 2, "shard-1")
+			job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, "shard-1")
 			for _, b := range testData.jobBlocks {
 				require.NoError(t, job.AppendMeta(b.meta))
 			}

--- a/pkg/compactor/split_merge_grouper.go
+++ b/pkg/compactor/split_merge_grouper.go
@@ -361,5 +361,17 @@ func getMaxTime(blocks []*metadata.Meta) int64 {
 // defaultGroupKeyWithoutShardID returns the default group key excluding ShardIDLabelName
 // when computing it.
 func defaultGroupKeyWithoutShardID(meta metadata.Thanos) string {
-	return defaultGroupKey(meta.Downsample.Resolution, labels.NewBuilder(labels.FromMap(meta.Labels)).Del(mimir_tsdb.CompactorShardIDExternalLabel).Labels())
+	return defaultGroupKey(meta.Downsample.Resolution, labelsWithoutShard(meta.Labels))
+}
+
+// Return labels built from base, but without any label with name equal to mimir_tsdb.CompactorShardIDExternalLabel.
+func labelsWithoutShard(base map[string]string) labels.Labels {
+	b := labels.NewScratchBuilder(len(base))
+	for k, v := range base {
+		if k != mimir_tsdb.CompactorShardIDExternalLabel {
+			b.Add(k, v)
+		}
+	}
+	b.Sort()
+	return b.Labels()
 }

--- a/pkg/compactor/split_merge_job.go
+++ b/pkg/compactor/split_merge_job.go
@@ -56,8 +56,8 @@ func (j *job) conflicts(other *job) bool {
 	// are never merged together, so they can't conflict. Since all blocks within the same job are expected to have the same
 	// downsample resolution and external labels, we just check the 1st block of each job.
 	if len(j.blocks) > 0 && len(other.blocks) > 0 {
-		myLabels := labels.NewBuilder(labels.FromMap(j.blocksGroup.blocks[0].Thanos.Labels)).Del(tsdb.CompactorShardIDExternalLabel).Labels()
-		otherLabels := labels.NewBuilder(labels.FromMap(other.blocksGroup.blocks[0].Thanos.Labels)).Del(tsdb.CompactorShardIDExternalLabel).Labels()
+		myLabels := labelsWithoutShard(j.blocksGroup.blocks[0].Thanos.Labels)
+		otherLabels := labelsWithoutShard(other.blocksGroup.blocks[0].Thanos.Labels)
 		if !labels.Equal(myLabels, otherLabels) {
 			return false
 		}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1695,6 +1695,19 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 	}
 }
 
+func mkLabels(n int, extra ...string) labels.Labels {
+	builder := labels.NewScratchBuilder(n + len(extra)/2)
+	builder.Add(model.MetricNameLabel, "foo")
+	for i := 0; i < n; i++ {
+		builder.Add(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+	}
+	for i := 0; i < len(extra); i += 2 {
+		builder.Add(extra[i], extra[i+1])
+	}
+	builder.Sort()
+	return builder.Labels()
+}
+
 func BenchmarkDistributor_Push(b *testing.B) {
 	const (
 		numSeriesPerRequest = 1000
@@ -1713,12 +1726,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 10; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-
-					metrics[i] = lbls.Labels()
+					metrics[i] = mkLabels(10)
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
@@ -1739,12 +1747,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 10; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-
-					metrics[i] = lbls.Labels()
+					metrics[i] = mkLabels(10)
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
@@ -1764,12 +1767,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 1; i < 31; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-
-					metrics[i] = lbls.Labels()
+					metrics[i] = mkLabels(31)
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
@@ -1789,15 +1787,8 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 10; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-
 					// Add a label with a very long name.
-					lbls.Set(fmt.Sprintf("xxx_%0.2000d", 1), "xxx")
-
-					metrics[i] = lbls.Labels()
+					metrics[i] = mkLabels(10, fmt.Sprintf("xxx_%0.2000d", 1), "xxx")
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
@@ -1817,15 +1808,8 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 10; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-
 					// Add a label with a very long value.
-					lbls.Set("xxx", fmt.Sprintf("xxx_%0.2000d", 1))
-
-					metrics[i] = lbls.Labels()
+					metrics[i] = mkLabels(10, "xxx", fmt.Sprintf("xxx_%0.2000d", 1))
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
@@ -1845,12 +1829,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 				samples := make([]mimirpb.Sample, numSeriesPerRequest)
 
 				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 10; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-
-					metrics[i] = lbls.Labels()
+					metrics[i] = mkLabels(10)
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().Add(time.Hour).UnixNano() / int64(time.Millisecond),

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -863,10 +863,11 @@ func checkReplicaDeletionState(t *testing.T, duration time.Duration, c *haTracke
 
 // fromLabelPairsToLabels converts dto.LabelPair into labels.Labels.
 func fromLabelPairsToLabels(pairs []*dto.LabelPair) labels.Labels {
-	builder := labels.NewBuilder(nil)
+	builder := labels.NewScratchBuilder(len(pairs))
 	for _, pair := range pairs {
-		builder.Set(pair.GetName(), pair.GetValue())
+		builder.Add(pair.GetName(), pair.GetValue())
 	}
+	builder.Sort()
 	return builder.Labels()
 }
 

--- a/pkg/frontend/querymiddleware/codec_json_test.go
+++ b/pkg/frontend/querymiddleware/codec_json_test.go
@@ -392,7 +392,10 @@ func findHistogramMatchingLabels(metrics dskit_metrics.MetricFamilyMap, name str
 		return nil, fmt.Errorf("no metric with name %v found", name)
 	}
 
-	l := labels.FromStrings(labelValuePairs...)
+	l := []labels.Label{}
+	for i := 0; i < len(labelValuePairs); i += 2 {
+		l = append(l, labels.Label{Name: labelValuePairs[i], Value: labelValuePairs[i+1]})
+	}
 	var matchingMetrics []*dto.Metric
 
 	for _, metric := range metricFamily.Metric {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -793,7 +793,7 @@ func TestQueryshardingDeterminism(t *testing.T) {
 		to   = from.Add(step)
 	)
 
-	labelsForShard := labelsForShardsGenerator(labels.FromStrings(labels.MetricName, "metric"), shards)
+	labelsForShard := labelsForShardsGenerator([]labels.Label{{Name: labels.MetricName, Value: "metric"}}, shards)
 	storageSeries := []*promql.StorageSeries{
 		newSeries(labelsForShard(0), from, to, step, constant(evilFloatA)),
 		newSeries(labelsForShard(1), from, to, step, constant(evilFloatA)),
@@ -832,15 +832,19 @@ func TestQueryshardingDeterminism(t *testing.T) {
 
 // labelsForShardsGenerator returns a function that provides labels.Labels for the shard requested
 // A single generator instance generates different label sets.
-func labelsForShardsGenerator(base labels.Labels, shards uint64) func(shard uint64) labels.Labels {
+func labelsForShardsGenerator(base []labels.Label, shards uint64) func(shard uint64) labels.Labels {
 	i := 0
+	builder := labels.ScratchBuilder{}
 	return func(shard uint64) labels.Labels {
 		for {
 			i++
-			ls := make(labels.Labels, len(base)+1)
-			copy(ls, base)
-			ls[len(ls)-1] = labels.Label{Name: "__test_shard_adjuster__", Value: fmt.Sprintf("adjusted to be %s by %d", sharding.FormatShardIDLabelValue(shard, shards), i)}
-			sort.Sort(ls)
+			builder.Reset()
+			for _, l := range base {
+				builder.Add(l.Name, l.Value)
+			}
+			builder.Add("__test_shard_adjuster__", fmt.Sprintf("adjusted to be %s by %d", sharding.FormatShardIDLabelValue(shard, shards), i))
+			builder.Sort()
+			ls := builder.Labels()
 			// If this label value makes this labels combination fall into the desired shard, return it, otherwise keep trying.
 			if labels.StableHash(ls)%shards == shard {
 				return ls
@@ -2068,9 +2072,6 @@ func newSeriesInner(metric labels.Labels, from, to time.Time, step time.Duration
 			})
 		}
 	}
-
-	// Ensure series labels are sorted.
-	sort.Sort(metric)
 
 	return promql.NewStorageSeries(promql.Series{
 		Metric:     metric,

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
 	"testing"
 	"time"
 
@@ -31,7 +30,7 @@ import (
 func genLabels(
 	labelSet []string,
 	labelBuckets int,
-) (result []labels.Labels) {
+) (result [][]labels.Label) {
 	if len(labelSet) == 0 {
 		return result
 	}
@@ -45,7 +44,7 @@ func genLabels(
 			Value: fmt.Sprintf("%d", i),
 		}
 		if len(rest) == 0 {
-			set := labels.Labels{x}
+			set := []labels.Label{x}
 			result = append(result, set)
 			continue
 		}
@@ -80,7 +79,7 @@ func newMockShardedQueryable(
 	sets := genLabels(labelSet, labelBuckets)
 	xs := make([]storage.Series, 0, len(sets))
 	for _, ls := range sets {
-		xs = append(xs, series.NewConcreteSeries(ls, samples, histograms))
+		xs = append(xs, series.NewConcreteSeries(labels.New(ls...), samples, histograms))
 	}
 
 	return &mockShardedQueryable{
@@ -172,19 +171,18 @@ type shardLabelSeries struct {
 // Labels impls storage.Series
 func (s *shardLabelSeries) Labels() labels.Labels {
 	ls := s.Series.Labels()
+	b := labels.NewBuilder(ls)
 
 	if s.name != "" {
-		ls = append(ls, labels.Label{
-			Name:  "__name__",
-			Value: s.name,
-		})
+		b.Set("__name__", s.name)
 	}
 
 	if s.shard != nil {
-		ls = append(ls, s.shard.Label())
+		l := s.shard.Label()
+		b.Set(l.Name, l.Value)
 	}
 
-	return ls
+	return b.Labels()
 }
 
 // LabelValues impls storage.Querier
@@ -204,16 +202,16 @@ func (q *mockShardedQueryable) Close() error {
 
 func TestGenLabelsCorrectness(t *testing.T) {
 	ls := genLabels([]string{"a", "b"}, 2)
-	for _, set := range ls {
-		sort.Sort(set)
-	}
 	expected := []labels.Labels{
 		labels.FromStrings("a", "0", "b", "0"),
 		labels.FromStrings("a", "0", "b", "1"),
 		labels.FromStrings("a", "1", "b", "0"),
 		labels.FromStrings("a", "1", "b", "1"),
 	}
-	require.Equal(t, expected, ls)
+	for i, x := range expected {
+		got := labels.New(ls[i]...)
+		require.Equal(t, x, got)
+	}
 }
 
 func TestGenLabelsSize(t *testing.T) {

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -405,16 +405,18 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 	} {
 		b.Run(fmt.Sprintf("rounds=%d series=%d", tt.nRounds, tt.nSeries), func(b *testing.B) {
 			// Prepare series
+			const nLabels = 10
+			builder := labels.NewScratchBuilder(nLabels)
 			series := make([]labels.Labels, tt.nSeries)
 			hash := make([]uint64, tt.nSeries)
 			for s := 0; s < tt.nSeries; s++ {
-				lbls := make(labels.Labels, 10)
-				for i := 0; i < len(lbls); i++ {
+				builder.Reset()
+				for i := 0; i < nLabels; i++ {
 					// Label ~20B name, ~40B value.
-					lbls[i] = labels.Label{Name: fmt.Sprintf("abcdefghijabcdefghi%d", i), Value: fmt.Sprintf("abcdefghijabcdefghijabcdefghijabcd%d", s)}
+					builder.Add(fmt.Sprintf("abcdefghijabcdefghi%d", i), fmt.Sprintf("abcdefghijabcdefghijabcdefghijabcd%d", s))
 				}
-				series[s] = lbls
-				hash[s] = lbls.Hash()
+				series[s] = builder.Labels()
+				hash[s] = series[s].Hash()
 			}
 
 			now := time.Now().UnixNano()

--- a/pkg/ingester/activeseries/matchers_test.go
+++ b/pkg/ingester/activeseries/matchers_test.go
@@ -99,14 +99,15 @@ func BenchmarkMatchesSeries(b *testing.B) {
 		if total < matching {
 			b.Fatal("wrong test setup, total < matching")
 		}
-		lbs := make(labels.Labels, 0, total)
+		builder := labels.NewScratchBuilder(total)
 		for i := 0; i < matching; i++ {
-			lbs = append(lbs, labels.Label{Name: fmt.Sprintf("this_will_match_%d", i), Value: "true"})
+			builder.Add(fmt.Sprintf("this_will_match_%d", i), "true")
 		}
 		for i := matching; i < total; i++ {
-			lbs = append(lbs, labels.Label{Name: fmt.Sprintf("something_else_%d", i), Value: "true"})
+			builder.Add(fmt.Sprintf("something_else_%d", i), "true")
 		}
-		return lbs
+		builder.Sort()
+		return builder.Labels()
 	}
 
 	for i, trackerCount := range trackerCounts {

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -34,7 +34,7 @@ func makeMetricLimitError(labels labels.Labels, err error) error {
 }
 
 func (e *validationError) Error() string {
-	if e.labels == nil {
+	if e.labels.IsEmpty() {
 		return e.err.Error()
 	}
 	return fmt.Sprintf("%s This is for series %s", e.err.Error(), e.labels.String())

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5220,7 +5220,7 @@ func generateSamplesForLabel(baseLabels labels.Labels, series, samples int) *mim
 	ss := make([]mimirpb.Sample, 0, series*samples)
 
 	for s := 0; s < series; s++ {
-		l := append(labels.FromStrings("series", strconv.Itoa(s)), baseLabels...)
+		l := labels.NewBuilder(baseLabels).Set("series", strconv.Itoa(s)).Labels()
 		for i := 0; i < samples; i++ {
 			ss = append(ss, mimirpb.Sample{
 				Value:       float64(i),
@@ -5755,12 +5755,8 @@ func benchmarkData(nSeries int) (allLabels []labels.Labels, allSamples []mimirpb
 	)
 
 	for j := 0; j < nSeries; j++ {
-		labels := benchmarkLabels.Copy()
-		for i := range labels {
-			if labels[i].Name == "cpu" {
-				labels[i].Value = fmt.Sprintf("cpu%02d", j)
-			}
-		}
+		b := labels.NewBuilder(benchmarkLabels).Set("cpu", fmt.Sprintf("cpu%02d", j))
+		labels := b.Labels()
 		allLabels = append(allLabels, labels)
 		allSamples = append(allSamples, mimirpb.Sample{TimestampMs: 0, Value: float64(j)})
 	}

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -150,11 +150,11 @@ func (i *timeSeriesIterator) Labels() (l labels.Labels) {
 	}
 
 	series := i.ts[i.posSeries]
-	i.labels = make(labels.Labels, len(series.Labels))
+	builder := labels.NewScratchBuilder(len(series.Labels))
 	for posLabel := range series.Labels {
-		i.labels[posLabel].Name = series.Labels[posLabel].Name
-		i.labels[posLabel].Value = series.Labels[posLabel].Value
+		builder.Add(series.Labels[posLabel].Name, series.Labels[posLabel].Value)
 	}
+	i.labels = builder.Labels()
 	i.labelsSeriesPos = i.posSeries
 	return i.labels
 }

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -92,7 +92,7 @@ func (bqss *blockQuerierSeriesSet) Warnings() storage.Warnings {
 }
 
 // newBlockQuerierSeries makes a new blockQuerierSeries. Input labels must be already sorted by name.
-func newBlockQuerierSeries(lbls []labels.Label, chunks []storepb.AggrChunk) *blockQuerierSeries {
+func newBlockQuerierSeries(lbls labels.Labels, chunks []storepb.AggrChunk) *blockQuerierSeries {
 	sort.Slice(chunks, func(i, j int) bool {
 		return chunks[i].MinTime < chunks[j].MinTime
 	})

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -486,12 +486,8 @@ func mkZLabels(s ...string) []mimirpb.LabelAdapter {
 	return result
 }
 
-func mkLabels(s ...string) []labels.Label {
-	return mimirpb.FromLabelAdaptersToLabels(mkZLabels(s...))
-}
-
 func Benchmark_newBlockQuerierSeries(b *testing.B) {
-	lbls := mkLabels(
+	lbls := labels.FromStrings(
 		"__name__", "test",
 		"label_1", "value_1",
 		"label_2", "value_2",

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2092,9 +2092,9 @@ func mockValuesHints(ids ...ulid.ULID) *types.Any {
 func namesFromSeries(series ...labels.Labels) []string {
 	namesMap := map[string]struct{}{}
 	for _, s := range series {
-		for _, l := range s {
+		s.Range(func(l labels.Label) {
 			namesMap[l.Name] = struct{}{}
-		}
+		})
 	}
 
 	names := []string{}
@@ -2109,11 +2109,11 @@ func namesFromSeries(series ...labels.Labels) []string {
 func valuesFromSeries(name string, series ...labels.Labels) []string {
 	valuesMap := map[string]struct{}{}
 	for _, s := range series {
-		for _, l := range s {
+		s.Range(func(l labels.Label) {
 			if l.Name == name {
 				valuesMap[l.Value] = struct{}{}
 			}
-		}
+		})
 	}
 
 	values := []string{}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2109,11 +2109,9 @@ func namesFromSeries(series ...labels.Labels) []string {
 func valuesFromSeries(name string, series ...labels.Labels) []string {
 	valuesMap := map[string]struct{}{}
 	for _, s := range series {
-		s.Range(func(l labels.Label) {
-			if l.Name == name {
-				valuesMap[l.Value] = struct{}{}
-			}
-		})
+		if value := s.Get(name); value != "" {
+			valuesMap[value] = struct{}{}
+		}
 	}
 
 	values := []string{}

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -141,7 +141,7 @@ func TestIngesterStreaming(t *testing.T) {
 	require.NoError(t, err)
 
 	clientChunks, err := chunkcompat.ToChunks([]chunk.Chunk{
-		chunk.NewChunk(nil, promChunk, model.Earliest, model.Earliest),
+		chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Earliest),
 	})
 	require.NoError(t, err)
 
@@ -478,15 +478,16 @@ func BenchmarkDistributorQueryable_Select(b *testing.B) {
 	require.NoError(b, err)
 
 	clientChunks, err := chunkcompat.ToChunks([]chunk.Chunk{
-		chunk.NewChunk(nil, promChunk, model.Earliest, model.Earliest),
+		chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Earliest),
 	})
 	require.NoError(b, err)
 
 	// Generate fixtures for series that are going to be returned by the mocked QueryStream().
-	commonLabelsBuilder := labels.NewBuilder(nil)
+	commonLabelsBuilder := labels.NewScratchBuilder(numLabelsPerSeries - 1)
 	for i := 0; i < numLabelsPerSeries-1; i++ {
-		commonLabelsBuilder.Set(fmt.Sprintf("label_%d", i), fmt.Sprintf("value_%d", i))
+		commonLabelsBuilder.Add(fmt.Sprintf("label_%d", i), fmt.Sprintf("value_%d", i))
 	}
+	commonLabelsBuilder.Sort()
 	commonLabels := commonLabelsBuilder.Labels()
 
 	response := &client.QueryStreamResponse{Chunkseries: make([]client.TimeSeriesChunk, 0, numSeries)}
@@ -570,7 +571,7 @@ func convertToChunks(t *testing.T, samples []interface{}) []client.Chunk {
 		if len(chunks) == 0 || chunks[len(chunks)-1].Data.Encoding() != enc {
 			c, err := chunk.NewForEncoding(enc)
 			require.NoError(t, err)
-			chunks = append(chunks, chunk.NewChunk(nil, c, model.Time(ts), model.Time(ts)))
+			chunks = append(chunks, chunk.NewChunk(labels.EmptyLabels(), c, model.Time(ts), model.Time(ts)))
 			return
 		}
 		chunks[len(chunks)-1].Through = model.Time(ts)

--- a/pkg/querier/matrix.go
+++ b/pkg/querier/matrix.go
@@ -7,6 +7,7 @@ package querier
 
 import (
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -41,5 +42,5 @@ func mergeChunks(chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterat
 		mergedSamples = modelutil.MergeNSampleSets(samples...)
 	}
 
-	return series.NewConcreteSeriesIterator(series.NewConcreteSeries(nil, mergedSamples, mergedHistograms))
+	return series.NewConcreteSeriesIterator(series.NewConcreteSeries(labels.EmptyLabels(), mergedSamples, mergedHistograms))
 }

--- a/pkg/querier/partitioner_test.go
+++ b/pkg/querier/partitioner_test.go
@@ -68,7 +68,7 @@ func testPartitionChunksOutputIsSortedByLabels(t *testing.T, encoding chunk.Enco
 	for i := count; i > 0; i-- {
 		ch := mkChunk(t, model.Time(0), model.Time(1000), time.Millisecond, encoding)
 		// mkChunk uses `foo` as metric name, so we rename metric to be unique
-		ch.Metric[0].Value = fmt.Sprintf("%02d", i)
+		ch.Metric = labels.FromStrings(model.MetricNameLabel, fmt.Sprintf("%02d", i))
 
 		allChunks = append(allChunks, ch)
 	}

--- a/pkg/querier/tenantfederation/merge_exemplar_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_exemplar_queryable_test.go
@@ -81,15 +81,16 @@ func (m *mockExemplarQuerier) Select(_, _ int64, allMatchers ...[]*labels.Matche
 }
 
 func (m *mockExemplarQuerier) matches(res exemplar.QueryResult, matchers []*labels.Matcher) bool {
-	for _, l := range res.SeriesLabels {
+	ret := true
+	res.SeriesLabels.Range(func(l labels.Label) {
 		for _, m := range matchers {
 			if m.Name == l.Name && !m.Matches(l.Value) {
-				return false
+				ret = false
 			}
 		}
-	}
+	})
 
-	return true
+	return ret
 }
 
 func TestMergeExemplarQueryable_ExemplarQuerier(t *testing.T) {

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -315,7 +315,7 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 		job := jobs[idx]
 		seriesSets[idx] = &addLabelsSeriesSet{
 			upstream: job.querier.Select(sortSeries, hints, filteredMatchers...),
-			labels: labels.Labels{
+			labels: []labels.Label{
 				{
 					Name:  m.idLabelName,
 					Value: job.id,
@@ -335,7 +335,7 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 
 type addLabelsSeriesSet struct {
 	upstream   storage.SeriesSet
-	labels     labels.Labels
+	labels     []labels.Label
 	currSeries storage.Series
 }
 
@@ -379,7 +379,7 @@ func rewriteLabelName(s string) string {
 }
 
 // this outputs a more readable error format
-func labelsToString(labels labels.Labels) string {
+func labelsToString(labels []labels.Label) string {
 	parts := make([]string, len(labels))
 	for pos, l := range labels {
 		parts[pos] = rewriteLabelName(l.Name) + " " + l.Value

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -857,34 +857,34 @@ func assertEqualWarnings(t *testing.T, exp []string, act storage.Warnings) {
 func TestSetLabelsRetainExisting(t *testing.T) {
 	for _, tc := range []struct {
 		labels           labels.Labels
-		additionalLabels labels.Labels
+		additionalLabels []labels.Label
 		expected         labels.Labels
 	}{
 		// Test adding labels at the end.
 		{
 			labels:           labels.FromStrings("a", "b"),
-			additionalLabels: labels.FromStrings("c", "d"),
+			additionalLabels: []labels.Label{{Name: "c", Value: "d"}},
 			expected:         labels.FromStrings("a", "b", "c", "d"),
 		},
 
 		// Test adding labels at the beginning.
 		{
 			labels:           labels.FromStrings("c", "d"),
-			additionalLabels: labels.FromStrings("a", "b"),
+			additionalLabels: []labels.Label{{Name: "a", Value: "b"}},
 			expected:         labels.FromStrings("a", "b", "c", "d"),
 		},
 
 		// Test we do override existing labels and expose the original value.
 		{
 			labels:           labels.FromStrings("a", "b"),
-			additionalLabels: labels.FromStrings("a", "c"),
+			additionalLabels: []labels.Label{{Name: "a", Value: "c"}},
 			expected:         labels.FromStrings("a", "c", "original_a", "b"),
 		},
 
 		// Test we do override existing labels but don't do it recursively.
 		{
 			labels:           labels.FromStrings("a", "b", "original_a", "i am lost"),
-			additionalLabels: labels.FromStrings("a", "d"),
+			additionalLabels: []labels.Label{{Name: "a", Value: "d"}},
 			expected:         labels.FromStrings("a", "d", "original_a", "b"),
 		},
 	} {

--- a/pkg/querier/timeseries_series_set_test.go
+++ b/pkg/querier/timeseries_series_set_test.go
@@ -8,6 +8,7 @@ package querier
 import (
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 
@@ -44,8 +45,7 @@ func TestTimeSeriesSeriesSet(t *testing.T) {
 	require.True(t, ss.Next())
 	series := ss.At()
 
-	require.Equal(t, ss.ts[0].Labels[0].Name, series.Labels()[0].Name)
-	require.Equal(t, ss.ts[0].Labels[0].Value, series.Labels()[0].Value)
+	require.Equal(t, labels.FromStrings("label1", "value1"), series.Labels())
 
 	it := series.Iterator(nil)
 	require.Equal(t, chunkenc.ValFloat, it.Next())

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -438,7 +438,7 @@ func TestManagerFactory_CorrectQueryableUsed(t *testing.T) {
 			manager := managerFactory(context.Background(), userID, notifierManager, options.logger, nil)
 
 			// load rules into manager and start
-			require.NoError(t, manager.Update(time.Millisecond, ruleFiles, nil, "", nil))
+			require.NoError(t, manager.Update(time.Millisecond, ruleFiles, labels.EmptyLabels(), "", nil))
 			go manager.Run()
 
 			select {

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/notifier"
 	promRules "github.com/prometheus/prometheus/rules"
@@ -195,7 +196,7 @@ func (r *DefaultMultiTenantManager) syncRulesToManager(ctx context.Context, user
 	level.Debug(r.logger).Log("msg", "updating rules", "user", user)
 	r.configUpdatesTotal.WithLabelValues(user).Inc()
 
-	err = manager.Update(r.cfg.EvaluationInterval, files, nil, r.cfg.ExternalURL.String(), nil)
+	err = manager.Update(r.cfg.EvaluationInterval, files, labels.EmptyLabels(), r.cfg.ExternalURL.String(), nil)
 	if err != nil {
 		r.lastReloadSuccessful.WithLabelValues(user).Set(0)
 		level.Error(r.logger).Log("msg", "unable to update rule manager", "user", user, "err", err)

--- a/pkg/ruler/remotequerier_decoder.go
+++ b/pkg/ruler/remotequerier_decoder.go
@@ -166,17 +166,17 @@ func (d protobufDecoder) decodeVector(v *mimirpb.VectorData) (promql.Vector, err
 
 func (protobufDecoder) metricToLabels(metric []string) (labels.Labels, error) {
 	if len(metric)%2 != 0 {
-		return nil, fmt.Errorf("metric is malformed, it contains an odd number of symbols: %d", len(metric))
+		return labels.EmptyLabels(), fmt.Errorf("metric is malformed, it contains an odd number of symbols: %d", len(metric))
 	}
 
 	labelCount := len(metric) / 2
-	m := make([]labels.Label, labelCount)
+	b := labels.NewScratchBuilder(labelCount)
 
 	for i := 0; i < labelCount; i++ {
-		m[i] = labels.Label{Name: metric[2*i], Value: metric[2*i+1]}
+		b.Add(metric[2*i], metric[2*i+1])
 	}
 
-	return m, nil
+	return b.Labels(), nil
 }
 
 func (protobufDecoder) dataTypeToHumanFriendlyName(resp mimirpb.QueryResponse) string {

--- a/pkg/storage/chunk/json_helpers.go
+++ b/pkg/storage/chunk/json_helpers.go
@@ -6,7 +6,6 @@
 package chunk
 
 import (
-	"sort"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
@@ -24,35 +23,38 @@ func init() {
 // Override Prometheus' labels.Labels decoder which goes via a map
 func decodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	labelsPtr := (*labels.Labels)(ptr)
-	*labelsPtr = make(labels.Labels, 0, 10)
+	builder := labels.ScratchBuilder{}
 	iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
 		value := iter.ReadString()
-		*labelsPtr = append(*labelsPtr, labels.Label{Name: key, Value: value})
+		builder.Add(key, value)
 		return true
 	})
 	// Labels are always sorted, but earlier Mimir using a map would
 	// output in any order so we have to sort on read in
-	sort.Sort(*labelsPtr)
+	builder.Sort()
+	*labelsPtr = builder.Labels()
 }
 
 // Override Prometheus' labels.Labels encoder which goes via a map
 func encodeLabels(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	labelsPtr := (*labels.Labels)(ptr)
 	stream.WriteObjectStart()
-	for i, v := range *labelsPtr {
+	i := 0
+	labelsPtr.Range(func(v labels.Label) {
 		if i != 0 {
 			stream.WriteMore()
 		}
+		i++
 		stream.WriteString(v.Name)
 		stream.WriteRaw(`:`)
 		stream.WriteString(v.Value)
-	}
+	})
 	stream.WriteObjectEnd()
 }
 
 func labelsIsEmpty(ptr unsafe.Pointer) bool {
 	labelsPtr := (*labels.Labels)(ptr)
-	return len(*labelsPtr) == 0
+	return labelsPtr.IsEmpty()
 }
 
 // Decode via jsoniter's float64 routine is faster than getting the string data and decoding as two integers

--- a/pkg/storage/chunk/json_helpers.go
+++ b/pkg/storage/chunk/json_helpers.go
@@ -23,7 +23,7 @@ func init() {
 // Override Prometheus' labels.Labels decoder which goes via a map
 func decodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	labelsPtr := (*labels.Labels)(ptr)
-	builder := labels.ScratchBuilder{}
+	builder := labels.NewScratchBuilder(10)
 	iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
 		value := iter.ReadString()
 		builder.Add(key, value)

--- a/pkg/storage/series/series_set.go
+++ b/pkg/storage/series/series_set.go
@@ -285,17 +285,12 @@ func LabelsToSeriesSet(ls []labels.Labels) storage.SeriesSet {
 }
 
 func metricToLabels(m model.Metric) labels.Labels {
-	ls := make(labels.Labels, 0, len(m))
+	builder := labels.NewScratchBuilder(len(m))
 	for k, v := range m {
-		ls = append(ls, labels.Label{
-			Name:  string(k),
-			Value: string(v),
-		})
+		builder.Add(string(k), string(v))
 	}
-	// PromQL expects all labels to be sorted! In general, anyone constructing
-	// a labels.Labels list is responsible for sorting it during construction time.
-	sort.Sort(ls)
-	return ls
+	builder.Sort() // PromQL expects all labels to be sorted.
+	return builder.Labels()
 }
 
 type byLabels []storage.Series

--- a/pkg/storage/tsdb/testutil/block_generator.go
+++ b/pkg/storage/tsdb/testutil/block_generator.go
@@ -63,11 +63,6 @@ func GenerateBlockFromSpec(_ string, storageDir string, specs BlockSeriesSpecs) 
 	blockID := ulid.MustNew(ulid.Now(), rand.Reader)
 	blockDir := filepath.Join(storageDir, blockID.String())
 
-	// Ensure series labels are sorted.
-	for _, series := range specs {
-		sort.Sort(series.Labels)
-	}
-
 	// Ensure series are sorted.
 	sort.Slice(specs, func(i, j int) bool {
 		return labels.Compare(specs[i].Labels, specs[j].Labels) < 0
@@ -76,10 +71,10 @@ func GenerateBlockFromSpec(_ string, storageDir string, specs BlockSeriesSpecs) 
 	// Build symbols.
 	uniqueSymbols := map[string]struct{}{}
 	for _, series := range specs {
-		for _, l := range series.Labels {
+		series.Labels.Range(func(l labels.Label) {
 			uniqueSymbols[l.Name] = struct{}{}
 			uniqueSymbols[l.Value] = struct{}{}
-		}
+		})
 	}
 
 	symbols := []string{}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1092,9 +1092,9 @@ func blockLabelNames(ctx context.Context, indexr *bucketIndexReader, matchers []
 	labelNames := map[string]struct{}{}
 	for seriesSet.Next() {
 		ls, _ := seriesSet.At()
-		for _, l := range ls {
+		ls.Range(func(l labels.Label) {
 			labelNames[l.Name] = struct{}{}
-		}
+		})
 	}
 	if seriesSet.Err() != nil {
 		return nil, errors.Wrap(seriesSet.Err(), "iterate series")

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -442,7 +442,7 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 	metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(registry)
 	require.NoError(t, err, "couldn't gather metrics from BucketStore")
 
-	toLabels := func(labelValuePairs []string) (result labels.Labels) {
+	toLabels := func(labelValuePairs []string) (result []labels.Label) {
 		if len(labelValuePairs)%2 != 0 {
 			t.Fatalf("invalid label name-value pairs %s", strings.Join(labelValuePairs, ""))
 		}
@@ -488,7 +488,7 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 	}
 }
 
-func getMetricsMatchingLabels(mf *dto.MetricFamily, selectors labels.Labels) []*dto.Metric {
+func getMetricsMatchingLabels(mf *dto.MetricFamily, selectors []labels.Label) []*dto.Metric {
 	var result []*dto.Metric
 	for _, m := range mf.GetMetric() {
 		if !util.MatchesSelectors(m, selectors) {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -675,20 +675,20 @@ func (r *bucketIndexReader) Close() error {
 }
 
 // LookupLabelsSymbols populates label set strings from symbolized label set.
-func (r *bucketIndexReader) LookupLabelsSymbols(symbolized []symbolizedLabel) (labels.Labels, error) {
-	lbls := make(labels.Labels, len(symbolized))
-	for ix, s := range symbolized {
+func (r *bucketIndexReader) LookupLabelsSymbols(symbolized []symbolizedLabel, builder *labels.ScratchBuilder) (labels.Labels, error) {
+	builder.Reset()
+	for _, s := range symbolized {
 		ln, err := r.dec.LookupSymbol(s.name)
 		if err != nil {
-			return nil, errors.Wrap(err, "lookup label name")
+			return labels.EmptyLabels(), errors.Wrap(err, "lookup label name")
 		}
 		lv, err := r.dec.LookupSymbol(s.value)
 		if err != nil {
-			return nil, errors.Wrap(err, "lookup label value")
+			return labels.EmptyLabels(), errors.Wrap(err, "lookup label value")
 		}
-		lbls[ix] = labels.Label{Name: ln, Value: lv}
+		builder.Add(ln, lv)
 	}
-	return lbls, nil
+	return builder.Labels(), nil
 }
 
 // bucketIndexLoadedSeries holds the result of a series load operation.

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -972,9 +972,7 @@ func generateSeries(card []int) []labels.Labels {
 	var rec func(idx int)
 	rec = func(lvl int) {
 		if lvl == len(card) {
-			cp := make([]labels.Label, len(card))
-			copy(cp, current)
-			series = append(series, cp)
+			series = append(series, labels.New(current...))
 			return
 		}
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2244,14 +2244,14 @@ func TestBucketStore_Series_Limits(t *testing.T) {
 		labels.FromStrings(labels.MetricName, "series_1"),
 		labels.FromStrings(labels.MetricName, "series_2"),
 		labels.FromStrings(labels.MetricName, "series_3"),
-	}, numSamplesPerSeries, minTime, maxTime, nil)
+	}, numSamplesPerSeries, minTime, maxTime, labels.EmptyLabels())
 	require.NoError(t, err)
 
 	_, err = testhelper.CreateBlock(ctx, bktDir, []labels.Labels{
 		labels.FromStrings(labels.MetricName, "series_1"),
 		labels.FromStrings(labels.MetricName, "series_2"),
 		labels.FromStrings(labels.MetricName, "series_3"),
-	}, numSamplesPerSeries, minTime, maxTime, nil)
+	}, numSamplesPerSeries, minTime, maxTime, labels.EmptyLabels())
 	require.NoError(t, err)
 
 	// Create a bucket and upload the block there.
@@ -2364,7 +2364,7 @@ func createBlockWithOneSeriesWithStep(t test.TB, dir string, lbls labels.Labels,
 	ref, err := app.Append(0, lbls, ts, random.Float64())
 	assert.NoError(t, err)
 	for i := 1; i < totalSamples; i++ {
-		_, err := app.Append(ref, nil, ts+step*int64(i), random.Float64())
+		_, err := app.Append(ref, lbls, ts+step*int64(i), random.Float64())
 		assert.NoError(t, err)
 	}
 	assert.NoError(t, app.Commit())
@@ -2779,16 +2779,17 @@ func createHeadWithSeries(t testing.TB, j int, opts headGenOptions) (*tsdb.Head,
 		lbls := labels.NewBuilder(opts.PrependLabels)
 		lbls.Set("foo", "bar")
 		lbls.Set("i", fmt.Sprintf("%07d%s", tsLabel, labelLongSuffix))
+		ll := lbls.Labels()
 		ref, err := app.Append(
 			0,
-			lbls.Labels(),
+			ll,
 			int64(tsLabel)*opts.ScrapeInterval.Milliseconds(),
 			opts.Random.Float64(),
 		)
 		assert.NoError(t, err)
 
 		for is := 1; is < opts.SamplesPerSeries; is++ {
-			_, err := app.Append(ref, nil, int64(tsLabel+is)*opts.ScrapeInterval.Milliseconds(), opts.Random.Float64())
+			_, err := app.Append(ref, ll, int64(tsLabel+is)*opts.ScrapeInterval.Milliseconds(), opts.Random.Float64())
 			assert.NoError(t, err)
 		}
 	}

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -218,7 +218,7 @@ func (b *seriesChunksSeriesSet) Next() bool {
 // At returns the current series. The result from At() MUST not be retained after calling Next()
 func (b *seriesChunksSeriesSet) At() (labels.Labels, []storepb.AggrChunk) {
 	if b.currOffset >= b.currSet.len() {
-		return nil, nil
+		return labels.EmptyLabels(), nil
 	}
 
 	return b.currSet.series[b.currOffset].lset, b.currSet.series[b.currOffset].chks

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -175,7 +175,7 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 		it := newSeriesChunksSeriesSet(source)
 
 		lbls, chks := it.At()
-		require.Zero(t, lbls)
+		require.True(t, lbls.IsEmpty())
 		require.Zero(t, chks)
 		require.NoError(t, it.Err())
 
@@ -195,7 +195,7 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 
 		require.False(t, it.Next())
 		lbls, chks = it.At()
-		require.Zero(t, lbls)
+		require.True(t, lbls.IsEmpty())
 		require.Zero(t, chks)
 		require.NoError(t, it.Err())
 		require.True(t, releasers[0].isReleased())
@@ -207,7 +207,7 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 		it := newSeriesChunksSeriesSet(source)
 
 		lbls, chks := it.At()
-		require.Zero(t, lbls)
+		require.True(t, lbls.IsEmpty())
 		require.Zero(t, chks)
 		require.NoError(t, it.Err())
 
@@ -247,7 +247,7 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 
 		require.False(t, it.Next())
 		lbls, chks = it.At()
-		require.Zero(t, lbls)
+		require.True(t, lbls.IsEmpty())
 		require.Zero(t, chks)
 		require.NoError(t, it.Err())
 		require.True(t, releasers[0].isReleased())
@@ -261,7 +261,7 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 		it := newSeriesChunksSeriesSet(source)
 
 		lbls, chks := it.At()
-		require.Zero(t, lbls)
+		require.True(t, lbls.IsEmpty())
 		require.Zero(t, chks)
 		require.NoError(t, it.Err())
 
@@ -281,7 +281,7 @@ func TestSeriesChunksSeriesSet(t *testing.T) {
 
 		require.False(t, it.Next())
 		lbls, chks = it.At()
-		require.Zero(t, lbls)
+		require.True(t, lbls.IsEmpty())
 		require.Zero(t, chks)
 		require.Equal(t, expectedErr, it.Err())
 

--- a/pkg/storegateway/snappy_gob_codec_test.go
+++ b/pkg/storegateway/snappy_gob_codec_test.go
@@ -14,14 +14,14 @@ import (
 
 func TestSnappyGobSeriesCacheEntryCodec(t *testing.T) {
 	type testType struct {
-		LabelSets   []labels.Labels
+		LabelSets   [][]labels.Label
 		MatchersKey indexcache.LabelMatchersKey
 	}
 
 	entry := testType{
-		LabelSets: []labels.Labels{
-			labels.FromStrings("foo", "bar"),
-			labels.FromStrings("baz", "boo"),
+		LabelSets: [][]labels.Label{
+			{{Name: "foo", Value: "bar"}},
+			{{Name: "baz", Value: "boo"}},
 		},
 		MatchersKey: indexcache.CanonicalLabelMatchersKey([]*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar")}),
 	}

--- a/pkg/storegateway/storepb/custom.go
+++ b/pkg/storegateway/storepb/custom.go
@@ -42,7 +42,7 @@ func NewStatsResponse(indexBytesFetched int) *SeriesResponse {
 type emptySeriesSet struct{}
 
 func (emptySeriesSet) Next() bool                       { return false }
-func (emptySeriesSet) At() (labels.Labels, []AggrChunk) { return nil, nil }
+func (emptySeriesSet) At() (labels.Labels, []AggrChunk) { return labels.EmptyLabels(), nil }
 func (emptySeriesSet) Err() error                       { return nil }
 
 // EmptySeriesSet returns a new series set that contains no series.

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -15,10 +15,10 @@ import (
 // LabelsToMetric converts a Labels to Metric
 // Don't do this on any performance sensitive paths.
 func LabelsToMetric(ls labels.Labels) model.Metric {
-	m := make(model.Metric, len(ls))
-	for _, l := range ls {
+	m := make(model.Metric, ls.Len())
+	ls.Range(func(l labels.Label) {
 		m[model.LabelName(l.Name)] = model.LabelValue(l.Value)
-	}
+	})
 	return m
 }
 

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-func MatchesSelectors(m *dto.Metric, selectors labels.Labels) bool {
+func MatchesSelectors(m *dto.Metric, selectors []labels.Label) bool {
 	for _, l := range selectors {
 		found := false
 		for _, lp := range m.GetLabel() {

--- a/pkg/util/metrics_helper_test.go
+++ b/pkg/util/metrics_helper_test.go
@@ -19,28 +19,28 @@ import (
 func TestMatchesSelectors(t *testing.T) {
 	tests := []struct {
 		name      string
-		selectors labels.Labels
+		selectors []labels.Label
 		expected  bool
 	}{
 		{
 			name: "with some matching selectors",
-			selectors: labels.Labels{
-				labels.Label{Name: "lbl1", Value: "value1"},
+			selectors: []labels.Label{
+				{Name: "lbl1", Value: "value1"},
 			},
 			expected: true,
 		},
 		{
 			name: "with all matching selectors",
-			selectors: labels.Labels{
-				labels.Label{Name: "lbl1", Value: "value1"},
-				labels.Label{Name: "lbl2", Value: "value2"},
+			selectors: []labels.Label{
+				{Name: "lbl1", Value: "value1"},
+				{Name: "lbl2", Value: "value2"},
 			},
 			expected: true,
 		},
 		{
 			name: "with non-matching selectors",
-			selectors: labels.Labels{
-				labels.Label{Name: "lbl1", Value: "barbaz"},
+			selectors: []labels.Label{
+				{Name: "lbl1", Value: "barbaz"},
 			},
 			expected: false,
 		},

--- a/tools/trafficdump/model.go
+++ b/tools/trafficdump/model.go
@@ -140,14 +140,16 @@ func writeJSONString(b *bytes.Buffer, s string) {
 
 func writeLabels(b *bytes.Buffer, lbls labels.Labels) {
 	b.WriteByte('{')
-	for i, l := range lbls {
+	i := 0
+	lbls.Range(func(l labels.Label) {
 		if i > 0 {
 			b.WriteByte(',')
 		}
 		writeJSONString(b, l.Name)
 		b.WriteByte(':')
 		writeJSONString(b, l.Value)
-	}
+		i++
+	})
 	b.WriteByte('}')
 }
 
@@ -159,7 +161,7 @@ type sampleWithLabels struct {
 
 func (s sampleWithLabels) marshalToBuffer(b *bytes.Buffer) {
 	b.WriteString("[")
-	if s.lbls != nil {
+	if !s.lbls.IsEmpty() {
 		writeLabels(b, s.lbls)
 		b.WriteString(",")
 	}

--- a/tools/tsdb-symbols/main.go
+++ b/tools/tsdb-symbols/main.go
@@ -148,7 +148,7 @@ func analyseSymbols(blockDir string, uniqueSymbols map[string]struct{}, uniqueSy
 			shardID = labels.StableHash(lbls) % uint64(shards)
 		}
 
-		for _, l := range lbls {
+		lbls.Range(func(l labels.Label) {
 			uniqueSymbols[l.Name] = struct{}{}
 			uniqueSymbols[l.Value] = struct{}{}
 
@@ -159,7 +159,7 @@ func analyseSymbols(blockDir string, uniqueSymbols map[string]struct{}, uniqueSy
 				uniqueSymbolsPerShard[shardID][l.Name] = struct{}{}
 				uniqueSymbolsPerShard[shardID][l.Value] = struct{}{}
 			}
-		}
+		})
 	}
 
 	if p.Err() != nil {


### PR DESCRIPTION
#### What this PR does

Instead of assuming it is a slice, which prevents moving to a more efficient structure.
Mostly using `labels.EmptyLabels()` instead of `nil`, and using various `Builder` types.
These changes are extracted from #3555 which actually does change the structure.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - not user-facing.
