### PR TITLE
Packaging: fix preremove script preventing the upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] Go: update to 1.20.3. #4773
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
+* [BUGFIX] Packaging: fix preremove script preventing upgrades. #4801
 
 ### Documentation
 

--- a/packaging/nfpm/mimir/preremove.sh
+++ b/packaging/nfpm/mimir/preremove.sh
@@ -13,12 +13,19 @@ uninstall() {
     systemctl stop mimir.service ||:
 }
 
+upgrade() {
+    :
+}
+
 # Step 2, check if this is a clean install or an upgrade
 action="$1"
 
 case "$action" in
   "0" | "remove")
     uninstall
+    ;;
+  "2" | "upgrade")
+    upgrade
     ;;
   *)
     echo "Unsupported action: ${action}"


### PR DESCRIPTION
#### What this PR does

nfpm migration introduce a regression in the prerm step. This step is used by the OS for doing necessary cleaning before removing a package. The underlying script is called upon remove or upgrade of a package by passing an argument to it, argument being `remove` or `upgrade`. The script expect *only* `remove` and raises an error for anything else. Therefore when trying to upgrade the script would failed with such error:

```
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following packages will be upgraded:
  mimir
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/20.8 MB of archives.
After this operation, 5,796 kB of additional disk space will be used.
Do you want to continue? [Y/n] Y
(Reading database ... 53494 files and directories currently installed.)
Preparing to unpack .../mimir_2.8.0~rc.0_amd64.deb ...
Unsupported action: upgrade <--- breaking change here
dpkg: warning: old mimir package pre-removal script subprocess returned error exit status 1
dpkg: trying script from the new package instead ...
Unsupported action: failed-upgrade
dpkg: error processing archive /var/cache/apt/archives/mimir_2.8.0~rc.0_amd64.deb (--unpack):
 new mimir package pre-removal script subprocess returned error exit status 1
 Alpine Post Install of an clean install
 Reload the service unit from disk
 Unmask the service
 Set the preset flag for the service unit
 Set the enabled flag for the service unit
Errors were encountered while processing:
 /var/cache/apt/archives/mimir_2.8.0~rc.0_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

The error is also triggered when trying to downgrade:
```
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be DOWNGRADED:
  mimir
0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.
Need to get 0 B/19.4 MB of archives.
After this operation, 5,796 kB disk space will be freed.
Do you want to continue? [Y/n] y
dpkg: warning: downgrading mimir from 2.8.0~rc.0 to 2.7.1
(Reading database ... 53400 files and directories currently installed.)
Preparing to unpack .../archives/mimir_2.7.1_amd64.deb ...
Unsupported action: upgrade <-- again
dpkg: error processing archive /var/cache/apt/archives/mimir_2.7.1_amd64.deb (--unpack):
 installed mimir package pre-removal script subprocess returned error exit status 1
 Alpine Post Install of an clean install
 Reload the service unit from disk
 Unmask the service
 Set the preset flag for the service unit
 Set the enabled flag for the service unit
Errors were encountered while processing:
 /var/cache/apt/archives/mimir_2.7.1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

With the resulting package built with the patched preremove script we have the following, notice that the error is gone:

```
Selecting previously unselected package mimir.
(Reading database ... 53397 files and directories currently installed.)
Preparing to unpack mimir_2.8.0~rc.0_amd64.deb ...
Unpacking mimir (2.8.0~rc.0) ...
Setting up mimir (2.8.0~rc.0) ...
 Post Install of an upgrade
 Post Install of an upgrade

Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be DOWNGRADED:
  mimir
0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.
Need to get 0 B/19.4 MB of archives.
After this operation, 6,148 kB disk space will be freed.
Do you want to continue? [Y/n] y
dpkg: warning: downgrading mimir from 2.8.0~rc.0 to 2.7.1
(Reading database ... 53400 files and directories currently installed.)
Preparing to unpack .../archives/mimir_2.7.1_amd64.deb ...
Unpacking mimir (2.7.1) over (2.8.0~rc.0) ...
Setting up mimir (2.7.1) ...
 Post Install of an upgrade
 Post Install of an upgrade
```

With this information we can patch the prerm script to do nothing on upgrade as nothing is necessary.

Unfortunately there is nothing we can do from here for fixing the upgrade from 2.7 to 2.8

Alternatively we could do like [loki](https://github.com/grafana/loki/blob/main/tools/packaging/nfpm.jsonnet#L31) or [tempo](https://github.com/grafana/tempo/tree/main/tools/packaging) packaging and not include. This way it would be consistent across all three of them.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
