### PR TITLE
Ingester shutdown marker improvements

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3905,6 +3905,11 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 1
 				`), "cortex_ingester_shipper_uploads_total"))
+
+				// If the ingester isn't "running", requests to the prepare-shutdown endpoint should fail
+				response6 := httptest.NewRecorder()
+				i.PrepareShutdownHandler(response6, httptest.NewRequest("POST", "/ingester/prepare-shutdown", nil))
+				require.Equal(t, 503, response6.Code)
 			},
 		},
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3864,7 +3864,7 @@ func TestIngester_flushing(t *testing.T) {
 
 				response1 := httptest.NewRecorder()
 				i.PrepareShutdownHandler(response1, httptest.NewRequest("GET", "/ingester/prepare-shutdown", nil))
-				require.Equal(t, "unset", response1.Body.String())
+				require.Equal(t, "unset\n", response1.Body.String())
 				require.Equal(t, 200, response1.Code)
 
 				response2 := httptest.NewRecorder()
@@ -3879,7 +3879,7 @@ func TestIngester_flushing(t *testing.T) {
 
 				response3 := httptest.NewRecorder()
 				i.PrepareShutdownHandler(response3, httptest.NewRequest("GET", "/ingester/prepare-shutdown", nil))
-				require.Equal(t, "set", response3.Body.String())
+				require.Equal(t, "set\n", response3.Body.String())
 				require.Equal(t, 200, response3.Code)
 
 				response4 := httptest.NewRecorder()

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -288,8 +288,12 @@ func (g *StoreGateway) running(ctx context.Context) error {
 
 func (g *StoreGateway) stopping(_ error) error {
 	if g.subservices != nil {
-		return services.StopManagerAndAwaitStopped(context.Background(), g.subservices)
+		if err := services.StopManagerAndAwaitStopped(context.Background(), g.subservices); err != nil {
+			level.Warn(g.logger).Log("msg", "failed to stop store-gateway subservices", "err", err)
+		}
 	}
+
+	g.unsetPrepareShutdownMarker()
 	return nil
 }
 

--- a/pkg/storegateway/gateway_prepare_shutdown_http.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http.go
@@ -42,9 +42,9 @@ func (g *StoreGateway) PrepareShutdownHandler(w http.ResponseWriter, req *http.R
 		}
 
 		if exists {
-			util.WriteTextResponse(w, "set")
+			util.WriteTextResponse(w, "set\n")
 		} else {
-			util.WriteTextResponse(w, "unset")
+			util.WriteTextResponse(w, "unset\n")
 		}
 	case http.MethodPost:
 		if err := shutdownmarker.Create(shutdownMarkerPath); err != nil {

--- a/pkg/storegateway/gateway_prepare_shutdown_http.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http.go
@@ -3,15 +3,14 @@
 package storegateway
 
 import (
-	"github.com/grafana/dskit/services"
 	"net/http"
 
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 
-	"github.com/grafana/mimir/pkg/util/shutdownmarker"
-
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/shutdownmarker"
 )
 
 // PrepareShutdownHandler possibly changes the configuration of the store-gateway in such a way

--- a/pkg/storegateway/gateway_prepare_shutdown_http.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
 
-	"github.com/grafana/dskit/services"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/shutdownmarker"
 )

--- a/pkg/storegateway/gateway_prepare_shutdown_http.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http.go
@@ -102,3 +102,12 @@ func (g *StoreGateway) setPrepareShutdownFromShutdownMarker() error {
 
 	return nil
 }
+
+// unsetPrepareShutdownMarker is executed when the store-gateway successfully shuts down and removes the
+// shutdown marker if it is present. It does not modify configuration in any way.
+func (g *StoreGateway) unsetPrepareShutdownMarker() {
+	shutdownMarkerPath := shutdownmarker.GetPath(g.storageCfg.BucketStore.SyncDir)
+	if err := shutdownmarker.Remove(shutdownMarkerPath); err != nil {
+		level.Warn(g.logger).Log("msg", "failed to remove shutdown marker", "path", shutdownMarkerPath, "err", err)
+	}
+}

--- a/pkg/storegateway/gateway_prepare_shutdown_http_test.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http_test.go
@@ -65,7 +65,7 @@ func TestStoreGateway_PrepareShutdownHandler(t *testing.T) {
 	// after GET is invoked, the expected result is "unset"
 	response1 := httptest.NewRecorder()
 	g.PrepareShutdownHandler(response1, httptest.NewRequest("GET", "/store-gateway/prepare-shutdown", nil))
-	require.Equal(t, "unset", response1.Body.String())
+	require.Equal(t, "unset\n", response1.Body.String())
 	require.Equal(t, 200, response1.Code)
 	exists, err = shutdownmarker.Exists(shutdownMarkerPath)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestStoreGateway_PrepareShutdownHandler(t *testing.T) {
 	// after GET is invoked, the expected result is now "set"
 	response3 := httptest.NewRecorder()
 	g.PrepareShutdownHandler(response3, httptest.NewRequest("GET", "/store-gateway/prepare-shutdown", nil))
-	require.Equal(t, "set", response3.Body.String())
+	require.Equal(t, "set\n", response3.Body.String())
 	require.Equal(t, 200, response3.Code)
 
 	// after DELETE is invoked, the effects of POST get reverted
@@ -125,6 +125,11 @@ func TestStoreGateway_PrepareShutdownHandler(t *testing.T) {
 	require.NoError(t, services.StopAndAwaitTerminated(ctx, g))
 	ringDesc = getRingDesc(ctx, t, ringStore)
 	assert.Empty(t, ringDesc.GetIngesters())
+
+	// Once the store-gateway isn't "running", requests to the prepare-shutdown endpoint should fail
+	response6 := httptest.NewRecorder()
+	g.PrepareShutdownHandler(response6, httptest.NewRequest("POST", "/store-gateway/prepare-shutdown", nil))
+	require.Equal(t, 503, response6.Code)
 }
 
 func TestStoreGateway_InitialisePrepareShutdownAtStartup(t *testing.T) {
@@ -150,7 +155,7 @@ func TestStoreGateway_InitialisePrepareShutdownAtStartup(t *testing.T) {
 	// after GET is invoked, the expected result is "set"
 	response1 := httptest.NewRecorder()
 	g.PrepareShutdownHandler(response1, httptest.NewRequest("GET", "/store-gateway/prepare-shutdown", nil))
-	require.Equal(t, "set", response1.Body.String())
+	require.Equal(t, "set\n", response1.Body.String())
 	require.Equal(t, 200, response1.Code)
 
 	// ensure that cortex_storegateway_prepare_shutdown_requested is 1


### PR DESCRIPTION
#### What this PR does

This PR improves the way shutdown markers for ingesters work. Namely it:

* Removes the shutdown marker while shutting down. The volumes used by ingesters are reused if an ingester is stopped (scaled down) but then later started again with the same name. Removing the marker during shutdown prevents the ingester from unregistering and flushing the next time it is stopped after having already performed its work for "permanently" shutting down.
* Prevents changes to the shutdown marker while the ingester is not running. This prevents the rollout-operator from calling the `prepare-shutdown` endpoint again while the ingester is already in the process of shutting down and about to remove the shutdown marker as noted previously.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
