### PR TITLE
Expose the minio console in dev docker-composes

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -212,9 +212,12 @@ std.manifestYamlDoc({
   minio:: {
     minio: {
       image: 'minio/minio',
-      command: ['server', '/data'],
+      command: ['server', '--console-address', ':9001', '/data'],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
-      ports: ['9000:9000'],
+      ports: [
+        '9000:9000',
+        '9001:9001',
+      ],
       volumes: ['.data-minio:/data:delegated'],
     },
   },

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -218,6 +218,8 @@
   "minio":
     "command":
       - "server"
+      - "--console-address"
+      - ":9001"
       - "/data"
     "environment":
       - "MINIO_ROOT_USER=mimir"
@@ -225,6 +227,7 @@
     "image": "minio/minio"
     "ports":
       - "9000:9000"
+      - "9001:9001"
     "volumes":
       - ".data-minio:/data:delegated"
   "otel_collector":

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -9,12 +9,13 @@ services:
 
   minio:
     image: minio/minio
-    command: [ "server", "/data" ]
+    command: [ "server", "--console-address", ":9001", "/data" ]
     environment:
       - MINIO_ROOT_USER=mimir
       - MINIO_ROOT_PASSWORD=supersecret
     ports:
       - 9000:9000
+      - 9001:9001
     volumes:
       - .data-minio:/data:delegated
 

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -60,9 +60,12 @@ std.manifestYamlDoc({
   minio:: {
     minio: {
       image: 'minio/minio',
-      command: ['server', '/data'],
+      command: ['server', '--console-address', ':9001', '/data'],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
-      ports: ['9000:9000'],
+      ports: [
+        '9000:9000',
+        '9001:9001',
+      ],
       volumes: ['.data-minio:/data:delegated'],
     },
   },

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -158,6 +158,8 @@
   "minio":
     "command":
       - "server"
+      - "--console-address"
+      - ":9001"
       - "/data"
     "environment":
       - "MINIO_ROOT_USER=mimir"
@@ -165,6 +167,7 @@
     "image": "minio/minio"
     "ports":
       - "9000:9000"
+      - "9001:9001"
     "volumes":
       - ".data-minio:/data:delegated"
 "version": "3.4"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This change exposes the minio console on port 9001 in the dev-docker compose stacks, which helps with debugging storage related problems in a dev environment. Recent minio versions require the console to be explicitly enabled and exposed on a separate port from the API. Port 9001 [is suggested](https://min.io/docs/minio/linux/administration/minio-console.html#static-vs-dynamic-port-assignment), and does not appear to be in use in the 3 updated docker-compose stacks.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
