### PR TITLE
store-gateway: reduce series size estimation

### DIFF
--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -64,6 +64,11 @@ const (
 	// This is an estimation that should cover >99% of series with less than 30 labels and around 50 chunks per series.
 	EstimatedSeriesP99Size = 512
 
+	// MaxSeriesSize is an estimated worst case for a series size in the index. A valid series may still be larger than this.
+	// This was calculated assuming a rate of 1 sample/sec, in a 24h block we have 744 chunks per series.
+	// The worst case scenario of each meta ref is 8*3=24 bytes, so 744*24 = 17856 bytes, which is 448 bytes away form 17 KiB.
+	MaxSeriesSize = 17 * 1024
+
 	// BytesPerPostingInAPostingList is the number of bytes that each posting (series ID) takes in a
 	// posting list in the index. Each posting is 4 bytes (uint32) which are the offset of the series in the index file.
 	BytesPerPostingInAPostingList = 4

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -65,7 +65,7 @@ const (
 	// because you barely get any improvements in compression when the number of samples is beyond this.
 	// Take a look at Figure 6 in this whitepaper http://www.vldb.org/pvldb/vol8/p1816-teller.pdf.
 	MaxSamplesPerChunk = 120
-	maxSeriesSize      = 64 * 1024
+
 	// Relatively large in order to reduce memory waste, yet small enough to avoid excessive allocations.
 	chunkBytesPoolMinSize = 64 * 1024        // 64 KiB
 	chunkBytesPoolMaxSize = 64 * 1024 * 1024 // 64 MiB


### PR DESCRIPTION
#### What this PR does

Related to https://github.com/grafana/mimir/issues/4593

The 64KiB size estimation for series was inherited from Thanos. The PR which adds this to Thanos (PR 1985) didn't give any explanation for why 64KiB was chosen. Based on some rough estimation we think that we can bring this number down in order to reduce the volume of fetched data.

Citing @pracucci 
> Assuming a worst case scenario of 1 sample /sec, in a 24h block we have 744 chunks per series.
> The worst case scenario of each meta ref is 8*3=24 bytes, so 744*24 = 17856 bytes.

This PR also moves this constant to the tsdb package which contains similar constants.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
