### PR TITLE
Improve helm release.md

### DIFF
--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -128,7 +128,7 @@ The [release process](https://github.com/grafana/mimir/blob/main/.github/workflo
 
    For example `user/update-mimir-distributed-release-x.y-final`.
 
-1. Update versions and links in the `user/update-mimir-distributed-release-x.y-final` branch.
+1. Update versions in the `user/update-mimir-distributed-release-x.y-final` branch.
 
    - Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired final release version.
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -31,71 +31,87 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
 1. Prepare changelog.
 
-   a. Create a PR, whose target is `main`, that updates the [Helm chart changelog](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md), and move any `## main / unreleased` items under this release’s version.
+   - Create a PR, whose target is `main`, that updates the [Helm chart changelog](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md), and move any `## main / unreleased` items under this release’s version.
 
    > **Note:** If there are any deprecated features that should be removed in this release, then verify that they have been removed, and move their deprecation notices into the section for this release.
 
-   b. Have the PR reviewed by a maintainer.
+   - Have the PR reviewed by a maintainer.
 
-   c. Merge the PR upon approval.
+   - Merge the PR upon approval.
 
 1. Create a release branch.
 
-   a. Create, switch to and push a branch starting from the commit created by the prepare changelog PR and name it `mimir-distributed-release-x.y`. For example, `mimir-distributed-release-4.5` for any `4.5.x` release.
+   - Create (if the branch is not created yet), switch to and push a branch starting from the commit created by the prepare changelog PR and name it `mimir-distributed-release-x.y`.
 
-   b. Push the branch to origin without any commit added.
+     For example, `mimir-distributed-release-4.5` for any `4.5.x` release.
 
-   c. Once the branch is pushed, all changes to `mimir-distributed-release-x.y` branch must be done through PR.
+   - Push the branch to origin without any commit added.
 
-1. Create a branch to update Mimir/GEM image and helm chart version. For example `user/update-mimir-distributed-release-x.y`. Do the following updates in the next steps from this branch.
+   - Once the branch is pushed, all changes to `mimir-distributed-release-x.y` branch must be done through PR.
 
-1. Set the image versions in [values.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml), as needed:
+1. Create a branch from release branch if it hasn't been created yet, to update Mimir/GEM image and helm chart version .
 
-   - `image.tag` (Mimir)
-   - `enterprise.image.tag` (GEM)
+   For example `user/update-mimir-distributed-release-x.y`.
 
-     > **Note:** Unlike the Mimir image tags, GEM image tags start with `v`. For example, `v2.6.0` instead of `2.6.0`.
+1. Update versions and links in the `user/update-mimir-distributed-release-x.y` branch.
 
-   - `smoke_test.image.tag` (Smoke test; usually the same as Mimir)
-   - `continuous_test.image.tag` (Continuous test; usually the same as Mimir)
+   - Set the image versions in [values.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml), as needed:
 
-1. Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired release candidate version.
+     - `image.tag` (Mimir)
+     - `enterprise.image.tag` (GEM)
 
-   For example, `4.5.0-rc.0`.
+       > **Note:** Unlike the Mimir image tags, GEM image tags start with `v`. For example, `v2.6.0` instead of `2.6.0`.
 
-   > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action. Unless you want to release final release, make sure to append the correct rc version.
+     - `smoke_test.image.tag` (Smoke test; usually the same as Mimir)
+     - `continuous_test.image.tag` (Continuous test; usually the same as Mimir)
 
-1. Set the `appVersion` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the version of Mimir that the Helm chart deploys.
+   - Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired release candidate version.
 
-   For example, `2.6.0`.
+     For example, `4.5.0-rc.0`.
 
-1. Create or update the release notes in [release notes](https://github.com/grafana/mimir/tree/mimir-distributed-release-4.2/docs/sources/helm-charts/mimir-distributed/release-notes).
+     > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action. Unless you want to release final release, make sure to append the correct rc version.
 
-   The release notes should refer to the correct Mimir and GEM versions and their specific documentation version.
+   - Set the `appVersion` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the version of Mimir that the Helm chart deploys.
 
-1. Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
+     For example, `2.6.0`.
 
-   The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
+   - Create or update the release notes in [release notes](https://github.com/grafana/mimir/tree/mimir-distributed-release-4.2/docs/sources/helm-charts/mimir-distributed/release-notes).
 
-1. Update the [Mimir Helm Chart Readme template](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md.gotmpl). Update the line that link to Mimir release note to the latest Mimir version. Example: `See the [Grafana Mimir version 2.6 release notes](https://grafana.com/docs/mimir/v2.6.x/release-notes/v2.6/)`.
+     The release notes should refer to the correct Mimir and GEM versions and their specific documentation version.
 
-1. From the root directory of the repository, run `make doc` so a template can update the [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
+   - Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
-1. Open a PR contains all the changes we have so far from `user/update-mimir-distributed-release-x.y` branch and make sure that your PR targets the release branch `mimir-distributed-release-x.y`.
+     The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
 
-1. Have the PR reviewed by a maintainer.
+   - Update the [Mimir Helm Chart Readme template](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md.gotmpl). Update the line that link to Mimir release note to the latest Mimir version. Example: `See the [Grafana Mimir version 2.6 release notes](https://grafana.com/docs/mimir/v2.6.x/release-notes/v2.6/)`.
 
-1. Merge the PR upon approval.
+   - From the root directory of the repository, run `make doc` to update [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 
-1. Verify that the Helm chart is published; run the following commands:
+1. Open PR to release branch
 
-   `helm repo update && helm search repo grafana/mimir-distributed --devel --version <VERSION>`
+   - Create PR that contains all the changes we have so far from `user/update-mimir-distributed-release-x.y` branch and make sure that your PR targets the release branch `mimir-distributed-release-x.y`.
 
-   You might have to wait a few minutes.
+   - Have the PR reviewed by a maintainer.
 
-1. In a browser, go to [https://grafana.com/docs/helm-charts/mimir-distributed](https://grafana.com/docs/helm-charts/mimir-distributed) and refresh the page.
+   - Merge the PR upon approval.
+
+1. Verify that the Helm chart is published
+
+   - Run the following commands:
+
+     `helm repo update && helm search repo grafana/mimir-distributed --devel --version <VERSION>`
+
+     You might have to wait a few minutes.
+
+   - In a browser, go to [https://grafana.com/docs/helm-charts/mimir-distributed](https://grafana.com/docs/helm-charts/mimir-distributed) and refresh the page.
 
 1. After the release tag in Git is created, merge the branch back into `main` by following the same procedure as for Mimir releases: [Merging release branch into main](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main).
+
+1. Backport and additional release candidate
+
+   - If additional changes need to be added to this release, another release candidate version has to be created.
+   - Follow [backport process](https://github.com/grafana/mimir/blob/main/RELEASE.md#cherry-picking-changes-into-release-branch) similar with Mimir release to backport changes from main branch.
+   - Go back to step 5. Update versions and links in the user/update-mimir-distributed-release-x.y branch to update the next release candidate.
 
 The [release process](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-release.yaml) checks and creates a Git tag formatted as `mimir-distributed-<version>`, for example `mimir-distributed-4.5.0`, on the merge commit created when the PR is merged. To prevent releasing the same version with different content, the release process fails if the tag already exists. The release is published in the [Grafana helm-charts](https://grafana.github.io/helm-charts/) Helm repository.
 
@@ -108,29 +124,37 @@ The [release process](https://github.com/grafana/mimir/blob/main/.github/workflo
    - The final version has the version `x.y.z`, for example `3.1.0`.
    - Normally we will proceed the same `x.y.z` version value from the release candidate step.
 
-1. Create a branch to update helm chart version. For example `user/update-mimir-distributed-release-x.y`. Do the following updates in the next steps from this branch.
+1. Create a branch from release branch to update Mimir/GEM image and helm chart version.
 
-1. Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired final release version.
+   For example `user/update-mimir-distributed-release-x.y-final`.
 
-   For example, `4.5.0`.
+1. Update versions and links in the `user/update-mimir-distributed-release-x.y-final` branch.
 
-   > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action.
+   - Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired final release version.
 
-1. There shouldn't be anymore update needed in release notes and documentation because that has been done in the release candidate step above.
+     For example, `4.5.0`.
 
-1. Open a PR contains all the changes we have so far from `user/update-mimir-distributed-release-x.y` branch and make sure that your PR targets the release branch `mimir-distributed-release-x.y`.
+     > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action.
 
-1. Have the PR reviewed by a maintainer.
+   - There shouldn't be anymore update needed in release notes and documentation because that has been done in the release candidate step above.
 
-1. Merge the PR upon approval.
+1. Open PR to release branch
 
-1. Verify that the Helm chart is published; run the following commands:
+   - Create PR that contains all the changes we have so far from `user/update-mimir-distributed-release-x.y-final` branch and make sure that your PR targets the release branch `mimir-distributed-release-x.y`.
 
-   `helm repo update && helm search repo grafana/mimir-distributed --version <VERSION>`
+   - Have the PR reviewed by a maintainer.
 
-   You might have to wait a few minutes.
+   - Merge the PR upon approval.
 
-1. In a browser, go to [https://grafana.com/docs/helm-charts/mimir-distributed](https://grafana.com/docs/helm-charts/mimir-distributed) and refresh the page.
+1. Verify that the Helm chart is published
+
+   - Run the following commands:
+
+     `helm repo update && helm search repo grafana/mimir-distributed --version <VERSION>`
+
+     You might have to wait a few minutes.
+
+   - In a browser, go to [https://grafana.com/docs/helm-charts/mimir-distributed](https://grafana.com/docs/helm-charts/mimir-distributed) and refresh the page.
 
 1. After the release tag in Git is created, merge the branch back into `main` by following the same procedure as for Mimir releases: [Merging release branch into main](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main).
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -104,7 +104,6 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
 The [release process](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-release.yaml) checks and creates a Git tag formatted as `mimir-distributed-<version>`, for example `mimir-distributed-4.5.0`, on the merge commit created when the PR is merged. To prevent releasing the same version with different content, the release process fails if the tag already exists. The release is published in the [Grafana helm-charts](https://grafana.github.io/helm-charts/) Helm repository.
 
-When a `mimir-distributed-x.y.z` final version tag is pushed, the Helm chart documentation is [published](https://github.com/grafana/mimir/blob/main/.github/workflows/publish-technical-documentation-release-helm-charts.yml) to [https://grafana.com/docs/helm-charts/mimir-distributed](https://grafana.com/docs/helm-charts/mimir-distributed).
 
 ## Release process for a final release
 
@@ -142,3 +141,5 @@ When a `mimir-distributed-x.y.z` final version tag is pushed, the Helm chart doc
 1. After the release tag in Git is created, merge the branch back into `main` by following the same procedure as for Mimir releases: [Merging release branch into main](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main).
 
 The [release process](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-release.yaml) checks and creates a Git tag formatted as `mimir-distributed-<version>`, for example `mimir-distributed-4.5.0`, on the merge commit created when the PR is merged. To prevent releasing the same version with different content, the release process fails if the tag already exists. The release is published in the [Grafana helm-charts](https://grafana.github.io/helm-charts/) Helm repository.
+
+When a `mimir-distributed-x.y.z` final version tag is pushed, the Helm chart documentation is [published](https://github.com/grafana/mimir/blob/main/.github/workflows/publish-technical-documentation-release-helm-charts.yml) to [https://grafana.com/docs/helm-charts/mimir-distributed](https://grafana.com/docs/helm-charts/mimir-distributed).

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -75,9 +75,11 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
      For example, `2.6.0`.
 
-   - Create or update the release notes in [release notes](https://github.com/grafana/mimir/tree/mimir-distributed-release-4.2/docs/sources/helm-charts/mimir-distributed/release-notes).
+   - Create or update the release notes in `docs/sources/helm-charts/mimir-distributed/release-notes` directory.
 
      The release notes should refer to the correct Mimir and GEM versions and their specific documentation version.
+
+     > **Note:** This step can be done in a separate PR and shouldn't block release candidate from getting published.
 
    - Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
@@ -128,7 +130,9 @@ The [release process](https://github.com/grafana/mimir/blob/main/.github/workflo
 
    For example `user/update-mimir-distributed-release-x.y-final`.
 
-1. Update versions in the `user/update-mimir-distributed-release-x.y-final` branch.
+1. Optionally finalise release note and update version in the `user/update-mimir-distributed-release-x.y-final` branch.
+
+   - Update and finalize the release notes in `docs/sources/helm-charts/mimir-distributed/release-notes` directory if there has been some changes after release candidate.
 
    - Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired final release version.
 
@@ -136,7 +140,9 @@ The [release process](https://github.com/grafana/mimir/blob/main/.github/workflo
 
      > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action.
 
-   - There shouldn't be anymore update needed in release notes and documentation because that has been done in the release candidate step above.
+   - There shouldn't be anymore update needed in documentation because that has been done in the release candidate step above.
+
+   - From the root directory of the repository, run `make doc` to update [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 
 1. Open PR to release branch
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -77,13 +77,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
    The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
 
-1. Update the [Mimir Helm Chart Readme template](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md.gotmpl). Update the line that link to Mimir release note to the latest Mimir version.
-
-   Example:
-
-   ```
-   See the [Grafana Mimir version 2.6 release notes](https://grafana.com/docs/mimir/v2.6.x/release-notes/v2.6/).
-   ```
+1. Update the [Mimir Helm Chart Readme template](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md.gotmpl). Update the line that link to Mimir release note to the latest Mimir version. Example: `See the [Grafana Mimir version 2.6 release notes](https://grafana.com/docs/mimir/v2.6.x/release-notes/v2.6/)`.
 
 1. From the root directory of the repository, run `make doc` so a template can update the [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -28,7 +28,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
    - Release candidates have the version `x.y.z-rc.w`, for example `3.1.0-rc.7`.
 
    > **Note**: You must precede the release candidate number (such as `7`) with a dot (`.`).
- 
+
 1. Prepare changelog.
 
    a. Create a PR, whose target is `main`, that updates the [Helm chart changelog](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md), and move any `## main / unreleased` items under this release’s version.
@@ -46,7 +46,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
    b. Push the branch to origin without any commit added.
 
    c. Once the branch is pushed, all changes to `mimir-distributed-release-x.y` branch must be done through PR.
- 
+
 1. Create a branch to update Mimir/GEM image and helm chart version. For example `user/update-mimir-distributed-release-x.y`. Do the following updates in the next steps from this branch.
 
 1. Set the image versions in [values.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml), as needed:
@@ -76,10 +76,11 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 1. Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
    The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
- 
+
 1. Update the [Mimir Helm Chart Readme template](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md.gotmpl). Update the line that link to Mimir release note to the latest Mimir version.
 
    Example:
+
    ```
    See the [Grafana Mimir version 2.6 release notes](https://grafana.com/docs/mimir/v2.6.x/release-notes/v2.6/).
    ```
@@ -104,7 +105,6 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
 The [release process](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-release.yaml) checks and creates a Git tag formatted as `mimir-distributed-<version>`, for example `mimir-distributed-4.5.0`, on the merge commit created when the PR is merged. To prevent releasing the same version with different content, the release process fails if the tag already exists. The release is published in the [Grafana helm-charts](https://grafana.github.io/helm-charts/) Helm repository.
 
-
 ## Release process for a final release
 
 1. Determine the Helm chart version number.
@@ -120,7 +120,7 @@ The [release process](https://github.com/grafana/mimir/blob/main/.github/workflo
 
    For example, `4.5.0`.
 
-   > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action. 
+   > **Note:** Once this change is merged to `mimir-distributed-x.y` branch, it will trigger the release process GitHub Action.
 
 1. There shouldn't be anymore update needed in release notes and documentation because that has been done in the release candidate step above.
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -107,7 +107,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
 1. After the release tag in Git is created, merge the branch back into `main` by following the same procedure as for Mimir releases: [Merging release branch into main](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main).
 
-1. Backport and additional release candidate
+1. Backport and additional release candidate.
 
    - If additional changes need to be added to this release, another release candidate version has to be created.
    - Follow [backport process](https://github.com/grafana/mimir/blob/main/RELEASE.md#cherry-picking-changes-into-release-branch) similar with Mimir release to backport changes from main branch.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Improve the release.md for mimir-distributed helm chart.

- Split the Release process step of release candidate and final release to prevent accidentally publishing a release prematurely. 
- Tidy up the granularity of the release steps. Originally there were 15 steps with inconsistent step granularity. This PR simplify the step into 9 step for release candidate release and 6 steps for final release. Fine grained step is moved as bulleted list within numbered list.
- Add step on merging release branch to main.
- Add step for possible backport.

Rendered release.md
- [New release.md](https://github.com/grafana/mimir/blob/lamida/improve-helm-release.md/operations/helm/charts/mimir-distributed/RELEASE.md) (this PR)
- [Original release.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/RELEASE.md)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- na Tests updated
- na Documentation added
- na `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
