### PR TITLE
Helm: version of Mimir and GEM documenation links is now parametric

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -7,11 +7,15 @@ keywords:
   - Grafana Mimir
   - Grafana Enterprise Metrics
   - Grafana metrics
+cascade:
+  # Used to generate relative URL paths to related documentation
+  mimir_docs_version: "v2.7.x"
+  gem_docs_version: "v2.7.x"
 ---
 
 # Grafana mimir-distributed Helm chart documentation
 
-The mimir-distributed Helm chart for Grafana Mimir and Grafana Enterprise Metrics (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
+The mimir-distributed Helm chart for [Grafana Mimir](/docs/mimir/{{< param "mimir_docs_version" >}}/) and [Grafana Enterprise Metrics](/docs/enterpries-metrics/{{< param "gem_docs_version" >}}) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
 
 > **Note:** By default, the mimir-distributed Helm chart documentation applies to both Grafana Mimir and GEM. If it only applies to GEM, it is explicitly stated.
 

--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -15,7 +15,7 @@ cascade:
 
 # Grafana mimir-distributed Helm chart documentation
 
-The mimir-distributed Helm chart for [Grafana Mimir](/docs/mimir/{{< param "mimir_docs_version" >}}/) and [Grafana Enterprise Metrics](/docs/enterpries-metrics/{{< param "gem_docs_version" >}}) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
+The mimir-distributed Helm chart for [Grafana Mimir](/docs/mimir/{{< param "mimir_docs_version" >}}/) and [Grafana Enterprise Metrics](/docs/enterprise-metrics/{{< param "gem_docs_version" >}}/) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
 
 > **Note:** By default, the mimir-distributed Helm chart documentation applies to both Grafana Mimir and GEM. If it only applies to GEM, it is explicitly stated.
 

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -65,4 +65,4 @@ spec:
 
 For more information about Vault and Vault Agent, see [Injecting Vault Secrets Into Kubernetes Pods via a Sidecar](https://www.hashicorp.com/blog/injecting-vault-secrets-into-kubernetes-pods-via-a-sidecar).
 
-To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS](/docs/mimir/v2.8.x/operators-guide/secure/securing-communications-with-tls.md)
+To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/secure/securing-communications-with-tls/)

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -6,9 +6,9 @@ description: "Learn how to configure Grafana Mimir to ingest and query native hi
 
 # Configure native histograms
 
-To enable support for ingesting Prometheus native histograms over the [remote write API](/docs/mimir/v2.7.x/references/http-api/#remote-write) endpoint, set the configuration parameter `native_histograms_ingestion_enabled` to true.
+To enable support for ingesting Prometheus native histograms over the [remote write API](/docs/mimir/{{< param "mimir_docs_version" >}}/references/http-api/#remote-write) endpoint, set the configuration parameter `native_histograms_ingestion_enabled` to true.
 
-To enable support for querying native histograms together with [Grafana Mimir query sharding](/docs/mimir/v2.7.x/operators-guide/architecture/query-sharding/), set the configuration parameter `query_result_response_format` to `protobuf`.
+To enable support for querying native histograms together with [Grafana Mimir query sharding](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/query-sharding/), set the configuration parameter `query_result_response_format` to `protobuf`.
 
 Example values file:
 

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -21,7 +21,7 @@ results-cache:
   enabled: false
 ```
 
-Next, configure Mimir to connect to Redis using `structuredConfig`. Refer to [the configuration parameters reference](/docs/mimir/latest/references/configuration-parameters/#redis) for Redis connection configuration options. For example:
+Next, configure Mimir to connect to Redis using `structuredConfig`. Refer to [the configuration parameters reference](/docs/mimir/{{< param "mimir_docs_version" >}}/references/configuration-parameters/#redis) for Redis connection configuration options. For example:
 
 ```yaml
 mimir:

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
@@ -12,7 +12,7 @@ The overview includes the steps required for any environment. To migrate deploym
 
 > **Note:** This document was tested with Cortex versions 1.10 and 1.11. It might work with more recent versions of Cortex, but that is not guaranteed.
 
-To migrate a Jsonnet deployment of Cortex refer to [Migrate from Cortex](/docs/mimir/latest/migration-guides/migrate-from-cortex).
+To migrate a Jsonnet deployment of Cortex refer to [Migrate from Cortex](/docs/mimir/{{< param "mimir_docs_version" >}}/migration-guides/migrate-from-cortex).
 
 Grafana Mimir includes significant changes that simplify the deployment and continued operation of a horizontally scalable, multi-tenant time series database with long-term storage.
 
@@ -36,8 +36,8 @@ It provides a simple migration by generating Mimir configuration from Cortex con
   Using the monitoring mixin, you need to install both alerting and recording rules in either Prometheus or Cortex. You also need to install dashboards in Grafana.
   To download a prebuilt ZIP file that contains the alerting and recording rules, refer to [Release Cortex-jsonnet 1.11.0](https://github.com/grafana/cortex-jsonnet/releases/download/1.11.0/cortex-mixin.zip).
 
-  To upload rules to the ruler using mimirtool, refer to [mimirtool rules](/docs/mimir/latest/operators-guide/tools/mimirtool/#rules).
-  To import the dashboards into Grafana, refer to [Import dashboard](/docs/grafana/latest/dashboards/export-import/#import-dashboard).
+  To upload rules to the ruler using mimirtool, refer to [mimirtool rules](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/tools/mimirtool/#rules).
+  To import the dashboards into Grafana, refer to [Import dashboard](/docs/grafana/{{< param "mimir_docs_version" >}}/dashboards/export-import/#import-dashboard).
 
 ## Notable changes
 
@@ -106,7 +106,7 @@ It provides a simple migration by generating Mimir configuration from Cortex con
 
 ## Generate the configuration for Grafana Mimir
 
-The [`mimirtool config convert`](/docs/mimir/latest/operators-guide/tools/mimirtool/#convert) command converts Cortex configuration to Mimir configuration. You can use it to update both flags and configuration files.
+The [`mimirtool config convert`](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/tools/mimirtool/#convert) command converts Cortex configuration to Mimir configuration. You can use it to update both flags and configuration files.
 
 ### Install mimirtool
 
@@ -125,7 +125,7 @@ The `mimirtool config convert` command converts Cortex 1.11 configuration files 
 It removes any configuration parameters that are no longer available in Grafana Mimir, and it renames configuration parameters that have a new name.
 If you have explicitly set configuration parameters to a value matching the Cortex default, by default, `mimirtool config convert` doesn't update the value.
 To have `mimirtool config convert` update explicitly set values from the Cortex defaults to the new Grafana Mimir defaults, provide the `--update-defaults` flag.
-Refer to [convert](/docs/mimir/latest/operators-guide/tools/mimirtool/#convert) for more information on using `mimirtool` for configuration conversion.
+Refer to [convert](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/tools/mimirtool/#convert) for more information on using `mimirtool` for configuration conversion.
 
 ## Migrate to Grafana Mimir using Helm
 
@@ -157,7 +157,7 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
    a. Add the dashboards to Grafana. The dashboards replace your Cortex dashboards and continue to work for monitoring Cortex deployments.
 
    > **Note:** Resource dashboards are now enabled by default and require additional metrics sources.
-   > To understand the required metrics sources, refer to [Additional resources metrics](/docs/mimir/v2.7.x/operators-guide/monitor-grafana-mimir/requirements/#additional-resources-metrics).
+   > To understand the required metrics sources, refer to [Additional resources metrics](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/monitor-grafana-mimir/requirements/#additional-resources-metrics).
 
    b. Install the recording and alerting rules into the ruler or a Prometheus server.
 
@@ -252,4 +252,4 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
    helm upgrade <RELEASE> grafana/mimir-distributed [-n <NAMESPACE>]
    ```
 
-To verify that the cluster is operating correctly, use the [monitoring mixin dashboards](/docs/mimir/v2.7.x/operators-guide/monitor-grafana-mimir/dashboards/).
+To verify that the cluster is operating correctly, use the [monitoring mixin dashboards](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/monitor-grafana-mimir/dashboards/).

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -7,7 +7,7 @@ weight: 10
 
 # Migrate from single zone to zone-aware replication
 
-This document explains how to migrate stateful components from single zone to [zone-aware replication](/docs/mimir/v2.7.x/operators-guide/configure/configure-zone-aware-replication/) with Helm. The three components in question are the [alertmanager](/docs/mimir/v2.7.x/operators-guide/architecture/components/alertmanager/), the [store-gateway](/docs/mimir/v2.7.x/operators-guide/architecture/components/store-gateway/) and the [ingester](/docs/mimir/v2.7.x/operators-guide/architecture/components/ingester/).
+This document explains how to migrate stateful components from single zone to [zone-aware replication](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-zone-aware-replication/) with Helm. The three components in question are the [alertmanager](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/components/alertmanager/), the [store-gateway](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/components/store-gateway/) and the [ingester](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/components/ingester/).
 
 The migration path of Alertmanager and store-gateway is straight forward, however migrating ingesters is more complicated.
 
@@ -584,7 +584,7 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    1. If the current `<N>` above in `ingester.zoneAwareReplication.migration.replicas` is less than `ingester.replicas`, go back and increase `<N>` with at most 21 and repeat these four steps.
 
-1. If you are using [shuffle sharding](/docs/mimir/v2.7.x/operators-guide/configure/configure-shuffle-sharding/), it must be turned off on the read path at this point.
+1. If you are using [shuffle sharding](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-shuffle-sharding/), it must be turned off on the read path at this point.
 
    1. Update your configuration with these values and keep them until otherwise instructed.
 
@@ -728,7 +728,7 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    The 3 hours is calculated from 2h TSDB block range period + `blocks_storage.tsdb.head_compaction_idle_timeout` Grafana Mimir parameters to give enough time for ingesters to remove stale series from memory. Stale series will be there due to series being moved between ingesters.
 
-1. If you are using [shuffle sharding](/docs/mimir/v2.7.x/operators-guide/configure/configure-shuffle-sharding/):
+1. If you are using [shuffle sharding](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-shuffle-sharding/):
 
    1. Wait an extra 12 hours.
 

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -55,7 +55,7 @@ usage patterns. Therefore, use the sizing plans as starting
 point for sizing your Grafana Mimir cluster, rather than as strict guidelines.
 To get a better idea of how to plan capacity, refer to the YAML comments at
 the beginning of `small.yaml` and `large.yaml` files, which relate to read and write workloads.
-See also [Planning Grafana Mimir capacity](/docs/mimir/v2.7.x/operators-guide/run-production-environment/planning-capacity/).
+See also [Planning Grafana Mimir capacity](/docs/mimir/{{< param "mimir_docs_version" >}}.x/operators-guide/run-production-environment/planning-capacity/).
 
 To use a sizing plan, copy it from the [mimir](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed)
 GitHub repository, and pass it as a values file to the `helm` command. Note that sizing plans may change with new
@@ -84,8 +84,8 @@ number_of_nodes >= max(number_of_ingesters_pods, number_of_store_gateway_pods)
 ```
 
 For more information about the failure modes of either the ingester or store-gateway
-component, refer to [Ingesters failure and data loss](/docs/mimir/v2.7.x/operators-guide/architecture/components/ingester/#ingesters-failure-and-data-loss/)
-or [Store-gateway: Blocks sharding and replication](/docs/mimir/v2.7.x/operators-guide/architecture/components/store-gateway/#blocks-sharding-and-replication/).
+component, refer to [Ingesters failure and data loss](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/components/ingester/#ingesters-failure-and-data-loss/)
+or [Store-gateway: Blocks sharding and replication](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/components/store-gateway/#blocks-sharding-and-replication/).
 
 ## Decide whether you need geographical redundancy, fast rolling updates, or both.
 
@@ -98,7 +98,7 @@ configure the Helm chart to deploy Grafana Mimir with zone-aware replication.
 
 ### New installations
 
-Grafana Mimir supports [replication across availability zones](/docs/mimir/v2.7.x/operators-guide/configure/configure-zone-aware-replication/)
+Grafana Mimir supports [replication across availability zones](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-zone-aware-replication/)
 within your Kubernetes cluster.
 This further increases fault tolerance of the Mimir cluster. Even if you
 do not currently have multiple zones across your Kubernetes cluster, you
@@ -153,7 +153,7 @@ zone-aware replication.
 ## Configure Mimir to use object storage
 
 For the different object storage types that Mimir supports, and examples,
-see [Configure Grafana Mimir object storage backend](/docs/mimir/v2.7.x/operators-guide/configure/configure-object-storage-backend).
+see [Configure Grafana Mimir object storage backend](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-object-storage-backend).
 
 1. Add the following YAML to your values file, if you are not using the sizing
    plans that are mentioned in [Plan capacity](#plan-capacity):
@@ -223,7 +223,7 @@ cluster, refer to
 To monitor the health of your Grafana Mimir cluster, which is also known as
 _metamonitoring_, you can use ready-made Grafana dashboards, and Prometheus
 alerting and recording rules.
-For more information, see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/v2.7.x/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts/).
+For more information, see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts/).
 
 The `mimir-distributed` Helm chart makes it easy for you to collect metrics and
 logs from Mimir. It assigns the correct labels for you so that the dashboards
@@ -265,7 +265,7 @@ Metrics) server.
    ```
 
    For details about how to set up the credentials, see [Collecting
-   metrics and logs from Grafana Mimir](/docs/mimir/v2.7.x/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/).
+   metrics and logs from Grafana Mimir](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/).
 
 Your Grafana Mimir cluster can now ingest metrics in production.
 

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
@@ -10,7 +10,7 @@ aliases:
 
 # Manage the configuration of Grafana Mimir with Helm
 
-The `mimir-distributed` Helm chart provides interfaces to set Grafana Mimir [configuration parameters](/docs/mimir/v2.7.x/references/configuration-parameters/) and customize how Grafana Mimir is deployed on a Kubernetes cluster. This document describes the configuration parameters.
+The `mimir-distributed` Helm chart provides interfaces to set Grafana Mimir [configuration parameters](/docs/mimir/{{< param "mimir_docs_version" >}}/references/configuration-parameters/) and customize how Grafana Mimir is deployed on a Kubernetes cluster. This document describes the configuration parameters.
 
 ## Overview
 

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
@@ -14,13 +14,13 @@ weight: 70
 # Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication with Consul
 
 Grafana Mimir can deduplicate data from a high-availability (HA) Prometheus setup. You can configure
-the deduplication by using the Grafana Mimir helm chart deployment that uses external Consul. For more information, see [Configure high availability](/docs/mimir/v2.7.x/operators-guide/configure/configure-high-availability-deduplication/).
+the deduplication by using the Grafana Mimir helm chart deployment that uses external Consul. For more information, see [Configure high availability](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-high-availability-deduplication/).
 
 ## Before you begin
 
 You need to have a Grafana Mimir installed via the mimir-distributed Helm chart.
 
-For conceptual information about how Mimir deduplicates incoming HA samples, refer to [Configure high availability](/docs/mimir/v2.7.x/operators-guide/configure/configure-high-availability-deduplication/).
+For conceptual information about how Mimir deduplicates incoming HA samples, refer to [Configure high availability](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-high-availability-deduplication/).
 
 You also need to configure HA for Prometheus or Grafana Agent. Lastly, you need a key-value store such as Consul KV.
 
@@ -42,7 +42,7 @@ global:
 
 Reload or restart Prometheus or Grafana Agent after you update the configuration.
 
-> **Note:** [Configure high availability](/docs/mimir/v2.7.x/operators-guide/configure/configure-high-availability-deduplication/).
+> **Note:** [Configure high availability](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/configure/configure-high-availability-deduplication/).
 > document contains the same information on Prometheus setup for HA dedup.
 
 ## Install Consul using Helm
@@ -151,7 +151,7 @@ If the table is empty, it means there is something wrong with the configuration.
 
 If you have set up [metamonitoring]({{< relref "../monitor-system-health.md" >}}) or if you
 run GEM with built-in system monitoring,
-Mimir [distributor](/docs/mimir/v2.7.x/operators-guide/architecture/components/distributor/)
+Mimir [distributor](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/architecture/components/distributor/)
 exposes some metrics related to HA deduplication. The relevant metrics are those with `cortex_ha_tracker_` prefix.
 
 ### Ensure HA metrics are deduplicated

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -12,9 +12,9 @@ weight: 60
 You can monitor Grafana Mimir or Grafana Enterprise Metrics itself, by collecting metrics and logs from Mimir or GEM that is running on a Kubernetes cluster. This is called _metamonitoring_.
 
 > **Note:** In Grafana, you can create dashboards and receive alerts about those metrics and logs. To set up dashboards and alerts,
-> see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/v2.7.x/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts/) or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/).
+> see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts/) or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/).
 
-Alternatively, to monitor the health of your system without using the Helm chart, see [Collect metrics and logs without the Helm chart](/docs/mimir/v2.7.x/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart).
+Alternatively, to monitor the health of your system without using the Helm chart, see [Collect metrics and logs without the Helm chart](/docs/mimir/{{< param "mimir_docs_version" >}}/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart).
 
 ## Configure the Grafana Agent operator via the Helm chart
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -72,6 +72,12 @@ The following steps apply to a release candidate or a final release.
 
 1. Create or update the release notes in [release notes](https://github.com/grafana/mimir/tree/mimir-distributed-release-4.2/docs/sources/helm-charts/mimir-distributed/release-notes).
 
+   The release notes should refer to the correct Mimir and GEM versions and their specific documentation version.
+
+1. Update the Mimir and GEM documentation version parameters in [_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
+
+   The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
+
 1. From the root directory of the repository, run `make doc` so a template can update the [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 
 1. Open a PR, and make sure that your PR targets the release branch.

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -74,7 +74,7 @@ The following steps apply to a release candidate or a final release.
 
    The release notes should refer to the correct Mimir and GEM versions and their specific documentation version.
 
-1. Update the Mimir and GEM documentation version parameters in [_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
+1. Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
    The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
 


### PR DESCRIPTION
#### What this PR does

Instead of heaving to sed replace a bunch of links, make it parametric. Later when tech writer team introduces relref support between projects, this should be taken into account.

Bonus: fix link in vault integration doc.

#### Which issue(s) this PR fixes or relates to

N/A internal improvement

#### Checklist

- N/A Tests updated
- [x] Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
