### PR TITLE
Allow injection of dashboard rows after Distributor row in Mimir / Writes dashboard

### DIFF
--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -634,5 +634,8 @@
     // Set to at least twice the scrape interval; otherwise, recording rules will output no data.
     // Set to four times the scrape interval to account for edge cases: https://www.robustperception.io/what-range-should-i-use-with-rate/
     recording_rules_range_interval: '1m',
+
+    // Used to inject rows into dashboards at specific places that support it.
+    injectRows: {},
   },
 }

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -137,6 +137,7 @@ local filename = 'mimir-writes.json';
         )
       )
     )
+    .addRowsIf(std.objectHasAll($._config.injectRows, 'postDistributor'), $._config.injectRows.postDistributor($))
     .addRow(
       $.row('Ingester')
       .addPanel(


### PR DESCRIPTION
I would like to inject some rows after the `Distributor` row of the `Mimir / Writes` dashboard, unfortunately I have not found a cleaner solution than this. If there is a better way to do this, please let me know.