### PR TITLE
Don't allow autoscaled deployments to have no available replicas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main / unreleased
 
+### Jsonnet
+
+* [BUGFIX] Don't allow auto-scaled deployments to have no available replicas. #5017
+
 ## 2.9.0-rc.0
 
 ### Grafana Mimir
@@ -105,7 +109,6 @@
 * [ENHANCEMENT] Store-gateway: add `store_gateway_lazy_loading_enabled` configuration option which combines disabled lazy-loading and reducing blocks sync concurrency. Reducing blocks sync concurrency improves startup times with disabled lazy loading on HDDs. #5025
 * [ENHANCEMENT] Update `rollout-operator` image to `v0.6.0`. #5155
 * [BUGFIX] Backend: configure `-ruler.alertmanager-url` to `mimir-backend` when running in read-write deployment mode. #4892
-* [BUGFIX] Don't allow auto-scaled deployments to have no available replicas. #5017
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 * [ENHANCEMENT] Store-gateway: add `store_gateway_lazy_loading_enabled` configuration option which combines disabled lazy-loading and reducing blocks sync concurrency. Reducing blocks sync concurrency improves startup times with disabled lazy loading on HDDs. #5025
 * [ENHANCEMENT] Update `rollout-operator` image to `v0.6.0`. #5155
 * [BUGFIX] Backend: configure `-ruler.alertmanager-url` to `mimir-backend` when running in read-write deployment mode. #4892
+* [BUGFIX] Don't allow auto-scaled deployments to have no available replicas. #5017
 
 ### Mimirtool
 

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -44,16 +44,14 @@
   local deployment = $.apps.v1.deployment,
 
   // Don't allow all distributors to be unavailable.
-  local fixed_replica_count = 3,
-
   local max_unavailable =
     if $._config.autoscaling_distributor_enabled then
       if $._config.autoscaling_distributor_min_replicas <= 1 then 0 else 1
     else
-      if fixed_replica_count <= 1 then 0 else 1,
+      if $.distributor_deployment.spec.replicas <= 1 then 0 else 1,
 
   distributor_deployment: if !$._config.is_microservices_deployment_mode then null else
-    deployment.new('distributor', fixed_replica_count, [$.distributor_container]) +
+    deployment.new('distributor', 3, [$.distributor_container]) +
     $.newMimirSpreadTopology('distributor', $._config.distributor_topology_spread_max_skew) +
     $.mimirVolumeMounts +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -44,11 +44,16 @@
   local deployment = $.apps.v1.deployment,
 
   // Don't allow all distributors to be unavailable.
-  local replica_count = 3,
-  local max_unavailable = std.min(1, if ($._config.autoscaling_distributor_enabled) then $._config.autoscaling_distributor_min_replicas - 1 else replica_count - 1),
+  local fixed_replica_count = 3,
+
+  local max_unavailable =
+    if $._config.autoscaling_distributor_enabled then
+      if $._config.autoscaling_distributor_min_replicas <= 1 then 0 else 1
+    else
+      if fixed_replica_count <= 1 then 0 else 1,
 
   distributor_deployment: if !$._config.is_microservices_deployment_mode then null else
-    deployment.new('distributor', replica_count, [$.distributor_container]) +
+    deployment.new('distributor', fixed_replica_count, [$.distributor_container]) +
     $.newMimirSpreadTopology('distributor', $._config.distributor_topology_spread_max_skew) +
     $.mimirVolumeMounts +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -60,7 +60,11 @@
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(max_unavailable),
 
   // Don't allow all queriers to be unavailable.
-  local max_unavailable = std.min(1, if ($._config.autoscaling_querier_enabled) then $._config.autoscaling_querier_min_replicas - 1 else $._config.querier.replicas - 1),
+  local max_unavailable =
+    if $._config.autoscaling_querier_enabled then
+      if $._config.autoscaling_querier_min_replicas <= 1 then 0 else 1
+    else
+      if $._config.querier.replicas <= 1 then 0 else 1,
 
   querier_deployment: if !$._config.is_microservices_deployment_mode then null else
     self.newQuerierDeployment('querier', $.querier_container, max_unavailable),

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -64,7 +64,7 @@
     if $._config.autoscaling_querier_enabled then
       if $._config.autoscaling_querier_min_replicas <= 1 then 0 else 1
     else
-      if $._config.querier.replicas <= 1 then 0 else 1,
+      if $.querier_deployment.spec.replicas <= 1 then 0 else 1,
 
   querier_deployment: if !$._config.is_microservices_deployment_mode then null else
     self.newQuerierDeployment('querier', $.querier_container, max_unavailable),

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -65,8 +65,6 @@
   querier_deployment: if !$._config.is_microservices_deployment_mode then null else
     self.newQuerierDeployment('querier', $.querier_container, max_unavailable),
 
-  local service = $.core.v1.service,
-
   querier_service: if !$._config.is_microservices_deployment_mode then null else
     $.util.serviceFor($.querier_deployment, $._config.service_ignored_labels),
 }

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -42,7 +42,11 @@
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(max_unavailable),
 
   // Don't allow all query-frontends to be unavailable.
-  local max_unavailable = std.min(1, if ($._config.autoscaling_query_frontend_enabled) then $._config.autoscaling_query_frontend_min_replicas - 1 else $._config.queryFrontend.replicas - 1),
+  local max_unavailable =
+    if $._config.autoscaling_query_frontend_enabled then
+      if $._config.autoscaling_query_frontend_min_replicas <= 1 then 0 else 1
+    else
+      if $._config.queryFrontend.replicas <= 1 then 0 else 1,
 
   query_frontend_deployment: if !$._config.is_microservices_deployment_mode then null else
     self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container, max_unavailable),

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -46,7 +46,7 @@
     if $._config.autoscaling_query_frontend_enabled then
       if $._config.autoscaling_query_frontend_min_replicas <= 1 then 0 else 1
     else
-      if $._config.queryFrontend.replicas <= 1 then 0 else 1,
+      if $.query_frontend_deployment.spec.replicas <= 1 then 0 else 1,
 
   query_frontend_deployment: if !$._config.is_microservices_deployment_mode then null else
     self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container, max_unavailable),

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -14,8 +14,6 @@
     'ruler.query-frontend.address': 'dns:///ruler-query-frontend.%(namespace)s.svc.cluster.local:9095' % $._config,
   },
 
-  local container = $.core.v1.container,
-  local deployment = $.apps.v1.deployment,
   local service = $.core.v1.service,
 
   local queryFrontendDisableResultCaching =

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -34,7 +34,11 @@
     $.newQuerierContainer('ruler-querier', $.ruler_querier_args),
 
   // Don't allow all ruler-queriers to be unavailable.
-  local querier_max_unavailable = std.min(1, if ($._config.autoscaling_ruler_querier_enabled) then $._config.autoscaling_ruler_querier_min_replicas - 1 else $._config.querier.replicas - 1),
+  local querier_max_unavailable =
+    if $._config.autoscaling_ruler_querier_enabled then
+      if $._config.autoscaling_ruler_querier_min_replicas <= 1 then 0 else 1
+    else
+      if $._config.querier.replicas <= 1 then 0 else 1,
 
   ruler_querier_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.newQuerierDeployment('ruler-querier', $.ruler_querier_container, querier_max_unavailable),
@@ -57,7 +61,11 @@
     $.newQueryFrontendContainer('ruler-query-frontend', $.ruler_query_frontend_args),
 
   // Don't allow all ruler-query-frontends to be unavailable.
-  local query_frontend_max_unavailable = std.min(1, if ($._config.autoscaling_ruler_query_frontend_enabled) then $._config.autoscaling_ruler_query_frontend_min_replicas - 1 else $._config.queryFrontend.replicas - 1),
+  local query_frontend_max_unavailable =
+    if $._config.autoscaling_ruler_query_frontend_enabled then
+      if $._config.autoscaling_ruler_query_frontend_min_replicas <= 1 then 0 else 1
+    else
+      if $._config.queryFrontend.replicas <= 1 then 0 else 1,
 
   ruler_query_frontend_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.newQueryFrontendDeployment('ruler-query-frontend', $.ruler_query_frontend_container, query_frontend_max_unavailable),

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -35,8 +35,11 @@
   ruler_querier_container::
     $.newQuerierContainer('ruler-querier', $.ruler_querier_args),
 
+  // Don't allow all ruler-queriers to be unavailable.
+  local querier_max_unavailable = std.min(1, if ($._config.autoscaling_ruler_querier_enabled) then $._config.autoscaling_ruler_querier_min_replicas - 1 else $._config.querier.replicas - 1),
+
   ruler_querier_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
-    $.newQuerierDeployment('ruler-querier', $.ruler_querier_container),
+    $.newQuerierDeployment('ruler-querier', $.ruler_querier_container, querier_max_unavailable),
 
   ruler_querier_service: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.util.serviceFor($.ruler_querier_deployment, $._config.service_ignored_labels),
@@ -55,8 +58,11 @@
   ruler_query_frontend_container::
     $.newQueryFrontendContainer('ruler-query-frontend', $.ruler_query_frontend_args),
 
+  // Don't allow all ruler-query-frontends to be unavailable.
+  local query_frontend_max_unavailable = std.min(1, if ($._config.autoscaling_ruler_query_frontend_enabled) then $._config.autoscaling_ruler_query_frontend_min_replicas - 1 else $._config.queryFrontend.replicas - 1),
+
   ruler_query_frontend_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
-    $.newQueryFrontendDeployment('ruler-query-frontend', $.ruler_query_frontend_container),
+    $.newQueryFrontendDeployment('ruler-query-frontend', $.ruler_query_frontend_container, query_frontend_max_unavailable),
 
   ruler_query_frontend_service: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.util.serviceFor($.ruler_query_frontend_deployment, $._config.service_ignored_labels) +

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -38,7 +38,7 @@
     if $._config.autoscaling_ruler_querier_enabled then
       if $._config.autoscaling_ruler_querier_min_replicas <= 1 then 0 else 1
     else
-      if $._config.querier.replicas <= 1 then 0 else 1,
+      if $.ruler_querier_deployment.spec.replicas <= 1 then 0 else 1,
 
   ruler_querier_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.newQuerierDeployment('ruler-querier', $.ruler_querier_container, querier_max_unavailable),
@@ -65,7 +65,7 @@
     if $._config.autoscaling_ruler_query_frontend_enabled then
       if $._config.autoscaling_ruler_query_frontend_min_replicas <= 1 then 0 else 1
     else
-      if $._config.queryFrontend.replicas <= 1 then 0 else 1,
+      if $.ruler_query_frontend_deployment.spec.replicas <= 1 then 0 else 1,
 
   ruler_query_frontend_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.newQueryFrontendDeployment('ruler-query-frontend', $.ruler_query_frontend_container, query_frontend_max_unavailable),


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where Kubernetes may allow an autoscaled deployment to have no available replicas if it is configured with a minimum replica count of 1, as `maxUnavailable` was always set to 1.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
