### PR TITLE
Mimirtool: refactor analyzer to facilitate usage through vendoring

### DIFF
--- a/pkg/mimirtool/commands/analyse_dashboards.go
+++ b/pkg/mimirtool/commands/analyse_dashboards.go
@@ -22,14 +22,28 @@ type DashboardAnalyzeCommand struct {
 }
 
 func (cmd *DashboardAnalyzeCommand) run(_ *kingpin.ParseContext) error {
+	output, err := AnalyzeDashboards(cmd.DashFilesList)
+	if err != nil {
+		return err
+	}
+
+	err = writeOut(output, cmd.outputFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// AnalyzeDashboards analyze the given list of dashboard files and return the list metrics used in them.
+func AnalyzeDashboards(dashFilesList []string) (*analyze.MetricsInGrafana, error) {
 	output := &analyze.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 
-	for _, file := range cmd.DashFilesList {
+	for _, file := range dashFilesList {
 		var board minisdk.Board
 		buf, err := loadFile(file)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err = json.Unmarshal(buf, &board); err != nil {
 			fmt.Fprintf(os.Stderr, "%s for %s\n", err, file)
@@ -37,12 +51,7 @@ func (cmd *DashboardAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 		}
 		analyze.ParseMetricsInBoard(output, board)
 	}
-
-	err := writeOut(output, cmd.outputFile)
-	if err != nil {
-		return err
-	}
-	return nil
+	return output, nil
 }
 
 func loadFile(filename string) ([]byte, error) {

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -49,9 +49,6 @@ func (f folderTitles) IsCumulative() bool {
 }
 
 func (cmd *GrafanaAnalyzeCommand) run(_ *kingpin.ParseContext) error {
-	output := &analyze.MetricsInGrafana{}
-	output.OverallMetrics = make(map[string]struct{})
-
 	ctx, cancel := context.WithTimeout(context.Background(), cmd.readTimeout)
 	defer cancel()
 
@@ -60,15 +57,33 @@ func (cmd *GrafanaAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 		return err
 	}
 
-	boardLinks, err := c.SearchDashboards(ctx, "", false)
+	output, err := AnalyzeGrafana(ctx, c, cmd.folders)
+	if err != nil {
+		return err
+	}
+	err = writeOut(output, cmd.outputFile)
 	if err != nil {
 		return err
 	}
 
-	filterOnFolders := len(cmd.folders) > 0
+	return nil
+}
+
+// AnalyzeGrafana analyze grafana's dashboards and return the list metrics used in them.
+func AnalyzeGrafana(ctx context.Context, c *sdk.Client, folders []string) (*analyze.MetricsInGrafana, error) {
+
+	output := &analyze.MetricsInGrafana{}
+	output.OverallMetrics = make(map[string]struct{})
+
+	boardLinks, err := c.SearchDashboards(ctx, "", false)
+	if err != nil {
+		return nil, err
+	}
+
+	filterOnFolders := len(folders) > 0
 
 	for _, link := range boardLinks {
-		if filterOnFolders && !slices.Contains(cmd.folders, link.FolderTitle) {
+		if filterOnFolders && !slices.Contains(folders, link.FolderTitle) {
 			continue
 		}
 		data, _, err := c.GetRawDashboardByUID(ctx, link.UID)
@@ -83,13 +98,7 @@ func (cmd *GrafanaAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 		}
 		analyze.ParseMetricsInBoard(output, board)
 	}
-
-	err = writeOut(output, cmd.outputFile)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return output, nil
 }
 
 func unmarshalDashboard(data []byte, link sdk.FoundBoard) (minisdk.Board, error) {

--- a/pkg/mimirtool/commands/analyse_rulefiles.go
+++ b/pkg/mimirtool/commands/analyse_rulefiles.go
@@ -20,21 +20,9 @@ type RuleFileAnalyzeCommand struct {
 
 func (cmd *RuleFileAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 
-	output := &analyze.MetricsInRuler{}
-	output.OverallMetrics = make(map[string]struct{})
-
-	nss, err := rules.ParseFiles(rules.MimirBackend, cmd.RuleFilesList)
+	output, err := AnalyzeRuleFiles(cmd.RuleFilesList)
 	if err != nil {
-		return errors.Wrap(err, "analyze operation unsuccessful, unable to parse rules files")
-	}
-
-	for _, ns := range nss {
-		for _, group := range ns.Groups {
-			err := analyze.ParseMetricsInRuleGroup(output, group, ns.Namespace)
-			if err != nil {
-				return err
-			}
-		}
+		return err
 	}
 
 	err = writeOutRuleMetrics(output, cmd.outputFile)
@@ -43,4 +31,25 @@ func (cmd *RuleFileAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 	}
 
 	return nil
+}
+
+// AnalyzeRuleFiles analyze rules files and return the list metrics used in them.
+func AnalyzeRuleFiles(ruleFiles []string) (*analyze.MetricsInRuler, error) {
+	output := &analyze.MetricsInRuler{}
+	output.OverallMetrics = make(map[string]struct{})
+
+	nss, err := rules.ParseFiles(rules.MimirBackend, ruleFiles)
+	if err != nil {
+		return nil, errors.Wrap(err, "analyze operation unsuccessful, unable to parse rules files")
+	}
+
+	for _, ns := range nss {
+		for _, group := range ns.Groups {
+			err := analyze.ParseMetricsInRuleGroup(output, group, ns.Namespace)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return output, nil
 }

--- a/pkg/mimirtool/commands/analyse_ruler.go
+++ b/pkg/mimirtool/commands/analyse_ruler.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/mimir/pkg/mimirtool/analyze"
@@ -22,32 +22,13 @@ import (
 
 type RulerAnalyzeCommand struct {
 	ClientConfig client.Config
-	cli          *client.MimirClient
 	outputFile   string
 }
 
 func (cmd *RulerAnalyzeCommand) run(_ *kingpin.ParseContext) error {
-	output := &analyze.MetricsInRuler{}
-	output.OverallMetrics = make(map[string]struct{})
-
-	cli, err := client.New(cmd.ClientConfig)
+	output, err := AnalyzeRuler(cmd.ClientConfig)
 	if err != nil {
 		return err
-	}
-
-	cmd.cli = cli
-	rules, err := cmd.cli.ListRules(context.Background(), "")
-	if err != nil {
-		log.Fatalf("Unable to read rules from Grafana Mimir, %v", err)
-	}
-
-	for ns := range rules {
-		for _, rg := range rules[ns] {
-			err := analyze.ParseMetricsInRuleGroup(output, rg, ns)
-			if err != nil {
-				log.Fatalf("metrics parse error %v", err)
-			}
-		}
 	}
 
 	err = writeOutRuleMetrics(output, cmd.outputFile)
@@ -56,6 +37,34 @@ func (cmd *RulerAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 	}
 
 	return nil
+}
+
+// AnalyzeRuler analyze Mimir's ruler and return the list metrics used in them.
+func AnalyzeRuler(c client.Config) (*analyze.MetricsInRuler, error) {
+	output := &analyze.MetricsInRuler{}
+	output.OverallMetrics = make(map[string]struct{})
+
+	cli, err := client.New(c)
+	if err != nil {
+		return nil, err
+	}
+
+	rules, err := cli.ListRules(context.Background(), "")
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to read rules from Grafana Mimir")
+
+	}
+
+	for ns := range rules {
+		for _, rg := range rules[ns] {
+			err := analyze.ParseMetricsInRuleGroup(output, rg, ns)
+			if err != nil {
+				return nil, errors.Wrap(err, "metrics parse error")
+
+			}
+		}
+	}
+	return output, nil
 }
 
 func writeOutRuleMetrics(mir *analyze.MetricsInRuler, outputFile string) error {


### PR DESCRIPTION
#### What this PR does

Mimir's users might want to reuse mimirtool to industrialize metrics usage analysis. The current state require scripting to wrap everything around.

For example, users might want to do something like:

```bash
source mimirtool.env
mimirtool analyze grafana
mimirtool analyze ruler
mimirtool analyze prometheus  --prometheus-http-prefix="/prometheus"
```

By using vendoring it become simpler to create a one-liner or an API that analyze a tenant.

This commit is the first step toward this. It splits each analyzer in two func:
* `run` which is use by the command line, call the analyzer and produce an output file.
* `Analyzer*` which takes a few argument and actually does the analysis.

A second step for refactoring [analyse_prometheus](https://github.com/grafana/mimir/blob/main/pkg/mimirtool/commands/analyse_prometheus.go#L46) will be needed if this PR is accepted.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
