### PR TITLE
Add `-enable-go-runtime-metrics` flag

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -58,6 +58,17 @@
       "fieldCategory": "experimental"
     },
     {
+      "kind": "field",
+      "name": "enable_go_runtime_metrics",
+      "required": false,
+      "desc": "Set to true to enable all Go runtime metrics, such as go_sched_* and go_memstats_*.",
+      "fieldValue": null,
+      "fieldDefaultValue": false,
+      "fieldFlag": "enable-go-runtime-metrics",
+      "fieldType": "boolean",
+      "fieldCategory": "advanced"
+    },
+    {
       "kind": "block",
       "name": "api",
       "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1147,6 +1147,8 @@ Usage of ./cmd/mimir/mimir:
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -enable-go-runtime-metrics
+    	Set to true to enable all Go runtime metrics, such as go_sched_* and go_memstats_*.
   -flusher.exit-after-flush
     	Stop after flush has finished. If false, process will keep running, doing nothing. (default true)
   -h

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -126,6 +126,11 @@ where `default_value` is the value to use if the environment variable is undefin
 # CLI flag: -max-separate-metrics-groups-per-user
 [max_separate_metrics_groups_per_user: <int> | default = 1000]
 
+# (advanced) Set to true to enable all Go runtime metrics, such as go_sched_*
+# and go_memstats_*.
+# CLI flag: -enable-go-runtime-metrics
+[enable_go_runtime_metrics: <boolean> | default = false]
+
 api:
   # (advanced) Allows to skip label name validation via
   # X-Mimir-SkipLabelNameValidation header on the http write path. Use with


### PR DESCRIPTION

#### What this PR does

This flag toggles `go_memstats_` and `go_sched_` metrics. They are disabled by default.

These metrics were shortly included in the default collected metrics by prometheus/client_golang, but were removed in client_golang PR 1033. These metrics have high cardinality (mostly due to some of the histograms), but can be very useful when investigating GC pressure or the effects of GOMAXPROCS.

I took the CLI flag and YAML field name from Tempo which [also has this flag](https://github.com/grafana/tempo/blob/dcf8a2a5b0af920b47603220f7fa1d798d9b1089/cmd/tempo/app/config.go#L36).


#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
