### PR TITLE
Update alpine to 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [ENHANCEMENT] Add `-enable-go-runtime-metrics` flag to expose all go runtime metrics as Prometheus metrics. #5009
 * [ENHANCEMENT] Ruler: trigger a synchronization of tenant's rule groups as soon as they change the rules configuration via API. This synchronization is in addition of the periodic syncing done every `-ruler.poll-interval`. #4975
 * [ENHANCEMENT] Store-gateway: record index header loading time separately in `cortex_bucket_store_series_request_stage_duration_seconds{stage="load_index"}`. Now index header loading will be visible in the "Mimir / Queries" dashboard in the "Series request p99/average latency" panels. #5011
+* [ENHANCEMENT] Update Docker base images from `alpine:3.17.3` to `alpine:3.18.0`. #5065
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782
 * [BUGFIX] Store-gateway: add collision detection on expanded postings and individual postings cache keys. #4770
 * [BUGFIX] Ruler: Support the `type=alert|record` query parameter for the API endpoint `<prometheus-http-prefix>/api/v1/rules`. #4302

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.17.3
+FROM       alpine:3.18.0
 RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimir-continuous-test/Dockerfile
+++ b/cmd/mimir-continuous-test/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.17.3
+FROM       alpine:3.18.0
 RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.17.3
+FROM       alpine:3.18.0
 RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM       alpine:3.17.3
+FROM       alpine:3.18.0
 RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.17.3
+FROM       alpine:3.18.0
 RUN        apk add --no-cache ca-certificates tzdata
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20.4
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-monolithic-mode-with-swift-storage/dev.dockerfile
+++ b/development/mimir-monolithic-mode-with-swift-storage/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-monolithic-mode/dev.dockerfile
+++ b/development/mimir-monolithic-mode/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20.4
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 
 RUN     mkdir /mimir
 WORKDIR /mimir


### PR DESCRIPTION
#### What this PR does

Updates Docker base images from `alpine:3.17.3` to `alpine:3.18.0`.
[3.18.0 release notes](https://alpinelinux.org/posts/Alpine-3.18.0-released.html)

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
