### PR TITLE
store-gateway: more precise estimations of LabelValues size

### DIFF
--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -354,7 +354,7 @@ func (e *postingValueOffsets) prefixOffsets(prefix string) (start, end int, foun
 	}
 
 	// Find the first offset which is larger than the prefix and doesn't have the prefix.
-	// All values after that offset will not match the prefix.
+	// All values at and after that offset will not match the prefix.
 	end = sort.Search(len(e.offsets)-start, func(i int) bool {
 		return prefix < e.offsets[i+start].value && !strings.HasPrefix(e.offsets[i+start].value, prefix)
 	})

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -324,6 +324,7 @@ type postingValueOffsets struct {
 }
 
 // prefixOffsets returns the index of the first matching offset (start) and the index of the first non-matching (end).
+// If all offsets match the prefix, then end will equal the length of offsets.
 // prefixOffsets returns false when no offsets match this prefix.
 func (e *postingValueOffsets) prefixOffsets(prefix string) (start, end int, found bool) {
 	// Find the first offset that is greater or equal to the value.

--- a/pkg/storegateway/indexheader/index/postings.go
+++ b/pkg/storegateway/indexheader/index/postings.go
@@ -323,34 +323,44 @@ type postingValueOffsets struct {
 	lastValOffset int64
 }
 
-func (e *postingValueOffsets) prefixOffset(prefix string) (int, bool) {
+// prefixOffsets returns the index of the first and last matching offset.
+// prefixOffsets returns false when no offsets match this prefix.
+func (e *postingValueOffsets) prefixOffsets(prefix string) (start, end int, found bool) {
 	// Find the first offset that is greater or equal to the value.
-	offsetIdx := sort.Search(len(e.offsets), func(i int) bool {
+	start = sort.Search(len(e.offsets), func(i int) bool {
 		return prefix <= e.offsets[i].value
 	})
 
 	// We always include the last value in the offsets,
 	// and given that prefix is always less or equal than the value,
 	// we can conclude that there are no values with this prefix.
-	if offsetIdx == len(e.offsets) {
-		return 0, false
+	if start == len(e.offsets) {
+		return 0, 0, false
 	}
 
 	// Prefix is lower than the first value in the offsets, and that first value doesn't have this prefix.
 	// Next values won't have the prefix, so we can return early.
-	if offsetIdx == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
-		return 0, false
+	if start == 0 && prefix < e.offsets[0].value && !strings.HasPrefix(e.offsets[0].value, prefix) {
+		return 0, 0, false
 	}
 
 	// If the value is not equal to the prefix, this value might have the prefix.
 	// But maybe the values in the previous offset also had the prefix,
 	// so we need to step back one offset to find all values with this prefix.
 	// Unless, of course, we are at the first offset.
-	if offsetIdx > 0 && e.offsets[offsetIdx].value != prefix {
-		offsetIdx--
+	if start > 0 && e.offsets[start].value != prefix {
+		start--
 	}
 
-	return offsetIdx, true
+	end = sort.Search(len(e.offsets)-start, func(i int) bool {
+		return prefix < e.offsets[i+start].value && !strings.HasPrefix(e.offsets[i+start].value, prefix)
+	})
+	end += start
+	if end == len(e.offsets) {
+		end-- // we should return the index of the last matching value, if all values match, then this index is the last index
+	}
+
+	return start, end, true
 }
 
 type postingOffset struct {
@@ -473,22 +483,22 @@ func postingOffsets[T any](t *PostingOffsetTableV2, name string, prefix string, 
 		return nil, nil
 	}
 
-	offsetIdx := 0
+	offsetsStart, offsetsEnd := 0, len(e.offsets)-1
 	if prefix != "" {
-		offsetIdx, ok = e.prefixOffset(prefix)
+		offsetsStart, offsetsEnd, ok = e.prefixOffsets(prefix)
 		if !ok {
 			return nil, nil
 		}
 	}
-	result := make([]T, 0, (len(e.offsets)-offsetIdx)*t.postingOffsetsInMemSampling)
+	result := make([]T, 0, (offsetsEnd-offsetsStart)*t.postingOffsetsInMemSampling)
 
 	// Don't Crc32 the entire postings offset table, this is very slow
 	// so hope any issues were caught at startup.
 	d := t.factory.NewDecbufAtUnchecked(t.tableOffset)
 	defer runutil.CloseWithErrCapture(&err, &d, "get label values")
 
-	d.ResetAt(e.offsets[offsetIdx].tableOff)
-	lastVal := e.offsets[len(e.offsets)-1].value
+	d.ResetAt(e.offsets[offsetsStart].tableOff)
+	lastVal := e.offsets[offsetsEnd].value
 
 	var skip int
 	readNextList := func() (val string, startOff int64, isAMatch bool, noMoreMatches bool) {

--- a/pkg/storegateway/indexheader/index/postings_test.go
+++ b/pkg/storegateway/indexheader/index/postings_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package index
 
 import (

--- a/pkg/storegateway/indexheader/index/postings_test.go
+++ b/pkg/storegateway/indexheader/index/postings_test.go
@@ -1,0 +1,100 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostingValueOffsets(t *testing.T) {
+	testCases := map[string]struct {
+		existingOffsets []postingOffset
+		prefix          string
+		expectedFound   bool
+		expectedStart   int
+		expectedEnd     int
+	}{
+		"prefix not found": {
+			existingOffsets: []postingOffset{
+				{value: "010"},
+				{value: "019"},
+				{value: "030"},
+				{value: "031"},
+			},
+			prefix:        "a",
+			expectedFound: false,
+		},
+		"prefix matches only one sampled offset": {
+			existingOffsets: []postingOffset{
+				{value: "010"},
+				{value: "019"},
+				{value: "030"},
+				{value: "031"},
+			},
+			prefix:        "02",
+			expectedFound: true,
+			expectedStart: 1,
+			expectedEnd:   2,
+		},
+		"prefix matches all offsets": {
+			existingOffsets: []postingOffset{
+				{value: "010"},
+				{value: "019"},
+				{value: "030"},
+				{value: "031"},
+			},
+			prefix:        "0",
+			expectedFound: true,
+			expectedStart: 0,
+			expectedEnd:   4,
+		},
+		"prefix matches only last offset": {
+			existingOffsets: []postingOffset{
+				{value: "010"},
+				{value: "019"},
+				{value: "030"},
+				{value: "031"},
+			},
+			prefix:        "031",
+			expectedFound: true,
+			expectedStart: 3,
+			expectedEnd:   4,
+		},
+		"prefix matches multiple offsets": {
+			existingOffsets: []postingOffset{
+				{value: "010"},
+				{value: "019"},
+				{value: "020"},
+				{value: "030"},
+				{value: "031"},
+			},
+			prefix:        "02",
+			expectedFound: true,
+			expectedStart: 1,
+			expectedEnd:   3,
+		},
+		"prefix matches only first offset": {
+			existingOffsets: []postingOffset{
+				{value: "010"},
+				{value: "019"},
+				{value: "020"},
+				{value: "030"},
+				{value: "031"},
+			},
+			prefix:        "015",
+			expectedFound: true,
+			expectedStart: 0,
+			expectedEnd:   1,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			offsets := postingValueOffsets{offsets: testCase.existingOffsets}
+			start, end, found := offsets.prefixOffsets(testCase.prefix)
+			assert.Equal(t, testCase.expectedStart, start)
+			assert.Equal(t, testCase.expectedEnd, end)
+			assert.Equal(t, testCase.expectedFound, found)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does

This is a follow-up of this comment https://github.com/grafana/mimir/pull/4667#issuecomment-1498855314

When there is a prefix in the matcher, such as `pod=~"querier.*"`, the postings offset table is optimized to only scan
the values that match this prefix. This reduces the duration of the whole lookup. PostingsOffsets also tries to
preallocate the size of the slice with matching values. When we have a prefix we can be more precise in estimating where
is the last value which matches the prefix.

The results are that we reduce allocated memory for LabelValues (and LabelValuesOffsets) by up to 90% in some cases.


#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
