### PR TITLE
Configure the alert manager URL when in read-write mode

### DIFF
--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -347,12 +347,11 @@ func startReadWriteModeCluster(t *testing.T, s *e2e.Scenario, extraFlags ...map[
 
 	flagSets = append(flagSets, extraFlags...)
 	commonFlags := mergeFlags(flagSets...)
-	backendFlags := mergeFlags(commonFlags, map[string]string{"-ruler.alertmanager-url": "http://localhost:8080/alertmanager"})
 
 	cluster := readWriteModeCluster{
 		readInstance:    e2emimir.NewReadInstance("mimir-read-1", commonFlags),
 		writeInstance:   e2emimir.NewWriteInstance("mimir-write-1", commonFlags),
-		backendInstance: e2emimir.NewBackendInstance("mimir-backend-1", backendFlags),
+		backendInstance: e2emimir.NewBackendInstance("mimir-backend-1", commonFlags),
 	}
 	require.NoError(t, s.StartAndWaitReady(cluster.readInstance, cluster.writeInstance, cluster.backendInstance))
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -671,6 +671,14 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		return nil, nil
 	}
 
+	if t.Cfg.Ruler.AlertmanagerURL == "" && t.ModuleManager.IsModuleRegistered(AlertManager) {
+		localAddress := t.Cfg.Server.HTTPListenAddress
+		if localAddress == "" {
+			localAddress = "http://127.0.0.1"
+		}
+		t.Cfg.Ruler.AlertmanagerURL = fmt.Sprintf("%v:%d%v", localAddress, t.Cfg.Server.HTTPListenPort, t.Cfg.API.AlertmanagerHTTPPrefix)
+	}
+
 	t.Cfg.Ruler.Ring.Common.ListenPort = t.Cfg.Server.GRPCListenPort
 
 	var embeddedQueryable prom_storage.Queryable


### PR DESCRIPTION
This PR should not be needed once ring based discover of alert managers is added.

---

#### What this PR does

This change configures the alert manager URL to localhost when no URL is present and the alert manager is registered.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Which issue(s) this PR fixes or relates to

Fixes #3876

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
