### PR TITLE
Chore: removed unused code from MetaFetcher

### DIFF
--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -34,8 +34,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/extprom"
 )
 
-const FetcherConcurrency = 32
-
 // FetcherMetrics holds metrics tracked by the metadata fetcher. This struct and its fields are exported
 // to allow depending projects (eg. Cortex) to implement their own custom metadata fetcher while tracking
 // compatible metrics.

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -488,8 +488,6 @@ type MetaFetcher struct {
 
 	filters []MetadataFilter
 
-	listener func([]metadata.Meta, error)
-
 	logger log.Logger
 }
 
@@ -498,20 +496,7 @@ type MetaFetcher struct {
 //
 // Returned error indicates a failure in fetching metadata. Returned meta can be assumed as correct, with some blocks missing.
 func (f *MetaFetcher) Fetch(ctx context.Context) (metas map[ulid.ULID]*metadata.Meta, partial map[ulid.ULID]error, err error) {
-	metas, partial, err = f.wrapped.fetch(ctx, f.metrics, f.filters)
-	if f.listener != nil {
-		blocks := make([]metadata.Meta, 0, len(metas))
-		for _, meta := range metas {
-			blocks = append(blocks, *meta)
-		}
-		f.listener(blocks, err)
-	}
-	return metas, partial, err
-}
-
-// UpdateOnChange allows to add listener that will be update on every change.
-func (f *MetaFetcher) UpdateOnChange(listener func([]metadata.Meta, error)) {
-	f.listener = listener
+	return f.wrapped.fetch(ctx, f.metrics, f.filters)
 }
 
 // Special label that will have an ULID of the meta.json being referenced to.

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -139,7 +139,6 @@ func NewFetcherMetrics(reg prometheus.Registerer, syncedExtraLabels, modifiedExt
 
 type MetadataFetcher interface {
 	Fetch(ctx context.Context) (metas map[ulid.ULID]*metadata.Meta, partial map[ulid.ULID]error, err error)
-	UpdateOnChange(func([]metadata.Meta, error))
 }
 
 // GaugeVec hides something like a Prometheus GaugeVec or an extprom.TxGaugeVec.

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -214,8 +214,8 @@ func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.Instrumente
 }
 
 // NewMetaFetcher transforms BaseFetcher into actually usable *MetaFetcher.
-func (f *BaseFetcher) NewMetaFetcher(reg prometheus.Registerer, filters []MetadataFilter, logTags ...interface{}) *MetaFetcher {
-	return &MetaFetcher{metrics: NewFetcherMetrics(reg, nil, nil), wrapped: f, filters: filters, logger: log.With(f.logger, logTags...)}
+func (f *BaseFetcher) NewMetaFetcher(reg prometheus.Registerer, filters []MetadataFilter) *MetaFetcher {
+	return &MetaFetcher{metrics: NewFetcherMetrics(reg, nil, nil), wrapped: f, filters: filters}
 }
 
 var (
@@ -487,8 +487,6 @@ type MetaFetcher struct {
 	metrics *FetcherMetrics
 
 	filters []MetadataFilter
-
-	logger log.Logger
 }
 
 // Fetch returns all block metas as well as partial blocks (blocks without or with corrupted meta file) from the bucket.

--- a/pkg/storegateway/bucket_index_metadata_fetcher.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher.go
@@ -121,8 +121,3 @@ func (f *BucketIndexMetadataFetcher) Fetch(ctx context.Context) (metas map[ulid.
 
 	return metas, nil, nil
 }
-
-func (f *BucketIndexMetadataFetcher) UpdateOnChange(callback func([]metadata.Meta, error)) {
-	// Unused by the store-gateway.
-	callback(nil, errors.New("UpdateOnChange is unsupported"))
-}


### PR DESCRIPTION
#### What this PR does
I'm investigating the object storage API calls issued by compactor and I noticed we have some unused code in `MetaFetcher`, which I'm removing in this PR. I think we can also merge the `BaseFetcher` with `MetaFetcher`, but I will eventually do it in a follow up PR once I have a better picture of the whole meta fetcher usefulness nowadays.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
