### PR TITLE
Compactor: do not issue object storage HEAD API calls to check if cached meta.json files still exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [ENHANCEMENT] Store-gateway: record index header loading time separately in `cortex_bucket_store_series_request_stage_duration_seconds{stage="load_index_header"}`. Now index header loading will be visible in the "Mimir / Queries" dashboard in the "Series request p99/average latency" panels. #5011 #5062
 * [ENHANCEMENT] Querier and ingester: add experimental support for streaming chunks from ingesters to queriers while evaluating queries. This can be enabled with `-querier.prefer-streaming-chunks=true`. #4886
 * [ENHANCEMENT] Update Docker base images from `alpine:3.17.3` to `alpine:3.18.0`. #5065
+* [ENHANCEMENT] Compactor: reduced the number of object storage `HEAD` API calls issued when syncing block's `meta.json` files. #5063
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 * [ENHANCEMENT] Store-gateway: record index header loading time separately in `cortex_bucket_store_series_request_stage_duration_seconds{stage="load_index_header"}`. Now index header loading will be visible in the "Mimir / Queries" dashboard in the "Series request p99/average latency" panels. #5011 #5062
 * [ENHANCEMENT] Querier and ingester: add experimental support for streaming chunks from ingesters to queriers while evaluating queries. This can be enabled with `-querier.prefer-streaming-chunks=true`. #4886
 * [ENHANCEMENT] Update Docker base images from `alpine:3.17.3` to `alpine:3.18.0`. #5065
-* [ENHANCEMENT] Compactor: reduced the number of object storage `HEAD` API calls issued when syncing block's `meta.json` files. #5063
+* [ENHANCEMENT] Compactor: reduced the number of "object exists" API calls issued by the compactor to the object storage when syncing block's `meta.json` files. #5063
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -225,11 +225,9 @@ func TestGroupCompactE2E(t *testing.T) {
 
 		reg := prometheus.NewRegistry()
 
-		ignoreDeletionMarkFilter := NewExcludeMarkedForDeletionFilter(objstore.WithNoopInstr(bkt))
 		duplicateBlocksFilter := NewShardAwareDeduplicateFilter()
 		noCompactMarkerFilter := NewNoCompactionMarkFilter(objstore.WithNoopInstr(bkt), true)
 		metaFetcher, err := block.NewMetaFetcher(nil, 32, objstore.WithNoopInstr(bkt), "", nil, []block.MetadataFilter{
-			ignoreDeletionMarkFilter,
 			duplicateBlocksFilter,
 			noCompactMarkerFilter,
 		})
@@ -520,11 +518,9 @@ func TestGarbageCollectDoesntCreateEmptyBlocksWithDeletionMarksOnly(t *testing.T
 		}
 
 		blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-		ignoreDeletionMarkFilter := NewExcludeMarkedForDeletionFilter(objstore.WithNoopInstr(bkt))
 
 		duplicateBlocksFilter := NewShardAwareDeduplicateFilter()
 		metaFetcher, err := block.NewMetaFetcher(nil, 32, objstore.WithNoopInstr(bkt), "", nil, []block.MetadataFilter{
-			ignoreDeletionMarkFilter,
 			duplicateBlocksFilter,
 		})
 		require.NoError(t, err)

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -697,9 +697,6 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 
 	userLogger := util_log.WithUserID(userID, c.logger)
 
-	// While fetching blocks, we filter out blocks that were marked for deletion by using ExcludeMarkedForDeletionFilter.
-	// No delay is used -- all blocks with deletion marker are ignored, and not considered for compaction.
-	excludeMarkedForDeletionFilter := NewExcludeMarkedForDeletionFilter(userBucket)
 	// Filters out duplicate blocks that can be formed from two or more overlapping
 	// blocks that fully submatches the source blocks of the older blocks.
 	deduplicateBlocksFilter := NewShardAwareDeduplicateFilter()
@@ -714,7 +711,6 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 			mimir_tsdb.DeprecatedTenantIDExternalLabel,
 			mimir_tsdb.DeprecatedIngesterIDExternalLabel,
 		}),
-		excludeMarkedForDeletionFilter,
 		deduplicateBlocksFilter,
 		// removes blocks that should not be compacted due to being marked so.
 		NewNoCompactionMarkFilter(userBucket, true),

--- a/pkg/compactor/split_merge_compactor_test.go
+++ b/pkg/compactor/split_merge_compactor_test.go
@@ -721,10 +721,10 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 				userBucket,
 				fetcherDir,
 				reg,
-				[]block.MetadataFilter{NewExcludeMarkedForDeletionFilter(userBucket)},
+				nil,
 			)
 			require.NoError(t, err)
-			metas, partials, err := fetcher.Fetch(ctx)
+			metas, partials, err := fetcher.FetchWithoutMarkedForDeletion(ctx)
 			require.NoError(t, err)
 			require.Empty(t, partials)
 
@@ -812,10 +812,10 @@ func TestMultitenantCompactor_ShouldGuaranteeSeriesShardingConsistencyOverTheTim
 		userBucket,
 		fetcherDir,
 		reg,
-		[]block.MetadataFilter{NewExcludeMarkedForDeletionFilter(userBucket)},
+		nil,
 	)
 	require.NoError(t, err)
-	metas, partials, err := fetcher.Fetch(ctx)
+	metas, partials, err := fetcher.FetchWithoutMarkedForDeletion(ctx)
 	require.NoError(t, err)
 	require.Empty(t, partials)
 

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -193,9 +193,8 @@ func (f *MetaFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*Meta, error)
 	//   When we'll try to read it from object storage (later on), it will fail with ErrorSyncMetaNotFound
 	//   which is correctly handled by the caller (partial block).
 	//
-	// - The block upload is completed: this is the normal case. Meta.json file still exists in the
-	//   object storage and it's expected to match the locally cached one (because immutable by design).
-	//
+	// - The block upload is completed: this is the normal case. meta.json file still exists in the
+	//   object storage and it's expected to match the locally cached one (because it's immutable by design).
 	// - The block has been marked for deletion: the deletion hasn't started yet, so the full block (including
 	//   the meta.json file) is still in the object storage. This case is not different than the previous one.
 	//

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -123,7 +123,7 @@ type GaugeVec interface {
 	WithLabelValues(lvs ...string) prometheus.Gauge
 }
 
-// Filter allows filtering or modifying metas from the provided map or returns error.
+// MetadataFilter allows filtering or modifying metas from the provided map or returns error.
 type MetadataFilter interface {
 	Filter(ctx context.Context, metas map[ulid.ULID]*Meta, synced GaugeVec) error
 }
@@ -176,23 +176,36 @@ var (
 )
 
 // loadMeta returns metadata from object storage or error.
-// It returns `ErrorSyncMetaNotFound` and `ErrorSyncMetaCorrupted` sentinel errors in those cases.
+// It returns ErrorSyncMetaNotFound and ErrorSyncMetaCorrupted sentinel errors in those cases.
 func (f *MetaFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*Meta, error) {
 	var (
 		metaFile       = path.Join(id.String(), MetaFilename)
 		cachedBlockDir = filepath.Join(f.cacheDir, id.String())
 	)
 
-	// TODO(bwplotka): If that causes problems (obj store rate limits), add longer ttl to cached items.
-	// For 1y and 100 block sources this generates ~1.5-3k HEAD RPM. AWS handles 330k RPM per prefix.
-	ok, err := f.bkt.Exists(ctx, metaFile)
-	if err != nil {
-		return nil, errors.Wrapf(err, "meta.json file exists: %v", metaFile)
-	}
-	if !ok {
-		return nil, ErrorSyncMetaNotFound
-	}
-
+	// Block meta.json file is immutable, so we lookup the cache as first thing without issuing
+	// any API call to the object storage. This significantly reduce the pressure on the object
+	// storage.
+	//
+	// Details of all possible cases:
+	//
+	// - The block upload is in progress: the meta.json file is guaranteed to be uploaded at last.
+	//   When we'll try to read it from object storage (later on), it will fail with ErrorSyncMetaNotFound
+	//   which is correctly handled by the caller (partial block).
+	//
+	// - The block upload is completed: this is the normal case. Meta.json file still exists in the
+	//   object storage and it's expected to match the locally cached one (because immutable by design).
+	//
+	// - The block has been marked for deletion: the deletion hasn't started yet, so the full block (including
+	//   the meta.json file) is still in the object storage. This case is not different than the previous one.
+	//
+	// - The block deletion is in progress: loadMeta() function may return the cached meta.json while it should
+	//   return ErrorSyncMetaNotFound. This is a race condition that could happen even if we check the meta.json
+	//   file in the storage, because the deletion could start right after we check it but before the MetaFetcher
+	//   completes its sync.
+	//
+	// - The block has been deleted: the loadMeta() function will not be called at all, because the block
+	//   was not discovered while iterating the bucket since all its files were already deleted.
 	if m, seen := f.cached[id]; seen {
 		return m, nil
 	}
@@ -253,14 +266,17 @@ func (f *MetaFetcher) loadMeta(ctx context.Context, id ulid.ULID) (*Meta, error)
 type response struct {
 	metas   map[ulid.ULID]*Meta
 	partial map[ulid.ULID]error
+
 	// If metaErr > 0 it means incomplete view, so some metas, failed to be loaded.
 	metaErrs multierror.MultiError
 
-	noMetas        float64
-	corruptedMetas float64
+	// Track the number of blocks not returned because of various reasons.
+	noMetasCount           float64
+	corruptedMetasCount    float64
+	markedForDeletionCount float64
 }
 
-func (f *MetaFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
+func (f *MetaFetcher) fetchMetadata(ctx context.Context, excludeMarkedForDeletion bool) (interface{}, error) {
 	var (
 		resp = response{
 			metas:   make(map[ulid.ULID]*Meta),
@@ -271,6 +287,19 @@ func (f *MetaFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 		mtx sync.Mutex
 	)
 	level.Debug(f.logger).Log("msg", "fetching meta data", "concurrency", f.concurrency)
+
+	// Get the list of blocks marked for deletion so that we'll exclude them (if required).
+	var markedForDeletion map[ulid.ULID]struct{}
+	if excludeMarkedForDeletion {
+		var err error
+
+		markedForDeletion, err = ListBlockDeletionMarks(ctx, f.bkt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Run workers.
 	for i := 0; i < f.concurrency; i++ {
 		eg.Go(func() error {
 			for id := range ch {
@@ -284,11 +313,11 @@ func (f *MetaFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 
 				if errors.Is(errors.Cause(err), ErrorSyncMetaNotFound) {
 					mtx.Lock()
-					resp.noMetas++
+					resp.noMetasCount++
 					mtx.Unlock()
 				} else if errors.Is(errors.Cause(err), ErrorSyncMetaCorrupted) {
 					mtx.Lock()
-					resp.corruptedMetas++
+					resp.corruptedMetasCount++
 					mtx.Unlock()
 				} else {
 					mtx.Lock()
@@ -311,6 +340,12 @@ func (f *MetaFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 		return f.bkt.Iter(ctx, "", func(name string) error {
 			id, ok := IsBlockDir(name)
 			if !ok {
+				return nil
+			}
+
+			// If requested, skip any block marked for deletion.
+			if _, marked := markedForDeletion[id]; excludeMarkedForDeletion && marked {
+				resp.markedForDeletionCount++
 				return nil
 			}
 
@@ -378,7 +413,22 @@ func (f *MetaFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 // It's caller responsibility to not change the returned metadata files. Maps can be modified.
 //
 // Returned error indicates a failure in fetching metadata. Returned meta can be assumed as correct, with some blocks missing.
-func (f *MetaFetcher) Fetch(ctx context.Context) (_ map[ulid.ULID]*Meta, _ map[ulid.ULID]error, err error) {
+func (f *MetaFetcher) Fetch(ctx context.Context) (metas map[ulid.ULID]*Meta, partials map[ulid.ULID]error, err error) {
+	metas, partials, err = f.fetch(ctx, false)
+	return
+}
+
+// FetchWithoutMarkedForDeletion returns all block metas as well as partial blocks (blocks without or with corrupted meta file) from the bucket.
+// This function excludes all blocks for deletion (no deletion delay applied).
+// It's caller responsibility to not change the returned metadata files. Maps can be modified.
+//
+// Returned error indicates a failure in fetching metadata. Returned meta can be assumed as correct, with some blocks missing.
+func (f *MetaFetcher) FetchWithoutMarkedForDeletion(ctx context.Context) (metas map[ulid.ULID]*Meta, partials map[ulid.ULID]error, err error) {
+	metas, partials, err = f.fetch(ctx, true)
+	return
+}
+
+func (f *MetaFetcher) fetch(ctx context.Context, excludeMarkedForDeletion bool) (_ map[ulid.ULID]*Meta, _ map[ulid.ULID]error, err error) {
 	start := time.Now()
 	defer func() {
 		f.metrics.SyncDuration.Observe(time.Since(start).Seconds())
@@ -392,7 +442,7 @@ func (f *MetaFetcher) Fetch(ctx context.Context) (_ map[ulid.ULID]*Meta, _ map[u
 	// Run this in thread safe run group.
 	v, err := f.g.Do("", func() (i interface{}, err error) {
 		// NOTE: First go routine context will go through.
-		return f.fetchMetadata(ctx)
+		return f.fetchMetadata(ctx, excludeMarkedForDeletion)
 	})
 	if err != nil {
 		return nil, nil, err
@@ -406,8 +456,11 @@ func (f *MetaFetcher) Fetch(ctx context.Context) (_ map[ulid.ULID]*Meta, _ map[u
 	}
 
 	f.metrics.Synced.WithLabelValues(FailedMeta).Set(float64(len(resp.metaErrs)))
-	f.metrics.Synced.WithLabelValues(NoMeta).Set(resp.noMetas)
-	f.metrics.Synced.WithLabelValues(CorruptedMeta).Set(resp.corruptedMetas)
+	f.metrics.Synced.WithLabelValues(NoMeta).Set(resp.noMetasCount)
+	f.metrics.Synced.WithLabelValues(CorruptedMeta).Set(resp.corruptedMetasCount)
+	if excludeMarkedForDeletion {
+		f.metrics.Synced.WithLabelValues(MarkedForDeletionMeta).Set(resp.markedForDeletionCount)
+	}
 
 	for _, filter := range f.filters {
 		// NOTE: filter can update synced metric accordingly to the reason of the exclude.
@@ -434,7 +487,7 @@ func (f *MetaFetcher) countCached() int {
 	return len(f.cached)
 }
 
-// Special label that will have an ULID of the meta.json being referenced to.
+// BlockIDLabel is a special label that will have an ULID of the meta.json being referenced to.
 const BlockIDLabel = "__block_id"
 
 // IgnoreDeletionMarkFilter is a filter that filters out the blocks that are marked for deletion after a given delay.

--- a/pkg/storage/tsdb/block/fetcher_test.go
+++ b/pkg/storage/tsdb/block/fetcher_test.go
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package block
+
+import (
+	"context"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
+)
+
+func TestMetaFetcher_Fetch_ShouldReturnDiscoveredBlocksIncludingMarkedForDeletion(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		reg    = prometheus.NewPedanticRegistry()
+		logger = log.NewNopLogger()
+	)
+
+	// Create a bucket client with global markers.
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: t.TempDir()})
+	require.NoError(t, err)
+	bkt = BucketWithGlobalMarkers(bkt)
+
+	f, err := NewMetaFetcher(logger, 10, objstore.BucketWithMetrics("test", bkt, reg), t.TempDir(), reg, nil)
+	require.NoError(t, err)
+
+	t.Run("should return no metas and no partials on no block in the storage", func(t *testing.T) {
+		actualMetas, actualPartials, actualErr := f.Fetch(ctx)
+		require.NoError(t, actualErr)
+		require.Empty(t, actualMetas)
+		require.Empty(t, actualPartials)
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+			# TYPE blocks_meta_sync_failures_total counter
+			blocks_meta_sync_failures_total 0
+			
+			# HELP blocks_meta_synced Number of block metadata synced
+			# TYPE blocks_meta_synced gauge
+			blocks_meta_synced{state="corrupted-meta-json"} 0
+			blocks_meta_synced{state="duplicate"} 0
+			blocks_meta_synced{state="failed"} 0
+			blocks_meta_synced{state="label-excluded"} 0
+			blocks_meta_synced{state="loaded"} 0
+			blocks_meta_synced{state="marked-for-deletion"} 0
+			blocks_meta_synced{state="marked-for-no-compact"} 0
+			blocks_meta_synced{state="no-meta-json"} 0
+			blocks_meta_synced{state="time-excluded"} 0
+
+			# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+			# TYPE blocks_meta_syncs_total counter
+			blocks_meta_syncs_total 1
+		`), "blocks_meta_syncs_total", "blocks_meta_sync_failures_total", "blocks_meta_synced"))
+	})
+
+	// Upload a block.
+	block1ID, block1Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block1Dir, nil))
+
+	// Upload a partial block.
+	block2ID, block2Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block2Dir, nil))
+	require.NoError(t, bkt.Delete(ctx, path.Join(block2ID.String(), MetaFilename)))
+
+	t.Run("should return metas and partials on some blocks in the storage", func(t *testing.T) {
+		actualMetas, actualPartials, actualErr := f.Fetch(ctx)
+		require.NoError(t, actualErr)
+		require.Len(t, actualMetas, 1)
+		require.Contains(t, actualMetas, block1ID)
+		require.Len(t, actualPartials, 1)
+		require.Contains(t, actualPartials, block2ID)
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+			# TYPE blocks_meta_sync_failures_total counter
+			blocks_meta_sync_failures_total 0
+			
+			# HELP blocks_meta_synced Number of block metadata synced
+			# TYPE blocks_meta_synced gauge
+			blocks_meta_synced{state="corrupted-meta-json"} 0
+			blocks_meta_synced{state="duplicate"} 0
+			blocks_meta_synced{state="failed"} 0
+			blocks_meta_synced{state="label-excluded"} 0
+			blocks_meta_synced{state="loaded"} 1
+			blocks_meta_synced{state="marked-for-deletion"} 0
+			blocks_meta_synced{state="marked-for-no-compact"} 0
+			blocks_meta_synced{state="no-meta-json"} 1
+			blocks_meta_synced{state="time-excluded"} 0
+
+			# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+			# TYPE blocks_meta_syncs_total counter
+			blocks_meta_syncs_total 2
+		`), "blocks_meta_syncs_total", "blocks_meta_sync_failures_total", "blocks_meta_synced"))
+	})
+
+	// Upload a block and mark it for deletion.
+	block3ID, block3Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block3Dir, nil))
+	require.NoError(t, MarkForDeletion(ctx, logger, bkt, block3ID, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
+
+	t.Run("should include blocks marked for deletion", func(t *testing.T) {
+		actualMetas, actualPartials, actualErr := f.Fetch(ctx)
+		require.NoError(t, actualErr)
+		require.Len(t, actualMetas, 2)
+		require.Contains(t, actualMetas, block1ID)
+		require.Contains(t, actualMetas, block3ID)
+		require.Len(t, actualPartials, 1)
+		require.Contains(t, actualPartials, block2ID)
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+			# TYPE blocks_meta_sync_failures_total counter
+			blocks_meta_sync_failures_total 0
+			
+			# HELP blocks_meta_synced Number of block metadata synced
+			# TYPE blocks_meta_synced gauge
+			blocks_meta_synced{state="corrupted-meta-json"} 0
+			blocks_meta_synced{state="duplicate"} 0
+			blocks_meta_synced{state="failed"} 0
+			blocks_meta_synced{state="label-excluded"} 0
+			blocks_meta_synced{state="loaded"} 2
+			blocks_meta_synced{state="marked-for-deletion"} 0
+			blocks_meta_synced{state="marked-for-no-compact"} 0
+			blocks_meta_synced{state="no-meta-json"} 1
+			blocks_meta_synced{state="time-excluded"} 0
+
+			# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+			# TYPE blocks_meta_syncs_total counter
+			blocks_meta_syncs_total 3
+		`), "blocks_meta_syncs_total", "blocks_meta_sync_failures_total", "blocks_meta_synced"))
+	})
+}
+
+func TestMetaFetcher_FetchWithoutMarkedForDeletion_ShouldReturnDiscoveredBlocksExcludingMarkedForDeletion(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		reg    = prometheus.NewPedanticRegistry()
+		logger = log.NewNopLogger()
+	)
+
+	// Create a bucket client with global markers.
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: t.TempDir()})
+	require.NoError(t, err)
+	bkt = BucketWithGlobalMarkers(bkt)
+
+	f, err := NewMetaFetcher(logger, 10, objstore.BucketWithMetrics("test", bkt, reg), t.TempDir(), reg, nil)
+	require.NoError(t, err)
+
+	t.Run("should return no metas and no partials on no block in the storage", func(t *testing.T) {
+		actualMetas, actualPartials, actualErr := f.FetchWithoutMarkedForDeletion(ctx)
+		require.NoError(t, actualErr)
+		require.Empty(t, actualMetas)
+		require.Empty(t, actualPartials)
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+			# TYPE blocks_meta_sync_failures_total counter
+			blocks_meta_sync_failures_total 0
+			
+			# HELP blocks_meta_synced Number of block metadata synced
+			# TYPE blocks_meta_synced gauge
+			blocks_meta_synced{state="corrupted-meta-json"} 0
+			blocks_meta_synced{state="duplicate"} 0
+			blocks_meta_synced{state="failed"} 0
+			blocks_meta_synced{state="label-excluded"} 0
+			blocks_meta_synced{state="loaded"} 0
+			blocks_meta_synced{state="marked-for-deletion"} 0
+			blocks_meta_synced{state="marked-for-no-compact"} 0
+			blocks_meta_synced{state="no-meta-json"} 0
+			blocks_meta_synced{state="time-excluded"} 0
+
+			# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+			# TYPE blocks_meta_syncs_total counter
+			blocks_meta_syncs_total 1
+		`), "blocks_meta_syncs_total", "blocks_meta_sync_failures_total", "blocks_meta_synced"))
+	})
+
+	// Upload a block.
+	block1ID, block1Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block1Dir, nil))
+
+	// Upload a partial block.
+	block2ID, block2Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block2Dir, nil))
+	require.NoError(t, bkt.Delete(ctx, path.Join(block2ID.String(), MetaFilename)))
+
+	t.Run("should return metas and partials on some blocks in the storage", func(t *testing.T) {
+		actualMetas, actualPartials, actualErr := f.FetchWithoutMarkedForDeletion(ctx)
+		require.NoError(t, actualErr)
+		require.Len(t, actualMetas, 1)
+		require.Contains(t, actualMetas, block1ID)
+		require.Len(t, actualPartials, 1)
+		require.Contains(t, actualPartials, block2ID)
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+			# TYPE blocks_meta_sync_failures_total counter
+			blocks_meta_sync_failures_total 0
+			
+			# HELP blocks_meta_synced Number of block metadata synced
+			# TYPE blocks_meta_synced gauge
+			blocks_meta_synced{state="corrupted-meta-json"} 0
+			blocks_meta_synced{state="duplicate"} 0
+			blocks_meta_synced{state="failed"} 0
+			blocks_meta_synced{state="label-excluded"} 0
+			blocks_meta_synced{state="loaded"} 1
+			blocks_meta_synced{state="marked-for-deletion"} 0
+			blocks_meta_synced{state="marked-for-no-compact"} 0
+			blocks_meta_synced{state="no-meta-json"} 1
+			blocks_meta_synced{state="time-excluded"} 0
+
+			# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+			# TYPE blocks_meta_syncs_total counter
+			blocks_meta_syncs_total 2
+		`), "blocks_meta_syncs_total", "blocks_meta_sync_failures_total", "blocks_meta_synced"))
+	})
+
+	// Upload a block and mark it for deletion.
+	block3ID, block3Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block3Dir, nil))
+	require.NoError(t, MarkForDeletion(ctx, logger, bkt, block3ID, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
+
+	t.Run("should include blocks marked for deletion", func(t *testing.T) {
+		actualMetas, actualPartials, actualErr := f.FetchWithoutMarkedForDeletion(ctx)
+		require.NoError(t, actualErr)
+		require.Len(t, actualMetas, 1)
+		require.Contains(t, actualMetas, block1ID)
+		require.Len(t, actualPartials, 1)
+		require.Contains(t, actualPartials, block2ID)
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+			# TYPE blocks_meta_sync_failures_total counter
+			blocks_meta_sync_failures_total 0
+			
+			# HELP blocks_meta_synced Number of block metadata synced
+			# TYPE blocks_meta_synced gauge
+			blocks_meta_synced{state="corrupted-meta-json"} 0
+			blocks_meta_synced{state="duplicate"} 0
+			blocks_meta_synced{state="failed"} 0
+			blocks_meta_synced{state="label-excluded"} 0
+			blocks_meta_synced{state="loaded"} 1
+			blocks_meta_synced{state="marked-for-deletion"} 1
+			blocks_meta_synced{state="marked-for-no-compact"} 0
+			blocks_meta_synced{state="no-meta-json"} 1
+			blocks_meta_synced{state="time-excluded"} 0
+
+			# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+			# TYPE blocks_meta_syncs_total counter
+			blocks_meta_syncs_total 3
+		`), "blocks_meta_syncs_total", "blocks_meta_sync_failures_total", "blocks_meta_synced"))
+	})
+}
+
+func TestMetaFetcher_ShouldNotIssueAnyAPICallToObjectStorageIfAllBlockMetasAreCached(t *testing.T) {
+	var (
+		ctx        = context.Background()
+		logger     = log.NewNopLogger()
+		fetcherDir = t.TempDir()
+	)
+
+	// Create a bucket client.
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: t.TempDir()})
+	require.NoError(t, err)
+
+	// Upload few blocks.
+	block1ID, block1Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block1Dir, nil))
+	block2ID, block2Dir := createTestBlock(t)
+	require.NoError(t, Upload(ctx, logger, bkt, block2Dir, nil))
+
+	// Create a fetcher and fetch block metas to populate the cache on disk.
+	reg1 := prometheus.NewPedanticRegistry()
+	fetcher1, err := NewMetaFetcher(logger, 10, objstore.BucketWithMetrics("test", bkt, reg1), fetcherDir, nil, nil)
+	require.NoError(t, err)
+	actualMetas, _, actualErr := fetcher1.Fetch(ctx)
+	require.NoError(t, actualErr)
+	require.Len(t, actualMetas, 2)
+	require.Contains(t, actualMetas, block1ID)
+	require.Contains(t, actualMetas, block2ID)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg1, strings.NewReader(`
+		# HELP thanos_objstore_bucket_operations_total Total number of all attempted operations against a bucket.
+		# TYPE thanos_objstore_bucket_operations_total counter
+		thanos_objstore_bucket_operations_total{bucket="test",operation="attributes"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="delete"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="exists"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="get"} 2
+		thanos_objstore_bucket_operations_total{bucket="test",operation="get_range"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="iter"} 1
+		thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 0
+	`), "thanos_objstore_bucket_operations_total"))
+
+	// Create a new fetcher and fetch blocks again. This time we expect all meta.json to be loaded from cache.
+	reg2 := prometheus.NewPedanticRegistry()
+	fetcher2, err := NewMetaFetcher(logger, 10, objstore.BucketWithMetrics("test", bkt, reg2), fetcherDir, nil, nil)
+	require.NoError(t, err)
+	actualMetas, _, actualErr = fetcher2.Fetch(ctx)
+	require.NoError(t, actualErr)
+	require.Len(t, actualMetas, 2)
+	require.Contains(t, actualMetas, block1ID)
+	require.Contains(t, actualMetas, block2ID)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg2, strings.NewReader(`
+		# HELP thanos_objstore_bucket_operations_total Total number of all attempted operations against a bucket.
+		# TYPE thanos_objstore_bucket_operations_total counter
+		thanos_objstore_bucket_operations_total{bucket="test",operation="attributes"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="delete"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="exists"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="get"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="get_range"} 0
+		thanos_objstore_bucket_operations_total{bucket="test",operation="iter"} 1
+		thanos_objstore_bucket_operations_total{bucket="test",operation="upload"} 0
+	`), "thanos_objstore_bucket_operations_total"))
+}
+
+func createTestBlock(t *testing.T) (blockID ulid.ULID, blockDir string) {
+	var err error
+
+	parentDir := t.TempDir()
+	series := []labels.Labels{
+		labels.FromStrings(labels.MetricName, "series_1"),
+		labels.FromStrings(labels.MetricName, "series_2"),
+		labels.FromStrings(labels.MetricName, "series_3"),
+	}
+
+	blockID, err = CreateBlock(context.Background(), parentDir, series, 100, 0, 1000, nil)
+	require.NoError(t, err)
+
+	blockDir = filepath.Join(parentDir, blockID.String())
+	return
+}

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -169,17 +169,11 @@ func (w *Updater) updateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Blo
 
 func (w *Updater) updateBlockDeletionMarks(ctx context.Context, old []*BlockDeletionMark) ([]*BlockDeletionMark, error) {
 	out := make([]*BlockDeletionMark, 0, len(old))
-	discovered := map[ulid.ULID]struct{}{}
 
 	// Find all markers in the storage.
-	err := w.bkt.Iter(ctx, block.MarkersPathname+"/", func(name string) error {
-		if blockID, ok := block.IsDeletionMarkFilename(path.Base(name)); ok {
-			discovered[blockID] = struct{}{}
-		}
-		return nil
-	})
+	discovered, err := block.ListBlockDeletionMarks(ctx, w.bkt)
 	if err != nil {
-		return nil, errors.Wrap(err, "list block deletion marks")
+		return nil, err
 	}
 
 	// Since deletion marks are immutable, all markers already existing in the index can just be copied.


### PR DESCRIPTION
#### What this PR does
The compactor issue a "object exists" API call for every block of each tenant every `-compactor.compaction-interval`. If you run a Mimir cluster with a large number of tenants (order of tens of thousands) and 1 year blocks retention, this can causes a very high number of API calls (order of hundred of millions per day). This PR removes such call.

The rationale of the change introduced in this PR is better explained [here](https://github.com/grafana/mimir/pull/5063/files#diff-949e4c7f50611c01ff05d35cfd88a3e0af9f07676c48acc02d0baf7193c86137R186-R207), but can be summarised as:
- Before this PR, we filtered out blocks marked for deletion after synching their metas. However, there's no need to do it that late, since we don't care about blocks marked for deletion, so in this PR I moved that filtering upfront. The new logic is: list blocks in the bucket, filter out the ones marked for deletion, sync meta.json files for the remaining ones.
- meta.json files are immutable. Before this PR, the only reason why we checked for meta.json existence was to find out if a block was deleted (or deletion was in progress) between the "list blocks" operations and their sync (which was calling `Exists()` on each block's meta.json). After this PR, where the call to `Exists()` as been removed, this case shouldn't be a real issue because we filter out the blocks that were marked for deletion before we start listing blocks in the bucket. The `block.Delete()` also guarantees that the deletion mark is the last file to be removed when deleting a block (and `meta.json` is the first one), so this should reduce the race conditions we may have.

#### Which issue(s) this PR fixes or relates to

Fixes #5056

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
