### PR TITLE
Show cancelled requests in grey in throughput panels on dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [ENHANCEMENT] Alerts: added labels to duplicated `MimirRolloutStuck` and `MimirCompactorHasNotUploadedBlocks` rules in order to distinguish them. #5023
 * [ENHANCEMENT] Dashboards: fix holes in graph for lightly loaded clusters #4915
 * [ENHANCEMENT] Dashboards: allow configuring additional services for the Rollout Progress dashboard. #5007
+* [BUGFIX] Dashboards: show cancelled requests in a different color to successful requests in throughput panels on dashboards. #5039
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -1161,6 +1161,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -6648,6 +6649,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -11231,6 +11233,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -11514,6 +11517,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -21125,6 +21129,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -21375,6 +21380,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -21743,6 +21749,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -21982,6 +21989,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -22221,6 +22229,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -22726,6 +22735,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -26615,6 +26625,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -26854,6 +26865,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -27042,6 +27054,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -29642,6 +29655,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -29830,6 +29844,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -30018,6 +30033,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -39702,6 +39718,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -39941,6 +39958,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -40518,6 +40536,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -40706,6 +40725,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },
@@ -40894,6 +40914,7 @@ data:
                          "3xx": "#6ED0E0",
                          "4xx": "#EF843C",
                          "5xx": "#E24D42",
+                         "cancel": "#A9A9A9",
                          "error": "#E24D42",
                          "success": "#7EB26D"
                       },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
@@ -281,6 +281,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
@@ -2031,6 +2031,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
@@ -180,6 +180,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -463,6 +464,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -461,6 +461,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -711,6 +712,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1079,6 +1081,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1318,6 +1321,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1557,6 +1561,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -2062,6 +2067,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -153,6 +153,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -392,6 +393,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -580,6 +582,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -541,6 +541,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -729,6 +730,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -917,6 +919,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -459,6 +459,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -698,6 +699,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1275,6 +1277,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1463,6 +1466,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1651,6 +1655,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -281,6 +281,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -2031,6 +2031,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -180,6 +180,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -463,6 +464,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -461,6 +461,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -711,6 +712,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1079,6 +1081,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1318,6 +1321,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1557,6 +1561,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -2062,6 +2067,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -153,6 +153,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -392,6 +393,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -580,6 +582,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -541,6 +541,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -729,6 +730,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -917,6 +919,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -459,6 +459,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -698,6 +699,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1275,6 +1277,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1463,6 +1466,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },
@@ -1651,6 +1655,7 @@
                      "3xx": "#6ED0E0",
                      "4xx": "#EF843C",
                      "5xx": "#E24D42",
+                     "cancel": "#A9A9A9",
                      "error": "#E24D42",
                      "success": "#7EB26D"
                   },

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "c132c4afcf17491718539db4c2d94c0ea4346120",
-      "sum": "tDR6yT2GVfw0wTU12iZH+m01HrbIr6g/xN+/8nzNkU0="
+      "version": "207b7e68d01e2f5dfb8dddf455479a676cdd4a9a",
+      "sum": "wp/L/9smcsHIiy24DH5WWMv2fcSckN2Lw/m7qDszaWU="
     },
     {
       "source": {


### PR DESCRIPTION
#### What this PR does

This PR updates `grafana/jsonnet-libs/grafana-builder` to include https://github.com/grafana/jsonnet-libs/pull/988. This fixes the issue where cancelled requests can be shown in the same green as successful requests in throughput panels on dashboards.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
