### PR TITLE
dashboard: Display alertmanager aggregation groups metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * [ENHANCEMENT] Improve `MimirIngesterReachingTenantsLimit` runbook. #4744 #4752
 
+### Mixin
+
+* [ENHANCEMENT] Alertmanager dashboard: display active aggregation groups #4772
+
 ## 2.8.0-rc.0
 
 ### Grafana Mimir

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -1442,6 +1442,94 @@ data:
                 "height": "250px",
                 "panels": [
                    {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "$datasource",
+                      "fill": 10,
+                      "id": 7,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 0,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [ ],
+                      "spaceLength": 10,
+                      "span": 12,
+                      "stack": true,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "cortex_alertmanager_dispatcher_aggregation_groups{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend.*))\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{pod}}",
+                            "legendLink": null,
+                            "step": 10
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "per pod Active Aggregation Groups",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
+                   }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Alerts grouping",
+                "titleSize": "h6"
+             },
+             {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                   {
                       "aliasColors": {
                          "failed": "#E24D42",
                          "successful": "#7EB26D"
@@ -1451,7 +1539,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 7,
+                      "id": 8,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -1535,7 +1623,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 8,
+                      "id": 9,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -1619,7 +1707,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 9,
+                      "id": 10,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -1723,7 +1811,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 10,
-                      "id": 10,
+                      "id": 11,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -1799,7 +1887,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 11,
+                      "id": 12,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -1875,7 +1963,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 12,
+                      "id": 13,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -1967,7 +2055,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 13,
+                      "id": 14,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2071,7 +2159,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 14,
+                      "id": 15,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2163,7 +2251,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 15,
+                      "id": 16,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2255,7 +2343,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 16,
+                      "id": 17,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2347,7 +2435,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 17,
+                      "id": 18,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2451,7 +2539,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 10,
-                      "id": 18,
+                      "id": 19,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2527,7 +2615,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 10,
-                      "id": 19,
+                      "id": 20,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2603,7 +2691,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 10,
-                      "id": 20,
+                      "id": 21,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2694,7 +2782,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 21,
+                      "id": 22,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2778,7 +2866,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 22,
+                      "id": 23,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2854,7 +2942,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 23,
+                      "id": 24,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -2942,7 +3030,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 24,
+                      "id": 25,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -3019,7 +3107,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 25,
+                      "id": 26,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -3117,7 +3205,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 26,
+                      "id": 27,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -3218,7 +3306,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 27,
+                      "id": 28,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -3305,7 +3393,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 28,
+                      "id": 29,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -3392,7 +3480,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 29,
+                      "id": 30,
                       "legend": {
                          "avg": false,
                          "current": false,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
@@ -562,6 +562,94 @@
             "height": "250px",
             "panels": [
                {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 7,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 12,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "cortex_alertmanager_dispatcher_aggregation_groups{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend.*))\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{instance}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "per instance Active Aggregation Groups",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Alerts grouping",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
                   "aliasColors": {
                      "failed": "#E24D42",
                      "successful": "#7EB26D"
@@ -571,7 +659,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 7,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -655,7 +743,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 8,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -739,7 +827,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 9,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -843,7 +931,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 10,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -919,7 +1007,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 11,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -995,7 +1083,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 12,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1087,7 +1175,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 13,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1191,7 +1279,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 14,
+                  "id": 15,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1283,7 +1371,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 15,
+                  "id": 16,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1375,7 +1463,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 16,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1467,7 +1555,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 17,
+                  "id": 18,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1571,7 +1659,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 18,
+                  "id": 19,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1647,7 +1735,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 19,
+                  "id": 20,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1723,7 +1811,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 20,
+                  "id": 21,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1814,7 +1902,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 21,
+                  "id": 22,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1898,7 +1986,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 22,
+                  "id": 23,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1974,7 +2062,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 23,
+                  "id": 24,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2062,7 +2150,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 24,
+                  "id": 25,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2139,7 +2227,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 25,
+                  "id": 26,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2237,7 +2325,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 26,
+                  "id": 27,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2338,7 +2426,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 27,
+                  "id": 28,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2425,7 +2513,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 28,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2512,7 +2600,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 29,
+                  "id": 30,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -562,6 +562,94 @@
             "height": "250px",
             "panels": [
                {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 7,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 12,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "cortex_alertmanager_dispatcher_aggregation_groups{cluster=~\"$cluster\", job=~\"($namespace)/((alertmanager|cortex|mimir|mimir-backend.*))\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "per pod Active Aggregation Groups",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Alerts grouping",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
                   "aliasColors": {
                      "failed": "#E24D42",
                      "successful": "#7EB26D"
@@ -571,7 +659,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 7,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -655,7 +743,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 8,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -739,7 +827,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 9,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -843,7 +931,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 10,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -919,7 +1007,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 11,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -995,7 +1083,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 12,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1087,7 +1175,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 13,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1191,7 +1279,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 14,
+                  "id": 15,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1283,7 +1371,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 15,
+                  "id": 16,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1375,7 +1463,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 16,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1467,7 +1555,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 17,
+                  "id": 18,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1571,7 +1659,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 18,
+                  "id": 19,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1647,7 +1735,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 19,
+                  "id": 20,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1723,7 +1811,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 10,
-                  "id": 20,
+                  "id": 21,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1814,7 +1902,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 21,
+                  "id": 22,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1898,7 +1986,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 22,
+                  "id": 23,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1974,7 +2062,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 23,
+                  "id": 24,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2062,7 +2150,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 24,
+                  "id": 25,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2139,7 +2227,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 25,
+                  "id": 26,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2237,7 +2325,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 26,
+                  "id": 27,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2338,7 +2426,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 27,
+                  "id": 28,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2425,7 +2513,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 28,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2512,7 +2600,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 29,
+                  "id": 30,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin/dashboards/alertmanager.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager.libsonnet
@@ -58,6 +58,17 @@ local filename = 'mimir-alertmanager.json';
       )
     )
     .addRow(
+      $.row('Alerts grouping')
+      .addPanel(
+        $.panel('per %s Active Aggregation Groups' % $._config.per_instance_label) +
+        $.queryPanel(
+          'cortex_alertmanager_dispatcher_aggregation_groups{%s}' % $.jobMatcher($._config.job_names.alertmanager),
+          '{{%s}}' % $._config.per_instance_label
+        ) +
+        $.stack
+      )
+    )
+    .addRow(
       $.row('Alert notifications')
       .addPanel(
         $.panel('NPS') +


### PR DESCRIPTION
#### What this PR does

Display cortex_alertmanager_dispatcher_aggregation_groups on alertmanager dashboard

#### Which issue(s) this PR fixes or relates to

Relate to #4151

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
