### PR TITLE
Ruler: do not list rule groups in the object storage for disabled tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * `cortex_alertmanager_silences_maintenance_total`
   * `cortex_alertmanager_silences_maintenance_errors_total`
 * [ENHANCEMENT] Add native histogram support for `cortex_request_duration_seconds` metric family. #4987
+* [ENHANCEMENT] Ruler: do not list rule groups in the object storage for disabled tenants. #5004
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -806,7 +806,7 @@ func TestSharding(t *testing.T) {
 			},
 
 			expectedRules: expectedRulesMap{
-				ruler1: map[string]rulespb.RuleGroupList{},
+				ruler1: nil,
 				ruler2: map[string]rulespb.RuleGroupList{},
 				ruler3: map[string]rulespb.RuleGroupList{
 					user2: {user2Group1},


### PR DESCRIPTION
#### What this PR does
This PR addresses a [comment received here](https://github.com/grafana/mimir/pull/5000#discussion_r1193376083): there's no point listing rule groups for explictely disabled tenants if we'll remove their rule groups right after. So, instead of filter out disabled tenants at the end of `listRuleGroupsToSyncForUsers()`, in this PR I'm moving it at the beginning.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
