### PR TITLE
Allow to specify -prometheus-http-prefix for mimirtool analyze prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
 * [ENHANCEMENT] Compactor: configure `-compactor.first-level-compaction-wait-period` to TSDB head compaction interval plus 10 minutes. #4872
 * [BUGFIX] Backend: configure `-ruler.alertmanager-url` to `mimir-backend` when running in read-write deployment mode. #4892
 
+### Mimirtool
+
+* [ENHANCEMENT] analyze prometheus: allow to specify `-prometheus-http-prefix`. #4966
+
 ## 2.8.0
 
 ### Grafana Mimir

--- a/docs/sources/mimir/operators-guide/tools/mimirtool.md
+++ b/docs/sources/mimir/operators-guide/tools/mimirtool.md
@@ -599,14 +599,15 @@ mimirtool analyze prometheus --address=<url> --id=<tenant_id>
 
 ##### Configuration
 
-| Environment variable | Flag                     | Description                                                                                                              |
-| -------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `MIMIR_ADDRESS`      | `--address`              | Sets the address of the Prometheus instance.                                                                             |
-| `MIMIR_TENANT_ID`    | `--id`                   | Sets the basic auth username. If you're using Grafana Cloud this variable is your instance ID.                           |
-| `MIMIR_API_KEY`      | `--key`                  | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.                              |
-| -                    | `--grafana-metrics-file` | `mimirtool analyze grafana` or `mimirtool analyze dashboard` output file, which by default is `metrics-in-grafana.json`. |
-| -                    | `--ruler-metrics-file`   | `mimirtool analyze ruler` or `mimirtool analyze rule-file` output file, which by default is `metrics-in-ruler.json`.     |
-| -                    | `--output`               | Sets the output file path, which by default is `prometheus-metrics.json`.                                                |
+| Environment variable | Flag                       | Description                                                                                                              |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `MIMIR_ADDRESS`      | `--address`                | Sets the address of the Prometheus instance.                                                                             |
+| `MIMIR_TENANT_ID`    | `--id`                     | Sets the basic auth username. If you're using Grafana Cloud this variable is your instance ID.                           |
+| `MIMIR_API_KEY`      | `--key`                    | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.                              |
+| -                    | `--grafana-metrics-file`   | `mimirtool analyze grafana` or `mimirtool analyze dashboard` output file, which by default is `metrics-in-grafana.json`. |
+| -                    | `--ruler-metrics-file`     | `mimirtool analyze ruler` or `mimirtool analyze rule-file` output file, which by default is `metrics-in-ruler.json`.     |
+| -                    | `--output`                 | Sets the output file path, which by default is `prometheus-metrics.json`.                                                |
+| -                    | `--prometheus-http-prefix` | Sets the HTTP URL path under which the Prometheus api will be served.                                                    |
 
 ##### Example output
 

--- a/pkg/mimirtool/commands/analyse.go
+++ b/pkg/mimirtool/commands/analyse.go
@@ -23,6 +23,9 @@ func (cmd *AnalyzeCommand) Register(app *kingpin.Application, envVars EnvVarName
 		Envar(envVars.Address).
 		Required().
 		StringVar(&paCmd.address)
+	prometheusAnalyzeCmd.Flag("prometheus-http-prefix", "HTTP URL path under which the Prometheus api will be served.").
+		Default("").
+		StringVar(&paCmd.prometheusHTTPPrefix)
 	prometheusAnalyzeCmd.Flag("id", "Username to use when contacting Prometheus or Grafana Mimir; alternatively, set "+envVars.TenantID+".").
 		Envar(envVars.TenantID).
 		Default("").

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"sort"
 	"sync"
@@ -30,10 +31,11 @@ import (
 )
 
 type PrometheusAnalyzeCommand struct {
-	address     string
-	username    string
-	password    string
-	readTimeout time.Duration
+	address              string
+	prometheusHTTPPrefix string
+	username             string
+	password             string
+	readTimeout          time.Duration
 
 	grafanaMetricsFile string
 	rulerMetricsFile   string
@@ -111,8 +113,12 @@ func (cmd *PrometheusAnalyzeCommand) newAPI() (v1.API, error) {
 		rt = config.NewBasicAuthRoundTripper(cmd.username, config.Secret(cmd.password), "", rt)
 	}
 
+	address, err := url.JoinPath(cmd.address, cmd.prometheusHTTPPrefix)
+	if err != nil {
+		return nil, err
+	}
 	client, err := api.NewClient(api.Config{
-		Address:      cmd.address,
+		Address:      address,
 		RoundTripper: rt,
 	})
 	if err != nil {


### PR DESCRIPTION
#### What this PR does

When configuring mimirtool via environment variables users might use the following:

```
MIMIR_ADDRESS=https://mimir:9090
MIMIR_TENANT_ID=default
MIMIR_API_USER=default
MIMIR_API_KEY=1234
```

It works as expected for `mimirtool analyze ruler` but not for `mimirtool analyze prometheus`.

The HTTP client for `analyze ruler` is done with
`github.com/grafana/mimir/pkg/mimirtool/client`, when for `analyze prometheus` it is done with only the address.

Depending on which prometheus the user wants to analyze the path is not the same. For a mimir based analysis user needs to provide `/prometheus`.

This commit allow to specify the path to use for a mimir based analysis. It also simplify the scripting around the tool.

Example:

```
source .secrets.env
mimirtool analyze grafana && \
mimirtool analyze ruler && \
mimirtool analyze prometheus --prometheus-http-prefix="/prometheus"
```
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
