### PR TITLE
Return an empty object when no metadata is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
 * [ENHANCEMENT] Go: update to 1.20.3. #4773
-* [BUGFIX] Metadata API: Mimir will now return HTTP 204 when no metadata is available, matching Prometheus. #4782
+* [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [ENHANCEMENT] Improved memory limit on the in-memory cache used for regular expression matchers. #4751
 * [ENHANCEMENT] Go: update to 1.20.3. #4773
+* [BUGFIX] Metadata API: Mimir will now return HTTP 204 when no metadata is available, matching Prometheus. #4782
 
 ### Documentation
 

--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -65,10 +65,6 @@ func NewMetadataHandler(m MetadataSupplier) http.Handler {
 			metrics[m.Metric] = append(ms, metricMetadata{Type: string(m.Type), Help: m.Help, Unit: m.Unit})
 		}
 
-		if len(metrics) == 0 {
-			w.WriteHeader(http.StatusNoContent)
-		}
-
 		util.WriteJSONResponse(w, metadataSuccessResult{Status: statusSuccess, Data: metrics})
 	})
 }

--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -32,10 +32,14 @@ type metricMetadata struct {
 	Unit string `json:"unit"`
 }
 
-type metadataResult struct {
+type metadataSuccessResult struct {
 	Status string                      `json:"status"`
-	Data   map[string][]metricMetadata `json:"data,omitempty"`
-	Error  string                      `json:"error,omitempty"`
+	Data   map[string][]metricMetadata `json:"data"`
+}
+
+type metadataErrorResult struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
 }
 
 // NewMetadataHandler creates a http.Handler for serving metric metadata held by
@@ -45,7 +49,7 @@ func NewMetadataHandler(m MetadataSupplier) http.Handler {
 		resp, err := m.MetricsMetadata(r.Context())
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			util.WriteJSONResponse(w, metadataResult{Status: statusError, Error: err.Error()})
+			util.WriteJSONResponse(w, metadataErrorResult{Status: statusError, Error: err.Error()})
 			return
 		}
 
@@ -65,6 +69,6 @@ func NewMetadataHandler(m MetadataSupplier) http.Handler {
 			w.WriteHeader(http.StatusNoContent)
 		}
 
-		util.WriteJSONResponse(w, metadataResult{Status: statusSuccess, Data: metrics})
+		util.WriteJSONResponse(w, metadataSuccessResult{Status: statusSuccess, Data: metrics})
 	})
 }

--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -61,6 +61,10 @@ func NewMetadataHandler(m MetadataSupplier) http.Handler {
 			metrics[m.Metric] = append(ms, metricMetadata{Type: string(m.Type), Help: m.Help, Unit: m.Unit})
 		}
 
+		if len(metrics) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+		}
+
 		util.WriteJSONResponse(w, metadataResult{Status: statusSuccess, Data: metrics})
 	})
 }

--- a/pkg/querier/metadata_handler_test.go
+++ b/pkg/querier/metadata_handler_test.go
@@ -75,7 +75,8 @@ func TestMetadataHandler_Empty(t *testing.T) {
 
 	expectedJSON := `
 	{
-		"status": "success"
+		"status": "success",
+		"data": {}
 	}
 	`
 

--- a/pkg/querier/metadata_handler_test.go
+++ b/pkg/querier/metadata_handler_test.go
@@ -69,7 +69,7 @@ func TestMetadataHandler_Empty(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, request)
 
-	require.Equal(t, http.StatusNoContent, recorder.Result().StatusCode)
+	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
 	responseBody, err := io.ReadAll(recorder.Result().Body)
 	require.NoError(t, err)
 

--- a/pkg/querier/metadata_handler_test.go
+++ b/pkg/querier/metadata_handler_test.go
@@ -55,6 +55,33 @@ func TestMetadataHandler_Success(t *testing.T) {
 	require.JSONEq(t, expectedJSON, string(responseBody))
 }
 
+func TestMetadataHandler_Empty(t *testing.T) {
+	d := &mockDistributor{}
+	d.On("MetricsMetadata", mock.Anything).Return(
+		[]scrape.MetricMetadata{},
+		nil)
+
+	handler := NewMetadataHandler(d)
+
+	request, err := http.NewRequest("GET", "/metadata", nil)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusNoContent, recorder.Result().StatusCode)
+	responseBody, err := io.ReadAll(recorder.Result().Body)
+	require.NoError(t, err)
+
+	expectedJSON := `
+	{
+		"status": "success"
+	}
+	`
+
+	require.JSONEq(t, expectedJSON, string(responseBody))
+}
+
 func TestMetadataHandler_Error(t *testing.T) {
 	d := &mockDistributor{}
 	d.On("MetricsMetadata", mock.Anything).Return([]scrape.MetricMetadata{}, fmt.Errorf("no user id"))


### PR DESCRIPTION
#### What this PR does

This PR updates the `/api/v1/metadata` endpoint to return an empty object when no metadata is present. This matches Prometheus behavior and also makes this endpoint compatible with the [public prometheus client](https://github.com/prometheus/client_golang/blob/c36c6abb8deadeb44d1e795c21a58bbd5c85a6ae/api/prometheus/v1/api.go#L1383).

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [X] Tests updated
- [N/A] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
