### PR TITLE
store-gateway: detect cache key collisions for Postings cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Store-gateway: change expanded postings and postings index cache key format. #4770
+* [CHANGE] Store-gateway: change expanded postings and postings index cache key format. These caches will be invalidated when rolling out the new Mimir version. #4770
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Store-gateway: change expanded postings index cache key format. #4770
+* [CHANGE] Store-gateway: change expanded postings and postings index cache key format. #4770
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
-* [BUGFIX] Store-gateway: add collision detection on expanded postings cache keys. #4770
+* [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 
 ### Documentation
 

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -549,7 +550,12 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 }
 
 func encodeLabelForPostingsCache(l labels.Label) indexcache.LabelMatchersKey {
-	return indexcache.LabelMatchersKey(l.Name + "=" + l.Value)
+	var sb strings.Builder
+	sb.Grow(len(l.Name) + 1 + len(l.Value))
+	sb.WriteString(l.Name)
+	sb.WriteByte('=')
+	sb.WriteString(l.Value)
+	return indexcache.LabelMatchersKey(sb.String())
 }
 
 func (r *bucketIndexReader) decodePostings(b []byte, stats *safeQueryStats) (index.Postings, indexcache.LabelMatchersKey, []*labels.Matcher, error) {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -549,7 +549,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 }
 
 func encodeLabelForPostingsCache(l labels.Label) indexcache.LabelMatchersKey {
-	return indexcache.LabelMatchersKey(fmt.Sprintf("%s=%s", l.Name, l.Value))
+	return indexcache.LabelMatchersKey(l.Name + "=" + l.Value)
 }
 
 func (r *bucketIndexReader) decodePostings(b []byte, stats *safeQueryStats) (index.Postings, indexcache.LabelMatchersKey, []*labels.Matcher, error) {

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -140,7 +140,7 @@ func postingsCacheKey(userID string, blockID ulid.ULID, l labels.Label) string {
 	// Use cryptographically hash functions to avoid hash collisions
 	// which would end up in wrong query results.
 	lblHash := blake2b.Sum256([]byte(l.Name + ":" + l.Value))
-	return "P:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
+	return "P2:" + userID + ":" + blockID.String() + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
 }
 
 // StoreSeriesForRef sets the series identified by the ulid and id to the value v.

--- a/pkg/storegateway/indexcache/remote_test.go
+++ b/pkg/storegateway/indexcache/remote_test.go
@@ -634,7 +634,7 @@ func TestStringCacheKeys_Values(t *testing.T) {
 				hash := blake2b.Sum256([]byte("foo:bar"))
 				encodedHash := base64.RawURLEncoding.EncodeToString(hash[0:])
 
-				return fmt.Sprintf("P:%s:%s:%s", user, uid.String(), encodedHash)
+				return fmt.Sprintf("P2:%s:%s:%s", user, uid.String(), encodedHash)
 			}(),
 		},
 		"should stringify series cache key": {
@@ -662,7 +662,7 @@ func TestStringCacheKeys_ShouldGuaranteeReasonablyShortKeysLength(t *testing.T) 
 		expectedLen int
 	}{
 		"should guarantee reasonably short key length for postings": {
-			expectedLen: 79,
+			expectedLen: 80,
 			keys: []string{
 				postingsCacheKey(user, uid, labels.Label{Name: "a", Value: "b"}),
 				postingsCacheKey(user, uid, labels.Label{Name: strings.Repeat("a", 100), Value: strings.Repeat("a", 1000)}),

--- a/pkg/storegateway/postings_codec.go
+++ b/pkg/storegateway/postings_codec.go
@@ -37,11 +37,6 @@ const (
 	codecHeaderSnappyWithMatchers codec = "dm"  // As in "dvs+matchers"
 )
 
-// isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint+snappy codec.
-func isDiffVarintSnappyEncodedPostings(input []byte) bool {
-	return bytes.HasPrefix(input, []byte(codecHeaderSnappy))
-}
-
 // diffVarintSnappyEncode encodes postings into diff+varint representation,
 // and applies snappy compression on the result.
 // Returned byte slice starts with codecHeaderSnappy header.
@@ -91,19 +86,6 @@ func diffVarintEncodeNoHeader(p index.Postings, length int) ([]byte, error) {
 	}
 
 	return buf.B, nil
-}
-
-func diffVarintSnappyDecode(input []byte) (index.Postings, error) {
-	if !isDiffVarintSnappyEncodedPostings(input) {
-		return nil, errors.New(string(codecHeaderSnappy) + " header not found")
-	}
-
-	raw, err := snappy.Decode(nil, input[len(codecHeaderSnappy):])
-	if err != nil {
-		return nil, errors.Wrap(err, "snappy decode")
-	}
-
-	return newDiffVarintPostings(raw), nil
 }
 
 // isDiffVarintSnappyEncodedPostings returns true, if input looks like it has been encoded by diff+varint+snappy+matchers codec.


### PR DESCRIPTION

#### What this PR does

This is a follow-up of https://github.com/grafana/mimir/pull/4770. It adds cache collision  detection for cached posting lists. Since the cache key is is a hashed label, it can collide between different postings lists from the same block.

This PR uses the already existing encoding of matchers into posting list cache keys to check for collisions. It encodes the label for the posting list as an "equals" matcher and then compares it when it is retrieved.

__Notes to reviewers__: This PR ended up smaller than I expected, so could have been merged with #4770 too, but I figured reviewing may be easier if they are smaller. I think reviewing #4770 first may be easier to review. I am happy to make them one PR too.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/4523

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
