### PR TITLE
Add grafana to dev mimir-monolithic-mode and mimir-read-write-mode docker composes

### DIFF
--- a/development/mimir-microservices-mode/config/datasource-mimir.yaml
+++ b/development/mimir-microservices-mode/config/datasource-mimir.yaml
@@ -6,6 +6,7 @@ datasources:
   uid: mimir
   orgID: 1
   url: http://query-frontend:8007/prometheus
+  isDefault: true
   jsonData:
     prometheusType: Mimir
     exemplarTraceIdDestinations:

--- a/development/mimir-monolithic-mode/config/datasource-mimir.yaml
+++ b/development/mimir-monolithic-mode/config/datasource-mimir.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+datasources:
+- name: Mimir
+  type: prometheus
+  access: proxy
+  uid: mimir
+  orgID: 1
+  url: http://mimir-1:8001/prometheus
+  jsonData:
+    prometheusType: Mimir
+    exemplarTraceIdDestinations:
+    - name: traceID
+      datasourceUid: jaeger
+- name: Jaeger
+  type: jaeger
+  access: proxy
+  uid: jaeger
+  orgID: 1
+  url: http://jaeger:16686/

--- a/development/mimir-monolithic-mode/config/datasource-mimir.yaml
+++ b/development/mimir-monolithic-mode/config/datasource-mimir.yaml
@@ -6,6 +6,7 @@ datasources:
   uid: mimir
   orgID: 1
   url: http://mimir-1:8001/prometheus
+  isDefault: true
   jsonData:
     prometheusType: Mimir
     exemplarTraceIdDestinations:

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -26,6 +26,16 @@ services:
     ports:
       - 9090:9090
 
+  grafana:
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    image: grafana/grafana:9.4.3
+    ports:
+      - 3000:3000
+    volumes:
+      - ./config/datasource-mimir.yaml:/etc/grafana/provisioning/datasources/mimir.yaml
+
   # Scrape the metrics also with the Grafana agent (useful to test metadata ingestion
   # until metadata remote write is supported by Prometheus).
   grafana-agent:

--- a/development/mimir-read-write-mode/config/datasource-mimir.yaml
+++ b/development/mimir-read-write-mode/config/datasource-mimir.yaml
@@ -6,6 +6,7 @@ datasources:
   uid: mimir
   orgID: 1
   url: http://mimir-read-1:8080/prometheus
+  isDefault: true
   jsonData:
     prometheusType: Mimir
 

--- a/development/mimir-read-write-mode/config/datasource-mimir.yaml
+++ b/development/mimir-read-write-mode/config/datasource-mimir.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+- name: Mimir
+  type: prometheus
+  access: proxy
+  uid: mimir
+  orgID: 1
+  url: http://mimir-read-1:8080/prometheus
+  jsonData:
+    prometheusType: Mimir
+

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -5,6 +5,7 @@ std.manifestYamlDoc({
     self.read +
     self.backend +
     self.minio +
+    self.grafana + 
     self.grafana_agent +
     self.memcached +
     {},
@@ -69,6 +70,20 @@ std.manifestYamlDoc({
   memcached:: {
     memcached: {
       image: 'memcached:1.6.19-alpine',
+    },
+  },
+
+  grafana:: {
+    grafana: {
+      image: 'grafana/grafana:9.4.3',
+      environment: [
+        'GF_AUTH_ANONYMOUS_ENABLED=true',
+        'GF_AUTH_ANONYMOUS_ORG_ROLE=Admin',
+      ],
+      volumes: [
+        './config/datasource-mimir.yaml:/etc/grafana/provisioning/datasources/mimir.yaml',
+      ],
+      ports: ['3000:3000'],
     },
   },
 

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -1,4 +1,13 @@
 "services":
+  "grafana":
+    "environment":
+      - "GF_AUTH_ANONYMOUS_ENABLED=true"
+      - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
+    "image": "grafana/grafana:9.4.3"
+    "ports":
+      - "3000:3000"
+    "volumes":
+      - "./config/datasource-mimir.yaml:/etc/grafana/provisioning/datasources/mimir.yaml"
   "grafana-agent":
     "command":
       - "-config.file=/etc/agent-config/grafana-agent.yaml"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds grafana to the dev mimir-monolithic-mode and mimir-read-write-mode docker compose setups, pre-configuring it with a datasource for the query-frontend.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
