### PR TITLE
Set CHANGELOG.md to have no entry in CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,6 @@
 # Packages.
 /Makefile @wilfriedroset @vaxvms @bubu11e @grafana/mimir-maintainers
 /packaging/ @wilfriedroset @vaxvms @bubu11e @grafana/mimir-maintainers
+
+# No owners - allows sub-maintainers to merge changes.
+CHANGELOG.md


### PR DESCRIPTION
Allows sub-maintainers to merge changes which have a changelog entry.
