### PR TITLE
Attempt to introduce a monolithic deployment with Helm

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [FEATURE] Support monolithic deployment with the helm chart. #4832
 * [CHANGE] Kafka: Removed `kafka.extraEnv`. Use `kafka.env` instead. #14892
 * [ENHANCEMENT] Kafka: Add `kafka.env` to let users selectively override default Kafka environment variables by name, following the same merge pattern used by other chart components (`ingester.env`, etc.). Individual defaults can be replaced in-place without discarding the rest of the list. #14892
 * [CHANGE] Update minimum supported Kubernetes version to 1.32. This reflects the fact that Grafana does not test with older versions of Kubernetes. #14335

--- a/operations/helm/charts/mimir-distributed/monolithic.yaml
+++ b/operations/helm/charts/mimir-distributed/monolithic.yaml
@@ -1,0 +1,81 @@
+# This is an example setup for monolithic mimir deployment
+
+deploymentMode: monolithic
+
+fullnameOverride: mimir
+
+serviceAccount:
+  annotations:
+    "eks.amazonaws.com/role-arn": "arn:aws:iam::829850591703:role/multi-az-eks-multi-az-mimir"
+
+mimir:
+  structuredConfig:
+    limits:
+      # Delete from storage metrics data older than 62 days.
+      compactor_blocks_retention_period: 62d
+    common:
+      storage:
+        backend: s3
+        s3:
+          endpoint: s3.eu-west-1.amazonaws.com
+          region: eu-west-1
+    blocks_storage:
+      storage_prefix: blocks
+      s3:
+        bucket_name: multi-az-eks-multi-az-mimir
+    alertmanager_storage:
+      storage_prefix: alertmanager
+      s3:
+        bucket_name: multi-az-eks-multi-az-mimir
+    ruler_storage:
+      storage_prefix: ruler
+      s3:
+        bucket_name: multi-az-eks-multi-az-mimir
+
+monolithic:
+  replicas: 3
+  persistentVolume:
+    enabled: true
+    size: "8Gi"
+    storageClass: gp3-3000-125
+  priorityClassName: "optional-rescheduling-priority-multi-az"
+    # The zone aware replication doesn't yet make a lot of difference, since it is not used at query side yet. This is
+    # however planned in an upcoming release, and therefore it's best to have this configuration already enabled.
+  zoneAwareReplication:
+    enabled: true
+    topologyKey: "topology.kubernetes.io/zone"  # This generates default anti-affinity rules
+    zones:  # Zone list has to be fully redefined for modification. Update with you actual zones or skip to use logical zones only.
+    - name: zone-a
+      nodeSelector:
+        topology.kubernetes.io/zone: eu-west-1a
+    - name: zone-b
+      nodeSelector:
+        topology.kubernetes.io/zone: eu-west-1b
+    - name: zone-c
+      nodeSelector:
+        topology.kubernetes.io/zone: eu-west-1c
+  compression:
+    enabled: true
+
+nginx:
+  replicas: 1
+  priorityClassName: "mandatory-rescheduling-priority-multi-az"
+  ingress:
+    enabled: true
+    hosts:
+      - host: "mimir.multi-az.test.ngdata.com"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+    # empty, disabled.
+
+# Disable Minio, we use S3 storage instead
+minio:
+  enabled: false
+  replicas: 0
+
+# The Alert manager is currently not used. When enabling, it has to be configured for zone aware replication similar to
+# monolithic setup.
+alertmanager:
+  enabled: false

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -406,6 +406,7 @@ Examples:
 */}}
 {{- define "mimir.componentSectionFromName" -}}
 {{- $componentsMap := dict
+  "monolithic" "monolithic"
   "alertmanager" "alertmanager"
   "chunks-cache" "chunks-cache"
   "compactor" "compactor"
@@ -449,6 +450,7 @@ mimir.vaultAgent.annotations takes 2 arguments
 */}}
 {{- define "mimir.vaultAgent.annotations" -}}
 {{- $vaultEnabledComponents := dict
+  "monolithic" true
   "admin-api" true
   "alertmanager" true
   "compactor" true
@@ -552,7 +554,7 @@ which allows us to keep generating everything for the default zone.
 {{- end -}}
 
 {{- $requestedReplicas := $componentSection.replicas -}}
-{{- if and (has .component (list "ingester" "alertmanager")) $componentSection.zoneAwareReplication.migration.enabled (not $componentSection.zoneAwareReplication.migration.writePath) -}}
+{{- if and (has .component (list "monolithic" "ingester" "alertmanager")) $componentSection.zoneAwareReplication.migration.enabled (not $componentSection.zoneAwareReplication.migration.writePath) -}}
 {{- $requestedReplicas = $componentSection.zoneAwareReplication.migration.replicas }}
 {{- end -}}
 {{- $replicaPerZone := div (add $requestedReplicas $numberOfZones -1) $numberOfZones -}}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
@@ -1,3 +1,4 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- if .Values.alertmanager.fallbackConfig -}}
 apiVersion: v1
@@ -14,3 +15,4 @@ data:
     {{- .Values.alertmanager.fallbackConfig | nindent 4 }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -1,3 +1,4 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- if not .Values.alertmanager.statefulSet.enabled -}}
 apiVersion: apps/v1
@@ -146,3 +147,4 @@ spec:
         {{- end }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "alertmanager" "memberlist" true) }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "alertmanager" "memberlist" true) }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- if .Values.alertmanager.statefulSet.enabled -}}
 {{- $args := dict "ctx" . "component" "alertmanager" "memberlist" true -}}
@@ -215,6 +216,7 @@ spec:
           {{- include "mimir.lib.containerEnv" (dict "ctx" . "component" "alertmanager") | nindent 10 }}
 
 ---
+{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -1,3 +1,4 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- $clusterPort := regexReplaceAll ".+[:]" (default "0.0.0.0:9094" (include "mimir.alertmanagerClusterBindAddress" .) ) "" -}}
 apiVersion: v1
@@ -35,3 +36,4 @@ spec:
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -1,3 +1,4 @@
+{{- if has .Values.deploymentMode (list "microservices" "monolithic")}}
 {{- if .Values.alertmanager.enabled -}}
 {{- $args := dict "ctx" . "component" "alertmanager" "memberlist" true -}}
 {{- $zonesMap := include "mimir.zoneAwareReplicationMap" $args | fromYaml -}}
@@ -41,6 +42,7 @@ spec:
     {{- include "mimir.selectorLabels" $args | nindent 4 }}
 
 ---
+{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "chunks-cache" "enabled" }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "chunks-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "chunks-cache" "enabled" }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "chunks-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "chunks-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.service" (dict "ctx" $ "component" "chunks-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.compactor.enabled }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "compactor" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.compactor.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "compactor" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.compactor.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -166,4 +167,5 @@ spec:
           securityContext:
             {{- toYaml .Values.compactor.containerSecurityContext | nindent 12 }}
           {{- include "mimir.lib.containerEnv" (dict "ctx" . "component" "compactor") | nindent 10 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.compactor.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.distributor.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -153,4 +154,5 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.distributor.enabled }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "distributor" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.distributor.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "distributor" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.distributor.enabled }}
 apiVersion: v1
 kind: Service
@@ -29,4 +30,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.distributor.enabled }}
 apiVersion: v1
 kind: Service
@@ -33,4 +34,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if (eq (include "mimir.gateway.isEnabled" .) "true") }}
 {{- with .Values.gateway }}
 apiVersion: apps/v1
@@ -152,3 +153,4 @@ spec:
         {{- end }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if and (eq (include "mimir.gateway.isEnabled" .) "true") .Values.gateway.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -45,3 +46,4 @@ spec:
           {{- end }}
     {{- end }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if eq (include "mimir.gateway.isEnabled" .) "true" -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "gateway") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-route.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-route.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.gateway.route.enabled }}
 kind: Route
 apiVersion: route.openshift.io/v1
@@ -21,5 +22,6 @@ spec:
 {{- with .Values.gateway.route.tls }}
   tls:
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if eq (include "mimir.gateway.isEnabled" .) "true" -}}
 apiVersion: v1
 kind: Service
@@ -45,3 +46,4 @@ spec:
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "gateway") | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-v2-hpa.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.gateway.autoscaling.enabled }}
 {{- if eq (include "mimir.hpa.version" .) "autoscaling/v2" }}
 apiVersion: autoscaling/v2
@@ -33,3 +34,4 @@ spec:
   {{- end }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-v2beta1-hpa.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.gateway.autoscaling.enabled }}
 {{- if eq (include "mimir.hpa.version" .) "autoscaling/v2beta1" }}
 apiVersion: autoscaling/v2beta1
@@ -29,3 +30,4 @@ spec:
   {{- end }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.gateway.enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -10,3 +11,4 @@ data:
   nginx.conf: |
     {{- tpl .Values.gateway.nginx.config.file . | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/nginx-secret.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/nginx-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if and .Values.gateway.enabled .Values.gateway.nginx.basicAuth.enabled (not .Values.gateway.nginx.basicAuth.existingSecret) }}
 apiVersion: v1
 kind: Secret
@@ -10,3 +11,4 @@ stringData:
   .htpasswd: |
     {{- tpl .Values.gateway.nginx.basicAuth.htpasswd $ | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "index-cache" "enabled" }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "index-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "index-cache" "enabled" }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "index-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "index-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.service" (dict "ctx" $ "component" "index-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ingester.enabled }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "ingester" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ingester.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "ingester" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ingester.enabled }}
 apiVersion: v1
 kind: Service
@@ -29,4 +30,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "metadata-cache" "enabled" }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "metadata-cache" ) }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "metadata-cache" "enabled" }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "metadata-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "metadata-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.service" (dict "ctx" $ "component" "metadata-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-pdb.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.deploymentMode "monolithic" }}
+{{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "monolithic" "memberlist" true) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-servmon.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.deploymentMode "monolithic" }}
+{{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "monolithic" "memberlist" true) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-statefulset.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.deploymentMode "microservices" }}
-{{- if .Values.ingester.enabled }}
-{{- $args := dict "ctx" . "component" "ingester" "memberlist" true -}}
+{{- if eq .Values.deploymentMode "monolithic" }}
+{{- $args := dict "ctx" . "component" "monolithic" "memberlist" true -}}
 {{- $zonesMap := include "mimir.zoneAwareReplicationMap" $args | fromYaml -}}
 {{- range $zoneName, $rolloutZone := $zonesMap }}
 {{- with $ -}}
@@ -11,31 +10,16 @@ metadata:
   name: {{ include "mimir.resourceName" $args }}
   labels:
     {{- include "mimir.labels" $args | nindent 4 }}
-    {{- if (eq $rolloutZone.noDownscale true )}}
-    grafana.com/no-downscale: {{ $rolloutZone.noDownscale | quote }}
-    {{- else }}
-    {{- if (eq $rolloutZone.prepareDownscale true )}}
-    grafana.com/prepare-downscale: {{ $rolloutZone.prepareDownscale | quote }}
-    grafana.com/min-time-between-zones-downscale: {{ $rolloutZone.minTimeBetweenZonesDownscale }}
-    {{- end }}
-    {{- end }}
   annotations:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
-    {{- if $rolloutZone.prepareDownscale }}
-    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . | quote }}
-    {{- end -}}
-    {{- if $rolloutZone.downscaleLeader }}
-    grafana.com/rollout-downscale-leader: {{ $rolloutZone.downscaleLeader }}
-    {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  podManagementPolicy: {{ .Values.ingester.podManagementPolicy }}
+  podManagementPolicy: {{ .Values.monolithic.podManagementPolicy }}
   replicas: {{ $rolloutZone.replicas }}
-  {{- if and (semverCompare ">= 1.23-0" (include "mimir.kubeVersion" .)) (.Values.ingester.persistentVolume.enableRetentionPolicy)  }}
+  {{- if and (semverCompare ">= 1.23-0" (include "mimir.kubeVersion" .)) (.Values.monolithic.persistentVolume.enableRetentionPolicy)  }}
   persistentVolumeClaimRetentionPolicy:
-    whenDeleted: {{ .Values.ingester.persistentVolume.whenDeleted }}
-    whenScaled: {{ .Values.ingester.persistentVolume.whenScaled }}
+    whenDeleted: {{ .Values.monolithic.persistentVolume.whenDeleted }}
+    whenScaled: {{ .Values.monolithic.persistentVolume.whenScaled }}
   {{- end }}
   selector:
     matchLabels:
@@ -44,11 +28,11 @@ spec:
     {{- if $zoneName }}
     type: OnDelete
     {{- else }}
-    {{- toYaml .Values.ingester.statefulStrategy | nindent 4 }}
+    {{- toYaml .Values.monolithic.statefulStrategy | nindent 4 }}
     {{- end }}
-  serviceName: {{ template "mimir.fullname" . }}-ingester-headless
-  {{- if .Values.ingester.persistentVolume.enabled }}
-  {{- with .Values.ingester.persistentVolume }}
+  serviceName: {{ template "mimir.fullname" . }}-monolithic-headless
+  {{- if .Values.monolithic.persistentVolume.enabled }}
+  {{- with .Values.monolithic.persistentVolume }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -57,10 +41,6 @@ spec:
         {{- if .annotations }}
         annotations:
           {{- toYaml .annotations | nindent 10 }}
-        {{- end }}
-        {{- if .labels }}
-        labels:
-          {{- toYaml .labels | nindent 10 }}
         {{- end }}
       spec:
         {{- $storageClass := default .storageClass $rolloutZone.storageClass }}
@@ -86,16 +66,16 @@ spec:
         {{- include "mimir.podAnnotations" $args | nindent 8 }}
       namespace: {{ .Release.Namespace | quote }}
     spec:
-      {{- with .Values.ingester.schedulerName }}
+      {{- with .Values.monolithic.schedulerName }}
       schedulerName: {{ . | quote }}
       {{- end }}
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
-      {{- if .Values.ingester.priorityClassName }}
-      priorityClassName: {{ .Values.ingester.priorityClassName }}
+      {{- if .Values.monolithic.priorityClassName }}
+      priorityClassName: {{ .Values.monolithic.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "mimir.lib.podSecurityContext" $args | nindent 8 }}
-      {{- with .Values.ingester.initContainers }}
+      {{- with .Values.monolithic.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -113,13 +93,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" . "component" "ingester") | nindent 6 }}
-      {{- with .Values.ingester.tolerations }}
+      {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" . "component" "monolithic") | nindent 6 }}
+      {{- with .Values.monolithic.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.ingester.terminationGracePeriodSeconds }}
-      {{- with .Values.ingester.dnsConfig }}
+      terminationGracePeriodSeconds: {{ .Values.monolithic.terminationGracePeriodSeconds }}
+      {{- with .Values.monolithic.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -129,12 +109,12 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
-        {{- if not .Values.ingester.persistentVolume.enabled }}
+        {{- if not .Values.monolithic.persistentVolume.enabled }}
         - name: storage
           emptyDir: {}
         {{- end }}
-        {{- if .Values.ingester.extraVolumes }}
-        {{ toYaml .Values.ingester.extraVolumes | nindent 8 }}
+        {{- if .Values.monolithic.extraVolumes }}
+        {{ toYaml .Values.monolithic.extraVolumes | nindent 8 }}
         {{- end }}
         {{- if .Values.global.extraVolumes }}
         {{ toYaml .Values.global.extraVolumes | nindent 8 }}
@@ -142,38 +122,50 @@ spec:
         - name: active-queries
           emptyDir: {}
       containers:
-        {{- if .Values.ingester.extraContainers }}
-        {{ toYaml .Values.ingester.extraContainers | nindent 8 }}
+        {{- if .Values.monolithic.extraContainers }}
+        {{ toYaml .Values.monolithic.extraContainers | nindent 8 }}
         {{- end }}
-        - name: ingester
-          image: {{ include "mimir.imageReference" (dict "ctx" . "component" "ingester") }}
+        - name: monolithic
+          image: "{{ include "mimir.imageReference" (dict "ctx" . "component" "monolithic") }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-target=ingester"
+            - "-target=all"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- if $zoneName }}
             - "-ingester.ring.instance-availability-zone={{ $zoneName }}"
-            {{- if and .Values.ingester.zoneAwareReplication.autoIngestStorageClientRack (ne (dig "ingest_storage" "enabled" true .Values.mimir.structuredConfig) false) }}
-            - "-ingest-storage.kafka.client-rack={{ $zoneName }}"
-            {{- end }}
+            - "-store-gateway.sharding-ring.instance-availability-zone={{ $zoneName }}"
             {{- else }}
             - "-ingester.ring.instance-availability-zone=zone-default"
-            {{- if .Values.ingester.zoneAwareReplication.migration.enabled }}
+            {{- if .Values.monolithic.zoneAwareReplication.migration.enabled }}
             - "-blocks-storage.tsdb.flush-blocks-on-shutdown=true"
             - "-ingester.ring.unregister-on-shutdown=true"
+            - "-store-gateway.sharding-ring.prefix=collectors/"
+            - "-store-gateway.sharding-ring.zone-awareness-enabled=false"
             {{- end }}
             - "-server.grpc-max-concurrent-streams=500"
+            {{- end }}
+            - "-server.grpc.keepalive.max-connection-age=60s"
+            - "-server.grpc.keepalive.max-connection-age-grace=5m"
+            - "-server.grpc.keepalive.max-connection-idle=1m"
+            {{- if .Values.monolithic.compression.enabled }}
+            - "-query-frontend.grpc-client-config.grpc-compression={{ .Values.monolithic.compression.algorithm }}"
+            - "-query-scheduler.grpc-client-config.grpc-compression={{ .Values.monolithic.compression.algorithm }}"
+            - "-ruler.client.grpc-compression={{ .Values.monolithic.compression.algorithm }}"
+            - "-ruler.query-frontend.grpc-client-config.grpc-compression={{ .Values.monolithic.compression.algorithm }}"
+            - "-ingester.client.grpc-compression={{ .Values.monolithic.compression.algorithm }}"
             {{- end }}
             {{- if $args.memberlist }}
             - "-memberlist.abort-if-fast-join-fails=true"
             {{- end }}
-            {{- range $key, $value := .Values.ingester.extraArgs }}
+            - "-querier.store-gateway-client.grpc-max-recv-msg-size={{ .Values.store_gateway.grpcMaxQueryResponseSizeBytes }}"
+            - "-server.grpc-max-send-msg-size-bytes={{ .Values.store_gateway.grpcMaxQueryResponseSizeBytes }}"
+            {{- range $key, $value := .Values.monolithic.extraArgs }}
             - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
-            {{- if .Values.ingester.extraVolumeMounts }}
-            {{ toYaml .Values.ingester.extraVolumeMounts | nindent 12}}
+            {{- if .Values.monolithic.extraVolumeMounts }}
+            {{ toYaml .Values.monolithic.extraVolumeMounts | nindent 12}}
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
             {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
@@ -184,8 +176,8 @@ spec:
               mountPath: /var/{{ include "mimir.name" . }}
             - name: storage
               mountPath: "/data"
-              {{- if .Values.ingester.persistentVolume.subPath }}
-              subPath: {{ .Values.ingester.persistentVolume.subPath }}
+              {{- if .Values.monolithic.persistentVolume.subPath }}
+              subPath: {{ .Values.monolithic.persistentVolume.subPath }}
               {{- end }}
             - name: active-queries
               mountPath: /active-query-tracker
@@ -200,23 +192,22 @@ spec:
               containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.monolithic.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.monolithic.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.ingester.resources | nindent 12 }}
+            {{- toYaml .Values.monolithic.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.ingester.containerSecurityContext | nindent 12 }}
+            {{- toYaml .Values.monolithic.containerSecurityContext | nindent 12 }}
           {{- $defaultEnv := list }}
-          {{- $cpu_request := dig "requests" "cpu" nil .Values.ingester.resources }}
+          {{- $cpu_request := dig "requests" "cpu" nil .Values.monolithic.resources }}
           {{- if $cpu_request }}
             {{- /* copy logic from operations/mimir/ingester.libsonnet */}}
             {{- $cpu_request_between_3_and_6 := include "mimir.parseCPU" (dict "value" $cpu_request) | float64 | min 6 | max 3 }}
             {{- $defaultEnv = mustAppend $defaultEnv (dict "name" "GOMAXPROCS" "value" (addf $cpu_request $cpu_request_between_3_and_6 1 | ceil | toString)) }}
           {{- end }}
-          {{- include "mimir.lib.containerEnv" (dict "ctx" . "component" "ingester" "env" $defaultEnv) | nindent 10 }}
+          {{- include "mimir.lib.containerEnv" (dict "ctx" . "component" "monolithic" "env" $defaultEnv) | nindent 10 }}
 ---
-{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-svc-headless.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Values.deploymentMode "monolithic" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "monolithic") }}-headless
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "monolithic" "memberlist" true) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
+    {{- with .Values.monolithic.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.monolithic.service.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ include "mimir.serverHttpListenPort" .}}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ include "mimir.serverGrpcListenPort" . }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+    {{- if .Values.monolithic.service.extraPorts }}
+    {{- toYaml .Values.monolithic.service.extraPorts | nindent 4 }}
+    {{- end }}
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "monolithic" "memberlist" true) | nindent 4 }}
+  publishNotReadyAddresses: true
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/monolithic/monolithic-svc.yaml
@@ -1,6 +1,5 @@
-{{- if eq .Values.deploymentMode "microservices" }}
-{{- if .Values.ingester.enabled }}
-{{- $args := dict "ctx" . "component" "ingester" "memberlist" true -}}
+{{- if eq .Values.deploymentMode "monolithic" }}
+{{- $args := dict "ctx" . "component" "monolithic" "memberlist" true -}}
 {{- $zonesMap := include "mimir.zoneAwareReplicationMap" $args | fromYaml -}}
 {{- range $zoneName, $rolloutZone := $zonesMap }}
 {{- with $ -}}
@@ -11,23 +10,23 @@ metadata:
   name: {{ include "mimir.resourceName" $args }}
   labels:
     {{- include "mimir.labels" $args | nindent 4 }}
-    {{- if and $zoneName .Values.ingester.zoneAwareReplication.migration.enabled }}
+    {{- if and $zoneName .Values.monolithic.zoneAwareReplication.migration.enabled }}
     # Prevent scraping PODs via this service during migration as the original non zone-aware service already scrapes all PODs and you get duplicate metrics.
     prometheus.io/service-monitor: "false"
     {{- end }}
-    {{- with .Values.ingester.service.labels }}
+    {{- with .Values.monolithic.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- toYaml .Values.ingester.service.annotations | nindent 4 }}
+    {{- toYaml .Values.monolithic.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: {{ .Values.ingester.service.type }}
+  type: {{ .Values.monolithic.service.type }}
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
-  internalTrafficPolicy: {{ .Values.ingester.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.monolithic.service.internalTrafficPolicy }}
   {{- end }}
-  {{- if .Values.ingester.service.trafficDistribution }}
-  trafficDistribution: {{ .Values.ingester.service.trafficDistribution }}
+  {{- if .Values.monolithic.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.monolithic.service.trafficDistribution }}
   {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
@@ -38,14 +37,13 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
-    {{- if .Values.ingester.service.extraPorts }}
-    {{- toYaml .Values.ingester.service.extraPorts | nindent 4 }}
+    {{- if .Values.monolithic.service.extraPorts }}
+    {{- toYaml .Values.monolithic.service.extraPorts | nindent 4 }}
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" $args | nindent 4 }}
 
 ---
-{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.overrides_exporter.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -125,3 +126,4 @@ spec:
         - name: active-queries
           emptyDir: {}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.overrides_exporter.enabled -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "overrides-exporter") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.overrides_exporter.enabled -}}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "overrides-exporter") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.overrides_exporter.enabled -}}
 apiVersion: v1
 kind: Service
@@ -31,3 +32,4 @@ spec:
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "overrides-exporter") | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.querier.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -150,4 +151,5 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.querier.enabled }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "querier" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.querier.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "querier" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.querier.enabled }}
 apiVersion: v1
 kind: Service
@@ -33,4 +34,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_frontend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -132,4 +133,5 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_frontend.enabled }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "query-frontend") }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_frontend.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "query-frontend") }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_frontend.enabled }}
 apiVersion: v1
 kind: Service
@@ -33,4 +34,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_scheduler.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -123,4 +124,5 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
@@ -1,3 +1,6 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if and .Values.query_scheduler.enabled .Values.query_scheduler.podDisruptionBudget -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "query-scheduler") }}
 {{- end -}}
+{{- end }}
+

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_scheduler.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "query-scheduler") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_scheduler.enabled }}
 apiVersion: v1
 kind: Service
@@ -30,4 +31,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-scheduler") | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.query_scheduler.enabled }}
 apiVersion: v1
 kind: Service
@@ -33,4 +34,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-scheduler") | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "results-cache" "enabled" }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "results-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if index .Values "results-cache" "enabled" }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "results-cache") }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.statefulSet" (dict "ctx" $ "component" "results-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
@@ -1,1 +1,3 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- include "mimir.memcached.service" (dict "ctx" $ "component" "results-cache" ) }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ruler.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -148,3 +149,4 @@ spec:
         - name: active-queries
           emptyDir: {}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ruler.enabled -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "ruler" "memberlist" true) }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ruler.enabled -}}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "ruler" "memberlist" true) }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.ruler.enabled -}}
 apiVersion: v1
 kind: Service
@@ -27,3 +28,4 @@ spec:
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}
 {{- end -}}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.store_gateway.enabled }}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "store-gateway" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-servmon.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.store_gateway.enabled }}
 {{- include "mimir.lib.serviceMonitor" (dict "ctx" $ "component" "store-gateway" "memberlist" true) }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.store_gateway.enabled }}
 {{- $args := dict "ctx" $ "component" "store-gateway" "memberlist" true -}}
 {{- $zonesMap := include "mimir.zoneAwareReplicationMap" $args | fromYaml -}}
@@ -214,6 +215,7 @@ spec:
           {{- include "mimir.lib.containerEnv" (dict "ctx" . "component" "store-gateway" "env" $defaultEnv) | nindent 10 }}
 
 ---
+{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.store_gateway.enabled }}
 apiVersion: v1
 kind: Service
@@ -29,4 +30,5 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentMode "microservices" }}
 {{- if .Values.store_gateway.enabled }}
 {{- $args := dict "ctx" $ "component" "store-gateway" "memberlist" true -}}
 {{- $zonesMap := include "mimir.zoneAwareReplicationMap" $args | fromYaml -}}
@@ -44,6 +45,7 @@ spec:
     {{- include "mimir.selectorLabels" $args | nindent 4 }}
 
 ---
+{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/validate.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/validate.yaml
@@ -149,7 +149,13 @@
 {{- end -}}
 
 
-{{- if and .Values.ingester.zoneAwareReplication.enabled (not ((($calculatedConfig).ingester).ring).zone_awareness_enabled) -}}
+{{- if
+   and
+     (or
+       (and (eq .Values.deploymentMode "microservices") .Values.ingester.zoneAwareReplication.enabled)
+       (and (eq .Values.deploymentMode "monolithic") .Values.monolithic.zoneAwareReplication.enabled))
+     (not ((($calculatedConfig).ingester).ring).zone_awareness_enabled)
+}}
 {{- fail "You have set ingester.zoneAwareReplication.enabled=true. The mimir.config must include ingester.ring.zone_awareness_enabled=true. Please merge the latest mimir.config from the chart with your mimir.config."}}
 {{- end -}}
 
@@ -174,8 +180,13 @@
 {{- end -}}
 {{- end -}}
 
-
-{{- if and .Values.store_gateway.zoneAwareReplication.enabled (not ((($calculatedConfig).store_gateway).sharding_ring).zone_awareness_enabled) -}}
+{{- if
+  and
+    (or
+      (and (eq .Values.deploymentMode "microservices") .Values.store_gateway.zoneAwareReplication.enabled)
+      (and (eq .Values.deploymentMode "monolithic") .Values.monolithic.zoneAwareReplication.enabled))
+    (not ((($calculatedConfig).store_gateway).sharding_ring).zone_awareness_enabled)
+}}
 {{- fail "You have set store_gateway.zoneAwareReplication.enabled=true. The mimir.config must include store_gateway.sharding_ring.zone_awareness_enabled=true. Please merge the latest mimir.config from the chart with your mimir.config."}}
 {{- end -}}
 
@@ -201,15 +212,15 @@
 {{- end -}}
 {{- end -}}
 
-{{- if and .Values.alertmanager.zoneAwareReplication.enabled (not .Values.alertmanager.statefulSet.enabled) -}}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.zoneAwareReplication.enabled (not .Values.alertmanager.statefulSet.enabled) -}}
 {{- fail "You have set alertmanager.zoneAwareReplication.enabled=true, but alertmanager.statefulSet.enabled=false. This is not a supported configuration." -}}
 {{- end -}}
 
-{{- if and .Values.alertmanager.zoneAwareReplication.enabled (not ((($calculatedConfig).alertmanager).sharding_ring).zone_awareness_enabled) -}}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.zoneAwareReplication.enabled (not ((($calculatedConfig).alertmanager).sharding_ring).zone_awareness_enabled) -}}
 {{- fail "You have set alertmanager.zoneAwareReplication.enabled=true. The mimir.config must include alertmanager.sharding_ring.zone_awareness_enabled=true. Please merge the latest mimir.config from the chart with your mimir.config."}}
 {{- end -}}
 
-{{- if and .Values.alertmanager.zoneAwareReplication.migration.enabled (not .Values.alertmanager.zoneAwareReplication.enabled) -}}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.zoneAwareReplication.migration.enabled (not .Values.alertmanager.zoneAwareReplication.enabled) -}}
 {{- fail "You have set alertmanager.zoneAwareReplication.migration.enabled=true, but alertmanager.zoneAwareReplication.enabled=false. Please consult the Migrating from single zone with Helm document."}}
 {{- end -}}
 
@@ -272,4 +283,15 @@
   {{- if and (eq .noDownscale true) (eq .prepareDownscale true) }}
     {{- fail (printf "For ingester zone '%s': noDownscale and prepareDownscale cannot be used simultaneously." .name) -}}
   {{- end }}
+{{- end }}
+
+{{- if and (eq .Values.deploymentMode "monolithic") (or
+  (index .Values "chunks-cache" "enabled")
+  (index .Values "index-cache" "enabled")
+  (index .Values "metadata-cache" "enabled")
+  (index .Values "results-cache" "enabled")
+) -}}
+{{/* To support this, we should start the containers that are normally part of the X-cache components in the monolithic
+statefulset, and adjust the adressing in _helpers.tpl accordingly. This is not implemented yet. */}}
+{{- fail "You have deploymentMode=monolithic, which does not support caching. Please disable chunks-cache, index-cache, metadata-cache and results-cache." }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -27,6 +27,8 @@ nameOverride: null
 # Note: Grafana provided dashboards rely on the default naming and will need changes.
 fullnameOverride: null
 
+deploymentMode: microservices
+
 image:
   # -- Grafana Mimir container image repository
   repository: docker.io/grafana/mimir
@@ -125,7 +127,7 @@ mimir:
       filepath: /active-query-tracker/activity.log
 
     alertmanager:
-      data_dir: /data
+      data_dir: /data/alertmanager
       enable_api: true
       external_url: /alertmanager
       {{- if .Values.alertmanager.zoneAwareReplication.enabled }}
@@ -198,7 +200,7 @@ mimir:
       max_opening_blocks_concurrency: 4
       symbols_flushers_concurrency: 4
       first_level_compaction_wait_period: 25m
-      data_dir: "/data"
+      data_dir: "/data/compactor"
       sharding_ring:
         wait_stability_min_duration: 1m
         heartbeat_period: 1m
@@ -224,12 +226,20 @@ mimir:
       cache_results: true
       query_sharding_target_series_per_shard: 2500
       {{- end }}
+      {{- if eq .Values.deploymentMode "microservices" }}
       scheduler_address: {{ template "mimir.fullname" . }}-query-scheduler-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}
+      {{- else if eq .Values.deploymentMode "monolithic" }}
+      scheduler_address: {{ include "mimir.resourceName" (dict "ctx" . "component" "monolithic") }}-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}
+      {{- end }}
 
     frontend_worker:
       grpc_client_config:
         max_send_msg_size: 419430400 # 400MiB
+      {{- if eq .Values.deploymentMode "microservices" }}
       scheduler_address: {{ template "mimir.fullname" . }}-query-scheduler-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}
+      {{- else if eq .Values.deploymentMode "monolithic" }}
+      scheduler_address: {{ include "mimir.resourceName" (dict "ctx" . "component" "monolithic") }}-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" . }}
+      {{- end }}
 
     ingest_storage:
       enabled: true
@@ -251,11 +261,14 @@ mimir:
       ring:
         final_sleep: 0s
         num_tokens: 512
-        tokens_file_path: /data/tokens
+        tokens_file_path: /data/ingester/tokens
         unregister_on_shutdown: false
         heartbeat_period: 2m
         heartbeat_timeout: 10m
-        {{- if .Values.ingester.zoneAwareReplication.enabled }}
+        {{- if or 
+             (and (eq .Values.deploymentMode "microservices") .Values.ingester.zoneAwareReplication.enabled) 
+             (and (eq .Values.deploymentMode "monolithic") .Values.monolithic.zoneAwareReplication.enabled) 
+        }}
         zone_awareness_enabled: true
         {{- end }}
 
@@ -291,12 +304,20 @@ mimir:
       max_outstanding_requests_per_tenant: 800
 
     ruler:
+      {{- if eq .Values.deploymentMode "microservices" }}
       alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/alertmanager
+      {{- else if eq .Values.deploymentMode "monolithic" }}
+      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.{{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/alertmanager
+      {{- end }}      
       enable_api: true
-      rule_path: /data
+      rule_path: "/data/ruler"
       {{- if .Values.ruler.remoteEvaluationDedicatedQueryPath }}
       query_frontend:
+        {{- if eq .Values.deploymentMode "microservices" }}
         address: dns:///{{ template "mimir.fullname" . }}-ruler-query-frontend.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" .  }}
+        {{- else if eq .Values.deploymentMode "monolithic" }}
+        address: dns:///{{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" .  }}
+        {{- end }}   
       {{- end }}
 
     {{- if or (.Values.minio.enabled) (index .Values "metadata-cache" "enabled") }}
@@ -328,13 +349,19 @@ mimir:
         heartbeat_period: 1m
         heartbeat_timeout: 10m
         wait_stability_min_duration: 1m
-        {{- if .Values.store_gateway.zoneAwareReplication.enabled }}
+        {{- if or 
+             (and (eq .Values.deploymentMode "microservices") .Values.store_gateway.zoneAwareReplication.enabled) 
+             (and (eq .Values.deploymentMode "monolithic") .Values.monolithic.zoneAwareReplication.enabled) 
+        }}
         kvstore:
           prefix: multi-zone/
         {{- end }}
         tokens_file_path: /data/tokens
         unregister_on_shutdown: false
-        {{- if .Values.store_gateway.zoneAwareReplication.enabled }}
+        {{- if or 
+             (and (eq .Values.deploymentMode "microservices") .Values.store_gateway.zoneAwareReplication.enabled) 
+             (and (eq .Values.deploymentMode "monolithic") .Values.monolithic.zoneAwareReplication.enabled) 
+        }}
         zone_awareness_enabled: true
         {{- end }}
 
@@ -3479,70 +3506,125 @@ gateway:
 
             # Distributor endpoints
             location /distributor {
-              set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $distributor {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$distributor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /api/v1/push {
-              set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $distributor {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$distributor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location /otlp/v1/metrics {
-              set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $distributor {{ template "mimir.fullname" . }}-distributor-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $distributor {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$distributor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
-
+   
             # Alertmanager endpoints
             location {{ template "mimir.alertmanagerHttpPrefix" . }} {
-              set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /multitenant_alertmanager/status {
-              set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /multitenant_alertmanager/configs {
-              set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /api/v1/alerts {
-              set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $alertmanager {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
-
+   
             # Ruler endpoints
             location {{ template "mimir.prometheusHttpPrefix" . }}/config/v1/rules {
-              set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $ruler {{ template "mimir.fullname" . }}-monolithic.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/rules {
-              set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $ruler {{ template "mimir.fullname" . }}-monolithic.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
-
+   
             location {{ template "mimir.prometheusHttpPrefix" . }}/api/v1/alerts {
-              set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $ruler {{ template "mimir.fullname" . }}-monolithic.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /ruler/ring {
-              set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $ruler {{ template "mimir.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $ruler {{ template "mimir.fullname" . }}-monolithic.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$ruler:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
-
+   
             # Rest of {{ template "mimir.prometheusHttpPrefix" . }} goes to the query frontend
             location {{ template "mimir.prometheusHttpPrefix" . }} {
-              set $query_frontend {{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $query_frontend {{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $query_frontend {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$query_frontend:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
-
+   
             # Buildinfo endpoint can go to any component
             location = /api/v1/status/buildinfo {
-              set $query_frontend {{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
-              proxy_pass      http://$query_frontend:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $query_frontend {{ template "mimir.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $query_frontend {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}            proxy_pass      http://$query_frontend:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
-
+   
             # Compactor endpoint for uploading blocks
             location /api/v1/upload/block/ {
-              set $compactor {{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- if eq .Values.deploymentMode "microservices" }}
+                set $compactor {{ template "mimir.fullname" . }}-compactor.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- else if eq .Values.deploymentMode "monolithic" }}
+                set $compactor {{ template "mimir.fullname" . }}-monolithic-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              {{- end }}
               proxy_pass      http://$compactor:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
 
@@ -3949,6 +4031,241 @@ continuous_test:
   dnsConfig: {}
   tolerations: []
   terminationGracePeriodSeconds: 30
+
+monolithic:
+  # -- Total number of replicas for the monolithic across all availability zones
+  # If ingester.zoneAwareReplication.enabled=false, this number is taken as is.
+  # Otherwise each zone starts `ceil(replicas / number_of_zones)` number of pods.
+  #   E.g. if 'replicas' is set to 4 and there are 3 zones, then 4/3=1.33 and after rounding up it means 2 pods per zone are started.
+  replicas: 3
+
+  # -- Allows to override the container image of the alertmanager component.
+  # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
+  image:
+    # repository: grafana/mimir
+    # tag: 2.16.0
+
+  # TODO Currently I have only foreseen to enable compression for the monolithic deployment mode
+  compression:
+    enabled: false
+    algorithm: snappy
+  statefulSet:
+    enabled: true
+
+  service:
+    annotations: {}
+    labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
+    extraPorts: []
+    # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+    trafficDistribution: ""
+
+  # -- Optionally set the scheduler for pods of the monolithic deployment
+  schedulerName: ""
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  # Additional monolithic container arguments, e.g. log level (debug, info, warn, error)
+  extraArgs: {}
+  # Pod Labels
+  podLabels: {}
+
+  # Pod Annotations
+  podAnnotations: {}
+
+  # -- The name of the PriorityClass for monolithic pods
+  priorityClassName: null
+
+  # -- Pod Disruption Budget for monolithic, this will be applied across availability zones to prevent losing redundancy
+  podDisruptionBudget:
+    maxUnavailable: 1
+
+  podManagementPolicy: Parallel
+
+  # -- NodeSelector to pin monolithic pods to certain set of nodes. This is ignored when monolithic.zoneAwareReplication.enabled=true.
+  nodeSelector: {}
+  # -- Pod affinity settings for the monolithic. This is ignored when monolithic.zoneAwareReplication.enabled=true.
+  affinity: {}
+  dnsConfig: {}
+
+  # -- topologySpreadConstraints allows to customize the default topologySpreadConstraints. This can be either a single dict as shown below or a slice of topologySpreadConstraints.
+  # labelSelector is taken from the constraint itself (if it exists) or is generated by the chart using the same selectors as for services.
+  # It is recommended to replace this with requiredDuringSchedulingIgnoredDuringExecution podAntiAffinity rules when
+  # deploying to production.
+  topologySpreadConstraints:
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    # minDomains: 1
+    # nodeAffinityPolicy: Honor
+    # nodeTaintsPolicy: Honor
+    # matchLabelKeys:
+    #   - pod-template-hash
+
+  annotations: {}
+
+  persistentVolume:
+    # If true and monolithic.statefulSet.enabled is true,
+    # Monolithic will create/use a Persistent Volume Claim
+    # If false, use emptyDir
+    #
+    enabled: true
+
+    # Monolithic data Persistent Volume Claim template name
+    #
+    name: storage
+
+    # Monolithic data Persistent Volume Claim annotations
+    #
+    annotations: {}
+
+    # Monolithic data Persistent Volume access modes
+    # Must match those of existing PV or dynamic provisioner
+    # Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    accessModes:
+      - ReadWriteOnce
+
+    # Monolithic data Persistent Volume size
+    size: 2Gi
+
+    # Subdirectory of Monolithic data Persistent Volume to mount
+    # Useful if the volume's root directory is not empty
+    subPath: ''
+
+
+    # Monolithic data Persistent Volume Storage Class
+    # If defined, storageClassName: <storageClass>
+    # If set to "-", storageClassName: "", which disables dynamic provisioning
+    # If undefined (the default) or set to null, no storageClassName spec is
+    #   set, choosing the default provisioner.
+    #
+    # storageClass: "-"
+
+    # -- Enable StatefulSetAutoDeletePVC feature
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    enableRetentionPolicy: false
+    whenDeleted: Retain
+    whenScaled: Retain
+
+  livenessProbe: null
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 60
+
+  # -- SecurityContext override for monolithic pods
+  securityContext: {}
+
+  # -- The SecurityContext for monolithic containers
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+
+  # -- updateStrategy of the monolithic statefulset. This is ignored when monolithic.zoneAwareReplication.enabled=true.
+  statefulStrategy:
+    type: RollingUpdate
+
+  terminationGracePeriodSeconds: 900
+
+  tolerations: []
+  initContainers: []
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  env: []
+  extraEnvFrom: []
+
+  # -- Options to configure zone-aware replication for monolithic
+  # Example configuration with full geographical redundancy:
+  # rollout_operator:
+  #   enabled: true
+  # monolithic:
+  #   zoneAwareReplication:
+  #     enabled: true
+  #     topologyKey: 'kubernetes.io/hostname'  # This generates default anti-affinity rules
+  #     zones:  # Zone list has to be fully redefined for modification. Update with you actual zones or skip to use logical zones only.
+  #     - name: zone-a
+  #       nodeSelector:
+  #         topology.kubernetes.io/zone: us-central1-a
+  #     - name: zone-a
+  #       nodeSelector:
+  #         topology.kubernetes.io/zone: us-central1-b
+  #     - name: zone-c
+  #       nodeSelector:
+  #         topology.kubernetes.io/zone: us-central1-c
+  #
+  zoneAwareReplication:
+    # -- Enable zone-aware replication for ingester
+    enabled: true
+    # -- Maximum number of ingesters that can be unavailable per zone during rollout
+    maxUnavailable: 50
+    # -- topologyKey to use in pod anti-affinity. If unset, no anti-affinity rules are generated. If set, the generated anti-affinity rule makes sure that pods from different zones do not mix.
+    # E.g.: topologyKey: 'kubernetes.io/hostname'
+    topologyKey: null
+    # -- Auxiliary values for migration, see https://grafana.com/docs/mimir/latest/migration-guide/migrating-from-single-zone-with-helm/
+    migration:
+      # -- Indicate if migration is ongoing for multi zone ingester
+      enabled: false
+      # -- Exclude default zone on write path
+      excludeDefaultZone: false
+      # -- Enable zone-awareness, read path only
+      readPath: false
+      # -- Total number of replicas to start in availability zones when migration is enabled
+      replicas: 0
+      # -- Scale default zone ingesters to 0
+      scaleDownDefaultZone: false
+      # -- Enable zone-awareness, write path only
+      writePath: false
+    # -- Zone definitions for monolithic zones. Note: you have to redefine the whole list to change parts as YAML does not allow to modify parts of a list.
+    zones:
+      # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+      - name: zone-a
+        # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
+        # nodeSelector:
+        #   topology.kubernetes.io/zone: zone-a
+        nodeSelector: null
+        # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
+        extraAffinity: {}
+        # -- Monolithic data Persistent Volume Storage Class
+        # If defined, storageClassName: <storageClass>
+        # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+        # If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`.
+        storageClass: null
+      # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+      - name: zone-b
+        # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
+        # nodeSelector:
+        #   topology.kubernetes.io/zone: zone-b
+        nodeSelector: null
+        # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
+        extraAffinity: {}
+        # -- Monolithic data Persistent Volume Storage Class
+        # If defined, storageClassName: <storageClass>
+        # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+        # If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`.
+        storageClass: null
+      # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+      - name: zone-c
+        # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
+        # nodeSelector:
+        #   topology.kubernetes.io/zone: zone-c
+        nodeSelector: null
+        # -- extraAffinity adds user defined custom affinity rules (merged with generated rules)
+        extraAffinity: {}
+        # -- Monolithic data Persistent Volume Storage Class
+        # If defined, storageClassName: <storageClass>
+        # If set to "-", then use `storageClassName: ""`, which disables dynamic provisioning
+        # If undefined or set to null (the default), then fall back to the value of `ingester.persistentVolume.storageClass`.
+        storageClass: null
+
 
 # -- Add dynamic manifests via values. Example:
 # extraObjects:


### PR DESCRIPTION
Ideally the same chart can be used for monolithic, read-write and microservices deployment mode.
This allows an easier migration between modes when the load on a system changes.

To do this a new parameter 'deploymentMode' has been added to the helm chart. All charts are adapted to deploy services when applicable according to the
deployment model.

A new template is being added that installs the
monolithic mimir container. All nginx endpoints are updated to direct to the monolithic service if this deployment mode has been chosen.

I attached a monolithic.yaml yaml file that I have used to do a monolithic setup.

Didn't fully get it working yet, but sharing it as it could be a starting point for a future implementation.

Currently stuck on issues with my monolithic container that reports errors that I don't really understand:

  rpc error: code = Unavailable desc = connection
  error: desc = \"transport: Error while dialing dial
  tcp 10.98.18.233:9095: connect: connection refused

If anyone has a clue and willing to help me out, let me know.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
