### PR TITLE
Removed -compactor.consistency-delay and -blocks-storage.bucket-store.consistency-delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   * `-blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes`
 * [CHANGE] Store-gateway: remove metrics `cortex_bucket_store_chunk_pool_requested_bytes_total` and `cortex_bucket_store_chunk_pool_returned_bytes_total`. #4996
 * [CHANGE] Compactor: change default of `-compactor.partial-block-deletion-delay` to `1d`. This will automatically clean up partial blocks that were a result of failed block upload or deletion. #5026
+* [CHANGE] Compactor: the deprecated configuration parameter `-compactor.consistency-delay` has been removed. #5050
+* [CHANGE] Store-gateway: the deprecated configuration parameter `-blocks-storage.bucket-store.consistency-delay` has been removed. #5050
 * [FEATURE] Query-frontend: add `-query-frontend.log-query-request-headers` to enable logging of request headers in query logs. #5030
 * [ENHANCEMENT] Add per-tenant limit `-validation.max-native-histogram-buckets` to be able to ignore native histogram samples that have too many buckets. #4765
 * [ENHANCEMENT] Store-gateway: reduce memory usage in some LabelValues calls. #4789

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5271,17 +5271,6 @@
               "fieldCategory": "advanced"
             },
             {
-              "kind": "field",
-              "name": "consistency_delay",
-              "required": false,
-              "desc": "Minimum age of a block before it's being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.",
-              "fieldValue": null,
-              "fieldDefaultValue": 0,
-              "fieldFlag": "blocks-storage.bucket-store.consistency-delay",
-              "fieldType": "duration",
-              "fieldCategory": "deprecated"
-            },
-            {
               "kind": "block",
               "name": "index_cache",
               "required": false,
@@ -7552,17 +7541,6 @@
           "fieldFlag": "compactor.meta-sync-concurrency",
           "fieldType": "int",
           "fieldCategory": "advanced"
-        },
-        {
-          "kind": "field",
-          "name": "consistency_delay",
-          "required": false,
-          "desc": "Minimum age of fresh (non-compacted) blocks before they are being processed.",
-          "fieldValue": null,
-          "fieldDefaultValue": 0,
-          "fieldFlag": "compactor.consistency-delay",
-          "fieldType": "duration",
-          "fieldCategory": "deprecated"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -385,8 +385,6 @@ Usage of ./cmd/mimir/mimir:
     	Client write timeout. (default 3s)
   -blocks-storage.bucket-store.chunks-cache.subrange-ttl duration
     	TTL for caching individual chunks subranges. (default 24h0m0s)
-  -blocks-storage.bucket-store.consistency-delay duration
-    	[deprecated] Minimum age of a block before it's being read. Set it to safe value (e.g 30m) if your object storage is eventually consistent. GCS and S3 are (roughly) strongly consistent.
   -blocks-storage.bucket-store.fine-grained-chunks-caching-ranges-per-series int
     	[experimental] This option controls into how many ranges the chunks of each series from each block are split. This value is effectively the number of chunks cache items per series per block when -blocks-storage.bucket-store.chunks-cache.fine-grained-chunks-caching-enabled is enabled. (default 1)
   -blocks-storage.bucket-store.ignore-blocks-within duration
@@ -877,8 +875,6 @@ Usage of ./cmd/mimir/mimir:
     	How many times to retry a failed compaction within a single compaction run. (default 3)
   -compactor.compactor-tenant-shard-size int
     	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
-  -compactor.consistency-delay duration
-    	[deprecated] Minimum age of fresh (non-compacted) blocks before they are being processed.
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
   -compactor.deletion-delay duration

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3033,12 +3033,6 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.meta-sync-concurrency
   [meta_sync_concurrency: <int> | default = 20]
 
-  # (deprecated) Minimum age of a block before it's being read. Set it to safe
-  # value (e.g 30m) if your object storage is eventually consistent. GCS and S3
-  # are (roughly) strongly consistent.
-  # CLI flag: -blocks-storage.bucket-store.consistency-delay
-  [consistency_delay: <duration> | default = 0s]
-
   index_cache:
     # The index cache backend type. Supported values: inmemory, memcached,
     # redis.
@@ -3453,11 +3447,6 @@ The `compactor` block configures the compactor component.
 # long term storage.
 # CLI flag: -compactor.meta-sync-concurrency
 [meta_sync_concurrency: <int> | default = 20]
-
-# (deprecated) Minimum age of fresh (non-compacted) blocks before they are being
-# processed.
-# CLI flag: -compactor.consistency-delay
-[consistency_delay: <duration> | default = 0s]
 
 # Directory to temporarily store blocks during compaction. This directory is not
 # required to be persisted between restarts.

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -56,7 +56,6 @@ import (
 func TestConfig_ShouldSupportYamlConfig(t *testing.T) {
 	yamlCfg := `
 block_ranges: [2h, 48h]
-consistency_delay: 1h
 block_sync_concurrency: 123
 data_dir: /tmp
 compaction_interval: 15m
@@ -67,7 +66,6 @@ compaction_retries: 123
 	flagext.DefaultValues(&cfg)
 	assert.NoError(t, yaml.Unmarshal([]byte(yamlCfg), &cfg))
 	assert.Equal(t, mimir_tsdb.DurationList{2 * time.Hour, 48 * time.Hour}, cfg.BlockRanges)
-	assert.Equal(t, time.Hour, cfg.DeprecatedConsistencyDelay)
 	assert.Equal(t, 123, cfg.BlockSyncConcurrency)
 	assert.Equal(t, "/tmp", cfg.DataDir)
 	assert.Equal(t, 15*time.Minute, cfg.CompactionInterval)
@@ -80,7 +78,6 @@ func TestConfig_ShouldSupportCliFlags(t *testing.T) {
 	cfg.RegisterFlags(fs, log.NewNopLogger())
 	require.NoError(t, fs.Parse([]string{
 		"-compactor.block-ranges=2h,48h",
-		"-compactor.consistency-delay=1h",
 		"-compactor.block-sync-concurrency=123",
 		"-compactor.data-dir=/tmp",
 		"-compactor.compaction-interval=15m",
@@ -88,7 +85,6 @@ func TestConfig_ShouldSupportCliFlags(t *testing.T) {
 	}))
 
 	assert.Equal(t, mimir_tsdb.DurationList{2 * time.Hour, 48 * time.Hour}, cfg.BlockRanges)
-	assert.Equal(t, time.Hour, cfg.DeprecatedConsistencyDelay)
 	assert.Equal(t, 123, cfg.BlockSyncConcurrency)
 	assert.Equal(t, "/tmp", cfg.DataDir)
 	assert.Equal(t, 15*time.Minute, cfg.CompactionInterval)
@@ -208,10 +204,6 @@ func TestMultitenantCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		# TYPE cortex_compactor_garbage_collection_total counter
 		cortex_compactor_garbage_collection_total 0
 
-		# HELP cortex_compactor_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_compactor_meta_sync_consistency_delay_seconds gauge
-		cortex_compactor_meta_sync_consistency_delay_seconds 0
-
 		# HELP cortex_compactor_meta_sync_duration_seconds Duration of the blocks metadata synchronization in seconds.
 		# TYPE cortex_compactor_meta_sync_duration_seconds histogram
 		cortex_compactor_meta_sync_duration_seconds_bucket{le="+Inf"} 0
@@ -274,7 +266,6 @@ func TestMultitenantCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		"cortex_compactor_garbage_collection_duration_seconds",
 		"cortex_compactor_garbage_collection_failures_total",
 		"cortex_compactor_garbage_collection_total",
-		"cortex_compactor_meta_sync_consistency_delay_seconds",
 		"cortex_compactor_meta_sync_duration_seconds",
 		"cortex_compactor_meta_sync_failures_total",
 		"cortex_compactor_meta_syncs_total",
@@ -352,10 +343,6 @@ func TestMultitenantCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUser
 		# TYPE cortex_compactor_garbage_collection_total counter
 		cortex_compactor_garbage_collection_total 0
 
-		# HELP cortex_compactor_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_compactor_meta_sync_consistency_delay_seconds gauge
-		cortex_compactor_meta_sync_consistency_delay_seconds 0
-
 		# HELP cortex_compactor_meta_sync_duration_seconds Duration of the blocks metadata synchronization in seconds.
 		# TYPE cortex_compactor_meta_sync_duration_seconds histogram
 		cortex_compactor_meta_sync_duration_seconds_bucket{le="+Inf"} 0
@@ -418,7 +405,6 @@ func TestMultitenantCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUser
 		"cortex_compactor_garbage_collection_duration_seconds",
 		"cortex_compactor_garbage_collection_failures_total",
 		"cortex_compactor_garbage_collection_total",
-		"cortex_compactor_meta_sync_consistency_delay_seconds",
 		"cortex_compactor_meta_sync_duration_seconds",
 		"cortex_compactor_meta_sync_failures_total",
 		"cortex_compactor_meta_syncs_total",

--- a/pkg/compactor/syncer_metrics.go
+++ b/pkg/compactor/syncer_metrics.go
@@ -20,7 +20,6 @@ type aggregatedSyncerMetrics struct {
 	metaSync                  prometheus.Counter
 	metaSyncFailures          prometheus.Counter
 	metaSyncDuration          *dskit_metrics.HistogramDataCollector // was prometheus.Histogram before
-	metaSyncConsistencyDelay  prometheus.Gauge
 	garbageCollections        prometheus.Counter
 	garbageCollectionFailures prometheus.Counter
 	garbageCollectionDuration *dskit_metrics.HistogramDataCollector // was prometheus.Histogram before
@@ -43,10 +42,6 @@ func newAggregatedSyncerMetrics(reg prometheus.Registerer) *aggregatedSyncerMetr
 		"cortex_compactor_meta_sync_duration_seconds",
 		"Duration of the blocks metadata synchronization in seconds.",
 		nil, nil))
-	m.metaSyncConsistencyDelay = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "cortex_compactor_meta_sync_consistency_delay_seconds",
-		Help: "Configured consistency delay in seconds.",
-	})
 
 	m.garbageCollections = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_compactor_garbage_collection_total",
@@ -88,7 +83,6 @@ func (m *aggregatedSyncerMetrics) gatherThanosSyncerMetrics(reg *prometheus.Regi
 	m.metaSync.Add(mfm.SumCounters("blocks_meta_syncs_total"))
 	m.metaSyncFailures.Add(mfm.SumCounters("blocks_meta_sync_failures_total"))
 	m.metaSyncDuration.Add(mfm.SumHistograms("blocks_meta_sync_duration_seconds"))
-	m.metaSyncConsistencyDelay.Set(mfm.MaxGauges("consistency_delay_seconds"))
 
 	m.garbageCollections.Add(mfm.SumCounters("thanos_compact_garbage_collection_total"))
 	m.garbageCollectionFailures.Add(mfm.SumCounters("thanos_compact_garbage_collection_failures_total"))

--- a/pkg/compactor/syncer_metrics_test.go
+++ b/pkg/compactor/syncer_metrics_test.go
@@ -25,10 +25,6 @@ func TestSyncerMetrics(t *testing.T) {
 	// total base = 111110
 
 	err := testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-			# HELP cortex_compactor_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-			# TYPE cortex_compactor_meta_sync_consistency_delay_seconds gauge
-			cortex_compactor_meta_sync_consistency_delay_seconds 300
-
 			# HELP cortex_compactor_meta_syncs_total Total blocks metadata synchronization attempts.
 			# TYPE cortex_compactor_meta_syncs_total counter
 			cortex_compactor_meta_syncs_total 111110
@@ -101,7 +97,6 @@ func generateTestData(base float64) *prometheus.Registry {
 	m.metaSync.Add(1 * base)
 	m.metaSyncFailures.Add(2 * base)
 	m.metaSyncDuration.Observe(3 * base / 10000)
-	m.metaSyncConsistencyDelay.Set(300)
 	m.garbageCollections.Add(5 * base)
 	m.garbageCollectionFailures.Add(6 * base)
 	m.garbageCollectionDuration.Observe(7 * base / 10000)
@@ -113,7 +108,6 @@ type testSyncerMetrics struct {
 	metaSync                  prometheus.Counter
 	metaSyncFailures          prometheus.Counter
 	metaSyncDuration          prometheus.Histogram
-	metaSyncConsistencyDelay  prometheus.Gauge
 	garbageCollections        prometheus.Counter
 	garbageCollectionFailures prometheus.Counter
 	garbageCollectionDuration prometheus.Histogram
@@ -134,10 +128,6 @@ func newTestSyncerMetrics(reg prometheus.Registerer) *testSyncerMetrics {
 		Name:    "blocks_meta_sync_duration_seconds",
 		Help:    "Duration of the blocks metadata synchronization in seconds.",
 		Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
-	})
-	m.metaSyncConsistencyDelay = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "consistency_delay_seconds",
-		Help: "Configured consistency delay in seconds.",
 	})
 
 	m.garbageCollections = promauto.With(reg).NewCounter(prometheus.CounterOpts{

--- a/pkg/querier/blocks_finder_bucket_scan.go
+++ b/pkg/querier/blocks_finder_bucket_scan.go
@@ -45,7 +45,6 @@ type BucketScanBlocksFinderConfig struct {
 	TenantsConcurrency       int
 	MetasConcurrency         int
 	CacheDir                 string
-	ConsistencyDelay         time.Duration
 	IgnoreDeletionMarksDelay time.Duration
 }
 
@@ -375,8 +374,6 @@ func (d *BucketScanBlocksFinder) createMetaFetcher(userID string) (block.Metadat
 	userReg := prometheus.NewRegistry()
 
 	// The following filters have been intentionally omitted:
-	// - Consistency delay filter: omitted because we should discover all uploaded blocks.
-	//   The consistency delay is taken in account when running the consistency check at query time.
 	// - Deduplicate filter: omitted because it could cause troubles with the consistency check if
 	//   we "hide" source blocks because recently compacted by the compactor before the store-gateway instances
 	//   discover and load the compacted ones.

--- a/pkg/querier/blocks_finder_bucket_scan_test.go
+++ b/pkg/querier/blocks_finder_bucket_scan_test.go
@@ -69,14 +69,9 @@ func TestBucketScanBlocksFinder_InitialScan(t *testing.T) {
 		# HELP cortex_blocks_meta_sync_failures_total Total blocks metadata synchronization failures
 		# TYPE cortex_blocks_meta_sync_failures_total counter
 		cortex_blocks_meta_sync_failures_total{component="querier"} 0
-
-		# HELP cortex_blocks_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_blocks_meta_sync_consistency_delay_seconds gauge
-		cortex_blocks_meta_sync_consistency_delay_seconds{component="querier"} 0
 	`),
 		"cortex_blocks_meta_syncs_total",
 		"cortex_blocks_meta_sync_failures_total",
-		"cortex_blocks_meta_sync_consistency_delay_seconds",
 	))
 
 	assert.Greater(t, testutil.ToFloat64(s.scanLastSuccess), float64(0))
@@ -121,17 +116,12 @@ func TestBucketScanBlocksFinder_InitialScanFailure(t *testing.T) {
 		# TYPE cortex_blocks_meta_sync_failures_total counter
 		cortex_blocks_meta_sync_failures_total{component="querier"} 3
 
-		# HELP cortex_blocks_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_blocks_meta_sync_consistency_delay_seconds gauge
-		cortex_blocks_meta_sync_consistency_delay_seconds{component="querier"} 0
-
 		# HELP cortex_querier_blocks_last_successful_scan_timestamp_seconds Unix timestamp of the last successful blocks scan.
 		# TYPE cortex_querier_blocks_last_successful_scan_timestamp_seconds gauge
 		cortex_querier_blocks_last_successful_scan_timestamp_seconds 0
 	`),
 		"cortex_blocks_meta_syncs_total",
 		"cortex_blocks_meta_sync_failures_total",
-		"cortex_blocks_meta_sync_consistency_delay_seconds",
 		"cortex_querier_blocks_last_successful_scan_timestamp_seconds",
 	))
 }

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -252,7 +252,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	consistency := NewBlocksConsistencyChecker(
 		// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
 		// to discover and load them (3 times the sync interval).
-		storageCfg.BucketStore.DeprecatedConsistencyDelay+(3*storageCfg.BucketStore.SyncInterval),
+		3*storageCfg.BucketStore.SyncInterval,
 		// To avoid any false positive in the consistency check, we do exclude blocks which have been
 		// recently marked for deletion, until the "ignore delay / 2". This means the consistency checker
 		// exclude such blocks about 50% of the time before querier and store-gateway stops querying them.

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -69,7 +69,6 @@ const (
 	// Synced label values.
 	labelExcludedMeta = "label-excluded"
 	timeExcludedMeta  = "time-excluded"
-	tooFreshMeta      = "too-fresh"
 	duplicateMeta     = "duplicate"
 	// Blocks that are marked for deletion can be loaded as well. This is done to make sure that we load blocks that are meant to be deleted,
 	// but don't have a replacement block yet.
@@ -113,7 +112,6 @@ func NewFetcherMetrics(reg prometheus.Registerer, syncedExtraLabels, modifiedExt
 			{CorruptedMeta},
 			{NoMeta},
 			{LoadedMeta},
-			{tooFreshMeta},
 			{FailedMeta},
 			{labelExcludedMeta},
 			{timeExcludedMeta},
@@ -230,7 +228,6 @@ func (f *BaseFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*metadata.Met
 
 	// TODO(bwplotka): If that causes problems (obj store rate limits), add longer ttl to cached items.
 	// For 1y and 100 block sources this generates ~1.5-3k HEAD RPM. AWS handles 330k RPM per prefix.
-	// TODO(bwplotka): Consider filtering by consistency delay here (can't do until compactor healthyOverride work).
 	ok, err := f.bkt.Exists(ctx, metaFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "meta.json file exists: %v", metaFile)
@@ -496,51 +493,6 @@ func (f *MetaFetcher) Fetch(ctx context.Context) (metas map[ulid.ULID]*metadata.
 
 // Special label that will have an ULID of the meta.json being referenced to.
 const BlockIDLabel = "__block_id"
-
-// ConsistencyDelayMetaFilter is a BaseFetcher filter that filters out blocks that are created before a specified consistency delay.
-// Not go-routine safe.
-type ConsistencyDelayMetaFilter struct {
-	logger           log.Logger
-	consistencyDelay time.Duration
-}
-
-// NewConsistencyDelayMetaFilter creates ConsistencyDelayMetaFilter.
-func NewConsistencyDelayMetaFilter(logger log.Logger, consistencyDelay time.Duration, reg prometheus.Registerer) *ConsistencyDelayMetaFilter {
-	if logger == nil {
-		logger = log.NewNopLogger()
-	}
-	_ = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "consistency_delay_seconds",
-		Help: "Configured consistency delay in seconds.",
-	}, func() float64 {
-		return consistencyDelay.Seconds()
-	})
-
-	return &ConsistencyDelayMetaFilter{
-		logger:           logger,
-		consistencyDelay: consistencyDelay,
-	}
-}
-
-// Filter filters out blocks that filters blocks that have are created before a specified consistency delay.
-func (f *ConsistencyDelayMetaFilter) Filter(_ context.Context, metas map[ulid.ULID]*metadata.Meta, synced GaugeVec, modified GaugeVec) error {
-	for id, meta := range metas {
-		// TODO(khyatisoneji): Remove the checks about Thanos Source
-		//  by implementing delete delay to fetch metas.
-		// TODO(bwplotka): Check consistency delay based on file upload / modification time instead of ULID.
-		if ulid.Now()-id.Time() < uint64(f.consistencyDelay/time.Millisecond) &&
-			meta.Thanos.Source != metadata.BucketRepairSource &&
-			meta.Thanos.Source != metadata.CompactorSource &&
-			meta.Thanos.Source != metadata.CompactorRepairSource {
-
-			level.Debug(f.logger).Log("msg", "block is too fresh for now", "block", id)
-			synced.WithLabelValues(tooFreshMeta).Inc()
-			delete(metas, id)
-		}
-	}
-
-	return nil
-}
 
 // IgnoreDeletionMarkFilter is a filter that filters out the blocks that are marked for deletion after a given delay.
 // The delay duration is to make sure that the replacement block can be fetched before we filter out the old block.

--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -94,7 +94,6 @@ func TestBucketIndexMetadataFetcher_Fetch(t *testing.T) {
 		blocks_meta_synced{state="no-meta-json"} 0
 		blocks_meta_synced{state="time-excluded"} 0
 		blocks_meta_synced{state="min-time-excluded"} 1
-		blocks_meta_synced{state="too-fresh"} 0
 
 		# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
 		# TYPE blocks_meta_syncs_total counter
@@ -146,7 +145,6 @@ func TestBucketIndexMetadataFetcher_Fetch_NoBucketIndex(t *testing.T) {
 		blocks_meta_synced{state="no-meta-json"} 0
 		blocks_meta_synced{state="time-excluded"} 0
 		blocks_meta_synced{state="min-time-excluded"} 0
-		blocks_meta_synced{state="too-fresh"} 0
 
 		# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
 		# TYPE blocks_meta_syncs_total counter
@@ -201,7 +199,6 @@ func TestBucketIndexMetadataFetcher_Fetch_CorruptedBucketIndex(t *testing.T) {
 		blocks_meta_synced{state="no-meta-json"} 0
 		blocks_meta_synced{state="time-excluded"} 0
 		blocks_meta_synced{state="min-time-excluded"} 0
-		blocks_meta_synced{state="too-fresh"} 0
 
 		# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
 		# TYPE blocks_meta_syncs_total counter

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -418,7 +418,6 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 	// The sharding strategy filter MUST be before the ones we create here (order matters).
 	filters := []block.MetadataFilter{
 		NewShardingMetadataFilterAdapter(userID, u.shardingStrategy),
-		block.NewConsistencyDelayMetaFilter(userLogger, u.cfg.BucketStore.DeprecatedConsistencyDelay, fetcherReg),
 		newMinTimeMetaFilter(u.cfg.BucketStore.IgnoreBlocksWithin),
 		// Use our own custom implementation.
 		NewIgnoreDeletionMarkFilter(userLogger, userBkt, u.cfg.BucketStore.IgnoreDeletionMarksDelay, u.cfg.BucketStore.MetaSyncConcurrency),

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1481,7 +1481,6 @@ func mockStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
 
-	cfg.BucketStore.DeprecatedConsistencyDelay = 0
 	cfg.BucketStore.BucketIndex.Enabled = false // mocks used in tests don't expect index reads
 	cfg.BucketStore.IgnoreBlocksWithin = 0
 	cfg.BucketStore.SyncDir = tmpDir

--- a/pkg/storegateway/metadata_fetcher_metrics.go
+++ b/pkg/storegateway/metadata_fetcher_metrics.go
@@ -18,11 +18,10 @@ type MetadataFetcherMetrics struct {
 	regs *dskit_metrics.TenantRegistries
 
 	// Exported metrics, gathered from Thanos MetaFetcher
-	syncs                *prometheus.Desc
-	syncFailures         *prometheus.Desc
-	syncDuration         *prometheus.Desc
-	syncConsistencyDelay *prometheus.Desc
-	synced               *prometheus.Desc
+	syncs        *prometheus.Desc
+	syncFailures *prometheus.Desc
+	syncDuration *prometheus.Desc
+	synced       *prometheus.Desc
 
 	// Ignored:
 	// blocks_meta_modified
@@ -47,10 +46,6 @@ func NewMetadataFetcherMetrics() *MetadataFetcherMetrics {
 			"cortex_blocks_meta_sync_duration_seconds",
 			"Duration of the blocks metadata synchronization in seconds",
 			nil, nil),
-		syncConsistencyDelay: prometheus.NewDesc(
-			"cortex_blocks_meta_sync_consistency_delay_seconds",
-			"Configured consistency delay in seconds.",
-			nil, nil),
 		synced: prometheus.NewDesc(
 			"cortex_blocks_meta_synced",
 			"Reflects current state of synced blocks (over all tenants).",
@@ -70,7 +65,6 @@ func (m *MetadataFetcherMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.syncs
 	out <- m.syncFailures
 	out <- m.syncDuration
-	out <- m.syncConsistencyDelay
 	out <- m.synced
 }
 
@@ -80,6 +74,5 @@ func (m *MetadataFetcherMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, m.syncs, "blocks_meta_syncs_total")
 	data.SendSumOfCounters(out, m.syncFailures, "blocks_meta_sync_failures_total")
 	data.SendSumOfHistograms(out, m.syncDuration, "blocks_meta_sync_duration_seconds")
-	data.SendMaxOfGauges(out, m.syncConsistencyDelay, "consistency_delay_seconds")
 	data.SendSumOfGaugesWithLabels(out, m.synced, "blocks_meta_synced", "state")
 }

--- a/pkg/storegateway/metadata_fetcher_metrics_test.go
+++ b/pkg/storegateway/metadata_fetcher_metrics_test.go
@@ -46,10 +46,6 @@ func TestMetadataFetcherMetrics(t *testing.T) {
 		# TYPE cortex_blocks_meta_syncs_total counter
 		cortex_blocks_meta_syncs_total 15
 
-		# HELP cortex_blocks_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_blocks_meta_sync_consistency_delay_seconds gauge
-		cortex_blocks_meta_sync_consistency_delay_seconds 300
-
 		# HELP cortex_blocks_meta_synced Reflects current state of synced blocks (over all tenants).
 		# TYPE cortex_blocks_meta_synced gauge
 		cortex_blocks_meta_synced{state="corrupted-meta-json"} 75
@@ -66,7 +62,6 @@ func populateMetadataFetcherMetrics(base float64) *prometheus.Registry {
 	m.syncs.Add(base * 1)
 	m.syncFailures.Add(base * 2)
 	m.syncDuration.Observe(3)
-	m.syncConsistencyDelay.Set(300)
 
 	m.synced.WithLabelValues("corrupted-meta-json").Set(base * 5)
 	m.synced.WithLabelValues("loaded").Set(base * 6)
@@ -76,11 +71,10 @@ func populateMetadataFetcherMetrics(base float64) *prometheus.Registry {
 }
 
 type metadataFetcherMetricsMock struct {
-	syncs                prometheus.Counter
-	syncFailures         prometheus.Counter
-	syncDuration         prometheus.Histogram
-	syncConsistencyDelay prometheus.Gauge
-	synced               *prometheus.GaugeVec
+	syncs        prometheus.Counter
+	syncFailures prometheus.Counter
+	syncDuration prometheus.Histogram
+	synced       *prometheus.GaugeVec
 }
 
 func newMetadataFetcherMetricsMock(reg prometheus.Registerer) *metadataFetcherMetricsMock {
@@ -101,10 +95,6 @@ func newMetadataFetcherMetricsMock(reg prometheus.Registerer) *metadataFetcherMe
 		Name:      "sync_duration_seconds",
 		Help:      "Duration of the blocks metadata synchronization in seconds",
 		Buckets:   []float64{0.01, 1, 10, 100, 1000},
-	})
-	m.syncConsistencyDelay = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Name: "consistency_delay_seconds",
-		Help: "Configured consistency delay in seconds.",
 	})
 	m.synced = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: "blocks_meta",

--- a/pkg/storegateway/metadata_fetcher_metrics_test.go
+++ b/pkg/storegateway/metadata_fetcher_metrics_test.go
@@ -50,7 +50,6 @@ func TestMetadataFetcherMetrics(t *testing.T) {
 		# TYPE cortex_blocks_meta_synced gauge
 		cortex_blocks_meta_synced{state="corrupted-meta-json"} 75
 		cortex_blocks_meta_synced{state="loaded"} 90
-		cortex_blocks_meta_synced{state="too-fresh"} 105
 `))
 	require.NoError(t, err)
 }
@@ -65,7 +64,6 @@ func populateMetadataFetcherMetrics(base float64) *prometheus.Registry {
 
 	m.synced.WithLabelValues("corrupted-meta-json").Set(base * 5)
 	m.synced.WithLabelValues("loaded").Set(base * 6)
-	m.synced.WithLabelValues("too-fresh").Set(base * 7)
 
 	return reg
 }


### PR DESCRIPTION
#### What this PR does
In 2.7 we announced the deprecation of `-compactor.consistency-delay` and `-blocks-storage.bucket-store.consistency-delay`. Since they're expected to be removed in the next release (2.9), I'm already opening a PR to remove them.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
