### PR TITLE
Add support to disable cache lookup to CachingBucket

### DIFF
--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -437,9 +437,9 @@ func TestCachedIter(t *testing.T) {
 		// (because result is picked up from the cache).
 		assert.NoError(t, inmem.Upload(context.Background(), "/file-6", strings.NewReader("world")))
 		verifyIter(ctx, t, cb, allFiles, true, true, cfgName)
-		allFiles = append(allFiles, "/file-6")
 
 		// Calling Iter() with cache lookup disabled should return the new object and also update the cached list.
+		allFiles = append(allFiles, "/file-6")
 		verifyIter(WithCacheLookupEnabled(ctx, false), t, cb, allFiles, false, false, cfgName)
 		verifyIter(ctx, t, cb, allFiles, true, true, cfgName)
 	})
@@ -459,8 +459,6 @@ func TestCachedIter(t *testing.T) {
 }
 
 func verifyIter(ctx context.Context, t *testing.T, cb *CachingBucket, expectedFiles []string, expectedCacheLookup, expectedFromCache bool, cfgName string) {
-	t.Helper()
-
 	requestsBefore := int(promtest.ToFloat64(cb.operationRequests.WithLabelValues(objstore.OpIter, cfgName)))
 	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(objstore.OpIter, cfgName)))
 
@@ -575,8 +573,6 @@ func TestExistsCachingDisabled(t *testing.T) {
 }
 
 func verifyExists(ctx context.Context, t *testing.T, cb *CachingBucket, file string, expectedExists, expectedCacheLookup, expectedFromCache bool, cfgName string) {
-	t.Helper()
-
 	requestsBefore := int(promtest.ToFloat64(cb.operationRequests.WithLabelValues(objstore.OpExists, cfgName)))
 	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(objstore.OpExists, cfgName)))
 
@@ -734,8 +730,6 @@ func TestGetPartialRead(t *testing.T) {
 }
 
 func verifyGet(ctx context.Context, t *testing.T, cb *CachingBucket, file string, expectedData []byte, expectedCacheLookup, expectedFromCache bool, cfgName string) {
-	t.Helper()
-
 	requestsBefore := int(promtest.ToFloat64(cb.operationRequests.WithLabelValues(objstore.OpGet, cfgName)))
 	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(objstore.OpGet, cfgName)))
 
@@ -971,8 +965,6 @@ func BenchmarkCachingKey(b *testing.B) {
 }
 
 func verifyObjectAttrs(ctx context.Context, t *testing.T, cb *CachingBucket, file string, expectedLength int, expectedCacheLookup, expectedFromCache bool, cfgName string) {
-	t.Helper()
-
 	requestsBefore := int(promtest.ToFloat64(cb.operationRequests.WithLabelValues(objstore.OpAttributes, cfgName)))
 	hitsBefore := int(promtest.ToFloat64(cb.operationHits.WithLabelValues(objstore.OpAttributes, cfgName)))
 


### PR DESCRIPTION
#### What this PR does
This PR is a preliminary PR before https://github.com/grafana/mimir/pull/4975. In this PR I propose to add support to disable cache lookup to `CachingBucket`: when the cache lookup is disabled, the cache is not checked but the result of the bucket operation is still stored to the cache (eventually overriding the previous one). I've took the opportunity to do some refactoring to the `CachingBucket` tests, trying to clarify what each test case does.

To simplify the review, I've pushed each function change as an individual commit:
- [Add cache lookup disabled support to Iter()](https://github.com/grafana/mimir/commit/4e3b263f72b926e7fcc240d95ff14d5f93d2a61d) 
- [Add cache lookup disabled support to Exists()](https://github.com/grafana/mimir/commit/b064e64d03cf4e491468c4677f7f4c4a2aeac577) 
- [Add cache lookup disabled support to Get()](https://github.com/grafana/mimir/commit/013ac08218a59b89314d379aa10b8f44bd4d76ce) 
- [Add cache lookup disabled support to Attributes()](https://github.com/grafana/mimir/commit/79a72eac4b04f2d6a36f2303293584244de09b43) 
- [Add cache lookup disabled support to GetRange()](https://github.com/grafana/mimir/commit/0de62fb97ebccb8dd8508c3916b88388741897ff) 

_I suggest to review changes with "hide whitespace changes"._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
