### PR TITLE
Extend runbook for MimirIngesterReachingTenantsLimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main / unreleased
 
+### Documentation
+
+* [ENHANCEMENT] Improve `MimirIngesterReachingTenantsLimit` runbook. #4744
+
 ## 2.8.0-rc.0
 
 ### Grafana Mimir

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -118,7 +118,7 @@ How to **fix** it:
 
 This alert fires when the `max_tenants` per ingester instance limit is enabled and the actual number of tenants in an ingester is reaching the limit. Once the limit is reached, writes to the ingester will fail (5xx) for new tenants, while they will continue to succeed for previously existing ones.
 
-The per-tenant memory utilisation in ingesters is made up mostly by allocations for TSDB stripes and chunk writer buffers. The size of these allocations is controlled by `-blocks-storage.tsdb.stripe-size` (default 16KiB) and `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` (default 4MiB), respectively. 
+The per-tenant memory utilisation in ingesters is made up mostly by allocations for TSDB stripes and chunk writer buffers. The size of these allocations is controlled by `-blocks-storage.tsdb.stripe-size` (default 16KiB) and `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` (default 4MiB), respectively.
 In case of **emergency**:
 
 - If the actual number of tenants is very close to or already hit the limit, then you can increase the limit via runtime config to gain some time

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -147,7 +147,7 @@ How to **fix** it:
 
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
-1. If the cell's number of series per ingester is below our target, we may want to increase the `max tenants` limit instead of adding more ingesters (which would make the cell over-provisioned in effect). If memory usage is high (due to the number of tenants), we might want to bring it down by reducing TSDB stripe size (`-blocks-storage.tsdb.stripe-size`) and chunk writer buffers (`-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes`). The latter will have a negative performance impacts for large tenants, but for smaller tenants it should be OK.
+1. If the cell's number of series per ingester is below our target, we may want to increase the `max tenants` limit instead of adding more ingesters (which would make the cell over-provisioned in effect). If memory usage is high (due to the number of tenants), we might want to bring it down by reducing TSDB stripe size (`-blocks-storage.tsdb.stripe-size`) and chunk writer buffers (`-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes`). The latter will have a negative performance impact for large tenants, but for smaller tenants it should be OK.
 
 ### MimirDistributorReachingInflightPushRequestLimit
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -119,6 +119,7 @@ How to **fix** it:
 This alert fires when the `max_tenants` per ingester instance limit is enabled and the actual number of tenants in an ingester is reaching the limit. Once the limit is reached, writes to the ingester will fail (5xx) for new tenants, while they will continue to succeed for previously existing ones.
 
 The per-tenant memory utilisation in ingesters is made up mostly by allocations for TSDB stripes and chunk writer buffers. The size of these allocations is controlled by `-blocks-storage.tsdb.stripe-size` (default 16KiB) and `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` (default 4MiB), respectively.
+
 In case of **emergency**:
 
 - If the actual number of tenants is very close to or already hit the limit, then you can increase the limit via runtime config to gain some time

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -118,6 +118,7 @@ How to **fix** it:
 
 This alert fires when the `max_tenants` per ingester instance limit is enabled and the actual number of tenants in an ingester is reaching the limit. Once the limit is reached, writes to the ingester will fail (5xx) for new tenants, while they will continue to succeed for previously existing ones.
 
+The per-tenant memory utilisation in ingesters is made up mostly by allocations for TSDB stripes and chunk writer buffers. The size of these allocations is controlled by `-blocks-storage.tsdb.stripe-size` (default 16KiB) and `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` (default 4MiB), respectively. 
 In case of **emergency**:
 
 - If the actual number of tenants is very close to or already hit the limit, then you can increase the limit via runtime config to gain some time
@@ -145,6 +146,7 @@ How to **fix** it:
 
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
+1. For small tenants, default allocations for TSDB stripes and chunk writer buffers may be oversized. If a cell contains only small tenants, these allocation sizes can be reduced to allow raising the `max_tenants` limit without causing greatly increased per-tenant memory consumption.
 
 ### MimirDistributorReachingInflightPushRequestLimit
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -118,7 +118,7 @@ How to **fix** it:
 
 This alert fires when the `max_tenants` per ingester instance limit is enabled and the actual number of tenants in an ingester is reaching the limit. Once the limit is reached, writes to the ingester will fail (5xx) for new tenants, while they will continue to succeed for previously existing ones.
 
-The per-tenant memory utilisation in ingesters is made up mostly by allocations for TSDB stripes and chunk writer buffers. The size of these allocations is controlled by `-blocks-storage.tsdb.stripe-size` (default 16KiB) and `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` (default 4MiB), respectively.
+The per-tenant memory utilisation in ingesters includes the overhead of allocations for TSDB stripes and chunk writer buffers. If the tenant number is high, this may contribute significantly to the total ingester memory utilization. The size of these allocations is controlled by `-blocks-storage.tsdb.stripe-size` (default 16KiB) and `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` (default 4MiB), respectively.
 
 In case of **emergency**:
 
@@ -147,7 +147,7 @@ How to **fix** it:
 
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
-1. For small tenants, default allocations for TSDB stripes and chunk writer buffers may be oversized. If a cell contains only small tenants, these allocation sizes can be reduced to allow raising the `max_tenants` limit without causing greatly increased per-tenant memory consumption.
+1. If the cell's number of series per ingester is below our target, we may want to increase the `max tenants` limit instead of adding more ingesters (which would make the cell over-provisioned in effect). If memory usage is high (due to the number of tenants), we might want to bring it down by reducing TSDB stripe size (`-blocks-storage.tsdb.stripe-size`) and chunk writer buffers (`-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes`). The latter will have a negative performance impacts for large tenants, but for smaller tenants it should be OK.
 
 ### MimirDistributorReachingInflightPushRequestLimit
 


### PR DESCRIPTION
This extends the runbook for `MimirIngesterReachingTenantsLimit` to explain what controls per-tenant allocation size in ingesters and its correlation to the `max_tenants` parameter.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
