### PR TITLE
WIP: Ingester: Add limit for max in-flight queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [ENHANCEMENT] Updated Kuberesolver dependency (github.com/sercand/kuberesolver) from v2.4.0 to v4.0.0 and gRPC dependency (google.golang.org/grpc) from v1.47.0 to v1.53.0. #4922
 * [ENHANCEMENT] Introduced new options for logging HTTP request headers: `-server.log-request-headers` enables logging HTTP request headers, `-server.log-request-headers-exclude-list` lists headers which should not be logged. #4922
 * [ENHANCEMENT] Block upload: `/api/v1/upload/block/{block}/files` endpoint now disables read and write HTTP timeout, overriding `-server.http-read-timeout` and `-server.http-write-timeout` values. This is done to allow large file uploads to succeed. #4956
+* [ENHANCEMENT] Ingester: Add instance query limit `-ingester.instance-limits.max-inflight-queries`, that limits the max number of queries an ingester can handle concurrently. #
 * [ENHANCEMENT] Alertmanager: Introduce new metrics from upstream. #4918
   * `cortex_alertmanager_notifications_failed_total` (added `reason` label)
   * `cortex_alertmanager_nflog_maintenance_total`

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2560,6 +2560,17 @@
               "fieldFlag": "ingester.instance-limits.max-inflight-push-requests",
               "fieldType": "int",
               "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "max_inflight_queries",
+              "required": false,
+              "desc": "Max inflight queries that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.",
+              "fieldValue": null,
+              "fieldDefaultValue": 30000,
+              "fieldFlag": "ingester.instance-limits.max-inflight-queries",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1209,6 +1209,8 @@ Usage of ./cmd/mimir/mimir:
     	Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.
   -ingester.instance-limits.max-inflight-push-requests int
     	Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited. (default 30000)
+  -ingester.instance-limits.max-inflight-queries int
+    	Max inflight queries that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited. (default 30000)
   -ingester.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
   -ingester.instance-limits.max-series int

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -19,6 +19,7 @@ const (
 	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
 	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
 	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
+	maxInflightQueriesFlag      = "ingester.instance-limits.max-inflight-queries"
 )
 
 var (
@@ -27,15 +28,17 @@ var (
 	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
 	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
 	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxInflightQueriesReached  = errors.New(globalerror.IngesterMaxInflightQueries.MessageWithPerInstanceLimitConfig("the query has been rejected because the ingester exceeded the allowed number of inflight queries", maxInflightQueriesFlag))
 )
 
-// InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return
-// (internal) error.
+// InstanceLimits describes read and write limits used by the ingester. Reaching any of these will result in respectively
+// the various query methods or the Push method returning an (internal) error.
 type InstanceLimits struct {
 	MaxIngestionRate        float64 `yaml:"max_ingestion_rate" category:"advanced"`
 	MaxInMemoryTenants      int64   `yaml:"max_tenants" category:"advanced"`
 	MaxInMemorySeries       int64   `yaml:"max_series" category:"advanced"`
 	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxInflightQueries      int64   `yaml:"max_inflight_queries" category:"advanced"`
 }
 
 func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
@@ -43,6 +46,7 @@ func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&l.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInflightQueries, maxInflightQueriesFlag, 30000, "Max inflight queries that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -136,7 +136,7 @@ type Config struct {
 	Common CommonConfig `yaml:"common"`
 }
 
-// RegisterFlags registers flag.
+// RegisterFlags registers flags.
 func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.ApplicationName = "Grafana Mimir"
 	c.Server.MetricsNamespace = "cortex"

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -40,6 +40,7 @@ const (
 	IngesterMaxTenants              ID = "ingester-max-tenants"
 	IngesterMaxInMemorySeries       ID = "ingester-max-series"
 	IngesterMaxInflightPushRequests ID = "ingester-max-inflight-push-requests"
+	IngesterMaxInflightQueries      ID = "ingester-max-inflight-queries"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"


### PR DESCRIPTION
#### What this PR does
Add ingester instance limit for max number of in-flight queries.

**TODO**:

- [ ] Figure out correct default value
- [ ] Add tests

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/3485.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
