### PR TITLE
Update 2.6 release notes with go bugfix

### DIFF
--- a/docs/sources/mimir/release-notes/v2.6.md
+++ b/docs/sources/mimir/release-notes/v2.6.md
@@ -61,3 +61,7 @@ The following experimental options and features are now stable:
 - Querier: Canceled requests are no longer reported as "consistency check" failures. [PR 3837](https://github.com/grafana/mimir/pull/3837) [PR 3927](https://github.com/grafana/mimir/pull/3927)
 - Distributor: Don't panic when `metric_relabel_configs` in overrides contains null element. [PR 3868](https://github.com/grafana/mimir/pull/3868)
 - Ingester, Compactor: Fix panic that can occur when compaction fails. [PR 3955](https://github.com/grafana/mimir/pull/3955)
+
+### 2.6.1
+
+- Security: updated the Go version to 1.20.3 to fix CVE-2023-24538. [PR 4798](https://github.com/grafana/mimir/pull/4798)


### PR DESCRIPTION
- N/A Tests updated
- [x] Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
