### PR TITLE
Enable Nginx Proxy HTTP/1.1 in Mimir for Istio Envoy Sidecar Compatibility

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -42,6 +42,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `jaegerReporterMaxQueueSize` Helm value for all components where configuring `JAEGER_REPORTER_MAX_QUEUE_SIZE` makes sense, and override the Jaeger client's default value of 100 for components expected to generate many trace spans. #7068 #7086
 * [ENHANCEMENT] Rollout-operator: upgraded to v0.10.1. #7125
 * [ENHANCEMENT] Query-frontend: configured `-shutdown-delay`, `-server.grpc.keepalive.max-connection-age` and termination grace period to reduce the likelihood of queries hitting terminated query-frontends. #7129
+* [ENHANCEMENT] nginx, Gateway: set `proxy_http_version: 1.1` to proxy to HTTP 1.1. #5040
 * [BUGFIX] Metamonitoring: update dashboards to drop unsupported `step` parameter in targets. #7157
 
 ## 5.2.1

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2448,8 +2448,8 @@ nginx:
         access_log   {{ .Values.nginx.nginxConfig.accessLogEnabled | ternary "/dev/stderr  main  if=$loggable;" "off;" }}
         {{- end }}
 
-        sendfile     on;
-        tcp_nopush   on;
+        sendfile           on;
+        tcp_nopush         on;
         proxy_http_version 1.1;
 
         {{- if .Values.nginx.nginxConfig.resolver }}
@@ -2831,8 +2831,9 @@ gateway:
           access_log   {{ .Values.gateway.nginx.config.accessLogEnabled | ternary "/dev/stderr  main  if=$loggable;" "off;" }}
           {{- end }}
 
-          sendfile     on;
-          tcp_nopush   on;
+          sendfile           on;
+          tcp_nopush         on;
+          proxy_http_version 1.1;
 
           {{- if .Values.gateway.nginx.config.resolver }}
           resolver {{ .Values.gateway.nginx.config.resolver }};

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2450,6 +2450,7 @@ nginx:
 
         sendfile     on;
         tcp_nopush   on;
+        proxy_http_version 1.1;
 
         {{- if .Values.nginx.nginxConfig.resolver }}
         resolver {{ .Values.nginx.nginxConfig.resolver }};

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -34,8 +34,9 @@ data:
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
     
-      sendfile     on;
-      tcp_nopush   on;
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
       resolver kube-dns.kube-system.svc.cluster.local.;
     
       # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.


### PR DESCRIPTION
## Description:

This PR is proposed to address issue #2845, which manifests as an HTTP 426 error when performing various operations with Mimir deployed in a Kubernetes namespace with Istio injection enabled.

### What this PR does

This PR sets the `proxy_http_version` directive to 1.1 in the Nginx configuration of Mimir. This change allows Mimir's Nginx to work harmoniously with the Istio Envoy sidecar. In our modern system architecture, the use of HTTP/1.1 is becoming increasingly crucial for the effective operation of service mesh architectures like Istio. 

### To Reproduce

The issue addressed by this PR can be reproduced using the following steps:

1. Enable Istio injection in your Kubernetes namespace.
2. Start Mimir from Helm chart 3.1.
3. Perform various operations (Read/Write/Others).

**Expected behavior**: The Read/Write path should work as intended.

**Actual behavior**: The server returns an HTTP 426 status error.

### Fixed issues

Fixes #2845

This PR resolves issue #2845 by enabling Nginx to use HTTP/1.1 as the default for proxying requests. This change helps improve the compatibility of Mimir with Istio sidecar Envoy.

### Checklist

- [x] Tests updated to validate the changes
- [x] Documentation updated to reflect new default configuration
- [x] `CHANGELOG.md` updated with a description of the changes, categorized under `[CHANGE]`

Please read the `CONTRIBUTING.md` guide before submitting and rebase your PR if it gets out of sync with the main branch. 

With this change, we're making a significant stride towards improving the interaction between Mimir, Nginx, and Istio. We believe it should be the default configuration, contributing to a more seamless experience for users in a modern system architecture.
