### PR TITLE
mixin: reduce sensitivity of MimirIngesterTSDBWALCorrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Alertmanager dashboard: display active aggregation groups #4772
+* [ENHANCEMENT] Alerts: `MimirIngesterTSDBWALCorrupted` now only fires when there are more than one corrupted WALs in single-zone deployments and when there are more than two zones affected in multi-zone deployments. #4920
 
 ### Jsonnet
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -450,9 +450,9 @@ How to **investigate**:
 
 ### MimirIngesterTSDBWALCorrupted
 
-This alert fires when a Mimir ingester finds a corrupted TSDB WAL (stored on disk) while replaying it at ingester startup or when creation of a checkpoint comes across a WAL corruption.
+This alert fires when more than one Mimir ingester finds a corrupted TSDB WAL (stored on disk) while replaying it at ingester startup or when creation of a checkpoint comes across a WAL corruption.
 
-If this alert fires during an **ingester startup**, the WAL should have been auto-repaired, but manual investigation is required. The WAL repair mechanism causes data loss because all WAL records after the corrupted segment are discarded, and so their samples are lost while replaying the WAL. If this happens only on 1 ingester then Mimir doesn't suffer any data loss because of the replication factor, but if it happens on multiple ingesters some data loss is possible.
+If this alert fires during an **ingester startup**, the WAL should have been auto-repaired, but manual investigation is required. The WAL repair mechanism causes data loss because all WAL records after the corrupted segment are discarded, and so their samples are lost while replaying the WAL. If this happens only on 1 ingester or only on one zone in a multi-zone cluster, then Mimir doesn't suffer any data loss because of the replication factor. But if it happens on multiple ingesters/zones some data loss is possible.
 
 To investigate how the ingester dealt with the WAL corruption, it's recommended you search the logs, e.g. with the following Grafana Loki query:
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -452,7 +452,7 @@ How to **investigate**:
 
 This alert fires when more than one Mimir ingester finds a corrupted TSDB WAL (stored on disk) while replaying it at ingester startup or when creation of a checkpoint comes across a WAL corruption.
 
-If this alert fires during an **ingester startup**, the WAL should have been auto-repaired, but manual investigation is required. The WAL repair mechanism causes data loss because all WAL records after the corrupted segment are discarded, and so their samples are lost while replaying the WAL. If this happens only on 1 ingester or only on one zone in a multi-zone cluster, then Mimir doesn't suffer any data loss because of the replication factor. But if it happens on multiple ingesters/zones some data loss is possible.
+If this alert fires during an **ingester startup**, the WAL should have been auto-repaired, but manual investigation is required. The WAL repair mechanism causes data loss because all WAL records after the corrupted segment are discarded, and so their samples are lost while replaying the WAL. If this happens only on 1 ingester or only on one zone in a multi-zone cluster, then Mimir doesn't suffer any data loss because of the replication factor. But if it happens on multiple ingesters, multiple zones, or both, some data loss is possible.
 
 To investigate how the ingester dealt with the WAL corruption, it's recommended you search the logs, e.g. with the following Grafana Loki query:
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -716,10 +716,10 @@ spec:
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
       expr: |
         # alert when there are more than one corruptions
-        count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+        count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
         and
         # and there is only one zone
-        count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+        count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
       labels:
         deployment: single-zone
         severity: critical
@@ -729,10 +729,10 @@ spec:
           }} got a corrupted TSDB WAL.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
       expr: |
-        count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+        count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
         and
         # and there are multiple zones
-        count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+        count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
       labels:
         deployment: multi-zone
         severity: critical

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -729,6 +729,7 @@ spec:
           }} got a corrupted TSDB WAL.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
       expr: |
+        # alert when there are more than one corruptions
         count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
         and
         # and there are multiple zones

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -715,8 +715,26 @@ spec:
           }} got a corrupted TSDB WAL.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
       expr: |
-        rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
+        # alert when there are more than one corruptions
+        count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+        and
+        # and there is only one zone in this cluster
+        count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
       labels:
+        deployment: single-zone
+        severity: critical
+    - alert: MimirIngesterTSDBWALCorrupted
+      annotations:
+        message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} got a corrupted TSDB WAL.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+      expr: |
+        count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+        and
+        # and there are multiple zones in this cluster
+        count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+      labels:
+        deployment: multi-zone
         severity: critical
     - alert: MimirIngesterTSDBWALWritesFailed
       annotations:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -716,10 +716,10 @@ spec:
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
       expr: |
         # alert when there are more than one corruptions
-        count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+        count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
         and
         # and there is only one zone in this cluster
-        count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+        count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
       labels:
         deployment: single-zone
         severity: critical
@@ -729,10 +729,10 @@ spec:
           }} got a corrupted TSDB WAL.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
       expr: |
-        count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+        count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
         and
         # and there are multiple zones in this cluster
-        count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+        count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
       labels:
         deployment: multi-zone
         severity: critical

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -718,7 +718,7 @@ spec:
         # alert when there are more than one corruptions
         count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
         and
-        # and there is only one zone in this cluster
+        # and there is only one zone
         count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
       labels:
         deployment: single-zone
@@ -731,7 +731,7 @@ spec:
       expr: |
         count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
         and
-        # and there are multiple zones in this cluster
+        # and there are multiple zones
         count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
       labels:
         deployment: multi-zone

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -696,10 +696,10 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
       # alert when there are more than one corruptions
-      count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+      count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
       and
       # and there is only one zone in this cluster
-      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
       deployment: single-zone
       severity: critical
@@ -709,10 +709,10 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
-      count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+      count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
       # and there are multiple zones in this cluster
-      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
     labels:
       deployment: multi-zone
       severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -709,6 +709,7 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
+      # alert when there are more than one corruptions
       count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
       # and there are multiple zones

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -696,10 +696,10 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
       # alert when there are more than one corruptions
-      count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+      count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
       and
       # and there is only one zone
-      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+      count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
       deployment: single-zone
       severity: critical
@@ -709,10 +709,10 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
-      count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+      count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
       # and there are multiple zones
-      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+      count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
     labels:
       deployment: multi-zone
       severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -695,8 +695,26 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
-      rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
+      # alert when there are more than one corruptions
+      count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+      and
+      # and there is only one zone in this cluster
+      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
+      deployment: single-zone
+      severity: critical
+  - alert: MimirIngesterTSDBWALCorrupted
+    annotations:
+      message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} got a corrupted TSDB WAL.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+    expr: |
+      count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+      and
+      # and there are multiple zones in this cluster
+      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+    labels:
+      deployment: multi-zone
       severity: critical
   - alert: MimirIngesterTSDBWALWritesFailed
     annotations:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -698,7 +698,7 @@ groups:
       # alert when there are more than one corruptions
       count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
       and
-      # and there is only one zone in this cluster
+      # and there is only one zone
       count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
       deployment: single-zone
@@ -711,7 +711,7 @@ groups:
     expr: |
       count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
-      # and there are multiple zones in this cluster
+      # and there are multiple zones
       count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
     labels:
       deployment: multi-zone

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -704,10 +704,10 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
       # alert when there are more than one corruptions
-      count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+      count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
       and
       # and there is only one zone in this cluster
-      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
       deployment: single-zone
       severity: critical
@@ -717,10 +717,10 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
-      count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+      count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
       # and there are multiple zones in this cluster
-      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
     labels:
       deployment: multi-zone
       severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -717,6 +717,7 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
+      # alert when there are more than one corruptions
       count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
       # and there are multiple zones

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -704,10 +704,10 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
       # alert when there are more than one corruptions
-      count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+      count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
       and
       # and there is only one zone
-      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+      count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
       deployment: single-zone
       severity: critical
@@ -717,10 +717,10 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
-      count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+      count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
       # and there are multiple zones
-      count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+      count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
     labels:
       deployment: multi-zone
       severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -703,8 +703,26 @@ groups:
         }} got a corrupted TSDB WAL.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
     expr: |
-      rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
+      # alert when there are more than one corruptions
+      count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+      and
+      # and there is only one zone in this cluster
+      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
+      deployment: single-zone
+      severity: critical
+  - alert: MimirIngesterTSDBWALCorrupted
+    annotations:
+      message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} got a corrupted TSDB WAL.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+    expr: |
+      count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+      and
+      # and there are multiple zones in this cluster
+      count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+    labels:
+      deployment: multi-zone
       severity: critical
   - alert: MimirIngesterTSDBWALWritesFailed
     annotations:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -706,7 +706,7 @@ groups:
       # alert when there are more than one corruptions
       count by (namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
       and
-      # and there is only one zone in this cluster
+      # and there is only one zone
       count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
     labels:
       deployment: single-zone
@@ -719,7 +719,7 @@ groups:
     expr: |
       count by (namespace) (sum by (namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
       and
-      # and there are multiple zones in this cluster
+      # and there are multiple zones
       count by (namespace) (group by (namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
     labels:
       deployment: multi-zone

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -140,10 +140,10 @@
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
             # alert when there are more than one corruptions
-            count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+            count by (%(per_namespace_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
             and
             # and there is only one zone in this cluster
-            count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+            count by (%(per_namespace_label)s) (group by (%(per_namespace_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
           ||| % $._config,
           labels: {
             severity: 'critical',
@@ -156,10 +156,10 @@
         {
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
-            count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+            count by (%(per_namespace_label)s) (sum by (%(per_namespace_label)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
             and
             # and there are multiple zones in this cluster
-            count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+            count by (%(per_namespace_label)s) (group by (%(per_namespace_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
           ||| % $._config,
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -142,7 +142,7 @@
             # alert when there are more than one corruptions
             count by (%(per_namespace_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
             and
-            # and there is only one zone in this cluster
+            # and there is only one zone
             count by (%(per_namespace_label)s) (group by (%(per_namespace_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
           ||| % $._config,
           labels: {
@@ -158,7 +158,7 @@
           expr: |||
             count by (%(per_namespace_label)s) (sum by (%(per_namespace_label)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
             and
-            # and there are multiple zones in this cluster
+            # and there are multiple zones
             count by (%(per_namespace_label)s) (group by (%(per_namespace_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
           ||| % $._config,
           labels: {

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -139,10 +139,31 @@
         {
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
-            rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0
-          |||,
+            # alert when there are more than one corruptions
+            count by ($(per_cluster_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+            and
+            # and there is only one zone in this cluster
+            count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+          ||| % $._config,
           labels: {
             severity: 'critical',
+            deployment: 'single-zone',
+          },
+          annotations: {
+            message: '%(product)s Ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s got a corrupted TSDB WAL.' % $._config,
+          },
+        },
+        {
+          alert: $.alertName('IngesterTSDBWALCorrupted'),
+          expr: |||
+            count by ($(per_cluster_label)s) (sum by ($(per_cluster_label)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+            and
+            # and there are multiple zones in this cluster
+            count by ($(per_cluster_label)s) (group by ($(per_cluster_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+          ||| % $._config,
+          labels: {
+            severity: 'critical',
+            deployment: 'multi-zone',
           },
           annotations: {
             message: '%(product)s Ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s got a corrupted TSDB WAL.' % $._config,

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -156,6 +156,7 @@
         {
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
+            # alert when there are more than one corruptions
             count by (%(alert_aggregation_labels)s) (sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
             and
             # and there are multiple zones

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -140,10 +140,10 @@
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
             # alert when there are more than one corruptions
-            count by (%(per_namespace_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+            count by (%(alert_aggregation_labels)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
             and
             # and there is only one zone
-            count by (%(per_namespace_label)s) (group by (%(per_namespace_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+            count by (%(alert_aggregation_labels)s) (group by (%(alert_aggregation_labels)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
           ||| % $._config,
           labels: {
             severity: 'critical',
@@ -156,10 +156,10 @@
         {
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
-            count by (%(per_namespace_label)s) (sum by (%(per_namespace_label)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+            count by (%(alert_aggregation_labels)s) (sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
             and
             # and there are multiple zones
-            count by (%(per_namespace_label)s) (group by (%(per_namespace_label)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+            count by (%(alert_aggregation_labels)s) (group by (%(alert_aggregation_labels)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
           ||| % $._config,
           labels: {
             severity: 'critical',


### PR DESCRIPTION
#### What this PR does

This PR makes two versions of the alert
* one for single-zone deployments
* one for multi-zone deployments

They fire at different conditions
* single-zone
  * only fire when there are more than one corrupted WAL; a single corrupted WAL means no data loss, so shouldn't be a critical alert
* multi-zone
  * only fire when there are more than one zones affected with arbitrary corrupted WALs within them; same reasoning as above - only multiple zones cause data loss

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
