### PR TITLE
Only use responses from a minimal set of ingesters when evaluating query results, and immediately cancel query requests to ingesters that we know we won't use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Ruler: do not list rule groups in the object storage for disabled tenants. #5004
 * [ENHANCEMENT] Query-frontend and querier: add HTTP API endpoint `<prometheus-http-prefix>/api/v1/format_query` to format a PromQL query. #4373
 * [ENHANCEMENT] Alertmanager: Add configuration option to enable or disable the deletion of alertmanager state from object storage. This is useful when migrating alertmanager tenants from one cluster to another, because it avoids a condition where the state object is copied but then deleted before the configuration object is copied. #4989
+* [ENHANCEMENT] Querier: only use the minimum set of chunks from ingesters when querying, and cancel unnecessary requests to ingesters sooner if we know their results won't be used. #5016
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -184,7 +184,7 @@ type ingesterQueryResult struct {
 	timeseriesBatches  [][]mimirpb.TimeSeries
 }
 
-// queryIngesterStream queries the ingesters using the new streaming API.
+// queryIngesterStream queries the ingesters using the gRPC streaming API.
 func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ring.ReplicationSet, req *ingester_client.QueryRequest) (*ingester_client.QueryStreamResponse, error) {
 	queryLimiter := limiter.QueryLimiterFromContextWithFallback(ctx)
 	reqStats := stats.FromContext(ctx)

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -178,130 +178,125 @@ func mergeExemplarQueryResponses(results []interface{}) *ingester_client.Exempla
 	return &ingester_client.ExemplarQueryResponse{Timeseries: result}
 }
 
+type ingesterQueryResult struct {
+	// Why retain the batches rather than build a single slice? We don't need a single slice for each ingester, so building a single slice for each ingester is a waste of time.
+	chunkseriesBatches [][]ingester_client.TimeSeriesChunk
+	timeseriesBatches  [][]mimirpb.TimeSeries
+}
+
 // queryIngesterStream queries the ingesters using the new streaming API.
 func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ring.ReplicationSet, req *ingester_client.QueryRequest) (*ingester_client.QueryStreamResponse, error) {
-	var (
-		queryLimiter = limiter.QueryLimiterFromContextWithFallback(ctx)
-		reqStats     = stats.FromContext(ctx)
-		results      = make(chan *ingester_client.QueryStreamResponse)
-		// Note we can't signal goroutines to stop by closing 'results', because it has multiple concurrent senders.
-		stop        = make(chan struct{}) // Signal all background goroutines to stop.
-		doneReading = make(chan struct{}) // Signal that the reader has stopped.
-	)
+	queryLimiter := limiter.QueryLimiterFromContextWithFallback(ctx)
+	reqStats := stats.FromContext(ctx)
 
-	hashToChunkseries := map[string]ingester_client.TimeSeriesChunk{}
-	hashToTimeSeries := map[string]mimirpb.TimeSeries{}
-
-	// Start reading and accumulating responses. stopReading chan will
-	// be closed when all calls to ingesters have finished.
-	go func() {
-		// We keep track of the number of chunks that were able to be deduplicated entirely
-		// via the accumulateChunks function (fast) instead of needing to merge samples one
-		// by one (slow). Useful to verify the performance impact of things that potentially
-		// result in different samples being written to each ingester.
-		var numDeduplicatedChunks int
-		var numTotalChunks int
-
-		defer func() {
-			close(doneReading)
-			d.ingesterChunksDeduplicated.Add(float64(numDeduplicatedChunks))
-			d.ingesterChunksTotal.Add(float64(numTotalChunks))
-		}()
-
-		for {
-			select {
-			case <-stop:
-				return
-			case response := <-results:
-				// Accumulate any chunk series
-				for _, series := range response.Chunkseries {
-					key := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(series.Labels))
-					existing := hashToChunkseries[key]
-					existing.Labels = series.Labels
-
-					numPotentialChunks := len(existing.Chunks) + len(series.Chunks)
-					existing.Chunks = accumulateChunks(existing.Chunks, series.Chunks)
-
-					numDeduplicatedChunks += numPotentialChunks - len(existing.Chunks)
-					numTotalChunks += len(series.Chunks)
-					hashToChunkseries[key] = existing
-				}
-
-				// Accumulate any time series
-				for _, series := range response.Timeseries {
-					key := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(series.Labels))
-					existing := hashToTimeSeries[key]
-					existing.Labels = series.Labels
-					if existing.Samples == nil {
-						existing.Samples = series.Samples
-					} else {
-						existing.Samples = mergeSamples(existing.Samples, series.Samples)
-					}
-					hashToTimeSeries[key] = existing
-				}
-			}
-		}
-	}()
-
-	// Fetch samples from multiple ingesters, and send them to the results chan
-	_, err := replicationSet.Do(ctx, 0, func(ctx context.Context, ing *ring.InstanceDesc) (interface{}, error) {
+	queryIngester := func(ctx context.Context, ing *ring.InstanceDesc) (ingesterQueryResult, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
-			return nil, err
+			return ingesterQueryResult{}, err
 		}
 
 		stream, err := client.(ingester_client.IngesterClient).QueryStream(ctx, req)
 		if err != nil {
-			return nil, err
+			return ingesterQueryResult{}, err
 		}
+
 		defer stream.CloseSend() //nolint:errcheck
+
+		result := ingesterQueryResult{}
 
 		for {
 			resp, err := stream.Recv()
 			if errors.Is(err, io.EOF) {
-				break
+				return result, nil
 			} else if err != nil {
-				return nil, err
+				return ingesterQueryResult{}, err
 			}
 
-			// Enforce the max chunks limits.
-			if chunkLimitErr := queryLimiter.AddChunks(resp.ChunksCount()); chunkLimitErr != nil {
-				return nil, validation.LimitError(chunkLimitErr.Error())
-			}
-
-			for _, series := range resp.Chunkseries {
-				if limitErr := queryLimiter.AddSeries(series.Labels); limitErr != nil {
-					return nil, validation.LimitError(limitErr.Error())
+			if len(resp.Timeseries) > 0 {
+				for _, series := range resp.Timeseries {
+					if limitErr := queryLimiter.AddSeries(series.Labels); limitErr != nil {
+						return ingesterQueryResult{}, validation.LimitError(limitErr.Error())
+					}
 				}
-			}
 
-			if chunkBytesLimitErr := queryLimiter.AddChunkBytes(resp.ChunksSize()); chunkBytesLimitErr != nil {
-				return nil, validation.LimitError(chunkBytesLimitErr.Error())
-			}
-
-			for _, series := range resp.Timeseries {
-				if limitErr := queryLimiter.AddSeries(series.Labels); limitErr != nil {
-					return nil, validation.LimitError(limitErr.Error())
+				result.timeseriesBatches = append(result.timeseriesBatches, resp.Timeseries)
+			} else if len(resp.Chunkseries) > 0 {
+				// Enforce the max chunks limits.
+				if chunkLimitErr := queryLimiter.AddChunks(resp.ChunksCount()); chunkLimitErr != nil {
+					return ingesterQueryResult{}, validation.LimitError(chunkLimitErr.Error())
 				}
-			}
 
-			// This goroutine could be left running after replicationSet.Do() returns,
-			// so check before writing to the results chan.
-			select {
-			case <-stop:
-				return nil, nil
-			case results <- resp:
+				for _, series := range resp.Chunkseries {
+					if limitErr := queryLimiter.AddSeries(series.Labels); limitErr != nil {
+						return ingesterQueryResult{}, validation.LimitError(limitErr.Error())
+					}
+				}
+
+				if chunkBytesLimitErr := queryLimiter.AddChunkBytes(resp.ChunksSize()); chunkBytesLimitErr != nil {
+					return ingesterQueryResult{}, validation.LimitError(chunkBytesLimitErr.Error())
+				}
+
+				result.chunkseriesBatches = append(result.chunkseriesBatches, resp.Chunkseries)
 			}
 		}
-		return nil, nil
-	})
-	close(stop)
+	}
+
+	cleanup := func(result ingesterQueryResult) {
+		// Nothing to do.
+	}
+
+	results, err := ring.DoUntilQuorum(ctx, replicationSet, queryIngester, cleanup)
 	if err != nil {
 		return nil, err
 	}
 
-	// Wait for reading loop to finish.
-	<-doneReading
+	// We keep track of the number of chunks that were able to be deduplicated entirely
+	// via the AccumulateChunks function (fast) instead of needing to merge samples one
+	// by one (slow). Useful to verify the performance impact of things that potentially
+	// result in different samples being written to each ingester.
+	deduplicatedChunks := 0
+	totalChunks := 0
+	defer func() {
+		d.ingesterChunksDeduplicated.Add(float64(deduplicatedChunks))
+		d.ingesterChunksTotal.Add(float64(totalChunks))
+	}()
+
+	hashToChunkseries := map[string]ingester_client.TimeSeriesChunk{}
+	hashToTimeSeries := map[string]mimirpb.TimeSeries{}
+
+	for _, res := range results {
+		// Accumulate any chunk series
+		for _, batch := range res.chunkseriesBatches {
+			for _, series := range batch {
+				key := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(series.Labels))
+				existing := hashToChunkseries[key]
+				existing.Labels = series.Labels
+
+				numPotentialChunks := len(existing.Chunks) + len(series.Chunks)
+				existing.Chunks = accumulateChunks(existing.Chunks, series.Chunks)
+
+				deduplicatedChunks += numPotentialChunks - len(existing.Chunks)
+				totalChunks += len(series.Chunks)
+				hashToChunkseries[key] = existing
+			}
+		}
+
+		// Accumulate any time series
+		for _, batch := range res.timeseriesBatches {
+			for _, series := range batch {
+				key := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(series.Labels))
+				existing := hashToTimeSeries[key]
+				existing.Labels = series.Labels
+				if existing.Samples == nil {
+					existing.Samples = series.Samples
+				} else {
+					existing.Samples = mergeSamples(existing.Samples, series.Samples)
+				}
+				hashToTimeSeries[key] = existing
+			}
+		}
+	}
+
 	// Now turn the accumulated maps into slices.
 	resp := &ingester_client.QueryStreamResponse{
 		Chunkseries: make([]ingester_client.TimeSeriesChunk, 0, len(hashToChunkseries)),

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -483,6 +483,10 @@ func BenchmarkDistributorQueryable_Select(b *testing.B) {
 	promChunk, err := chunk.NewForEncoding(chunk.PrometheusXorChunk)
 	require.NoError(b, err)
 
+	overflowChunk, err := promChunk.Add(model.SamplePair{Timestamp: model.Now(), Value: 1})
+	require.NoError(b, err)
+	require.Nil(b, overflowChunk)
+
 	clientChunks, err := chunkcompat.ToChunks([]chunk.Chunk{
 		chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Earliest),
 	})


### PR DESCRIPTION
#### What this PR does

This PR modifies the behaviour of queriers when querying ingesters:

* Previously, queriers used responses from all ingesters that responded before quorum was reached. With this change, queriers will only use responses from the minimum set of ingesters required to reach quorum, reducing the number of series that need to be merged and chunks that need to be deduplicated without affecting our current query correctness guarantees.

* Previously, queriers only cancelled requests to ingesters once quorum was reached. With this change, queriers will immediately cancel requests to ingesters once they know the responses will not be used (eg. because another ingester in the same zone returned an error).

This is best illustrated with an example. Let's say we're running three zones, with three ingesters in each zone and a maximum of one unavailable zone. A querier issues query requests to all ingesters, and receives the following responses, in this order:

1. zone A, ingester 1: successful response
2. zone A, ingester 2: successful response
3. zone A, ingester 3: successful response
4. zone B, ingester 1: error response
5. zone C, ingester 1: successful response
6. zone C, ingester 2: successful response
7. zone B, ingester 2: successful response
8. zone C, ingester 3: successful response (at this point, quorum is reached)

Previously, the querier would use all successful responses to evaluate the query - so responses 1-3 and 5-8 for a total of 7 responses. With this change, the querier would use only the responses from zones A and C (1-3, 5, 6 and 7, for a total of 6 responses).

At the same time, previously, the querier would have only cancelled the outstanding request to zone B ingester 3 once response 8 was received. With this change, the querier would cancel all requests to zone B as soon as the fourth response, from zone B ingester 1, is received, as we know we won't use any responses from zone B once one ingester returns an error.

These changes are expected to reduce the overall CPU and memory utilisation of both ingesters and queriers, with querier CPU utilisation expected to receive the biggest benefit. However, this change may increase querier memory utilisation peaks (see [comment below](https://github.com/grafana/mimir/pull/5016#discussion_r1194722628)).

#### Which issue(s) this PR fixes or relates to

(this has been split out from #4886)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
