### PR TITLE
[BUGFIX] Update nginx deployment to mount nginx.conf as file

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -81,7 +81,8 @@ spec:
             {{- toYaml .Values.nginx.containerSecurityContext | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             {{- if .Values.nginx.basicAuth.enabled }}
             - name: auth
               mountPath: /etc/nginx/secrets


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does



At the moment, the nginx-config configmap is mounted as folder, masking everything else that is located in `/etc/nginx`.
I'm trying to load a module in the `nginx.conf` with `load_module modules/ngx_http_js_module.so;`.

With the current setup, this fails with the following logs:
`/docker-entrypoint.sh: No files found in /docker-entrypoint.d/, skipping configuration
2023/05/09 11:46:27 [emerg] 1#1: dlopen() "/etc/nginx/modules/ngx_http_js_module.so" failed (/etc/nginx/modules/ngx_http_js_module.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.conf:1
nginx: [emerg] dlopen() "/etc/nginx/modules/ngx_http_js_module.so" failed (/etc/nginx/modules/ngx_http_js_module.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.conf:1`

With the proposed change, the `nginx.conf` file is still mounted to `/etc/nginx/nginx.conf`, however loading modules is now possible.

Unfortunately, I did not find any parameters to nginx which would allow an alternative module path (e.g. in `/usr/lib/nginx/modules`) and since the directory is mounted read-only, it is not possible copying the module through an entrypoint script.

Alternative fixes would include larger changes, such as moving the config volume & mount to the `values.yaml`

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
