### PR TITLE
Update mimir-prometheus#483

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230418130726-d162bb51b6ef
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230418223807-fc3fa8995a23
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9 h1:WB3bGH2f1UN6
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230418130726-d162bb51b6ef h1:jsrCY75xwUUrt9Xd2V6pP8lqhdlGrQSNzMw6dEYc2Ew=
-github.com/grafana/mimir-prometheus v0.0.0-20230418130726-d162bb51b6ef/go.mod h1:7cY9a98yoTl0qTVsrHKAPzSurtekpMpjvOsG3T7OON4=
+github.com/grafana/mimir-prometheus v0.0.0-20230418223807-fc3fa8995a23 h1:K2WkyvnWEjCSRI5uffAkCeUGky/5fw2hGI0GxUkwFSE=
+github.com/grafana/mimir-prometheus v0.0.0-20230418223807-fc3fa8995a23/go.mod h1:7cY9a98yoTl0qTVsrHKAPzSurtekpMpjvOsG3T7OON4=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/vendor/github.com/prometheus/prometheus/tsdb/querier.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/querier.go
@@ -338,6 +338,26 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching values of label %s", name)
 	}
+
+	// If we have a matcher for the label name, we can filter out values that don't match
+	// before we fetch postings. This is especially useful for labels with many values.
+	// e.g. __name__ with a selector like {__name__="xyz"}
+	for _, m := range matchers {
+		if m.Name != name {
+			continue
+		}
+
+		// re-use the allValues slice to avoid allocations
+		// this is safe because the iteration is always ahead of the append
+		filteredValues := allValues[:0]
+		for _, v := range allValues {
+			if m.Matches(v) {
+				filteredValues = append(filteredValues, v)
+			}
+		}
+		allValues = filteredValues
+	}
+
 	valuesPostings := make([]index.Postings, len(allValues))
 	for i, value := range allValues {
 		valuesPostings[i], err = r.Postings(name, value)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -844,7 +844,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230418130726-d162bb51b6ef
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230418223807-fc3fa8995a23
 ## explicit; go 1.19
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1433,7 +1433,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230418130726-d162bb51b6ef
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230418223807-fc3fa8995a23
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # google.golang.org/grpc => google.golang.org/grpc v1.47.0
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094


### PR DESCRIPTION
#### What this PR does

This PR updates mimir-prometheus to include https://github.com/grafana/mimir-prometheus/pull/483, which will speed up some cardinality endpoint queries especially.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
