### PR TITLE
store-gateway: fix stats recording in filtering...Iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [CHANGE] Store-gateway: change expanded postings and postings index cache key format. These caches will be invalidated when rolling out the new Mimir version. #4770
 * [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. #4765
 * [ENHANCEMENT] Store-gateway: reduce memory usage in some LabelValues calls. #4789
-* [ENHANCEMENT] Store-gateway: add a `stage` label to the metric `cortex_bucket_store_series_data_touched`. This label now applies to `data_type="chunks"` and `data_type="series"`. The `stage` label has 2 values: `processed` - the number of series that parsed - and `returned` - the number of series selected from the processed bytes to satisfy the query. #4797
+* [ENHANCEMENT] Store-gateway: add a `stage` label to the metric `cortex_bucket_store_series_data_touched`. This label now applies to `data_type="chunks"` and `data_type="series"`. The `stage` label has 2 values: `processed` - the number of series that parsed - and `returned` - the number of series selected from the processed bytes to satisfy the query. #4797 #4830
 * [ENHANCEMENT] Distributor: make `__meta_tenant_id` label available in relabeling rules configured via `metric_relabel_configs`. #4725
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1304,7 +1304,7 @@ func labelValuesFromSeries(ctx context.Context, labelName string, seriesPerBatch
 		b.logger,
 	)
 	if len(pendingMatchers) > 0 {
-		iterator = &filteringSeriesChunkRefsSetIterator{from: iterator, matchers: pendingMatchers}
+		iterator = newFilteringSeriesChunkRefsSetIterator(pendingMatchers, iterator, stats)
 	}
 	iterator = seriesStreamingFetchRefsDurationIterator(iterator, stats)
 	seriesSet := newSeriesSetWithoutChunks(ctx, iterator, stats)

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -455,7 +455,7 @@ func TestBlockLabelValues(t *testing.T) {
 		require.Equal(t, []string{"bar"}, values)
 
 		// we break the indexHeaderReader to ensure that results come from a cache
-		b.indexHeaderReader = deadlineExceededIndexHeader(b.indexHeaderReader)
+		b.indexHeaderReader = deadlineExceededIndexHeader()
 
 		values, err = blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", pFooMatchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
@@ -479,7 +479,7 @@ func TestBlockLabelValues(t *testing.T) {
 		require.Equal(t, []string{"foo"}, values)
 
 		// we break the indexHeaderReader to ensure that results come from a cache
-		b.indexHeaderReader = deadlineExceededIndexHeader(b.indexHeaderReader)
+		b.indexHeaderReader = deadlineExceededIndexHeader()
 
 		values, err = blockLabelValues(context.Background(), b, worstCaseFetchedDataStrategy{1.0}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
@@ -901,9 +901,8 @@ func (iir *interceptedIndexReader) LabelValuesOffsets(name string, prefix string
 	return iir.Reader.LabelValuesOffsets(name, prefix, filter)
 }
 
-func deadlineExceededIndexHeader(r indexheader.Reader) *interceptedIndexReader {
+func deadlineExceededIndexHeader() *interceptedIndexReader {
 	return &interceptedIndexReader{
-		Reader:                     r,
 		onLabelNamesCalled:         func() error { return context.DeadlineExceeded },
 		onLabelValuesCalled:        func(string) error { return context.DeadlineExceeded },
 		onLabelValuesOffsetsCalled: func(string) error { return context.DeadlineExceeded },

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -725,7 +725,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		logger,
 	)
 	if len(pendingMatchers) > 0 {
-		iterator = &filteringSeriesChunkRefsSetIterator{stats: stats, from: iterator, matchers: pendingMatchers}
+		iterator = newFilteringSeriesChunkRefsSetIterator(pendingMatchers, iterator, stats)
 	}
 
 	return seriesStreamingFetchRefsDurationIterator(iterator, stats), nil
@@ -1044,6 +1044,14 @@ type filteringSeriesChunkRefsSetIterator struct {
 	matchers []*labels.Matcher
 
 	current seriesChunkRefsSet
+}
+
+func newFilteringSeriesChunkRefsSetIterator(matchers []*labels.Matcher, from seriesChunkRefsSetIterator, stats *safeQueryStats) *filteringSeriesChunkRefsSetIterator {
+	return &filteringSeriesChunkRefsSetIterator{
+		stats:    stats,
+		from:     from,
+		matchers: matchers,
+	}
 }
 
 func (m *filteringSeriesChunkRefsSetIterator) Next() bool {


### PR DESCRIPTION
#### What this PR does

This is a follow-up of #4797. This code is panicking because `stats` are `nil`. I am planning to backport this to r235

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
