### PR TITLE
Add mising changelog since mimir-2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 
-### Grafana Mimir
+### 2.8.0-rc.0
 
 * [CHANGE] Ingester: changed experimental CLI flag from `-out-of-order-blocks-external-label-enabled` to `-ingester.out-of-order-blocks-external-label-enabled` #4440
 * [CHANGE] Store-gateway: The following metrics have been removed: #4332

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
   * `-query-scheduler.ring.etcd.*`
   * `-overrides-exporter.ring.etcd.*`
 * [FEATURE] Distributor, ingester, querier, query-frontend, store-gateway: add experimental support for native histograms. Requires that the experimental protobuf query result response format is enabled by `-query-frontend.query-result-response-format=protobuf` on the query frontend. #4286 #4352 #4354 #4376 #4377 #4387 #4396 #4425 #4442 #4494 #4512 #4513 #4526
-* [FEATURE] Added `-<prefix>.s3.storage-class` flag to configure the S3 storage class for objects written to S3 buckets. #3438
+* [FEATURE] Added `-<prefix>.s3.storage-class` flag to configure the S3 storage class for objects written to S3 buckets. #4300
 * [FEATURE] Add `freebsd` to the target OS when generating binaries for a Mimir release. #4654
 * [FEATURE] Ingester: Add `prepare-shutdown` endpoint which can be used as part of Kubernetes scale down automations. #4718
 * [ENHANCEMENT] Add timezone information to Alpine Docker images. #4583
@@ -86,6 +86,7 @@
 * [ENHANCEMENT] Querier: improve performance when shuffle sharding is enabled and the shard size is large. #4711
 * [ENHANCEMENT] Ingester: improve performance when Active Series Tracker is in use. #4717
 * [ENHANCEMENT] Store-gateway: optionally select `-blocks-storage.bucket-store.series-selection-strategy`, which can limit the impact of large posting lists (when many series share the same label name and value). #4667 #4695 #4698
+* [ENHANCEMENT] Querier: Put converted float histogram in chunkIterator.AtFloatHistogram into cache. #4684
 * [BUGFIX] Querier: Streaming remote read will now continue to return multiple chunks per frame after the first frame. #4423
 * [BUGFIX] Store-gateway: the values for `stage="processed"` for the metrics `cortex_bucket_store_series_data_touched` and  `cortex_bucket_store_series_data_size_touched_bytes` when using fine-grained chunks caching is now reporting the correct values of chunks held in memory. #4449
 * [BUGFIX] Compactor: fixed reporting a compaction error when compactor is correctly shut down while populating blocks. #4580
@@ -96,6 +97,7 @@
 * [BUGFIX] Native histograms: fix how IsFloatHistogram determines if mimirpb.Histogram is a float histogram. #4706
 * [BUGFIX] Query-frontend: fix query sharding for native histograms. #4666
 * [BUGFIX] Ring status page: fixed the owned tokens percentage value displayed. #4730
+* [BUGFIX] Querier: fixed chunkIterator may return values after Seek beyond end of chunk. #4450
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 
-### 2.8.0-rc.0
+### Grafana Mimir
 
 * [CHANGE] Ingester: changed experimental CLI flag from `-out-of-order-blocks-external-label-enabled` to `-ingester.out-of-order-blocks-external-label-enabled` #4440
 * [CHANGE] Store-gateway: The following metrics have been removed: #4332


### PR DESCRIPTION
check-changelog.sh output
```
Found 203 PRs from 52 authors.

List of missing PR in the CHANGELOG.md:
- #4733: Fix marshalling of Limits extensions (#4733)
- #4734: mimirtool: Fix typos in rules subcommand help and error messages (#4734)
- #4716: Added missing imagePullSecrets configuration to the graphite-web mimir helm chart (#4716)
- #4723: Helm: Remove default storage class references in mimir-distributed (#4723)
- #4635: Update integration tests for native histograms (#4635)
- #4721: Update mimir-prometheus to 8ef48ad9a7f0 (#4721)
- #4719: Fix few typos (#4719)
- #4690: [Helm] Set unregister_on_shutdown to false for store-gateway (#4690)
- #4705: Helm: update minio subchart to 5.0.7  (#4705)
- #4669: Update _index.md (#4669)
- #4348: Add documentation to use external Redis using mimir-distributed helm chart (#4348)
- #4694: Release mimir-distributed Helm chart 4.4.0-weekly.233 (#4694)
- #4691: development/mimir-monolithic-mode: Fix typo in comment (#4691)
- #4676: Rename YoloByteSlice to UnsafeByteSlice. (#4676)
- #4646: Helo: Expose image repo path for grafana-agent-operator (#4646)
- #4642: Helm: Set HPA default MetricTarget type to Utilization (#4642)
- #4653: Release mimir-distributed Helm chart 4.4.0-weekly.232 (#4653)
- #4641: store-gateway index header: return posting offset in LabelVales (#4641)
- #4665: helm: fix out of sync CI (#4665)
- #4659: update rollout operator to 0.4.1 (#4659)
- #4618: feat(helm): allow for deploying dashboards from mixin (#4618)
- #4617: ruler remotequerier: sort labels received in json (#4617)
- #4657: querier: stop importing stats under two names (#4657)
- #4651: Add new maintainers (#4651)
- #4650: Rename DirectlyUnmarshalledByteSlice to YoloByteSlice. (#4650)
- #4183: querier: reformat some wide comments (#4183)
- #4644: Remove unused galaxycache replace inherited from Thanos (#4644)
- #4545: Store-gateway: correctly estimate length of last posting list (#4545)
- #4634: Update docker-compose development configs for native histograms (#4634)
- #4556: Add ability to specify tenant ID through env variable (#4556)
- #4626: Ingester: add logs for finishing block upload (#4626)
- #4624: Remove unused methods. (#4624)
- #4584: Helm: Multiple topology spread constraints support (#4584)
- #4500: Helm: review and update of release process by tech writer (#4500)
- #4594: store-gateway: Add BenchmarkOpenBlockSeriesChunkRefsSetsIterator (#4594)
- #4600: Update mimir-distributed chart to 4.4.0-weekly.231 (#4600)
- #4444: Unit and integration tests for native histograms in remote read (#4444)
- #4428: Extra tests for native histograms in queryStreamSamples and queryStreamChunks (#4428)
- #4586: Fix timing issue in ReaderPool idle unload test (#4586)
- #4574: Fix http port for ingester-headless and store-gateway-headless services (#4574)
- #4571: Typo in the docs (#4571)
- #4565: Docs: fix again broken reference configuration aliases (#4565)
- #4563: Add "streaming enabled" to avg latency panel (#4563)
- #4562: Docs: Add and fix aliases for configuration-parameters (#4562)
- #4559: Removed spurious spacing (#4559)
- #4540: Include podAnnotations on tokengen job (#4540)
- #4544: Release mimir-distributed Helm chart 4.4.0-weekly.230 (#4544)
- #4470: Docs: Fix broken links (#4470)
- #4530: Helm: Add basic documentation about native histograms (#4530)
- #4534: Add release 2.7.1 to backwards compatibility integration test (#4534)
- #4533: Release Helm chart v4.3.0 (#4533)
- #4536: Helm: fix issues in helm chart release notes for 4.2 (#4536)
- #4531: Helm: fix order of steps in Helm release (#4531)
- #4532: Helm: Update changelog with version 4.3.0 (#4532)
- #4529: Fix aliases for http reference docs (#4529)
- #4528: Fix flaky test by using 0 query time. (#4528)
- #4400: Release notes for v2.7 (#4400)
- #4507: docs: force running website image as linux/amd64 (#4507)
- #4506: docs: fix spacing in link for consul article (#4506)
- #4504: Bump google.golang.org/protobuf from 1.29.0 to 1.29.1 (#4504)
- #4497: Check README.md file for any broken links. (#4497)
- #4407: fix: Allow for single arg values in memcached extraArgs. (#4407)
- #4483: Docs: Helm: prepare update doc links for 2.7.x (#4483)
- #4485: Fix metricRelabelings for kube state monitor (#4485)
- #4490: Remove generics from native histograms code (#4490)
- #4477: Store-gateway: remove refs field from seriesEntry (#4477)
- #4481: Docs: Move configuration information to top level, and rename section to Configure. (#4481)
- #4479: Update RELEASE.md with note about release candidate versioning (#4479)
- #4476: Update mimir-distributed chart to 4.3.0-weekly.229 (#4476)
- #4474: Update mimir-prometheus (#4474)
- #4473: Remove extraneous Helm-related doc from Mimir. (#4473)
- #4468: Move Get started per new TOC structure. (#4468)
- #4272: Helm: allow easier install on OpenShift (#4272)
- #4467: Store-gateway: make ranges per series per block configurable (#4467)
- #4443: math: Convert Min and Max to be generic (#4443)
- #4427: Start a Grafana instance in microservices docker-compose (#4427)
- #4441: distributor: Fix type docstring (#4441)
- #4393: Helm: added HttpListenPort in distributor-svc-headless (#4393)
- #4426: Remove replace directives in go.mod (#4426)
- #4437: Move entry for #4423 into main / unreleased section. (#4437)
- #4431: Updated CHANGELOG prior to release 2.7.0-rc.0 (#4431)
- #4429: Add protobuf internal query result payload format to experimental features list. (#4429)
- #4424: Cleanup ephemeral storage entries from CHANGELOG (#4424)
- #4314: Docs: Clarify requirements for up-to-date-ness of bucket index (#4314)
- #4123: Integration tests for compacting native histogram blocks (#4123)
- #4418: Limits extensions with default values (#4418)
- #4414: Make extensions getter work with nil *Limits (#4414)
- #4126: Helm: apply clusterLabel to k8s ServiceMonitors (#4126)
- #4397: Limits with Extensions (#4397)
- #4372: `mimir-rules-action`: `set-output` is deprecated (#4372)
- #4360: New internal query result payload format: bring changes from `sparsehistogram` onto `main` (#4360)
- #4388: Release mimir-distributed Helm chart 4.3.0-weekly.228 (#4388)
- #3740: Add memcache support for admin bucket in helm (#3740)
- #4370: Move "Note:" about cross-zone costs to "Costs" (#4370)
```

We will not add changelog for helm changes because helm has its own changelog.

Non-helm changes prefixes with comments whether we should add as changelog.
```
List of missing PR in the CHANGELOG.md:
- $internal-change #4733 : Fix marshalling of Limits extensions (#4733)
- $internal-change #4734 : mimirtool : Fix typos in rules subcommand help and error messages (#4734)
- $to-add-improvement - #4684 : Cache converted float histogram in chunkIterator.AtFloatHistogram (#4684)
- $internal-change #4635 : Update integration tests for native histograms (#4635)
- $internal-change #4721 : Update mimir-prometheus to 8ef48ad9a7f0 (#4721)
- $internal-change #4719 : Fix few typos (#4719)
- $internal-change #4669 : Update _index.md (#4669)
- $internal-change #4691 : development/mimir-monolithic-mode : Fix typo in comment (#4691)
- $internal-change #4676 : Rename YoloByteSlice to UnsafeByteSlice. (#4676)
- $to-add-fix-wrong-pr-num #4300 : Configurable s3 storage class (#4300)
- $internal-change-helm #4646 : Helo : Expose image repo path for grafana-agent-operator (#4646)
- $internal-change #4641 : store-gateway index header : return posting offset in LabelVales (#4641)
- $internal-change-helm #4659 : update rollout operator to 0.4.1 (#4659)
- $maybe-to-add #4617 : ruler remotequerier : sort labels received in json (#4617)
- $internal-change #4657 : querier : stop importing stats under two names (#4657)
- $internal-change #4651 : Add new maintainers (#4651)
- $internal-change #4650 : Rename DirectlyUnmarshalledByteSlice to YoloByteSlice. (#4650)
- $internal-change #4183 : querier : reformat some wide comments (#4183)
- $internal-change-deps #4644 : Remove unused galaxycache replace inherited from Thanos (#4644)
- $internal-change #4545 : Store-gateway : correctly estimate length of last posting list (#4545)
- $internal-change #4634 : Update docker-compose development configs for native histograms (#4634)
- $maybe-to-add #4556 : Add ability to specify tenant ID through env variable (#4556)
- $internal-change #4626 : Ingester : add logs for finishing block upload (#4626)
- $internal-change #4624 : Remove unused methods. (#4624)
- $internal-change #4594 : store-gateway : Add BenchmarkOpenBlockSeriesChunkRefsSetsIterator (#4594)
- $internal-change-release #4600 : Update mimir-distributed chart to 4.4.0-weekly.231 (#4600)
- $internal-change #4444 : Unit and integration tests for native histograms in remote read (#4444)
- $internal-change #4428 : Extra tests for native histograms in queryStreamSamples and queryStreamChunks (#4428)
- $internal-change #4586 : Fix timing issue in ReaderPool idle unload test (#4586)
- $internal-change-helm #4574 : Fix http port for ingester-headless and store-gateway-headless services (#4574)
- $internal-doc #4571 : Typo in the docs (#4571)
- $internal-change #4565 : Docs : fix again broken reference configuration aliases (#4565)
- $internal-change #4563 : Add "streaming enabled" to avg latency panel (#4563)
- $internal-change-doc #4562 : Docs : Add and fix aliases for configuration-parameters (#4562)
- $internal-change-doc #4559 : Removed spurious spacing (#4559)
- $internal-change-helm #4540 : Include podAnnotations on tokengen job (#4540)
- $internal-change-doc  #4470 : Docs : Fix broken links (#4470)
- $internal-change-test #4534 : Add release 2.7.1 to backwards compatibility integration test (#4534)
- $internal-change-doc #4529 : Fix aliases for http reference docs (#4529)
- $internal-change-test #4528 : Fix flaky test by using 0 query time. (#4528)
- $internal-change-release #4400 : Release notes for v2.7 (#4400)
- $internal-change #4507 : docs : force running website image as linux/amd64 (#4507)
- $internal-change-doc #4506 : docs : fix spacing in link for consul article (#4506)
- $internal-change-deps #4504 : Bump google.golang.org/protobuf from 1.29.0 to 1.29.1 (#4504)
- $internal-change-doc #4497 : Check README.md file for any broken links. (#4497)
- $internal-change-helm #4407 : fix : Allow for single arg values in memcached extraArgs. (#4407)
- $internal-change-helm #4485 : Fix metricRelabelings for kube state monitor (#4485)
- $internal-change #4490 : Remove generics from native histograms code (#4490)
- $internal-change #4477 : Store-gateway : remove refs field from seriesEntry (#4477)
- $internal-change #4481 : Docs : Move configuration information to top level, and rename section to Configure. (#4481)
- $internal-change-release #4479 : Update RELEASE.md with note about release candidate versioning (#4479)
- $maybe-to-add #4450 : Exhaust iterators.chunkIterator after seek shortcut (#4450)
- $internal-change-release #4476 : Update mimir-distributed chart to 4.3.0-weekly.229 (#4476)
-$internal-change-deps  #4474 : Update mimir-prometheus (#4474)
- $internal-change-doc #4468 : Move Get started per new TOC structure. (#4468)
- $internal-change #4467 : Store-gateway : make ranges per series per block configurable (#4467)
- $internal-change #4443 : math : Convert Min and Max to be generic (#4443)
- $internal-change-ops #4427 : Start a Grafana instance in microservices docker-compose (#4427)
- $internal-change-code-doc #4441 : distributor : Fix type docstring (#4441)
- $internal-change-deps #4426 : Remove replace directives in go.mod (#4426)
- $internal-change-cl #4437 : Move entry for #4423 into main / unreleased section. (#4437)
- $internal-change-cl #4431 : Updated CHANGELOG prior to release 2.7.0-rc.0 (#4431)
- $internal-change #4429 : Add protobuf internal query result payload format to experimental features list. (#4429)
- $internal-change-cl #4424 : Cleanup ephemeral storage entries from CHANGELOG (#4424)
- $internal-change-doc #4314 : Docs : Clarify requirements for up-to-date-ness of bucket index (#4314)
- $internal-change-test #4123 : Integration tests for compacting native histogram blocks (#4123)
- $maybe-to-add #4418 : Limits extensions with default values (#4418)
- $maybe-to-add #4414 : Make extensions getter work with nil *Limits (#4414)
- $maybe-to-add #4397 : Limits with Extensions (#4397)
- $internal-change #4372 : `mimir-rules-action` : `set-output` is deprecated (#4372)
- $internal-change #4360 : New internal query result payload format : bring changes from `sparsehistogram` onto `main` (#4360)
- $internal-change-doc #4370 : Move "Note:" about cross-zone costs to "Costs" (#4370)
```