### PR TITLE
Alertmanager: Introduce new metrics from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302
 * [BUGFIX] Backend: Check that alertmanager's data-dir doesn't overlap with bucket-sync dir. #4921
 * [ENHANCEMENT] Alertmanager: Introduce new metrics from upstream. #4918
+  * `cortex_alertmanager_notifications_failed_total` (added `reason` label)
+  * `cortex_alertmanager_nflog_maintenance_total`
+  * `cortex_alertmanager_nflog_maintenance_errors_total`
+  * `cortex_alertmanager_silences_maintenance_total`
+  * `cortex_alertmanager_silences_maintenance_errors_total`
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302
 * [BUGFIX] Backend: Check that alertmanager's data-dir doesn't overlap with bucket-sync dir. #4921
+* [ENHANCEMENT] Alertmanager: Introduce new metrics from upstream. #4918
 
 ### Documentation
 

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -94,7 +94,7 @@ func newAlertmanagerMetrics() *alertmanagerMetrics {
 		numFailedNotifications: prometheus.NewDesc(
 			"cortex_alertmanager_notifications_failed_total",
 			"The total number of failed notifications.",
-			[]string{"user", "integration"}, nil),
+			[]string{"user", "integration", "reason"}, nil),
 		numNotificationRequestsTotal: prometheus.NewDesc(
 			"cortex_alertmanager_notification_requests_total",
 			"The total number of attempted notification requests.",
@@ -312,7 +312,7 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerTenant(out, m.alertsInvalid, "alertmanager_alerts_invalid_total")
 
 	data.SendSumOfCountersPerTenant(out, m.numNotifications, "alertmanager_notifications_total", dskit_metrics.WithLabels("integration"), dskit_metrics.WithSkipZeroValueMetrics)
-	data.SendSumOfCountersPerTenant(out, m.numFailedNotifications, "alertmanager_notifications_failed_total", dskit_metrics.WithLabels("integration"), dskit_metrics.WithSkipZeroValueMetrics)
+	data.SendSumOfCountersPerTenant(out, m.numFailedNotifications, "alertmanager_notifications_failed_total", dskit_metrics.WithLabels("integration", "reason"), dskit_metrics.WithSkipZeroValueMetrics)
 	data.SendSumOfCountersPerTenant(out, m.numNotificationRequestsTotal, "alertmanager_notification_requests_total", dskit_metrics.WithLabels("integration"), dskit_metrics.WithSkipZeroValueMetrics)
 	data.SendSumOfCountersPerTenant(out, m.numNotificationRequestsFailedTotal, "alertmanager_notification_requests_failed_total", dskit_metrics.WithLabels("integration"), dskit_metrics.WithSkipZeroValueMetrics)
 	data.SendSumOfHistograms(out, m.notificationLatencySeconds, "alertmanager_notification_latency_seconds")

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -32,6 +32,8 @@ type alertmanagerMetrics struct {
 	nflogGCDuration              *prometheus.Desc
 	nflogSnapshotDuration        *prometheus.Desc
 	nflogSnapshotSize            *prometheus.Desc
+	nflogMaintenanceTotal        *prometheus.Desc
+	nflogMaintenanceErrorsTotal  *prometheus.Desc
 	nflogQueriesTotal            *prometheus.Desc
 	nflogQueryErrorsTotal        *prometheus.Desc
 	nflogQueryDuration           *prometheus.Desc
@@ -120,6 +122,14 @@ func newAlertmanagerMetrics() *alertmanagerMetrics {
 		nflogSnapshotSize: prometheus.NewDesc(
 			"cortex_alertmanager_nflog_snapshot_size_bytes",
 			"Size of the last notification log snapshot in bytes.",
+			nil, nil),
+		nflogMaintenanceTotal: prometheus.NewDesc(
+			"cortex_alertmanager_nflog_maintenance_total",
+			"How many maintenances were executed for the notification log.",
+			nil, nil),
+		nflogMaintenanceErrorsTotal: prometheus.NewDesc(
+			"cortex_alertmanager_nflog_maintenance_errors_total",
+			"How many maintenances were executed for the notification log that failed.",
 			nil, nil),
 		nflogQueriesTotal: prometheus.NewDesc(
 			"cortex_alertmanager_nflog_queries_total",
@@ -282,6 +292,8 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.nflogGCDuration
 	out <- m.nflogSnapshotDuration
 	out <- m.nflogSnapshotSize
+	out <- m.nflogMaintenanceTotal
+	out <- m.nflogMaintenanceErrorsTotal
 	out <- m.nflogQueriesTotal
 	out <- m.nflogQueryErrorsTotal
 	out <- m.nflogQueryDuration
@@ -333,6 +345,8 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfSummaries(out, m.nflogGCDuration, "alertmanager_nflog_gc_duration_seconds")
 	data.SendSumOfSummaries(out, m.nflogSnapshotDuration, "alertmanager_nflog_snapshot_duration_seconds")
 	data.SendSumOfGauges(out, m.nflogSnapshotSize, "alertmanager_nflog_snapshot_size_bytes")
+	data.SendSumOfCounters(out, m.nflogMaintenanceTotal, "alertmanager_nflog_maintenance_total")
+	data.SendSumOfCounters(out, m.nflogMaintenanceErrorsTotal, "alertmanager_nflog_maintenance_errors_total")
 	data.SendSumOfCounters(out, m.nflogQueriesTotal, "alertmanager_nflog_queries_total")
 	data.SendSumOfCounters(out, m.nflogQueryErrorsTotal, "alertmanager_nflog_query_errors_total")
 	data.SendSumOfHistograms(out, m.nflogQueryDuration, "alertmanager_nflog_query_duration_seconds")

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -42,6 +42,8 @@ type alertmanagerMetrics struct {
 
 	// exported metrics, gathered from Alertmanager Silences
 	silencesGCDuration              *prometheus.Desc
+	silencesMaintenanceTotal        *prometheus.Desc
+	silencesMaintenanceErrorsTotal  *prometheus.Desc
 	silencesSnapshotDuration        *prometheus.Desc
 	silencesSnapshotSize            *prometheus.Desc
 	silencesQueriesTotal            *prometheus.Desc
@@ -142,6 +144,14 @@ func newAlertmanagerMetrics() *alertmanagerMetrics {
 		silencesGCDuration: prometheus.NewDesc(
 			"cortex_alertmanager_silences_gc_duration_seconds",
 			"Duration of the last silence garbage collection cycle.",
+			nil, nil),
+		silencesMaintenanceTotal: prometheus.NewDesc(
+			"cortex_alertmanager_silences_maintenance_total",
+			"How many maintenances were executed for silences.",
+			nil, nil),
+		silencesMaintenanceErrorsTotal: prometheus.NewDesc(
+			"cortex_alertmanager_silences_maintenance_errors_total",
+			"How many maintenances were executed for silences that failed.",
 			nil, nil),
 		silencesSnapshotDuration: prometheus.NewDesc(
 			"cortex_alertmanager_silences_snapshot_duration_seconds",
@@ -277,6 +287,8 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.nflogQueryDuration
 	out <- m.nflogPropagatedMessagesTotal
 	out <- m.silencesGCDuration
+	out <- m.silencesMaintenanceTotal
+	out <- m.silencesMaintenanceErrorsTotal
 	out <- m.silencesSnapshotDuration
 	out <- m.silencesSnapshotSize
 	out <- m.silencesQueriesTotal
@@ -327,6 +339,8 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, m.nflogPropagatedMessagesTotal, "alertmanager_nflog_gossip_messages_propagated_total")
 
 	data.SendSumOfSummaries(out, m.silencesGCDuration, "alertmanager_silences_gc_duration_seconds")
+	data.SendSumOfCounters(out, m.silencesMaintenanceTotal, "alertmanager_silences_maintenance_total")
+	data.SendSumOfCounters(out, m.silencesMaintenanceErrorsTotal, "alertmanager_silences_maintenance_errors_total")
 	data.SendSumOfSummaries(out, m.silencesSnapshotDuration, "alertmanager_silences_snapshot_duration_seconds")
 	data.SendSumOfGauges(out, m.silencesSnapshotSize, "alertmanager_silences_snapshot_size_bytes")
 	data.SendSumOfCounters(out, m.silencesQueriesTotal, "alertmanager_silences_queries_total")

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -71,6 +71,12 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		# HELP cortex_alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
 		# TYPE cortex_alertmanager_nflog_gossip_messages_propagated_total counter
 		cortex_alertmanager_nflog_gossip_messages_propagated_total 111
+		# HELP cortex_alertmanager_nflog_maintenance_errors_total How many maintenances were executed for the notification log that failed.
+        # TYPE cortex_alertmanager_nflog_maintenance_errors_total counter
+        cortex_alertmanager_nflog_maintenance_errors_total 111
+        # HELP cortex_alertmanager_nflog_maintenance_total How many maintenances were executed for the notification log.
+        # TYPE cortex_alertmanager_nflog_maintenance_total counter
+        cortex_alertmanager_nflog_maintenance_total 111
 		# HELP cortex_alertmanager_nflog_queries_total Number of notification log queries were received.
 		# TYPE cortex_alertmanager_nflog_queries_total counter
 		cortex_alertmanager_nflog_queries_total 111
@@ -384,7 +390,12 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            # HELP cortex_alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
         	            # TYPE cortex_alertmanager_nflog_gossip_messages_propagated_total counter
         	            cortex_alertmanager_nflog_gossip_messages_propagated_total 111
-
+						# HELP cortex_alertmanager_nflog_maintenance_errors_total How many maintenances were executed for the notification log that failed.
+						# TYPE cortex_alertmanager_nflog_maintenance_errors_total counter
+						cortex_alertmanager_nflog_maintenance_errors_total 111
+						# HELP cortex_alertmanager_nflog_maintenance_total How many maintenances were executed for the notification log.
+						# TYPE cortex_alertmanager_nflog_maintenance_total counter
+						cortex_alertmanager_nflog_maintenance_total 111
         	            # HELP cortex_alertmanager_nflog_queries_total Number of notification log queries were received.
         	            # TYPE cortex_alertmanager_nflog_queries_total counter
         	            cortex_alertmanager_nflog_queries_total 111
@@ -697,7 +708,12 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		# HELP cortex_alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
     		# TYPE cortex_alertmanager_nflog_gossip_messages_propagated_total counter
     		cortex_alertmanager_nflog_gossip_messages_propagated_total 111
-
+			# HELP cortex_alertmanager_nflog_maintenance_errors_total How many maintenances were executed for the notification log that failed.
+			# TYPE cortex_alertmanager_nflog_maintenance_errors_total counter
+			cortex_alertmanager_nflog_maintenance_errors_total 111
+			# HELP cortex_alertmanager_nflog_maintenance_total How many maintenances were executed for the notification log.
+			# TYPE cortex_alertmanager_nflog_maintenance_total counter
+			cortex_alertmanager_nflog_maintenance_total 111
     		# HELP cortex_alertmanager_nflog_queries_total Number of notification log queries were received.
     		# TYPE cortex_alertmanager_nflog_queries_total counter
     		cortex_alertmanager_nflog_queries_total 111
@@ -957,6 +973,8 @@ func populateAlertmanager(base float64) *prometheus.Registry {
 	n.queryErrorsTotal.Add(base)
 	n.queryDuration.Observe(base)
 	n.propagatedMessagesTotal.Add(base)
+	n.maintenanceTotal.Add(base)
+	n.maintenanceErrorsTotal.Add(base)
 
 	nm := newNotifyMetrics(reg)
 	for i, integration := range integrations {
@@ -1003,6 +1021,8 @@ type nflogMetrics struct {
 	queryErrorsTotal        prometheus.Counter
 	queryDuration           prometheus.Histogram
 	propagatedMessagesTotal prometheus.Counter
+	maintenanceTotal        prometheus.Counter
+	maintenanceErrorsTotal  prometheus.Counter
 }
 
 func newNflogMetrics(r prometheus.Registerer) *nflogMetrics {
@@ -1021,6 +1041,14 @@ func newNflogMetrics(r prometheus.Registerer) *nflogMetrics {
 	m.snapshotSize = promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_nflog_snapshot_size_bytes",
 		Help: "Size of the last notification log snapshot in bytes.",
+	})
+	m.maintenanceTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_nflog_maintenance_total",
+		Help: "How many maintenances were executed for the notification log.",
+	})
+	m.maintenanceErrorsTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_nflog_maintenance_errors_total",
+		Help: "How many maintenances were executed for the notification log that failed.",
 	})
 	m.queriesTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_nflog_queries_total",

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -26,6 +27,7 @@ var integrations = []string{
 	"webhook",
 	"victorops",
 	"sns",
+	"telegram",
 }
 
 func TestAlertmanagerMetricsStore(t *testing.T) {
@@ -100,40 +102,43 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_nflog_snapshot_size_bytes 111
 		# HELP cortex_alertmanager_notification_latency_seconds The latency of notifications in seconds.
 		# TYPE cortex_alertmanager_notification_latency_seconds histogram
-		cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 15
-		cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 21
-		cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 23
-		cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 25
-		cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 27
-		cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 27
-		cortex_alertmanager_notification_latency_seconds_sum 99.9
-		cortex_alertmanager_notification_latency_seconds_count 27
+		cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 16
+		cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 23
+		cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 25
+		cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 27
+		cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 29
+		cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 30
+		cortex_alertmanager_notification_latency_seconds_sum 124.875
+		cortex_alertmanager_notification_latency_seconds_count 30
 		# HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
 		# TYPE cortex_alertmanager_notifications_failed_total counter
-		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
-		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
-		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user3"} 500
-		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user1"} 1
-		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user2"} 10
-		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user3"} 100
-		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user1"} 3
-		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user2"} 30
-		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user3"} 300
-		cortex_alertmanager_notifications_failed_total{integration="slack",user="user1"} 4
-		cortex_alertmanager_notifications_failed_total{integration="slack",user="user2"} 40
-		cortex_alertmanager_notifications_failed_total{integration="slack",user="user3"} 400
-		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user1"} 7
-		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user2"} 70
-		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user3"} 700
-		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user1"} 6
-		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user2"} 60
-		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user3"} 600
-		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user1"} 2
-		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user2"} 20
-		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user3"} 200
-		cortex_alertmanager_notifications_failed_total{integration="sns",user="user1"} 8
-		cortex_alertmanager_notifications_failed_total{integration="sns",user="user2"} 80
-		cortex_alertmanager_notifications_failed_total{integration="sns",user="user3"} 800
+		cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user1"} 5
+		cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user2"} 50
+		cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user3"} 500
+		cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user1"} 1
+		cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user2"} 10
+		cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user3"} 100
+		cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user1"} 3
+		cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user2"} 30
+		cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user3"} 300
+		cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user1"} 4
+		cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user2"} 40
+		cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user3"} 400
+		cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user1"} 7
+		cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user2"} 70
+		cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user3"} 700
+		cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user1"} 6
+		cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user2"} 60
+		cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user3"} 600
+		cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user1"} 2
+		cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user2"} 20
+		cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user3"} 200
+		cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user1"} 8
+		cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user2"} 80
+		cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user3"} 800
+		cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user1"} 9
+		cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user2"} 90
+		cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user3"} 900
 		# HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
 		# TYPE cortex_alertmanager_notification_requests_total counter
 		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user1"} 5
@@ -160,6 +165,9 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notification_requests_total{integration="sns",user="user1"} 8
 		cortex_alertmanager_notification_requests_total{integration="sns",user="user2"} 80
 		cortex_alertmanager_notification_requests_total{integration="sns",user="user3"} 800
+		cortex_alertmanager_notification_requests_total{integration="telegram",user="user1"} 9
+		cortex_alertmanager_notification_requests_total{integration="telegram",user="user2"} 90
+		cortex_alertmanager_notification_requests_total{integration="telegram",user="user3"} 900
 		# HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
 		# TYPE cortex_alertmanager_notification_requests_failed_total counter
 		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user1"} 5
@@ -186,6 +194,9 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user1"} 8
 		cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user2"} 80
 		cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user3"} 800
+		cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user1"} 9
+		cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user2"} 90
+		cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user3"} 900
 		# HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
 		# TYPE cortex_alertmanager_notifications_total counter
 		cortex_alertmanager_notifications_total{integration="opsgenie",user="user1"} 5
@@ -212,6 +223,9 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_notifications_total{integration="sns",user="user1"} 8
 		cortex_alertmanager_notifications_total{integration="sns",user="user2"} 80
 		cortex_alertmanager_notifications_total{integration="sns",user="user3"} 800
+		cortex_alertmanager_notifications_total{integration="telegram",user="user1"} 9
+		cortex_alertmanager_notifications_total{integration="telegram",user="user2"} 90
+		cortex_alertmanager_notifications_total{integration="telegram",user="user3"} 900
 
 		# HELP cortex_alertmanager_silences How many silences by state.
 		# TYPE cortex_alertmanager_silences gauge
@@ -401,14 +415,14 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
 						# HELP cortex_alertmanager_notification_latency_seconds The latency of notifications in seconds.
         	           	# TYPE cortex_alertmanager_notification_latency_seconds histogram
-        	            cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 15
-        	            cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 21
-        	            cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 23
-        	            cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 25
-        	            cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 27
-        	            cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 27
-        	            cortex_alertmanager_notification_latency_seconds_sum 99.9
-        	            cortex_alertmanager_notification_latency_seconds_count 27
+        	            cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 16
+        	            cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 23
+        	            cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 25
+        	            cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 27
+        	            cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 29
+        	            cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 30
+        	            cortex_alertmanager_notification_latency_seconds_sum 124.875
+        	            cortex_alertmanager_notification_latency_seconds_count 30
 
         	            # HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
         	            # TYPE cortex_alertmanager_notification_requests_failed_total counter
@@ -436,6 +450,9 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user1"} 8
         	            cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user2"} 80
         	            cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user3"} 800
+						cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user1"} 9
+        	            cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user2"} 90
+        	            cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user3"} 900
 
         	            # HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
         	            # TYPE cortex_alertmanager_notification_requests_total counter
@@ -463,33 +480,39 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            cortex_alertmanager_notification_requests_total{integration="sns",user="user1"} 8
         	            cortex_alertmanager_notification_requests_total{integration="sns",user="user2"} 80
         	            cortex_alertmanager_notification_requests_total{integration="sns",user="user3"} 800
+						cortex_alertmanager_notification_requests_total{integration="telegram",user="user1"} 9
+        	            cortex_alertmanager_notification_requests_total{integration="telegram",user="user2"} 90
+        	            cortex_alertmanager_notification_requests_total{integration="telegram",user="user3"} 900
 
         	            # HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
         	            # TYPE cortex_alertmanager_notifications_failed_total counter
-        	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
-        	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
-        	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user3"} 500
-        	            cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user1"} 1
-        	            cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user2"} 10
-        	            cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user3"} 100
-        	            cortex_alertmanager_notifications_failed_total{integration="pushover",user="user1"} 3
-        	            cortex_alertmanager_notifications_failed_total{integration="pushover",user="user2"} 30
-        	            cortex_alertmanager_notifications_failed_total{integration="pushover",user="user3"} 300
-        	            cortex_alertmanager_notifications_failed_total{integration="slack",user="user1"} 4
-        	            cortex_alertmanager_notifications_failed_total{integration="slack",user="user2"} 40
-        	            cortex_alertmanager_notifications_failed_total{integration="slack",user="user3"} 400
-        	            cortex_alertmanager_notifications_failed_total{integration="victorops",user="user1"} 7
-        	            cortex_alertmanager_notifications_failed_total{integration="victorops",user="user2"} 70
-        	            cortex_alertmanager_notifications_failed_total{integration="victorops",user="user3"} 700
-        	            cortex_alertmanager_notifications_failed_total{integration="webhook",user="user1"} 6
-        	            cortex_alertmanager_notifications_failed_total{integration="webhook",user="user2"} 60
-        	            cortex_alertmanager_notifications_failed_total{integration="webhook",user="user3"} 600
-        	            cortex_alertmanager_notifications_failed_total{integration="wechat",user="user1"} 2
-        	            cortex_alertmanager_notifications_failed_total{integration="wechat",user="user2"} 20
-        	            cortex_alertmanager_notifications_failed_total{integration="wechat",user="user3"} 200
-        	            cortex_alertmanager_notifications_failed_total{integration="sns",user="user1"} 8
-        	            cortex_alertmanager_notifications_failed_total{integration="sns",user="user2"} 80
-        	            cortex_alertmanager_notifications_failed_total{integration="sns",user="user3"} 800
+        	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user1"} 5
+        	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user2"} 50
+        	            cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user3"} 500
+        	            cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user1"} 1
+        	            cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user2"} 10
+        	            cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user3"} 100
+        	            cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user1"} 3
+        	            cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user2"} 30
+        	            cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user3"} 300
+        	            cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user1"} 4
+        	            cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user2"} 40
+        	            cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user3"} 400
+        	            cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user1"} 7
+        	            cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user2"} 70
+        	            cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user3"} 700
+        	            cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user1"} 6
+        	            cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user2"} 60
+        	            cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user3"} 600
+        	            cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user1"} 2
+        	            cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user2"} 20
+        	            cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user3"} 200
+        	            cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user1"} 8
+        	            cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user2"} 80
+        	            cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user3"} 800
+						cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user1"} 9
+        	            cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user2"} 90
+        	            cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user3"} 900
 
         	            # HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
         	            # TYPE cortex_alertmanager_notifications_total counter
@@ -517,6 +540,9 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            cortex_alertmanager_notifications_total{integration="sns",user="user1"} 8
         	            cortex_alertmanager_notifications_total{integration="sns",user="user2"} 80
         	            cortex_alertmanager_notifications_total{integration="sns",user="user3"} 800
+						cortex_alertmanager_notifications_total{integration="telegram",user="user1"} 9
+        	            cortex_alertmanager_notifications_total{integration="telegram",user="user2"} 90
+        	            cortex_alertmanager_notifications_total{integration="telegram",user="user3"} 900
 
         	            # HELP cortex_alertmanager_silences How many silences by state.
         	            # TYPE cortex_alertmanager_silences gauge
@@ -696,14 +722,14 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 
     		# HELP cortex_alertmanager_notification_latency_seconds The latency of notifications in seconds.
     		# TYPE cortex_alertmanager_notification_latency_seconds histogram
-    		cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 15
-    		cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 21
-    		cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 23
-    		cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 25
-    		cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 27
-    		cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 27
-    		cortex_alertmanager_notification_latency_seconds_sum 99.9
-    		cortex_alertmanager_notification_latency_seconds_count 27
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 16
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 23
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 25
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 27
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 29
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 30
+    		cortex_alertmanager_notification_latency_seconds_sum 124.875
+    		cortex_alertmanager_notification_latency_seconds_count 30
 
     		# HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
     		# TYPE cortex_alertmanager_notification_requests_failed_total counter
@@ -723,6 +749,8 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		cortex_alertmanager_notification_requests_failed_total{integration="wechat",user="user2"} 20
     		cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user1"} 8
     		cortex_alertmanager_notification_requests_failed_total{integration="sns",user="user2"} 80
+			cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user1"} 9
+    		cortex_alertmanager_notification_requests_failed_total{integration="telegram",user="user2"} 90
 
     		# HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
     		# TYPE cortex_alertmanager_notification_requests_total counter
@@ -742,25 +770,29 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		cortex_alertmanager_notification_requests_total{integration="wechat",user="user2"} 20
     		cortex_alertmanager_notification_requests_total{integration="sns",user="user1"} 8
     		cortex_alertmanager_notification_requests_total{integration="sns",user="user2"} 80
+			cortex_alertmanager_notification_requests_total{integration="telegram",user="user1"} 9
+    		cortex_alertmanager_notification_requests_total{integration="telegram",user="user2"} 90
 
     		# HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
     		# TYPE cortex_alertmanager_notifications_failed_total counter
-    		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
-    		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
-    		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user1"} 1
-    		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user2"} 10
-    		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user1"} 3
-    		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user2"} 30
-    		cortex_alertmanager_notifications_failed_total{integration="slack",user="user1"} 4
-    		cortex_alertmanager_notifications_failed_total{integration="slack",user="user2"} 40
-    		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user1"} 7
-    		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user2"} 70
-    		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user1"} 6
-    		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user2"} 60
-    		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user1"} 2
-    		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user2"} 20
-    		cortex_alertmanager_notifications_failed_total{integration="sns",user="user1"} 8
-    		cortex_alertmanager_notifications_failed_total{integration="sns",user="user2"} 80
+    		cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user1"} 5
+    		cortex_alertmanager_notifications_failed_total{integration="opsgenie",reason="clientError",user="user2"} 50
+    		cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user1"} 1
+    		cortex_alertmanager_notifications_failed_total{integration="pagerduty",reason="clientError",user="user2"} 10
+    		cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user1"} 3
+    		cortex_alertmanager_notifications_failed_total{integration="pushover",reason="clientError",user="user2"} 30
+    		cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user1"} 4
+    		cortex_alertmanager_notifications_failed_total{integration="slack",reason="clientError",user="user2"} 40
+    		cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user1"} 7
+    		cortex_alertmanager_notifications_failed_total{integration="victorops",reason="clientError",user="user2"} 70
+    		cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user1"} 6
+    		cortex_alertmanager_notifications_failed_total{integration="webhook",reason="clientError",user="user2"} 60
+    		cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user1"} 2
+    		cortex_alertmanager_notifications_failed_total{integration="wechat",reason="clientError",user="user2"} 20
+    		cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user1"} 8
+    		cortex_alertmanager_notifications_failed_total{integration="sns",reason="clientError",user="user2"} 80
+			cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user1"} 9
+    		cortex_alertmanager_notifications_failed_total{integration="telegram",reason="clientError",user="user2"} 90
 
     		# HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
     		# TYPE cortex_alertmanager_notifications_total counter
@@ -780,6 +812,8 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		cortex_alertmanager_notifications_total{integration="wechat",user="user2"} 20
     		cortex_alertmanager_notifications_total{integration="sns",user="user1"} 8
     		cortex_alertmanager_notifications_total{integration="sns",user="user2"} 80
+			cortex_alertmanager_notifications_total{integration="telegram",user="user1"} 9
+    		cortex_alertmanager_notifications_total{integration="telegram",user="user2"} 90
 
     		# HELP cortex_alertmanager_silences How many silences by state.
     		# TYPE cortex_alertmanager_silences gauge
@@ -908,7 +942,7 @@ func populateAlertmanager(base float64) *prometheus.Registry {
 	nm := newNotifyMetrics(reg)
 	for i, integration := range integrations {
 		nm.numNotifications.WithLabelValues(integration).Add(base * float64(i))
-		nm.numFailedNotifications.WithLabelValues(integration).Add(base * float64(i))
+		nm.numTotalFailedNotifications.WithLabelValues(integration, notify.ClientErrorReason.String()).Add(base * float64(i))
 		nm.numNotificationRequestsTotal.WithLabelValues(integration).Add(base * float64(i))
 		nm.numNotificationRequestsFailedTotal.WithLabelValues(integration).Add(base * float64(i))
 		nm.notificationLatencySeconds.WithLabelValues(integration).Observe(base * float64(i) * 0.025)
@@ -1058,7 +1092,7 @@ func newSilenceMetrics(r prometheus.Registerer) *silenceMetrics {
 // Copied from github.com/alertmanager/notify/notify.go
 type notifyMetrics struct {
 	numNotifications                   *prometheus.CounterVec
-	numFailedNotifications             *prometheus.CounterVec
+	numTotalFailedNotifications        *prometheus.CounterVec
 	numNotificationRequestsTotal       *prometheus.CounterVec
 	numNotificationRequestsFailedTotal *prometheus.CounterVec
 	notificationLatencySeconds         *prometheus.HistogramVec
@@ -1071,11 +1105,11 @@ func newNotifyMetrics(r prometheus.Registerer) *notifyMetrics {
 			Name:      "notifications_total",
 			Help:      "The total number of attempted notifications.",
 		}, []string{"integration"}),
-		numFailedNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		numTotalFailedNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notifications_failed_total",
 			Help:      "The total number of failed notifications.",
-		}, []string{"integration"}),
+		}, []string{"integration", "reason"}),
 		numNotificationRequestsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notification_requests_total",
@@ -1093,15 +1127,33 @@ func newNotifyMetrics(r prometheus.Registerer) *notifyMetrics {
 			Buckets:   []float64{1, 5, 10, 15, 20},
 		}, []string{"integration"}),
 	}
-	for _, integration := range integrations {
+	for _, integration := range []string{
+		"email",
+		"pagerduty",
+		"wechat",
+		"pushover",
+		"slack",
+		"opsgenie",
+		"webhook",
+		"victorops",
+		"sns",
+		"telegram",
+	} {
 		m.numNotifications.WithLabelValues(integration)
-		m.numFailedNotifications.WithLabelValues(integration)
 		m.numNotificationRequestsTotal.WithLabelValues(integration)
 		m.numNotificationRequestsFailedTotal.WithLabelValues(integration)
 		m.notificationLatencySeconds.WithLabelValues(integration)
+
+		for _, reason := range possibleFailureReasonCategory {
+			m.numTotalFailedNotifications.WithLabelValues(integration, reason)
+		}
 	}
 	return m
 }
+
+// Copied from github.com/alertmanager/notify/util.go
+// possibleFailureReasonCategory is a list of possible failure reason.
+var possibleFailureReasonCategory = []string{notify.DefaultReason.String(), notify.ClientErrorReason.String(), notify.ServerErrorReason.String()}
 
 type markerMetrics struct {
 	alerts *prometheus.GaugeVec

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -245,6 +245,12 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		# HELP cortex_alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
 		# TYPE cortex_alertmanager_silences_gossip_messages_propagated_total counter
 		cortex_alertmanager_silences_gossip_messages_propagated_total 111
+		# HELP cortex_alertmanager_silences_maintenance_errors_total How many maintenances were executed for silences that failed.
+        # TYPE cortex_alertmanager_silences_maintenance_errors_total counter
+    	cortex_alertmanager_silences_maintenance_errors_total 111
+        # HELP cortex_alertmanager_silences_maintenance_total How many maintenances were executed for silences.
+        # TYPE cortex_alertmanager_silences_maintenance_total counter
+        cortex_alertmanager_silences_maintenance_total 111
 		# HELP cortex_alertmanager_silences_queries_total How many silence queries were received.
 		# TYPE cortex_alertmanager_silences_queries_total counter
 		cortex_alertmanager_silences_queries_total 111
@@ -564,6 +570,12 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            # HELP cortex_alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
         	            # TYPE cortex_alertmanager_silences_gossip_messages_propagated_total counter
         	            cortex_alertmanager_silences_gossip_messages_propagated_total 111
+						# HELP cortex_alertmanager_silences_maintenance_errors_total How many maintenances were executed for silences that failed.
+						# TYPE cortex_alertmanager_silences_maintenance_errors_total counter
+						cortex_alertmanager_silences_maintenance_errors_total 111
+						# HELP cortex_alertmanager_silences_maintenance_total How many maintenances were executed for silences.
+						# TYPE cortex_alertmanager_silences_maintenance_total counter
+						cortex_alertmanager_silences_maintenance_total 111
 
         	            # HELP cortex_alertmanager_silences_queries_total How many silence queries were received.
         	            # TYPE cortex_alertmanager_silences_queries_total counter
@@ -832,7 +844,12 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		# HELP cortex_alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
     		# TYPE cortex_alertmanager_silences_gossip_messages_propagated_total counter
     		cortex_alertmanager_silences_gossip_messages_propagated_total 111
-
+			# HELP cortex_alertmanager_silences_maintenance_errors_total How many maintenances were executed for silences that failed.
+			# TYPE cortex_alertmanager_silences_maintenance_errors_total counter
+			cortex_alertmanager_silences_maintenance_errors_total 111
+			# HELP cortex_alertmanager_silences_maintenance_total How many maintenances were executed for silences.
+			# TYPE cortex_alertmanager_silences_maintenance_total counter
+			cortex_alertmanager_silences_maintenance_total 111
     		# HELP cortex_alertmanager_silences_queries_total How many silence queries were received.
     		# TYPE cortex_alertmanager_silences_queries_total counter
     		cortex_alertmanager_silences_queries_total 111
@@ -929,6 +946,8 @@ func populateAlertmanager(base float64) *prometheus.Registry {
 	s.silencesActive.Set(base)
 	s.silencesExpired.Set(base * 2)
 	s.silencesPending.Set(base * 3)
+	s.maintenanceTotal.Add(base)
+	s.maintenanceErrorsTotal.Add(base)
 
 	n := newNflogMetrics(reg)
 	n.gcDuration.Observe(base)
@@ -1035,6 +1054,8 @@ type silenceMetrics struct {
 	silencesPending         prometheus.Gauge
 	silencesExpired         prometheus.Gauge
 	propagatedMessagesTotal prometheus.Counter
+	maintenanceTotal        prometheus.Counter
+	maintenanceErrorsTotal  prometheus.Counter
 }
 
 func newSilenceMetrics(r prometheus.Registerer) *silenceMetrics {
@@ -1053,6 +1074,14 @@ func newSilenceMetrics(r prometheus.Registerer) *silenceMetrics {
 	m.snapshotSize = promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_silences_snapshot_size_bytes",
 		Help: "Size of the last silence snapshot in bytes.",
+	})
+	m.maintenanceTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_silences_maintenance_total",
+		Help: "How many maintenances were executed for silences.",
+	})
+	m.maintenanceErrorsTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_silences_maintenance_errors_total",
+		Help: "How many maintenances were executed for silences that failed.",
 	})
 	m.queriesTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_silences_queries_total",


### PR DESCRIPTION
#### What this PR does

The upstream `prometheus/alertmanager` has recently been enhanced with new metrics:
- New `reason` label on `alertmanager_notifications_failed_total`
- `alertmanager_silences_maintenance_total`
- `alertmanager_silences_maintenance_errors_total`
- `alertmanager_nflog_maintenance_total`
- `alertmanager_nflog_maintenance_errors_total`

Since we recently upgraded alertmanager, these metrics are now available for us to consume.
This PR exposes these metrics in Mimir.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/4895

#### Checklist

- [x] Tests updated
- [ ] Documentation added
  - I found no documentation listing each metric by name, but happy to update this if there is one! :smile: 
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
