### PR TITLE
Add dynicamic suffix to make-minio-buckets k8s job

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -45,6 +45,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Configure ingester TSDB WAL replay concurrency to 3. #4864
 * [ENHANCEMENT] Configure compactor's first level compaction wait period to 25m. #4872
 * [ENHANCEMENT] You can now configure `storageClass` per zone for Alertmanager, StoreGateway and Ingester. #4234
+* [ENHANCEMENT] Add suffix to minio create buckets job to avoid mimir-distributed helm chart fail to upgrade when minio image version changes. #4936
 * [BUGFIX] Helm-Chart: fix route to service port mapping. #4728
 * [BUGFIX] Include podAnnotations on the tokengen Job. #4540
 * [BUGFIX] Add http port in ingester and store-gateway headless services. #4573

--- a/operations/helm/charts/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "make-minio-buckets") }}
+  {{- $minioSub := index .Subcharts "minio" }}
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "make-minio-buckets") }}-{{ $minioSub.Chart.Version }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "minio.name" . }}-make-bucket-job

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: gateway-enterprise-values-mimir-make-minio-buckets
+  name: gateway-enterprise-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: gateway-nginx-values-mimir-make-minio-buckets
+  name: gateway-nginx-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: graphite-enabled-values-mimir-make-minio-buckets
+  name: graphite-enabled-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: metamonitoring-values-mimir-make-minio-buckets
+  name: metamonitoring-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-enterprise-configmap-values-mimir-make-minio-buckets
+  name: test-enterprise-configmap-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-enterprise-k8s-1.25-values-mimir-make-minio-buckets
+  name: test-enterprise-k8s-1.25-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-enterprise-legacy-label-values-enterprise-metrics-make-minio-buckets
+  name: test-enterprise-legacy-label-values-enterprise-metrics-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-enterprise-values-mimir-make-minio-buckets
+  name: test-enterprise-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-oss-k8s-1.25-values-mimir-make-minio-buckets
+  name: test-oss-k8s-1.25-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-oss-logical-multizone-values-mimir-make-minio-buckets
+  name: test-oss-logical-multizone-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-oss-multizone-values-mimir-make-minio-buckets
+  name: test-oss-multizone-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-oss-topology-spread-constraints-values-mimir-make-minio-buckets
+  name: test-oss-topology-spread-constraints-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-oss-values-mimir-make-minio-buckets
+  name: test-oss-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: test-vault-agent-values-mimir-make-minio-buckets
+  name: test-vault-agent-values-mimir-make-minio-buckets-5.0.7
   namespace: "citestns"
   labels:
     app: mimir-distributed-make-bucket-job


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
`operations/helm/charts/mimir-distributed/templates/minio/create-bucket-job.yaml` is used to create buckets for minio as post-install hooks of mimir-distributed helm chart. If new mimir-distributed helm chart is updated with a new minio subchart, it will prevent mimir-distributed chart upgrade because helm try to modify the job with new minio image. That wouldn't work because job spec is immutable.

Example upgrade error log:
```
client.go:429: [debug] error updating the resource "my-mimir-make-minio-buckets":
         cannot patch "my-mimir-make-minio-buckets" with kind Job: Job.batch "my-mimir-make-minio-buckets" is invalid: spec.template: Invalid value: core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"app":"mimir-distributed-job", "controller-uid":"9592a988-8a86-46ee-bcaf-29446bb97613", "job-name":"my-mimir-make-minio-buckets", "release":"my-mimir"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:core.PodSpec{Volumes:[]core.Volume{core.Volume{Name:"minio-configuration", VolumeSource:core.VolumeSource{HostPath:(*core.HostPathVolumeSource)(nil), EmptyDir:(*core.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*core.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*core.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*core.GitRepoVolumeSource)(nil), Secret:(*core.SecretVolumeSource)(nil), NFS:(*core.NFSVolumeSource)(nil), ISCSI:(*core.ISCSIVolumeSource)(nil), Glusterfs:(*core.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*core.PersistentVolumeClaimVolumeSource)(nil), RBD:(*core.RBDVolumeSource)(nil), Quobyte:(*core.QuobyteVolumeSource)(nil), FlexVolume:(*core.FlexVolumeSource)(nil), Cinder:(*core.CinderVolumeSource)(nil), CephFS:(*core.CephFSVolumeSource)(nil), Flocker:(*core.FlockerVolumeSource)(nil), DownwardAPI:(*core.DownwardAPIVolumeSource)(nil), FC:(*core.FCVolumeSource)(nil), AzureFile:(*core.AzureFileVolumeSource)(nil), ConfigMap:(*core.ConfigMapVolumeSource)(nil), VsphereVolume:(*core.VsphereVirtualDiskVolumeSource)(nil), AzureDisk:(*core.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*core.PhotonPersistentDiskVolumeSource)(nil), Projected:(*core.ProjectedVolumeSource)(0xc016bd6200), PortworxVolume:(*core.PortworxVolumeSource)(nil), ScaleIO:(*core.ScaleIOVolumeSource)(nil), StorageOS:(*core.StorageOSVolumeSource)(nil), CSI:(*core.CSIVolumeSource)(nil), Ephemeral:(*core.EphemeralVolumeSource)(nil)}}}, InitContainers:[]core.Container(nil), Containers:[]core.Container{core.Container{Name:"minio-mc", Image:"quay.io/minio/mc:RELEASE.2023-01-28T20-29-38Z", Command:[]string{"/bin/sh", "/config/initialize"}, Args:[]string(nil), WorkingDir:"", Ports:[]core.ContainerPort(nil), EnvFrom:[]core.EnvFromSource(nil), Env:[]core.EnvVar{core.EnvVar{Name:"MINIO_ENDPOINT", Value:"my-mimir-minio", ValueFrom:(*core.EnvVarSource)(nil)}, core.EnvVar{Name:"MINIO_PORT", Value:"9000", ValueFrom:(*core.EnvVarSource)(nil)}}, Resources:core.ResourceRequirements{Limits:core.ResourceList(nil), Requests:core.ResourceList{"memory":resource.Quantity{i:resource.int64Amount{value:134217728, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"", Format:"BinarySI"}}}, VolumeMounts:[]core.VolumeMount{core.VolumeMount{Name:"minio-configuration", ReadOnly:false, MountPath:"/config", SubPath:"", MountPropagation:(*core.MountPropagationMode)(nil), SubPathExpr:""}}, VolumeDevices:[]core.VolumeDevice(nil), LivenessProbe:(*core.Probe)(nil), ReadinessProbe:(*core.Probe)(nil), StartupProbe:(*core.Probe)(nil), Lifecycle:(*core.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*core.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, EphemeralContainers:[]core.EphemeralContainer(nil), RestartPolicy:"OnFailure", TerminationGracePeriodSeconds:(*int64)(0xc0186b6270), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"", AutomountServiceAccountToken:(*bool)(nil), NodeName:"", SecurityContext:(*core.PodSecurityContext)(0xc0045c2ab0), ImagePullSecrets:[]core.LocalObjectReference(nil), Hostname:"", Subdomain:"", SetHostnameAsFQDN:(*bool)(nil), Affinity:(*core.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]core.Toleration(nil), HostAliases:[]core.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), PreemptionPolicy:(*core.PreemptionPolicy)(nil), DNSConfig:(*core.PodDNSConfig)(nil), ReadinessGates:[]core.PodReadinessGate(nil), RuntimeClassName:(*string)(nil), Overhead:core.ResourceList(nil), EnableServiceLinks:(*bool)(nil), TopologySpreadConstraints:[]core.TopologySpreadConstraint(nil), OS:(*core.PodOS)(nil)}}: field is immutable
client.go:688: [debug] Patch Ingress "my-mimir-gateway" in namespace x-mimir
```

This PR adding suffix to the create buckets job with minio helm version suffix. Hence every time mimir upgrade its minio version, the suffix will be added automatically. User should clean old create bucket job manually. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
