### PR TITLE
Helm add udp port for memberlist

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,7 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
 * [BUGFIX] Set `gateway` and `nginx` HPA MetricTarget type to Utilization to align with usage of averageUtilization. #4642
 * [BUGFIX] Add missing imagePullSecrets configuration to the `graphite-web` deployment template. #4716
-* [BUGFIX] Add UDP port to service and pod manifests since memberlist uses UDP and TCP
+* [BUGFIX] Add UDP port to service and pod manifests since memberlist uses UDP and TCP #4816
 
 ## 4.3.1
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,6 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573
 * [BUGFIX] Set `gateway` and `nginx` HPA MetricTarget type to Utilization to align with usage of averageUtilization. #4642
 * [BUGFIX] Add missing imagePullSecrets configuration to the `graphite-web` deployment template. #4716
+* [BUGFIX] Add UDP port to service and pod manifests since memberlist uses UDP and TCP
 
 ## 4.3.1
 

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -72,9 +72,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.admin_api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -82,9 +82,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -165,9 +165,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -130,9 +130,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.compactor.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -79,9 +79,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.distributor.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -9,9 +9,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: {{ include "mimir.memberlistBindPort" . }}
       protocol: TCP
+      targetPort: {{ include "mimir.memberlistBindPort" . }}
+    - name: udp-gossip-ring
+      port: {{ include "mimir.memberlistBindPort" . }}
+      protocol: UDP
       targetPort: {{ include "mimir.memberlistBindPort" . }}
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -150,9 +150,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -81,9 +81,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.querier.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -86,9 +86,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.ruler.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -147,9 +147,12 @@ spec:
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
+              protocol: UDP
           livenessProbe:
             {{- toYaml .Values.store_gateway.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -118,9 +118,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -109,9 +109,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -119,9 +119,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -262,9 +265,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -405,9 +411,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -72,9 +72,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -118,9 +118,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -260,9 +263,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -402,9 +408,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -114,9 +114,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -252,9 +255,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -390,9 +396,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -250,9 +253,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -387,9 +393,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -118,9 +118,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -109,9 +109,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -111,9 +111,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -72,9 +72,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -109,9 +109,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -126,9 +126,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -278,9 +281,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -430,9 +436,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -125,9 +125,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -276,9 +279,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -427,9 +433,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -106,9 +106,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -65,9 +65,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -115,9 +115,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -106,9 +106,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -116,9 +116,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -256,9 +259,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -396,9 +402,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -65,9 +65,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -115,9 +115,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -254,9 +257,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -393,9 +399,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -114,9 +114,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -105,9 +105,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -115,9 +115,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -254,9 +257,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -393,9 +399,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -250,9 +253,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -387,9 +393,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -126,9 +126,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -278,9 +281,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -430,9 +436,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -125,9 +125,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -276,9 +279,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -427,9 +433,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -112,9 +112,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -103,9 +103,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -105,9 +105,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -73,9 +73,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -103,9 +103,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -118,9 +118,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -109,9 +109,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -119,9 +119,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -262,9 +265,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -405,9 +411,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -72,9 +72,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -118,9 +118,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -260,9 +263,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -402,9 +408,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -65,9 +65,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -111,9 +111,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -102,9 +102,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -13,9 +13,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -111,9 +111,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -246,9 +249,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -381,9 +387,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -65,9 +65,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -110,9 +110,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -244,9 +247,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -378,9 +384,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -115,9 +115,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -106,9 +106,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -116,9 +116,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -256,9 +259,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -396,9 +402,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -72,9 +72,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -115,9 +115,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -254,9 +257,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -393,9 +399,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -114,9 +114,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -252,9 +255,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -390,9 +396,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -113,9 +113,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -250,9 +253,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -387,9 +393,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -115,9 +115,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -252,9 +255,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -389,9 +395,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -97,9 +97,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -107,9 +107,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -236,9 +239,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -365,9 +371,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -106,9 +106,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -234,9 +237,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -362,9 +368,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -134,9 +134,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -292,9 +295,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -450,9 +456,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -104,9 +104,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -135,9 +135,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -294,9 +297,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -453,9 +459,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -66,9 +66,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -70,9 +70,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -125,9 +125,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -274,9 +277,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -423,9 +429,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -125,9 +125,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -117,9 +117,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -69,9 +69,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -125,9 +125,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -274,9 +277,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -423,9 +429,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -72,9 +72,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -118,9 +118,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -260,9 +263,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -402,9 +408,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -107,9 +107,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -98,9 +98,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -68,9 +68,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -100,9 +100,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -67,9 +67,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -71,9 +71,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -98,9 +98,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -120,9 +120,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -111,9 +111,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -74,9 +74,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -14,9 +14,13 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: gossip-ring
+    - name: tcp-gossip-ring
       port: 7946
       protocol: TCP
+      targetPort: 7946
+    - name: udp-gossip-ring
+      port: 7946
+      protocol: UDP
       targetPort: 7946
   publishNotReadyAddresses: true
   selector:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -121,9 +121,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -266,9 +269,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -411,9 +417,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -73,9 +73,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -77,9 +77,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -120,9 +120,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -264,9 +267,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:
@@ -408,9 +414,12 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
-            - name: memberlist
+            - name: tcp-memberlist
               containerPort: 7946
               protocol: TCP
+            - name: udp-memberlist
+              containerPort: 7946
+              protocol: UDP
           livenessProbe:
             null
           readinessProbe:


### PR DESCRIPTION
#### What this PR does
This PR adds the memberlist UDP port to the service and pod manifests. Not defining the port can result in traffic being blocked when Mimir is deployed with Istio.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
