### PR TITLE
mixin: remove MimirQuerierHighRefetchRate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 * [ENHANCEMENT] Alertmanager dashboard: display active aggregation groups #4772
 * [ENHANCEMENT] Alerts: `MimirIngesterTSDBWALCorrupted` now only fires when there are more than one corrupted WALs in single-zone deployments and when there are more than two zones affected in multi-zone deployments. #4920
+* [CHANGE] Alerts: Remove `MimirQuerierHighRefetchRate`. #4980
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@
 
 ### Mixin
 
+* [CHANGE] Alerts: Remove `MimirQuerierHighRefetchRate`. #4980
 * [ENHANCEMENT] Alertmanager dashboard: display active aggregation groups #4772
 * [ENHANCEMENT] Alerts: `MimirIngesterTSDBWALCorrupted` now only fires when there are more than one corrupted WALs in single-zone deployments and when there are more than two zones affected in multi-zone deployments. #4920
-* [CHANGE] Alerts: Remove `MimirQuerierHighRefetchRate`. #4980
 
 ### Jsonnet
 

--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -521,15 +521,6 @@ How to **investigate**:
 
 - Look for any scan error in the querier logs (ie. networking or rate limiting issues)
 
-### MimirQuerierHighRefetchRate
-
-This alert fires when there's an high number of queries for which series have been refetched from a different store-gateway because of missing blocks. This could happen for a short time whenever a store-gateway ring resharding occurs (e.g. during/after an outage or while rolling out store-gateway) but store-gateways should reconcile in a short time. This alert fires if the issue persist for an unexpected long time and thus it should be investigated.
-
-How to **investigate**:
-
-- Ensure there are no errors related to blocks scan or sync in the queriers and store-gateways
-- Check store-gateway logs to see if all store-gateway have successfully completed a blocks sync
-
 ### MimirStoreGatewayHasNotSyncTheBucket
 
 This alert fires when a Mimir store-gateway is not successfully scanning blocks in the storage (bucket). A store-gateway is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket for a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -760,26 +760,6 @@ spec:
       for: 5m
       labels:
         severity: critical
-    - alert: MimirQuerierHighRefetchRate
-      annotations:
-        message: Mimir Queries in {{ $labels.cluster }}/{{ $labels.namespace }} are
-          refetching series from different store-gateways (because of missing blocks)
-          for the {{ printf "%.0f" $value }}% of queries.
-        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirquerierhighrefetchrate
-      expr: |
-        100 * (
-          (
-            sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-            -
-            sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_bucket{le="0.0"}[5m]))
-          )
-          /
-          sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-        )
-        > 1
-      for: 10m
-      labels:
-        severity: warning
     - alert: MimirStoreGatewayHasNotSyncTheBucket
       annotations:
         message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -740,26 +740,6 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: MimirQuerierHighRefetchRate
-    annotations:
-      message: Mimir Queries in {{ $labels.cluster }}/{{ $labels.namespace }} are
-        refetching series from different store-gateways (because of missing blocks)
-        for the {{ printf "%.0f" $value }}% of queries.
-      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirquerierhighrefetchrate
-    expr: |
-      100 * (
-        (
-          sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-          -
-          sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_bucket{le="0.0"}[5m]))
-        )
-        /
-        sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-      )
-      > 1
-    for: 10m
-    labels:
-      severity: warning
   - alert: MimirStoreGatewayHasNotSyncTheBucket
     annotations:
       message: Mimir store-gateway {{ $labels.instance }} in {{ $labels.cluster }}/{{

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -748,26 +748,6 @@ groups:
     for: 5m
     labels:
       severity: critical
-  - alert: MimirQuerierHighRefetchRate
-    annotations:
-      message: Mimir Queries in {{ $labels.cluster }}/{{ $labels.namespace }} are
-        refetching series from different store-gateways (because of missing blocks)
-        for the {{ printf "%.0f" $value }}% of queries.
-      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirquerierhighrefetchrate
-    expr: |
-      100 * (
-        (
-          sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-          -
-          sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_bucket{le="0.0"}[5m]))
-        )
-        /
-        sum by(cluster, namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-      )
-      > 1
-    for: 10m
-    labels:
-      severity: warning
   - alert: MimirStoreGatewayHasNotSyncTheBucket
     annotations:
       message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -200,30 +200,6 @@
           },
         },
         {
-          // Alert if the number of queries for which we had to refetch series from different store-gateways
-          // (because of missing blocks) is greater than a %.
-          alert: $.alertName('QuerierHighRefetchRate'),
-          'for': '10m',
-          expr: |||
-            100 * (
-              (
-                sum by(%(alert_aggregation_labels)s) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-                -
-                sum by(%(alert_aggregation_labels)s) (rate(cortex_querier_storegateway_refetches_per_query_bucket{le="0.0"}[5m]))
-              )
-              /
-              sum by(%(alert_aggregation_labels)s) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
-            )
-            > 1
-          ||| % $._config,
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: '%(product)s Queries in %(alert_aggregation_variables)s are refetching series from different store-gateways (because of missing blocks) for the {{ printf "%%.0f" $value }}%% of queries.' % $._config,
-          },
-        },
-        {
           // Alert if the store-gateway is not successfully synching the bucket.
           alert: $.alertName('StoreGatewayHasNotSyncTheBucket'),
           'for': '5m',


### PR DESCRIPTION
#### What this PR does

This alert fires every time there is a store-gateway restart. This makes this alert very rarely actionable. Refetches themselves also aren't a problem. There are other alerts that will fire when store-gateways are unavailable (MimirRequestErrors) or overwhelmed (MimirSchedulerQueriesStuck).

I am not in a hurry to merge this and am interested in feedback.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
