### PR TITLE
Add native histogram bucket limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
+* [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. Defaults to 1024. #4765
 
 ### Documentation
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2961,6 +2961,16 @@
         },
         {
           "kind": "field",
+          "name": "max_native_histogram_buckets",
+          "required": false,
+          "desc": "Maximum number of buckets per native histogram sample. 0 to disable the limit.",
+          "fieldValue": null,
+          "fieldDefaultValue": 1024,
+          "fieldFlag": "validation.max-native-histogram-buckets",
+          "fieldType": "int"
+        },
+        {
+          "kind": "field",
           "name": "creation_grace_period",
           "required": false,
           "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t \u003e (now + validation.create-grace-period)`. Also used by query-frontend to avoid querying too far into the future. 0 to disable.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2965,7 +2965,7 @@
           "required": false,
           "desc": "Maximum number of buckets per native histogram sample. 0 to disable the limit.",
           "fieldValue": null,
-          "fieldDefaultValue": 1024,
+          "fieldDefaultValue": 0,
           "fieldFlag": "validation.max-native-histogram-buckets",
           "fieldType": "int"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2384,7 +2384,7 @@ Usage of ./cmd/mimir/mimir:
   -validation.max-metadata-length int
     	Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated. (default 1024)
   -validation.max-native-histogram-buckets int
-    	Maximum number of buckets per native histogram sample. 0 to disable the limit. (default 1024)
+    	Maximum number of buckets per native histogram sample. 0 to disable the limit.
   -validation.separate-metrics-group-label string
     	[experimental] Label used to define the group label for metrics separation. For each write request, the group is obtained from the first non-empty group label from the first timeseries in the incoming list of timeseries. Specific distributor and ingester metrics will be further separated adding a 'group' label with group label's value. Currently applies to the following metrics: cortex_discarded_samples_total
   -vault.enabled

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2383,6 +2383,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum length accepted for label value. This setting also applies to the metric name (default 2048)
   -validation.max-metadata-length int
     	Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated. (default 1024)
+  -validation.max-native-histogram-buckets int
+    	Maximum number of buckets per native histogram sample. 0 to disable the limit. (default 1024)
   -validation.separate-metrics-group-label string
     	[experimental] Label used to define the group label for metrics separation. For each write request, the group is obtained from the first non-empty group label from the first timeseries in the incoming list of timeseries. Specific distributor and ingester metrics will be further separated adding a 'group' label with group label's value. Currently applies to the following metrics: cortex_discarded_samples_total
   -vault.enabled

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -655,6 +655,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum length accepted for label value. This setting also applies to the metric name (default 2048)
   -validation.max-metadata-length int
     	Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated. (default 1024)
+  -validation.max-native-histogram-buckets int
+    	Maximum number of buckets per native histogram sample. 0 to disable the limit. (default 1024)
   -version
     	Print application version and exit.
 

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -656,7 +656,7 @@ Usage of ./cmd/mimir/mimir:
   -validation.max-metadata-length int
     	Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated. (default 1024)
   -validation.max-native-histogram-buckets int
-    	Maximum number of buckets per native histogram sample. 0 to disable the limit. (default 1024)
+    	Maximum number of buckets per native histogram sample. 0 to disable the limit.
   -version
     	Print application version and exit.
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1240,7 +1240,7 @@ The limit protects the system’s stability from potential abuse or mistakes. To
 
 > **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
-### max-native-histogram-buckets
+### err-mimir-max-native-histogram-buckets
 
 This non-critical error occurs when Mimir receives a write request that contains a sample that is a native histogram that has too many observation buckets.
 The limit protects the system from using too much memory. To configure the limit on a per-tenant basis, use the `-validation.max-native-histogram-buckets` option.

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1240,6 +1240,13 @@ The limit protects the system’s stability from potential abuse or mistakes. To
 
 > **Note:** Invalid series are skipped during the ingestion, and valid series within the same request are ingested.
 
+### max-native-histogram-buckets
+
+This non-critical error occurs when Mimir receives a write request that contains a sample that is a native histogram that has too many observation buckets.
+The limit protects the system from using too much memory. To configure the limit on a per-tenant basis, use the `-validation.max-native-histogram-buckets` option.
+
+> **Note:** The series containing such samples are skipped during ingestion, and valid series within the same request are ingested.
+
 ### err-mimir-label-invalid
 
 This non-critical error occurs when Mimir receives a write request that contains a series with an invalid label name.

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2549,7 +2549,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 
 # Maximum number of buckets per native histogram sample. 0 to disable the limit.
 # CLI flag: -validation.max-native-histogram-buckets
-[max_native_histogram_buckets: <int> | default = 1024]
+[max_native_histogram_buckets: <int> | default = 0]
 
 # (advanced) Controls how far into the future incoming samples are accepted
 # compared to the wall clock. Any sample with timestamp `t` will be rejected if

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2547,6 +2547,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -validation.max-metadata-length
 [max_metadata_length: <int> | default = 1024]
 
+# Maximum number of buckets per native histogram sample. 0 to disable the limit.
+# CLI flag: -validation.max-native-histogram-buckets
+[max_native_histogram_buckets: <int> | default = 1024]
+
 # (advanced) Controls how far into the future incoming samples are accepted
 # compared to the wall clock. Any sample with timestamp `t` will be rejected if
 # `t > (now + validation.create-grace-period)`. Also used by query-frontend to

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1498,10 +1498,15 @@ func TestDistributor_Push_ExemplarValidation(t *testing.T) {
 func TestDistributor_Push_HistogramValidation(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
 
+	// For testing bucket limit
+	testHistogram := util_test.GenerateTestFloatHistogram(0)
+	require.Equal(t, 8, len(testHistogram.PositiveBuckets)+len(testHistogram.NegativeBuckets), "selftest, check generator drift")
+
 	tests := map[string]struct {
-		req    *mimirpb.WriteRequest
-		errMsg string
-		errID  globalerror.ID
+		req         *mimirpb.WriteRequest
+		errMsg      string
+		errID       globalerror.ID
+		bucketLimit int
 	}{
 		"valid histogram": {
 			req: makeWriteRequestHistogram([]string{model.MetricNameLabel, "test"}, 1000, generateTestHistogram(0)),
@@ -1519,6 +1524,16 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 			errMsg: "received a sample whose timestamp is too far in the future",
 			errID:  globalerror.SampleTooFarInFuture,
 		},
+		"buckets at limit": {
+			req:         makeWriteRequestFloatHistogram([]string{model.MetricNameLabel, "test"}, 1000, testHistogram),
+			bucketLimit: 8,
+		},
+		"buckets over limit": {
+			req:         makeWriteRequestFloatHistogram([]string{model.MetricNameLabel, "test"}, 1000, testHistogram),
+			bucketLimit: 7,
+			errMsg:      "received a native histogram sample with too many buckets, timestamp",
+			errID:       globalerror.MaxNativeHistogramBuckets,
+		},
 	}
 
 	for testName, tc := range tests {
@@ -1526,6 +1541,7 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 			limits := &validation.Limits{}
 			flagext.DefaultValues(limits)
 			limits.CreationGracePeriod = model.Duration(time.Minute)
+			limits.MaxNativeHistogramBuckets = tc.bucketLimit
 
 			ds, _, _ := prepare(t, prepConfig{
 				numIngesters:     2,
@@ -1538,6 +1554,7 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 			_, err := ds[0].Push(ctx, tc.req)
 			if tc.errMsg != "" {
 				fromError, _ := status.FromError(err)
+				require.Equal(t, int32(400), fromError.Proto().Code)
 				assert.Contains(t, fromError.Message(), tc.errMsg)
 				assert.Contains(t, fromError.Message(), tc.errID)
 			} else {
@@ -5094,6 +5111,66 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 			receivedSamples:   10,
 			receivedExemplars: 5,
 			receivedMetadata:  10})
+
+		require.NoError(t, testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(expectedMetrics),
+			metricNames...,
+		))
+	})
+
+	t.Run("Drop half of samples via native histogram bucket limit", func(t *testing.T) {
+		bucketLimit := 2
+		cfg := getDefaultConfig()
+		cfg.limits.MaxNativeHistogramBuckets = bucketLimit
+		dist, reg := getDistributor(cfg)
+
+		validHistogram := mimirpb.Histogram{
+			Count:          &mimirpb.Histogram_CountInt{CountInt: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			NegativeDeltas: []int64{1},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			PositiveDeltas: []int64{1},
+			Timestamp:      100,
+		}
+		invalidHistogram := mimirpb.Histogram{
+			Count:          &mimirpb.Histogram_CountInt{CountInt: 3},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			NegativeDeltas: []int64{1},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 2}},
+			PositiveDeltas: []int64{1, 2},
+			Timestamp:      100,
+		}
+
+		req := mimirpb.NewWriteRequest(nil, mimirpb.API)
+		for sampleIdx := 0; sampleIdx < 20; sampleIdx++ {
+			lbs := mimirpb.FromLabelAdaptersToLabels(uniqueMetricsGen(sampleIdx))
+			if sampleIdx%2 == 0 {
+				req.AddHistogramSeries([]labels.Labels{lbs}, []mimirpb.Histogram{validHistogram}, nil)
+			} else {
+				req.AddHistogramSeries([]labels.Labels{lbs}, []mimirpb.Histogram{invalidHistogram}, nil)
+			}
+		}
+
+		dist.Push(getCtx(), req) //nolint:errcheck
+
+		expectedMetrics, metricNames := getExpectedMetrics(expectedMetricsCfg{
+			requestsIn:        1,
+			samplesIn:         20,
+			exemplarsIn:       0,
+			metadataIn:        0,
+			receivedRequests:  1,
+			receivedSamples:   10,
+			receivedExemplars: 0,
+			receivedMetadata:  0})
 
 		require.NoError(t, testutil.GatherAndCompare(
 			reg,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5120,9 +5120,8 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 	})
 
 	t.Run("Drop half of samples via native histogram bucket limit", func(t *testing.T) {
-		bucketLimit := 2
 		cfg := getDefaultConfig()
-		cfg.limits.MaxNativeHistogramBuckets = bucketLimit
+		cfg.limits.MaxNativeHistogramBuckets = 2
 		dist, reg := getDistributor(cfg)
 
 		validHistogram := mimirpb.Histogram{

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -17,6 +17,7 @@ const (
 	MissingMetricName             ID = "missing-metric-name"
 	InvalidMetricName             ID = "metric-name-invalid"
 	MaxLabelNamesPerSeries        ID = "max-label-names-per-series"
+	MaxNativeHistogramBuckets     ID = "max-native-histogram-buckets"
 	SeriesInvalidLabel            ID = "label-invalid"
 	SeriesLabelNameTooLong        ID = "label-name-too-long"
 	SeriesLabelValueTooLong       ID = "label-value-too-long"

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -140,6 +140,27 @@ func (e sampleValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.timestamp, e.metricName)
 }
 
+type maxNativeHistogramBucketsError struct {
+	seriesLabels []mimirpb.LabelAdapter
+	timestamp    int64
+	bucketCount  int
+	bucketLimit  int
+}
+
+func newMaxNativeHistogramBucketsError(seriesLabels []mimirpb.LabelAdapter, timestamp int64, bucketCount, bucketLimit int) maxNativeHistogramBucketsError {
+	return maxNativeHistogramBucketsError{
+		seriesLabels: seriesLabels,
+		timestamp:    timestamp,
+		bucketCount:  bucketCount,
+		bucketLimit:  bucketLimit,
+	}
+}
+
+func (e maxNativeHistogramBucketsError) Error() string {
+	return fmt.Sprintf("received a native histogram sample with too many buckets, timestamp: %d series: %s, buckets: %d, limit: %d (%s)",
+		e.timestamp, mimirpb.FromLabelAdaptersToLabels(e.seriesLabels).String(), e.bucketCount, e.bucketLimit, globalerror.MaxNativeHistogramBuckets)
+}
+
 var sampleTimestampTooNewMsgFormat = globalerror.SampleTooFarInFuture.MessageWithPerTenantLimitConfig(
 	"received a sample whose timestamp is too far in the future, timestamp: %d series: '%.200s'",
 	creationGracePeriodFlag)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -204,7 +204,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelValueLength, maxLabelValueLengthFlag, 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, maxLabelNamesPerSeriesFlag, 30, "Maximum number of label names per series.")
 	f.IntVar(&l.MaxMetadataLength, maxMetadataLengthFlag, 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated.")
-	f.IntVar(&l.MaxNativeHistogramBuckets, maxNativeHistogramBucketsFlag, 1024, "Maximum number of buckets per native histogram sample. 0 to disable the limit.")
+	f.IntVar(&l.MaxNativeHistogramBuckets, maxNativeHistogramBucketsFlag, 0, "Maximum number of buckets per native histogram sample. 0 to disable the limit.")
 	_ = l.CreationGracePeriod.Set("10m")
 	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`. Also used by query-frontend to avoid querying too far into the future. 0 to disable.")
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -37,6 +37,7 @@ const (
 	maxLabelNameLengthFlag                 = "validation.max-length-label-name"
 	maxLabelValueLengthFlag                = "validation.max-length-label-value"
 	maxMetadataLengthFlag                  = "validation.max-metadata-length"
+	maxNativeHistogramBucketsFlag          = "validation.max-native-histogram-buckets"
 	creationGracePeriodFlag                = "validation.create-grace-period"
 	maxQueryLengthFlag                     = "store.max-query-length"
 	maxPartialQueryLengthFlag              = "querier.max-partial-query-length"
@@ -86,6 +87,7 @@ type Limits struct {
 	MaxLabelValueLength       int                 `yaml:"max_label_value_length" json:"max_label_value_length"`
 	MaxLabelNamesPerSeries    int                 `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
 	MaxMetadataLength         int                 `yaml:"max_metadata_length" json:"max_metadata_length"`
+	MaxNativeHistogramBuckets int                 `yaml:"max_native_histogram_buckets" json:"max_native_histogram_buckets"`
 	CreationGracePeriod       model.Duration      `yaml:"creation_grace_period" json:"creation_grace_period" category:"advanced"`
 	EnforceMetadataMetricName bool                `yaml:"enforce_metadata_metric_name" json:"enforce_metadata_metric_name" category:"advanced"`
 	IngestionTenantShardSize  int                 `yaml:"ingestion_tenant_shard_size" json:"ingestion_tenant_shard_size"`
@@ -202,6 +204,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelValueLength, maxLabelValueLengthFlag, 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, maxLabelNamesPerSeriesFlag, 30, "Maximum number of label names per series.")
 	f.IntVar(&l.MaxMetadataLength, maxMetadataLengthFlag, 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated.")
+	f.IntVar(&l.MaxNativeHistogramBuckets, maxNativeHistogramBucketsFlag, 1024, "Maximum number of buckets per native histogram sample. 0 to disable the limit.")
 	_ = l.CreationGracePeriod.Set("10m")
 	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`. Also used by query-frontend to avoid querying too far into the future. 0 to disable.")
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")
@@ -459,6 +462,12 @@ func (o *Overrides) MaxLabelNamesPerSeries(userID string) int {
 // to the Metric Name, HELP and UNIT.
 func (o *Overrides) MaxMetadataLength(userID string) int {
 	return o.getOverridesForUser(userID).MaxMetadataLength
+}
+
+// MaxNativeHistogramBuckets returns the maximum number of buckets per native
+// histogram sample.
+func (o *Overrides) MaxNativeHistogramBuckets(userID string) int {
+	return o.getOverridesForUser(userID).MaxNativeHistogramBuckets
 }
 
 // CreationGracePeriod is misnamed, and actually returns how far into the future

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -411,6 +411,58 @@ func TestMaxNativeHistorgramBuckets(t *testing.T) {
 			ResetHint:      mimirpb.Histogram_GAUGE,
 			Timestamp:      0,
 		},
+		"integer counter positive buckets": {
+			Count:          &mimirpb.Histogram_CountInt{CountInt: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{},
+			NegativeDeltas: []int64{},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}, {Offset: 2, Length: 1}},
+			PositiveDeltas: []int64{1, 0},
+			ResetHint:      mimirpb.Histogram_UNKNOWN,
+			Timestamp:      0,
+		},
+		"integer counter negative buckets": {
+			Count:          &mimirpb.Histogram_CountInt{CountInt: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 2}},
+			NegativeDeltas: []int64{1, 0},
+			PositiveSpans:  []mimirpb.BucketSpan{},
+			PositiveDeltas: []int64{},
+			ResetHint:      mimirpb.Histogram_UNKNOWN,
+			Timestamp:      0,
+		},
+		"float counter positive buckets": {
+			Count:          &mimirpb.Histogram_CountFloat{CountFloat: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountFloat{ZeroCountFloat: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{},
+			NegativeCounts: []float64{},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 2}},
+			PositiveCounts: []float64{1, 1},
+			ResetHint:      mimirpb.Histogram_UNKNOWN,
+			Timestamp:      0,
+		},
+		"float counter negative buckets": {
+			Count:          &mimirpb.Histogram_CountFloat{CountFloat: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountFloat{ZeroCountFloat: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 2}},
+			NegativeCounts: []float64{1, 1},
+			PositiveSpans:  []mimirpb.BucketSpan{},
+			PositiveCounts: []float64{},
+			ResetHint:      mimirpb.Histogram_UNKNOWN,
+			Timestamp:      0,
+		},
 	}
 
 	registry := prometheus.NewRegistry()
@@ -438,6 +490,6 @@ func TestMaxNativeHistorgramBuckets(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="group-1",reason="max_native_histogram_buckets",user="user-1"} 4
+			cortex_discarded_samples_total{group="group-1",reason="max_native_histogram_buckets",user="user-1"} 8
 	`), "cortex_discarded_samples_total"))
 }

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -6,8 +6,10 @@
 package validation
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -340,4 +342,102 @@ func TestValidateLabelDuplication(t *testing.T) {
 		{Name: "a", Value: "a"},
 	}, "a")
 	assert.Equal(t, expected, actual)
+}
+
+type sampleValidationConfig struct {
+	maxNativeHistogramBuckets int
+}
+
+func (c sampleValidationConfig) CreationGracePeriod(userID string) time.Duration {
+	return 0
+}
+
+func (c sampleValidationConfig) MaxNativeHistogramBuckets(userID string) int {
+	return c.maxNativeHistogramBuckets
+}
+
+func TestMaxNativeHistorgramBuckets(t *testing.T) {
+	// All will have 2 buckets, one negative and one positive
+	testCases := map[string]mimirpb.Histogram{
+		"integer counter": {
+			Count:          &mimirpb.Histogram_CountInt{CountInt: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			NegativeDeltas: []int64{1},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			PositiveDeltas: []int64{1},
+			ResetHint:      mimirpb.Histogram_UNKNOWN,
+			Timestamp:      0,
+		},
+		"integer gauge": {
+			Count:          &mimirpb.Histogram_CountInt{CountInt: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			NegativeDeltas: []int64{1},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			PositiveDeltas: []int64{1},
+			ResetHint:      mimirpb.Histogram_GAUGE,
+			Timestamp:      0,
+		},
+		"float counter": {
+			Count:          &mimirpb.Histogram_CountFloat{CountFloat: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountFloat{ZeroCountFloat: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			NegativeCounts: []float64{1},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			PositiveCounts: []float64{1},
+			ResetHint:      mimirpb.Histogram_UNKNOWN,
+			Timestamp:      0,
+		},
+		"float gauge": {
+			Count:          &mimirpb.Histogram_CountFloat{CountFloat: 2},
+			Sum:            10,
+			Schema:         1,
+			ZeroThreshold:  0.001,
+			ZeroCount:      &mimirpb.Histogram_ZeroCountFloat{ZeroCountFloat: 0},
+			NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			NegativeCounts: []float64{1},
+			PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+			PositiveCounts: []float64{1},
+			ResetHint:      mimirpb.Histogram_GAUGE,
+			Timestamp:      0,
+		},
+	}
+
+	registry := prometheus.NewRegistry()
+	metrics := NewSampleValidationMetrics(registry)
+
+	for _, limit := range []int{0, 1, 2} {
+		for name, h := range testCases {
+			t.Run(fmt.Sprintf("limit-%d-%s", limit, name), func(t *testing.T) {
+				var cfg sampleValidationConfig
+				cfg.maxNativeHistogramBuckets = limit
+
+				err := ValidateSampleHistogram(metrics, model.Now(), cfg, "user-1", "group-1", []mimirpb.LabelAdapter{
+					{Name: model.MetricNameLabel, Value: "a"},
+					{Name: "a", Value: "a"}}, h)
+
+				if limit == 1 {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
+	}
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+			# TYPE cortex_discarded_samples_total counter
+			cortex_discarded_samples_total{group="group-1",reason="max_native_histogram_buckets",user="user-1"} 4
+	`), "cortex_discarded_samples_total"))
 }


### PR DESCRIPTION
#### What this PR does

Memory protection from ingesting unreasonably huge samples. Classic sample is fixed size with a timestamp and value, but native histogram may contain 2^31 buckets.

Out of scope: validate histogram makes sense, only check valid histogram.

#### Which issue(s) this PR fixes or relates to

Relates to: #4542 

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
