### PR TITLE
store-gateway: remove internal LabelValues

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -883,15 +883,6 @@ func (iir *interceptedIndexReader) LabelNames() ([]string, error) {
 	return iir.Reader.LabelNames()
 }
 
-func (iir *interceptedIndexReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
-	if iir.onLabelValuesCalled != nil {
-		if err := iir.onLabelValuesCalled(name); err != nil {
-			return nil, err
-		}
-	}
-	return iir.Reader.LabelValues(name, prefix, filter)
-}
-
 func (iir *interceptedIndexReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]index.PostingListOffset, error) {
 	if iir.onLabelValuesOffsetsCalled != nil {
 		if err := iir.onLabelValuesOffsetsCalled(name); err != nil {

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -36,14 +36,6 @@ type Reader interface {
 	// Error is return if the symbol can't be found.
 	LookupSymbol(o uint32) (string, error)
 
-	// LabelValues returns all label values for given label name or error.
-	// The returned label values are sorted lexicographically.
-	// If no values are found for label name, or label name does not exists,
-	// then empty slice is returned and no error.
-	// If non-empty prefix is provided, only values starting with the prefix are returned.
-	// If non-nil filter is provided, then only values for which filter returns true are returned.
-	LabelValues(name string, prefix string, filter func(string) bool) ([]string, error)
-
 	// LabelValuesOffsets returns all label values and the offsets for their posting lists for given label name or error.
 	// The returned label values are sorted lexicographically (which the same as sorted by posting offset).
 	// The ranges of each posting list are the same as returned by PostingsOffset.

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -251,7 +251,7 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *meta
 	return m
 }
 
-func TestReadersLabelValues(t *testing.T) {
+func TestReadersLabelValuesOffsets(t *testing.T) {
 	tests, blockID, blockDir := labelValuesTestCases(test.NewTB(t))
 	for _, impl := range implementations {
 		t.Run(impl.name, func(t *testing.T) {

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -180,10 +180,6 @@ func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerRe
 		expectedLabelVals, err := indexReader.SortedLabelValues(lname)
 		require.NoError(t, err)
 
-		strVals, err := headerReader.LabelValues(lname, "", nil)
-		require.NoError(t, err)
-		require.Equal(t, expectedLabelVals, strVals)
-
 		valOffsets, err := headerReader.LabelValuesOffsets(lname, "", nil)
 		require.NoError(t, err)
 		strValsFromOffsets := make([]string, len(valOffsets))
@@ -260,7 +256,7 @@ func TestReadersLabelValuesOffsets(t *testing.T) {
 				t.Run(lbl, func(t *testing.T) {
 					for _, tc := range tcs {
 						t.Run(fmt.Sprintf("prefix='%s'%s", tc.prefix, tc.desc), func(t *testing.T) {
-							values, err := r.LabelValues(lbl, tc.prefix, tc.filter)
+							values, err := r.LabelValuesOffsets(lbl, tc.prefix, tc.filter)
 							require.NoError(t, err)
 							require.Equal(t, tc.expected, len(values))
 						})

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -176,19 +176,6 @@ func (r *LazyBinaryReader) LookupSymbol(o uint32) (string, error) {
 	return r.reader.LookupSymbol(o)
 }
 
-// LabelValues implements Reader.
-func (r *LazyBinaryReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
-		return nil, err
-	}
-
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.LabelValues(name, prefix, filter)
-}
-
 // LabelValuesOffsets implements Reader.
 func (r *LazyBinaryReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {
 	r.readerMx.RLock()

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -179,7 +179,7 @@ func BenchmarkLabelValuesOffsetsIndexV1(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := names[i%len(names)]
 
-			values, err := br.LabelValues(name, "", func(s string) bool {
+			values, err := br.LabelValuesOffsets(name, "", func(s string) bool {
 				return true
 			})
 
@@ -223,7 +223,7 @@ func BenchmarkLabelValuesOffsetsIndexV2(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := names[i%len(names)]
 
-			values, err := br.LabelValues(name, "", func(s string) bool {
+			values, err := br.LabelValuesOffsets(name, "", func(s string) bool {
 				return true
 			})
 

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -141,7 +141,7 @@ func BenchmarkLabelNames(b *testing.B) {
 	}
 }
 
-func BenchmarkLabelValuesIndexV1(b *testing.B) {
+func BenchmarkLabelValuesOffsetsIndexV1(b *testing.B) {
 	ctx := context.Background()
 
 	bucketDir := b.TempDir()
@@ -189,7 +189,7 @@ func BenchmarkLabelValuesIndexV1(b *testing.B) {
 	})
 }
 
-func BenchmarkLabelValuesIndexV2(b *testing.B) {
+func BenchmarkLabelValuesOffsetsIndexV2(b *testing.B) {
 	ctx := context.Background()
 
 	bucketDir := b.TempDir()
@@ -233,7 +233,7 @@ func BenchmarkLabelValuesIndexV2(b *testing.B) {
 	})
 }
 
-func BenchmarkLabelValuesIndexV2_WithPrefix(b *testing.B) {
+func BenchmarkLabelValuesOffsetsIndexV2_WithPrefix(b *testing.B) {
 	tests, blockID, blockDir := labelValuesTestCases(test.NewTB(b))
 	r, err := NewStreamBinaryReader(context.Background(), log.NewNopLogger(), nil, blockDir, blockID, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 	require.NoError(b, err)
@@ -243,7 +243,7 @@ func BenchmarkLabelValuesIndexV2_WithPrefix(b *testing.B) {
 			for _, tc := range tcs {
 				b.Run(fmt.Sprintf("prefix='%s'%s", tc.prefix, tc.desc), func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
-						values, err := r.LabelValues(lbl, tc.prefix, tc.filter)
+						values, err := r.LabelValuesOffsets(lbl, tc.prefix, tc.filter)
 						require.NoError(b, err)
 						require.Equal(b, tc.expected, len(values))
 					}

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -222,10 +222,6 @@ func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
 	return s, nil
 }
 
-func (r *StreamBinaryReader) LabelValues(name string, prefix string, filter func(string) bool) ([]string, error) {
-	return r.postingsOffsetTable.LabelValues(name, prefix, filter)
-}
-
 func (r *StreamBinaryReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {
 	return r.postingsOffsetTable.LabelValuesOffsets(name, prefix, filter)
 }


### PR DESCRIPTION
#### What this PR does

As part of #4593 I replaced the usages of `LabelValues() []string` with `LabelValuesOffsets() []PostingListOffset`

This PR is in internal clean-up, which removes the implementation of LabelValues from the postings tables and index header readers.
It also replaces a few tests and benchmarks to use the new implementation.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
