### PR TITLE
Fix issue where API endpoint table on HTTP API docs page appears behind table of contents

### DIFF
--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -25,75 +25,75 @@ This document groups API endpoints by service. Note that the API endpoints are e
 ## Endpoints
 
 {{% responsive-table %}}
-| API                                                                                   | Service                        | Endpoint                                                                  |
+| API | Service | Endpoint |
 | ------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------- |
-| [Index page](#index-page)                                                             | _All services_                 | `GET /`                                                                   |
-| [Configuration](#configuration)                                                       | _All services_                 | `GET /config`                                                             |
-| [Status Configuration](#status-configuration)                                         | _All services_                 | `GET /api/v1/status/config`                                               |
-| [Status Flags](#status-flags)                                                         | _All services_                 | `GET /api/v1/status/flags`                                                |
-| [Runtime Configuration](#runtime-configuration)                                       | _All services_                 | `GET /runtime_config`                                                     |
-| [Services' status](#services-status)                                                  | _All services_                 | `GET /services`                                                           |
-| [Readiness probe](#readiness-probe)                                                   | _All services_                 | `GET /ready`                                                              |
-| [Metrics](#metrics)                                                                   | _All services_                 | `GET /metrics`                                                            |
-| [Pprof](#pprof)                                                                       | _All services_                 | `GET /debug/pprof`                                                        |
-| [Fgprof](#fgprof)                                                                     | _All services_                 | `GET /debug/fgprof`                                                       |
-| [Build information](#build-information)                                               | _All services_                 | `GET /api/v1/status/buildinfo`                                            |
-| [Memberlist cluster](#memberlist-cluster)                                             | _All services_                 | `GET /memberlist`                                                         |
-| [Get tenant limits](#get-tenant-limits)                                               | _All services_                 | `GET /api/v1/user_limits`                                                 |
-| [Remote write](#remote-write)                                                         | Distributor                    | `POST /api/v1/push`                                                       |
-| [OTLP](#otlp)                                                                         | Distributor                    | `POST /otlp/v1/metrics`                                                   |
-| [Tenants stats](#tenants-stats)                                                       | Distributor                    | `GET /distributor/all_user_stats`                                         |
-| [HA tracker status](#ha-tracker-status)                                               | Distributor                    | `GET /distributor/ha_tracker`                                             |
-| [Flush chunks / blocks](#flush-chunks--blocks)                                        | Ingester                       | `GET,POST /ingester/flush`                                                |
-| [Prepare for Shutdown](#prepare-for-shutdown)                                         | Ingester                       | `GET,POST,DELETE /ingester/prepare-shutdown`                              |
-| [Shutdown](#shutdown)                                                                 | Ingester                       | `GET,POST /ingester/shutdown`                                             |
-| [Ingesters ring status](#ingesters-ring-status)                                       | Distributor,Ingester           | `GET /ingester/ring`                                                      |
-| [Instant query](#instant-query)                                                       | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/query`                          |
-| [Range query](#range-query)                                                           | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/query_range`                    |
-| [Exemplar query](#exemplar-query)                                                     | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/query_exemplars`                |
-| [Get series by label matchers](#get-series-by-label-matchers)                         | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/series`                         |
-| [Get label names](#get-label-names)                                                   | Querier, Query-frontend        | `GET,POST <prometheus-http-prefix>/api/v1/labels`                         |
-| [Get label values](#get-label-values)                                                 | Querier, Query-frontend        | `GET <prometheus-http-prefix>/api/v1/label/{name}/values`                 |
-| [Get metric metadata](#get-metric-metadata)                                           | Querier, Query-frontend        | `GET <prometheus-http-prefix>/api/v1/metadata`                            |
-| [Remote read](#remote-read)                                                           | Querier, Query-frontend        | `POST <prometheus-http-prefix>/api/v1/read`                               |
-| [Label names cardinality](#label-names-cardinality)                                   | Querier, Query-frontend        | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_names`       |
-| [Label values cardinality](#label-values-cardinality)                                 | Querier, Query-frontend        | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_values`      |
-| [Build information](#build-information)                                               | Querier, Query-frontend, Ruler | `GET <prometheus-http-prefix>/api/v1/status/buildinfo`                    |
-| [Format query](#format-query)                                                         | Querier, Query-frontend        | `GET, POST <prometheus-http-prefix>/api/v1/format_query`                  |
-| [Get tenant ingestion stats](#get-tenant-ingestion-stats)                             | Querier                        | `GET /api/v1/user_stats`                                                  |
-| [Query-scheduler ring status](#query-scheduler-ring-status)                           | Query-scheduler                | `GET /query-scheduler/ring`                                               |
-| [Ruler ring status](#ruler-ring-status)                                               | Ruler                          | `GET /ruler/ring`                                                         |
-| [Ruler rules ](#ruler-rules)                                                          | Ruler                          | `GET /ruler/rule_groups`                                                  |
-| [List Prometheus rules](#list-prometheus-rules)                                       | Ruler                          | `GET <prometheus-http-prefix>/api/v1/rules`                               |
-| [List Prometheus alerts](#list-prometheus-alerts)                                     | Ruler                          | `GET <prometheus-http-prefix>/api/v1/alerts`                              |
-| [List rule groups](#list-rule-groups)                                                 | Ruler                          | `GET <prometheus-http-prefix>/config/v1/rules`                            |
-| [Get rule groups by namespace](#get-rule-groups-by-namespace)                         | Ruler                          | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}`                |
-| [Get rule group](#get-rule-group)                                                     | Ruler                          | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}`    |
-| [Set rule group](#set-rule-group)                                                     | Ruler                          | `POST <prometheus-http-prefix>/config/v1/rules/{namespace}`               |
-| [Delete rule group](#delete-rule-group)                                               | Ruler                          | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}` |
-| [Delete namespace](#delete-namespace)                                                 | Ruler                          | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}`             |
-| [Delete tenant configuration](#delete-tenant-configuration)                           | Ruler                          | `POST /ruler/delete_tenant_config`                                        |
-| [Alertmanager status](#alertmanager-status)                                           | Alertmanager                   | `GET /multitenant_alertmanager/status`                                    |
-| [Alertmanager configs](#alertmanager-configs)                                         | Alertmanager                   | `GET /multitenant_alertmanager/configs`                                   |
-| [Alertmanager ring status](#alertmanager-ring-status)                                 | Alertmanager                   | `GET /multitenant_alertmanager/ring`                                      |
-| [Alertmanager UI](#alertmanager-ui)                                                   | Alertmanager                   | `GET <alertmanager-http-prefix>`                                          |
-| [Build Information](#build-information)                                               | Alertmanager                   | `GET <alertmanager-http-prefix>/api/v1/status/buildinfo`                  |
-| [Alertmanager Delete Tenant Configuration](#alertmanager-delete-tenant-configuration) | Alertmanager                   | `POST /multitenant_alertmanager/delete_tenant_config`                     |
-| [Get Alertmanager configuration](#get-alertmanager-configuration)                     | Alertmanager                   | `GET /api/v1/alerts`                                                      |
-| [Set Alertmanager configuration](#set-alertmanager-configuration)                     | Alertmanager                   | `POST /api/v1/alerts`                                                     |
-| [Delete Alertmanager configuration](#delete-alertmanager-configuration)               | Alertmanager                   | `DELETE /api/v1/alerts`                                                   |
-| [Store-gateway ring status](#store-gateway-ring-status)                               | Store-gateway                  | `GET /store-gateway/ring`                                                 |
-| [Store-gateway tenants](#store-gateway-tenants)                                       | Store-gateway                  | `GET /store-gateway/tenants`                                              |
-| [Store-gateway tenant blocks](#store-gateway-tenant-blocks)                           | Store-gateway                  | `GET /store-gateway/tenant/{tenant}/blocks`                               |
-| [Prepare for Shutdown](#prepare-for-shutdown)                                         | Store-gateway                  | `GET,POST,DELETE /store-gateway/prepare-shutdown`                         |
-| [Compactor ring status](#compactor-ring-status)                                       | Compactor                      | `GET /compactor/ring`                                                     |
-| [Start block upload](#start-block-upload)                                             | Compactor                      | `POST /api/v1/upload/block/{block}/start`                                 |
-| [Upload block file](#upload-block-file)                                               | Compactor                      | `POST /api/v1/upload/block/{block}/files?path={path}`                     |
-| [Complete block upload](#complete-block-upload)                                       | Compactor                      | `POST /api/v1/upload/block/{block}/finish`                                |
-| [Check block upload](#check-block-upload)                                             | Compactor                      | `GET /api/v1/upload/block/{block}/check`                                  |
-| [Tenant delete request](#tenant-delete-request)                                       | Compactor                      | `POST /compactor/delete_tenant`                                           |
-| [Tenant delete status](#tenant-delete-status)                                         | Compactor                      | `GET /compactor/delete_tenant_status`                                     |
-| [Overrides-exporter ring status](#overrides-exporter-ring-status)                     | Overrides-exporter             | `GET /overrides-exporter/ring`                                            |
+| [Index page](#index-page) | _All services_ | `GET /` |
+| [Configuration](#configuration) | _All services_ | `GET /config` |
+| [Status Configuration](#status-configuration) | _All services_ | `GET /api/v1/status/config` |
+| [Status Flags](#status-flags) | _All services_ | `GET /api/v1/status/flags` |
+| [Runtime Configuration](#runtime-configuration) | _All services_ | `GET /runtime_config` |
+| [Services' status](#services-status) | _All services_ | `GET /services` |
+| [Readiness probe](#readiness-probe) | _All services_ | `GET /ready` |
+| [Metrics](#metrics) | _All services_ | `GET /metrics` |
+| [Pprof](#pprof) | _All services_ | `GET /debug/pprof` |
+| [Fgprof](#fgprof) | _All services_ | `GET /debug/fgprof` |
+| [Build information](#build-information) | _All services_ | `GET /api/v1/status/buildinfo` |
+| [Memberlist cluster](#memberlist-cluster) | _All services_ | `GET /memberlist` |
+| [Get tenant limits](#get-tenant-limits) | _All services_ | `GET /api/v1/user_limits` |
+| [Remote write](#remote-write) | Distributor | `POST /api/v1/push` |
+| [OTLP](#otlp) | Distributor | `POST /otlp/v1/metrics` |
+| [Tenants stats](#tenants-stats) | Distributor | `GET /distributor/all_user_stats` |
+| [HA tracker status](#ha-tracker-status) | Distributor | `GET /distributor/ha_tracker` |
+| [Flush chunks / blocks](#flush-chunks--blocks) | Ingester | `GET,POST /ingester/flush` |
+| [Prepare for Shutdown](#prepare-for-shutdown) | Ingester | `GET,POST,DELETE /ingester/prepare-shutdown` |
+| [Shutdown](#shutdown) | Ingester | `GET,POST /ingester/shutdown` |
+| [Ingesters ring status](#ingesters-ring-status) | Distributor,Ingester | `GET /ingester/ring` |
+| [Instant query](#instant-query) | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/query` |
+| [Range query](#range-query) | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/query_range` |
+| [Exemplar query](#exemplar-query) | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/query_exemplars` |
+| [Get series by label matchers](#get-series-by-label-matchers) | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/series` |
+| [Get label names](#get-label-names) | Querier, Query-frontend | `GET,POST <prometheus-http-prefix>/api/v1/labels` |
+| [Get label values](#get-label-values) | Querier, Query-frontend | `GET <prometheus-http-prefix>/api/v1/label/{name}/values` |
+| [Get metric metadata](#get-metric-metadata) | Querier, Query-frontend | `GET <prometheus-http-prefix>/api/v1/metadata` |
+| [Remote read](#remote-read) | Querier, Query-frontend | `POST <prometheus-http-prefix>/api/v1/read` |
+| [Label names cardinality](#label-names-cardinality) | Querier, Query-frontend | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_names` |
+| [Label values cardinality](#label-values-cardinality) | Querier, Query-frontend | `GET, POST <prometheus-http-prefix>/api/v1/cardinality/label_values` |
+| [Build information](#build-information) | Querier, Query-frontend, Ruler | `GET <prometheus-http-prefix>/api/v1/status/buildinfo` |
+| [Format query](#format-query) | Querier, Query-frontend | `GET, POST <prometheus-http-prefix>/api/v1/format_query` |
+| [Get tenant ingestion stats](#get-tenant-ingestion-stats) | Querier | `GET /api/v1/user_stats` |
+| [Query-scheduler ring status](#query-scheduler-ring-status) | Query-scheduler | `GET /query-scheduler/ring` |
+| [Ruler ring status](#ruler-ring-status) | Ruler | `GET /ruler/ring` |
+| [Ruler rules ](#ruler-rules) | Ruler | `GET /ruler/rule_groups` |
+| [List Prometheus rules](#list-prometheus-rules) | Ruler | `GET <prometheus-http-prefix>/api/v1/rules` |
+| [List Prometheus alerts](#list-prometheus-alerts) | Ruler | `GET <prometheus-http-prefix>/api/v1/alerts` |
+| [List rule groups](#list-rule-groups) | Ruler | `GET <prometheus-http-prefix>/config/v1/rules` |
+| [Get rule groups by namespace](#get-rule-groups-by-namespace) | Ruler | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}` |
+| [Get rule group](#get-rule-group) | Ruler | `GET <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}` |
+| [Set rule group](#set-rule-group) | Ruler | `POST <prometheus-http-prefix>/config/v1/rules/{namespace}` |
+| [Delete rule group](#delete-rule-group) | Ruler | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}/{groupName}` |
+| [Delete namespace](#delete-namespace) | Ruler | `DELETE <prometheus-http-prefix>/config/v1/rules/{namespace}` |
+| [Delete tenant configuration](#delete-tenant-configuration) | Ruler | `POST /ruler/delete_tenant_config` |
+| [Alertmanager status](#alertmanager-status) | Alertmanager | `GET /multitenant_alertmanager/status` |
+| [Alertmanager configs](#alertmanager-configs) | Alertmanager | `GET /multitenant_alertmanager/configs` |
+| [Alertmanager ring status](#alertmanager-ring-status) | Alertmanager | `GET /multitenant_alertmanager/ring` |
+| [Alertmanager UI](#alertmanager-ui) | Alertmanager | `GET <alertmanager-http-prefix>` |
+| [Build Information](#build-information) | Alertmanager | `GET <alertmanager-http-prefix>/api/v1/status/buildinfo` |
+| [Alertmanager Delete Tenant Configuration](#alertmanager-delete-tenant-configuration) | Alertmanager | `POST /multitenant_alertmanager/delete_tenant_config` |
+| [Get Alertmanager configuration](#get-alertmanager-configuration) | Alertmanager | `GET /api/v1/alerts` |
+| [Set Alertmanager configuration](#set-alertmanager-configuration) | Alertmanager | `POST /api/v1/alerts` |
+| [Delete Alertmanager configuration](#delete-alertmanager-configuration) | Alertmanager | `DELETE /api/v1/alerts` |
+| [Store-gateway ring status](#store-gateway-ring-status) | Store-gateway | `GET /store-gateway/ring` |
+| [Store-gateway tenants](#store-gateway-tenants) | Store-gateway | `GET /store-gateway/tenants` |
+| [Store-gateway tenant blocks](#store-gateway-tenant-blocks) | Store-gateway | `GET /store-gateway/tenant/{tenant}/blocks` |
+| [Prepare for Shutdown](#prepare-for-shutdown) | Store-gateway | `GET,POST,DELETE /store-gateway/prepare-shutdown` |
+| [Compactor ring status](#compactor-ring-status) | Compactor | `GET /compactor/ring` |
+| [Start block upload](#start-block-upload) | Compactor | `POST /api/v1/upload/block/{block}/start` |
+| [Upload block file](#upload-block-file) | Compactor | `POST /api/v1/upload/block/{block}/files?path={path}` |
+| [Complete block upload](#complete-block-upload) | Compactor | `POST /api/v1/upload/block/{block}/finish` |
+| [Check block upload](#check-block-upload) | Compactor | `GET /api/v1/upload/block/{block}/check` |
+| [Tenant delete request](#tenant-delete-request) | Compactor | `POST /compactor/delete_tenant` |
+| [Tenant delete status](#tenant-delete-status) | Compactor | `GET /compactor/delete_tenant_status` |
+| [Overrides-exporter ring status](#overrides-exporter-ring-status) | Overrides-exporter | `GET /overrides-exporter/ring` |
 {{% /responsive-table %}}
 
 ### Path prefixes

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -24,6 +24,7 @@ This document groups API endpoints by service. Note that the API endpoints are e
 
 ## Endpoints
 
+{{% responsive-table %}}
 | API                                                                                   | Service                        | Endpoint                                                                  |
 | ------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------- |
 | [Index page](#index-page)                                                             | _All services_                 | `GET /`                                                                   |
@@ -93,6 +94,7 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Tenant delete request](#tenant-delete-request)                                       | Compactor                      | `POST /compactor/delete_tenant`                                           |
 | [Tenant delete status](#tenant-delete-status)                                         | Compactor                      | `GET /compactor/delete_tenant_status`                                     |
 | [Overrides-exporter ring status](#overrides-exporter-ring-status)                     | Overrides-exporter             | `GET /overrides-exporter/ring`                                            |
+{{% /responsive-table %}}
 
 ### Path prefixes
 


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where the table on [the HTTP API docs page](https://grafana.com/docs/mimir/latest/references/http-api/) appears behind the table of contents on the right side of the page on small screens:

https://github.com/grafana/mimir/assets/4017646/f3844f11-8884-47d5-a93b-5c5d441a99dc

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
