### PR TITLE
store-gateway: detect cache key collisions for ExpandedPostings cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Store-gateway: change expanded postings index cache key format. #4770
+* [CHANGE] Store-gateway: change expanded postings and postings index cache key format. These caches will be invalidated when rolling out the new Mimir version. #4770
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
-* [BUGFIX] Store-gateway: add collision detection on expanded postings cache keys. #4770
+* [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Store-gateway: change expanded postings index cache key format. #4770
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
+* [BUGFIX] Store-gateway: add collision detection on expanded postings cache keys. #4770
 
 ### Documentation
 

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -418,7 +418,6 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			})
 
 			l, _, pendingMatchers, err := r.decodePostings(b, stats)
-			// TODO dimitarvdimitrov add cache collision to check if the returned matcher is actually the same as the current label
 			if len(pendingMatchers) > 0 {
 				return nil, fmt.Errorf("not expecting matchers on non-expanded postings for %s=%s in block %s, but got %s",
 					key.Name, key.Value, r.block.meta.ULID, util.MatchersStringer(pendingMatchers))
@@ -499,50 +498,50 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 					return err
 				}
 
-				// Return postings and account for touched postings. Truncate first 4 bytes which are length of the posting list.
+				dataToCache := pBytes
+
+				compressionTime := time.Duration(0)
+				compressions, compressionErrors, compressedSize := 0, 0, 0
+
+				// Reencode postings before storing to cache. If that fails, we store original bytes.
+				// This can only fail, if postings data was somehow corrupted,
+				// and there is nothing we can do about it.
+				// Errors from corrupted postings will be reported when postings are used.
+				compressions++
+				s := time.Now()
+				bep := newBigEndianPostings(pBytes[4:])
+				data, err := diffVarintSnappyEncode(bep, bep.length())
+				compressionTime = time.Since(s)
+				if err == nil {
+					dataToCache = data
+					compressedSize = len(data)
+				} else {
+					compressionErrors = 1
+				}
+
+				// Return postings. Truncate first 4 bytes which are length of posting.
 				// Access to output is not protected by a mutex because each goroutine
 				// is expected to handle a different set of keys.
 				output[p.keyID] = newBigEndianPostings(pBytes[4:])
+
+				r.block.indexCache.StorePostings(r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache)
+
+				// If we just fetched it we still have to update the stats for touched postings.
 				stats.update(func(stats *queryStats) {
 					stats.postingsTouched++
 					stats.postingsTouchedSizeSum += len(pBytes)
+					stats.cachedPostingsCompressions += compressions
+					stats.cachedPostingsCompressionErrors += compressionErrors
+					stats.cachedPostingsOriginalSizeSum += len(pBytes)
+					stats.cachedPostingsCompressedSizeSum += compressedSize
+					stats.cachedPostingsCompressionTimeSum += compressionTime
 				})
-
-				storeCachedPostings(pBytes, r, keys[p.keyID], stats)
 			}
 			return nil
 		})
 	}
 
 	return output, g.Wait()
-}
-
-func storeCachedPostings(toCache []byte, r *bucketIndexReader, key labels.Label, stats *safeQueryStats) {
-	compressionErrors, compressedSize := 0, 0
-
-	// Reencode postings before storing to cache. If that fails, we store original bytes.
-	// This can only fail, if postings data was somehow corrupted,
-	// and there is nothing we can do about it.
-	// Errors from corrupted postings will be reported when postings are used.
-	compressionStart := time.Now()
-	bep := newBigEndianPostings(toCache[4:])
-	data, err := diffVarintSnappyEncode(bep, bep.length()) // TODO dimitarvdimitrov add one matcher with the label name
-	compressionTime := time.Since(compressionStart)
-	if err == nil {
-		toCache = data
-		compressedSize = len(data)
-	} else {
-		compressionErrors = 1
-	}
-
-	stats.update(func(stats *queryStats) {
-		stats.cachedPostingsCompressions++
-		stats.cachedPostingsCompressionErrors += compressionErrors
-		stats.cachedPostingsOriginalSizeSum += len(toCache)
-		stats.cachedPostingsCompressedSizeSum += compressedSize
-		stats.cachedPostingsCompressionTimeSum += compressionTime
-	})
-	r.block.indexCache.StorePostings(r.block.userID, r.block.meta.ULID, key, toCache)
 }
 
 func (r *bucketIndexReader) decodePostings(b []byte, stats *safeQueryStats) (index.Postings, indexcache.LabelMatchersKey, []*labels.Matcher, error) {

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -140,7 +140,7 @@ func postingsCacheKey(userID string, blockID ulid.ULID, l labels.Label) string {
 	// Use cryptographically hash functions to avoid hash collisions
 	// which would end up in wrong query results.
 	lblHash := blake2b.Sum256([]byte(l.Name + ":" + l.Value))
-	return "P:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
+	return "P2:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
 }
 
 // StoreSeriesForRef sets the series identified by the ulid and id to the value v.

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -217,7 +217,7 @@ func (c *RemoteIndexCache) FetchExpandedPostings(ctx context.Context, userID str
 
 func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatchersKey, postingsSelectionStrategy string) string {
 	hash := blake2b.Sum256([]byte(lmKey))
-	return "E:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(hash[0:]) + ":" + postingsSelectionStrategy
+	return "E2:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(hash[0:]) + ":" + postingsSelectionStrategy
 }
 
 // StoreSeriesForPostings stores a series set for the provided postings.

--- a/pkg/storegateway/indexcache/remote_test.go
+++ b/pkg/storegateway/indexcache/remote_test.go
@@ -634,7 +634,7 @@ func TestStringCacheKeys_Values(t *testing.T) {
 				hash := blake2b.Sum256([]byte("foo:bar"))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
 
-				return fmt.Sprintf("P:%s:%s:%s", user, uid.String(), encodedHash)
+				return fmt.Sprintf("P2:%s:%s:%s", user, uid.String(), encodedHash)
 			}(),
 		},
 		"should stringify series cache key": {
@@ -662,7 +662,7 @@ func TestStringCacheKeys_ShouldGuaranteeReasonablyShortKeysLength(t *testing.T) 
 		expectedLen int
 	}{
 		"should guarantee reasonably short key length for postings": {
-			expectedLen: 79,
+			expectedLen: 80,
 			keys: []string{
 				postingsCacheKey(user, uid, labels.Label{Name: "a", Value: "b"}),
 				postingsCacheKey(user, uid, labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)}),

--- a/pkg/storegateway/postings_codec.go
+++ b/pkg/storegateway/postings_codec.go
@@ -37,11 +37,6 @@ const (
 	codecHeaderSnappyWithMatchers codec = "dm"  // As in "dvs+matchers"
 )
 
-// isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint+snappy codec.
-func isDiffVarintSnappyEncodedPostings(input []byte) bool {
-	return bytes.HasPrefix(input, []byte(codecHeaderSnappy))
-}
-
 // diffVarintSnappyEncode encodes postings into diff+varint representation,
 // and applies snappy compression on the result.
 // Returned byte slice starts with codecHeaderSnappy header.
@@ -91,19 +86,6 @@ func diffVarintEncodeNoHeader(p index.Postings, length int) ([]byte, error) {
 	}
 
 	return buf.B, nil
-}
-
-func diffVarintSnappyDecode(input []byte) (index.Postings, error) {
-	if !isDiffVarintSnappyEncodedPostings(input) {
-		return nil, errors.New(string(codecHeaderSnappy) + " header not found")
-	}
-
-	raw, err := snappy.Decode(nil, input[len(codecHeaderSnappy):])
-	if err != nil {
-		return nil, errors.Wrap(err, "snappy decode")
-	}
-
-	return newDiffVarintPostings(raw), nil
 }
 
 // isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint+snappy+matchers codec.

--- a/pkg/storegateway/postings_codec.go
+++ b/pkg/storegateway/postings_codec.go
@@ -34,7 +34,7 @@ type codec string
 
 const (
 	codecHeaderSnappy             codec = "dvs" // As in "diff+varint+snappy".
-	codecHeaderSnappyWithMatchers codec = "dcm" // As in "dvs+cache_collision+matchers"
+	codecHeaderSnappyWithMatchers codec = "dm"  // As in "dvs+matchers"
 )
 
 // isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint+snappy codec.

--- a/pkg/storegateway/postings_codec.go
+++ b/pkg/storegateway/postings_codec.go
@@ -140,14 +140,14 @@ func diffVarintSnappyWithMatchersEncode(p index.Postings, length int, requestMat
 	offsetAfterReqMatchers += len(requestMatchers)
 
 	// Pending matchers size + matchers
-	actualPendingMatchersLen, err := encodeMatchers(estPendingMatchersLen, pendingMatchers, result[offsetAfterReqMatchers:])
+	actualMatchersLen, err := encodeMatchers(estPendingMatchersLen, pendingMatchers, result[offsetAfterReqMatchers:])
 	if err != nil {
 		return nil, err
 	}
-	if actualPendingMatchersLen != estPendingMatchersLen {
-		return nil, fmt.Errorf("encoding pending matchers wrote unexpected number of bytes: wrote %d, expected %d", actualPendingMatchersLen, estPendingMatchersLen)
+	if actualMatchersLen != estPendingMatchersLen {
+		return nil, fmt.Errorf("encoding matchers wrote unexpected number of bytes: wrote %d, expected %d", actualMatchersLen, estPendingMatchersLen)
 	}
-	offsetAfterPendingMatchers := offsetAfterReqMatchers + actualPendingMatchersLen
+	offsetAfterPendingMatchers := offsetAfterReqMatchers + actualMatchersLen
 
 	// Compressed postings
 	compressedPostings := snappy.Encode(result[offsetAfterPendingMatchers:], varintPostings)

--- a/pkg/storegateway/postings_codec.go
+++ b/pkg/storegateway/postings_codec.go
@@ -194,7 +194,8 @@ func diffVarintSnappyMatchersDecode(input []byte) (index.Postings, indexcache.La
 
 	codecLen := len(codecHeaderSnappyWithMatchers)
 	requestMatchersKeyLen, requestMatchersKeyLenSize := varint.Uvarint(input[codecLen:])
-	offsetAfterMatchersKey := codecLen + requestMatchersKeyLenSize + int(requestMatchersKeyLen) // the uint64 - int coversion should be safe since the length of the key is much smaller than math.MaxUint64
+	// the uint64 to int conversion should be safe since the length of the key is much smaller than math.MaxUint64
+	offsetAfterMatchersKey := codecLen + requestMatchersKeyLenSize + int(requestMatchersKeyLen)
 	requestMatchersKey := indexcache.LabelMatchersKey(input[codecLen+requestMatchersKeyLenSize : offsetAfterMatchersKey])
 
 	pendingMatchers, pendingMatchersLen, err := decodeMatchers(input[offsetAfterMatchersKey:])


### PR DESCRIPTION
#### What this PR does

When storing an ExpandedPostings cache item the key is the hashed matchers from the query. However, we do not check the stored values for cache collisions.

This PR adds cache collisions for ExpandedPostings. It stores the string of the request matchers with the item value and then rechecks it upon retrieval.

To ensure we don't misinterpret some cache item, this PR also changes cache key for expanded postings.

#### Which issue(s) this PR fixes or relates to

closes #4523 

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
