### PR TITLE
Add the ruler as a grafana datasource in mimir-microservices-mode

### DIFF
--- a/development/mimir-microservices-mode/config/datasource-mimir.yaml
+++ b/development/mimir-microservices-mode/config/datasource-mimir.yaml
@@ -12,6 +12,14 @@ datasources:
     exemplarTraceIdDestinations:
     - name: traceID
       datasourceUid: jaeger
+- name: Ruler
+  type: prometheus
+  access: proxy
+  uid: ruler
+  orgID: 1
+  url: http://ruler-1:8021/prometheus
+  jsonData:
+    prometheusType: Mimir
 - name: Jaeger
   type: jaeger
   access: proxy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds the ruler as a grafana datasource in mimir-microservices-mode. This allows the existing mimir managed rules to show up in the grafana UI.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
