### PR TITLE
Refactoring: decouple listing tenants from listing rule groups in Ruler

### DIFF
--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -461,7 +461,7 @@ func TestGetRules(t *testing.T) {
 			totalConfiguredRules := 0
 
 			forEachRuler(func(rID string, r *Ruler) {
-				localRules, err := r.listRuleGroupsToSync(context.Background(), rulerSyncReasonPeriodic)
+				localRules, err := r.listRuleGroupsToSyncForAllUsers(context.Background(), rulerSyncReasonPeriodic)
 				require.NoError(t, err)
 				for _, rules := range localRules {
 					totalLoadedRules += len(rules)
@@ -905,7 +905,7 @@ func TestSharding(t *testing.T) {
 			}
 
 			// Always add ruler1 to expected rulers, even if there is no ring (no sharding).
-			loadedRules1, err := r1.listRuleGroupsToSync(context.Background(), rulerSyncReasonPeriodic)
+			loadedRules1, err := r1.listRuleGroupsToSyncForAllUsers(context.Background(), rulerSyncReasonPeriodic)
 			require.NoError(t, err)
 
 			expected := expectedRulesMap{
@@ -915,7 +915,7 @@ func TestSharding(t *testing.T) {
 			addToExpected := func(id string, r *Ruler) {
 				// Only expect rules from other rulers when using ring, and they are present in the ring.
 				if r != nil && rulerRing != nil && rulerRing.HasInstance(id) {
-					loaded, err := r.listRuleGroupsToSync(context.Background(), rulerSyncReasonPeriodic)
+					loaded, err := r.listRuleGroupsToSyncForAllUsers(context.Background(), rulerSyncReasonPeriodic)
 					require.NoError(t, err)
 					// Normalize nil map to empty one.
 					if loaded == nil {


### PR DESCRIPTION
#### What this PR does

This PR propose a small refactoring of `DefaultMultiTenantManager` in order to make an [upcoming PR](https://github.com/grafana/mimir/pull/4975) easier to review.

The refactoring in this PR:
- Decouple listing tenants from listing rule groups in Ruler, moving listing rule groups to sync logic to `listRuleGroupsToSyncForUsers()` (which takes in input the list of tenants)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
