### PR TITLE
Allow to filter based on folder for mimirtool anlyze grafana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] analyze prometheus: allow to specify `-prometheus-http-prefix`. #4966
+* [ENHANCEMENT] analyze grafana: allow to specify `--folder-title` to limit dashboards analysis based on their exact folder title. #4973
 
 ## 2.8.0
 

--- a/docs/sources/mimir/operators-guide/tools/mimirtool.md
+++ b/docs/sources/mimir/operators-guide/tools/mimirtool.md
@@ -477,11 +477,12 @@ mimirtool analyze grafana --address=<url>
 
 ##### Configuration
 
-| Environment variable | Flag        | Description                                                                                                                     |
-| -------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `GRAFANA_ADDRESS`    | `--address` | Sets the address of the Grafana instance.                                                                                       |
-| `GRAFANA_API_KEY`    | `--key`     | Sets the API Key for the Grafana instance. To create a key, refer to [Authentication API](/docs/grafana/latest/http_api/auth/). |
-| -                    | `--output`  | Sets the output file path, which by default is `metrics-in-grafana.json`.                                                       |
+| Environment variable | Flag             | Description                                                                                                                                                           |
+| -------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GRAFANA_ADDRESS`    | `--address`      | Sets the address of the Grafana instance.                                                                                                                             |
+| `GRAFANA_API_KEY`    | `--key`          | Sets the API Key for the Grafana instance. To create a key, refer to [Authentication API](/docs/grafana/latest/http_api/auth/).                                       |
+| -                    | `--output`       | Sets the output file path, which by default is `metrics-in-grafana.json`.                                                                                             |
+| -                    | `--folder-title` | Sets the folder filter to limit dashboards analysis for unused metrics based on their exact folder title. When repeated any of the matching folders will be analyzed. |
 
 ##### Example output file
 

--- a/pkg/mimirtool/commands/analyse.go
+++ b/pkg/mimirtool/commands/analyse.go
@@ -67,6 +67,8 @@ func (cmd *AnalyzeCommand) Register(app *kingpin.Application, envVars EnvVarName
 	grafanaAnalyzeCmd.Flag("output", "The path for the output file").
 		Default("metrics-in-grafana.json").
 		StringVar(&gaCmd.outputFile)
+	grafanaAnalyzeCmd.Flag("folder-title", "Limit dashboards analysis for unused metrics based on their exact folder title. When repeated any of the matching folders will be analyzed.").
+		SetValue(&gaCmd.folders)
 
 	raCmd := &RulerAnalyzeCommand{}
 	rulerAnalyzeCmd := analyzeCmd.Command("ruler", "Analyze and extract the metrics that are used in Grafana Mimir rules").

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana-tools/sdk"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -26,8 +28,24 @@ type GrafanaAnalyzeCommand struct {
 	address     string
 	apiKey      string
 	readTimeout time.Duration
+	folders     folderTitles
 
 	outputFile string
+}
+
+type folderTitles []string
+
+func (f *folderTitles) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+func (f folderTitles) String() string {
+	return strings.Join(f, ",")
+}
+
+func (f folderTitles) IsCumulative() bool {
+	return true
 }
 
 func (cmd *GrafanaAnalyzeCommand) run(k *kingpin.ParseContext) error {
@@ -47,7 +65,12 @@ func (cmd *GrafanaAnalyzeCommand) run(k *kingpin.ParseContext) error {
 		return err
 	}
 
+	filterOnFolders := len(cmd.folders) > 0
+
 	for _, link := range boardLinks {
+		if filterOnFolders && !slices.Contains(cmd.folders, link.FolderTitle) {
+			continue
+		}
 		data, _, err := c.GetRawDashboardByUID(ctx, link.UID)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s for %s %s\n", err, link.UID, link.Title)


### PR DESCRIPTION
#### What this PR does

In shared environment, it is expected to have several teams within the same Grafana's organization. Team A might store its dashboard in folder A and Team B in folder B. Without filtering on folder we can have false positive on unused series.

This commit allow users to specify from which folders to keep the dashboards. The flag might be repeated as users might have several source folders

```
mimirtool analyze grafana --folder-titles "00 / Ready to use Prometheus dashboards" --folder-titles "01 / Dedicated Folder Team A"
mimirtool analyze grafana --folder-titles "00 / Ready to use Prometheus dashboards" --folder-titles "01 / Dedicated Folder Team B"
```
#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
