### PR TITLE
Ensure `MimirAllocatingTooMuchMemory` only targets Mimir pods

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -387,7 +387,10 @@ spec:
           container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
             /
           ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-        ) > 0.65
+        ) *
+        # Make sure that the pods are really all Mimir pods.
+        on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+        > 0.65
       for: 15m
       labels:
         severity: warning
@@ -403,7 +406,10 @@ spec:
           container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
             /
           ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-        ) > 0.8
+        ) *
+        # Make sure that the pods are really all Mimir pods.
+        on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+        > 0.8
       for: 15m
       labels:
         severity: critical

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -388,8 +388,8 @@ spec:
             /
           ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
         )
-        # Make sure that the pods are really all Mimir pods.
-        and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+        # Make sure that we really only target Mimir containers
+        and on(cluster, namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (cluster, namespace, pod, container)
         > 0.65
       for: 15m
       labels:
@@ -407,8 +407,8 @@ spec:
             /
           ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
         )
-        # Make sure that the pods are really all Mimir pods.
-        and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+        # Make sure that we really only target Mimir containers
+        and on(cluster, namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (cluster, namespace, pod, container)
         > 0.8
       for: 15m
       labels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -387,9 +387,9 @@ spec:
           container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
             /
           ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-        ) *
+        )
         # Make sure that the pods are really all Mimir pods.
-        on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+        and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
         > 0.65
       for: 15m
       labels:
@@ -406,9 +406,9 @@ spec:
           container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
             /
           ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-        ) *
+        )
         # Make sure that the pods are really all Mimir pods.
-        on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+        and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
         > 0.8
       for: 15m
       labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -376,8 +376,8 @@ groups:
           /
         ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
       )
-      # Make sure that the pods are really all Mimir pods.
-      and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+      # Make sure that we really only target Mimir containers
+      and on(cluster, namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (cluster, namespace, pod, container)
       > 0.65
     for: 15m
     labels:
@@ -395,8 +395,8 @@ groups:
           /
         ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
       )
-      # Make sure that the pods are really all Mimir pods.
-      and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+      # Make sure that we really only target Mimir containers
+      and on(cluster, namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (cluster, namespace, pod, container)
       > 0.8
     for: 15m
     labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -375,9 +375,9 @@ groups:
         container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
           /
         ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-      ) *
+      )
       # Make sure that the pods are really all Mimir pods.
-      on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+      and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
       > 0.65
     for: 15m
     labels:
@@ -394,9 +394,9 @@ groups:
         container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
           /
         ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-      ) *
+      )
       # Make sure that the pods are really all Mimir pods.
-      on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+      and on(namespace, pod, container) group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
       > 0.8
     for: 15m
     labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -375,7 +375,10 @@ groups:
         container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
           /
         ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-      ) > 0.65
+      ) *
+      # Make sure that the pods are really all Mimir pods.
+      on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+      > 0.65
     for: 15m
     labels:
       severity: warning
@@ -391,7 +394,10 @@ groups:
         container_memory_rss{container=~"(ingester|mimir-write|mimir-backend)"}
           /
         ( container_spec_memory_limit_bytes{container=~"(ingester|mimir-write|mimir-backend)"} > 0 )
-      ) > 0.8
+      ) *
+      # Make sure that the pods are really all Mimir pods.
+      on(namespace, pod, container) group_left group(cortex_build_info{container=~"(ingester|mimir-write|mimir-backend)"}) by (namespace, pod, container)
+      > 0.8
     for: 15m
     labels:
       severity: critical

--- a/operations/mimir-mixin-tests/test-custom-labels-asserts.sh
+++ b/operations/mimir-mixin-tests/test-custom-labels-asserts.sh
@@ -20,7 +20,7 @@ assert_failed() {
 }
 
 # In this test we customize some labels. We expect to not find any reference to default labels.
-FORBIDDEN_LABELS="cluster instance node"
+FORBIDDEN_LABELS="cluster pod node"
 
 for LABEL in ${FORBIDDEN_LABELS}; do
   QUERY_REGEX="[^\$a-z_]${LABEL}[^a-z_]"

--- a/operations/mimir-mixin-tests/test-custom-labels-asserts.sh
+++ b/operations/mimir-mixin-tests/test-custom-labels-asserts.sh
@@ -20,7 +20,7 @@ assert_failed() {
 }
 
 # In this test we customize some labels. We expect to not find any reference to default labels.
-FORBIDDEN_LABELS="cluster instance pod"
+FORBIDDEN_LABELS="cluster instance node"
 
 for LABEL in ${FORBIDDEN_LABELS}; do
   QUERY_REGEX="[^\$a-z_]${LABEL}[^a-z_]"

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -526,79 +526,81 @@ local utils = import 'mixin-utils/utils.libsonnet';
     {
       name: 'mimir-provisioning',
       rules: [
-        {
-          alert: $.alertName('ProvisioningTooManyActiveSeries'),
-          // We target each ingester to 1.5M in-memory series. This alert fires if the average
-          // number of series / ingester in a Mimir cluster is > 1.6M for 2h (we compact
-          // the TSDB head every 2h).
-          expr: |||
-            avg by (%s) (cortex_ingester_memory_series) > 1.6e6
-          ||| % [$._config.alert_aggregation_labels],
-          'for': '2h',
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: |||
-              The number of in-memory series per ingester in %(alert_aggregation_variables)s is too high.
-            ||| % $._config,
-          },
-        },
-        {
-          alert: $.alertName('ProvisioningTooManyWrites'),
-          // 80k writes / s per ingester max.
-          expr: |||
-            avg by (%(alert_aggregation_labels)s) (%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate1m) > 80e3
-          ||| % $._config,
-          'for': '15m',
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: |||
-              Ingesters in %(alert_aggregation_variables)s ingest too many samples per second.
-            ||| % $._config,
-          },
-        },
-        {
-          alert: $.alertName('AllocatingTooMuchMemory'),
-          expr: $._config.ingester_alerts[$._config.deployment_type].memory_allocation % {
-            allocationpercent: '0.65',
-            instanceLabel: $._config.per_instance_label,
-            ingester: $._config.container_names.ingester,
-            mimir_write: $._config.container_names.mimir_write,
-            mimir_backend: $._config.container_names.mimir_backend,
-          },
-          'for': '15m',
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-            message: |||
-              Instance %(alert_instance_variable)s in %(alert_aggregation_variables)s is using too much memory.
-            ||| % $._config,
-          },
-        },
-        {
-          alert: $.alertName('AllocatingTooMuchMemory'),
-          expr: $._config.ingester_alerts[$._config.deployment_type].memory_allocation % {
-            allocationpercent: '0.8',
-            instanceLabel: $._config.per_instance_label,
-            ingester: $._config.container_names.ingester,
-            mimir_write: $._config.container_names.mimir_write,
-            mimir_backend: $._config.container_names.mimir_backend,
-          },
-          'for': '15m',
-          labels: {
-            severity: 'critical',
-          },
-          annotations: {
-            message: |||
-              Instance %(alert_instance_variable)s in %(alert_aggregation_variables)s is using too much memory.
-            ||| % $._config,
-          },
-        },
-      ],
+               {
+                 alert: $.alertName('ProvisioningTooManyActiveSeries'),
+                 // We target each ingester to 1.5M in-memory series. This alert fires if the average
+                 // number of series / ingester in a Mimir cluster is > 1.6M for 2h (we compact
+                 // the TSDB head every 2h).
+                 expr: |||
+                   avg by (%s) (cortex_ingester_memory_series) > 1.6e6
+                 ||| % [$._config.alert_aggregation_labels],
+                 'for': '2h',
+                 labels: {
+                   severity: 'warning',
+                 },
+                 annotations: {
+                   message: |||
+                     The number of in-memory series per ingester in %(alert_aggregation_variables)s is too high.
+                   ||| % $._config,
+                 },
+               },
+               {
+                 alert: $.alertName('ProvisioningTooManyWrites'),
+                 // 80k writes / s per ingester max.
+                 expr: |||
+                   avg by (%(alert_aggregation_labels)s) (%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate1m) > 80e3
+                 ||| % $._config,
+                 'for': '15m',
+                 labels: {
+                   severity: 'warning',
+                 },
+                 annotations: {
+                   message: |||
+                     Ingesters in %(alert_aggregation_variables)s ingest too many samples per second.
+                   ||| % $._config,
+                 },
+               },
+             ]
+             +
+             local vars = {
+               instanceLabel: $._config.per_instance_label,
+               ingester: $._config.container_names.ingester,
+               mimir_write: $._config.container_names.mimir_write,
+               mimir_backend: $._config.container_names.mimir_backend,
+               group_by: $._config.alert_aggregation_labels + ', ' + $._config.per_instance_label + ', container',
+             };
+             [
+               {
+                 alert: $.alertName('AllocatingTooMuchMemory'),
+                 expr: $._config.ingester_alerts[$._config.deployment_type].memory_allocation % vars {
+                   allocationpercent: '0.65',
+                 },
+                 'for': '15m',
+                 labels: {
+                   severity: 'warning',
+                 },
+                 annotations: {
+                   message: |||
+                     Instance %(alert_instance_variable)s in %(alert_aggregation_variables)s is using too much memory.
+                   ||| % $._config,
+                 },
+               },
+               {
+                 alert: $.alertName('AllocatingTooMuchMemory'),
+                 expr: $._config.ingester_alerts[$._config.deployment_type].memory_allocation % vars {
+                   allocationpercent: '0.8',
+                 },
+                 'for': '15m',
+                 labels: {
+                   severity: 'critical',
+                 },
+                 annotations: {
+                   message: |||
+                     Instance %(alert_instance_variable)s in %(alert_aggregation_variables)s is using too much memory.
+                   ||| % $._config,
+                 },
+               },
+             ],
     },
     {
       name: 'ruler_alerts',

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -233,8 +233,8 @@
               /
             ( container_spec_memory_limit_bytes{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"} > 0 )
           )
-          # Make sure that the pods are really all Mimir pods.
-          and on(namespace, pod, container) group(cortex_build_info{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}) by (namespace, pod, container)
+          # Make sure that we really only target Mimir containers
+          and on(%(group_by)s) group(cortex_build_info{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}) by (%(group_by)s)
           > %(allocationpercent)s
         |||,
       },

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -232,7 +232,10 @@
             container_memory_rss{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}
               /
             ( container_spec_memory_limit_bytes{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"} > 0 )
-          ) > %(allocationpercent)s
+          ) *
+          # Make sure that the pods are really all Mimir pods.
+          on(namespace, pod, container) group_left group(cortex_build_info{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}) by (namespace, pod, container)
+          > %(allocationpercent)s
         |||,
       },
       baremetal: {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -232,9 +232,9 @@
             container_memory_rss{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}
               /
             ( container_spec_memory_limit_bytes{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"} > 0 )
-          ) *
+          )
           # Make sure that the pods are really all Mimir pods.
-          on(namespace, pod, container) group_left group(cortex_build_info{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}) by (namespace, pod, container)
+          and on(namespace, pod, container) group(cortex_build_info{container=~"(%(ingester)s|%(mimir_write)s|%(mimir_backend)s)"}) by (namespace, pod, container)
           > %(allocationpercent)s
         |||,
       },


### PR DESCRIPTION
This change makes sure that the alert is only firing for Mimir pods. This is done by making sure there is a metric `cortex_build_info` with the same `namespace, pod, container` combination.

We had seen similar alerts for e.g. Phlare/Loki pods which had `container="ingester"` and hence matched the alerting rule.
