### PR TITLE
Fix find_prev_release() in tools/release/common.sh returns incorrect tag

### DIFF
--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -44,9 +44,9 @@ find_prev_release() {
   find_last_release
 
   if [[ $LAST_RELEASE_VERSION =~ "-rc" ]]; then
-    PREV_RELEASE_TAG=$(git tag --list --sort=taggerdate 'mimir-[0-9]*' | tail -2 | head -1)
+    PREV_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | tail -2 | head -1)
   else
-    PREV_RELEASE_TAG=$(git tag --list --sort=taggerdate 'mimir-[0-9]*' | grep -v -- '-rc' | tail -2 | head -1)
+    PREV_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | grep -v -- '-rc' | tail -2 | head -1)
   fi
 
   if [ -z "${PREV_RELEASE_TAG}" ]; then

--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -6,6 +6,9 @@
 
 set -e
 
+# Use GNU sed on MacOS falling back to `sed` everywhere else
+SED=$(which gsed || which sed)
+
 check_required_setup() {
   # Ensure "gh" tool is installed.
   if ! command -v gh &> /dev/null; then
@@ -22,8 +25,9 @@ check_required_setup() {
   fi
 }
 
+# Last release is the version we want to release now
 find_last_release() {
-  LAST_RELEASE_TAG=$(git tag --list --sort=taggerdate 'mimir-[0-9]*' | tail -1)
+  LAST_RELEASE_TAG=$(git describe --abbrev=0 --match 'mimir-[0-9]*')
 
   if [ -z "${LAST_RELEASE_TAG}" ]; then
     echo "Unable to find the last release git tag" > /dev/stderr
@@ -38,15 +42,21 @@ find_last_release() {
   export LAST_RELEASE_VERSION
 }
 
-# Find the previous release. If the last release is a stable release then it only takes in account stable releases
-# (the previous release of a stable release must be another stable release).
+# Previous release is one version before last release.
+# If last release is an rc we will find any previous release.
+# If last release is a stable (non-rc) release, previous release also must be a non-rc release.
 find_prev_release() {
   find_last_release
 
+  ALL_RELEASE_TAGS=$(git tag --list 'mimir-[0-9]*')
+
+  # To sort rc version correctly we use sed to append non-rc version with a temporary suffix
+  SORTED_RELEASE_TAGS=$(echo "$ALL_RELEASE_TAGS" | $SED '/rc/b; s/\(.*\)/\1-xx.x/' | sort --version-sort | gsed 's/-xx.x//')
+
   if [[ $LAST_RELEASE_VERSION =~ "-rc" ]]; then
-    PREV_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | tail -2 | head -1)
+    PREV_RELEASE_TAG=$(echo "$SORTED_RELEASE_TAGS" | grep $(echo $LAST_RELEASE_VERSION) -B1 | head -1)
   else
-    PREV_RELEASE_TAG=$(git tag --list 'mimir-[0-9]*' | grep -v -- '-rc' | tail -2 | head -1)
+    PREV_RELEASE_TAG=$(echo "$SORTED_RELEASE_TAGS" | grep -v -- '-rc' | grep $(echo $LAST_RELEASE_VERSION) -B1 | head -1)
   fi
 
   if [ -z "${PREV_RELEASE_TAG}" ]; then

--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -25,7 +25,7 @@ check_required_setup() {
   fi
 }
 
-# Last release is the version we want to release now
+# Last release is the version we want to release now.
 find_last_release() {
   LAST_RELEASE_TAG=$(git describe --abbrev=0 --match 'mimir-[0-9]*')
 
@@ -43,8 +43,8 @@ find_last_release() {
 }
 
 # Previous release is one version before last release.
-# If last release is an rc we will find any previous release.
-# If last release is a stable (non-rc) release, previous release also must be a non-rc release.
+# If last release is an rc, previous release can be any rc or non-rc.
+# If last release is a stable (non-rc) release, previous release must be a non-rc release.
 find_prev_release() {
   find_last_release
 

--- a/tools/release/common.sh
+++ b/tools/release/common.sh
@@ -51,7 +51,7 @@ find_prev_release() {
   ALL_RELEASE_TAGS=$(git tag --list 'mimir-[0-9]*')
 
   # To sort rc version correctly we use sed to append non-rc version with a temporary suffix
-  SORTED_RELEASE_TAGS=$(echo "$ALL_RELEASE_TAGS" | $SED '/rc/b; s/\(.*\)/\1-xx.x/' | sort --version-sort | gsed 's/-xx.x//')
+  SORTED_RELEASE_TAGS=$(echo "$ALL_RELEASE_TAGS" | $SED '/rc/b; s/\(.*\)/\1-xx.x/' | sort --version-sort | $SED 's/-xx.x//')
 
   if [[ $LAST_RELEASE_VERSION =~ "-rc" ]]; then
     PREV_RELEASE_TAG=$(echo "$SORTED_RELEASE_TAGS" | grep $(echo $LAST_RELEASE_VERSION) -B1 | head -1)

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -3,9 +3,6 @@
 
 set -e
 
-# Use GNU sed on MacOS falling back to `sed` everywhere else
-SED=$(which gsed || which sed)
-
 # Load common lib.
 CURR_DIR="$(dirname "$0")"
 . "${CURR_DIR}/common.sh"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #4824

* Get the last release using `git describe` (thanks to @pstibrany)
* Get previous release using some bash/sed-fu (thanks to @pracucci)

To test use this script in your local mimir repo. This script has some logic with the one in the PR. Please make sure to switch to release-xxx branch you want to test.

```bash
SED=$(which gsed || which sed)
# update last release version to test on correctly finding the previous release
LAST_RELEASE_VERSION="mimir-2.10.0-rc.2"
ALL_RELEASE_TAGS=$(git tag --list 'mimir-[0-9]*')
SORTED_RELEASE_TAGS=$(echo "$ALL_RELEASE_TAGS" | $SED '/rc/b; s/\(.*\)/\1-xx.x/' | sort --version-sort | gsed 's/-xx.x//')
if [[ $LAST_RELEASE_VERSION =~ "-rc" ]]; then
  PREV_RELEASE_TAG=$(echo "$SORTED_RELEASE_TAGS" | grep $(echo $LAST_RELEASE_VERSION) -B1 | head -1)
else 
  PREV_RELEASE_TAG=$(echo "$SORTED_RELEASE_TAGS" | grep -v -- '-rc' | grep $(echo $LAST_RELEASE_VERSION) -B1 | head -1) 
fi
echo $PREV_RELEASE_TAG
```


#### Checklist

- na Tests updated
- na Documentation added
- na `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
