### PR TITLE
copyblocks: support copying between Azure Blob Storage buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@
 
 ### Tools
 
-* [CHANGE] copyblocks: copying between Azure Blob Storage buckets is now supported so the `--service` flag is now required to be specified (accepted values are `gcs` or `abs`). #4756
+* [CHANGE] copyblocks: copying between Azure Blob Storage buckets is now supported in addition to copying between Google Cloud Storage buckets. As a result, the `--service` flag is now required to be specified (accepted values are `gcs` or `abs`). #4756
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,7 @@
 
 ### Tools
 
+* [CHANGE] copyblocks: copying between Azure Blob Storage buckets is now supported so the `--service` flag is now required to be specified (accepted values are `gcs` or `abs`). #4756
 * [ENHANCEMENT] tsdb-index: iteration over index is now faster when any equal matcher is supplied. #4515
 
 ## 2.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@
 * [ENHANCEMENT] analyze prometheus: allow to specify `-prometheus-http-prefix`. #4966
 * [ENHANCEMENT] analyze grafana: allow to specify `--folder-title` to limit dashboards analysis based on their exact folder title. #4973
 
+### Tools
+
+* [CHANGE] copyblocks: copying between Azure Blob Storage buckets is now supported so the `--service` flag is now required to be specified (accepted values are `gcs` or `abs`). #4756
+
 ## 2.8.0
 
 ### Grafana Mimir
@@ -256,7 +260,6 @@
 
 ### Tools
 
-* [CHANGE] copyblocks: copying between Azure Blob Storage buckets is now supported so the `--service` flag is now required to be specified (accepted values are `gcs` or `abs`). #4756
 * [ENHANCEMENT] tsdb-index: iteration over index is now faster when any equal matcher is supplied. #4515
 
 ## 2.7.3

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/mimir
 go 1.18
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.5.1
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/dustin/go-humanize v1.0.0
 	github.com/edsrzf/mmap-go v1.1.0
@@ -81,7 +82,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.5.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1 // indirect
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -34,5 +34,5 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
   --azure-destination-account-name <destination account name> \
   --azure-destination-account-key <destination account key> \
   --destination-bucket https://<destination account name>.blob.core.windows.net/<destination bucket name> \
-  --min-block-duration 24h
+  --min-block-duration 23h
 ```

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -10,7 +10,7 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
 - Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that will be compacted
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
-- Log what would be copied without actually copying anything with `--dry-run` 
+- Log what would be copied without actually copying anything with `--dry-run`
 
 ### Example for Google Cloud Storage
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -19,7 +19,7 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
   --copy-period 24h \
   --source-bucket <source bucket name> \
   --destination-bucket <destination bucket name> \
-  --min-block-duration 24h
+  --min-block-duration 23h
 ```
 
 ### Example for Azure Blob Storage

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -6,10 +6,11 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
 ## Features
 
 - Prevents copying blocks multiple times to the same destination bucket by uploading block marker files to the source bucket
-- Run as a one-time copy job, or run continuously with periodic checks (`--copy-period`)
+- Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits.
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
-- Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that are too small
+- Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that will be compacted
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
+- Log what would be copied without actually copying anything with `--dry-run` 
 
 ### Example for Google Cloud Storage
 
@@ -31,8 +32,8 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
   --source-bucket https://<source account name>.blob.core.windows.net/<source bucket name> \
   --azure-source-account-name <source account name> \
   --azure-source-account-key <source account key> \
+  --destination-bucket https://<destination account name>.blob.core.windows.net/<destination bucket name> \
   --azure-destination-account-name <destination account name> \
   --azure-destination-account-key <destination account key> \
-  --destination-bucket https://<destination account name>.blob.core.windows.net/<destination bucket name> \
   --min-block-duration 23h
 ```

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -6,7 +6,7 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
 ## Features
 
 - Prevents copying blocks multiple times to the same destination bucket by uploading block marker files to the source bucket
-- Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits.
+- Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
 - Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that will be compacted
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -11,7 +11,7 @@ It is specific to these two services and performs server-side copies between buc
 - Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that are too small
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
 
-## Example for Google Cloud Storage
+### Example for Google Cloud Storage
 
 ```bash
 ./copyblocks \
@@ -22,7 +22,7 @@ It is specific to these two services and performs server-side copies between buc
   --min-block-duration 24h
 ```
 
-## Example for Azure Blob Storage
+### Example for Azure Blob Storage
 
 ```bash
 ./copyblocks \

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -1,7 +1,7 @@
 # Copyblocks
 
-This program can copy Mimir blocks between two Google Cloud Storage (GCS) buckets or two Azure Blob Storage (ABS) buckets.
-It is specific to these two services and performs server-side copies between buckets.
+This program can copy Mimir blocks server-side between two buckets on the same object storage service provider.
+The currently supported services are Google Cloud Storage (GCS) and Azure Blob Storage (ABS).
 
 ## Features
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -1,9 +1,38 @@
 # Copyblocks
 
-This program can copy Mimir blocks between two GCS buckets. It is GCS specific and uses special calls to copy
-files between buckets directly, without download to a local system first.
+This program can copy Mimir blocks between two Google Cloud Storage (GCS) buckets or two Azure Blob Storage (ABS) buckets.
+It is specific to these two services and performs server-side copies between buckets.
 
-The copyblocks program can run a one-time copy job, or it can run continuously as a service that periodically checks to see if there are blocks to copy and if so runs the copy job.
+## Features
 
-You can configure it with a minimum block time range to avoid copying blocks that are too small.
-You can configure an allowlist and a blocklist of users to copy or not to copy.
+- Prevents copying blocks multiple times to the same destination bucket by uploading block marker files to the source bucket
+- Run as a one-time copy job, or run continuously with periodic checks (`--copy-period`)
+- Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
+- Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that are too small
+- Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
+
+## Example for Google Cloud Storage
+
+```bash
+./copyblocks \
+  --service gcs \
+  --copy-period 24h \
+  --source-bucket <source bucket name> \
+  --destination-bucket <destination bucket name> \
+  --min-block-duration 24h
+```
+
+## Example for Azure Blob Storage
+
+```bash
+./copyblocks \
+  --service abs \
+  --copy-period 24h \
+  --source-bucket https://<source account name>.blob.core.windows.net/<source bucket name> \
+  --azure-source-account-name <source account name> \
+  --azure-source-account-key <source account key> \
+  --azure-destination-account-name <destination account name> \
+  --azure-destination-account-key <destination account key> \
+  --destination-bucket https://<destination account name>.blob.core.windows.net/<destination bucket name> \
+  --min-block-duration 24h
+```

--- a/tools/copyblocks/bucket.go
+++ b/tools/copyblocks/bucket.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
+	"github.com/grafana/dskit/backoff"
+	"github.com/pkg/errors"
+	"google.golang.org/api/iterator"
+)
+
+type bucket interface {
+	Get(ctx context.Context, name string) (io.ReadCloser, error)
+	Copy(ctx context.Context, name string, dstBucket bucket) error
+	ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error)
+	UploadMarkerFile(ctx context.Context, name string) error
+	Name() string
+}
+
+type gcsBucket struct {
+	storage.BucketHandle
+	name string
+}
+
+func (bkt *gcsBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	obj := bkt.Object(name)
+	r, err := obj.NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (bkt *gcsBucket) Copy(ctx context.Context, name string, dstBucket bucket) error {
+	d, ok := dstBucket.(*gcsBucket)
+	if !ok {
+		return errors.New("destination bucket wasn't a gcs bucket")
+	}
+	srcObj := bkt.Object(name)
+	dstObject := d.BucketHandle.Object(name)
+	copier := dstObject.CopierFrom(srcObj)
+	_, err := copier.Run(ctx)
+	return err
+}
+
+func (bkt *gcsBucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {
+	if len(prefix) > 0 && prefix[len(prefix)-1:] != delim {
+		prefix = prefix + delim
+	}
+
+	q := &storage.Query{
+		Prefix: prefix,
+	}
+	if !recursive {
+		q.Delimiter = delim
+	}
+
+	var result []string
+
+	it := bkt.Objects(ctx, q)
+	for {
+		obj, err := it.Next()
+
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "listPrefix: error listing %v", prefix)
+		}
+
+		path := ""
+		if obj.Prefix != "" { // synthetic directory, only returned when recursive=false
+			path = obj.Prefix
+		} else {
+			path = obj.Name
+		}
+
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimPrefix(path, prefix)
+		} else {
+			return nil, errors.Errorf("listPrefix: path has invalid prefix: %v, expected prefix: %v", path, prefix)
+		}
+
+		result = append(result, path)
+	}
+
+	return result, nil
+}
+
+func (bkt *gcsBucket) UploadMarkerFile(ctx context.Context, name string) error {
+	obj := bkt.Object(name)
+	w := obj.NewWriter(ctx)
+	return w.Close()
+}
+
+func (bkt *gcsBucket) Name() string {
+	return bkt.name
+}
+
+type azureBucket struct {
+	azblob.Client
+	containerClient container.Client
+	containerName   string
+}
+
+func (bkt *azureBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	client := bkt.containerClient.NewBlobClient(name)
+	response, err := client.DownloadStream(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return response.Body, nil
+}
+
+func (bkt *azureBucket) Copy(ctx context.Context, name string, dstBucket bucket) error {
+	sourceClient := bkt.containerClient.NewBlobClient(name)
+	sasURL, err := sourceClient.GetSASURL(sas.BlobPermissions{Read: true}, time.Now(), time.Now().Add(10*time.Minute))
+	if err != nil {
+		return err
+	}
+	d, ok := dstBucket.(*azureBucket)
+	if !ok {
+		return errors.New("destination bucket wasn't a blob storage bucket")
+	}
+	dstClient := d.containerClient.NewBlobClient(name)
+
+	response, err := dstClient.StartCopyFromURL(ctx, sasURL, nil)
+	if err != nil {
+		return err
+	}
+
+	copyStatus := response.CopyStatus
+	backoff := backoff.New(ctx, backoff.Config{
+		MinBackoff: time.Second,
+		MaxBackoff: time.Minute,
+		MaxRetries: 10,
+	})
+
+	for {
+		if copyStatus == nil {
+			return errors.New("no copy status present for blob copy")
+		}
+		if *copyStatus == blob.CopyStatusTypeSuccess {
+			return nil
+		}
+		if *copyStatus == blob.CopyStatusTypeAborted {
+			return errors.New("copy aborted")
+		}
+		if *copyStatus == blob.CopyStatusTypeFailed {
+			return errors.New("copy failed")
+		}
+
+		if !backoff.Ongoing() {
+			break
+		}
+
+		backoff.Wait()
+
+		response, err := dstClient.GetProperties(ctx, nil)
+		if err != nil {
+			return err
+		}
+		copyStatus = response.CopyStatus
+	}
+	return errors.Wrap(backoff.Err(), "waiting for blob copy status")
+}
+
+func (bkt *azureBucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {
+	if prefix != "" && !strings.HasSuffix(prefix, delim) {
+		prefix = prefix + delim
+	}
+
+	list := make([]string, 0, 10)
+	if recursive {
+		pager := bkt.containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{Prefix: &prefix})
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, blobItem := range page.Segment.BlobItems {
+				list = append(list, *blobItem.Name)
+			}
+		}
+	} else {
+		pager := bkt.containerClient.NewListBlobsHierarchyPager(delim, &container.ListBlobsHierarchyOptions{Prefix: &prefix})
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, blobItem := range page.Segment.BlobItems {
+				list = append(list, *blobItem.Name)
+			}
+			for _, blobPrefix := range page.Segment.BlobPrefixes {
+				list = append(list, *blobPrefix.Name)
+			}
+		}
+	}
+
+	var hasPrefix bool
+	for i, s := range list {
+		list[i], hasPrefix = strings.CutPrefix(s, prefix)
+		if !hasPrefix {
+			return nil, errors.Errorf("listPrefix: path has invalid prefix: %v, expected prefix: %v", s, prefix)
+		}
+	}
+
+	return list, nil
+}
+
+func (bkt *azureBucket) UploadMarkerFile(ctx context.Context, name string) error {
+	_, err := bkt.UploadBuffer(ctx, bkt.containerName, name, []byte{}, nil)
+	return err
+}
+
+func (bkt *azureBucket) Name() string {
+	return bkt.containerName
+}

--- a/tools/copyblocks/gcs.go
+++ b/tools/copyblocks/gcs.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/pkg/errors"
+	"google.golang.org/api/iterator"
+)
+
+type gcsBucket struct {
+	storage.BucketHandle
+	name string
+}
+
+func newGCSBucket(client *storage.Client, name string) bucket {
+	return &gcsBucket{
+		BucketHandle: *client.Bucket(name),
+		name:         name,
+	}
+}
+
+func (bkt *gcsBucket) Get(ctx context.Context, objectName string) (io.ReadCloser, error) {
+	obj := bkt.Object(objectName)
+	r, err := obj.NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (bkt *gcsBucket) Copy(ctx context.Context, objectName string, dstBucket bucket) error {
+	d, ok := dstBucket.(*gcsBucket)
+	if !ok {
+		return errors.New("destination bucket wasn't a gcs bucket")
+	}
+	srcObj := bkt.Object(objectName)
+	dstObject := d.BucketHandle.Object(objectName)
+	copier := dstObject.CopierFrom(srcObj)
+	_, err := copier.Run(ctx)
+	return err
+}
+
+func (bkt *gcsBucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {
+	if len(prefix) > 0 && prefix[len(prefix)-1:] != delim {
+		prefix = prefix + delim
+	}
+
+	q := &storage.Query{
+		Prefix: prefix,
+	}
+	if !recursive {
+		q.Delimiter = delim
+	}
+
+	var result []string
+
+	it := bkt.Objects(ctx, q)
+	for {
+		obj, err := it.Next()
+
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "listPrefix: error listing %v", prefix)
+		}
+
+		path := ""
+		if obj.Prefix != "" { // synthetic directory, only returned when recursive=false
+			path = obj.Prefix
+		} else {
+			path = obj.Name
+		}
+
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimPrefix(path, prefix)
+		} else {
+			return nil, errors.Errorf("listPrefix: path has invalid prefix: %v, expected prefix: %v", path, prefix)
+		}
+
+		result = append(result, path)
+	}
+
+	return result, nil
+}
+
+func (bkt *gcsBucket) UploadMarkerFile(ctx context.Context, objectName string) error {
+	obj := bkt.Object(objectName)
+	w := obj.NewWriter(ctx)
+	return w.Close()
+}
+
+func (bkt *gcsBucket) Name() string {
+	return bkt.name
+}

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -402,11 +402,7 @@ func copySingleBlock(ctx context.Context, tenantID string, blockID ulid.ULID, ma
 
 func uploadCopiedMarkerFile(ctx context.Context, bkt bucket, tenantID string, blockID ulid.ULID, targetBucketName string) error {
 	err := bkt.UploadMarkerFile(ctx, tenantID+delim+CopiedToBucketMarkFilename(blockID, targetBucketName))
-	if err != nil {
-		return errors.Wrap(err, "uploadCopiedMarkerFile")
-
-	}
-	return nil
+	return errors.Wrap(err, "uploadCopiedMarkerFile")
 }
 
 func loadMetaJSONFile(ctx context.Context, bkt bucket, tenantID string, blockID ulid.ULID) (block.Meta, error) {

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -19,9 +19,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
@@ -121,11 +118,6 @@ func main() {
 	logger := log.NewLogfmtLogger(os.Stdout)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 
-	if cfg.sourceBucket == "" || cfg.destBucket == "" || cfg.sourceBucket == cfg.destBucket {
-		level.Error(logger).Log("msg", "no source or destination bucket, or buckets are the same")
-		os.Exit(1)
-	}
-
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -161,6 +153,46 @@ func main() {
 	}
 }
 
+func initializeBuckets(ctx context.Context, cfg config) (sourceBucket bucket, destBucket bucket, err error) {
+	if cfg.sourceBucket == "" || cfg.destBucket == "" {
+		return nil, nil, errors.New("--source-bucket or --destination-bucket is missing")
+	}
+	if cfg.sourceBucket == cfg.destBucket {
+		return nil, nil, errors.New("--source-bucket and --destination-bucket can not be the same")
+	}
+
+	switch strings.ToLower(cfg.service) {
+	case serviceGCS:
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to create client")
+		}
+		sourceBucket = newGCSBucket(client, cfg.sourceBucket)
+		destBucket = newGCSBucket(client, cfg.destBucket)
+	case serviceABS:
+		if cfg.azureSourceAccountKey == "" || cfg.azureSourceAccountName == "" {
+			return nil, nil, errors.New("the azure source bucket's account name (--azure-source-account-name) and account key (--azure-source-account-key) are required")
+		}
+		if cfg.azureDestinationAccountKey == "" || cfg.azureDestinationAccountName == "" {
+			return nil, nil, errors.New("the azure destination bucket's account name (--azure-destination-account-name) and account key (--azure-destination-account-key) are required")
+		}
+
+		var err error
+		sourceBucket, err = newAzureBucketClient(cfg.sourceBucket, cfg.azureSourceAccountName, cfg.azureSourceAccountKey)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to create source azure bucket client")
+		}
+		destBucket, err = newAzureBucketClient(cfg.destBucket, cfg.azureDestinationAccountName, cfg.azureDestinationAccountKey)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to create destination azure bucket client")
+		}
+	default:
+		return nil, nil, errors.Errorf("invalid service: %v", cfg.service)
+	}
+
+	return sourceBucket, destBucket, nil
+}
+
 func runCopy(ctx context.Context, cfg config, logger log.Logger, m *metrics) bool {
 	err := copyBlocks(ctx, cfg, logger, m)
 	if err != nil {
@@ -175,86 +207,23 @@ func runCopy(ctx context.Context, cfg config, logger log.Logger, m *metrics) boo
 }
 
 func copyBlocks(ctx context.Context, cfg config, logger log.Logger, m *metrics) error {
-	enabledUsers := map[string]struct{}{}
-	disabledUsers := map[string]struct{}{}
-
-	for _, u := range cfg.enabledUsers {
-		enabledUsers[u] = struct{}{}
-	}
-	for _, u := range cfg.disabledUsers {
-		disabledUsers[u] = struct{}{}
-	}
-
-	var sourceBucket, destBucket bucket
-	switch strings.ToLower(cfg.service) {
-	case serviceGCS:
-		client, err := storage.NewClient(ctx)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create client")
-		}
-		sourceBucket = &gcsBucket{
-			BucketHandle: *client.Bucket(cfg.sourceBucket),
-			name:         cfg.sourceBucket,
-		}
-		destBucket = &gcsBucket{
-			BucketHandle: *client.Bucket(cfg.destBucket),
-			name:         cfg.destBucket,
-		}
-	case serviceABS:
-		if cfg.azureSourceAccountKey == "" || cfg.azureSourceAccountName == "" {
-			return errors.New("the azure source bucket's account name and account key are required")
-		}
-		if cfg.azureDestinationAccountKey == "" || cfg.azureDestinationAccountName == "" {
-			return errors.New("the azure destination bucket's account name and account key are required")
-		}
-
-		newAzureBucketClient := func(containerURL string, accountName string, sharedKey string) (bucket, error) {
-			urlParts, err := blob.ParseURL(containerURL)
-			if err != nil {
-				return nil, err
-			}
-			containerName := urlParts.ContainerName
-			if containerName == "" {
-				return nil, errors.New("container name missing from azure bucket URL")
-			}
-			serviceURL, found := strings.CutSuffix(containerURL, containerName)
-			if !found {
-				return nil, errors.New("malformed or unexpected azure bucket URL")
-			}
-			keyCred, err := azblob.NewSharedKeyCredential(accountName, sharedKey)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get azure shared key credential")
-			}
-			client, err := azblob.NewClientWithSharedKeyCredential(serviceURL, keyCred, nil)
-			if err != nil {
-				return nil, err
-			}
-			containerClient, err := container.NewClientWithSharedKeyCredential(containerURL, keyCred, nil)
-			if err != nil {
-				return nil, err
-			}
-			return &azureBucket{
-				Client:          *client,
-				containerClient: *containerClient,
-				containerName:   containerName,
-			}, nil
-		}
-		var err error
-		sourceBucket, err = newAzureBucketClient(cfg.sourceBucket, cfg.azureSourceAccountName, cfg.azureSourceAccountKey)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create source azure bucket client")
-		}
-		destBucket, err = newAzureBucketClient(cfg.destBucket, cfg.azureDestinationAccountName, cfg.azureDestinationAccountKey)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create destination azure bucket client")
-		}
-	default:
-		return errors.Errorf("invalid service: %v", cfg.service)
+	sourceBucket, destBucket, err := initializeBuckets(ctx, cfg)
+	if err != nil {
+		return err
 	}
 
 	tenants, err := listTenants(ctx, sourceBucket)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list tenants")
+	}
+
+	enabledUsers := map[string]struct{}{}
+	disabledUsers := map[string]struct{}{}
+	for _, u := range cfg.enabledUsers {
+		enabledUsers[u] = struct{}{}
+	}
+	for _, u := range cfg.disabledUsers {
+		disabledUsers[u] = struct{}{}
 	}
 
 	return concurrency.ForEachUser(ctx, tenants, cfg.tenantConcurrency, func(ctx context.Context, tenantID string) error {


### PR DESCRIPTION
#### What this PR does
Adds support for copying between two Azure Blob Storage buckets with the copyblocks tool. This tool previously only supported Google Cloud Storage buckets. I first moved the object storage calls behind a `bucket` interface and then added the Azure implementation.

Note:

- The only Azure authentication method supported is with the account name and key since that is required to generate the SAS token that must be passed in the copy call.
- Each copy on Azure has to be polled to see if it is done. I added backoff for these poll checks ~and didn't make them configurable to hopefully hide the complexity of this~ made them configurable.
- These changes (except some minor cleanup) were tested in a migration between development buckets. It went well!

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
