### PR TITLE
Don't use zeropool for postings cache key building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Distributor: make `__meta_tenant_id` label available in relabeling rules configured via `metric_relabel_configs`. #4725
 * [ENHANCEMENT] Querier: reduce CPU utilisation when shuffle sharding is enabled with large shard sizes. #4851
 * [ENHANCEMENT] Packaging: facilitate configuration management by instructing systemd to start mimir with a configuration file. #4810
-* [ENHANCEMENT] Store-gateway: reduce memory allocations when looking up postings from cache. #4861
+* [ENHANCEMENT] Store-gateway: reduce memory allocations when looking up postings from cache. #4861 #4869
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -5,7 +5,7 @@ std.manifestYamlDoc({
     self.read +
     self.backend +
     self.minio +
-    self.grafana + 
+    self.grafana +
     self.grafana_agent +
     self.memcached +
     {},

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -33,6 +33,7 @@ const (
 
 var (
 	postingsCacheKeyLabelHashBufferPool = sync.Pool{New: func() any {
+		// We assume the label name/value pair is typically not longer than 1KB.
 		b := make([]byte, 1024)
 		return &b
 	}}

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/util/zeropool"
 	"golang.org/x/crypto/blake2b"
 
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -32,10 +32,10 @@ const (
 )
 
 var (
-	postingsCacheKeyLabelHashBufferPool = zeropool.New[[]byte](func() []byte {
-		// We assume the label name/value pair is typically not longer than 1KB.
-		return make([]byte, 0, 1024)
-	})
+	postingsCacheKeyLabelHashBufferPool = sync.Pool{New: func() any {
+		b := make([]byte, 1024)
+		return &b
+	}}
 )
 
 // RemoteIndexCache is a memcached or redis based index cache.
@@ -183,7 +183,9 @@ func postingsCacheKeyLabelHash(l labels.Label) [blake2b.Size256]byte {
 	expectedLen := len(l.Name) + len(separator) + len(l.Value)
 
 	// Get a buffer from the pool and fill it with the label name/value pair to hash.
-	buf := postingsCacheKeyLabelHashBufferPool.Get()
+	bp := postingsCacheKeyLabelHashBufferPool.Get().(*[]byte)
+	buf := *bp
+
 	if cap(buf) < expectedLen {
 		buf = make([]byte, expectedLen)
 	} else {
@@ -203,7 +205,10 @@ func postingsCacheKeyLabelHash(l labels.Label) [blake2b.Size256]byte {
 	// Use cryptographically hash functions to avoid hash collisions
 	// which would end up in wrong query results.
 	hash := blake2b.Sum256(buf)
-	postingsCacheKeyLabelHashBufferPool.Put(buf)
+
+	// Reuse the same pointer to put the buffer back into the pool.
+	*bp = buf
+	postingsCacheKeyLabelHashBufferPool.Put(bp)
 
 	return hash
 }


### PR DESCRIPTION
#### What this PR does

Late feedback on https://github.com/grafana/mimir/pull/4861, so I decided to open a PR instead of commenting.

Zeropool is useful when we can't retain the pointer to put it back into the pool, but when we can it causes an unnecessary overhead of a second pool.

This saves some nanoseconds, without an allocations change

```
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/storegateway/indexcache cpu: 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz
                                     │   main.txt   │               new.txt                │
                                     │    sec/op    │    sec/op     vs base                │
StringCacheKeys/postings-16            1.011µ ±  0%   1.001µ ±  3%   -0.94% (p=0.033 n=10)
StringCacheKeys/series_ref-16          133.9n ± 13%   120.5n ±  9%   -9.97% (p=0.000 n=10)
StringCacheKeys/expanded_postings-16   418.0n ±  7%   328.2n ± 21%  -21.47% (p=0.000 n=10)
geomean                                383.8n         340.8n        -11.20%
```

#### Which issue(s) this PR fixes or relates to

None, followup on https://github.com/grafana/mimir/pull/4861

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
