### PR TITLE
Pull images for integration tests in parallel in CI pipeline.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -227,7 +227,7 @@ jobs:
         # We download docker images used by integration tests so that all images are available
         # locally and the download time doesn't account in the test execution time, which is subject
         # to a timeout
-        run: go run ./tools/pre-pull-images | xargs -n1 docker pull
+        run: go run ./tools/pre-pull-images | xargs -n1 -P4 docker pull
       - name: Integration Tests
         run: |
           export IMAGE_TAG=$(make image-tag)


### PR DESCRIPTION
#### What this PR does

This PR modifies the CI pipeline to pull images for integration tests in parallel.

Pulling them sequentially currently takes ~2 minutes and integration tests are often the last job to finish, so improving the speed of the integration test job should improve the overall CI pipeline duration.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
