### PR TITLE
store-gateway: rename `seriesEntry` to `seriesChunks`

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -533,7 +533,7 @@ func (s *BucketStore) TimeRange() (mint, maxt int64) {
 	return mint, maxt
 }
 
-type seriesEntry struct {
+type seriesChunks struct {
 	lset labels.Labels
 	chks []storepb.AggrChunk
 }

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1224,8 +1224,8 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 			st.chunkPool = &trackedBytesPool{parent: st.chunkPool}
 
 			// Reset the memory pools.
-			seriesEntrySlicePool.(*pool.TrackedPool).Reset()
 			seriesChunksSlicePool.(*pool.TrackedPool).Reset()
+			chunksSlicePool.(*pool.TrackedPool).Reset()
 		}
 
 		assert.NoError(t, st.SyncBlocks(context.Background()))
@@ -1267,11 +1267,11 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 				assert.Zero(t, st.chunkPool.(*trackedBytesPool).balance.Load())
 				st.chunkPool.(*trackedBytesPool).gets.Store(0)
 
-				assert.Zero(t, seriesEntrySlicePool.(*pool.TrackedPool).Balance.Load())
 				assert.Zero(t, seriesChunksSlicePool.(*pool.TrackedPool).Balance.Load())
+				assert.Zero(t, chunksSlicePool.(*pool.TrackedPool).Balance.Load())
 
-				assert.Greater(t, int(seriesEntrySlicePool.(*pool.TrackedPool).Gets.Load()), 0)
 				assert.Greater(t, int(seriesChunksSlicePool.(*pool.TrackedPool).Gets.Load()), 0)
+				assert.Greater(t, int(chunksSlicePool.(*pool.TrackedPool).Gets.Load()), 0)
 			}
 
 			for _, b := range st.blocks {


### PR DESCRIPTION
Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

#### What this PR does

One of the last parts of #3348 was to rename some of the structs for consistency. This PR does a couple of renames. It should be a noop in terms of functionality or performance.

* `seriesEntry` -> `seriesChunks`; this keeps the consistency with `seriesChunkRefs`
  * `seriesChunksSlicePool` -> `chunksSlicePool`; this holds `[]storepb.AggrChunk`, so I think the rename makes sense
  * `seriesEntrySlicePool` -> `seriesChunksSlicePool`; this change makes some of the diff confusing
* a few places in tests that were using `entry` for a variable name while holding `seriesEntry`. I renamed them to `series`
* `loadIdx.chunk` -> `loadIdx.chunkEntry` to have a bit more consistency with `seriesEntry` and may disabiguate what `entry` refers to

__Notes to reviewers__
* `seriesEntry` isn't used in any gob or other encodings which may break after this change.
* I used Goland's rename functionality instead of doing these manually, so correctness should be retained


#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
