### PR TITLE
Alertmanager: Reloading config and templates no longer needs to hit the disk

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -312,17 +312,6 @@ func clusterWait(position func() int, timeout time.Duration) func() time.Duratio
 
 // ApplyConfig applies a new configuration to an Alertmanager.
 func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, tmpls []io.Reader, rawCfg string) error {
-	templateFiles := make([]string, len(conf.Templates))
-	for i, t := range conf.Templates {
-		templateFilepath, err := safeTemplateFilepath(filepath.Join(am.cfg.TenantDataDir, templatesDir), t)
-		if err != nil {
-			return err
-		}
-
-		templateFiles[i] = templateFilepath
-	}
-
-	// tmpl, err := template.FromGlobs(templateFiles, withCustomFunctions(userID))
 	tmpl, err := loadTemplates(tmpls, withCustomFunctions(userID))
 	if err != nil {
 		return err

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api"
-	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 	"github.com/prometheus/alertmanager/config"
@@ -712,36 +711,4 @@ func alertSize(alert model.Alert) int {
 	}
 	size += len(alert.GeneratorURL)
 	return size
-}
-
-// loadTemplates produces a template.Template from several in-memory template files.
-// It is adapted from FromGlobs in github.com/prometheus/alertmanager/template/template.go
-func loadTemplates(tmpls []io.Reader, options ...template.Option) (*template.Template, error) {
-	t, err := template.New(options...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prometheus keeps its default templates in a virtual filesystem.
-	// Ensure these are included - this does not actually hit the disk.
-	defaultTemplates := []string{"default.tmpl", "email.tmpl"}
-
-	for _, file := range defaultTemplates {
-		f, err := asset.Assets.Open(path.Join("/templates", file))
-		if err != nil {
-			return nil, err
-		}
-		if err := t.Parse(f); err != nil {
-			f.Close()
-			return nil, err
-		}
-		f.Close()
-	}
-
-	for _, tp := range tmpls {
-		if err := t.Parse(tp); err != nil {
-			return nil, err
-		}
-	}
-	return t, nil
 }

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -10,6 +10,7 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -23,6 +24,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api"
+	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 	"github.com/prometheus/alertmanager/config"
@@ -309,7 +311,7 @@ func clusterWait(position func() int, timeout time.Duration) func() time.Duratio
 }
 
 // ApplyConfig applies a new configuration to an Alertmanager.
-func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, rawCfg string) error {
+func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, tmpls []io.Reader, rawCfg string) error {
 	templateFiles := make([]string, len(conf.Templates))
 	for i, t := range conf.Templates {
 		templateFilepath, err := safeTemplateFilepath(filepath.Join(am.cfg.TenantDataDir, templatesDir), t)
@@ -320,7 +322,8 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, rawCfg s
 		templateFiles[i] = templateFilepath
 	}
 
-	tmpl, err := template.FromGlobs(templateFiles, withCustomFunctions(userID))
+	// tmpl, err := template.FromGlobs(templateFiles, withCustomFunctions(userID))
+	tmpl, err := loadTemplates(tmpls, withCustomFunctions(userID))
 	if err != nil {
 		return err
 	}
@@ -720,4 +723,36 @@ func alertSize(alert model.Alert) int {
 	}
 	size += len(alert.GeneratorURL)
 	return size
+}
+
+// loadTemplates produces a template.Template from several in-memory template files.
+// It is adapted from FromGlobs in github.com/prometheus/alertmanager/template/template.go
+func loadTemplates(tmpls []io.Reader, options ...template.Option) (*template.Template, error) {
+	t, err := template.New(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prometheus keeps its default templates in a virtual filesystem.
+	// Ensure these are included - this does not actually hit the disk.
+	defaultTemplates := []string{"default.tmpl", "email.tmpl"}
+
+	for _, file := range defaultTemplates {
+		f, err := asset.Assets.Open(path.Join("/templates", file))
+		if err != nil {
+			return nil, err
+		}
+		if err := t.Parse(f); err != nil {
+			f.Close()
+			return nil, err
+		}
+		f.Close()
+	}
+
+	for _, tp := range tmpls {
+		if err := t.Parse(tp); err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
 }

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -6,9 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	tmplhtml "html/template"
+	"io"
 	"net/url"
+	"path"
 	tmpltext "text/template"
 
+	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/template"
 )
 
@@ -88,4 +91,36 @@ func withCustomFunctions(userID string) template.Option {
 		text.Funcs(funcs)
 		html.Funcs(funcs)
 	}
+}
+
+// loadTemplates produces a template.Template from several in-memory template files.
+// It is adapted from FromGlobs in github.com/prometheus/alertmanager/template/template.go
+func loadTemplates(tmpls []io.Reader, options ...template.Option) (*template.Template, error) {
+	t, err := template.New(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prometheus keeps its default templates in a virtual filesystem.
+	// Ensure these are included - this does not actually hit the disk.
+	defaultTemplates := []string{"default.tmpl", "email.tmpl"}
+
+	for _, file := range defaultTemplates {
+		f, err := asset.Assets.Open(path.Join("/templates", file))
+		if err != nil {
+			return nil, err
+		}
+		if err := t.Parse(f); err != nil {
+			f.Close()
+			return nil, err
+		}
+		f.Close()
+	}
+
+	for _, tp := range tmpls {
+		if err := t.Parse(tp); err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
 }

--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -3,10 +3,15 @@
 package alertmanager
 
 import (
+	"fmt"
+	"io"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -89,4 +94,79 @@ func Test_withCustomFunctions(t *testing.T) {
 			assert.Equal(t, c.result, res)
 		})
 	}
+}
+
+func Test_loadTemplates(t *testing.T) {
+	type tc struct {
+		name   string
+		loaded []string
+		invoke string
+		exp    string
+		expErr string
+	}
+
+	cases := []tc{
+		{
+			name: "can reference loaded templates",
+			loaded: []string{
+				`
+{{ define "my_tmpl_1" }}My Template 1{{ end }}
+`,
+			},
+			invoke: "my_tmpl_1",
+			exp:    "My Template 1",
+		},
+		{
+			name: "fails to reference nonexistant templates",
+			loaded: []string{
+				`
+{{ define "my_tmpl_1" }}My Template 1{{ end }}
+`,
+			},
+			invoke: "does_not_exist",
+			expErr: "not defined",
+		},
+		{
+			name:   "can reference default templates without loading them",
+			invoke: "discord.default.message",
+			exp:    "Alerts Firing:\nLabels:\nAnnotations:\nSource: http://localhost:9090",
+		},
+		{
+			name:   "can reference default email templates without loading them",
+			invoke: "email.default.html",
+			exp:    "DOCTYPE html",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			readers := make([]io.Reader, 0, len(c.loaded))
+			for _, tmpl := range c.loaded {
+				readers = append(readers, strings.NewReader(tmpl))
+			}
+			tmpl, err := loadTemplates(readers, withCustomFunctions("test"))
+			assert.NoError(t, err)
+
+			call := fmt.Sprintf(`{{ template "%s" . }}`, c.invoke)
+
+			data := templateDataForTests(t, tmpl)
+			res, err := tmpl.ExecuteTextString(call, data)
+			if c.expErr != "" {
+				assert.Contains(t, err.Error(), c.expErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Contains(t, res, c.exp)
+			}
+		})
+	}
+}
+
+func templateDataForTests(t *testing.T, tmpl *template.Template) *template.Data {
+	eurl, _ := url.Parse("http://localhost:9090")
+	tmpl.ExternalURL = eurl // This is done externally, by the system using the templates.
+	return tmpl.Data("receiver", model.LabelSet{}, &types.Alert{
+		Alert: model.Alert{
+			GeneratorURL: "http://localhost:9090",
+		},
+	})
 }

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -8,6 +8,7 @@ package alertmanager
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 	"testing"
@@ -85,7 +86,8 @@ route:
 
 	cfg, err := config.Load(cfgRaw)
 	require.NoError(t, err)
-	require.NoError(t, am.ApplyConfig(user, cfg, cfgRaw))
+	tmpls := make([]io.Reader, 0)
+	require.NoError(t, am.ApplyConfig(user, cfg, tmpls, cfgRaw))
 
 	now := time.Now()
 
@@ -168,7 +170,8 @@ route:
 
 	cfg, err := config.Load(cfgRaw)
 	require.NoError(t, err)
-	require.NoError(t, am.ApplyConfig(user, cfg, cfgRaw))
+	tmpls := make([]io.Reader, 0)
+	require.NoError(t, am.ApplyConfig(user, cfg, tmpls, cfgRaw))
 
 	now := time.Now()
 	inputAlerts := []*types.Alert{

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -654,52 +654,16 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alertspb.AlertCon
 // setConfig applies the given configuration to the alertmanager for `userID`,
 // creating an alertmanager if it doesn't already exist.
 func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error {
-	var userAmConfig *amconfig.Config
-	var err error
-	var userTemplateDir = filepath.Join(am.getTenantDirectory(cfg.User), templatesDir)
-	var pathsToRemove = make(map[string]struct{})
-
-	// List existing files to keep track of the ones to be removed
-	if oldTemplateFiles, err := os.ReadDir(userTemplateDir); err == nil {
-		for _, file := range oldTemplateFiles {
-			templateFilePath, err := safeTemplateFilepath(userTemplateDir, file.Name())
-			if err != nil {
-				return err
-			}
-			pathsToRemove[templateFilePath] = struct{}{}
-		}
-	}
-
-	templates := make([]io.Reader, 0, len(cfg.Templates))
-	for _, tmpl := range cfg.Templates {
-		templateFilePath, err := safeTemplateFilepath(userTemplateDir, tmpl.Filename)
-		if err != nil {
-			return err
-		}
-
-		// Removing from pathsToRemove map the files that still exists in the config
-		delete(pathsToRemove, templateFilePath)
-		_, err = storeTemplateFile(templateFilePath, tmpl.Body)
-		templates = append(templates, strings.NewReader(tmpl.Body))
-		if err != nil {
-			return err
-		}
-	}
-
-	for pathToRemove := range pathsToRemove {
-		err := os.Remove(pathToRemove)
-		if err != nil {
-			level.Warn(am.logger).Log("msg", "failed to remove file", "file", pathToRemove, "err", err)
-		}
-	}
-
 	level.Debug(am.logger).Log("msg", "setting config", "user", cfg.User)
 
 	am.alertmanagersMtx.Lock()
 	defer am.alertmanagersMtx.Unlock()
+
 	existing, hasExisting := am.alertmanagers[cfg.User]
 
 	rawCfg := cfg.RawConfig
+	var userAmConfig *amconfig.Config
+	var err error
 	if cfg.RawConfig == "" {
 		if am.fallbackConfig == "" {
 			return fmt.Errorf("blank Alertmanager configuration for %v", cfg.User)
@@ -726,6 +690,11 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 	// 3) finally, the cortex AM instance is restarted and the running version is no longer present
 	if userAmConfig == nil {
 		return fmt.Errorf("no usable Alertmanager configuration for %v", cfg.User)
+	}
+
+	templates := make([]io.Reader, 0, len(cfg.Templates))
+	for _, tmpl := range cfg.Templates {
+		templates = append(templates, strings.NewReader(tmpl.Body))
 	}
 
 	// If no Alertmanager instance exists for this user yet, start one.

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -670,6 +671,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 		}
 	}
 
+	templates := make([]io.Reader, 0, len(cfg.Templates))
 	for _, tmpl := range cfg.Templates {
 		templateFilePath, err := safeTemplateFilepath(userTemplateDir, tmpl.Filename)
 		if err != nil {
@@ -679,6 +681,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 		// Removing from pathsToRemove map the files that still exists in the config
 		delete(pathsToRemove, templateFilePath)
 		hasChanged, err := storeTemplateFile(templateFilePath, tmpl.Body)
+		templates = append(templates, strings.NewReader(tmpl.Body))
 		if err != nil {
 			return err
 		}
@@ -734,7 +737,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 	// If no Alertmanager instance exists for this user yet, start one.
 	if !hasExisting {
 		level.Debug(am.logger).Log("msg", "initializing new per-tenant alertmanager", "user", cfg.User)
-		newAM, err := am.newAlertmanager(cfg.User, userAmConfig, rawCfg)
+		newAM, err := am.newAlertmanager(cfg.User, userAmConfig, templates, rawCfg)
 		if err != nil {
 			return err
 		}
@@ -742,7 +745,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 	} else if am.cfgs[cfg.User].RawConfig != cfg.RawConfig || hasTemplateChanges {
 		level.Info(am.logger).Log("msg", "updating new per-tenant alertmanager", "user", cfg.User)
 		// If the config changed, apply the new one.
-		err := existing.ApplyConfig(cfg.User, userAmConfig, rawCfg)
+		err := existing.ApplyConfig(cfg.User, userAmConfig, templates, rawCfg)
 		if err != nil {
 			return fmt.Errorf("unable to apply Alertmanager config for user %v: %v", cfg.User, err)
 		}
@@ -756,7 +759,7 @@ func (am *MultitenantAlertmanager) getTenantDirectory(userID string) string {
 	return filepath.Join(am.cfg.DataDir, userID)
 }
 
-func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amconfig.Config, rawCfg string) (*Alertmanager, error) {
+func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amconfig.Config, templates []io.Reader, rawCfg string) (*Alertmanager, error) {
 	reg := prometheus.NewRegistry()
 
 	tenantDir := am.getTenantDirectory(userID)
@@ -783,7 +786,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 		return nil, fmt.Errorf("unable to start Alertmanager for user %v: %v", userID, err)
 	}
 
-	if err := newAM.ApplyConfig(userID, amConfig, rawCfg); err != nil {
+	if err := newAM.ApplyConfig(userID, amConfig, templates, rawCfg); err != nil {
 		return nil, fmt.Errorf("unable to apply initial config for user %v: %v", userID, err)
 	}
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -656,7 +656,6 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alertspb.AlertCon
 func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error {
 	var userAmConfig *amconfig.Config
 	var err error
-	var hasTemplateChanges bool
 	var userTemplateDir = filepath.Join(am.getTenantDirectory(cfg.User), templatesDir)
 	var pathsToRemove = make(map[string]struct{})
 
@@ -680,14 +679,10 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 
 		// Removing from pathsToRemove map the files that still exists in the config
 		delete(pathsToRemove, templateFilePath)
-		hasChanged, err := storeTemplateFile(templateFilePath, tmpl.Body)
+		_, err = storeTemplateFile(templateFilePath, tmpl.Body)
 		templates = append(templates, strings.NewReader(tmpl.Body))
 		if err != nil {
 			return err
-		}
-
-		if hasChanged {
-			hasTemplateChanges = true
 		}
 	}
 
@@ -696,7 +691,6 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 		if err != nil {
 			level.Warn(am.logger).Log("msg", "failed to remove file", "file", pathToRemove, "err", err)
 		}
-		hasTemplateChanges = true
 	}
 
 	level.Debug(am.logger).Log("msg", "setting config", "user", cfg.User)
@@ -742,7 +736,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 			return err
 		}
 		am.alertmanagers[cfg.User] = newAM
-	} else if am.cfgs[cfg.User].RawConfig != cfg.RawConfig || hasTemplateChanges {
+	} else if configChanged(am.cfgs[cfg.User], cfg) {
 		level.Info(am.logger).Log("msg", "updating new per-tenant alertmanager", "user", cfg.User)
 		// If the config changed, apply the new one.
 		err := existing.ApplyConfig(cfg.User, userAmConfig, templates, rawCfg)
@@ -1227,4 +1221,35 @@ func storeTemplateFile(templateFilepath, content string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func configChanged(left, right alertspb.AlertConfigDesc) bool {
+	if left.User != right.User {
+		return true
+	}
+	if left.RawConfig != right.RawConfig {
+		return true
+	}
+
+	existing := make(map[string]string)
+	for _, tm := range left.Templates {
+		existing[tm.Filename] = tm.Body
+	}
+
+	for _, tm := range right.Templates {
+		corr, ok := existing[tm.Filename]
+		if !ok {
+			return true // Right has a template that left does not.
+		}
+		if corr != tm.Body {
+			return true // The template content is different.
+		}
+		delete(existing, tm.Filename)
+	}
+
+	if len(existing) != 0 {
+		return true // Left has a template that right does not.
+	}
+
+	return false
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -66,10 +66,10 @@ receivers:
   - name: dummy`
 
 	simpleConfigTwo = `route:
-  receiver: dummy
+  receiver: dummy2
 
 receivers:
-  - name: dummy`
+  - name: dummy2`
 
 	simpleTemplateOne = `{{ define "some.template.one" }}{{ end }}`
 	simpleTemplateTwo = `{{ define "some.template.two" }}{{ end }}`
@@ -2276,8 +2276,7 @@ func Test_configChanged(t *testing.T) {
 			},
 			exp: true,
 		},
-		// TODO: this does not work correctly because the configs used for tests do not actually differ.
-		/*{
+		{
 			name: "config changed",
 			left: alertspb.AlertConfigDesc{
 				User:      "user1",
@@ -2300,7 +2299,7 @@ func Test_configChanged(t *testing.T) {
 				},
 			},
 			exp: true,
-		},*/
+		},
 		{
 			name: "template body changed",
 			left: alertspb.AlertConfigDesc{

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -70,6 +70,9 @@ receivers:
 
 receivers:
   - name: dummy`
+
+	simpleTemplateOne = `{{ define "some.template.one" }}{{ end }}`
+	simpleTemplateTwo = `{{ define "some.template.two" }}{{ end }}`
 )
 
 func mockAlertmanagerConfig(t *testing.T) *MultitenantAlertmanagerConfig {
@@ -346,6 +349,28 @@ templates:
 	currentConfig, cfgExists = am.cfgs["user1"]
 	require.True(t, cfgExists)
 	require.Equal(t, simpleConfigTwo, currentConfig.RawConfig)
+	require.Empty(t, currentConfig.Templates)
+
+	// Ensure the config is reloaded if only templates changed
+	require.NoError(t, store.SetAlertConfig(ctx, alertspb.AlertConfigDesc{
+		User:      "user1",
+		RawConfig: simpleConfigTwo,
+		Templates: []*alertspb.TemplateDesc{
+			{
+				Filename: "some-template.tmpl",
+				Body:     simpleTemplateOne,
+			},
+		},
+	}))
+
+	err = am.loadAndSyncConfigs(context.Background(), reasonPeriodic)
+	require.NoError(t, err)
+
+	currentConfig, cfgExists = am.cfgs["user1"]
+	require.True(t, cfgExists)
+	require.Len(t, currentConfig.Templates, 1)
+	require.Equal(t, "some-template.tmpl", currentConfig.Templates[0].Filename)
+	require.Contains(t, currentConfig.Templates[0].Body, "some.template")
 
 	// Test Delete User, ensure config is removed and the resources are freed.
 	require.NoError(t, store.DeleteAlertConfig(ctx, "user3"))
@@ -2184,6 +2209,210 @@ func TestMultitenantAlertmanager_computeFallbackConfig(t *testing.T) {
 	fallbackConfig, err = ComputeFallbackConfig(configFile)
 	require.NoError(t, err)
 	require.Equal(t, simpleConfigOne, string(fallbackConfig))
+}
+
+func Test_configChanged(t *testing.T) {
+	type tc struct {
+		name  string
+		left  alertspb.AlertConfigDesc
+		right alertspb.AlertConfigDesc
+		exp   bool
+	}
+
+	cases := []tc{
+		{
+			name: "matching",
+			left: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+					{
+						Filename: "template-two.tmpl",
+						Body:     simpleTemplateTwo,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+					{
+						Filename: "template-two.tmpl",
+						Body:     simpleTemplateTwo,
+					},
+				},
+			},
+			exp: false,
+		},
+		{
+			name: "user changed",
+			left: alertspb.AlertConfigDesc{
+				User:      "user2",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			exp: true,
+		},
+		// TODO: this does not work correctly because the configs used for tests do not actually differ.
+		/*{
+			name: "config changed",
+			left: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigTwo,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			exp: true,
+		},*/
+		{
+			name: "template body changed",
+			left: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateTwo,
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			name: "template name changed",
+			left: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-two.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			name: "template added",
+			left: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+					{
+						Filename: "template-two.tmpl",
+						Body:     simpleTemplateTwo,
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			name: "template removed",
+			left: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+					{
+						Filename: "template-two.tmpl",
+						Body:     simpleTemplateTwo,
+					},
+				},
+			},
+			right: alertspb.AlertConfigDesc{
+				User:      "user1",
+				RawConfig: simpleConfigOne,
+				Templates: []*alertspb.TemplateDesc{
+					{
+						Filename: "template-one.tmpl",
+						Body:     simpleTemplateOne,
+					},
+				},
+			},
+			exp: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := configChanged(c.left, c.right)
+			require.Equal(t, c.exp, r)
+		})
+	}
 }
 
 type passthroughAlertmanagerClient struct {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -253,9 +253,6 @@ templates:
 		userDir := dirs["user"]
 		require.NotZero(t, userDir)
 		require.True(t, dirExists(t, userDir))
-		require.True(t, dirExists(t, filepath.Join(userDir, templatesDir)))
-		require.True(t, fileExists(t, filepath.Join(userDir, templatesDir, "first.tpl")))
-		require.True(t, fileExists(t, filepath.Join(userDir, templatesDir, "second.tpl")))
 	}
 }
 
@@ -324,9 +321,11 @@ templates:
 	user3Dir := dirs["user3"]
 	require.NotZero(t, user3Dir)
 	require.True(t, dirExists(t, user3Dir))
-	require.True(t, dirExists(t, filepath.Join(user3Dir, templatesDir)))
-	require.True(t, fileExists(t, filepath.Join(user3Dir, templatesDir, "first.tpl")))
-	require.True(t, fileExists(t, filepath.Join(user3Dir, templatesDir, "second.tpl")))
+	finalUser3Cfg, ok := am.cfgs["user3"]
+	require.True(t, ok)
+	require.Len(t, finalUser3Cfg.Templates, 2)
+	require.Equal(t, "first.tpl", finalUser3Cfg.Templates[0].Filename)
+	require.Equal(t, "second.tpl", finalUser3Cfg.Templates[1].Filename)
 
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP cortex_alertmanager_config_last_reload_successful Boolean set to 1 whenever the last configuration reload attempt was successful.
@@ -414,9 +413,6 @@ templates:
 
 	// Hierarchy that existed before should exist again.
 	require.True(t, dirExists(t, user3Dir))
-	require.True(t, dirExists(t, filepath.Join(user3Dir, templatesDir)))
-	require.True(t, fileExists(t, filepath.Join(user3Dir, templatesDir, "first.tpl")))
-	require.True(t, fileExists(t, filepath.Join(user3Dir, templatesDir, "second.tpl")))
 
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP cortex_alertmanager_config_last_reload_successful Boolean set to 1 whenever the last configuration reload attempt was successful.
@@ -440,8 +436,6 @@ templates:
 	require.NoError(t, err)
 
 	require.True(t, dirExists(t, user3Dir))
-	require.True(t, fileExists(t, filepath.Join(user3Dir, templatesDir, "first.tpl")))
-	require.False(t, fileExists(t, filepath.Join(user3Dir, templatesDir, "second.tpl")))
 }
 
 func TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Currently, we pass notification templates to tenant alertmanagers by way of the disk - we write them to a directory, and pass that directory to the alertmanager which then reads the templates.

With https://github.com/prometheus/alertmanager/pull/3225, this is no longer necessary. Alertmanager can be initialized directly with templates in memory.

This PR leverages the above to remove the disk dependency at a few crucial points in the config reload flow:
- Alertmanagers no longer need to read the tenant `templates` directory when starting up.
- Change detection for tenant configurations no longer needs to read state from disk.
- We no longer need to write templates to disk, at all.

This has a number of benefits:
- Significantly faster reloads of configuration.
- Updating the templates on disk was previously done outside of the AM config mutex. This PR eliminates race conditions around this area, and makes `setConfig` thread-safe.
- One dependency on the disk is removed, which a step toward easier operability.

**What about rollouts?**

Currently, this PR simply starts ignoring any existing user `/template` directories. It does not attempt to actively delete them. Some will disappear naturally as tenant directories are cleaned up, but stale data will still exist for some tenants. This is done initially to make the rollout process simpler and remove edge cases with tenants being shuffled, resulting in the templates on disk being unexpectedly missing.

I suspect we **are** able to clean them up on startup since this data is only ever _typically_ stored in a per-instance directory anyway. Tenant shuffles would then call `setConfig` when moved to a new instance, which will re-create any deleted templates on the new node if that node's version is older. I'm happy to implement this if we feel comfortable with this plan, but also am open to feedback here.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
