### PR TITLE
Helm docs: multi-zone resources pruning; metamonitoring list of metrics

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -164,6 +164,10 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
+   This step should also delete the Service and StatefulSet of the old non zone-aware alertmanagers.
+   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
+
 1. Wait until old non zone-aware alertmanagers are terminated.
 
 ## Migrate store-gateways to zone-aware replication
@@ -252,6 +256,10 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
+   This step should also delete the Service and StatefulSet of the old non zone-aware store-gateways.
+   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
+
 1. Wait until all store-gateways are running and ready.
 
 ### Migrate store-gateways without downtime
@@ -321,6 +329,10 @@ Before starting this procedure, set up your zones according to [Configure zone-a
    These values are actually the default, which means that removing the values `store_gateway.zoneAwareReplication.enabled` and `rollout_operator.enabled` is also a valid step.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
+
+   This step should also delete the Service and StatefulSet of the old non zone-aware store-gateways.
+   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait for non zone-aware store-gateways to terminate.
 
@@ -494,6 +506,10 @@ Before starting this procedure, set up your zones according to [Configure zone-a
    ```
 
    These values are actually the default, which means that removing the values `ingester.zoneAwareReplication.enabled` and `rollout_operator.enabled` is also a valid step.
+
+   This step should also delete the Service and StatefulSet of the old non zone-aware ingesters.
+   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
@@ -721,6 +737,10 @@ Before starting this procedure, set up your zones according to [Configure zone-a
    [//]: # "ingester-step7"
 
    These values are actually the default, which means that removing the values `ingester.zoneAwareReplication.enabled` and `rollout_operator.enabled` from your `custom.yaml` is also a valid step.
+
+   This step should also delete the Service and StatefulSet of the old non zone-aware ingesters.
+   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -164,8 +164,9 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-   This step should also delete the Service and StatefulSet of the old non zone-aware alertmanagers.
-   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   This step also removes the Service and StatefulSet manifests of the old non zone-aware alertmanagers.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
+   You need to manually prune the old Service and StatefulSet.
    Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait until old non zone-aware alertmanagers are terminated.
@@ -256,8 +257,9 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-   This step should also delete the Service and StatefulSet of the old non zone-aware store-gateways.
-   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   This step also removes the Service and StatefulSet manifests of the old non zone-aware store-gateways.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
+   You need to manually prune the old Service and StatefulSet.
    Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait until all store-gateways are running and ready.
@@ -330,8 +332,9 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-   This step should also delete the Service and StatefulSet of the old non zone-aware store-gateways.
-   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   This step also removes the Service and StatefulSet manifests of the old non zone-aware store-gateways.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
+   You need to manually prune the old Service and StatefulSet.
    Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait for non zone-aware store-gateways to terminate.
@@ -507,8 +510,9 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    These values are actually the default, which means that removing the values `ingester.zoneAwareReplication.enabled` and `rollout_operator.enabled` is also a valid step.
 
-   This step should also delete the Service and StatefulSet of the old non zone-aware ingesters.
-   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   This step also removes the Service and StatefulSet manifests of the old non zone-aware ingesters.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
+   You need to manually prune the old Service and StatefulSet.
    Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
@@ -738,8 +742,9 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    These values are actually the default, which means that removing the values `ingester.zoneAwareReplication.enabled` and `rollout_operator.enabled` from your `custom.yaml` is also a valid step.
 
-   This step should also delete the Service and StatefulSet of the old non zone-aware ingesters.
-   In some cases, such as when using Helm from Tanka, you may need to manually prune the old Service and StatefulSet.
+   This step also removes the Service and StatefulSet manifests of the old non zone-aware ingesters.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
+   You need to manually prune the old Service and StatefulSet.
    Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -164,10 +164,11 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-   This step also removes the Service and StatefulSet manifests of the old non zone-aware alertmanagers.
-   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
-   You need to manually prune the old Service and StatefulSet.
-   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
+1. Ensure that the Service and StatefulSet resources of the non zone-aware alertmanagers have been deleted.
+   The previous step also removes the Service and StatefulSet manifests of the old non zone-aware alertmanagers.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster
+   even if the Helm chart no longer renders them. If the old resources still exist, delete them manually.
+   If not deleted, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait until old non zone-aware alertmanagers are terminated.
 
@@ -257,10 +258,11 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-   This step also removes the Service and StatefulSet manifests of the old non zone-aware store-gateways.
-   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
-   You need to manually prune the old Service and StatefulSet.
-   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
+1. Ensure that the Service and StatefulSet resources of the non zone-aware store-gateways have been deleted.
+   The previous step also removes the Service and StatefulSet manifests of the old non zone-aware store-gateways.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster
+   even if the Helm chart no longer renders them. If the old resources still exist, delete them manually.
+   If not deleted, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait until all store-gateways are running and ready.
 
@@ -332,10 +334,11 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-   This step also removes the Service and StatefulSet manifests of the old non zone-aware store-gateways.
-   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
-   You need to manually prune the old Service and StatefulSet.
-   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
+1. Ensure that the Service and StatefulSet resources of the non zone-aware store-gateways have been deleted.
+   The previous step also removes the Service and StatefulSet manifests of the old non zone-aware store-gateways.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster
+   even if the Helm chart no longer renders them. If the old resources still exist, delete them manually.
+   If not deleted, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait for non zone-aware store-gateways to terminate.
 
@@ -510,10 +513,11 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    These values are actually the default, which means that removing the values `ingester.zoneAwareReplication.enabled` and `rollout_operator.enabled` is also a valid step.
 
-   This step also removes the Service and StatefulSet manifests of the old non zone-aware ingesters.
-   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
-   You need to manually prune the old Service and StatefulSet.
-   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
+1. Ensure that the Service and StatefulSet resources of the non zone-aware ingesters have been deleted.
+   The previous step also removes the Service and StatefulSet manifests of the old non zone-aware ingesters.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster
+   even if the Helm chart no longer renders them. If the old resources still exist, delete them manually.
+   If not deleted, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
@@ -742,12 +746,13 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    These values are actually the default, which means that removing the values `ingester.zoneAwareReplication.enabled` and `rollout_operator.enabled` from your `custom.yaml` is also a valid step.
 
-   This step also removes the Service and StatefulSet manifests of the old non zone-aware ingesters.
-   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster.
-   You need to manually prune the old Service and StatefulSet.
-   Otherwise, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
-
 1. Upgrade the installation with the `helm` command using your regular command line flags.
+
+1. Ensure that the Service and StatefulSet resources of the non zone-aware ingesters have been deleted.
+   The previous step also removes the Service and StatefulSet manifests of the old non zone-aware ingesters.
+   In some cases, such as when using Helm from Tanka, these resources will not be automatically deleted from your Kubernetes cluster
+   even if the Helm chart no longer renders them. If the old resources still exist, delete them manually.
+   If not deleted, some of the pods may be scraped multiple times when using the Prometheus operator for metamonitoring.
 
 1. Wait at least 3 hours.
 

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -27,7 +27,7 @@ The Helm chart does not collect Prometheus node_exporter metrics;
 metrics from node_exporter must all have an instance label on them
 that has the same value as the instance label on Mimir metrics.
 For the list of necessary node_exporter metrics see the metrics
-prefixed with `node_` in [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/#metrics).
+prefixed with `node` in [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/#metrics).
 
 You can configure your collection of metrics and logs
 by using the [Grafana Agent operator](/docs/agent/latest/operator/).

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -26,6 +26,8 @@ The Helm chart can also scrape additional metrics from kube-state-metrics, kubel
 The Helm chart does not collect Prometheus node_exporter metrics;
 metrics from node_exporter must all have an instance label on them
 that has the same value as the instance label on Mimir metrics.
+For the list of necessary node_exporter metrics see the metrics
+prefixed with `node_` in [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/#metrics).
 
 You can configure your collection of metrics and logs
 by using the [Grafana Agent operator](/docs/agent/latest/operator/).


### PR DESCRIPTION
#### What this PR does

This PR bundles two changes
* mentions that you may need to manually prune the Services and StatefulSets of the old non zone-aware deployments; this causes some double scraping and misfiring alerts
* mention how to find the list of node_exporter metrics necessary for metamonitoring

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
