### PR TITLE
mimirtool: fail on duplicate rules with --strict

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -80,6 +80,8 @@ jobs:
         run: make BUILD_IN_CONTAINER=false check-mixin
       - name: Check Mixin Tests
         run: make BUILD_IN_CONTAINER=false check-mixin-tests
+      - name: Check Mixin with Mimirtool rules check
+        run: make BUILD_IN_CONTAINER=false check-mixin-mimirtool-rules
       - name: Check Jsonnet Manifests
         run: make BUILD_IN_CONTAINER=false check-jsonnet-manifests
       - name: Check Jsonnet Getting Started

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 
 ### Mimirtool
 
+* [CHANGE] check rules: will fail on duplicate rules when `--strict` is provided. #5035
 * [ENHANCEMENT] analyze prometheus: allow to specify `-prometheus-http-prefix`. #4966
 * [ENHANCEMENT] analyze grafana: allow to specify `--folder-title` to limit dashboards analysis based on their exact folder title. #4973
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks build-mixin format-mixin check-jsonnet-manifests format-jsonnet-manifests push-multiarch-mimir list-image-targets check-jsonnet-getting-started mixin-screenshots
+.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks check-mixin-mimirtool-rules build-mixin format-mixin check-jsonnet-manifests format-jsonnet-manifests push-multiarch-mimir list-image-targets check-jsonnet-getting-started mixin-screenshots
 .DEFAULT_GOAL := all
 
 # Version number
@@ -527,6 +527,12 @@ check-mixin-mixtool: check-mixin-jb
 
 check-mixin-runbooks: build-mixin
 	@tools/lint-runbooks.sh
+
+check-mixin-mimirtool-rules: build-mixin
+	@echo "Checking 'mimirtool rules check':"
+	@for suffix in $(MIXIN_OUT_PATH_SUFFIXES); do \
+		go run ./cmd/mimirtool rules check --rule-dirs "$(MIXIN_OUT_PATH)$$suffix"; \
+	done
 
 mixin-serve: ## Runs Grafana loading the mixin dashboards compiled at operations/mimir-mixin-compiled.
 	@./operations/mimir-mixin-tools/serve/run.sh

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -141,7 +141,7 @@ func TestRuleCommand_checkRules(t *testing.T) {
 		shouldFail bool
 	}{
 		{
-			name:       "completely rule name, not strict fals too",
+			name:       "completely bad rule name, not strict fails too",
 			rules:      []rulefmt.RuleNode{validRule1, completelyBadRuleName, validRule2},
 			strict:     false,
 			shouldFail: true,
@@ -159,7 +159,7 @@ func TestRuleCommand_checkRules(t *testing.T) {
 			shouldFail: true,
 		},
 		{
-			name:       "strictly rule name, not strict",
+			name:       "strictly bad rule name, not strict",
 			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
 			strict:     false,
 			shouldFail: false,

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -189,6 +189,8 @@ func TestRuleCommand_checkRules(t *testing.T) {
 				// Setup.
 				f, err := os.Create(file)
 				require.NoError(t, err)
+				t.Cleanup(func() { _ = f.Close() })
+
 				contents := rules.RuleNamespace{
 					Namespace: "test",
 					Groups: []rwrulefmt.RuleGroup{{

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -8,6 +8,8 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/rulefmt"
@@ -111,6 +113,105 @@ func TestCheckDuplicates(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, checkDuplicates(tc.in))
+		})
+	}
+}
+
+func TestRuleCommand_checkRules(t *testing.T) {
+	completelyBadRuleName := rulefmt.RuleNode{
+		Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
+		Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+	}
+	strictlyBadRuleName := rulefmt.RuleNode{
+		Record: yaml.Node{Value: "up:onecolonmissing", Kind: yaml.ScalarNode},
+		Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+	}
+	validRule1 := rulefmt.RuleNode{
+		Record: yaml.Node{Value: "rule:up:nothing", Kind: yaml.ScalarNode},
+		Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+	}
+	validRule2 := rulefmt.RuleNode{
+		Record: yaml.Node{Value: "rule:down:nothing", Kind: yaml.ScalarNode},
+		Expr:   yaml.Node{Value: "up==0", Kind: yaml.ScalarNode},
+	}
+	for _, tc := range []struct {
+		name       string
+		rules      []rulefmt.RuleNode
+		strict     bool
+		shouldFail bool
+	}{
+		{
+			name:       "completely rule name, not strict fals too",
+			rules:      []rulefmt.RuleNode{validRule1, completelyBadRuleName, validRule2},
+			strict:     false,
+			shouldFail: true,
+		},
+		{
+			name:       "bad rule name, not strict",
+			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
+			strict:     false,
+			shouldFail: false,
+		},
+		{
+			name:       "bad rule name, strict",
+			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
+			strict:     true,
+			shouldFail: true,
+		},
+		{
+			name:       "strictly rule name, not strict",
+			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
+			strict:     false,
+			shouldFail: false,
+		},
+		{
+			name:       "no duplicates, strict",
+			rules:      []rulefmt.RuleNode{validRule1, validRule2},
+			strict:     true,
+			shouldFail: false,
+		},
+		{
+			name:       "with duplicates, not strict",
+			rules:      []rulefmt.RuleNode{validRule1, validRule1},
+			strict:     false,
+			shouldFail: false,
+		},
+		{
+			name:       "with duplicates, strict",
+			rules:      []rulefmt.RuleNode{validRule1, validRule1},
+			strict:     true,
+			shouldFail: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "rules.yaml")
+			{
+				// Setup.
+				f, err := os.Create(file)
+				require.NoError(t, err)
+				contents := rules.RuleNamespace{
+					Namespace: "test",
+					Groups: []rwrulefmt.RuleGroup{{
+						RuleGroup: rulefmt.RuleGroup{
+							Name:  "rulegroup",
+							Rules: tc.rules,
+						},
+					}},
+				}
+				require.NoError(t, yaml.NewEncoder(f).Encode(contents))
+				require.NoError(t, f.Close())
+			}
+
+			{
+				// Test.
+				cmd := &RuleCommand{Strict: tc.strict, RuleFilesList: []string{file}, Backend: rules.MimirBackend}
+				err := cmd.checkRules(nil)
+				if tc.shouldFail {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
 		})
 	}
 }

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -147,13 +147,7 @@ func TestRuleCommand_checkRules(t *testing.T) {
 			shouldFail: true,
 		},
 		{
-			name:       "bad rule name, not strict",
-			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
-			strict:     false,
-			shouldFail: false,
-		},
-		{
-			name:       "bad rule name, strict",
+			name:       "strictly bad rule name, strict",
 			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
 			strict:     true,
 			shouldFail: true,


### PR DESCRIPTION
#### What this PR does

Changes the behaviour of `mimirtool rules check` to fail on duplicated rules when `--strict` is provided.

Also changed the output to use the logger instead of fmt, and added a test.

The output looks like this (on main before https://github.com/grafana/mimir/pull/5023 was merged):

```
$ go run ./cmd/mimirtool rules check --strict --rule-dirs ./operations/mimir-mixin-compiled
ERRO[0000] duplicate rules found                         duplicate_rules=2 error="rules should emit unique series, to avoid producing inconsistencies while recording expressions" namespace=alerts
ERRO[0000] duplicate rule                                label[severity]=warning metric=MimirRolloutStuck namespace=alerts
ERRO[0000] duplicate rule                                label[severity]=critical metric=MimirCompactorHasNotUploadedBlocks namespace=alerts
mimirtool: error: 2 duplicate rules found in namespace "alerts", try --help
exit status 1
```

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/5023

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
