### PR TITLE
Only load existing rule groups when enforcing group limit (#4828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.0-rc.2
+
+### Grafana Mimir
+
+* [ENHANCEMENT] Ruler: Improve rule upload performance when not enforcing per-tenant rule group limits. #4828
+
 ## 2.8.0-rc.1
 
 ### Grafana Mimir

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -662,6 +662,79 @@ rules:
 	}
 }
 
+func TestRuler_RulerGroupLimitsDisabled(t *testing.T) {
+	cfg := defaultRulerConfig(t)
+
+	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
+		defaults.RulerMaxRuleGroupsPerTenant = 0
+		defaults.RulerMaxRulesPerRuleGroup = 0
+	})))
+
+	a := NewAPI(r, r.store, log.NewNopLogger())
+
+	tc := []struct {
+		name   string
+		input  string
+		output string
+		err    error
+		status int
+	}{
+		{
+			name:   "when pushing the first group with disabled limit",
+			status: 202,
+			input: `
+name: test_first_group_will_succeed
+interval: 15s
+rules:
+- record: up_rule
+  expr: up{}
+- alert: up_alert
+  expr: sum(up{}) > 1
+  for: 30s
+  annotations:
+    test: test
+  labels:
+    test: test
+`,
+			output: "{\"status\":\"success\",\"data\":null,\"errorType\":\"\",\"error\":\"\"}",
+		},
+		{
+			name:   "when pushing the second group with disabled limit",
+			status: 202,
+			input: `
+name: test_second_group_will_also_succeed
+interval: 15s
+rules:
+- record: up_rule
+  expr: up{}
+- alert: up_alert
+  expr: sum(up{}) > 1
+  for: 30s
+  annotations:
+    test: test
+  labels:
+    test: test
+`,
+			output: "{\"status\":\"success\",\"data\":null,\"errorType\":\"\",\"error\":\"\"}",
+		},
+	}
+
+	router := mux.NewRouter()
+	router.Path("/prometheus/config/v1/rules/{namespace}").Methods("POST").HandlerFunc(a.CreateRuleGroup)
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			// POST
+			req := requestFor(t, http.MethodPost, "https://localhost:8080/prometheus/config/v1/rules/namespace", strings.NewReader(tt.input), "user1")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+			require.Equal(t, tt.status, w.Code)
+			require.Equal(t, tt.output, w.Body.String())
+		})
+	}
+}
+
 func TestAlertStateDescToPrometheusAlert(t *testing.T) {
 	t.Run("should not export KeepFiringSince if it's the zero value", func(t *testing.T) {
 		actual := alertStateDescToPrometheusAlert(&AlertStateDesc{})

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -881,6 +881,12 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 	return groupDescs, nil
 }
 
+// IsMaxRuleGroupsLimited returns true if there is a limit set for the max
+// number of rule groups for the tenant.
+func (r *Ruler) IsMaxRuleGroupsLimited(userID string) bool {
+	return r.limits.RulerMaxRuleGroupsPerTenant(userID) > 0
+}
+
 // AssertMaxRuleGroups limit has not been reached compared to the current
 // number of total rule groups in input and returns an error if so.
 func (r *Ruler) AssertMaxRuleGroups(userID string, rg int) error {


### PR DESCRIPTION
Cherry pick of 95b41a86ab6059c79a6f16537a8d7bf86973e8de

In order to validate a tenant hasn't exceeded their max number of rule groups, we iterate every existing rule group for that tenant and count them. This isn't great but we can avoid doing it entirely when the limit is disabled for that particular tenant.

See #4826

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>
