### PR TITLE
Specify which APIs use query sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * [ENHANCEMENT] Improve `MimirIngesterReachingTenantsLimit` runbook. #4744 #4752
 * [ENHANCEMENT] Add `symbol table size exceeds` case to `MimirCompactorHasNotSuccessfullyRunCompaction` runbook. #4945
+* [ENHANCEMENT] Clarify which APIs use query sharding. #4948
 
 ### Mixin
 

--- a/docs/sources/mimir/references/architecture/query-sharding/index.md
+++ b/docs/sources/mimir/references/architecture/query-sharding/index.md
@@ -16,6 +16,9 @@ partial queries are distributed by the query-frontend to run on different
 queriers in parallel. The results of those partial queries are aggregated by the
 query-frontend to return the full query result.
 
+Query sharding is applied on the [`query`]({{< relref "../../http-api/index.md#instant-query" >}})
+and [`query_range`]({{< relref "../../http-api/index.md#range-query" >}}) APIs only.
+
 ## Query sharding at glance
 
 Not all queries are shardable. While the full query is not shardable, the inner


### PR DESCRIPTION
#### What this PR does

Docs are not clear whether remote read API uses sharding or not.

#### Which issue(s) this PR fixes or relates to

Ref: internal support case 5848

#### Checklist

- N/A Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
