### PR TITLE
Split integration tests over more parallel runners.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -190,10 +190,10 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 4 groups.
+      # Split tests into 6 groups.
       matrix:
-        test_group_id:    [0, 1, 2, 3]
-        test_group_total: [4]
+        test_group_id:    [0, 1, 2, 3, 4, 5]
+        test_group_total: [6]
     steps:
       - name: Upgrade golang
         uses: actions/setup-go@v3


### PR DESCRIPTION
#### What this PR does

This PR modifies the CI pipeline to split the integration tests over more runners (ie. run more in parallel).

Integration tests are often the last job to finish, so improving the speed of the integration test job should improve the overall CI pipeline duration.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
