### PR TITLE
Rename NewConcreteSeriesSet and introduce NewConcreteSeriesSetFromSortedSeries

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -158,7 +158,7 @@ func (q *mockShardedQueryable) Select(_ bool, _ *storage.SelectHints, matchers .
 	}
 
 	// sorted
-	return series.NewConcreteSeriesSet(results)
+	return series.NewConcreteSeriesSetFromUnsortedSeries(results)
 }
 
 // shardLabelSeries allows extending a Series with new labels. This is helpful for adding cortex shard labels

--- a/pkg/frontend/querymiddleware/sharded_queryable.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable.go
@@ -281,7 +281,7 @@ func newSeriesSetFromEmbeddedQueriesResults(results [][]SampleStream, hints *sto
 			set = append(set, series.NewConcreteSeries(mimirpb.FromLabelAdaptersToLabels(stream.Labels), samples, histograms))
 		}
 	}
-	return series.NewConcreteSeriesSet(set)
+	return series.NewConcreteSeriesSetFromUnsortedSeries(set)
 }
 
 // responseToSamples is needed to map back from api response to the underlying series data

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -169,7 +169,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 	}
 
 	if len(serieses) > 0 {
-		sets = append(sets, series.NewConcreteSeriesSet(serieses))
+		sets = append(sets, series.NewConcreteSeriesSetFromUnsortedSeries(serieses))
 	}
 
 	if len(sets) == 0 {
@@ -178,7 +178,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 	if len(sets) == 1 {
 		return sets[0]
 	}
-	// Sets need to be sorted. Both series.NewConcreteSeriesSet and newTimeSeriesSeriesSet take care of that.
+	// Sets need to be sorted. Both series.NewConcreteSeriesSetFromUnsortedSeries and newTimeSeriesSeriesSet take care of that.
 	return storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
 }
 

--- a/pkg/querier/partitioner.go
+++ b/pkg/querier/partitioner.go
@@ -37,7 +37,7 @@ func partitionChunks(chunks []chunk.Chunk, mint, maxt int64, iteratorFunc chunkI
 		})
 	}
 
-	return seriesset.NewConcreteSeriesSet(series)
+	return seriesset.NewConcreteSeriesSetFromUnsortedSeries(series)
 }
 
 // Implements SeriesWithChunks

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -71,7 +71,7 @@ func TestSampledRemoteRead(t *testing.T) {
 	q := &mockSampleAndChunkQueryable{
 		queryableFn: func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 			return mockQuerier{
-				seriesSet: series.NewConcreteSeriesSet([]storage.Series{
+				seriesSet: series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
 					series.NewConcreteSeries(
 						labels.FromStrings("foo", "bar"),
 						[]model.SamplePair{{Timestamp: 0, Value: 0}, {Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}, {Timestamp: 3, Value: 3}},
@@ -295,7 +295,7 @@ func TestStreamedRemoteRead(t *testing.T) {
 			q := &mockSampleAndChunkQueryable{
 				chunkQueryableFn: func(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
 					return mockChunkQuerier{
-						seriesSet: series.NewConcreteSeriesSet([]storage.Series{
+						seriesSet: series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
 							series.NewConcreteSeries(
 								labels.FromStrings("foo", "bar"),
 								tc.samples,

--- a/pkg/storage/series/series_set.go
+++ b/pkg/storage/series/series_set.go
@@ -28,6 +28,12 @@ type ConcreteSeriesSet struct {
 // Series will be sorted by labels.
 func NewConcreteSeriesSetFromUnsortedSeries(series []storage.Series) storage.SeriesSet {
 	sort.Sort(byLabels(series))
+	return NewConcreteSeriesSetFromSortedSeries(series)
+}
+
+// NewConcreteSeriesSetFromSortedSeries instantiates an in-memory series set from a slice
+// of sorted series.
+func NewConcreteSeriesSetFromSortedSeries(series []storage.Series) storage.SeriesSet {
 	return &ConcreteSeriesSet{
 		cur:    -1,
 		series: series,

--- a/pkg/storage/series/series_set.go
+++ b/pkg/storage/series/series_set.go
@@ -24,9 +24,9 @@ type ConcreteSeriesSet struct {
 	series []storage.Series
 }
 
-// NewConcreteSeriesSet instantiates an in-memory series set from a series
+// NewConcreteSeriesSetFromUnsortedSeries instantiates an in-memory series set from a series
 // Series will be sorted by labels.
-func NewConcreteSeriesSet(series []storage.Series) storage.SeriesSet {
+func NewConcreteSeriesSetFromUnsortedSeries(series []storage.Series) storage.SeriesSet {
 	sort.Sort(byLabels(series))
 	return &ConcreteSeriesSet{
 		cur:    -1,
@@ -270,7 +270,7 @@ func MatrixToSeriesSet(m model.Matrix) storage.SeriesSet {
 			// histograms: ss.Histograms, // cannot convert the decoded matrix form to the expected encoded format. this method is only used in tests so ignoring histogram support for now
 		})
 	}
-	return NewConcreteSeriesSet(series)
+	return NewConcreteSeriesSetFromUnsortedSeries(series)
 }
 
 // LabelsToSeriesSet creates a storage.SeriesSet from a []labels.Labels
@@ -281,7 +281,7 @@ func LabelsToSeriesSet(ls []labels.Labels) storage.SeriesSet {
 			labels: l,
 		})
 	}
-	return NewConcreteSeriesSet(series)
+	return NewConcreteSeriesSetFromUnsortedSeries(series)
 }
 
 func metricToLabels(m model.Metric) labels.Labels {

--- a/pkg/storage/series/series_set_test.go
+++ b/pkg/storage/series/series_set_test.go
@@ -36,7 +36,7 @@ func TestConcreteSeriesSet(t *testing.T) {
 		labels:     labels.FromStrings("foo", "bay"),
 		histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(5, generateTestHistogram(6))},
 	}
-	c := NewConcreteSeriesSet([]storage.Series{series3, series2, series1})
+	c := NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{series3, series2, series1})
 	require.True(t, c.Next())
 	require.Equal(t, series1, c.At())
 	require.True(t, c.Next())


### PR DESCRIPTION
#### What this PR does

This is a refactoring PR that renames `NewConcreteSeriesSet` to `NewConcreteSeriesSetFromUnsortedSeries` and introduces `NewConcreteSeriesSetFromSortedSeries`.

#### Which issue(s) this PR fixes or relates to

(this has been split out from https://github.com/grafana/mimir/pull/4886)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
