### PR TITLE
Docs: Update ingester docs on replication and availability

### DIFF
--- a/docs/sources/mimir/references/architecture/components/ingester.md
+++ b/docs/sources/mimir/references/architecture/components/ingester.md
@@ -52,7 +52,7 @@ There are the following ways to mitigate this failure mode:
 
 ### Replication and availability
 
-Writes to the Mimir cluster are successful if a quorum of ingesters received the data. With the default replication factor of 3, this means 2 out of 3 writes to ingesters must succeed.
+Writes to the Mimir cluster are successful if a majority of ingesters received the data. With the default replication factor of 3, this means 2 out of 3 writes to ingesters must succeed.
 If the Mimir cluster loses a minority of ingesters, the in-memory series samples held by the lost ingesters are available in at least one other ingester, meaning no time series samples are lost.
 If a majority of ingesters fail, time series might be lost if the failure affects all the ingesters holding the replicas of a specific time series.
 

--- a/docs/sources/mimir/references/architecture/components/ingester.md
+++ b/docs/sources/mimir/references/architecture/components/ingester.md
@@ -50,13 +50,11 @@ There are the following ways to mitigate this failure mode:
 - Write-ahead log (WAL)
 - Write-behind log (WBL), only used if out-of-order ingestion is enabled.
 
-### Replication
+### Replication and availability
 
-By default, each series is replicated to three ingesters.
-Writes to the Mimir cluster are successful if a quorum of ingesters received the data, which is a minimum of 2 with a replication factor of 3.
-If the Mimir cluster loses an ingester, the in-memory series samples held by the lost ingester are available at least in one other ingester.
-In the event of a single ingester failure, no time series samples are lost.
-If multiple ingesters fail, time series might be lost if the failure affects all the ingesters holding the replicas of a specific time series.
+Writes to the Mimir cluster are successful if a quorum of ingesters received the data. With the default replication factor of 3, this means 2 out of 3 writes to ingesters must succeed.
+If the Mimir cluster loses a minority of ingesters, the in-memory series samples held by the lost ingesters are available in at least one other ingester, meaning no time series samples are lost.
+If a majority of ingesters fail, time series might be lost if the failure affects all the ingesters holding the replicas of a specific time series.
 
 > **Note:** Replication only happens at write time. If an ingester is unavailable during a period when writes are actively being written to other ingesters, that particular ingester will never recover those missed samples.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR updates the ingester doc section on replication to also discuss availability in terms of majorities and minorities, since odd replication factors (2) could cause behavior that doesn't match the current docs. This change was prompted by #3844, where a user mentioned running with RF=2.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
