### PR TITLE
helm: fix weekly release version calculation

### DIFF
--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -42,14 +42,12 @@ increment_semver() {
   echo $(local IFS=$delimiter ; echo "${array[*]}")
 }
 
-# Sets a part of the semver string
+# Sets the patch segment of a semver to 0
 # $1: version itself
-# $2: number of part: 0 – major, 1 – minor, 2 – patch
-# $3: the number to set the part to
-set_semver() {
+set_semver_patch_to_zero() {
   local delimiter=.
   local array=($(echo "$1" | tr $delimiter '\n'))
-  array[$2]=$3
+  array[2]="0"
   echo $(local IFS=$delimiter ; echo "${array[*]}")
 }
 
@@ -65,7 +63,7 @@ calculate_next_chart_version() {
     # _This_ weekly release should have a semver that's one above the stable release.
     new_chart_semver=$(increment_semver $current_chart_semver 1)
     # Also reset the patch release number to 0.
-    new_chart_semver=$(set_semver $new_chart_semver 2 0)
+    new_chart_semver=$(set_semver_patch_to_zero $new_chart_semver)
   fi
   echo "$new_chart_semver-weekly.$new_chart_weekly"
 }

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -32,13 +32,24 @@ get_yaml_node() {
   echo $(yq $yaml_node $filename)
 }
 
-# Increments the part of the string
+# Increments the part of the semver string
 # $1: version itself
 # $2: number of part: 0 – major, 1 – minor, 2 – patch
 increment_semver() {
   local delimiter=.
   local array=($(echo "$1" | tr $delimiter '\n'))
   array[$2]=$((array[$2]+1))
+  echo $(local IFS=$delimiter ; echo "${array[*]}")
+}
+
+# Sets a part of the semver string
+# $1: version itself
+# $2: number of part: 0 – major, 1 – minor, 2 – patch
+# $3: the number to set the part to
+set_semver() {
+  local delimiter=.
+  local array=($(echo "$1" | tr $delimiter '\n'))
+  array[$2]=$3
   echo $(local IFS=$delimiter ; echo "${array[*]}")
 }
 
@@ -51,8 +62,10 @@ calculate_next_chart_version() {
   local new_chart_semver=$current_chart_semver
   if [[ $current_chart_version != *weekly* ]]; then
     # If previous version was not a weekly, then it was a stable release.
-    # _This_ weekly release should have a semver that's one above the
+    # _This_ weekly release should have a semver that's one above the stable release.
     new_chart_semver=$(increment_semver $current_chart_semver 1)
+    # Also reset the patch release number to 0.
+    new_chart_semver=$(set_semver $new_chart_semver 2 0)
   fi
   echo "$new_chart_semver-weekly.$new_chart_weekly"
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The weekly release calculates the next weekly semver by incrementing the minor version of the current release.
 But it doesn't reset the patch version. Because of that the weekly release after 4.4.1 is 4.5.1 instead of 4.5.0 ([PR](https://github.com/grafana/mimir/pull/4970)). This PR fixes that.
