### PR TITLE
Fix alertmanager /data contain /data/tsdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302
+* [BUGFIX] Backend: Check that alertmanager's data-dir doesn't overlap with bucket-sync dir. #4921
 
 ### Documentation
 
@@ -31,7 +32,7 @@
 
 * [CHANGE] Ruler: changed ruler autoscaling policy, extended scale down period from 60s to 600s. #4786
 * [CHANGE] Update to v0.5.0 rollout-operator. #4893
-* [CHANGE] Backend: add `alertmanager_args` to `mimir-backend` when running in read-write deployment mode. Remove hardcoded `filesystem` alertmanager storage. #4907
+* [CHANGE] Backend: add `alertmanager_args` to `mimir-backend` when running in read-write deployment mode. Remove hardcoded `filesystem` alertmanager storage. This moves alertmanager's data-dir to `/data/alertmanager` by default. #4907 #4921
 * [ENHANCEMENT] Ingester: configure `-blocks-storage.tsdb.head-compaction-interval=15m` to spread TSDB head compaction over a wider time range. #4870
 * [ENHANCEMENT] Ingester: configure `-blocks-storage.tsdb.wal-replay-concurrency` to CPU request minus 1. #4864
 * [ENHANCEMENT] Compactor: configure `-compactor.first-level-compaction-wait-period` to TSDB head compaction interval plus 10 minutes. #4872

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2147,7 +2147,7 @@ spec:
         - -alertmanager-storage.gcs.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
@@ -2328,7 +2328,7 @@ spec:
         - -alertmanager-storage.gcs.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
@@ -2509,7 +2509,7 @@ spec:
         - -alertmanager-storage.gcs.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -813,7 +813,7 @@ spec:
         - -alertmanager-storage.s3.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
@@ -995,7 +995,7 @@ spec:
         - -alertmanager-storage.s3.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
@@ -1177,7 +1177,7 @@ spec:
         - -alertmanager-storage.s3.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -814,7 +814,7 @@ spec:
         - -alertmanager-storage.s3.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
@@ -996,7 +996,7 @@ spec:
         - -alertmanager-storage.s3.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211
@@ -1178,7 +1178,7 @@ spec:
         - -alertmanager-storage.s3.bucket-name=alerts-bucket
         - -alertmanager.sharding-ring.replication-factor=3
         - -alertmanager.sharding-ring.store=memberlist
-        - -alertmanager.storage.path=/data
+        - -alertmanager.storage.path=/data/alertmanager
         - -alertmanager.web.external-url=http://test/alertmanager
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
         - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local:11211

--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -24,6 +24,7 @@
       target: 'backend',
 
       // Do not conflict with /data/tsdb and /data/tokens used by store-gateway.
+      'alertmanager.storage.path': '/data/alertmanager',
       'compactor.data-dir': '/data/compactor',
 
       // Use ruler's remote evaluation mode.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -419,7 +419,7 @@ func (c *Config) validateFilesystemPaths(logger log.Logger) error {
 	}
 
 	// Alertmanager.
-	if c.isAnyModuleEnabled(AlertManager) {
+	if c.isAnyModuleEnabled(AlertManager, Backend) {
 		paths = append(paths, pathConfig{
 			name:       "alertmanager data directory",
 			cfgValue:   c.Alertmanager.DataDir,

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -428,7 +428,6 @@ func TestConfigValidation(t *testing.T) {
 		})
 	}
 }
-
 func TestConfig_validateFilesystemPaths(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -439,6 +438,14 @@ func TestConfig_validateFilesystemPaths(t *testing.T) {
 	}{
 		"should succeed with the default configuration": {
 			setup: func(cfg *Config) {},
+		},
+		"should fail if alertmanager data directory contains bucket store sync directory when running mimir-backend": {
+			setup: func(cfg *Config) {
+				cfg.Target = flagext.StringSliceCSV{Backend}
+				cfg.Alertmanager.DataDir = "/data"
+				cfg.BlocksStorage.BucketStore.SyncDir = "/data/tsdb"
+			},
+			expectedErr: `the configured bucket store sync directory "/data/tsdb" cannot overlap with the configured alertmanager data directory "/data"`,
 		},
 		"should fail if alertmanager filesystem backend directory is equal to alertmanager data directory": {
 			setup: func(cfg *Config) {


### PR DESCRIPTION
#### What this PR does

The default alertmanager data dir `/data` contains `/data/tsdb`, when running mimir-backend, both modules run, and alertmanager deletes the `/data/tsdb` continuously (and complains about the `tokens` file).

The validation was missing the `Backend` module when adding `Alertmanager` paths.

#### Which issue(s) this PR fixes or relates to

Follow up on: https://github.com/grafana/mimir/pull/4907

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
