### PR TITLE
Removes consistency_delay setting from mimir-microservices-mode docker compose

### DIFF
--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -44,7 +44,6 @@ blocks_storage:
 
   bucket_store:
     sync_dir: /tmp/mimir-tsdb-querier
-    consistency_delay: 5s
     index_header_lazy_loading_enabled: true
     sync_interval: 1m
 
@@ -111,7 +110,6 @@ alertmanager_storage:
 compactor:
   compaction_interval: 30s
   data_dir:            /tmp/mimir-compactor
-  consistency_delay:   1m
   cleanup_interval:    1m
   tenant_cleanup_delay: 1m
   sharding_ring:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Since consistency_delay was previously removed in #5050, this change removes it from mimir-microservices-mode.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
