### PR TITLE
store-gateway: choose one postings selection strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [CHANGE] Query-frontend: Change the default value of `-query-frontend.query-sharding-max-regexp-size-bytes` from `0` to `4096`. #4932
 * [CHANGE] Querier: `-querier.query-ingesters-within` has been moved from a global flag to a per-tenant override. #4287
 * [CHANGE] Querier: Use `-blocks-storage.tsdb.retention-period` instead of `-querier.query-ingesters-within` for calculating the lookback period for shuffle sharded ingesters. Setting `-querier.query-ingesters-within=0` no longer disables shuffle sharding on the read path. #4287
+* [CHANGE] Store-gateway: remove `-blocks-storage.bucket-store.series-selection-strategy` and always use a postrings selection strategy. This reduces the cost of running queries against long-term storage that select only few series but use labels that are present in many series.
 * [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. #4765
 * [ENHANCEMENT] Store-gateway: reduce memory usage in some LabelValues calls. #4789
 * [ENHANCEMENT] Store-gateway: add a `stage` label to the metric `cortex_bucket_store_series_data_touched`. This label now applies to `data_type="chunks"` and `data_type="series"`. The `stage` label has 2 values: `processed` - the number of series that parsed - and `returned` - the number of series selected from the processed bytes to satisfy the query. #4797 #4830

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [CHANGE] Query-frontend: Change the default value of `-query-frontend.query-sharding-max-regexp-size-bytes` from `0` to `4096`. #4932
 * [CHANGE] Querier: `-querier.query-ingesters-within` has been moved from a global flag to a per-tenant override. #4287
 * [CHANGE] Querier: Use `-blocks-storage.tsdb.retention-period` instead of `-querier.query-ingesters-within` for calculating the lookback period for shuffle sharded ingesters. Setting `-querier.query-ingesters-within=0` no longer disables shuffle sharding on the read path. #4287
-* [CHANGE] Store-gateway: remove `-blocks-storage.bucket-store.series-selection-strategy` and always use a postrings selection strategy. This reduces the cost of running queries against long-term storage that select only few series but use labels that are present in many series.
+* [CHANGE] Store-gateway: remove `-blocks-storage.bucket-store.series-selection-strategy` and always use a postings selection strategy. This reduces the cost of running queries against long-term storage that select only few series but use labels that are present in many series. #4963
 * [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. #4765
 * [ENHANCEMENT] Store-gateway: reduce memory usage in some LabelValues calls. #4789
 * [ENHANCEMENT] Store-gateway: add a `stage` label to the metric `cortex_bucket_store_series_data_touched`. This label now applies to `data_type="chunks"` and `data_type="series"`. The `stage` label has 2 values: `processed` - the number of series that parsed - and `returned` - the number of series selected from the processed bytes to satisfy the query. #4797 #4830

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7158,17 +7158,6 @@
               "fieldFlag": "blocks-storage.bucket-store.fine-grained-chunks-caching-ranges-per-series",
               "fieldType": "int",
               "fieldCategory": "experimental"
-            },
-            {
-              "kind": "field",
-              "name": "series_selection_strategy",
-              "required": false,
-              "desc": "This option controls the strategy to selection of series and deferring application of matchers. A more aggressive strategy will fetch less posting lists at the cost of more series. This is useful when querying large blocks in which many series share the same label name and value. Supported values (most aggressive to least aggressive): speculative, worst-case, worst-case-small-posting-lists, all.",
-              "fieldValue": null,
-              "fieldDefaultValue": "all",
-              "fieldFlag": "blocks-storage.bucket-store.series-selection-strategy",
-              "fieldType": "string",
-              "fieldCategory": "experimental"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -609,8 +609,6 @@ Usage of ./cmd/mimir/mimir:
     	Controls what is the ratio of postings offsets that the store will hold in memory. (default 32)
   -blocks-storage.bucket-store.series-hash-cache-max-size-bytes uint
     	Max size - in bytes - of the in-memory series hash cache. The cache is shared across all tenants and it's used only when query sharding is enabled. (default 1073741824)
-  -blocks-storage.bucket-store.series-selection-strategy string
-    	[experimental] This option controls the strategy to selection of series and deferring application of matchers. A more aggressive strategy will fetch less posting lists at the cost of more series. This is useful when querying large blocks in which many series share the same label name and value. Supported values (most aggressive to least aggressive): speculative, worst-case, worst-case-small-posting-lists, all. (default "all")
   -blocks-storage.bucket-store.sync-dir string
     	Directory to store synchronized TSDB index headers. This directory is not required to be persisted between restarts, but it's highly recommended in order to improve the store-gateway startup time. (default "./tsdb-sync/")
   -blocks-storage.bucket-store.sync-interval duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -104,7 +104,6 @@ The following features are currently experimental:
   - `-blocks-storage.bucket-store.chunks-cache.fine-grained-chunks-caching-enabled`
   - `-blocks-storage.bucket-store.fine-grained-chunks-caching-ranges-per-series`
   - Use of Redis cache backend (`-blocks-storage.bucket-store.chunks-cache.backend=redis`, `-blocks-storage.bucket-store.index-cache.backend=redis`, `-blocks-storage.bucket-store.metadata-cache.backend=redis`)
-  - `-blocks-storage.bucket-store.series-selection-strategy`
 - Blocks Storage, Alertmanager, and Ruler support for partitioning access to the same storage bucket
   - `-alertmanager-storage.storage-prefix`
   - `-blocks-storage.storage-prefix`

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3248,15 +3248,6 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.fine-grained-chunks-caching-ranges-per-series
   [fine_grained_chunks_caching_ranges_per_series: <int> | default = 1]
 
-  # (experimental) This option controls the strategy to selection of series and
-  # deferring application of matchers. A more aggressive strategy will fetch
-  # less posting lists at the cost of more series. This is useful when querying
-  # large blocks in which many series share the same label name and value.
-  # Supported values (most aggressive to least aggressive): speculative,
-  # worst-case, worst-case-small-posting-lists, all.
-  # CLI flag: -blocks-storage.bucket-store.series-selection-strategy
-  [series_selection_strategy: <string> | default = "all"]
-
 tsdb:
   # Directory to store TSDBs (including WAL) in the ingesters. This directory is
   # required to be persisted between restarts.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -364,23 +364,8 @@ type BucketStoreConfig struct {
 	// Controls experimental options for index-header file reading.
 	IndexHeader indexheader.Config `yaml:"index_header" category:"experimental"`
 
-	StreamingBatchSize          int    `yaml:"streaming_series_batch_size" category:"advanced"`
-	ChunkRangesPerSeries        int    `yaml:"fine_grained_chunks_caching_ranges_per_series" category:"experimental"`
-	SeriesSelectionStrategyName string `yaml:"series_selection_strategy" category:"experimental"`
-}
-
-const (
-	SpeculativePostingsStrategy                = "speculative"
-	WorstCasePostingsStrategy                  = "worst-case"
-	WorstCaseSmallPostingListsPostingsStrategy = "worst-case-small-posting-lists"
-	AllPostingsStrategy                        = "all"
-)
-
-var validSeriesSelectionStrategies = []string{
-	SpeculativePostingsStrategy,
-	WorstCasePostingsStrategy,
-	WorstCaseSmallPostingListsPostingsStrategy,
-	AllPostingsStrategy,
+	StreamingBatchSize   int `yaml:"streaming_series_batch_size" category:"advanced"`
+	ChunkRangesPerSeries int `yaml:"fine_grained_chunks_caching_ranges_per_series" category:"experimental"`
 }
 
 // RegisterFlags registers the BucketStore flags
@@ -411,7 +396,6 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) 
 	f.Uint64Var(&cfg.PartitionerMaxGapBytes, "blocks-storage.bucket-store.partitioner-max-gap-bytes", DefaultPartitionerMaxGapSize, "Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests.")
 	f.IntVar(&cfg.StreamingBatchSize, "blocks-storage.bucket-store.batch-series-size", 5000, "This option controls how many series to fetch per batch. The batch size must be greater than 0.")
 	f.IntVar(&cfg.ChunkRangesPerSeries, "blocks-storage.bucket-store.fine-grained-chunks-caching-ranges-per-series", 1, "This option controls into how many ranges the chunks of each series from each block are split. This value is effectively the number of chunks cache items per series per block when -blocks-storage.bucket-store.chunks-cache.fine-grained-chunks-caching-enabled is enabled.")
-	f.StringVar(&cfg.SeriesSelectionStrategyName, "blocks-storage.bucket-store.series-selection-strategy", AllPostingsStrategy, "This option controls the strategy to selection of series and deferring application of matchers. A more aggressive strategy will fetch less posting lists at the cost of more series. This is useful when querying large blocks in which many series share the same label name and value. Supported values (most aggressive to least aggressive): "+strings.Join(validSeriesSelectionStrategies, ", ")+".")
 }
 
 // Validate the config.
@@ -430,9 +414,6 @@ func (cfg *BucketStoreConfig) Validate(logger log.Logger) error {
 	}
 	if cfg.DeprecatedConsistencyDelay > 0 {
 		util.WarnDeprecatedConfig(consistencyDelayFlag, logger)
-	}
-	if !util.StringsContain(validSeriesSelectionStrategies, cfg.SeriesSelectionStrategyName) {
-		return errors.New("invalid series-selection-strategy, set one of " + strings.Join(validSeriesSelectionStrategies, ", "))
 	}
 	return nil
 }

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1243,7 +1243,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 // so we could also intersect those with each label's postings being each one non-empty and leading to the same result.
 func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy postingsSelectionStrategy, maxSeriesPerBatch int, labelName string, matchers []*labels.Matcher, logger log.Logger, stats *safeQueryStats) ([]string, error) {
 	// This index reader shouldn't be used for ExpandedPostings, since it doesn't have the correct strategy.
-	labelValuesReader := b.indexReader(selectAllStrategy{})
+	labelValuesReader := b.indexReader(postingsStrategy)
 	defer runutil.CloseWithLogOnErr(b.logger, labelValuesReader, "close block index reader")
 
 	values, ok := fetchCachedLabelValues(ctx, b.indexCache, b.userID, b.meta.ULID, labelName, matchers, logger)

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -479,7 +479,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 		u.syncDirForUser(userID),
 		u.cfg.BucketStore.StreamingBatchSize,
 		u.cfg.BucketStore.ChunkRangesPerSeries,
-		selectPostingsStrategy(u.logger, u.cfg.BucketStore.SeriesSelectionStrategyName),
+		minimizeFetchedDataStrategy{},
 		NewChunksLimiterFactory(func() uint64 {
 			return uint64(u.limits.MaxChunksPerQuery(userID))
 		}),
@@ -504,24 +504,6 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 	u.metaFetcherMetrics.AddUserRegistry(userID, fetcherReg)
 
 	return bs, nil
-}
-
-func selectPostingsStrategy(l log.Logger, name string) postingsSelectionStrategy {
-	switch name {
-	case tsdb.AllPostingsStrategy:
-		return selectAllStrategy{}
-	case tsdb.SpeculativePostingsStrategy:
-		return speculativeFetchedDataStrategy{}
-	case tsdb.WorstCasePostingsStrategy:
-		return worstCaseFetchedDataStrategy{postingListActualSizeFactor: 1.0}
-	case tsdb.WorstCaseSmallPostingListsPostingsStrategy:
-		return worstCaseFetchedDataStrategy{postingListActualSizeFactor: 0.3}
-	default:
-		// This should only be reached if the tsdb package has mismatching names for these strategies.
-		// Prefer keeping the store-gateway running as opposed to failing, since strategies are still an experimental feature anyway.
-		level.Warn(l).Log("msg", "unknown posting strategy; using "+tsdb.AllPostingsStrategy+" instead", "strategy", name)
-		return selectAllStrategy{}
-	}
 }
 
 // closeBucketStoreAndDeleteLocalFilesForExcludedTenants closes bucket store and removes local "sync" directories

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -803,7 +803,7 @@ func BenchmarkBucketStoreLabelValues(tb *testing.B) {
 	prepareCfg := defaultPrepareStoreConfig(tb)
 	prepareCfg.tempDir = dir
 	prepareCfg.series = series
-	prepareCfg.postingsStrategy = worstCaseFetchedDataStrategy{1.0}
+	prepareCfg.postingsStrategy = minimizeFetchedDataStrategy{}
 
 	s := prepareStoreWithTestBlocks(tb, bkt, prepareCfg)
 	mint, maxt := s.store.TimeRange()

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -474,14 +474,14 @@ func TestBlockLabelValues(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchRegexp, "i", "1234.+"),
 			labels.MustNewMatcher(labels.MatchRegexp, "j", ".+"), // this is too weak and doesn't bring much value, it should be shortcut
 		}
-		values, err := blockLabelValues(context.Background(), b, worstCaseFetchedDataStrategy{1.0}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
+		values, err := blockLabelValues(context.Background(), b, minimizeFetchedDataStrategy{}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"foo"}, values)
 
 		// we break the indexHeaderReader to ensure that results come from a cache
 		b.indexHeaderReader = deadlineExceededIndexHeader()
 
-		values, err = blockLabelValues(context.Background(), b, worstCaseFetchedDataStrategy{1.0}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
+		values, err = blockLabelValues(context.Background(), b, minimizeFetchedDataStrategy{}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
 		require.Equal(t, []string{"foo"}, values)
 	})

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -2780,3 +2780,13 @@ type mockIndexCacheEntry struct {
 func (c mockIndexCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey) ([]byte, bool) {
 	return c.fetchSeriesForPostingsResponse.contents, c.fetchSeriesForPostingsResponse.cached
 }
+
+type selectAllStrategy struct{}
+
+func (selectAllStrategy) name() string {
+	return "all"
+}
+
+func (selectAllStrategy) selectPostings(groups []postingGroup) (selected, omitted []postingGroup) {
+	return groups, nil
+}


### PR DESCRIPTION
#### What this PR does

Related to https://github.com/grafana/mimir/issues/4593

We ran the three different postings strategies in clusters at Grafana Labs. The summarized results are below:
* `worst-case` and `speculative` strategies don't show significantly different results
* `worst-case-small-posting-lists` showed worse performance: on average 20% higher memory usage due to the increased postings fetching

Because of this we decided to go with `worst-case`. After internal feedback and because this doesn't sound like a very descriptive name, I am also renaming it to `minimizeFetchedDataPostingsStrategy`. 

This PR removes the configuration flag which sets the postings strategy (`-blocks-storage.bucket-store.series-selection-strategy`, previously experimental) and always uses the `minimizeFetchedDataPostingsStrategy`.

The abstractions for `postingsSelectionStrategy` are kept for `LabelValues` requests and easier testing.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
