### PR TITLE
Disable HTTP timeout on block upload endpoint for uploading a file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [ENHANCEMENT] Store-gateway: added HTTP `/store-gateway/prepare-shutdown` endpoint for gracefully scaling down of store-gateways. A gauge `cortex_store_gateway_prepare_shutdown_requested` has been introduced for tracing this process. #4955
 * [ENHANCEMENT] Updated Kuberesolver dependency (github.com/sercand/kuberesolver) from v2.4.0 to v4.0.0 and gRPC dependency (google.golang.org/grpc) from v1.47.0 to v1.53.0. #4922
 * [ENHANCEMENT] Introduced new options for logging HTTP request headers: `-server.log-request-headers` enables logging HTTP request headers, `-server.log-request-headers-exclude-list` lists headers which should not be logged. #4922
+* [ENHANCEMENT] Block upload: `/api/v1/upload/block/{block}/files` endpoint now disables read and write HTTP timeout, overriding `-server.http-read-timeout` and `-server.http-write-timeout` values. This is done to allow large file uploads to succeed. #4956 
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [CHANGE] Query-frontend: Change the default value of `-query-frontend.query-sharding-max-regexp-size-bytes` from `0` to `4096`. #4932
 * [CHANGE] Querier: `-querier.query-ingesters-within` has been moved from a global flag to a per-tenant override. #4287
 * [CHANGE] Querier: Use `-blocks-storage.tsdb.retention-period` instead of `-querier.query-ingesters-within` for calculating the lookback period for shuffle sharded ingesters. Setting `-querier.query-ingesters-within=0` no longer disables shuffle sharding on the read path. #4287
-* [CHANGE] Block upload: `/api/v1/upload/block/{block}/files` endpoint now allows file uploads with unset Content-Length. #4956
+* [CHANGE] Block upload: `/api/v1/upload/block/{block}/files` endpoint now allows file uploads with no `Content-Length`. #4956
 * [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. #4765
 * [ENHANCEMENT] Store-gateway: reduce memory usage in some LabelValues calls. #4789
 * [ENHANCEMENT] Store-gateway: add a `stage` label to the metric `cortex_bucket_store_series_data_touched`. This label now applies to `data_type="chunks"` and `data_type="series"`. The `stage` label has 2 values: `processed` - the number of series that parsed - and `returned` - the number of series selected from the processed bytes to satisfy the query. #4797 #4830

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [ENHANCEMENT] Store-gateway: added HTTP `/store-gateway/prepare-shutdown` endpoint for gracefully scaling down of store-gateways. A gauge `cortex_store_gateway_prepare_shutdown_requested` has been introduced for tracing this process. #4955
 * [ENHANCEMENT] Updated Kuberesolver dependency (github.com/sercand/kuberesolver) from v2.4.0 to v4.0.0 and gRPC dependency (google.golang.org/grpc) from v1.47.0 to v1.53.0. #4922
 * [ENHANCEMENT] Introduced new options for logging HTTP request headers: `-server.log-request-headers` enables logging HTTP request headers, `-server.log-request-headers-exclude-list` lists headers which should not be logged. #4922
-* [ENHANCEMENT] Block upload: `/api/v1/upload/block/{block}/files` endpoint now disables read and write HTTP timeout, overriding `-server.http-read-timeout` and `-server.http-write-timeout` values. This is done to allow large file uploads to succeed. #4956 
+* [ENHANCEMENT] Block upload: `/api/v1/upload/block/{block}/files` endpoint now disables read and write HTTP timeout, overriding `-server.http-read-timeout` and `-server.http-write-timeout` values. This is done to allow large file uploads to succeed. #4956
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [CHANGE] Query-frontend: Change the default value of `-query-frontend.query-sharding-max-regexp-size-bytes` from `0` to `4096`. #4932
 * [CHANGE] Querier: `-querier.query-ingesters-within` has been moved from a global flag to a per-tenant override. #4287
 * [CHANGE] Querier: Use `-blocks-storage.tsdb.retention-period` instead of `-querier.query-ingesters-within` for calculating the lookback period for shuffle sharded ingesters. Setting `-querier.query-ingesters-within=0` no longer disables shuffle sharding on the read path. #4287
+* [CHANGE] Block upload: `/api/v1/upload/block/{block}/files` endpoint now allows file uploads with unset Content-Length. #4956
 * [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. #4765
 * [ENHANCEMENT] Store-gateway: reduce memory usage in some LabelValues calls. #4789
 * [ENHANCEMENT] Store-gateway: add a `stage` label to the metric `cortex_bucket_store_series_data_touched`. This label now applies to `data_type="chunks"` and `data_type="series"`. The `stage` label has 2 values: `processed` - the number of series that parsed - and `returned` - the number of series selected from the processed bytes to satisfy the query. #4797 #4830

--- a/go.mod
+++ b/go.mod
@@ -264,3 +264,6 @@ replace github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-2022100509
 
 // Replace goautoneg with a fork until https://github.com/munnerz/goautoneg/pull/5 is merged
 replace github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc
+
+// Replace opentracing-contrib/go-stdlib with a fork until https://github.com/opentracing-contrib/go-stdlib/pull/68 is merged.
+replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956

--- a/go.sum
+++ b/go.sum
@@ -888,6 +888,8 @@ github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/mimir-prometheus v0.0.0-20230505111100-e5eb66f42202 h1:k8CBunu54/JHvViFJsZ3uLEB9EkO1rdee9q2t8LHgmY=
 github.com/grafana/mimir-prometheus v0.0.0-20230505111100-e5eb66f42202/go.mod h1:AStQQY2ye5J14mIU0lA2Sj210AS/knrqe2UoW5Ihr0w=
+github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
+github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -1134,9 +1136,6 @@ github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrB
 github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02/go.mod h1:JNdpVEzCpXBgIiv4ds+TzhN1hrtxq6ClLrTlT9OQRSc=
 github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e h1:4cPxUYdgaGzZIT5/j0IfqOrrXmq6bG8AwvwisMXpdrg=
 github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
-github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
-github.com/opentracing-contrib/go-stdlib v1.0.0 h1:TBS7YuVotp8myLon4Pv7BtCBzOTo1DeZCld0Z63mW2w=
-github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -360,20 +360,20 @@ func getURL(url string) (string, error) {
 }
 
 func newRateLimitedReader(r io.Reader, bytesPerSec float64, burst int) io.Reader {
-	return &reader{
+	return &rateLimitedReader{
 		r:      r,
 		burst:  burst,
 		bucket: rate.NewLimiter(rate.Limit(bytesPerSec), burst),
 	}
 }
 
-type reader struct {
+type rateLimitedReader struct {
 	r      io.Reader
 	burst  int
 	bucket *rate.Limiter
 }
 
-func (r *reader) Read(buf []byte) (int, error) {
+func (r *rateLimitedReader) Read(buf []byte) (int, error) {
 	// We can't wait for more bytes than our burst size.
 	if len(buf) > r.burst {
 		buf = buf[:r.burst]

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -259,7 +259,7 @@ func TestSlowUploadSpeed(t *testing.T) {
 	}
 
 	// Now start uploading block data, slowly, so that it takes longer than http server timeout.
-	// This will only succeed if timeout is overriden for the endpoint.
+	// This will only succeed if timeout is overridden for the endpoint.
 	{
 		const targetDuration = httpServerTimeout * 2
 		chunksFilename := fmt.Sprintf("%s/%s/chunks/000001", tmpDir, block.String())

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -188,7 +188,7 @@ overrides:
 	}
 }
 
-func TestSlowUploadSpeed(t *testing.T) {
+func TestBackfillSlowUploadSpeed(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -4,9 +4,12 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -23,8 +26,10 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+	"golang.org/x/time/rate"
 
 	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/grafana/mimir/pkg/mimirtool/client"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/s3"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
@@ -183,6 +188,116 @@ overrides:
 	}
 }
 
+func TestSlowUploadSpeed(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, mimirBucketName)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	dataDir := filepath.Join(s.SharedDir(), "data")
+	require.NoError(t, os.Mkdir(dataDir, os.ModePerm))
+
+	const httpServerTimeout = 2 * time.Second
+
+	flags := mergeFlags(CommonStorageBackendFlags(), BlocksStorageFlags(), map[string]string{
+		"-compactor.data-dir": filepath.Join(e2e.ContainerSharedDir, "data"),
+
+		// Enable uploads for all tenants
+		"-compactor.block-upload-enabled": "true",
+
+		// Use short timeouts for HTTP endpoints.
+		// This timeout will not be applied to file upload endpoint.
+		"-server.http-read-timeout":  httpServerTimeout.String(),
+		"-server.http-write-timeout": httpServerTimeout.String(),
+		"-querier.timeout":           httpServerTimeout.String(), // must be set too, otherwise validation check fails because default value is too high compared to -server.http-write-timeout.
+		"-log.level":                 "debug",
+	})
+
+	// Start Mimir compactor.
+	compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(compactor))
+
+	// Create block that we will try to upload.
+	tmpDir := t.TempDir()
+	blockEnd := time.Now().Truncate(2 * time.Hour)
+
+	block, err := testhelper.CreateBlock(
+		context.Background(), tmpDir,
+		[]labels.Labels{
+			labels.FromStrings("test", "test1", "a", "1"),
+			labels.FromStrings("test", "test1", "a", "2"),
+			labels.FromStrings("test", "test1", "a", "3"),
+		},
+		100, blockEnd.Add(-2*time.Hour).UnixMilli(), blockEnd.UnixMilli(), labels.EmptyLabels())
+	require.NoError(t, err)
+
+	httpClient := &http.Client{}
+
+	// Initiate new block upload.
+	{
+		// client.GetBlockMeta will generate correct meta.json file ready for initiating upload of our block.
+		meta, err := client.GetBlockMeta(fmt.Sprintf("%s/%s", tmpDir, block.String()))
+		require.NoError(t, err)
+
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, json.NewEncoder(buf).Encode(meta))
+
+		req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/api/v1/upload/block/%s/start", compactor.HTTPEndpoint(), block.String()), buf)
+		req.Header.Set("X-Scope-OrgID", userID)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+
+		body := readAndCloseBody(t, resp.Body)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	}
+
+	// Now start uploading block data, slowly, so that it takes longer than http server timeout.
+	// This will only succeed if timeout is overriden for the endpoint.
+	{
+		const targetDuration = httpServerTimeout * 2
+		chunksFilename := fmt.Sprintf("%s/%s/chunks/000001", tmpDir, block.String())
+		chunksFiledata, err := os.ReadFile(chunksFilename)
+		require.NoError(t, err)
+
+		// We add one second, because rate-limited reader already allows reading in time 0.
+		rateLimit := float64(len(chunksFiledata)) / (targetDuration.Seconds() + 1)
+		require.True(t, rateLimit > 0) // sanity check
+
+		rr := newRateLimitedReader(bytes.NewReader(chunksFiledata), rateLimit, int(rateLimit))
+
+		req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/api/v1/upload/block/%s/files?path=chunks/000001", compactor.HTTPEndpoint(), block.String()), rr)
+		req.Header.Set("X-Scope-OrgID", userID)
+		require.NoError(t, err)
+
+		start := time.Now()
+		resp, err := httpClient.Do(req)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+
+		body := readAndCloseBody(t, resp.Body)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+		// Verify that it actually took as long as we expected.
+		require.True(t, elapsed > targetDuration)
+	}
+}
+
+func readAndCloseBody(t *testing.T, r io.ReadCloser) []byte {
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	return b
+}
+
 func verifyBlock(t *testing.T, client objstore.Bucket, ulid ulid.ULID, localPath string) {
 	for _, fn := range []string{"index", "chunks/000001"} {
 		a, err := client.Attributes(context.Background(), path.Join("blocks/anonymous", ulid.String(), fn))
@@ -242,4 +357,54 @@ func getURL(url string) (string, error) {
 	body, err := io.ReadAll(res.Body)
 
 	return string(body), err
+}
+
+func newRateLimitedReader(r io.Reader, bytesPerSec float64, burst int) io.Reader {
+	return &reader{
+		r:      r,
+		burst:  burst,
+		bucket: rate.NewLimiter(rate.Limit(bytesPerSec), burst),
+	}
+}
+
+type reader struct {
+	r      io.Reader
+	burst  int
+	bucket *rate.Limiter
+}
+
+func (r *reader) Read(buf []byte) (int, error) {
+	// We can't wait for more bytes than our burst size.
+	if len(buf) > r.burst {
+		buf = buf[:r.burst]
+	}
+
+	n, err := r.r.Read(buf)
+	if n <= 0 {
+		return n, err
+	}
+
+	err1 := r.bucket.WaitN(context.Background(), n)
+	if err == nil {
+		err = err1
+	}
+	return n, err
+}
+
+func TestRateLimitedReader(t *testing.T) {
+	t.Skip("slow test, checking implementation of rate-limited reader.")
+
+	const dataLen = 16384
+	const dataRate = 4096
+
+	data := make([]byte, dataLen)
+
+	start := time.Now()
+	n, err := io.Copy(io.Discard, newRateLimitedReader(bytes.NewReader(data), dataRate, dataRate))
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(len(data)), n)
+	// rate limiter starts "full", hence "dataLen - dataRate".
+	require.InDelta(t, elapsed.Seconds(), (dataLen-dataRate)/dataRate, 1)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -335,11 +335,29 @@ func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
 	})
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/api/v1/upload/block/{block}/start", http.HandlerFunc(c.StartBlockUpload), true, false, http.MethodPost)
-	a.RegisterRoute("/api/v1/upload/block/{block}/files", http.HandlerFunc(c.UploadBlockFile), true, false, http.MethodPost)
+	a.RegisterRoute("/api/v1/upload/block/{block}/files", a.DisableServerHTTPTimeouts(http.HandlerFunc(c.UploadBlockFile)), true, false, http.MethodPost)
 	a.RegisterRoute("/api/v1/upload/block/{block}/finish", http.HandlerFunc(c.FinishBlockUpload), true, false, http.MethodPost)
 	a.RegisterRoute("/api/v1/upload/block/{block}/check", http.HandlerFunc(c.GetBlockUploadStateHandler), true, false, http.MethodGet)
 	a.RegisterRoute("/compactor/delete_tenant", http.HandlerFunc(c.DeleteTenant), true, true, "POST")
 	a.RegisterRoute("/compactor/delete_tenant_status", http.HandlerFunc(c.DeleteTenantStatus), true, true, "GET")
+}
+
+func (a *API) DisableServerHTTPTimeouts(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c := http.NewResponseController(w)
+		zero := time.Time{}
+
+		level.Debug(a.logger).Log("msg", "disabling HTTP server timeouts for URL", "url", r.URL)
+
+		if err := c.SetReadDeadline(zero); err != nil {
+			level.Warn(a.logger).Log("msg", "failed to clear read deadline on HTTP connection", "url", r.URL, "err", err)
+		}
+		if err := c.SetWriteDeadline(zero); err != nil {
+			level.Warn(a.logger).Log("msg", "failed to clear write deadline on HTTP connection", "url", r.URL, "err", err)
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 type Distributor interface {

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -767,12 +767,38 @@ func TestMultitenantCompactor_UploadBlockFile(t *testing.T) {
 		},
 	}
 
+	setupFnForValidRequest := func(bkt *bucket.ClientMock) {
+		bkt.MockExists(metaPath, false, nil)
+
+		b, err := json.Marshal(validMeta)
+		setUpGet(bkt, path.Join(tenantID, blockID, uploadingMetaFilename), b, err)
+		setUpGet(bkt, path.Join(tenantID, blockID, validationFilename), nil, bucket.ErrObjectDoesNotExist)
+
+		bkt.MockUpload(path.Join(tenantID, blockID, "chunks/000001"), nil)
+	}
+
+	verifyFuncForValidRequest := func(t *testing.T, bkt *bucket.ClientMock, expContent string) {
+		var call mock.Call
+		for _, c := range bkt.Calls {
+			if c.Method == "Upload" {
+				call = c
+				break
+			}
+		}
+
+		rdr := call.Arguments[2].(io.Reader)
+		got, err := io.ReadAll(rdr)
+		require.NoError(t, err)
+		assert.Equal(t, []byte(expContent), got)
+	}
+
 	testCases := []struct {
 		name                   string
 		tenantID               string
 		blockID                string
 		path                   string
 		body                   string
+		unknownContentLength   bool
 		disableBlockUpload     bool
 		expBadRequest          string
 		expConflict            string
@@ -938,34 +964,23 @@ func TestMultitenantCompactor_UploadBlockFile(t *testing.T) {
 			expBadRequest: "unexpected file",
 		},
 		{
-			name:     "valid request",
-			tenantID: tenantID,
-			blockID:  blockID,
-			path:     "chunks/000001",
-			body:     chunkBodyContent,
-			setUpBucketMock: func(bkt *bucket.ClientMock) {
-				bkt.MockExists(metaPath, false, nil)
-
-				b, err := json.Marshal(validMeta)
-				setUpGet(bkt, path.Join(tenantID, blockID, uploadingMetaFilename), b, err)
-				setUpGet(bkt, path.Join(tenantID, blockID, validationFilename), nil, bucket.ErrObjectDoesNotExist)
-
-				bkt.MockUpload(path.Join(tenantID, blockID, "chunks/000001"), nil)
-			},
-			verifyUpload: func(t *testing.T, bkt *bucket.ClientMock, expContent string) {
-				var call mock.Call
-				for _, c := range bkt.Calls {
-					if c.Method == "Upload" {
-						call = c
-						break
-					}
-				}
-
-				rdr := call.Arguments[2].(io.Reader)
-				got, err := io.ReadAll(rdr)
-				require.NoError(t, err)
-				assert.Equal(t, []byte(expContent), got)
-			},
+			name:            "valid request",
+			tenantID:        tenantID,
+			blockID:         blockID,
+			path:            "chunks/000001",
+			body:            chunkBodyContent,
+			setUpBucketMock: setupFnForValidRequest,
+			verifyUpload:    verifyFuncForValidRequest,
+		},
+		{
+			name:                 "valid request, with unknown content-length",
+			tenantID:             tenantID,
+			blockID:              blockID,
+			path:                 "chunks/000001",
+			body:                 chunkBodyContent,
+			unknownContentLength: true,
+			setUpBucketMock:      setupFnForValidRequest,
+			verifyUpload:         verifyFuncForValidRequest,
 		},
 	}
 	for _, tc := range testCases {
@@ -995,6 +1010,9 @@ func TestMultitenantCompactor_UploadBlockFile(t *testing.T) {
 			}
 			if tc.body != "" {
 				r.ContentLength = int64(len(tc.body))
+				if tc.unknownContentLength {
+					r.ContentLength = -1
+				}
 			}
 			w := httptest.NewRecorder()
 			c.UploadBlockFile(w, r)

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -60,7 +60,7 @@ func drainAndCloseBody(resp *http.Response) {
 
 func (c *MimirClient) backfillBlock(ctx context.Context, blockDir string, logctx *logrus.Entry, sleepTime time.Duration) error {
 	// blockMeta returned by getBlockMeta will have thanos.files section pre-populated.
-	blockMeta, err := getBlockMeta(blockDir)
+	blockMeta, err := GetBlockMeta(blockDir)
 	if err != nil {
 		return err
 	}
@@ -177,9 +177,9 @@ func (c *MimirClient) uploadBlockFile(ctx context.Context, tf metadata.File, blo
 	return nil
 }
 
-// getBlockMeta reads meta.json file, and adds (or replaces) thanos.files section with
+// GetBlockMeta reads meta.json file, and adds (or replaces) thanos.files section with
 // list of local files from the local block.
-func getBlockMeta(blockDir string) (metadata.Meta, error) {
+func GetBlockMeta(blockDir string) (metadata.Meta, error) {
 	var blockMeta metadata.Meta
 
 	metaPath := filepath.Join(blockDir, block.MetaFilename)

--- a/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/metrics-tracker.go
+++ b/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/metrics-tracker.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package nethttp
@@ -7,25 +8,38 @@ import (
 	"net/http"
 )
 
-type statusCodeTracker struct {
+type metricsTracker struct {
 	http.ResponseWriter
 	status int
+	size   int
 }
 
-func (w *statusCodeTracker) WriteHeader(status int) {
+func (w *metricsTracker) WriteHeader(status int) {
 	w.status = status
 	w.ResponseWriter.WriteHeader(status)
 }
 
-func (w *statusCodeTracker) Write(b []byte) (int, error) {
-	return w.ResponseWriter.Write(b)
+func (w *metricsTracker) Write(b []byte) (int, error) {
+	size, err := w.ResponseWriter.Write(b)
+	w.size += size
+	return size, err
+}
+
+// Unwrap method is used by http.ResponseController to get access to original http.ResponseWriter.
+func (w *metricsTracker) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// rwUnwrapper is a copy of interface used by http.ResponseController to get access to original http.ResponseWriter.
+type rwUnwrapper interface {
+	Unwrap() http.ResponseWriter
 }
 
 // wrappedResponseWriter returns a wrapped version of the original
 // ResponseWriter and only implements the same combination of additional
 // interfaces as the original.  This implementation is based on
 // https://github.com/felixge/httpsnoop.
-func (w *statusCodeTracker) wrappedResponseWriter() http.ResponseWriter {
+func (w *metricsTracker) wrappedResponseWriter() http.ResponseWriter {
 	var (
 		hj, i0 = w.ResponseWriter.(http.Hijacker)
 		cn, i1 = w.ResponseWriter.(http.CloseNotifier)
@@ -37,215 +51,248 @@ func (w *statusCodeTracker) wrappedResponseWriter() http.ResponseWriter {
 	switch {
 	case !i0 && !i1 && !i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
-		}{w}
+		}{w, w}
 	case !i0 && !i1 && !i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			io.ReaderFrom
-		}{w, rf}
+		}{w, w, rf}
 	case !i0 && !i1 && !i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Flusher
-		}{w, fl}
+		}{w, w, fl}
 	case !i0 && !i1 && !i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
-		}{w, fl, rf}
+		}{w, w, fl, rf}
 	case !i0 && !i1 && i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Pusher
-		}{w, pu}
+		}{w, w, pu}
 	case !i0 && !i1 && i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Pusher
 			io.ReaderFrom
-		}{w, pu, rf}
+		}{w, w, pu, rf}
 	case !i0 && !i1 && i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Pusher
 			http.Flusher
-		}{w, pu, fl}
+		}{w, w, pu, fl}
 	case !i0 && !i1 && i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{w, pu, fl, rf}
+		}{w, w, pu, fl, rf}
 	case !i0 && i1 && !i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
-		}{w, cn}
+		}{w, w, cn}
 	case !i0 && i1 && !i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
-		}{w, cn, rf}
+		}{w, w, cn, rf}
 	case !i0 && i1 && !i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Flusher
-		}{w, cn, fl}
+		}{w, w, cn, fl}
 	case !i0 && i1 && !i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Flusher
 			io.ReaderFrom
-		}{w, cn, fl, rf}
+		}{w, w, cn, fl, rf}
 	case !i0 && i1 && i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
-		}{w, cn, pu}
+		}{w, w, cn, pu}
 	case !i0 && i1 && i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
 			io.ReaderFrom
-		}{w, cn, pu, rf}
+		}{w, w, cn, pu, rf}
 	case !i0 && i1 && i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
 			http.Flusher
-		}{w, cn, pu, fl}
+		}{w, w, cn, pu, fl}
 	case !i0 && i1 && i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{w, cn, pu, fl, rf}
+		}{w, w, cn, pu, fl, rf}
 	case i0 && !i1 && !i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
-		}{w, hj}
+		}{w, w, hj}
 	case i0 && !i1 && !i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
-		}{w, hj, rf}
+		}{w, w, hj, rf}
 	case i0 && !i1 && !i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Flusher
-		}{w, hj, fl}
+		}{w, w, hj, fl}
 	case i0 && !i1 && !i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Flusher
 			io.ReaderFrom
-		}{w, hj, fl, rf}
+		}{w, w, hj, fl, rf}
 	case i0 && !i1 && i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
-		}{w, hj, pu}
+		}{w, w, hj, pu}
 	case i0 && !i1 && i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
 			io.ReaderFrom
-		}{w, hj, pu, rf}
+		}{w, w, hj, pu, rf}
 	case i0 && !i1 && i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
 			http.Flusher
-		}{w, hj, pu, fl}
+		}{w, w, hj, pu, fl}
 	case i0 && !i1 && i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{w, hj, pu, fl, rf}
+		}{w, w, hj, pu, fl, rf}
 	case i0 && i1 && !i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
-		}{w, hj, cn}
+		}{w, w, hj, cn}
 	case i0 && i1 && !i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			io.ReaderFrom
-		}{w, hj, cn, rf}
+		}{w, w, hj, cn, rf}
 	case i0 && i1 && !i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Flusher
-		}{w, hj, cn, fl}
+		}{w, w, hj, cn, fl}
 	case i0 && i1 && !i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Flusher
 			io.ReaderFrom
-		}{w, hj, cn, fl, rf}
+		}{w, w, hj, cn, fl, rf}
 	case i0 && i1 && i2 && !i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Pusher
-		}{w, hj, cn, pu}
+		}{w, w, hj, cn, pu}
 	case i0 && i1 && i2 && !i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Pusher
 			io.ReaderFrom
-		}{w, hj, cn, pu, rf}
+		}{w, w, hj, cn, pu, rf}
 	case i0 && i1 && i2 && i3 && !i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Pusher
 			http.Flusher
-		}{w, hj, cn, pu, fl}
+		}{w, w, hj, cn, pu, fl}
 	case i0 && i1 && i2 && i3 && i4:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{w, hj, cn, pu, fl, rf}
+		}{w, w, hj, cn, pu, fl, rf}
 	default:
 		return struct {
+			rwUnwrapper
 			http.ResponseWriter
-		}{w}
+		}{w, w}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -750,7 +750,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometh
 # github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 ## explicit; go 1.11
 github.com/opentracing-contrib/go-grpc
-# github.com/opentracing-contrib/go-stdlib v1.0.0
+# github.com/opentracing-contrib/go-stdlib v1.0.0 => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 ## explicit; go 1.14
 github.com/opentracing-contrib/go-stdlib/nethttp
 # github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
@@ -1443,3 +1443,4 @@ sigs.k8s.io/yaml
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 # github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc
+# github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956


### PR DESCRIPTION
This PR disables HTTP timeout values on compactor's endpoint for uploading a file for a block. This is done to allow uploads of big files.

In the future we may want to introduce minimum upload rate instead of just disabling timeout.

Note that block upload feature is disabled by default, and must be enabled for tenant to use it.

This PR also changes `/api/v1/upload/block/{block}/files` endpoint to allow upload of files with unset `Content-Length` (chunked uploads).